### PR TITLE
Security: fix path traversal, tighten CSP, reduce PII logging, fix MVVM violations

### DIFF
--- a/QuickMail/Services/ImapService.cs
+++ b/QuickMail/Services/ImapService.cs
@@ -46,7 +46,8 @@ public class ImapService : IImapService
             ? SecureSocketOptions.SslOnConnect
             : SecureSocketOptions.StartTlsWhenAvailable;
 
-        LogService.Log($"Connecting to {account.ImapHost}:{account.ImapPort} ssl={account.ImapUseSsl} user={account.Username} auth={account.AuthType}");
+        LogService.Log($"Connecting to {account.ImapHost}:{account.ImapPort} ssl={account.ImapUseSsl} auth={account.AuthType}");
+        LogService.Debug($"  user={account.Username}");
         await client.ConnectAsync(account.ImapHost, account.ImapPort, ssl, ct);
 
         if (account.AuthType == AuthType.OAuth2Microsoft)
@@ -645,7 +646,7 @@ public class ImapService : IImapService
         if (_clients.TryGetValue(accountId, out client) && client.IsConnected && client.IsAuthenticated)
             return client;
 
-        LogService.Log($"Reconnecting {account.Username}…");
+        LogService.Debug($"Reconnecting…");
         await ConnectAsync(account, password, ct);
         return _clients[accountId];
     }

--- a/QuickMail/Services/SmtpService.cs
+++ b/QuickMail/Services/SmtpService.cs
@@ -34,14 +34,14 @@ public class SmtpService : ISmtpService
         if (account.AuthType == AuthType.OAuth2Microsoft)
         {
             var token = await _oauth.GetAccessTokenAsync(account, ct);
-            LogService.Log($"SmtpService: authenticating {account.Username} via XOAUTH2");
+            LogService.Debug($"SmtpService: authenticating via XOAUTH2");
             await client.AuthenticateAsync(new SaslMechanismOAuth2(account.Username, token), ct);
         }
         else
         {
             await client.AuthenticateAsync(account.Username, password!, ct);
         }
-        LogService.Log($"SmtpService: authenticated, sending to {compose.To}");
+        LogService.Debug($"SmtpService: authenticated, sending.");
         await client.SendAsync(message, ct);
         LogService.Log($"SmtpService: send complete");
         await client.DisconnectAsync(true, ct);

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -1700,17 +1700,20 @@ public partial class MainViewModel : ObservableObject
 
     public event Action<AccountModel>? OpenAccountSettingsRequested;
 
+    /// <summary>
+    /// Set by the View to show a Yes/No confirmation dialog.
+    /// Parameters: message, title. Returns true when the user confirms.
+    /// </summary>
+    public Func<string, string, bool>? ConfirmationRequested { get; set; }
+
     [RelayCommand]
     private void DeleteAccount(AccountModel? account)
     {
         if (account == null) return;
 
-        var result = MessageBox.Show(
+        if (ConfirmationRequested?.Invoke(
             $"Remove the account '{account.AccountLabel}'? This only removes it from QuickMail — your mail on the server is not affected.",
-            "Remove Account",
-            MessageBoxButton.YesNo,
-            MessageBoxImage.Question);
-        if (result != MessageBoxResult.Yes) return;
+            "Remove Account") != true) return;
 
         _credentials.DeletePassword(account.Id);
         Accounts.Remove(account);
@@ -1837,12 +1840,9 @@ public partial class MainViewModel : ObservableObject
     {
         if (node.Folder == null || node.IsHeader) return;
 
-        var result = MessageBox.Show(
+        if (ConfirmationRequested?.Invoke(
             $"Delete the folder '{node.Label}' and move all its messages to Trash?",
-            "Delete Folder",
-            MessageBoxButton.YesNo,
-            MessageBoxImage.Warning);
-        if (result != MessageBoxResult.Yes) return;
+            "Delete Folder") != true) return;
 
         StatusText = $"Deleting folder '{node.Label}'…";
         IsBusy     = true;
@@ -2219,7 +2219,13 @@ public partial class MainViewModel : ObservableObject
                         MessageDetail.UniqueId, att.PartSpecifier, cts.Token);
 
                 if (att.Content != null)
-                    await File.WriteAllBytesAsync(Path.Combine(folder, att.FileName), att.Content);
+                {
+                    // Strip directory components from the server-supplied filename to
+                    // prevent path traversal writing outside the chosen save folder.
+                    var safeFileName = Path.GetFileName(att.FileName);
+                    if (string.IsNullOrEmpty(safeFileName)) safeFileName = "attachment";
+                    await File.WriteAllBytesAsync(Path.Combine(folder, safeFileName), att.Content);
+                }
             }
             StatusText = "All attachments saved.";
         }
@@ -2257,20 +2263,22 @@ public partial class MainViewModel : ObservableObject
             IsBusy = false;
         }
 
-        var ext = Path.GetExtension(att.FileName).ToLowerInvariant();
+        // Strip any directory components from the server-supplied filename to prevent
+        // path traversal (e.g. a crafted name like "../../Startup/evil.exe").
+        var safeFileName = Path.GetFileName(att.FileName);
+        if (string.IsNullOrEmpty(safeFileName)) safeFileName = "attachment";
+
+        var ext = Path.GetExtension(safeFileName).ToLowerInvariant();
         if (DangerousExtensions.Contains(ext))
         {
-            var result = MessageBox.Show(
-                $"'{att.FileName}' is an executable file type. Opening it could be dangerous. Continue?",
-                "Security Warning",
-                MessageBoxButton.YesNo,
-                MessageBoxImage.Warning);
-            if (result != MessageBoxResult.Yes) return;
+            if (ConfirmationRequested?.Invoke(
+                $"'{safeFileName}' is an executable file type. Opening it could be dangerous. Continue?",
+                "Security Warning") != true) return;
         }
 
         var tempDir = Path.Combine(Path.GetTempPath(), "QuickMail");
         Directory.CreateDirectory(tempDir);
-        var tempPath = Path.Combine(tempDir, att.FileName);
+        var tempPath = Path.Combine(tempDir, safeFileName);
         await File.WriteAllBytesAsync(tempPath, att.Content!);
         Process.Start(new ProcessStartInfo(tempPath) { UseShellExecute = true });
     }

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -103,6 +103,9 @@ public partial class MainWindow : Window
         vm.OpenAccountSettingsRequested += OpenAccountManagerForAccount;
         vm.MessageListFocusRequested += ReturnFocusToMessageList;
         vm.AnnouncementRequested += (_, text) => AccessibilityHelper.Announce(this, text, interrupt: true);
+        vm.ConfirmationRequested = (message, title) =>
+            MessageBox.Show(message, title, MessageBoxButton.YesNo, MessageBoxImage.Warning)
+            == MessageBoxResult.Yes;
 
         // Re-focus the active message panel whenever the message collections are replaced
         // (happens after Refresh, Load More, folder changes, and view-mode switches).
@@ -972,7 +975,7 @@ public partial class MainWindow : Window
             // was added via AddScriptToExecuteOnDocumentCreatedAsync and is unaffected by CSP.
             const string cspTag =
                 "<meta http-equiv=\"Content-Security-Policy\" " +
-                "content=\"script-src 'none'; object-src 'none'; frame-src 'none';\">";
+                "content=\"script-src 'none'; object-src 'none'; frame-src 'none'; img-src cid: data:;\">";
             var body = detail.HtmlBody;
 
             // Replace any existing <title> so screen readers announce our subject, not the sender's.


### PR DESCRIPTION
## Summary

Four security and architectural issues identified in a code review, all addressed in this PR.

### HIGH — Path traversal in attachment handling
`OpenAttachmentAsync` and `SaveAllAttachmentsAsync` used the server-supplied `att.FileName` directly in `Path.Combine`. A crafted filename like `../../AppData/Roaming/.../Startup/evil.exe` could write files outside the intended directory. Fixed by calling `Path.GetFileName()` before combining, with a fallback to `"attachment"` for empty results.

### MEDIUM — CSP allowed external image loading (tracking pixels)
The WebView2 Content-Security-Policy meta tag was missing an `img-src` directive, permitting external image requests that can be used as read receipts / tracking pixels. Added `img-src cid: data:` to block remote images while preserving inline (`cid:`) and data-URI images common in email bodies.

### MEDIUM — PII in always-on log
The IMAP connect log included `user={username}` at the normal (non-debug) log level, and the SMTP send log included the recipient address. Both moved to `LogService.Debug()` so they only appear when the app is launched with `/debug`.

### Architectural — MessageBox in ViewModel (MVVM violation)
`DeleteAccount`, `DeleteFolderAsync`, and `OpenAttachmentAsync` in `MainViewModel` called `MessageBox.Show` directly, violating the MVVM rule against touching the View layer from a ViewModel. Replaced with a `Func<string, string, bool>? ConfirmationRequested` delegate property, wired up in `MainWindow.xaml.cs`.