### PR TITLE
Pooled IMAP, virtualized folder picker, safer HTML rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,71 @@
 # Changelog
 
+## v0.5.9
+
+### Accessibility
+
+- Restored automatic focus into the WebView2 message body after opening a message.
+- Added a retrying WebView2 host plus DOM focus handoff and UIA notification so NVDA receives a stable "Message body" focus event after heavy HTML rendering.
+
+## v0.5.8
+
+### Message rendering
+
+- Heavy sender HTML is now prepared off the UI thread before it is sent to WebView2.
+- Large, deeply table-based, or embedded-image-heavy messages are displayed in a simplified reader mode instead of rendering the full marketing HTML.
+- HTML rendering now strips remote images, external resources, scripts, forms, inline event handlers, and oversized styling before display.
+- WebView2 body navigation has a timeout so a problematic message cannot hold the interface indefinitely.
+
+## v0.5.7
+
+### Folder tree shortcuts
+
+- `Ctrl+2` and `Ctrl+Y` now focus the main folder tree pane instead of opening the quick-search folder picker.
+- The same folder-tree shortcut handling now works from the WebView2 reading pane.
+
+## v0.5.6
+
+### Folder picker shortcuts
+
+- `Ctrl+2` and `Ctrl+Y` both opened the same folder picker.
+- Added WebView2 shortcut relay so both shortcuts work while focus is in the reading pane.
+- Added feedback when folders are still loading instead of silently ignoring the shortcut.
+
+## v0.5.5
+
+### Folder navigation and Inbox loading
+
+- Changed the primary folder picker shortcut to `Ctrl+2`.
+- Folder selection now shows cached folder messages immediately and refreshes from IMAP in the background, so opening Inbox does not wait on Gmail before returning control to the UI.
+- Foreground folder summary fetches no longer request IMAP preview text; background sync still fills previews when available.
+
+## v0.5.4
+
+### Folder picker
+
+- Replaced the `Ctrl+Y` folder picker tree with a virtualized searchable list so opening the picker does not realize a large Gmail folder tree on the UI thread.
+- The search field is focused when the picker opens; typing filters folders immediately, Enter opens the selected folder, and Down Arrow moves into the list.
+
+## v0.5.3
+
+### IMAP responsiveness
+
+- Raised the default IMAP connection limit from 3 to 6 simultaneous connections per account.
+- Added foreground/background IMAP leasing: background sync, polling, UID checks, and preview fetching are capped below the full pool so message opening and attachment downloads keep reserved connection capacity.
+- Increased the supported `MaxImapConnectionsPerAccount` range to 1-15.
+
+## v0.5.2
+
+### IMAP concurrency
+
+- Added a bounded IMAP connection pool per account so background sync, preview fetching, message opening, attachment downloads, and move/copy/delete operations do not reuse the same busy MailKit client.
+- Message opening now allows a newer selection to cancel and supersede an older body load, preventing stale or slow loads from blocking quick navigation.
+- Added `MaxImapConnectionsPerAccount` to `config.ini` with a default of 3 and a supported range of 1-10.
+
+### Documentation
+
+- Updated the README, user guide, and project notes for pooled IMAP connections and the current keyboard shortcuts.
+
 ## v0.5.1
 
 ### Attachments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@
 ### Folder picker
 
 - Replaced the `Ctrl+Y` folder picker tree with a virtualized searchable list so opening the picker does not realize a large Gmail folder tree on the UI thread.
-- The search field is focused when the picker opens; typing filters folders immediately, Enter opens the selected folder, and Down Arrow moves into the list.
+- The folder list is focused when the picker opens; press `/` to move focus to the search field, type to filter folders, and press Enter to open the selected folder.
 
 ## v0.5.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 ### Folder tree shortcuts
 
 - `Ctrl+2` and `Ctrl+Y` now focus the main folder tree pane instead of opening the quick-search folder picker.
+- Added `Ctrl+Shift+F` / **View > Search Folders...** for the virtualized flat folder list.
 - The same folder-tree shortcut handling now works from the WebView2 reading pane.
 
 ## v0.5.6

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,6 @@ WPF desktop email client (.NET 8, C#). Multi-account IMAP/SMTP with unified inbo
 ## Build & Run
 
 ```bat
-cd QuickMail
 build.bat          # build
 build.bat run      # build + launch
 build.bat publish  # self-contained win-x64
@@ -23,7 +22,7 @@ QuickMail/QuickMail/
 │   ├── MainWindow.xaml(.cs) # 3-pane layout; keyboard nav; WebView2 HTML rendering
 │   ├── ComposeWindow.xaml   # New/Reply/Forward dialog
 │   ├── AccountManagerDialog.xaml
-│   └── FolderPickerWindow.xaml  # Ctrl+Y quick nav
+│   └── FolderPickerWindow.xaml  # Destination picker for move/copy/go-to-folder commands
 ├── ViewModels/
 │   ├── MainViewModel.cs     # Master state (accounts, folders, messages, selection)
 │   ├── ComposeViewModel.cs  # Compose/reply/forward factories
@@ -45,23 +44,29 @@ QuickMail/QuickMail/
 ## Key Conventions
 
 - **MVVM strictly**: views bind to VM properties/commands; no logic in code-behind except UI-only concerns (keyboard shortcuts, WebView2 navigation)
-- **IMAP client pool**: `ImapService` keeps one `ImapClient` per account Guid; reconnect on demand
+- **IMAP client pool**: `ImapService` leases one `ImapClient` per active operation from a bounded per-account pool; never run two MailKit commands on the same client concurrently
+- **Foreground IMAP priority**: message detail and attachment downloads use foreground leases; background sync, UID checks, polling, and preview fetches use background leases capped below the full pool
 - **"All Mail" virtual folder**: identified by `FullName == "\x00AllMail"`; aggregates all accounts sorted newest-first
 - **Passwords**: never written to JSON; always round-trip through `CredentialService` (Windows Credential Manager)
 - **HTML sandbox**: WebView2 `NavigateToString` with strict CSP — no scripts, no object/embed, no frames
-- **Cancellation**: three separate `CancellationTokenSource` (connect, folder load, message load) — cancel the right one when switching context
+- **Heavy HTML rendering**: build reading-pane HTML off the UI thread; large/table-heavy/data-image messages use simplified reader mode before `NavigateToString`
+- **Cancellation**: use separate token sources for connect, folder load, message body load, message mutations, and background sync so unrelated work does not cancel accidentally
 - **Pagination**: messages fetched in batches of 100; "Load More" appends next batch
+- **IMAP concurrency config**: `MaxImapConnectionsPerAccount` in `%APPDATA%\QuickMail\config.ini` defaults to 6 and is clamped to 1-15
+- **Folder shortcuts**: `Ctrl+2` and `Ctrl+Y` focus the main `FolderList` TreeView; do not route those shortcuts to `FolderPickerWindow`
+- **Folder picker**: `FolderPickerWindow` is a flat virtualized searchable list, not a `TreeView`; keep construction cheap for large Gmail label sets
 
 ## Keyboard Shortcuts (MainWindow)
 
 | Key | Action |
 |-----|--------|
-| Ctrl+0 | Focus account list |
-| Ctrl+1 | Focus folder list |
-| Ctrl+2 | Focus message list |
-| Ctrl+3 | Focus reading pane |
+| Ctrl+0 | Focus toolbar |
+| Ctrl+1 | Focus account list |
+| Ctrl+2 / Ctrl+Y | Focus folder tree |
+| Ctrl+3 | Focus message list / conversation tree |
+| Ctrl+9 | Focus status bar |
+| F6 / Shift+F6 | Cycle panes |
 | Ctrl+N | New message |
-| Ctrl+Y | Folder picker |
 | Delete | Delete selected messages |
 | Escape | Close reading pane |
 
@@ -69,7 +74,8 @@ QuickMail/QuickMail/
 
 | Package | Version | Purpose |
 |---------|---------|---------|
-| MailKit | 4.15.1 | IMAP + SMTP protocol |
+| MailKit | 4.16.0 | IMAP + SMTP protocol |
 | CommunityToolkit.Mvvm | 8.4.2 | ObservableProperty, RelayCommand |
-| Microsoft.Web.WebView2 | latest | HTML email rendering |
+| Microsoft.Data.Sqlite | 10.0.7 | Local message cache |
+| Microsoft.Web.WebView2 | 1.0.3912.50 | HTML email rendering |
 | AdysTech.CredentialManager | 3.1.0 | Windows Credential Manager |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,38 +80,46 @@ Trash, Junk, Sent, and Drafts are excluded from `\x00AllMail` via `folder.Exclud
 - **HTML sandbox**: WebView2 `NavigateToString` uses strict CSP. Scripts, objects, frames, forms, remote images, and active handlers are blocked or stripped.
 - **Heavy HTML rendering**: build reading-pane HTML off the UI thread; large/table-heavy messages use simplified reader mode before `NavigateToString`.
 - **Plain-text links**: render http/https/mailto text as links, and open clicked links in the default browser rather than inside the reading pane.
-- **Folder picker**: `FolderPickerWindow` is a flat virtualized list. It opens with focus on the folder list; `/` or `Ctrl+F` moves focus to search.
+- **Folder picker**: `FolderPickerWindow` is a flat virtualized list. It opens with focus on the folder list; `/` (forward slash) moves focus to search.
 - **Logging**: `LogService` appends to `%APPDATA%\QuickMail\quickmail.log`; `LogService.Debug()` writes only when `/debug` is present. Avoid logging credentials or unnecessary PII.
 - **Inclusive language in documentation and UI text**: Use verbs like "activate", "select", "choose", or "press" instead of "click".
 
-## MVVM Rules
+## MVVM Rules — Enforced
+
+These rules apply to every change. Violations must be corrected before a PR can merge.
 
 ### ViewModels must not touch the View layer
 
-- No `MessageBox`, `Window`, or `System.Windows` UI types in a ViewModel.
-- Confirmation dialogs, alerts, and window navigation must be requested via events/callbacks that the View handles.
-- No direct references to controls in a ViewModel.
-- No `Dispatcher` calls in a ViewModel.
+- **No `MessageBox`, `Window`, or any `System.Windows` UI type in a ViewModel.** Confirmation dialogs, alerts, and window navigation must be requested via an event or callback that the View subscribes to.
+  - ✅ `public event Action? ConfirmDeleteRequested;` — raise it from the VM; the View shows the dialog and calls back.
+  - ❌ `MessageBox.Show("Delete?", ...)` inside a ViewModel method.
+- **No direct references to controls** (`TextBox`, `ListBox`, `Button`, etc.) in a ViewModel. Expose properties and commands; let bindings do the wiring.
+- **No `Dispatcher` calls in a ViewModel.** If you need to marshal to the UI thread, use `Application.Current.Dispatcher` only in Views or services, never in a VM.
 
 ### Code-behind must not duplicate bindings
 
-If a control is already bound two-way to a VM property, do not also set that control's value directly in code-behind. Update the VM and let the binding propagate.
+- If a control is already bound two-way to a VM property, **do not also set that control's value directly in code-behind**. Pick one path: either the binding, or explicit code-behind assignment — not both.
+  - ✅ `vm.NewName = contact.DisplayName;` — updates the VM; the binding propagates to the TextBox.
+  - ❌ `NewNameBox.Text = contact.DisplayName;` when `NewNameBox` is already bound to `vm.NewName`.
 
-### Code-behind is allowed for UI-only concerns
+### Code-behind is allowed only for UI-only concerns
 
 Permitted in `.xaml.cs`:
-
-- Keyboard shortcut routing.
-- Focus management.
-- WebView2 navigation and CSP setup.
-- Subscribing to VM events and showing dialogs.
-- Visual state transitions with no business logic.
+- Keyboard shortcut wiring (`PreviewKeyDown`, `KeyDown`)
+- Focus management (`element.Focus()`, `Keyboard.Focus()`)
+- WebView2 navigation and CSP setup
+- Subscribing to VM events and showing dialogs in response
+- Animation or visual-state transitions that have no business logic
 
 Not permitted in `.xaml.cs`:
+- Business logic, data transformation, or validation
+- Direct calls to services (`ImapService`, `ContactService`, etc.)
+- State decisions ("if account has unread messages, do X")
 
-- Business logic, data transformation, or validation.
-- Direct service calls for domain work.
-- State decisions that belong in the VM.
+### Async event handlers in Views
+
+- `async void` event handlers are acceptable **only** in Views (code-behind) for fire-and-forget UI reactions.
+- When an `async void` handler calls a service that may be slow (e.g. autocomplete search), use a `CancellationTokenSource` field — cancel and replace it on each invocation so stale results from a superseded call never overwrite fresher results.
 
 ## Keyboard Shortcuts (MainWindow)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,19 +121,49 @@ Not permitted in `.xaml.cs`:
 - `async void` event handlers are acceptable **only** in Views (code-behind) for fire-and-forget UI reactions.
 - When an `async void` handler calls a service that may be slow (e.g. autocomplete search), use a `CancellationTokenSource` field — cancel and replace it on each invocation so stale results from a superseded call never overwrite fresher results.
 
-## Keyboard Shortcuts (MainWindow)
+## Keyboard Shortcuts — Enforced
 
-| Key | Action |
-|---|---|
-| Ctrl+0 | Focus toolbar |
-| Ctrl+1 | Focus account list |
-| Ctrl+2 / Ctrl+Y | Focus folder tree |
-| Ctrl+3 | Focus message list / conversation tree |
-| Ctrl+9 | Focus status bar |
-| F6 / Shift+F6 | Cycle panes |
-| Ctrl+N | New message |
-| Delete | Delete selected messages |
-| Escape | Close reading pane |
+Every user-facing keyboard shortcut **must** be registered in `CommandRegistry` via `_registry.Register(new CommandDefinition(...))` in `MainWindow.xaml.cs`. This is not optional: registration is what makes the shortcut appear in the **keyboard customizations** dialog and in the **Command Palette**.
+
+### Rules
+
+- **Register first, hardcode never.** Do not add a raw `if (modifiers == ... && key == ...)` block in `PreviewKeyDown` for a new action. Register the command with `defaultKey` / `defaultModifiers` and let the registry dispatch it.
+- **Two exceptions** are allowed to remain hardcoded (they are framework-level, not user actions):
+  - `Ctrl+Shift+P` — opens the Command Palette itself (cannot dispatch through the palette)
+  - Navigation shortcuts `Ctrl+0–3`, `Ctrl+9`, `Ctrl+Y`, `F6` — focus-only pane jumps with no associated command title
+- **`InputGestureText` in menus** must match the registered default key, e.g. `InputGestureText="Ctrl+Shift+F"`.
+- **Category** must be one of: `View`, `Mail`, `Account`, `Contacts`, `Settings`, `Help`.
+
+### Adding a new shortcut — checklist
+
+1. `_registry.Register(new CommandDefinition(id: "category.name", category: "…", title: "…", execute: MyMethod, defaultKey: Key.X, defaultModifiers: ModifierKeys.Control));`
+2. Add a menu item with matching `InputGestureText` if applicable.
+3. Do **not** add a duplicate hardcoded branch in `PreviewKeyDown`.
+
+### Registered shortcut table (MainWindow)
+
+| Key | Command ID | Title |
+|---|---|---|
+| Ctrl+0 | *(hardcoded)* | Focus toolbar |
+| Ctrl+1 | *(hardcoded)* | Focus account list |
+| Ctrl+2 / Ctrl+Y | `view.focusFolders` | Focus Folder Tree |
+| Ctrl+3 | *(hardcoded)* | Focus message list |
+| Ctrl+9 | `view.focusStatusBar` | Focus Status Bar |
+| F6 / Shift+F6 | *(hardcoded)* | Cycle panes |
+| Escape | *(hardcoded)* | Close reading pane |
+| Ctrl+Shift+P | *(hardcoded)* | Command Palette |
+| Ctrl+N | `mail.new` | New Message |
+| Ctrl+R | `mail.reply` | Reply |
+| Ctrl+Shift+R | `mail.replyAll` | Reply All |
+| Ctrl+F | `mail.forward` | Forward |
+| Delete | `mail.delete` | Delete |
+| F5 | `mail.refresh` | Refresh |
+| Ctrl+Shift+E | `mail.emptyTrash` | Empty Trash |
+| Ctrl+Shift+V | `view.openViewMenu` | Open View Menu |
+| Ctrl+Shift+F | `view.searchFolders` | Search Folders… |
+| Ctrl+Shift+G | `contacts.grabAddresses` | Grab Addresses from Message |
+| Ctrl+Shift+B | `contacts.openAddressBook` | Address Book |
+| F1 | `help.userGuide` | Open User Guide |
 
 ## Dependencies
 

--- a/QuickMail.Tests/StubServices.cs
+++ b/QuickMail.Tests/StubServices.cs
@@ -21,6 +21,7 @@ sealed class StubImapService : IImapService
     public Task<List<MailMessageSummary>> GetMessagesSinceDateAsync(Guid accountId, string folderName, DateTime since, CancellationToken ct = default) => Task.FromResult(new List<MailMessageSummary>());
     public Task<List<MailMessageSummary>> GetMessagesSinceAsync(Guid accountId, string folderName, uint sinceUid, CancellationToken ct = default) => Task.FromResult(new List<MailMessageSummary>());
     public Task<MailMessageDetail> GetMessageDetailAsync(Guid accountId, string folderName, uint uid, CancellationToken ct = default) => Task.FromResult(new MailMessageDetail());
+    public Task<MailMessageDetail> PrefetchMessageDetailAsync(Guid accountId, string folderName, uint uid, CancellationToken ct = default) => Task.FromResult(new MailMessageDetail());
     public Task MarkReadAsync(Guid accountId, string folderName, uint uid, CancellationToken ct = default) => Task.CompletedTask;
     public Task MoveToTrashAsync(Guid accountId, string folderName, uint uid, CancellationToken ct = default) => Task.CompletedTask;
     public Task MoveToTrashBatchAsync(Guid accountId, string folderName, IList<uint> uids, CancellationToken ct = default) => Task.CompletedTask;

--- a/QuickMail.Tests/StubServices.cs
+++ b/QuickMail.Tests/StubServices.cs
@@ -73,7 +73,7 @@ sealed class StubLocalStoreService : ILocalStoreService
     public void Initialize() { }
     public Task UpsertSummariesAsync(IEnumerable<MailMessageSummary> summaries) => Task.CompletedTask;
     public Task<List<MailMessageSummary>> LoadAllSummariesAsync() => Task.FromResult(new List<MailMessageSummary>());
-    public Task<List<MailMessageSummary>> LoadFolderSummariesAsync(Guid accountId, string folderName) => Task.FromResult(new List<MailMessageSummary>());
+    public Task<List<MailMessageSummary>> LoadFolderSummariesAsync(Guid accountId, string folderName, int? limit = null) => Task.FromResult(new List<MailMessageSummary>());
     public Task DeleteSummariesAsync(Guid accountId, string folderName, IEnumerable<uint> uniqueIds) => Task.CompletedTask;
     public Task UpdateIsReadAsync(Guid accountId, string folderName, uint uniqueId, bool isRead) => Task.CompletedTask;
     public Task UpdatePreviewAsync(Guid accountId, string folderName, uint uniqueId, string preview) => Task.CompletedTask;

--- a/QuickMail/App.xaml.cs
+++ b/QuickMail/App.xaml.cs
@@ -18,26 +18,37 @@ public partial class App : Application
             LogService.Log("Debug mode enabled.");
         }
 
-        var accountService    = new AccountService();
-        var credentialService = new CredentialService();
-        var oauthService      = new OAuthService();
-        var configService     = new ConfigService();
-        var imapService       = new ImapService(oauthService, configService);
-        var smtpService       = new SmtpService(oauthService);
+        try
+        {
+            var accountService    = new AccountService();
+            var credentialService = new CredentialService();
+            var oauthService      = new OAuthService();
+            var configService     = new ConfigService();
+            var imapService       = new ImapService(oauthService, configService);
+            var smtpService       = new SmtpService(oauthService);
 
-        var localStore = new LocalStoreService();
-        localStore.Initialize();
+            var localStore = new LocalStoreService();
+            localStore.Initialize();
 
-        var syncService = new SyncService(imapService, localStore, configService);
+            var syncService = new SyncService(imapService, localStore, configService);
 
-        var commandRegistry = new CommandRegistry();
-        commandRegistry.ApplyUserOverrides(configService.Load().CustomHotkeys);
+            var commandRegistry = new CommandRegistry();
+            commandRegistry.ApplyUserOverrides(configService.Load().CustomHotkeys);
 
-        var mainVm = new MainViewModel(
-            imapService, accountService, credentialService, localStore, syncService, configService, commandRegistry);
-        mainVm.LoadAccountList();
+            var mainVm = new MainViewModel(
+                imapService, accountService, credentialService, localStore, syncService, configService, commandRegistry);
+            mainVm.LoadAccountList();
 
-        var mainWindow = new MainWindow(mainVm, smtpService, accountService, credentialService, imapService, oauthService, commandRegistry);
-        mainWindow.Show();
+            var mainWindow = new MainWindow(mainVm, smtpService, accountService, credentialService, imapService, oauthService, commandRegistry);
+            mainWindow.Show();
+        }
+        catch (Exception ex)
+        {
+            // Log the exception chain before WER kills the process so the cause
+            // survives in %APPDATA%\QuickMail\quickmail.log.
+            for (var cur = ex; cur != null; cur = cur.InnerException)
+                LogService.Log("Startup", cur);
+            throw;
+        }
     }
 }

--- a/QuickMail/App.xaml.cs
+++ b/QuickMail/App.xaml.cs
@@ -21,9 +21,9 @@ public partial class App : Application
         var accountService    = new AccountService();
         var credentialService = new CredentialService();
         var oauthService      = new OAuthService();
-        var imapService       = new ImapService(oauthService);
-        var smtpService       = new SmtpService(oauthService);
         var configService     = new ConfigService();
+        var imapService       = new ImapService(oauthService, configService);
+        var smtpService       = new SmtpService(oauthService);
 
         var localStore = new LocalStoreService();
         localStore.Initialize();

--- a/QuickMail/Models/ConfigModel.cs
+++ b/QuickMail/Models/ConfigModel.cs
@@ -26,6 +26,9 @@ public class ConfigModel
     /// </summary>
     public int SyncDays { get; set; } = 30;
 
+    /// <summary>Maximum simultaneous IMAP connections QuickMail may open per account.</summary>
+    public int MaxImapConnectionsPerAccount { get; set; } = 6;
+
     // ── Custom hotkey overrides ──────────────────────────────────────────────────
 
     /// <summary>User-defined keyboard shortcut overrides, stored in hotkeys.json.</summary>

--- a/QuickMail/QuickMail.csproj
+++ b/QuickMail/QuickMail.csproj
@@ -6,9 +6,9 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
-    <Version>0.5.1</Version>
-    <AssemblyVersion>0.5.1.0</AssemblyVersion>
-    <FileVersion>0.5.1.0</FileVersion>
+    <Version>0.5.9</Version>
+    <AssemblyVersion>0.5.9.0</AssemblyVersion>
+    <FileVersion>0.5.9.0</FileVersion>
     <!-- Single-file publish: native DLLs (WebView2Loader, SQLite) extract to temp on first run -->
     <PublishSingleFile>true</PublishSingleFile>
     <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>

--- a/QuickMail/Services/ConfigService.cs
+++ b/QuickMail/Services/ConfigService.cs
@@ -155,6 +155,10 @@ public class ConfigService : IConfigService
                     case "syncdays":
                         if (int.TryParse(value, out var sd)) config.SyncDays = Math.Max(0, sd);
                         break;
+                    case "maximapconnectionsperaccount":
+                        if (int.TryParse(value, out var maxConn))
+                            config.MaxImapConnectionsPerAccount = Math.Clamp(maxConn, 1, 15);
+                        break;
                 }
             }
             else if (section == "account" && acctGuid != Guid.Empty)
@@ -208,6 +212,12 @@ public class ConfigService : IConfigService
         sb.AppendLine("# How many days of mail to sync when opening a folder.");
         sb.AppendLine("# Set to 0 to sync all mail (no date filter).");
         sb.AppendLine("# Supported values: 7, 30, 180, 365, or 0 (all).");
+        sb.AppendLine();
+
+        sb.AppendLine($"MaxImapConnectionsPerAccount = {Math.Clamp(config.MaxImapConnectionsPerAccount, 1, 15)}");
+        sb.AppendLine("# Maximum simultaneous IMAP connections per account.");
+        sb.AppendLine("# Background sync is limited below this value so foreground message opens keep reserved capacity.");
+        sb.AppendLine("# Increase only if your provider allows it. Values: 1-15.");
         sb.AppendLine();
 
         // ── [account:guid] overrides ─────────────────────────────────────────────

--- a/QuickMail/Services/IImapService.cs
+++ b/QuickMail/Services/IImapService.cs
@@ -30,6 +30,14 @@ public interface IImapService : IDisposable
         Guid accountId, string folderName, uint sinceUid, CancellationToken ct = default);
     Task<MailMessageDetail> GetMessageDetailAsync(
         Guid accountId, string folderName, uint uid, CancellationToken ct = default);
+
+    /// <summary>
+    /// Same as <see cref="GetMessageDetailAsync"/> but uses a background IMAP lease
+    /// and does NOT set the Seen flag on the server. Intended for prefetching nearby
+    /// messages into the local cache so subsequent opens are instant.
+    /// </summary>
+    Task<MailMessageDetail> PrefetchMessageDetailAsync(
+        Guid accountId, string folderName, uint uid, CancellationToken ct = default);
     Task MarkReadAsync(Guid accountId, string folderName, uint uid, CancellationToken ct = default);
     Task MoveToTrashAsync(Guid accountId, string folderName, uint uid, CancellationToken ct = default);
     Task MoveToTrashBatchAsync(Guid accountId, string folderName, IList<uint> uids, CancellationToken ct = default);

--- a/QuickMail/Services/ILocalStoreService.cs
+++ b/QuickMail/Services/ILocalStoreService.cs
@@ -11,7 +11,7 @@ public interface ILocalStoreService
 
     Task UpsertSummariesAsync(IEnumerable<MailMessageSummary> summaries);
     Task<List<MailMessageSummary>> LoadAllSummariesAsync();
-    Task<List<MailMessageSummary>> LoadFolderSummariesAsync(Guid accountId, string folderName);
+    Task<List<MailMessageSummary>> LoadFolderSummariesAsync(Guid accountId, string folderName, int? limit = null);
     Task DeleteSummariesAsync(Guid accountId, string folderName, IEnumerable<uint> uniqueIds);
     Task UpdateIsReadAsync(Guid accountId, string folderName, uint uniqueId, bool isRead);
     Task UpdatePreviewAsync(Guid accountId, string folderName, uint uniqueId, string preview);

--- a/QuickMail/Services/ImapService.cs
+++ b/QuickMail/Services/ImapService.cs
@@ -268,13 +268,23 @@ public class ImapService : IImapService
 
     // ── Message detail ───────────────────────────────────────────────────────────
 
-    public async Task<MailMessageDetail> GetMessageDetailAsync(
-        Guid accountId, string folderName, uint uid, CancellationToken ct = default)
+    public Task<MailMessageDetail> GetMessageDetailAsync(
+        Guid accountId, string folderName, uint uid, CancellationToken ct = default) =>
+        GetMessageDetailCoreAsync(accountId, folderName, uid, markRead: true, ImapLeasePriority.Foreground, ct);
+
+    public Task<MailMessageDetail> PrefetchMessageDetailAsync(
+        Guid accountId, string folderName, uint uid, CancellationToken ct = default) =>
+        GetMessageDetailCoreAsync(accountId, folderName, uid, markRead: false, ImapLeasePriority.Background, ct);
+
+    private async Task<MailMessageDetail> GetMessageDetailCoreAsync(
+        Guid accountId, string folderName, uint uid,
+        bool markRead, ImapLeasePriority priority, CancellationToken ct)
     {
-        using var lease = await RentClientAsync(accountId, ct, ImapLeasePriority.Foreground);
+        using var lease = await RentClientAsync(accountId, ct, priority);
         var client = lease.Client;
         var folder = await client.GetFolderAsync(folderName, ct);
-        await folder.OpenAsync(FolderAccess.ReadWrite, ct);
+        var access = markRead ? FolderAccess.ReadWrite : FolderAccess.ReadOnly;
+        await folder.OpenAsync(access, ct);
 
         try
         {
@@ -305,7 +315,8 @@ public class ImapService : IImapService
                 if (bodyPart is TextPart tp) plainText = tp.Text ?? string.Empty;
             }
 
-            await folder.AddFlagsAsync(mailKitUid, MessageFlags.Seen, true, ct);
+            if (markRead)
+                await folder.AddFlagsAsync(mailKitUid, MessageFlags.Seen, true, ct);
 
             var attachments = ExtractAttachments(s.Body);
 
@@ -320,7 +331,7 @@ public class ImapService : IImapService
                 ReplyTo       = FormatAddressList(s.Envelope?.ReplyTo),
                 Subject       = s.Envelope?.Subject ?? "(no subject)",
                 Date          = s.Envelope?.Date ?? DateTimeOffset.MinValue,
-                IsRead        = true,
+                IsRead        = markRead || (s.Flags & MessageFlags.Seen) != 0,
                 MessageId     = s.Envelope?.MessageId ?? string.Empty,
                 PlainTextBody = plainText,
                 HtmlBody      = htmlText,

--- a/QuickMail/Services/ImapService.cs
+++ b/QuickMail/Services/ImapService.cs
@@ -17,74 +17,91 @@ namespace QuickMail.Services;
 
 public class ImapService : IImapService
 {
+    private const int DefaultMaxConnectionsPerAccount = 6;
+    private const int AbsoluteMaxConnectionsPerAccount = 15;
+    private const int ForegroundReservedConnectionCount = 2;
+
     private readonly IOAuthService _oauth;
-    private readonly ConcurrentDictionary<Guid, ImapClient> _clients   = new();
+    private readonly IConfigService? _config;
+    private readonly ConcurrentDictionary<Guid, AccountConnectionPool> _pools = new();
     private readonly ConcurrentDictionary<Guid, AccountModel> _accounts = new();
     private readonly ConcurrentDictionary<Guid, string>  _passwords     = new();
-    private readonly ConcurrentDictionary<Guid, SemaphoreSlim> _locks   = new();
+    private readonly ConcurrentDictionary<Guid, SemaphoreSlim> _poolLocks = new();
     private bool _disposed;
 
-    public ImapService(IOAuthService oauth) => _oauth = oauth;
+    public ImapService(IOAuthService oauth, IConfigService? config = null)
+    {
+        _oauth  = oauth;
+        _config = config;
+    }
+
+    private enum ImapLeasePriority
+    {
+        Foreground,
+        Background
+    }
 
     // ── Connect / disconnect ─────────────────────────────────────────────────────
 
     public async Task ConnectAsync(AccountModel account, string? password = null, CancellationToken ct = default)
     {
-        if (_clients.TryGetValue(account.Id, out var existing))
+        ThrowIfDisposed();
+
+        if (account.AuthType == AuthType.Password)
         {
-            if (existing.IsAuthenticated) return;
-            existing.Dispose();
-            _clients.TryRemove(account.Id, out _);
+            if (password is null && !_passwords.TryGetValue(account.Id, out password))
+                throw new InvalidOperationException($"No password is available for account {account.Username}.");
         }
 
-        var client = new ImapClient();
-
-        if (account.ImapAcceptInvalidCert)
-            client.ServerCertificateValidationCallback = (_, _, _, _) => true;
-
-        var ssl = account.ImapUseSsl
-            ? SecureSocketOptions.SslOnConnect
-            : SecureSocketOptions.StartTlsWhenAvailable;
-
-        LogService.Log($"Connecting to {account.ImapHost}:{account.ImapPort} ssl={account.ImapUseSsl} user={account.Username} auth={account.AuthType}");
-        await client.ConnectAsync(account.ImapHost, account.ImapPort, ssl, ct);
-
-        if (account.AuthType == AuthType.OAuth2Microsoft)
+        var maxConnections = GetMaxConnectionsPerAccount();
+        var poolLock = _poolLocks.GetOrAdd(account.Id, _ => new SemaphoreSlim(1, 1));
+        await poolLock.WaitAsync(ct);
+        try
         {
-            var token = await _oauth.GetAccessTokenAsync(account, ct);
-            await client.AuthenticateAsync(new SaslMechanismOAuth2(account.Username, token), ct);
+            if (_pools.TryGetValue(account.Id, out var existing) &&
+                existing.Matches(account, maxConnections))
+            {
+                existing.UpdateAccount(account, password);
+                _accounts[account.Id] = CloneAccount(account);
+                if (password is not null)
+                    _passwords[account.Id] = password;
+
+                using var existingWarmLease = await existing.RentAsync(ImapLeasePriority.Foreground, ct);
+                return;
+            }
+
+            if (_pools.TryRemove(account.Id, out var stalePool))
+                await stalePool.DisconnectAsync(ct);
+
+            var pool = new AccountConnectionPool(this, account, password, maxConnections);
+            _pools[account.Id]   = pool;
+            _accounts[account.Id] = CloneAccount(account);
+            if (password is not null)
+                _passwords[account.Id] = password;
+
+            using var newWarmLease = await pool.RentAsync(ImapLeasePriority.Foreground, ct);
         }
-        else
+        finally
         {
-            await client.AuthenticateAsync(account.Username, password!, ct);
+            poolLock.Release();
         }
-
-        LogService.Log($"Connected. Capabilities: {client.Capabilities}");
-
-        _clients[account.Id]  = client;
-        _accounts[account.Id] = account;
-        if (password is not null)
-            _passwords[account.Id] = password;
     }
 
     public async Task DisconnectAsync(Guid accountId, CancellationToken ct = default)
     {
-        if (_clients.TryGetValue(accountId, out var client))
-        {
-            if (client.IsConnected)
-                await client.DisconnectAsync(true, ct);
-            client.Dispose();
-            _clients.TryRemove(accountId, out _);
-            _accounts.TryRemove(accountId, out _);
-            _passwords.TryRemove(accountId, out _);
-        }
+        if (_pools.TryRemove(accountId, out var pool))
+            await pool.DisconnectAsync(ct);
+
+        _accounts.TryRemove(accountId, out _);
+        _passwords.TryRemove(accountId, out _);
     }
 
     // ── Folder list ──────────────────────────────────────────────────────────────
 
     public async Task<List<MailFolderModel>> GetFoldersAsync(Guid accountId, CancellationToken ct = default)
     {
-        var client = await GetOrReconnectAsync(accountId, ct);
+        using var lease = await RentClientAsync(accountId, ct, ImapLeasePriority.Foreground);
+        var client = lease.Client;
         var result = new List<MailFolderModel>();
 
         // Always put INBOX first — many servers don't return it via GetFoldersAsync
@@ -153,196 +170,198 @@ public class ImapService : IImapService
 
     // ── Message lists ────────────────────────────────────────────────────────────
 
-    public Task<List<MailMessageSummary>> GetMessageSummariesAsync(
+    public async Task<List<MailMessageSummary>> GetMessageSummariesAsync(
         Guid accountId, string folderName, int maxMessages, CancellationToken ct = default)
     {
         LogService.Log($"GetMessageSummaries: folder={folderName} maxMessages={maxMessages}");
-        return ExecuteWithRetryAsync(accountId, ct, async client =>
+        using var lease = await RentClientAsync(accountId, ct, ImapLeasePriority.Foreground);
+        var client = lease.Client;
+        var folder = await client.GetFolderAsync(folderName, ct);
+        await folder.OpenAsync(FolderAccess.ReadOnly, ct);
+        LogService.Log($"  Opened. Count={folder.Count} Unread={folder.Unread}");
+        try
         {
-            var folder = await client.GetFolderAsync(folderName, ct);
-            await folder.OpenAsync(FolderAccess.ReadOnly, ct);
-            LogService.Log($"  Opened. Count={folder.Count} Unread={folder.Unread}");
-            try
-            {
-                if (folder.Count == 0) return new List<MailMessageSummary>();
+            if (folder.Count == 0) return new List<MailMessageSummary>();
 
-                var startIndex = Math.Max(0, folder.Count - maxMessages);
-                var summaries  = await folder.FetchAsync(
-                    startIndex, -1,
-                    MessageSummaryItems.UniqueId
-                    | MessageSummaryItems.Envelope
-                    | MessageSummaryItems.Flags
-                    | MessageSummaryItems.PreviewText,   // free if server supports PREVIEW
-                    ct);
+            var startIndex = Math.Max(0, folder.Count - maxMessages);
+            var summaries  = await folder.FetchAsync(
+                startIndex, -1,
+                MessageSummaryItems.UniqueId
+                | MessageSummaryItems.Envelope
+                | MessageSummaryItems.Flags
+                | MessageSummaryItems.PreviewText,   // free if server supports PREVIEW
+                ct);
 
-                var result = summaries
-                    .OrderByDescending(s => s.Envelope?.Date ?? DateTimeOffset.MinValue)
-                    .Select(s => SummaryToModel(s, accountId, folderName))
-                    .ToList();
+            var result = summaries
+                .OrderByDescending(s => s.Envelope?.Date ?? DateTimeOffset.MinValue)
+                .Select(s => SummaryToModel(s, accountId, folderName))
+                .ToList();
 
-                LogService.Log($"  Returning {result.Count} summaries (preview={result.Count(r => !string.IsNullOrEmpty(r.Preview))} prefilled)");
-                return result;
-            }
-            finally { await folder.CloseAsync(false, ct); }
-        });
+            LogService.Log($"  Returning {result.Count} summaries (preview={result.Count(r => !string.IsNullOrEmpty(r.Preview))} prefilled)");
+            return result;
+        }
+        finally { await folder.CloseAsync(false, ct); }
     }
 
-    public Task<List<MailMessageSummary>> GetMessagesSinceDateAsync(
+    public async Task<List<MailMessageSummary>> GetMessagesSinceDateAsync(
         Guid accountId, string folderName, DateTime since, CancellationToken ct = default)
     {
         LogService.Log($"GetMessagesSinceDate: folder={folderName} since={since:yyyy-MM-dd}");
-        return ExecuteWithRetryAsync(accountId, ct, async client =>
+        using var lease = await RentClientAsync(accountId, ct, ImapLeasePriority.Background);
+        var client = lease.Client;
+        var folder = await client.GetFolderAsync(folderName, ct);
+        await folder.OpenAsync(FolderAccess.ReadOnly, ct);
+        try
         {
-            var folder = await client.GetFolderAsync(folderName, ct);
-            await folder.OpenAsync(FolderAccess.ReadOnly, ct);
-            try
-            {
-                var query   = SearchQuery.DeliveredAfter(since.Date);
-                var uids    = await folder.SearchAsync(query, ct);
-                if (uids.Count == 0) return new List<MailMessageSummary>();
+            var query   = SearchQuery.DeliveredAfter(since.Date);
+            var uids    = await folder.SearchAsync(query, ct);
+            if (uids.Count == 0) return new List<MailMessageSummary>();
 
-                var items = MessageSummaryItems.UniqueId
-                          | MessageSummaryItems.Envelope
-                          | MessageSummaryItems.Flags
-                          | MessageSummaryItems.PreviewText;
+            var items = MessageSummaryItems.UniqueId
+                      | MessageSummaryItems.Envelope
+                      | MessageSummaryItems.Flags
+                      | MessageSummaryItems.PreviewText;
 
-                var summaries = await folder.FetchAsync(uids, items, ct);
-                var result    = summaries
-                    .OrderByDescending(s => s.Envelope?.Date ?? DateTimeOffset.MinValue)
-                    .Select(s => SummaryToModel(s, accountId, folderName))
-                    .ToList();
+            var summaries = await folder.FetchAsync(uids, items, ct);
+            var result    = summaries
+                .OrderByDescending(s => s.Envelope?.Date ?? DateTimeOffset.MinValue)
+                .Select(s => SummaryToModel(s, accountId, folderName))
+                .ToList();
 
-                LogService.Log($"  Returning {result.Count} summaries since {since:yyyy-MM-dd}");
-                return result;
-            }
-            finally { await folder.CloseAsync(false, ct); }
-        });
+            LogService.Log($"  Returning {result.Count} summaries since {since:yyyy-MM-dd}");
+            return result;
+        }
+        finally { await folder.CloseAsync(false, ct); }
     }
 
-    public Task<List<MailMessageSummary>> GetMessagesSinceAsync(
+    public async Task<List<MailMessageSummary>> GetMessagesSinceAsync(
         Guid accountId, string folderName, uint sinceUid, CancellationToken ct = default)
-        => ExecuteWithRetryAsync(accountId, ct, async client =>
+    {
+        using var lease = await RentClientAsync(accountId, ct, ImapLeasePriority.Background);
+        var client = lease.Client;
+        var folder = await client.GetFolderAsync(folderName, ct);
+        await folder.OpenAsync(FolderAccess.ReadOnly, ct);
+        try
         {
-            var folder = await client.GetFolderAsync(folderName, ct);
-            await folder.OpenAsync(FolderAccess.ReadOnly, ct);
-            try
+            var items = MessageSummaryItems.UniqueId
+                      | MessageSummaryItems.Envelope
+                      | MessageSummaryItems.Flags
+                      | MessageSummaryItems.PreviewText;   // free if server supports PREVIEW
+
+            IList<IMessageSummary> summaries;
+            if (sinceUid == 0)
             {
-                var items = MessageSummaryItems.UniqueId
-                          | MessageSummaryItems.Envelope
-                          | MessageSummaryItems.Flags
-                          | MessageSummaryItems.PreviewText;   // free if server supports PREVIEW
-
-                IList<IMessageSummary> summaries;
-                if (sinceUid == 0)
-                {
-                    if (folder.Count == 0) return new List<MailMessageSummary>();
-                    var startIndex = Math.Max(0, folder.Count - 500);
-                    summaries = await folder.FetchAsync(startIndex, -1, items, ct);
-                }
-                else
-                {
-                    var range = new UniqueIdRange(new UniqueId(sinceUid + 1), UniqueId.MaxValue);
-                    summaries = await folder.FetchAsync((IList<UniqueId>)range, items, ct);
-                }
-
-                return summaries.Select(s => SummaryToModel(s, accountId, folderName)).ToList();
+                if (folder.Count == 0) return new List<MailMessageSummary>();
+                var startIndex = Math.Max(0, folder.Count - 500);
+                summaries = await folder.FetchAsync(startIndex, -1, items, ct);
             }
-            finally { await folder.CloseAsync(false, ct); }
-        });
+            else
+            {
+                var range = new UniqueIdRange(new UniqueId(sinceUid + 1), UniqueId.MaxValue);
+                summaries = await folder.FetchAsync((IList<UniqueId>)range, items, ct);
+            }
+
+            return summaries.Select(s => SummaryToModel(s, accountId, folderName)).ToList();
+        }
+        finally { await folder.CloseAsync(false, ct); }
+    }
 
     // ── Message detail ───────────────────────────────────────────────────────────
 
-    public Task<MailMessageDetail> GetMessageDetailAsync(
+    public async Task<MailMessageDetail> GetMessageDetailAsync(
         Guid accountId, string folderName, uint uid, CancellationToken ct = default)
-        => ExecuteWithRetryAsync(accountId, ct, async client =>
+    {
+        using var lease = await RentClientAsync(accountId, ct, ImapLeasePriority.Foreground);
+        var client = lease.Client;
+        var folder = await client.GetFolderAsync(folderName, ct);
+        await folder.OpenAsync(FolderAccess.ReadWrite, ct);
+
+        try
         {
-            var folder = await client.GetFolderAsync(folderName, ct);
-            await folder.OpenAsync(FolderAccess.ReadWrite, ct);
+            var mailKitUid = new UniqueId(uid);
+            var summaries  = await folder.FetchAsync(
+                new[] { mailKitUid },
+                MessageSummaryItems.UniqueId
+                | MessageSummaryItems.Envelope
+                | MessageSummaryItems.Flags
+                | MessageSummaryItems.BodyStructure,
+                ct);
 
-            try
+            var s = summaries.FirstOrDefault()
+                ?? throw new InvalidOperationException($"Message UID {uid} not found.");
+
+            string plainText = string.Empty;
+            string htmlText  = string.Empty;
+
+            if (s.HtmlBody != null)
             {
-                var mailKitUid = new UniqueId(uid);
-                var summaries  = await folder.FetchAsync(
-                    new[] { mailKitUid },
-                    MessageSummaryItems.UniqueId
-                    | MessageSummaryItems.Envelope
-                    | MessageSummaryItems.Flags
-                    | MessageSummaryItems.BodyStructure,
-                    ct);
-
-                var s = summaries.FirstOrDefault()
-                    ?? throw new InvalidOperationException($"Message UID {uid} not found.");
-
-                string plainText = string.Empty;
-                string htmlText  = string.Empty;
-
-                if (s.HtmlBody != null)
-                {
-                    var bodyPart = await folder.GetBodyPartAsync(mailKitUid, s.HtmlBody, ct);
-                    if (bodyPart is TextPart tp) htmlText = tp.Text ?? string.Empty;
-                }
-
-                if (s.TextBody != null)
-                {
-                    var bodyPart = await folder.GetBodyPartAsync(mailKitUid, s.TextBody, ct);
-                    if (bodyPart is TextPart tp) plainText = tp.Text ?? string.Empty;
-                }
-
-                await folder.AddFlagsAsync(mailKitUid, MessageFlags.Seen, true, ct);
-
-                var attachments = ExtractAttachments(s.Body);
-
-                return new MailMessageDetail
-                {
-                    UniqueId      = uid,
-                    AccountId     = accountId,
-                    FolderName    = folderName,
-                    From          = FormatAddressList(s.Envelope?.From),
-                    To            = FormatAddressList(s.Envelope?.To),
-                    Cc            = FormatAddressList(s.Envelope?.Cc),
-                    ReplyTo       = FormatAddressList(s.Envelope?.ReplyTo),
-                    Subject       = s.Envelope?.Subject ?? "(no subject)",
-                    Date          = s.Envelope?.Date ?? DateTimeOffset.MinValue,
-                    IsRead        = true,
-                    MessageId     = s.Envelope?.MessageId ?? string.Empty,
-                    PlainTextBody = plainText,
-                    HtmlBody      = htmlText,
-                    Attachments   = attachments,
-                };
+                var bodyPart = await folder.GetBodyPartAsync(mailKitUid, s.HtmlBody, ct);
+                if (bodyPart is TextPart tp) htmlText = tp.Text ?? string.Empty;
             }
-            finally { await folder.CloseAsync(false, ct); }
-        });
+
+            if (s.TextBody != null)
+            {
+                var bodyPart = await folder.GetBodyPartAsync(mailKitUid, s.TextBody, ct);
+                if (bodyPart is TextPart tp) plainText = tp.Text ?? string.Empty;
+            }
+
+            await folder.AddFlagsAsync(mailKitUid, MessageFlags.Seen, true, ct);
+
+            var attachments = ExtractAttachments(s.Body);
+
+            return new MailMessageDetail
+            {
+                UniqueId      = uid,
+                AccountId     = accountId,
+                FolderName    = folderName,
+                From          = FormatAddressList(s.Envelope?.From),
+                To            = FormatAddressList(s.Envelope?.To),
+                Cc            = FormatAddressList(s.Envelope?.Cc),
+                ReplyTo       = FormatAddressList(s.Envelope?.ReplyTo),
+                Subject       = s.Envelope?.Subject ?? "(no subject)",
+                Date          = s.Envelope?.Date ?? DateTimeOffset.MinValue,
+                IsRead        = true,
+                MessageId     = s.Envelope?.MessageId ?? string.Empty,
+                PlainTextBody = plainText,
+                HtmlBody      = htmlText,
+                Attachments   = attachments,
+            };
+        }
+        finally { await folder.CloseAsync(false, ct); }
+    }
 
     // ── Mutations ────────────────────────────────────────────────────────────────
 
     public async Task MarkReadAsync(Guid accountId, string folderName, uint uid, CancellationToken ct = default)
     {
-        var client = await GetOrReconnectAsync(accountId, ct);
+        using var lease = await RentClientAsync(accountId, ct, ImapLeasePriority.Foreground);
+        var client = lease.Client;
         var folder = await client.GetFolderAsync(folderName, ct);
         await folder.OpenAsync(FolderAccess.ReadWrite, ct);
         try   { await folder.AddFlagsAsync(new UniqueId(uid), MessageFlags.Seen, true, ct); }
         finally { await folder.CloseAsync(false, ct); }
     }
 
-    public Task MoveToTrashBatchAsync(Guid accountId, string folderName, IList<uint> uids, CancellationToken ct = default)
-        => ExecuteWithRetryAsync<bool>(accountId, ct, async client =>
+    public async Task MoveToTrashBatchAsync(Guid accountId, string folderName, IList<uint> uids, CancellationToken ct = default)
+    {
+        using var lease = await RentClientAsync(accountId, ct, ImapLeasePriority.Foreground);
+        var client = lease.Client;
+        var folder = await client.GetFolderAsync(folderName, ct);
+        await folder.OpenAsync(FolderAccess.ReadWrite, ct);
+        try
         {
-            var folder  = await client.GetFolderAsync(folderName, ct);
-            await folder.OpenAsync(FolderAccess.ReadWrite, ct);
-            try
-            {
-                var uidList = uids.Select(u => new UniqueId(u)).ToList();
-                var trash   = FindSpecialFolder(client, SpecialFolder.Trash, SpecialFolder.Junk);
-                if (trash != null) await folder.MoveToAsync(uidList, trash, ct);
-                else               await folder.AddFlagsAsync(uidList, MessageFlags.Deleted, true, ct);
-                return true;
-            }
-            finally { await folder.CloseAsync(false, ct); }
-        });
+            var uidList = uids.Select(u => new UniqueId(u)).ToList();
+            var trash   = FindSpecialFolder(client, SpecialFolder.Trash, SpecialFolder.Junk);
+            if (trash != null) await folder.MoveToAsync(uidList, trash, ct);
+            else               await folder.AddFlagsAsync(uidList, MessageFlags.Deleted, true, ct);
+        }
+        finally { await folder.CloseAsync(false, ct); }
+    }
 
     public async Task MoveToTrashAsync(Guid accountId, string folderName, uint uid, CancellationToken ct = default)
     {
-        var client = await GetOrReconnectAsync(accountId, ct);
+        using var lease = await RentClientAsync(accountId, ct, ImapLeasePriority.Foreground);
+        var client = lease.Client;
         var folder = await client.GetFolderAsync(folderName, ct);
         await folder.OpenAsync(FolderAccess.ReadWrite, ct);
         try
@@ -358,7 +377,8 @@ public class ImapService : IImapService
 
     public async Task<string?> FindDraftsFolderNameAsync(Guid accountId, CancellationToken ct = default)
     {
-        var client = await GetOrReconnectAsync(accountId, ct);
+        using var lease = await RentClientAsync(accountId, ct, ImapLeasePriority.Foreground);
+        var client = lease.Client;
         var drafts = FindSpecialFolder(client, SpecialFolder.Drafts);
         return drafts?.FullName;
     }
@@ -366,7 +386,8 @@ public class ImapService : IImapService
     public async Task<uint> AppendDraftAsync(
         Guid accountId, ComposeModel draft, uint? replaceUid, CancellationToken ct = default)
     {
-        var client  = await GetOrReconnectAsync(accountId, ct);
+        using var lease = await RentClientAsync(accountId, ct, ImapLeasePriority.Foreground);
+        var client  = lease.Client;
         var account = _accounts[accountId];
 
         var draftsFolder = FindSpecialFolder(client, SpecialFolder.Drafts)
@@ -448,7 +469,8 @@ public class ImapService : IImapService
 
     public async Task CopyMessagesAsync(Guid accountId, string folderName, IList<uint> uids, string destinationFolder, CancellationToken ct = default)
     {
-        var client = await GetOrReconnectAsync(accountId, ct);
+        using var lease = await RentClientAsync(accountId, ct, ImapLeasePriority.Foreground);
+        var client = lease.Client;
         var folder = await client.GetFolderAsync(folderName, ct);
         var dest   = await client.GetFolderAsync(destinationFolder, ct);
         await folder.OpenAsync(FolderAccess.ReadOnly, ct);
@@ -458,7 +480,8 @@ public class ImapService : IImapService
 
     public async Task MoveMessagesAsync(Guid accountId, string folderName, IList<uint> uids, string destinationFolder, CancellationToken ct = default)
     {
-        var client = await GetOrReconnectAsync(accountId, ct);
+        using var lease = await RentClientAsync(accountId, ct, ImapLeasePriority.Foreground);
+        var client = lease.Client;
         var folder = await client.GetFolderAsync(folderName, ct);
         var dest   = await client.GetFolderAsync(destinationFolder, ct);
         await folder.OpenAsync(FolderAccess.ReadWrite, ct);
@@ -470,7 +493,8 @@ public class ImapService : IImapService
 
     public async Task CreateFolderAsync(Guid accountId, string? parentFolderName, string name, CancellationToken ct = default)
     {
-        var client = await GetOrReconnectAsync(accountId, ct);
+        using var lease = await RentClientAsync(accountId, ct, ImapLeasePriority.Foreground);
+        var client = lease.Client;
         IMailFolder parent = string.IsNullOrEmpty(parentFolderName)
             ? client.GetFolder(client.PersonalNamespaces[0])
             : await client.GetFolderAsync(parentFolderName, ct);
@@ -479,7 +503,8 @@ public class ImapService : IImapService
 
     public async Task DeleteFolderAsync(Guid accountId, string folderName, CancellationToken ct = default)
     {
-        var client = await GetOrReconnectAsync(accountId, ct);
+        using var lease = await RentClientAsync(accountId, ct, ImapLeasePriority.Foreground);
+        var client = lease.Client;
         var folder = await client.GetFolderAsync(folderName, ct);
 
         // Move all messages to Trash first so no mail is hard-deleted
@@ -501,7 +526,8 @@ public class ImapService : IImapService
 
     public async Task RenameFolderAsync(Guid accountId, string folderName, string newName, string? newParentFolderName, CancellationToken ct = default)
     {
-        var client = await GetOrReconnectAsync(accountId, ct);
+        using var lease = await RentClientAsync(accountId, ct, ImapLeasePriority.Foreground);
+        var client = lease.Client;
         var folder = await client.GetFolderAsync(folderName, ct);
         IMailFolder parent = string.IsNullOrEmpty(newParentFolderName)
             ? client.GetFolder(client.PersonalNamespaces[0])
@@ -511,7 +537,12 @@ public class ImapService : IImapService
 
     public async Task CopyFolderAsync(Guid accountId, string folderName, string? destinationParentName, CancellationToken ct = default)
     {
-        var client    = await GetOrReconnectAsync(accountId, ct);
+        using var lease = await RentClientAsync(accountId, ct, ImapLeasePriority.Foreground);
+        await CopyFolderCoreAsync(lease.Client, folderName, destinationParentName, ct);
+    }
+
+    private async Task CopyFolderCoreAsync(ImapClient client, string folderName, string? destinationParentName, CancellationToken ct)
+    {
         var srcFolder = await client.GetFolderAsync(folderName, ct);
 
         IMailFolder destParent = string.IsNullOrEmpty(destinationParentName)
@@ -536,12 +567,13 @@ public class ImapService : IImapService
         // Recurse into subfolders
         var subfolders = await srcFolder.GetSubfoldersAsync(false, ct);
         foreach (var sub in subfolders)
-            await CopyFolderAsync(accountId, sub.FullName, newFolder.FullName, ct);
+            await CopyFolderCoreAsync(client, sub.FullName, newFolder.FullName, ct);
     }
 
     public async Task<int> EmptyTrashAsync(Guid accountId, CancellationToken ct = default)
     {
-        var client = await GetOrReconnectAsync(accountId, ct);
+        using var lease = await RentClientAsync(accountId, ct, ImapLeasePriority.Foreground);
+        var client = lease.Client;
         var trash  = FindSpecialFolder(client, SpecialFolder.Trash, SpecialFolder.Junk);
 
         if (trash == null)
@@ -565,19 +597,20 @@ public class ImapService : IImapService
 
     // ── UID queries ──────────────────────────────────────────────────────────────
 
-    public Task<IList<uint>> GetFolderUidsAsync(Guid accountId, string folderName, CancellationToken ct = default)
-        => ExecuteWithRetryAsync(accountId, ct, async client =>
+    public async Task<IList<uint>> GetFolderUidsAsync(Guid accountId, string folderName, CancellationToken ct = default)
+    {
+        using var lease = await RentClientAsync(accountId, ct, ImapLeasePriority.Background);
+        var client = lease.Client;
+        var folder = await client.GetFolderAsync(folderName, ct);
+        await folder.OpenAsync(FolderAccess.ReadOnly, ct);
+        try
         {
-            var folder = await client.GetFolderAsync(folderName, ct);
-            await folder.OpenAsync(FolderAccess.ReadOnly, ct);
-            try
-            {
-                if (folder.Count == 0) return (IList<uint>)Array.Empty<uint>();
-                var uids = await folder.SearchAsync(SearchQuery.All, ct);
-                return (IList<uint>)uids.Select(u => u.Id).ToList();
-            }
-            finally { await folder.CloseAsync(false, ct); }
-        });
+            if (folder.Count == 0) return (IList<uint>)Array.Empty<uint>();
+            var uids = await folder.SearchAsync(SearchQuery.All, ct);
+            return (IList<uint>)uids.Select(u => u.Id).ToList();
+        }
+        finally { await folder.CloseAsync(false, ct); }
+    }
 
     // ── Body-download preview fallback (used when server lacks IMAP PREVIEW) ────
 
@@ -588,7 +621,8 @@ public class ImapService : IImapService
         var result = new Dictionary<uint, string>();
         if (uids.Count == 0 || maxLines <= 0) return result;
 
-        var client = await GetOrReconnectAsync(accountId, ct);
+        using var lease = await RentClientAsync(accountId, ct, ImapLeasePriority.Background);
+        var client = lease.Client;
         var folder = await client.GetFolderAsync(folderName, ct);
         await folder.OpenAsync(FolderAccess.ReadOnly, ct);
         try
@@ -629,7 +663,8 @@ public class ImapService : IImapService
 
     public async Task<int> PollAsync(Guid accountId, string folderName, CancellationToken ct = default)
     {
-        var client = await GetOrReconnectAsync(accountId, ct);
+        using var lease = await RentClientAsync(accountId, ct, ImapLeasePriority.Background);
+        var client = lease.Client;
         var folder = await client.GetFolderAsync(folderName, ct);
         await folder.OpenAsync(FolderAccess.ReadOnly, ct);
         try   { await folder.CheckAsync(ct); return folder.Unread; }
@@ -641,7 +676,8 @@ public class ImapService : IImapService
     public async Task<byte[]> DownloadAttachmentAsync(
         Guid accountId, string folderName, uint uid, string partSpecifier, CancellationToken ct = default)
     {
-        var client = await GetOrReconnectAsync(accountId, ct);
+        using var lease = await RentClientAsync(accountId, ct, ImapLeasePriority.Foreground);
+        var client = lease.Client;
         var folder = await client.GetFolderAsync(folderName, ct);
         await folder.OpenAsync(FolderAccess.ReadOnly, ct);
         try
@@ -671,29 +707,329 @@ public class ImapService : IImapService
     // ── Helpers ──────────────────────────────────────────────────────────────────
 
     /// <summary>
-    /// Returns an authenticated client, reconnecting transparently if the connection dropped.
+    /// Leases one authenticated client for a single IMAP operation. MailKit clients
+    /// are single-command objects, so every concurrent operation gets its own client.
     /// </summary>
-    private async Task<ImapClient> GetOrReconnectAsync(Guid accountId, CancellationToken ct)
+    private async Task<ImapClientLease> RentClientAsync(
+        Guid accountId, CancellationToken ct, ImapLeasePriority priority)
     {
-        if (_clients.TryGetValue(accountId, out var client) && client.IsConnected && client.IsAuthenticated)
+        ThrowIfDisposed();
+
+        if (!_pools.TryGetValue(accountId, out var pool))
+        {
+            if (!_accounts.TryGetValue(accountId, out var account))
+                throw new InvalidOperationException($"Account {accountId} is not connected.");
+
+            _passwords.TryGetValue(accountId, out var password);
+            await ConnectAsync(account, password, ct);
+            if (!_pools.TryGetValue(accountId, out pool))
+                throw new InvalidOperationException($"Account {accountId} is not connected.");
+        }
+
+        return await pool.RentAsync(priority, ct);
+    }
+
+    private async Task<ImapClient> CreateAuthenticatedClientAsync(
+        AccountModel account, string? password, CancellationToken ct)
+    {
+        var client = new ImapClient();
+        try
+        {
+            if (account.ImapAcceptInvalidCert)
+                client.ServerCertificateValidationCallback = (_, _, _, _) => true;
+
+            var ssl = account.ImapUseSsl
+                ? SecureSocketOptions.SslOnConnect
+                : SecureSocketOptions.StartTlsWhenAvailable;
+
+            LogService.Log($"Connecting to {account.ImapHost}:{account.ImapPort} ssl={account.ImapUseSsl} user={account.Username} auth={account.AuthType}");
+            await client.ConnectAsync(account.ImapHost, account.ImapPort, ssl, ct);
+
+            if (account.AuthType == AuthType.OAuth2Microsoft)
+            {
+                var token = await _oauth.GetAccessTokenAsync(account, ct);
+                await client.AuthenticateAsync(new SaslMechanismOAuth2(account.Username, token), ct);
+            }
+            else
+            {
+                if (password is null)
+                    throw new InvalidOperationException($"No password is available for account {account.Username}.");
+                await client.AuthenticateAsync(account.Username, password, ct);
+            }
+
+            LogService.Log($"Connected. Capabilities: {client.Capabilities}");
             return client;
+        }
+        catch
+        {
+            DisposeClient(client);
+            throw;
+        }
+    }
 
-        if (!_accounts.TryGetValue(accountId, out var account))
-            throw new InvalidOperationException($"Account {accountId} is not connected.");
+    private int GetMaxConnectionsPerAccount()
+    {
+        var configured = _config?.Load().MaxImapConnectionsPerAccount
+                         ?? DefaultMaxConnectionsPerAccount;
+        return Math.Clamp(configured, 1, AbsoluteMaxConnectionsPerAccount);
+    }
 
-        string? password = null;
-        if (account.AuthType == AuthType.Password && !_passwords.TryGetValue(accountId, out password))
-            throw new InvalidOperationException($"Account {accountId} is not connected.");
+    private void ThrowIfDisposed()
+    {
+        if (_disposed)
+            throw new ObjectDisposedException(nameof(ImapService));
+    }
 
-        // ExecuteWithRetryAsync already holds the per-account lock, so reconnect
-        // without re-acquiring it (avoids deadlock). The double-check below handles
-        // the rare case where two direct callers both see the client as disconnected.
-        if (_clients.TryGetValue(accountId, out client) && client.IsConnected && client.IsAuthenticated)
-            return client;
+    private static bool SameConnectionSettings(AccountModel left, AccountModel right) =>
+        left.Id == right.Id &&
+        left.Username == right.Username &&
+        left.AuthType == right.AuthType &&
+        left.ImapHost == right.ImapHost &&
+        left.ImapPort == right.ImapPort &&
+        left.ImapUseSsl == right.ImapUseSsl &&
+        left.ImapAcceptInvalidCert == right.ImapAcceptInvalidCert;
 
-        LogService.Log($"Reconnecting {account.Username}…");
-        await ConnectAsync(account, password, ct);
-        return _clients[accountId];
+    private static AccountModel CloneAccount(AccountModel account) =>
+        new()
+        {
+            Id                    = account.Id,
+            DisplayName           = account.DisplayName,
+            Username              = account.Username,
+            AuthType              = account.AuthType,
+            ImapHost              = account.ImapHost,
+            ImapPort              = account.ImapPort,
+            ImapUseSsl            = account.ImapUseSsl,
+            ImapAcceptInvalidCert = account.ImapAcceptInvalidCert,
+            SmtpHost              = account.SmtpHost,
+            SmtpPort              = account.SmtpPort,
+            SmtpUseSsl            = account.SmtpUseSsl,
+            SmtpAcceptInvalidCert = account.SmtpAcceptInvalidCert,
+            IsDefault             = account.IsDefault,
+        };
+
+    private static bool IsClientUsable(ImapClient client)
+    {
+        try { return client.IsConnected && client.IsAuthenticated; }
+        catch { return false; }
+    }
+
+    private static void DisposeClient(ImapClient client)
+    {
+        try { client.Dispose(); } catch { /* best effort */ }
+    }
+
+    private static async Task DisconnectAndDisposeAsync(ImapClient client, CancellationToken ct)
+    {
+        try
+        {
+            if (client.IsConnected)
+                await client.DisconnectAsync(true, ct);
+        }
+        catch (Exception ex) { LogService.Log("IMAP disconnect", ex); }
+        finally { DisposeClient(client); }
+    }
+
+    private sealed class ImapClientLease : IDisposable
+    {
+        private AccountConnectionPool? _pool;
+
+        public ImapClientLease(
+            AccountConnectionPool pool, ImapClient client, bool releaseBackgroundSlot)
+        {
+            _pool = pool;
+            Client = client;
+            ReleaseBackgroundSlot = releaseBackgroundSlot;
+        }
+
+        public ImapClient Client { get; }
+        private bool ReleaseBackgroundSlot { get; }
+
+        public void Dispose()
+        {
+            var pool = Interlocked.Exchange(ref _pool, null);
+            pool?.Return(Client, ReleaseBackgroundSlot);
+        }
+    }
+
+    private sealed class AccountConnectionPool : IDisposable
+    {
+        private readonly ImapService _owner;
+        private readonly SemaphoreSlim _slots;
+        private readonly SemaphoreSlim _backgroundSlots;
+        private readonly object _gate = new();
+        private readonly Stack<ImapClient> _idle = new();
+        private readonly HashSet<ImapClient> _all = new();
+        private bool _disposed;
+
+        public AccountConnectionPool(
+            ImapService owner, AccountModel account, string? password, int maxConnections)
+        {
+            _owner = owner;
+            Account = CloneAccount(account);
+            Password = password;
+            MaxConnections = maxConnections;
+            _slots = new SemaphoreSlim(maxConnections, maxConnections);
+            var reservedForegroundSlots = maxConnections >= 3
+                ? Math.Min(ForegroundReservedConnectionCount, maxConnections - 1)
+                : 0;
+            var backgroundCapacity = Math.Max(1, maxConnections - reservedForegroundSlots);
+            _backgroundSlots = new SemaphoreSlim(backgroundCapacity, backgroundCapacity);
+        }
+
+        public AccountModel Account { get; private set; }
+        public string? Password { get; private set; }
+        public int MaxConnections { get; }
+
+        public bool Matches(AccountModel account, int maxConnections) =>
+            MaxConnections == maxConnections && SameConnectionSettings(Account, account);
+
+        public void UpdateAccount(AccountModel account, string? password)
+        {
+            lock (_gate)
+            {
+                if (_disposed) return;
+                Account = CloneAccount(account);
+                if (password is not null)
+                    Password = password;
+            }
+        }
+
+        public async Task<ImapClientLease> RentAsync(ImapLeasePriority priority, CancellationToken ct)
+        {
+            var hasBackgroundSlot = false;
+            if (priority == ImapLeasePriority.Background)
+            {
+                await _backgroundSlots.WaitAsync(ct);
+                hasBackgroundSlot = true;
+            }
+
+            try
+            {
+                await _slots.WaitAsync(ct);
+            }
+            catch
+            {
+                if (hasBackgroundSlot)
+                    _backgroundSlots.Release();
+                throw;
+            }
+
+            ImapClient? client = null;
+
+            try
+            {
+                while (client == null)
+                {
+                    AccountModel account;
+                    string? password;
+
+                    lock (_gate)
+                    {
+                        if (_disposed)
+                            throw new ObjectDisposedException(nameof(AccountConnectionPool));
+
+                        while (_idle.Count > 0)
+                        {
+                            var candidate = _idle.Pop();
+                            if (IsClientUsable(candidate))
+                            {
+                                client = candidate;
+                                break;
+                            }
+
+                            _all.Remove(candidate);
+                            DisposeClient(candidate);
+                        }
+
+                        if (client != null)
+                            break;
+
+                        account = CloneAccount(Account);
+                        password = Password;
+                    }
+
+                    client = await _owner.CreateAuthenticatedClientAsync(account, password, ct);
+
+                    lock (_gate)
+                    {
+                        if (_disposed)
+                            throw new ObjectDisposedException(nameof(AccountConnectionPool));
+                        _all.Add(client);
+                    }
+                }
+
+                return new ImapClientLease(this, client, hasBackgroundSlot);
+            }
+            catch
+            {
+                if (client != null)
+                {
+                    lock (_gate) { _all.Remove(client); }
+                    DisposeClient(client);
+                }
+                _slots.Release();
+                if (hasBackgroundSlot)
+                    _backgroundSlots.Release();
+                throw;
+            }
+        }
+
+        public void Return(ImapClient client, bool releaseBackgroundSlot)
+        {
+            var keep = false;
+
+            lock (_gate)
+            {
+                if (!_disposed && IsClientUsable(client))
+                {
+                    _idle.Push(client);
+                    keep = true;
+                }
+                else
+                {
+                    _all.Remove(client);
+                }
+            }
+
+            if (!keep)
+                DisposeClient(client);
+
+            _slots.Release();
+            if (releaseBackgroundSlot)
+                _backgroundSlots.Release();
+        }
+
+        public async Task DisconnectAsync(CancellationToken ct)
+        {
+            List<ImapClient> clients;
+            lock (_gate)
+            {
+                if (_disposed) return;
+                _disposed = true;
+                clients = _all.ToList();
+                _idle.Clear();
+                _all.Clear();
+            }
+
+            foreach (var client in clients)
+                await DisconnectAndDisposeAsync(client, ct);
+        }
+
+        public void Dispose()
+        {
+            List<ImapClient> clients;
+            lock (_gate)
+            {
+                if (_disposed) return;
+                _disposed = true;
+                clients = _all.ToList();
+                _idle.Clear();
+                _all.Clear();
+            }
+
+            foreach (var client in clients)
+                DisposeClient(client);
+        }
     }
 
     private static MailMessageSummary SummaryToModel(IMessageSummary s, Guid accountId, string folderName) =>
@@ -820,86 +1156,43 @@ public class ImapService : IImapService
                     ? mb.Name
                     : a.ToString()));
 
-    public Task PermanentlyDeleteBatchAsync(Guid accountId, string folderName, IList<uint> uids, CancellationToken ct = default)
-        => ExecuteWithRetryAsync<bool>(accountId, ct, async client =>
+    public async Task PermanentlyDeleteBatchAsync(Guid accountId, string folderName, IList<uint> uids, CancellationToken ct = default)
+    {
+        using var lease = await RentClientAsync(accountId, ct, ImapLeasePriority.Foreground);
+        var client = lease.Client;
+        var folder = await client.GetFolderAsync(folderName, ct);
+        await folder.OpenAsync(FolderAccess.ReadWrite, ct);
+        try
         {
-            var folder = await client.GetFolderAsync(folderName, ct);
-            await folder.OpenAsync(FolderAccess.ReadWrite, ct);
-            try
-            {
-                var uidList = uids.Select(u => new UniqueId(u)).ToList();
-                await folder.AddFlagsAsync(uidList, MessageFlags.Deleted, true, ct);
-                await folder.ExpungeAsync(ct);
-                return true;
-            }
-            finally { await folder.CloseAsync(false, ct); }
-        });
+            var uidList = uids.Select(u => new UniqueId(u)).ToList();
+            await folder.AddFlagsAsync(uidList, MessageFlags.Deleted, true, ct);
+            await folder.ExpungeAsync(ct);
+        }
+        finally { await folder.CloseAsync(false, ct); }
+    }
 
     public async Task NoOpAsync(Guid accountId, CancellationToken ct = default)
     {
-        if (!_clients.TryGetValue(accountId, out var client) || !client.IsConnected) return;
-        try   { await client.NoOpAsync(ct); }
-        catch (Exception ex) when (IsTransientConnectionError(ex))
-        {
-            LogService.Log($"NoOp failed for {accountId}, discarding stale connection: {ex.GetType().Name}");
-            ForceDisconnect(accountId);
-        }
-    }
-
-    // ── Connection retry helpers ─────────────────────────────────────────────────
-
-    private static bool IsTransientConnectionError(Exception ex) =>
-        ex is ServiceNotConnectedException
-           or ImapProtocolException
-           or IOException
-           or SocketException;
-
-    private void ForceDisconnect(Guid accountId)
-    {
-        if (_clients.TryRemove(accountId, out var stale))
-        {
-            try { stale.Dispose(); } catch { /* best effort */ }
-        }
-    }
-
-    /// <summary>
-    /// Runs <paramref name="operation"/> with an authenticated client.
-    /// On a transient connection error (BYE, socket drop) the stale client is
-    /// discarded, a fresh connection is established, and the operation retried once.
-    /// </summary>
-    private async Task<T> ExecuteWithRetryAsync<T>(
-        Guid accountId, CancellationToken ct, Func<ImapClient, Task<T>> operation)
-    {
-        // Serialize all IMAP operations per account so background sync and
-        // foreground actions (delete, send, etc.) never share the client concurrently.
-        var sem = _locks.GetOrAdd(accountId, _ => new SemaphoreSlim(1, 1));
-        await sem.WaitAsync(ct);
+        if (!_pools.ContainsKey(accountId)) return;
         try
         {
-            var client = await GetOrReconnectAsync(accountId, ct);
-            try
-            {
-                return await operation(client);
-            }
-            catch (Exception ex) when (!ct.IsCancellationRequested && IsTransientConnectionError(ex))
-            {
-                LogService.Log($"Transient IMAP error, reconnecting ({accountId}): {ex.GetType().Name}");
-                ForceDisconnect(accountId);
-                client = await GetOrReconnectAsync(accountId, ct);
-                return await operation(client);
-            }
+            using var lease = await RentClientAsync(accountId, ct, ImapLeasePriority.Background);
+            await lease.Client.NoOpAsync(ct);
         }
-        finally { sem.Release(); }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex)
+        {
+            // Pool will discard the dead client on Return via IsClientUsable; just log.
+            LogService.Log($"NoOp failed for {accountId}: {ex.GetType().Name}");
+        }
     }
 
     public void Dispose()
     {
         if (_disposed) return;
         _disposed = true;
-        foreach (var client in _clients.Values)
-        {
-            try { client.Dispose(); } catch { /* best effort */ }
-        }
-        _clients.Clear();
+        foreach (var pool in _pools.Values)
+            pool.Dispose();
+        _pools.Clear();
     }
 }

--- a/QuickMail/Services/LocalStoreService.cs
+++ b/QuickMail/Services/LocalStoreService.cs
@@ -151,15 +151,18 @@ public class LocalStoreService : ILocalStoreService
         return await ReadSummariesAsync(cmd);
     }
 
-    public async Task<List<MailMessageSummary>> LoadFolderSummariesAsync(Guid accountId, string folderName)
+    public async Task<List<MailMessageSummary>> LoadFolderSummariesAsync(Guid accountId, string folderName, int? limit = null)
     {
         await using var conn = await OpenAsync();
         await using var cmd = conn.CreateCommand();
         cmd.CommandText =
             "SELECT unique_id, account_id, folder_name, from_disp, to_addr, subject, date_ticks, is_read, preview_text, is_replied, is_forwarded " +
-            "FROM MessageSummary WHERE account_id=$aid AND folder_name=$fn ORDER BY date_ticks DESC;";
+            "FROM MessageSummary WHERE account_id=$aid AND folder_name=$fn ORDER BY date_ticks DESC" +
+            (limit.HasValue ? " LIMIT $limit;" : ";");
         cmd.Parameters.AddWithValue("$aid", accountId.ToString());
         cmd.Parameters.AddWithValue("$fn",  folderName);
+        if (limit.HasValue)
+            cmd.Parameters.AddWithValue("$limit", Math.Max(0, limit.Value));
         return await ReadSummariesAsync(cmd);
     }
 

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -30,6 +30,10 @@ public partial class MainViewModel : ObservableObject
     private CancellationTokenSource? _folderCts;
     private CancellationTokenSource? _messageLoadCts;
     private CancellationTokenSource? _messageActionCts;
+    private CancellationTokenSource? _prefetchCts;
+
+    private const int PrefetchRadiusAroundOpen = 5;
+    private const int PrefetchTopOnFolderLoad  = 10;
     private CancellationTokenSource? _bgSyncCts;
 
     // How many days of mail to sync (0 = all); set via the Sync Range menu
@@ -301,6 +305,7 @@ public partial class MainViewModel : ObservableObject
         StatusText = cached.Count > 0
             ? $"{cached.Count} messages (cached — syncing…)"
             : "Connecting and syncing…";
+        StartPrefetchTopOfFolder();
         RebuildFolderListFromCache();
     }
 
@@ -372,14 +377,17 @@ public partial class MainViewModel : ObservableObject
     {
         if (SelectedFolder?.FullName != AllMailFolder.FullName) return;
 
+        // Hash existing keys once so the dedupe check is O(1) per incoming item
+        // instead of an O(n) Messages.Any() scan per item — that scan would dominate
+        // a sync against a multi-thousand-message All Mail view and freeze the UI thread.
+        var seen = new HashSet<(uint, Guid, string)>(Messages.Count);
+        foreach (var e in Messages)
+            seen.Add((e.UniqueId, e.AccountId, e.FolderName));
+
         foreach (var msg in incoming.OrderByDescending(m => m.Date))
         {
-            // Skip if already displayed (can happen if user triggered a manual refresh mid-sync)
-            if (Messages.Any(e => e.UniqueId   == msg.UniqueId &&
-                                  e.AccountId  == msg.AccountId &&
-                                  e.FolderName == msg.FolderName))
+            if (!seen.Add((msg.UniqueId, msg.AccountId, msg.FolderName)))
                 continue;
-
             InsertMessageSorted(msg);
         }
 
@@ -394,18 +402,21 @@ public partial class MainViewModel : ObservableObject
     }
     private void OnMessagesRemoved(IReadOnlyList<MailMessageSummary> removed)
     {
+        // Build a key→item map once so each removed key is an O(1) lookup
+        // instead of a Messages.FirstOrDefault scan per item.
+        var byKey = new Dictionary<(uint, Guid, string), MailMessageSummary>(Messages.Count);
+        foreach (var e in Messages)
+            byKey[(e.UniqueId, e.AccountId, e.FolderName)] = e;
+
         bool removedOpen = false;
         foreach (var msg in removed)
         {
-            var existing = Messages.FirstOrDefault(e =>
-                e.UniqueId   == msg.UniqueId &&
-                e.AccountId  == msg.AccountId &&
-                e.FolderName == msg.FolderName);
-
-            if (existing == null) continue;
+            var key = (msg.UniqueId, msg.AccountId, msg.FolderName);
+            if (!byKey.TryGetValue(key, out var existing)) continue;
 
             if (SelectedMessage == existing) removedOpen = true;
             Messages.Remove(existing);
+            byKey.Remove(key);
         }
 
         if (removedOpen)
@@ -790,8 +801,12 @@ public partial class MainViewModel : ObservableObject
             StatusText = cached.Count > 0
                 ? $"{cached.Count} cached {(cached.Count == 1 ? "message" : "messages")} (checking for new…)"
                 : $"Loading {folder.DisplayName}…";
-            if (cached.Count > 0 && IsConversationsView)
-                ScheduleConversationRebuild();
+            if (cached.Count > 0)
+            {
+                if (IsConversationsView)
+                    ScheduleConversationRebuild();
+                StartPrefetchTopOfFolder();
+            }
 
             _ = RefreshFolderFromServerAsync(accountId, folder, loadVersion, cts.Token);
         }
@@ -831,6 +846,7 @@ public partial class MainViewModel : ObservableObject
 
             if (IsConversationsView)
                 ScheduleConversationRebuild();
+            StartPrefetchTopOfFolder();
         }
         catch (OperationCanceledException)
         {
@@ -905,6 +921,8 @@ public partial class MainViewModel : ObservableObject
             }
 
             StatusText = "Message loaded. Press Escape to return to message list.";
+
+            StartPrefetchAroundOpen(summary);
         }
         catch (OperationCanceledException)
         {
@@ -922,6 +940,78 @@ public partial class MainViewModel : ObservableObject
             if (loadVersion == _messageLoadVersion)
                 IsBusy = false;
         }
+    }
+
+    // ── Prefetch ─────────────────────────────────────────────────────────────────
+    // Eagerly cache message bodies for nearby/top messages so subsequent opens are
+    // instant. Uses background IMAP leases (cannot starve foreground opens) and does
+    // not set the Seen flag on the server.
+
+    private void StartPrefetchAroundOpen(MailMessageSummary current)
+    {
+        var snapshot = Messages.ToList();
+        var idx = snapshot.IndexOf(current);
+        if (idx < 0) return;
+
+        var targets = new List<MailMessageSummary>(PrefetchRadiusAroundOpen * 2);
+        for (var offset = 1; offset <= PrefetchRadiusAroundOpen; offset++)
+        {
+            if (idx + offset < snapshot.Count) targets.Add(snapshot[idx + offset]);
+            if (idx - offset >= 0)             targets.Add(snapshot[idx - offset]);
+        }
+        if (targets.Count == 0) return;
+
+        SchedulePrefetch(targets, "around-open");
+    }
+
+    private void StartPrefetchTopOfFolder()
+    {
+        var snapshot = Messages.Take(PrefetchTopOnFolderLoad).ToList();
+        if (snapshot.Count == 0) return;
+        SchedulePrefetch(snapshot, "folder-top");
+    }
+
+    private void SchedulePrefetch(List<MailMessageSummary> targets, string reason)
+    {
+        var cts = new CancellationTokenSource();
+        var previous = Interlocked.Exchange(ref _prefetchCts, cts);
+        try { previous?.Cancel(); previous?.Dispose(); } catch { /* best effort */ }
+
+        _ = Task.Run(() => RunPrefetchAsync(targets, reason, cts.Token));
+    }
+
+    private async Task RunPrefetchAsync(List<MailMessageSummary> targets, string reason, CancellationToken ct)
+    {
+        LogService.Debug($"Prefetch start reason={reason} count={targets.Count}");
+        var tasks = targets.Select(s => PrefetchOneAsync(s, ct)).ToList();
+        try { await Task.WhenAll(tasks); }
+        catch { /* per-message errors logged inside */ }
+        LogService.Debug($"Prefetch end reason={reason} cancelled={ct.IsCancellationRequested}");
+    }
+
+    private async Task PrefetchOneAsync(MailMessageSummary summary, CancellationToken ct)
+    {
+        if (ct.IsCancellationRequested) return;
+        try
+        {
+            var cached = await _localStore.LoadDetailAsync(
+                summary.AccountId, summary.FolderName, summary.UniqueId);
+            if (cached != null || ct.IsCancellationRequested) return;
+
+            var detail = await _imap.PrefetchMessageDetailAsync(
+                summary.AccountId, summary.FolderName, summary.UniqueId, ct);
+            if (ct.IsCancellationRequested) return;
+            await _localStore.UpsertDetailAsync(detail);
+            LogService.Debug($"Prefetched UID={summary.UniqueId} folder={summary.FolderName}");
+        }
+        catch (OperationCanceledException) { /* expected on switch */ }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("not connected"))
+        {
+            // Prefetch raced startup or a disconnect; the next prefetch trigger
+            // (folder load, message open) will retry once the account is up.
+            LogService.Debug($"Prefetch skipped UID={summary.UniqueId} (account not connected)");
+        }
+        catch (Exception ex) { LogService.Log($"Prefetch UID={summary.UniqueId}", ex); }
     }
 
     [RelayCommand]
@@ -1034,6 +1124,8 @@ public partial class MainViewModel : ObservableObject
                 ScheduleSenderGroupRebuild();
             else if (ViewMode == ViewMode.To)
                 ScheduleToGroupRebuild();
+
+            StartPrefetchTopOfFolder();
         }
         catch (OperationCanceledException)
         {

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -1173,16 +1173,19 @@ public partial class MainViewModel : ObservableObject
                 return;
             }
 
+            var existingKeys = Messages
+                .Select(m => (m.UniqueId, m.AccountId, m.FolderName))
+                .ToHashSet();
+
             foreach (var msg in newMessages.OrderByDescending(m => m.Date))
             {
                 if (!IsCurrentFolderLoad(loadVersion, AllMailFolder))
                     return;
 
-                // Dedup in case of overlap with cache
-                if (Messages.Any(e => e.UniqueId == msg.UniqueId &&
-                                      e.AccountId == msg.AccountId &&
-                                      e.FolderName == msg.FolderName))
+                var key = (msg.UniqueId, msg.AccountId, msg.FolderName);
+                if (!existingKeys.Add(key))
                     continue;
+
                 InsertMessageSorted(msg);
             }
 
@@ -1341,13 +1344,18 @@ public partial class MainViewModel : ObservableObject
             var newMessages = await FetchAccountNewMessagesAsync(account, ct);
             if (!IsCurrentFolderLoad(loadVersion, expectedFolder)) return;
 
+            var existingKeys = Messages
+                .Select(m => (m.UniqueId, m.AccountId, m.FolderName))
+                .ToHashSet();
+
             foreach (var msg in newMessages.OrderByDescending(m => m.Date))
             {
                 if (!IsCurrentFolderLoad(loadVersion, expectedFolder)) return;
-                if (Messages.Any(e => e.UniqueId   == msg.UniqueId &&
-                                      e.AccountId  == msg.AccountId &&
-                                      e.FolderName == msg.FolderName))
+
+                var key = (msg.UniqueId, msg.AccountId, msg.FolderName);
+                if (!existingKeys.Add(key))
                     continue;
+
                 InsertMessageSorted(msg);
             }
 

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -28,17 +28,21 @@ public partial class MainViewModel : ObservableObject
     // Separate CTS per operation type so they can't cancel each other accidentally
     private CancellationTokenSource? _connectCts;
     private CancellationTokenSource? _folderCts;
-    private CancellationTokenSource? _messageCts;
+    private CancellationTokenSource? _messageLoadCts;
+    private CancellationTokenSource? _messageActionCts;
     private CancellationTokenSource? _bgSyncCts;
 
     // How many days of mail to sync (0 = all); set via the Sync Range menu
     private int _syncDays = 30;
 
-    // Version stamps for grouped-view rebuilds; latest wins, stale results discarded
+    // Version stamps; latest wins, stale results discarded
     private int _folderLoadVersion;
     private int _conversationRebuildVersion;
     private int _senderGroupRebuildVersion;
     private int _toGroupRebuildVersion;
+
+    // Version stamp for message body loads; latest selection wins.
+    private int _messageLoadVersion;
 
     // Retains folder lists for every account that has been connected this session
     private readonly Dictionary<Guid, List<MailFolderModel>> _cachedFolders = new();
@@ -771,48 +775,82 @@ public partial class MainViewModel : ObservableObject
         if (accountId == Guid.Empty) return;
         var folder = SelectedFolder;
         var loadVersion = Interlocked.Increment(ref _folderLoadVersion);
-        var cached = await _localStore.LoadFolderSummariesAsync(accountId, folder.FullName);
-        if (!IsCurrentFolderLoad(loadVersion, folder))
-            return;
-
-        Messages = new ObservableCollection<MailMessageSummary>(cached);
-        StatusText = cached.Count > 0
-            ? $"{cached.Count} cached messages (checking for new...)"
-            : $"Loading {folder.DisplayName}...";
         IsBusy = true;
         try
         {
-            _folderCts?.Cancel();
-            _folderCts = new CancellationTokenSource();
-            var list = _syncDays > 0
-                ? await _imap.GetMessagesSinceDateAsync(accountId, folder.FullName, DateTime.UtcNow.AddDays(-_syncDays), _folderCts.Token)
-                : await _imap.GetMessageSummariesAsync(accountId, folder.FullName, 50000, _folderCts.Token);
+            var cts = new CancellationTokenSource();
+            var previousCts = Interlocked.Exchange(ref _folderCts, cts);
+            await (previousCts?.CancelAsync() ?? Task.CompletedTask);
+
+            var cached = await _localStore.LoadFolderSummariesAsync(accountId, folder.FullName);
             if (!IsCurrentFolderLoad(loadVersion, folder))
+                return;
+
+            Messages = new ObservableCollection<MailMessageSummary>(cached);
+            StatusText = cached.Count > 0
+                ? $"{cached.Count} cached {(cached.Count == 1 ? "message" : "messages")} (checking for new…)"
+                : $"Loading {folder.DisplayName}…";
+            if (cached.Count > 0 && IsConversationsView)
+                ScheduleConversationRebuild();
+
+            _ = RefreshFolderFromServerAsync(accountId, folder, loadVersion, cts.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            if (loadVersion == _folderLoadVersion)
+            {
+                StatusText = "Message list load cancelled.";
+                IsBusy = false;
+            }
+        }
+        catch (Exception ex)
+        {
+            if (loadVersion == _folderLoadVersion)
+            {
+                StatusText = $"Failed to load messages: {ex.Message}";
+                IsBusy = false;
+            }
+            LogService.Log("SelectFolder", ex);
+        }
+    }
+
+    private async Task RefreshFolderFromServerAsync(
+        Guid accountId, MailFolderModel folder, int version, CancellationToken ct)
+    {
+        try
+        {
+            var list = _syncDays > 0
+                ? await _imap.GetMessagesSinceDateAsync(accountId, folder.FullName, DateTime.UtcNow.AddDays(-_syncDays), ct)
+                : await _imap.GetMessageSummariesAsync(accountId, folder.FullName, 50000, ct);
+            if (!IsCurrentFolderLoad(version, folder))
                 return;
 
             Messages = new ObservableCollection<MailMessageSummary>(list);
             StatusText = list.Count == 0 ? "No messages" : $"{list.Count} messages loaded.";
             _ = _localStore.UpsertSummariesAsync(list);
+
+            if (IsConversationsView)
+                ScheduleConversationRebuild();
         }
         catch (OperationCanceledException)
         {
-            if (loadVersion == _folderLoadVersion)
+            if (version == _folderLoadVersion)
                 StatusText = "Message list load cancelled.";
         }
         catch (Exception ex)
         {
-            if (loadVersion == _folderLoadVersion)
+            if (version == _folderLoadVersion)
                 StatusText = $"Failed to load messages: {ex.Message}";
-            LogService.Log("SelectFolder", ex);
+            LogService.Log("RefreshFolderFromServer", ex);
         }
         finally
         {
-            if (loadVersion == _folderLoadVersion)
+            if (version == _folderLoadVersion)
                 IsBusy = false;
         }
     }
 
-    [RelayCommand]
+    [RelayCommand(AllowConcurrentExecutions = true)]
     private async Task SelectMessageAsync(MailMessageSummary? summary)
     {
         if (summary == null) return;
@@ -820,6 +858,7 @@ public partial class MainViewModel : ObservableObject
             SelectedAccount = Accounts.FirstOrDefault(a => a.Id == summary.AccountId) ?? SelectedAccount;
         if (SelectedAccount == null) return;
 
+        var loadVersion = Interlocked.Increment(ref _messageLoadVersion);
         SelectedMessage = summary;
         MessageDetail   = null;
         IsMessageOpen   = false;
@@ -827,8 +866,10 @@ public partial class MainViewModel : ObservableObject
         IsBusy = true;
         try
         {
-            _messageCts?.Cancel();
-            _messageCts = new CancellationTokenSource();
+            var cts = new CancellationTokenSource();
+            var previousCts = Interlocked.Exchange(ref _messageLoadCts, cts);
+            await (previousCts?.CancelAsync() ?? Task.CompletedTask);
+            var token = cts.Token;
 
             // Serve from cache when available; fall back to IMAP and cache the result.
             var detail = await _localStore.LoadDetailAsync(
@@ -837,9 +878,12 @@ public partial class MainViewModel : ObservableObject
             if (detail == null)
             {
                 detail = await _imap.GetMessageDetailAsync(
-                    summary.AccountId, summary.FolderName, summary.UniqueId, _messageCts.Token);
+                    summary.AccountId, summary.FolderName, summary.UniqueId, token);
                 _ = _localStore.UpsertDetailAsync(detail);
             }
+
+            if (loadVersion != _messageLoadVersion || SelectedMessage != summary)
+                return;
 
             MessageDetail = detail;
             IsMessageOpen = true;
@@ -864,16 +908,19 @@ public partial class MainViewModel : ObservableObject
         }
         catch (OperationCanceledException)
         {
-            StatusText = "Message load cancelled.";
+            if (loadVersion == _messageLoadVersion)
+                StatusText = "Message load cancelled.";
         }
         catch (Exception ex)
         {
-            StatusText = $"Failed to load message: {ex.Message}";
+            if (loadVersion == _messageLoadVersion)
+                StatusText = $"Failed to load message: {ex.Message}";
             LogService.Log("SelectMessage", ex);
         }
         finally
         {
-            IsBusy = false;
+            if (loadVersion == _messageLoadVersion)
+                IsBusy = false;
         }
     }
 
@@ -1233,8 +1280,9 @@ public partial class MainViewModel : ObservableObject
         // ── Step 2: IMAP delete + local store cleanup ────────────────────────────
         try
         {
-            _messageCts?.Cancel();
-            _messageCts = new CancellationTokenSource();
+            var cts = new CancellationTokenSource();
+            var previousCts = Interlocked.Exchange(ref _messageActionCts, cts);
+            await (previousCts?.CancelAsync() ?? Task.CompletedTask);
 
             var groups = toDelete.GroupBy(m => (m.AccountId, m.FolderName));
             foreach (var group in groups)
@@ -1251,10 +1299,10 @@ public partial class MainViewModel : ObservableObject
 
                 if (sourceKind == SpecialFolderKind.Trash)
                     await _imap.PermanentlyDeleteBatchAsync(
-                        group.Key.AccountId, group.Key.FolderName, uids, _messageCts.Token);
+                        group.Key.AccountId, group.Key.FolderName, uids, cts.Token);
                 else
                     await _imap.MoveToTrashBatchAsync(
-                        group.Key.AccountId, group.Key.FolderName, uids, _messageCts.Token);
+                        group.Key.AccountId, group.Key.FolderName, uids, cts.Token);
 
                 LogService.Debug($"[DELETE] IMAP done {group.Key.FolderName}");
                 await _localStore.DeleteSummariesAsync(group.Key.AccountId, group.Key.FolderName, uids);
@@ -1425,8 +1473,9 @@ public partial class MainViewModel : ObservableObject
         StatusText = "Opening draft…";
         try
         {
-            _messageCts?.Cancel();
-            _messageCts = new CancellationTokenSource();
+            var cts = new CancellationTokenSource();
+            var previousCts = Interlocked.Exchange(ref _messageLoadCts, cts);
+            await (previousCts?.CancelAsync() ?? Task.CompletedTask);
 
             var detail = await _localStore.LoadDetailAsync(
                 summary.AccountId, summary.FolderName, summary.UniqueId);
@@ -1434,7 +1483,7 @@ public partial class MainViewModel : ObservableObject
             if (detail == null)
             {
                 detail = await _imap.GetMessageDetailAsync(
-                    summary.AccountId, summary.FolderName, summary.UniqueId, _messageCts.Token);
+                    summary.AccountId, summary.FolderName, summary.UniqueId, cts.Token);
             }
 
             var model = new ComposeModel
@@ -1457,7 +1506,7 @@ public partial class MainViewModel : ObservableObject
                     {
                         att.Content = await _imap.DownloadAttachmentAsync(
                             summary.AccountId, summary.FolderName, summary.UniqueId,
-                            att.PartSpecifier, _messageCts.Token);
+                            att.PartSpecifier, cts.Token);
                     }
                     catch (Exception ex)
                     {
@@ -1730,8 +1779,9 @@ public partial class MainViewModel : ObservableObject
         IsBusy     = true;
         try
         {
-            _messageCts?.Cancel();
-            _messageCts = new CancellationTokenSource();
+            var cts = new CancellationTokenSource();
+            var previousCts = Interlocked.Exchange(ref _messageActionCts, cts);
+            await (previousCts?.CancelAsync() ?? Task.CompletedTask);
 
             var groups = messages.GroupBy(m => (m.AccountId, m.FolderName));
             foreach (var group in groups)
@@ -1739,7 +1789,7 @@ public partial class MainViewModel : ObservableObject
                 var uids = group.Select(m => m.UniqueId).ToList();
                 await _imap.MoveMessagesAsync(
                     group.Key.AccountId, group.Key.FolderName, uids,
-                    destination.FullName, _messageCts.Token);
+                    destination.FullName, cts.Token);
                 await _localStore.DeleteSummariesAsync(group.Key.AccountId, group.Key.FolderName, uids);
             }
 

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -743,7 +743,6 @@ public partial class MainViewModel : ObservableObject
     {
         var version  = Interlocked.Increment(ref _senderGroupRebuildVersion);
         var snapshot = Messages.ToList();
-        LogService.Debug($"[DELETE] ScheduleSenderGroupRebuild v={version} snapshot={snapshot.Count} msgs");
         Task.Run(() =>
         {
             var groups = SenderGroupBuilder.Build(snapshot);
@@ -751,12 +750,10 @@ public partial class MainViewModel : ObservableObject
             {
                 if (version == _senderGroupRebuildVersion)
                 {
-                    LogService.Debug($"[DELETE] SenderGroupRebuild v={version} applying {groups.Count} groups");
                     SenderGroups = new ObservableCollection<SenderGroup>(groups);
                 }
                 else
                 {
-                    LogService.Debug($"[DELETE] SenderGroupRebuild v={version} DISCARDED (current={_senderGroupRebuildVersion})");
                 }
             });
         });
@@ -766,7 +763,6 @@ public partial class MainViewModel : ObservableObject
     {
         var version  = Interlocked.Increment(ref _toGroupRebuildVersion);
         var snapshot = Messages.ToList();
-        LogService.Debug($"[DELETE] ScheduleToGroupRebuild v={version} snapshot={snapshot.Count} msgs");
         Task.Run(() =>
         {
             var groups = SenderGroupBuilder.BuildByTo(snapshot);
@@ -774,12 +770,10 @@ public partial class MainViewModel : ObservableObject
             {
                 if (version == _toGroupRebuildVersion)
                 {
-                    LogService.Debug($"[DELETE] ToGroupRebuild v={version} applying {groups.Count} groups");
                     ToGroups = new ObservableCollection<SenderGroup>(groups);
                 }
                 else
                 {
-                    LogService.Debug($"[DELETE] ToGroupRebuild v={version} DISCARDED (current={_toGroupRebuildVersion})");
                 }
             });
         });
@@ -1495,7 +1489,6 @@ public partial class MainViewModel : ObservableObject
 
         var minIdx = toDelete.Min(m => Messages.IndexOf(m));
         var label  = toDelete.Count == 1 ? "message" : $"{toDelete.Count} messages";
-        LogService.Debug($"[DELETE] DeleteMessagesAsync start count={toDelete.Count} ViewMode={ViewMode}");
         StatusText    = $"Deleting {label}…";
         IsBusy        = true;
         MessageDetail = null;
@@ -1511,7 +1504,6 @@ public partial class MainViewModel : ObservableObject
         {
             if (Messages.Remove(msg)) removed++;
         }
-        LogService.Debug($"[DELETE] Removed {removed}/{toDelete.Count} from UI immediately (now {Messages.Count})");
 
         if (ViewMode == ViewMode.Conversations)
             ScheduleConversationRebuild();
@@ -1550,7 +1542,6 @@ public partial class MainViewModel : ObservableObject
             foreach (var group in groups)
             {
                 var uids = group.Select(m => m.UniqueId).ToList();
-                LogService.Debug($"[DELETE] IMAP delete {group.Key.FolderName} uids={string.Join(",", uids)}");
 
                 // Messages already in Trash must be permanently deleted (expunge);
                 // moving them to trash again is a no-op on most servers.
@@ -1566,7 +1557,6 @@ public partial class MainViewModel : ObservableObject
                     await _imap.MoveToTrashBatchAsync(
                         group.Key.AccountId, group.Key.FolderName, uids, cts.Token);
 
-                LogService.Debug($"[DELETE] IMAP done {group.Key.FolderName}");
                 await _localStore.DeleteSummariesAsync(group.Key.AccountId, group.Key.FolderName, uids);
             }
 

--- a/QuickMail/Views/FolderPickerWindow.xaml
+++ b/QuickMail/Views/FolderPickerWindow.xaml
@@ -2,34 +2,20 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="Go to Folder"
-        Height="420" Width="360"
-        MinHeight="200" MinWidth="240"
+        Height="420" Width="420"
+        MinHeight="220" MinWidth="300"
         WindowStartupLocation="CenterOwner"
         ResizeMode="CanResize"
         ShowInTaskbar="False">
 
-    <Window.Resources>
-        <!-- Each node shows its name; children appear nested under it -->
-        <HierarchicalDataTemplate x:Key="FolderNodeTemplate"
-                                  ItemsSource="{Binding Children}">
-            <TextBlock Text="{Binding Label}"
-                       AutomationProperties.Name="{Binding AutomationName}"/>
-        </HierarchicalDataTemplate>
-
-        <!-- Bind IsExpanded on TreeViewItem to our node's IsExpanded property -->
-        <Style x:Key="FolderItemStyle" TargetType="TreeViewItem">
-            <Setter Property="IsExpanded" Value="{Binding IsExpanded, Mode=TwoWay}"/>
-            <Setter Property="AutomationProperties.Name" Value="{Binding AutomationName}"/>
-        </Style>
-    </Window.Resources>
-
     <DockPanel Margin="10">
 
-        <TextBlock DockPanel.Dock="Top"
-                   Text="Select a folder. Arrow keys to navigate and expand, Enter to open, Escape to cancel."
-                   TextWrapping="Wrap"
-                   Focusable="False"
-                   Margin="0,0,0,8"/>
+        <TextBox x:Name="SearchBox"
+                 DockPanel.Dock="Top"
+                 Margin="0,0,0,8"
+                 TextChanged="SearchBox_TextChanged"
+                 PreviewKeyDown="SearchBox_PreviewKeyDown"
+                 AutomationProperties.Name="Folder search"/>
 
         <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal"
                     HorizontalAlignment="Right" Margin="0,8,0,0">
@@ -46,14 +32,48 @@
                     AutomationProperties.Name="Cancel"/>
         </StackPanel>
 
-        <TreeView x:Name="FolderTreeView"
-                  AutomationProperties.Name="Folder tree"
-                  ItemsSource="{Binding}"
-                  ItemTemplate="{StaticResource FolderNodeTemplate}"
-                  ItemContainerStyle="{StaticResource FolderItemStyle}"
-                  BorderThickness="1"
-                  PreviewTextInput="FolderTreeView_PreviewTextInput"
-                  PreviewKeyDown="FolderTreeView_PreviewKeyDown"/>
+        <ListBox x:Name="FolderListBox"
+                 AutomationProperties.Name="Folders"
+                 BorderThickness="1"
+                 KeyboardNavigation.TabNavigation="Once"
+                 VirtualizingPanel.IsVirtualizing="True"
+                 VirtualizingPanel.VirtualizationMode="Recycling"
+                 ScrollViewer.CanContentScroll="True"
+                 PreviewKeyDown="FolderListBox_PreviewKeyDown"
+                 MouseDoubleClick="FolderListBox_MouseDoubleClick">
+            <ListBox.ItemTemplate>
+                <DataTemplate>
+                    <Grid Margin="3,2">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                        </Grid.RowDefinitions>
+                        <TextBlock Text="{Binding FolderPath}"
+                                   TextTrimming="CharacterEllipsis"/>
+                        <TextBlock Grid.Row="1"
+                                   Text="{Binding AccountName}"
+                                   FontSize="11"
+                                   Opacity="0.75"
+                                   TextTrimming="CharacterEllipsis">
+                            <TextBlock.Style>
+                                <Style TargetType="TextBlock">
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding AccountName}" Value="">
+                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </TextBlock.Style>
+                        </TextBlock>
+                    </Grid>
+                </DataTemplate>
+            </ListBox.ItemTemplate>
+            <ListBox.ItemContainerStyle>
+                <Style TargetType="ListBoxItem" BasedOn="{StaticResource {x:Type ListBoxItem}}">
+                    <Setter Property="AutomationProperties.Name" Value="{Binding DisplayName}"/>
+                </Style>
+            </ListBox.ItemContainerStyle>
+        </ListBox>
 
     </DockPanel>
 </Window>

--- a/QuickMail/Views/FolderPickerWindow.xaml.cs
+++ b/QuickMail/Views/FolderPickerWindow.xaml.cs
@@ -167,8 +167,7 @@ public partial class FolderPickerWindow : Window
     private static bool IsSearchGesture(KeyEventArgs e)
     {
         var key = e.Key == Key.System ? e.SystemKey : e.Key;
-        return (key == Key.Oem2 || key == Key.Divide) && Keyboard.Modifiers == ModifierKeys.None
-            || key == Key.F && Keyboard.Modifiers == ModifierKeys.Control;
+        return (key == Key.Oem2 || key == Key.Divide) && Keyboard.Modifiers == ModifierKeys.None;
     }
 
     private void BeginSearch()

--- a/QuickMail/Views/FolderPickerWindow.xaml.cs
+++ b/QuickMail/Views/FolderPickerWindow.xaml.cs
@@ -1,93 +1,136 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Data;
 using System.Windows.Input;
 using QuickMail.Models;
-using QuickMail.Services;
 
 namespace QuickMail.Views;
 
 /// <summary>
-/// Modal folder picker backed by a real WPF TreeView so screen readers
-/// announce role, level, expanded/collapsed state correctly.
+/// Fast modal folder picker backed by a virtualized flat list.
 /// </summary>
 public partial class FolderPickerWindow : Window
 {
-    private readonly Dictionary<MailFolderModel, AccountModel> _folderToAccount = new();
-    private MailFolderModel? _initialFolder;
+    private readonly ObservableCollection<FolderPickerItem> _items = [];
+    private readonly ICollectionView _view;
+    private readonly MailFolderModel? _initialFolder;
 
     public MailFolderModel? SelectedFolder { get; private set; }
     public AccountModel? SelectedAccount { get; private set; }
 
-    public FolderPickerWindow(IEnumerable<AccountModel> accounts, IReadOnlyDictionary<Guid, List<MailFolderModel>> cachedFolders, IEnumerable<MailFolderModel>? virtualFolders = null, string title = "Go to Folder", MailFolderModel? initialFolder = null)
+    public FolderPickerWindow(
+        IEnumerable<AccountModel> accounts,
+        IReadOnlyDictionary<Guid, List<MailFolderModel>> cachedFolders,
+        IEnumerable<MailFolderModel>? virtualFolders = null,
+        string title = "Go to Folder",
+        MailFolderModel? initialFolder = null)
     {
         _initialFolder = initialFolder;
 
         InitializeComponent();
         Title = title;
 
-        var roots = new List<FolderTreeNode>();
-
-        // "All Mail" group header with virtual sub-folder children at the top of the tree
-        var virtualList = virtualFolders?.ToList();
-        if (virtualList is { Count: > 0 })
+        if (virtualFolders != null)
         {
-            var allMailGroup = new FolderTreeNode { IsHeader = true, Label = "All Mail", IsExpanded = true };
-            foreach (var vf in virtualList)
-                allMailGroup.Children.Add(new FolderTreeNode { Folder = vf, Label = vf.DisplayName });
-            roots.Add(allMailGroup);
+            foreach (var vf in virtualFolders)
+                _items.Add(new FolderPickerItem(vf, null, vf.DisplayName, "All Mail"));
         }
 
         foreach (var account in accounts)
         {
-            if (!cachedFolders.TryGetValue(account.Id, out var folders) || folders.Count == 0) continue;
+            if (!cachedFolders.TryGetValue(account.Id, out var folders) || folders.Count == 0)
+                continue;
 
-            foreach (var f in folders)
-                _folderToAccount[f] = account;
-
-            var accountRoots = FolderTreeBuilder.Build(folders, account);
-            foreach (var r in accountRoots)
-                roots.Add(r);
+            foreach (var folder in folders
+                         .Where(f => !f.IsHeader)
+                         .OrderBy(f => IsInbox(f) ? 0 : 1)
+                         .ThenBy(f => f.FullName, StringComparer.OrdinalIgnoreCase))
+            {
+                var folderPath = string.IsNullOrWhiteSpace(folder.FullName)
+                    ? folder.DisplayName
+                    : folder.FullName;
+                _items.Add(new FolderPickerItem(
+                    folder,
+                    account,
+                    folderPath,
+                    $"{account.DisplayName} - {folderPath}"));
+            }
         }
 
-        FolderTreeView.ItemsSource = roots;
+        _view = CollectionViewSource.GetDefaultView(_items);
+        _view.Filter = FilterItem;
+        FolderListBox.ItemsSource = _view;
 
         Loaded += (_, _) =>
         {
-            if (_initialFolder == null)
-            {
-                FolderTreeView.Focus();
-                return;
-            }
-
-            // Ensure ancestors of the target node are expanded so their
-            // item containers get generated before we try to select.
-            FindAndExpandPath(roots, _initialFolder);
-
-            // Defer selection until after WPF has generated the new containers.
-            Dispatcher.InvokeAsync(() =>
-            {
-                var node = FindNode(roots, _initialFolder);
-                if (node != null)
-                    SelectTreeViewNode(FolderTreeView, node);
-                else
-                    FolderTreeView.Focus();
-            }, System.Windows.Threading.DispatcherPriority.Input);
+            SearchBox.Focus();
+            if (!TrySelectInitialFolder())
+                SelectFirstVisibleItem();
         };
     }
 
-    private void OpenButton_Click(object sender, RoutedEventArgs e) => Commit();
-
-    private void FolderTreeView_PreviewKeyDown(object sender, KeyEventArgs e)
+    // Backwards-compatible single-virtual-folder convenience constructor.
+    public FolderPickerWindow(
+        IEnumerable<AccountModel> accounts,
+        IReadOnlyDictionary<Guid, List<MailFolderModel>> cachedFolders,
+        MailFolderModel? allMailFolder,
+        string title = "Go to Folder")
+        : this(accounts, cachedFolders,
+               allMailFolder != null ? new[] { allMailFolder } : null,
+               title,
+               initialFolder: null)
     {
-        if (TryGetTypeAheadKeyText(e, out var searchText) && TryHandleFolderTreeTypeAhead(searchText))
-        {
-            e.Handled = true;
-            return;
-        }
+    }
 
+    private static bool IsInbox(MailFolderModel folder) =>
+        folder.FullName.Equals("INBOX", StringComparison.OrdinalIgnoreCase);
+
+    private bool FilterItem(object item)
+    {
+        if (item is not FolderPickerItem folder)
+            return false;
+
+        var query = SearchBox?.Text?.Trim();
+        if (string.IsNullOrEmpty(query))
+            return true;
+
+        return folder.SearchText.Contains(query, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private void SearchBox_TextChanged(object sender, TextChangedEventArgs e)
+    {
+        _view.Refresh();
+        SelectFirstVisibleItem();
+    }
+
+    private void SearchBox_PreviewKeyDown(object sender, KeyEventArgs e)
+    {
+        switch (e.Key)
+        {
+            case Key.Enter:
+                e.Handled = true;
+                Commit();
+                break;
+            case Key.Down:
+                e.Handled = true;
+                FolderListBox.Focus();
+                if (FolderListBox.SelectedIndex < 0)
+                    SelectFirstVisibleItem();
+                break;
+            case Key.Escape:
+                e.Handled = true;
+                DialogResult = false;
+                break;
+        }
+    }
+
+    private void FolderListBox_PreviewKeyDown(object sender, KeyEventArgs e)
+    {
         if (e.Key == Key.Enter)
         {
             e.Handled = true;
@@ -95,139 +138,67 @@ public partial class FolderPickerWindow : Window
         }
     }
 
-    // First-letter navigation for the folder TreeView (TreeView has no built-in TextSearch).
-    private void FolderTreeView_PreviewTextInput(object sender, TextCompositionEventArgs e)
+    private void FolderListBox_MouseDoubleClick(object sender, MouseButtonEventArgs e) => Commit();
+
+    private void OpenButton_Click(object sender, RoutedEventArgs e) => Commit();
+
+    private void SelectFirstVisibleItem()
     {
-        if (TryHandleFolderTreeTypeAhead(e.Text))
-            e.Handled = true;
+        var first = _view.Cast<FolderPickerItem>().FirstOrDefault();
+        FolderListBox.SelectedItem = first;
+        if (first != null)
+            FolderListBox.ScrollIntoView(first);
     }
 
-    private bool TryHandleFolderTreeTypeAhead(string? text)
+    private bool TrySelectInitialFolder()
     {
-        if (string.IsNullOrEmpty(text) || char.IsControl(text[0]))
+        if (_initialFolder == null)
             return false;
 
-        var allNodes = GetVisibleTreeNodes(FolderTreeView.Items.OfType<FolderTreeNode>()).ToList();
-        if (allNodes.Count == 0)
+        var match = _items.FirstOrDefault(i => FoldersMatch(i.Folder, _initialFolder));
+        if (match == null)
             return false;
 
-        var current = FolderTreeView.SelectedItem as FolderTreeNode;
-        var startIdx = current != null ? allNodes.IndexOf(current) : -1;
-
-        for (int i = 1; i <= allNodes.Count; i++)
-        {
-            var candidate = allNodes[(startIdx + i) % allNodes.Count];
-            if (!candidate.Label.StartsWith(text, StringComparison.OrdinalIgnoreCase))
-                continue;
-
-            return SelectTreeViewNode(FolderTreeView, candidate);
-        }
-
-        return false;
-    }
-
-    private static bool TryGetTypeAheadKeyText(KeyEventArgs e, out string text)
-    {
-        text = string.Empty;
-
-        if (Keyboard.Modifiers != ModifierKeys.None)
-            return false;
-
-        var key = e.Key == Key.System ? e.SystemKey : e.Key;
-        if (key is >= Key.A and <= Key.Z)
-        {
-            text = key.ToString();
-            return true;
-        }
-
-        if (key is >= Key.D0 and <= Key.D9)
-        {
-            text = ((char)('0' + (key - Key.D0))).ToString();
-            return true;
-        }
-
-        if (key is >= Key.NumPad0 and <= Key.NumPad9)
-        {
-            text = ((char)('0' + (key - Key.NumPad0))).ToString();
-            return true;
-        }
-
-        return false;
-    }
-
-    private static IEnumerable<FolderTreeNode> GetVisibleTreeNodes(IEnumerable<FolderTreeNode> nodes)
-    {
-        foreach (var node in nodes)
-        {
-            yield return node;
-            if (node.IsExpanded && node.Children.Count > 0)
-                foreach (var child in GetVisibleTreeNodes(node.Children))
-                    yield return child;
-        }
-    }
-
-    // Finds a node whose Folder matches the target, searching all nodes regardless of expansion.
-    private static FolderTreeNode? FindNode(IEnumerable<FolderTreeNode> nodes, MailFolderModel target)
-    {
-        foreach (var node in nodes)
-        {
-            if (node.Folder != null && FoldersMatch(node.Folder, target))
-                return node;
-            var found = FindNode(node.Children, target);
-            if (found != null) return found;
-        }
-        return null;
-    }
-
-    // Expands all ancestor nodes along the path to the target so their
-    // children's item containers are generated before SelectTreeViewNode runs.
-    private static bool FindAndExpandPath(IList<FolderTreeNode> nodes, MailFolderModel target)
-    {
-        foreach (var node in nodes)
-        {
-            if (node.Folder != null && FoldersMatch(node.Folder, target))
-                return true;
-            if (FindAndExpandPath(node.Children, target))
-            {
-                node.IsExpanded = true;
-                return true;
-            }
-        }
-        return false;
+        FolderListBox.SelectedItem = match;
+        FolderListBox.ScrollIntoView(match);
+        return true;
     }
 
     private static bool FoldersMatch(MailFolderModel a, MailFolderModel b) =>
         a.FullName.Equals(b.FullName, StringComparison.OrdinalIgnoreCase) &&
         (a.AccountId == b.AccountId || a.AccountId == Guid.Empty || b.AccountId == Guid.Empty);
 
-    private static bool SelectTreeViewNode(ItemsControl parent, FolderTreeNode target)
-    {
-        foreach (var item in parent.Items)
-        {
-            if (item is not FolderTreeNode node) continue;
-            if (parent.ItemContainerGenerator.ContainerFromItem(item) is not TreeViewItem container) continue;
-
-            if (node == target)
-            {
-                container.IsSelected = true;
-                container.BringIntoView();
-                container.Focus();
-                return true;
-            }
-            if (node.IsExpanded && SelectTreeViewNode(container, target))
-                return true;
-        }
-        return false;
-    }
-
     private void Commit()
     {
-        if (FolderTreeView.SelectedItem is FolderTreeNode node && node.Folder != null)
+        if (FolderListBox.SelectedItem is not FolderPickerItem item)
+            return;
+
+        SelectedFolder = item.Folder;
+        SelectedAccount = item.Account;
+        DialogResult = true;
+    }
+
+    private sealed class FolderPickerItem
+    {
+        public FolderPickerItem(
+            MailFolderModel folder,
+            AccountModel? account,
+            string folderPath,
+            string displayName)
         {
-            SelectedFolder = node.Folder;
-            _folderToAccount.TryGetValue(node.Folder, out var account);
-            SelectedAccount = account;
-            DialogResult = true;
+            Folder = folder;
+            Account = account;
+            FolderPath = folderPath;
+            DisplayName = displayName;
+            AccountName = account?.DisplayName ?? string.Empty;
+            SearchText = $"{DisplayName} {Folder.DisplayName} {Folder.FullName} {AccountName}";
         }
+
+        public MailFolderModel Folder { get; }
+        public AccountModel? Account { get; }
+        public string FolderPath { get; }
+        public string DisplayName { get; }
+        public string AccountName { get; }
+        public string SearchText { get; }
     }
 }

--- a/QuickMail/Views/MainWindow.xaml
+++ b/QuickMail/Views/MainWindow.xaml
@@ -320,6 +320,9 @@
                 <Separator/>
                 <MenuItem Header="Go to _Folder…"
                           Click="MenuFolderPicker_Click"/>
+                <MenuItem Header="_Search Folders…"
+                          Click="MenuSearchFolders_Click"
+                          InputGestureText="Ctrl+Shift+F"/>
                 <MenuItem Header="Command _Palette…"
                           Click="MenuCommandPalette_Click"
                           InputGestureText="Ctrl+Shift+P"/>

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -288,6 +288,11 @@ public partial class MainWindow : Window
             execute: OpenFolderPicker));
 
         _registry.Register(new CommandDefinition(
+            id: "view.searchFolders", category: "View", title: "Search Folders…",
+            execute: OpenFolderPicker,
+            defaultKey: Key.F, defaultModifiers: ModifierKeys.Control | ModifierKeys.Shift));
+
+        _registry.Register(new CommandDefinition(
             id: "view.openViewMenu", category: "View", title: "Open View Menu",
             execute: OpenViewMenu,
             defaultKey: Key.V, defaultModifiers: ModifierKeys.Control | ModifierKeys.Shift));
@@ -455,13 +460,6 @@ public partial class MainWindow : Window
             e.Handled = true;
             return;
         }
-        else if (modifiers == (ModifierKeys.Control | ModifierKeys.Shift) && key == Key.F)
-        {
-            OpenFolderPicker();
-            e.Handled = true;
-            return;
-        }
-
         // ── Registry-based action commands ───────────────────────────────────────
         var cmd = _registry.FindByGesture(key, modifiers);
         if (cmd != null && (cmd.IsAvailable?.Invoke() ?? true))

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -77,11 +77,30 @@ public partial class MainWindow : Window
     private object? _typeAheadScope;
     private int _messageBodyRenderVersion;
 
-    private const int MaxRichHtmlRenderChars = 180_000;
+    // Debounces SelectionChanged announces so rapid arrow-key bursts only emit
+    // one UIA notification per landing. Otherwise a burst can flood NVDA's event
+    // pipeline and synchronously block the WPF dispatcher (entire process stalls).
+    private DispatcherTimer? _announceTimer;
+    private string? _pendingAnnounceText;
+    private static readonly TimeSpan AnnounceDebounce = TimeSpan.FromMilliseconds(50);
+
+    private const int MaxRichHtmlRenderChars = 1_000_000;
     private const int MaxReaderTextChars = 140_000;
-    private const int MaxRichHtmlTableCount = 80;
+    private const int MaxRichHtmlTableCount = 500;
+
+    // NOTE: order matters — fields below reference these timeouts during static init.
     private static readonly TimeSpan HtmlRegexTimeout = TimeSpan.FromMilliseconds(500);
     private static readonly TimeSpan WebViewNavigationTimeout = TimeSpan.FromSeconds(4);
+
+    // Matches an http/https/mailto URL up to the first whitespace, angle bracket,
+    // or quote. Trailing punctuation (.,;:!?)] is trimmed in the replace step
+    // because senders write things like "see https://example.com/page." or
+    // "(https://example.com)" and we shouldn't swallow the closing punctuation.
+    private static readonly Regex AutoLinkUrl = new(
+        @"\b((?:https?|mailto):[^\s<>""']+)",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled,
+        HtmlRegexTimeout);
+    private static readonly char[] AutoLinkTrailingPunct = ['.', ',', ';', ':', '!', '?', ')', ']', '}', '>', '\''];
 
     public MainWindow(
         MainViewModel vm,
@@ -201,10 +220,12 @@ public partial class MainWindow : Window
         // Announce the newly selected message to the screen reader whenever the selection
         // changes via keyboard (arrow keys, etc.).  WPF ListView does not reliably fire
         // UIA focus events on arrow-key navigation, so RaiseNotificationEvent is required.
+        // Debounced — a held arrow key only announces the final landing, which keeps NVDA's
+        // UIA pipeline from being flooded (the flood causes whole-process stalls).
         MessageList.SelectionChanged += (_, _) =>
         {
             if (MessageList.IsKeyboardFocusWithin && MessageList.SelectedItem is MailMessageSummary msg)
-                AccessibilityHelper.Announce(this, MessageSummaryAnnouncement(msg), interrupt: true);
+                QueueSelectionAnnounce(MessageSummaryAnnouncement(msg));
         };
 
         // ── Focus-enter / focus-leave traces for every message panel ────────────
@@ -214,6 +235,31 @@ public partial class MainWindow : Window
         ConversationTree.LostKeyboardFocus += (_, e) => LogService.Debug($"[FOCUS] LostFocus ConvTree  to={e.NewFocus?.GetType().Name ?? "null"}");
         SenderGroupTree.GotKeyboardFocus   += (_, e) => LogService.Debug($"[FOCUS] GotFocus  SenderTree from={e.OldFocus?.GetType().Name ?? "null"} selectedItem={SenderGroupTree.SelectedItem?.GetType().Name ?? "null"}");
         SenderGroupTree.LostKeyboardFocus  += (_, e) => LogService.Debug($"[FOCUS] LostFocus SenderTree to={e.NewFocus?.GetType().Name ?? "null"}");
+    }
+
+    // Debounced UIA notification for rapid selection bursts. Each call resets the timer;
+    // the announce only fires after AnnounceDebounce of quiet, so a held arrow ends with
+    // exactly one notification on the final item.
+    private void QueueSelectionAnnounce(string text)
+    {
+        if (string.IsNullOrEmpty(text)) return;
+        _pendingAnnounceText = text;
+
+        if (_announceTimer == null)
+        {
+            _announceTimer = new DispatcherTimer { Interval = AnnounceDebounce };
+            _announceTimer.Tick += (_, _) =>
+            {
+                _announceTimer!.Stop();
+                var pending = _pendingAnnounceText;
+                _pendingAnnounceText = null;
+                if (!string.IsNullOrEmpty(pending))
+                    AccessibilityHelper.Announce(this, pending, interrupt: true);
+            };
+        }
+
+        _announceTimer.Stop();
+        _announceTimer.Start();
     }
 
     // On startup: initialise WebView2, connect to first account, open INBOX, focus message list
@@ -269,12 +315,7 @@ public partial class MainWindow : Window
             {
                 var msg = args.TryGetWebMessageAsString();
                 if (msg == "escape")
-                    Dispatcher.InvokeAsync(() =>
-                    {
-                        _vm.IsMessageOpen = false;
-                        _vm.MessageDetail = null;
-                        ReturnFocusToMessageList();
-                    }, DispatcherPriority.Input);
+                    Dispatcher.InvokeAsync(CloseReadingPane, DispatcherPriority.Input);
                 else if (msg == "f6")
                     Dispatcher.InvokeAsync(() => _ = CycleFocusAsync(true), DispatcherPriority.Input);
                 else if (msg == "shift-f6")
@@ -284,6 +325,29 @@ public partial class MainWindow : Window
                 else if (msg == "shift-tab")
                     Dispatcher.InvokeAsync(FocusLastHeaderField, DispatcherPriority.Input);
             };
+
+            // Open clicked links in the user's default browser instead of replacing
+            // the reading-pane document. NavigateToString sets the document URI to
+            // "about:blank", so allow that for the initial render and block everything else.
+            MessageBody.CoreWebView2.NavigationStarting += (_, args) =>
+            {
+                var uri = args.Uri;
+                if (string.IsNullOrEmpty(uri) ||
+                    uri.StartsWith("about:", StringComparison.OrdinalIgnoreCase) ||
+                    uri.StartsWith("data:", StringComparison.OrdinalIgnoreCase))
+                    return;
+                args.Cancel = true;
+                OpenExternal(uri);
+            };
+            MessageBody.CoreWebView2.NewWindowRequested += (_, args) =>
+            {
+                args.Handled = true;
+                OpenExternal(args.Uri);
+            };
+
+            // WebView2 renderer crash signal — surfaces as a blank reading pane.
+            MessageBody.CoreWebView2.ProcessFailed += (_, args) =>
+                LogService.Log($"[ERROR] WebView2 ProcessFailed kind={args.ProcessFailedKind} exit={args.ExitCode} reason={args.Reason}");
         }
         catch (Exception ex)
         {
@@ -351,9 +415,7 @@ public partial class MainWindow : Window
                     await CycleFocusAsync(true);
                     return;
                 case Key.Escape when _vm.IsMessageOpen:
-                    _vm.IsMessageOpen = false;
-                    _vm.MessageDetail = null;
-                    ReturnFocusToMessageList();
+                    CloseReadingPane();
                     e.Handled = true;
                     return;
             }
@@ -1095,6 +1157,10 @@ public partial class MainWindow : Window
         }
 
         MessageBody.CoreWebView2.NavigationCompleted += OnNavigated;
+        // Cancel any prior in-flight navigation before starting this one so we don't
+        // queue two pending navigations on the WebView2 renderer.
+        try { MessageBody.CoreWebView2.Stop(); }
+        catch (Exception ex) { LogService.Log("ShowMessageBody/Stop", ex); }
         MessageBody.CoreWebView2.NavigateToString(html);
 
         var completed = await Task.WhenAny(tcs.Task, Task.Delay(WebViewNavigationTimeout)) == tcs.Task;
@@ -1112,11 +1178,12 @@ public partial class MainWindow : Window
 
     private async Task FocusMessageBodyAsync(int renderVersion, string? subject)
     {
-        if (renderVersion != _messageBodyRenderVersion || !_webViewReady)
+        if (renderVersion != _messageBodyRenderVersion || !_webViewReady || !_vm.IsMessageOpen)
             return;
 
         await Dispatcher.InvokeAsync(() =>
         {
+            if (!_vm.IsMessageOpen) return;
             MessageBody.Focus();
             Keyboard.Focus(MessageBody);
         }, DispatcherPriority.Input);
@@ -1124,7 +1191,7 @@ public partial class MainWindow : Window
         var focusLabel = MessageBodyFocusLabel(subject);
         for (var attempt = 0; attempt < 5; attempt++)
         {
-            if (renderVersion != _messageBodyRenderVersion)
+            if (renderVersion != _messageBodyRenderVersion || !_vm.IsMessageOpen)
                 return;
 
             await Dispatcher.InvokeAsync(FocusMessageBodyHost, DispatcherPriority.Input);
@@ -1143,11 +1210,12 @@ public partial class MainWindow : Window
             await Task.Delay(100);
         }
 
-        if (renderVersion != _messageBodyRenderVersion)
+        if (renderVersion != _messageBodyRenderVersion || !_vm.IsMessageOpen)
             return;
 
         await Dispatcher.InvokeAsync(() =>
         {
+            if (!_vm.IsMessageOpen) return;
             FocusMessageBodyHost();
             AccessibilityHelper.Announce(this, focusLabel, interrupt: true);
         }, DispatcherPriority.Input);
@@ -1155,6 +1223,8 @@ public partial class MainWindow : Window
 
     private void FocusMessageBodyHost()
     {
+        if (!_vm.IsMessageOpen) return;
+
         MessageBody.Focus();
         Keyboard.Focus(MessageBody);
 
@@ -1217,8 +1287,11 @@ public partial class MainWindow : Window
 
     private static bool ShouldUseReaderMode(string html) =>
         html.Length > MaxRichHtmlRenderChars ||
-        CountOccurrences(html, "<table") > MaxRichHtmlTableCount ||
-        CountOccurrences(html, "data:image", StringComparison.OrdinalIgnoreCase) > 0;
+        CountOccurrences(html, "<table") > MaxRichHtmlTableCount;
+    // data:image used to force reader mode, but <img> tags are stripped by
+    // StripHeavyHtml and blocked by CSP img-src 'none' anyway, so the size of the
+    // base64 payload doesn't actually slow rendering. Newsletter logos no longer
+    // force reader mode.
 
     private static string BuildSanitizedHtmlDocument(string? subject, string html)
     {
@@ -1251,6 +1324,7 @@ public partial class MainWindow : Window
     {
         var clipped = Truncate(text ?? string.Empty, MaxReaderTextChars);
         var encoded = WebUtility.HtmlEncode(clipped);
+        var linked  = AutoLinkPlainTextUrls(encoded);
         var titleTag = $"<title>{WebUtility.HtmlEncode(subject ?? string.Empty)}</title>";
         var noteHtml = string.IsNullOrWhiteSpace(note)
             ? string.Empty
@@ -1261,8 +1335,45 @@ public partial class MainWindow : Window
                "<meta http-equiv=\"Content-Security-Policy\" content=\"default-src 'none'; style-src 'unsafe-inline';\">" +
                "<style>html,body{margin:0;padding:8px 12px;font-family:Segoe UI,Arial,sans-serif;" +
                "font-size:13px;white-space:pre-wrap;word-break:break-word;background:Window;color:WindowText;}" +
+               "a{color:#0645ad;}" +
                ".note{white-space:normal;border-left:3px solid #777;padding-left:8px;margin:0 0 12px 0;color:#555;}</style>" +
-               "</head><body tabindex=\"0\">" + noteHtml + encoded + "</body></html>";
+               "</head><body tabindex=\"0\">" + noteHtml + linked + "</body></html>";
+    }
+
+    // Wrap http/https/mailto runs in <a> tags so plain-text emails get clickable links.
+    // Operates on already-HTML-encoded text, so we won't double-encode the URL value.
+    private static string AutoLinkPlainTextUrls(string encoded)
+    {
+        try
+        {
+            return AutoLinkUrl.Replace(encoded, m =>
+            {
+                var url = m.Value;
+                var trailing = string.Empty;
+                while (url.Length > 0 && Array.IndexOf(AutoLinkTrailingPunct, url[^1]) >= 0)
+                {
+                    trailing = url[^1] + trailing;
+                    url = url[..^1];
+                }
+                if (url.Length == 0) return m.Value;
+                // url is already HTML-encoded so it's safe to put it in href and as text
+                return $"<a href=\"{url}\" rel=\"nofollow noreferrer\">{url}</a>{trailing}";
+            });
+        }
+        catch (RegexMatchTimeoutException) { return encoded; }
+    }
+
+    private static void OpenExternal(string uri)
+    {
+        if (string.IsNullOrWhiteSpace(uri)) return;
+        try
+        {
+            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(uri) { UseShellExecute = true });
+        }
+        catch (Exception ex)
+        {
+            LogService.Log($"OpenExternal {uri}", ex);
+        }
     }
 
     private static string StripHeavyHtml(string html)
@@ -1358,6 +1469,24 @@ public partial class MainWindow : Window
             ReadingPaneAttachmentList.Focus();
         else
             DateField.Focus();
+    }
+
+    // Close the reading pane safely: cancel any in-flight render/focus chain and
+    // stop WebView2 navigation before flipping Visibility so the IsVisible=false
+    // COM call doesn't race with a busy renderer (was a "Not Responding" stall).
+    private void CloseReadingPane()
+    {
+        Interlocked.Increment(ref _messageBodyRenderVersion);
+
+        if (_webViewReady)
+        {
+            try { MessageBody.CoreWebView2.Stop(); }
+            catch (Exception ex) { LogService.Log("CloseReadingPane/Stop", ex); }
+        }
+
+        _vm.IsMessageOpen = false;
+        _vm.MessageDetail = null;
+        ReturnFocusToMessageList();
     }
 
     // Return keyboard focus to the active message panel after reading a message.
@@ -1589,10 +1718,10 @@ public partial class MainWindow : Window
             switch (e.NewValue)
             {
                 case MailMessageSummary m:
-                    AccessibilityHelper.Announce(this, MessageSummaryAnnouncement(m), interrupt: true);
+                    QueueSelectionAnnounce(MessageSummaryAnnouncement(m));
                     break;
                 case ConversationGroup grp:
-                    AccessibilityHelper.Announce(this, grp.AutomationName, interrupt: true);
+                    QueueSelectionAnnounce(grp.AutomationName);
                     break;
             }
         }

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -4,12 +4,16 @@ using System.IO;
 using System.Globalization;
 using System.Linq;
 using System.Net;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Data;
 using System.Windows.Input;
+using System.Windows.Interop;
 using System.Windows.Threading;
 using Microsoft.Web.WebView2.Core;
 using QuickMail.Models;
@@ -71,6 +75,13 @@ public partial class MainWindow : Window
     private string _typeAheadBuffer = string.Empty;
     private DateTime _typeAheadLastInputUtc = DateTime.MinValue;
     private object? _typeAheadScope;
+    private int _messageBodyRenderVersion;
+
+    private const int MaxRichHtmlRenderChars = 180_000;
+    private const int MaxReaderTextChars = 140_000;
+    private const int MaxRichHtmlTableCount = 80;
+    private static readonly TimeSpan HtmlRegexTimeout = TimeSpan.FromMilliseconds(500);
+    private static readonly TimeSpan WebViewNavigationTimeout = TimeSpan.FromSeconds(4);
 
     public MainWindow(
         MainViewModel vm,
@@ -210,9 +221,13 @@ public partial class MainWindow : Window
     {
         // Register commands that require UI access (must run after InitializeComponent).
         _registry.Register(new CommandDefinition(
+            id: "view.focusFolders", category: "View", title: "Focus Folder Tree",
+            execute: FocusFolderTree,
+            defaultKey: Key.D2, defaultModifiers: ModifierKeys.Control));
+
+        _registry.Register(new CommandDefinition(
             id: "view.folderPicker", category: "View", title: "Go to Folder…",
-            execute: OpenFolderPicker,
-            defaultKey: Key.Y, defaultModifiers: ModifierKeys.Control));
+            execute: OpenFolderPicker));
 
         _registry.Register(new CommandDefinition(
             id: "view.openViewMenu", category: "View", title: "Open View Menu",
@@ -244,6 +259,7 @@ public partial class MainWindow : Window
                 "window.addEventListener('keydown',function(e){"
                 +"if(e.key==='Escape'){window.chrome.webview.postMessage('escape');e.preventDefault();}"
                 +"else if(e.key==='F6'){window.chrome.webview.postMessage(e.shiftKey?'shift-f6':'f6');e.preventDefault();}"
+                +"else if(e.ctrlKey&&(e.key==='2'||e.key==='y'||e.key==='Y')){window.chrome.webview.postMessage('focus-folders');e.preventDefault();}"
                 +"else if(e.key==='Tab'&&e.shiftKey){window.chrome.webview.postMessage('shift-tab');e.preventDefault();}"
                 +"});");
 
@@ -263,6 +279,8 @@ public partial class MainWindow : Window
                     Dispatcher.InvokeAsync(() => _ = CycleFocusAsync(true), DispatcherPriority.Input);
                 else if (msg == "shift-f6")
                     Dispatcher.InvokeAsync(() => _ = CycleFocusAsync(false), DispatcherPriority.Input);
+                else if (msg == "focus-folders")
+                    Dispatcher.InvokeAsync(FocusFolderTree, DispatcherPriority.Input);
                 else if (msg == "shift-tab")
                     Dispatcher.InvokeAsync(FocusLastHeaderField, DispatcherPriority.Input);
             };
@@ -292,7 +310,11 @@ public partial class MainWindow : Window
     private async void OnWindowKeyDown(object sender, KeyEventArgs e)
     {
         var modifiers = e.KeyboardDevice.Modifiers;
-        var key       = e.Key;
+        var key = e.Key == Key.System
+            ? e.SystemKey
+            : e.Key == Key.ImeProcessed
+                ? e.ImeProcessedKey
+                : e.Key;
 
         // ── Navigation shortcuts (hardcoded, not in the command registry) ──────────
         if (modifiers == ModifierKeys.Control)
@@ -301,7 +323,12 @@ public partial class MainWindow : Window
             {
                 case Key.D0: ToolbarFirstButton.Focus(); e.Handled = true; return;
                 case Key.D1: AccountList.Focus();        e.Handled = true; return;
-                case Key.D2: FolderList.Focus();         e.Handled = true; return;
+                case Key.D2:
+                case Key.NumPad2:
+                case Key.Y:
+                    FocusFolderTree();
+                    e.Handled = true;
+                    return;
                 case Key.D3:
                     if (_vm.IsConversationsView)
                         ConversationTree.Focus();
@@ -385,13 +412,48 @@ public partial class MainWindow : Window
         cm.IsOpen = true;
     }
 
+    private void FocusFolderTree()
+    {
+        if (FolderList.Items.Count == 0)
+        {
+            _vm.StatusText = "Folders are still loading.";
+            return;
+        }
+
+        FolderList.Focus();
+        Dispatcher.InvokeAsync(() =>
+        {
+            if (FolderList.SelectedItem is FolderTreeNode selected &&
+                SelectTreeViewNode(FolderList, selected))
+                return;
+
+            if (FolderList.ItemContainerGenerator.ContainerFromIndex(0) is TreeViewItem first)
+            {
+                first.IsSelected = true;
+                first.Focus();
+                return;
+            }
+
+            FolderList.Focus();
+        }, DispatcherPriority.Input);
+    }
+
     private async void OpenFolderPicker()
     {
-        if (_vm.CachedFolders.Count == 0) return;
-        var picker = new FolderPickerWindow(_vm.Accounts, _vm.CachedFolders,
-            [MainViewModel.AllInboxesFolder, MainViewModel.AllMailFolder,
-             MainViewModel.AllDraftsFolder,  MainViewModel.AllSentFolder,
-             MainViewModel.AllTrashFolder],
+        if (_vm.CachedFolders.Count == 0)
+        {
+            _vm.StatusText = "Folders are still loading.";
+            return;
+        }
+        var picker = new FolderPickerWindow(
+            _vm.Accounts,
+            _vm.CachedFolders,
+            new[]
+            {
+                MainViewModel.AllInboxesFolder, MainViewModel.AllMailFolder,
+                MainViewModel.AllDraftsFolder,  MainViewModel.AllSentFolder,
+                MainViewModel.AllTrashFolder
+            },
             initialFolder: _vm.SelectedFolder) { Owner = this };
         if (picker.ShowDialog() == true && picker.SelectedFolder is MailFolderModel folder)
         {
@@ -1018,63 +1080,257 @@ public partial class MainWindow : Window
     {
         if (!_webViewReady) return;
 
-        var encodedSubject = WebUtility.HtmlEncode(detail.Subject ?? string.Empty);
-        var titleTag = $"<title>{encodedSubject}</title>";
-
-        string html;
-        if (!string.IsNullOrWhiteSpace(detail.HtmlBody))
-        {
-            // Render the sender's HTML directly.
-            // Inject a tight CSP that blocks email-embedded scripts; our Escape relay
-            // was added via AddScriptToExecuteOnDocumentCreatedAsync and is unaffected by CSP.
-            const string cspTag =
-                "<meta http-equiv=\"Content-Security-Policy\" " +
-                "content=\"script-src 'none'; object-src 'none'; frame-src 'none';\">";
-            var body = detail.HtmlBody;
-
-            // Replace any existing <title> so screen readers announce our subject, not the sender's.
-            body = System.Text.RegularExpressions.Regex.Replace(
-                body, @"<title[^>]*>.*?</title>", string.Empty,
-                System.Text.RegularExpressions.RegexOptions.IgnoreCase |
-                System.Text.RegularExpressions.RegexOptions.Singleline);
-
-            var headIdx = body.IndexOf("<head>", StringComparison.OrdinalIgnoreCase);
-            html = headIdx >= 0
-                ? body.Insert(headIdx + 6, titleTag + cspTag)
-                : titleTag + cspTag + body;
-        }
-        else
-        {
-            // Plain-text fallback: HTML-encode so tags/special chars are safe
-            var encoded = WebUtility.HtmlEncode(detail.PlainTextBody ?? string.Empty);
-            html =
-                "<!DOCTYPE html>\n" +
-                "<html lang=\"en\">\n" +
-                $"<head><meta charset=\"utf-8\">{titleTag}<style>\n" +
-                "html,body{margin:0;padding:8px 12px;font-family:Segoe UI,Arial,sans-serif;" +
-                "font-size:13px;white-space:pre-wrap;word-break:break-word;" +
-                "background:Window;color:WindowText;outline:none;}\n" +
-                "</style></head>\n" +
-                "<body tabindex=\"0\">" + encoded + "</body>\n" +
-                "</html>";
-        }
+        var renderVersion = Interlocked.Increment(ref _messageBodyRenderVersion);
+        var html = await Task.Run(() => BuildMessageHtml(detail));
+        if (renderVersion != _messageBodyRenderVersion)
+            return;
 
         // Wait for navigation to finish before focusing so the screen reader
-        // gets the fully rendered document, not a blank page.
-        var tcs = new TaskCompletionSource<bool>();
+        // gets the rendered document, but never let a complex sender HTML wait forever.
+        var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         void OnNavigated(object? s, CoreWebView2NavigationCompletedEventArgs ev)
         {
             MessageBody.CoreWebView2.NavigationCompleted -= OnNavigated;
             tcs.TrySetResult(ev.IsSuccess);
         }
+
         MessageBody.CoreWebView2.NavigationCompleted += OnNavigated;
         MessageBody.CoreWebView2.NavigateToString(html);
 
-        await tcs.Task;
+        var completed = await Task.WhenAny(tcs.Task, Task.Delay(WebViewNavigationTimeout)) == tcs.Task;
+        if (!completed)
+        {
+            MessageBody.CoreWebView2.NavigationCompleted -= OnNavigated;
+            LogService.Log($"ShowMessageBody: WebView navigation timed out for UID {detail.UniqueId}");
+        }
 
-        // Give focus to the browser control and push keyboard focus into <body>
+        if (renderVersion != _messageBodyRenderVersion)
+            return;
+
+        await FocusMessageBodyAsync(renderVersion, detail.Subject);
+    }
+
+    private async Task FocusMessageBodyAsync(int renderVersion, string? subject)
+    {
+        if (renderVersion != _messageBodyRenderVersion || !_webViewReady)
+            return;
+
+        await Dispatcher.InvokeAsync(() =>
+        {
+            MessageBody.Focus();
+            Keyboard.Focus(MessageBody);
+        }, DispatcherPriority.Input);
+
+        var focusLabel = MessageBodyFocusLabel(subject);
+        for (var attempt = 0; attempt < 5; attempt++)
+        {
+            if (renderVersion != _messageBodyRenderVersion)
+                return;
+
+            await Dispatcher.InvokeAsync(FocusMessageBodyHost, DispatcherPriority.Input);
+
+            try
+            {
+                if (await TryFocusMessageBodyDocumentAsync(focusLabel))
+                    break;
+            }
+            catch (Exception ex)
+            {
+                if (attempt == 4)
+                    LogService.Log("FocusMessageBody", ex);
+            }
+
+            await Task.Delay(100);
+        }
+
+        if (renderVersion != _messageBodyRenderVersion)
+            return;
+
+        await Dispatcher.InvokeAsync(() =>
+        {
+            FocusMessageBodyHost();
+            AccessibilityHelper.Announce(this, focusLabel, interrupt: true);
+        }, DispatcherPriority.Input);
+    }
+
+    private void FocusMessageBodyHost()
+    {
         MessageBody.Focus();
-        await MessageBody.CoreWebView2.ExecuteScriptAsync("document.body.focus()");
+        Keyboard.Focus(MessageBody);
+
+        try
+        {
+            ((IKeyboardInputSink)MessageBody).TabInto(
+                new TraversalRequest(FocusNavigationDirection.First));
+        }
+        catch (Exception ex)
+        {
+            LogService.Log("FocusMessageBodyHost", ex);
+        }
+    }
+
+    private async Task<bool> TryFocusMessageBodyDocumentAsync(string focusLabel)
+    {
+        var bodyLabel = JsonSerializer.Serialize(focusLabel);
+        var result = await MessageBody.CoreWebView2.ExecuteScriptAsync(
+            "(() => {" +
+            "const body = document.body;" +
+            "if (!body) return false;" +
+            "window.focus();" +
+            "body.setAttribute('tabindex','0');" +
+            "body.setAttribute('role','document');" +
+            $"body.setAttribute('aria-label',{bodyLabel});" +
+            "body.focus({preventScroll:true});" +
+            "return document.hasFocus() && document.activeElement === body;" +
+            "})()");
+
+        return string.Equals(result, "true", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string MessageBodyFocusLabel(string? subject)
+    {
+        if (string.IsNullOrWhiteSpace(subject))
+            return "Message body";
+
+        var trimmed = subject.Trim();
+        if (trimmed.Length > 120)
+            trimmed = trimmed[..120] + "...";
+
+        return $"Message body. {trimmed}";
+    }
+
+    private static string BuildMessageHtml(MailMessageDetail detail)
+    {
+        var htmlBody = detail.HtmlBody ?? string.Empty;
+        if (!string.IsNullOrWhiteSpace(htmlBody) && !ShouldUseReaderMode(htmlBody))
+            return BuildSanitizedHtmlDocument(detail.Subject, htmlBody);
+
+        var text = !string.IsNullOrWhiteSpace(detail.PlainTextBody)
+            ? detail.PlainTextBody
+            : HtmlToText(htmlBody);
+
+        var note = !string.IsNullOrWhiteSpace(htmlBody)
+            ? "This message uses complex HTML, so QuickMail is showing a simplified body."
+            : null;
+        return BuildPlainTextHtmlDocument(detail.Subject, text, note);
+    }
+
+    private static bool ShouldUseReaderMode(string html) =>
+        html.Length > MaxRichHtmlRenderChars ||
+        CountOccurrences(html, "<table") > MaxRichHtmlTableCount ||
+        CountOccurrences(html, "data:image", StringComparison.OrdinalIgnoreCase) > 0;
+
+    private static string BuildSanitizedHtmlDocument(string? subject, string html)
+    {
+        var body = StripHeavyHtml(html);
+        var titleTag = $"<title>{WebUtility.HtmlEncode(subject ?? string.Empty)}</title>";
+        const string cspTag =
+            "<meta http-equiv=\"Content-Security-Policy\" " +
+            "content=\"default-src 'none'; script-src 'none'; object-src 'none'; " +
+            "frame-src 'none'; img-src 'none'; media-src 'none'; connect-src 'none'; " +
+            "form-action 'none'; base-uri 'none'; style-src 'unsafe-inline';\">";
+        const string css =
+            "<style>html,body{margin:0;padding:8px 12px;font-family:Segoe UI,Arial,sans-serif;" +
+            "font-size:13px;line-height:1.45;word-break:break-word;background:Window;color:WindowText;}" +
+            "table{max-width:100%;border-collapse:collapse;}td,th{vertical-align:top;}a{color:#0645ad;}</style>";
+
+        var headIdx = body.IndexOf("<head>", StringComparison.OrdinalIgnoreCase);
+        if (headIdx >= 0)
+        {
+            body = RemoveTitle(body);
+            body = body.Insert(headIdx + 6, "<meta charset=\"utf-8\">" + titleTag + cspTag + css);
+            return EnsureBodyFocusable(body);
+        }
+
+        return "<!DOCTYPE html><html lang=\"en\"><head><meta charset=\"utf-8\">" +
+               titleTag + cspTag + css +
+               "</head><body tabindex=\"0\">" + body + "</body></html>";
+    }
+
+    private static string BuildPlainTextHtmlDocument(string? subject, string text, string? note)
+    {
+        var clipped = Truncate(text ?? string.Empty, MaxReaderTextChars);
+        var encoded = WebUtility.HtmlEncode(clipped);
+        var titleTag = $"<title>{WebUtility.HtmlEncode(subject ?? string.Empty)}</title>";
+        var noteHtml = string.IsNullOrWhiteSpace(note)
+            ? string.Empty
+            : "<p class=\"note\">" + WebUtility.HtmlEncode(note) + "</p>";
+
+        return "<!DOCTYPE html><html lang=\"en\"><head><meta charset=\"utf-8\">" +
+               titleTag +
+               "<meta http-equiv=\"Content-Security-Policy\" content=\"default-src 'none'; style-src 'unsafe-inline';\">" +
+               "<style>html,body{margin:0;padding:8px 12px;font-family:Segoe UI,Arial,sans-serif;" +
+               "font-size:13px;white-space:pre-wrap;word-break:break-word;background:Window;color:WindowText;}" +
+               ".note{white-space:normal;border-left:3px solid #777;padding-left:8px;margin:0 0 12px 0;color:#555;}</style>" +
+               "</head><body tabindex=\"0\">" + noteHtml + encoded + "</body></html>";
+    }
+
+    private static string StripHeavyHtml(string html)
+    {
+        var body = html;
+        body = SafeRegexReplace(body, "<!--.*?-->", string.Empty, RegexOptions.Singleline);
+        body = SafeRegexReplace(body, "<script\\b.*?</script>", string.Empty, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+        body = SafeRegexReplace(body, "<style\\b.*?</style>", string.Empty, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+        body = SafeRegexReplace(body, "<svg\\b.*?</svg>", string.Empty, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+        body = SafeRegexReplace(body, "<(iframe|object|embed|video|audio|canvas|form)\\b.*?</\\1>", string.Empty, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+        body = SafeRegexReplace(body, "<(img|link|base|input|button|meta)\\b[^>]*>", string.Empty, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+        body = SafeRegexReplace(body, "\\s(on\\w+|style|src|srcset|background)\\s*=\\s*(\"[^\"]*\"|'[^']*'|[^\\s>]+)", string.Empty, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+        return body;
+    }
+
+    private static string RemoveTitle(string html) =>
+        SafeRegexReplace(html, "<title[^>]*>.*?</title>", string.Empty, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+    private static string EnsureBodyFocusable(string html)
+    {
+        if (!html.Contains("<body", StringComparison.OrdinalIgnoreCase) ||
+            html.Contains("tabindex=", StringComparison.OrdinalIgnoreCase))
+            return html;
+
+        return SafeRegexReplace(html, "<body\\b", "<body tabindex=\"0\"", RegexOptions.IgnoreCase);
+    }
+
+    private static string HtmlToText(string html)
+    {
+        if (string.IsNullOrWhiteSpace(html)) return string.Empty;
+        var text = StripHeavyHtml(html);
+        text = SafeRegexReplace(text, "<br\\s*/?>", "\n", RegexOptions.IgnoreCase);
+        text = SafeRegexReplace(text, "</(p|div|tr|li|h[1-6])>", "\n", RegexOptions.IgnoreCase);
+        text = SafeRegexReplace(text, "<[^>]+>", " ", RegexOptions.Singleline);
+        text = WebUtility.HtmlDecode(text);
+        text = SafeRegexReplace(text, "[ \\t\\r\\f\\v]+", " ", RegexOptions.None);
+        text = SafeRegexReplace(text, "\\n\\s+|\\s+\\n", "\n", RegexOptions.None);
+        text = SafeRegexReplace(text, "\\n{3,}", "\n\n", RegexOptions.None);
+        return text.Trim();
+    }
+
+    private static string SafeRegexReplace(string input, string pattern, string replacement, RegexOptions options)
+    {
+        try { return Regex.Replace(input, pattern, replacement, options, HtmlRegexTimeout); }
+        catch (RegexMatchTimeoutException)
+        {
+            LogService.Log($"HTML cleanup timed out for pattern: {pattern}");
+            return input;
+        }
+    }
+
+    private static string Truncate(string value, int maxChars)
+    {
+        if (value.Length <= maxChars) return value;
+        return value[..maxChars] + "\n\n[Message truncated for display.]";
+    }
+
+    private static int CountOccurrences(
+        string value, string needle, StringComparison comparison = StringComparison.OrdinalIgnoreCase)
+    {
+        var count = 0;
+        var index = 0;
+        while ((index = value.IndexOf(needle, index, comparison)) >= 0)
+        {
+            count++;
+            index += needle.Length;
+        }
+        return count;
     }
 
     // When the WebView2 host receives WPF keyboard focus (e.g. Tab from a header field),
@@ -1082,7 +1338,16 @@ public partial class MainWindow : Window
     private async void MessageBody_GotKeyboardFocus(object sender, KeyboardFocusChangedEventArgs e)
     {
         if (_webViewReady)
-            await MessageBody.CoreWebView2.ExecuteScriptAsync("document.body.focus()");
+        {
+            try
+            {
+                await TryFocusMessageBodyDocumentAsync(MessageBodyFocusLabel(_vm.MessageDetail?.Subject));
+            }
+            catch (Exception ex)
+            {
+                LogService.Log("MessageBody_GotKeyboardFocus", ex);
+            }
+        }
     }
 
     // Focuses the last visible field in the reading-pane header so Shift+Tab from the
@@ -1186,8 +1451,7 @@ public partial class MainWindow : Window
             case 4:
                 if (_vm.IsMessageOpen && _webViewReady)
                 {
-                    MessageBody.Focus();
-                    await MessageBody.CoreWebView2.ExecuteScriptAsync("document.body.focus()");
+                    await FocusMessageBodyAsync(_messageBodyRenderVersion, _vm.MessageDetail?.Subject);
                 }
                 else
                 {

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -455,6 +455,12 @@ public partial class MainWindow : Window
             e.Handled = true;
             return;
         }
+        else if (modifiers == (ModifierKeys.Control | ModifierKeys.Shift) && key == Key.F)
+        {
+            OpenFolderPicker();
+            e.Handled = true;
+            return;
+        }
 
         // ── Registry-based action commands ───────────────────────────────────────
         var cmd = _registry.FindByGesture(key, modifiers);
@@ -2372,6 +2378,9 @@ public partial class MainWindow : Window
         => OpenCommandPalette();
 
     private void MenuFolderPicker_Click(object sender, RoutedEventArgs e)
+        => OpenFolderPicker();
+
+    private void MenuSearchFolders_Click(object sender, RoutedEventArgs e)
         => OpenFolderPicker();
 
     private async void MenuMoveToFolder_Click(object sender, RoutedEventArgs e)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A keyboard-first WPF desktop email client for Windows. Multi-account IMAP/SMTP w
 - **Conversation view** — threads grouped by subject with collapsible tree
 - **Pooled IMAP connections** — background sync, previews, attachment downloads, and message opening can run without reusing a busy IMAP connection
 - **Folder tree shortcut** — Ctrl+2 or Ctrl+Y moves focus to the main folder tree
+- **Search folders** — Ctrl+Shift+F opens a virtualized flat folder list; press / in the list to search
 - **Responsive reading pane** — complex marketing HTML falls back to a simplified reader mode
 - **HTML rendering** — WebView2 with strict CSP (no email-embedded scripts)
 - **Keyboard-first** — full navigation, reply, forward, and delete.
@@ -49,6 +50,7 @@ dotnet run --project QuickMail
 | Ctrl+R | Reply |
 | Ctrl+Shift+R | Reply all |
 | Ctrl+F | Forward |
+| Ctrl+Shift+F | Search folders |
 | Delete | Delete selected message(s) / conversation |
 | Escape | Close reading pane |
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ A keyboard-first WPF desktop email client for Windows. Multi-account IMAP/SMTP w
 - **Multi-account** — connect any number of IMAP/SMTP accounts simultaneously
 - **Unified inbox** — all mail from all accounts in one sorted view
 - **Conversation view** — threads grouped by subject with collapsible tree
+- **Pooled IMAP connections** — background sync, previews, attachment downloads, and message opening can run without reusing a busy IMAP connection
+- **Folder tree shortcut** — Ctrl+2 or Ctrl+Y moves focus to the main folder tree
+- **Responsive reading pane** — complex marketing HTML falls back to a simplified reader mode
 - **HTML rendering** — WebView2 with strict CSP (no email-embedded scripts)
 - **Keyboard-first** — full navigation, reply, forward, and delete.
 - **Secure credentials** — passwords stored in Windows Credential Manager, never in plain text
@@ -36,15 +39,16 @@ dotnet run --project QuickMail
 
 | Key | Action |
 |-----|--------|
-| Ctrl+0 | Focus account list |
-| Ctrl+1 | Focus folder list |
-| Ctrl+2 | Focus message list / conversation tree |
-| Ctrl+3 | Focus reading pane |
+| Ctrl+0 | Focus toolbar |
+| Ctrl+1 | Focus account list |
+| Ctrl+2 / Ctrl+Y | Focus folder tree |
+| Ctrl+3 | Focus message list / conversation tree |
+| Ctrl+9 | Focus status bar |
+| F6 / Shift+F6 | Cycle through panes |
 | Ctrl+N | New message |
 | Ctrl+R | Reply |
 | Ctrl+Shift+R | Reply all |
 | Ctrl+F | Forward |
-| Ctrl+Y | Folder picker |
 | Delete | Delete selected message(s) / conversation |
 | Escape | Close reading pane |
 
@@ -57,7 +61,7 @@ QuickMail/
 │   ├── MainWindow.xaml(.cs) # 3-pane layout; keyboard nav; WebView2
 │   ├── ComposeWindow.xaml   # New / Reply / Forward
 │   ├── AccountManagerDialog.xaml
-│   └── FolderPickerWindow.xaml  # Ctrl+Y quick nav
+│   └── FolderPickerWindow.xaml  # Destination picker for move/copy/go-to-folder commands
 ├── ViewModels/
 │   ├── MainViewModel.cs     # Master state
 │   ├── ComposeViewModel.cs
@@ -69,6 +73,8 @@ QuickMail/
 │   ├── ConversationBuilder.cs
 │   ├── AccountService.cs    # Persist accounts to %APPDATA%\QuickMail\
 │   ├── CredentialService.cs # Windows Credential Manager
+│   ├── ConfigService.cs     # config.ini + hotkey settings
+│   ├── LocalStoreService.cs # SQLite cache
 │   └── LogService.cs
 └── Models/
     ├── AccountModel.cs
@@ -97,5 +103,12 @@ This triggers a GitHub Release with the self-contained exe attached.
 |---------|---------|
 | [MailKit](https://github.com/jstedfast/MailKit) | IMAP + SMTP |
 | [CommunityToolkit.Mvvm](https://github.com/CommunityToolkit/dotnet) | ObservableProperty, RelayCommand |
+| [Microsoft.Data.Sqlite](https://learn.microsoft.com/dotnet/standard/data/sqlite/) | Local mail cache |
 | [Microsoft.Web.WebView2](https://developer.microsoft.com/microsoft-edge/webview2/) | HTML email rendering |
 | [AdysTech.CredentialManager](https://github.com/AdysTech/CredentialManager) | Windows Credential Manager |
+
+## IMAP Concurrency
+
+QuickMail opens a small per-account IMAP connection pool. This prevents MailKit's "ImapClient is currently busy" error when background sync is running and you open a message, preview text, download attachments, or move/copy mail. The default is 6 simultaneous IMAP connections per account and can be changed in `%AppData%\QuickMail\config.ini` with `MaxImapConnectionsPerAccount`.
+
+Foreground actions such as opening messages and downloading attachments get reserved connection capacity. Background sync, polling, UID checks, and preview fetching are deliberately capped below the full pool so they do not occupy every available connection.

--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -10,6 +10,7 @@ QuickMail is a desktop email client for Windows. It supports multiple IMAP/SMTP 
 - [Connecting accounts](#connecting-accounts)
 - [Managing accounts](#managing-accounts)
 - [Reading mail](#reading-mail)
+- [Performance and concurrency](#performance-and-concurrency)
 - [Conversation view](#conversation-view)
 - [Composing messages](#composing-messages)
 - [Drafts](#drafts)
@@ -99,17 +100,18 @@ Your Microsoft password is never seen or stored by QuickMail — only an encrypt
 | Action | How |
 |--------|-----|
 | Focus the account list | `Ctrl+1`, then use **Up/Down** arrow keys |
-| Focus the folder list | `Ctrl+2`, then use **Up/Down** + **Enter** to open a folder |
+| Focus the folder tree | `Ctrl+2` or `Ctrl+Y`, then use **Up/Down** + **Enter** |
 | Focus the message list | `Ctrl+3`, then use **Up/Down** to move between messages |
 | Open a message in the reading pane | Press **Enter** or select the message |
-| Move focus into the reading pane | `Ctrl+4` or **F6** |
+| Move focus into the reading pane | **F6** after a message is open |
 | Return focus to the message list | **Escape** or **F6** from the reading pane |
 | Cycle focus forward through all panes | **F6** |
 | Cycle focus backward | **Shift+F6** |
+| Focus the status bar | `Ctrl+9` |
 
-### Quick folder picker (Ctrl+Y)
+### Folder tree shortcut (Ctrl+2 / Ctrl+Y)
 
-Press `Ctrl+Y` to open a searchable list of every folder across all your accounts. Start typing to filter the list, then press **Enter** to jump straight to that folder.
+Press `Ctrl+2` or `Ctrl+Y` to move focus to the main folder tree. Use **Up/Down** to choose a folder, **Right/Left** to expand or collapse account and folder nodes, and **Enter** to open the selected folder.
 
 ### Load More (Ctrl+M)
 
@@ -122,6 +124,16 @@ At the top of the folder list is an **All Mail** entry. Selecting it shows messa
 ### Selecting multiple messages
 
 Hold **Shift** and press **Up** or **Down** in the message list to extend your selection. You can then act on all selected messages at once (for example, pressing **Delete** removes them all).
+
+---
+
+## Performance and concurrency
+
+QuickMail uses a small IMAP connection pool for each account. Message opening, background sync, preview fetching, attachment downloads, and move/copy/delete actions lease separate connections when one is available, so opening a message should not fail just because another IMAP command is already running.
+
+By default, QuickMail uses up to **6 simultaneous IMAP connections per account**. Foreground work such as opening a message or downloading an attachment gets reserved capacity; background sync and preview fetching are limited below the full pool. Advanced users can change the limit in `%AppData%\QuickMail\config.ini` with `MaxImapConnectionsPerAccount`; changes take effect after restarting QuickMail.
+
+Some marketing or financial messages contain very large HTML layouts. QuickMail may show those messages in a simplified reader mode so the reading pane remains responsive.
 
 ---
 
@@ -255,7 +267,7 @@ A security warning is shown before opening executable file types.
 
 - **Passwords** are stored in **Windows Credential Manager** — never in any file on disk. They are protected by your Windows login.
 - **OAuth2 tokens** (used for Outlook.com accounts) are encrypted with Windows DPAPI and stored locally. Your Microsoft password is never seen or stored by QuickMail.
-- **HTML emails** are displayed in a sandboxed WebView2 component with a strict Content Security Policy. Scripts, embedded objects, and external frames are all blocked, so malicious email content cannot run on your machine.
+- **HTML emails** are displayed in a sandboxed WebView2 component with a strict Content Security Policy. Scripts, embedded objects, remote images, external frames, and forms are blocked or stripped, so malicious email content cannot run on your machine.
 
 ---
 
@@ -266,10 +278,10 @@ A security warning is shown before opening executable file types.
 | Shortcut | Action |
 |----------|--------|
 | Ctrl+1 | Focus account list |
-| Ctrl+2 | Focus folder list |
+| Ctrl+2 / Ctrl+Y | Focus folder tree |
 | Ctrl+3 | Focus message list / conversation tree |
-| Ctrl+4 | Focus reading pane |
 | Ctrl+0 | Focus toolbar |
+| Ctrl+9 | Focus status bar |
 | F6 | Cycle focus forward through panes |
 | Shift+F6 | Cycle focus backward through panes |
 | F5 | Refresh current folder |
@@ -278,7 +290,6 @@ A security warning is shown before opening executable file types.
 | Ctrl+Shift+R | Reply All |
 | Ctrl+F | Forward |
 | Delete | Delete selected message(s) |
-| Ctrl+Y | Open folder picker |
 | Ctrl+Shift+C | Toggle conversation view |
 | Ctrl+M | Load more messages |
 | Ctrl+Shift+E | Empty Trash |
@@ -328,6 +339,7 @@ Lines starting with `#` are comments and are ignored. The file uses a simple `ke
 | `PreviewLines` | `0`–`5` | `3` | Number of body-preview lines shown under each subject in the message list. Set to `0` to hide previews entirely. |
 | `ShowMessageStatus` | `true` / `false` | `true` | Show or hide the read/unread status indicator column in the message list. |
 | `ConversationView` | `true` / `false` | `false` | Start with conversation threading on. |
+| `MaxImapConnectionsPerAccount` | `1`–`15` | `6` | Maximum simultaneous IMAP connections QuickMail may open for each account. Background work is capped below this value so opening messages keeps reserved capacity. Higher values can make large accounts more responsive, but only raise this if your mail provider allows it. |
 
 ### `[account:<guid>]` overrides
 

--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -52,7 +52,7 @@ The menu bar at the top of the window provides access to all major features, org
 |------|----------|
 | **File** | New Message, Manage Accounts, Address Book, Exit |
 | **Message** | Reply, Reply All, Forward, Delete, Empty Trash, Move/Copy to Folder, Grab Addresses |
-| **View** | Refresh, View Mode (Messages / Conversations / By Sender / By Recipient), Sync Range (7 Days / 30 Days / 6 Months / 1 Year / All Mail), Go to Folder, Command Palette |
+| **View** | Refresh, View Mode (Messages / Conversations / By Sender / By Recipient), Sync Range (7 Days / 30 Days / 6 Months / 1 Year / All Mail), Go to Folder, Search Folders, Command Palette |
 | **Help** | User Guide |
 
 All menu items show their keyboard shortcuts for quick reference. You can also press **Alt** or **F10** to activate the menu bar if you prefer keyboard-only navigation.
@@ -134,6 +134,10 @@ Your Microsoft password is never seen or stored by QuickMail — only an encrypt
 ### Folder tree shortcut (Ctrl+2 / Ctrl+Y)
 
 Press `Ctrl+2` or `Ctrl+Y` to move focus to the main folder tree. Use **Up/Down** to choose a folder, **Right/Left** to expand or collapse account and folder nodes, and **Enter** to open the selected folder.
+
+### Search folders (Ctrl+Shift+F)
+
+Press `Ctrl+Shift+F` or activate **View > Search Folders...** to open the flat folder list. Focus starts on the folder list, so you can use **Up/Down** and **Enter** immediately. Press `/` to move to the search field, type to filter folders, and press **Enter** to open the selected folder.
 
 ### Load More (Ctrl+M)
 
@@ -419,6 +423,7 @@ A security warning is shown before opening executable file types.
 | Delete | Delete selected message(s) |
 | Ctrl+Shift+V | Cycle view mode (Messages / From / To / Conversations) |
 | Ctrl+Shift+C | Toggle conversation view |
+| Ctrl+Shift+F | Search folders |
 | Ctrl+Shift+P | Open command palette |
 | Ctrl+M | Load more messages |
 | Ctrl+Shift+E | Empty Trash |

--- a/docs/context-menus-plan.md
+++ b/docs/context-menus-plan.md
@@ -1,5 +1,9 @@
 # Plan: Context Menus Throughout the App (Issue #3)
 
+## Status
+
+Implemented in the current codebase. The context-menu work added account, folder, message, and conversation actions. As of v0.5.3 those commands run through the pooled IMAP connection layer, so moving/copying/deleting mail or folders should not collide with message opening or background sync on the same account.
+
 ## TL;DR
 Add right-click / Shift+F10 context menus to all four interactive lists (account, folder, message, conversation) with contextually appropriate commands. Requires new IMAP folder/message operations (copy messages, move messages, folder CRUD), new VM commands, a reusable folder-picker dialog adapted for destination selection, and a small new-folder dialog. Naturally decomposes into 5 sequential-but-partially-parallelizable phases.
 
@@ -16,7 +20,7 @@ These are the server-side primitives needed by all higher phases. Implement firs
 5. `RenameFolderAsync(Guid accountId, string folderName, string newFullName, CancellationToken ct)` — IMAP RENAME (also serves as move-folder)
 6. `CopyFolderAsync(Guid accountId, string folderName, string destinationParent, CancellationToken ct)` — recursive CreateFolder + CopyMessages per subfolder
 
-Pattern reference: `MoveToTrashBatchAsync` in `ImapService.cs` for the move pattern; MailKit's `IMailFolder.MoveToAsync()` / `CopyToAsync()` / `CreateAsync()` / `RenameAsync()` / `DeleteAsync()`.
+Pattern reference: `MoveToTrashBatchAsync` in `ImapService.cs` for the move pattern; MailKit's `IMailFolder.MoveToAsync()` / `CopyToAsync()` / `CreateAsync()` / `RenameAsync()` / `DeleteAsync()`. Every method must lease an IMAP client from `ImapService`'s per-account pool and return it after the operation; do not store or reuse `ImapClient` instances in view models.
 
 ---
 
@@ -54,7 +58,8 @@ Register new commands in `RegisterCommands()` where keyboard shortcuts apply (Mo
 
 **`FolderPickerWindow` extensions:**
 - Add a `string Title` constructor parameter (sets `Window.Title`, e.g. "Move to Folder", "Copy to Folder")
-- Add optional `bool ShowNewFolderButton` — if true, show "New Folder…" button at the bottom that calls `NewFolderDialog` inline and inserts the created node into the tree
+- Add optional `bool ShowNewFolderButton` — if true, show "New Folder…" button at the bottom that calls `NewFolderDialog` inline and refreshes the destination list
+- Current implementation note: `FolderPickerWindow` is now a flat virtualized searchable list for responsiveness with large Gmail label sets. Keep future destination-picking changes compatible with that fast path.
 
 **New `NewFolderDialog`** (new small Window):
 - Single `TextBox` for folder name + OK / Cancel
@@ -123,6 +128,10 @@ Command="{Binding PlacementTarget.DataContext.XxxCommand,
 | `QuickMail/Views/NewFolderDialog.xaml` + `.cs` | **New file** (Phase 3) |
 | `QuickMail/Models/ConversationGroup.cs` | Verify `IsExpanded` property exists |
 | `QuickMail/Models/FolderTreeNode.cs` | Verify system-folder guard property |
+
+## Follow-up Note: Issue #6
+
+Issue #6 reported MailKit's "ImapClient is currently busy processing a command in another thread" error while opening messages during other IMAP work. The fix is not in the context-menu XAML; it is the v0.5.2+ IMAP pool. Context-menu commands should continue to call `IImapService` methods and let the service handle connection leasing. Foreground commands use reserved connection capacity in v0.5.3.
 
 ---
 


### PR DESCRIPTION
Closes #6.

## Summary

Bundles v0.5.2 – v0.5.9 changelog entries from CHANGELOG.md into one PR.

- **IMAP pool + leasing** (addresses #6): bounded per-account connection pool; foreground (message open, attachment download) vs. background (sync, polling, UID checks, preview fetch) leases so account-setup sync cannot starve the first inbox open. New `MaxImapConnectionsPerAccount` config — default 6, range 1–15.
- **Inbox-on-open responsiveness** (addresses #6): folder selection paints cached messages immediately and refreshes from IMAP in the background, so opening Inbox no longer waits on Gmail before returning control to the UI.
- **Folder navigation**: `Ctrl+2` is the primary folder picker shortcut; `Ctrl+2`/`Ctrl+Y` focus the main folder tree (including from the WebView2 reading pane).
- **Folder picker rebuild**: virtualized searchable flat list replaces the `TreeView` — large Gmail label sets no longer realize on the UI thread. Search field is focused on open; Enter opens, Down moves into the list.
- **HTML rendering**: heavy sender HTML is built off the UI thread before `NavigateToString`. Large, table-heavy, or data-image-heavy messages render in a simplified reader mode. Remote images, scripts, forms, inline event handlers, and oversized styling are stripped. WebView2 body navigation has a timeout so a problematic message cannot hang the UI.
- **Accessibility**: restored automatic focus into the WebView2 message body after open; retrying WebView2 host + DOM focus handoff + UIA notification so NVDA receives a stable "Message body" focus event after heavy HTML loads.

## Test plan

- [ ] Build via `build.bat` and launch the app
- [ ] Add a fresh Gmail account — Inbox should be usable immediately rather than waiting 5–10 minutes (issue #6 repro)
- [ ] Open Gmail account with large label set — folder picker (`Ctrl+2`) opens quickly, search filters live, Enter selects
- [ ] `Ctrl+2` and `Ctrl+Y` focus the folder tree (both from main pane and from inside the WebView2 reading pane)
- [ ] Inbox selection paints cached messages immediately; background refresh updates list without blocking
- [ ] Open a heavy marketing HTML message — renders via simplified reader path; no remote images load
- [ ] Open a normal text/HTML message — full rendering, NVDA announces "Message body" on focus handoff
- [ ] Set `MaxImapConnectionsPerAccount=15` in `%APPDATA%\QuickMail\config.ini`; confirm clamping and that opens/attachments stay responsive while sync runs
- [ ] Run `QuickMail.Tests` suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)