### PR TITLE
Fix: hotkey UI, UIA announcements, spell-check crash, IMAP concurrency

### DIFF
--- a/QuickMail.Tests/SettingsViewModelTests.cs
+++ b/QuickMail.Tests/SettingsViewModelTests.cs
@@ -1,0 +1,133 @@
+using System.Collections.Generic;
+using System.Windows.Input;
+using QuickMail.Models;
+using QuickMail.Services;
+using QuickMail.ViewModels;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+public class SettingsViewModelTests
+{
+    [Fact]
+    public void Constructor_InitializesWithDefaultValues()
+    {
+        var configService = new StubConfigService();
+        var registry = new StubCommandRegistry();
+
+        var vm = new SettingsViewModel(configService, registry);
+
+        Assert.Equal(3, vm.PreviewLines);
+        Assert.True(vm.ShowMessageStatus);
+        Assert.Equal("messages", vm.ViewMode);
+        Assert.Equal(30, vm.SyncDays);
+        Assert.Equal(500, vm.InitialSyncCount);
+        Assert.Empty(vm.HotkeyRows);
+    }
+
+    [Fact]
+    public void Save_PersistsChanges()
+    {
+        var configService = new StubConfigService();
+        var registry = new StubCommandRegistry();
+        var vm = new SettingsViewModel(configService, registry);
+
+        vm.PreviewLines = 5;
+        vm.ShowMessageStatus = false;
+        vm.ViewMode = "conversations";
+        vm.SyncDays = 7;
+        vm.InitialSyncCount = 100;
+
+        vm.SaveCommand.Execute(null);
+
+        var loadedConfig = configService.Load();
+        Assert.Equal(5, loadedConfig.PreviewLines);
+        Assert.False(loadedConfig.ShowMessageStatus);
+        Assert.Equal("conversations", loadedConfig.ViewMode);
+        Assert.Equal(7, loadedConfig.SyncDays);
+        Assert.Equal(100, loadedConfig.InitialSyncCount);
+    }
+
+    [Fact]
+    public void SaveWithHotkeys_PersistsHotkeysInConfig()
+    {
+        var configService = new StubConfigService();
+        var registry = new StubCommandRegistry();
+        registry.RegisterTestCommand("test.cmd1", "Test", "Command 1");
+
+        var vm = new SettingsViewModel(configService, registry);
+
+        Assert.Single(vm.HotkeyRows);
+        var row = vm.HotkeyRows[0];
+        row.SetCustomBinding(Key.K, ModifierKeys.Control | ModifierKeys.Shift);
+
+        vm.SaveCommand.Execute(null);
+
+        var loadedConfig = configService.Load();
+        Assert.Single(loadedConfig.CustomHotkeys);
+        var binding = loadedConfig.CustomHotkeys[0];
+        Assert.Equal("test.cmd1", binding.CommandId);
+        Assert.Equal((int)Key.K, binding.Key);
+        Assert.Equal((int)(ModifierKeys.Control | ModifierKeys.Shift), binding.Modifiers);
+    }
+
+    [Fact]
+    public void ClearHotkey_RemovesCustomBinding()
+    {
+        var configService = new StubConfigService();
+        var registry = new StubCommandRegistry();
+        registry.RegisterTestCommand("test.cmd", "Test", "Command");
+
+        var vm = new SettingsViewModel(configService, registry);
+        var row = vm.HotkeyRows[0];
+
+        row.SetCustomBinding(Key.A, ModifierKeys.Control);
+        Assert.True(row.HasCustomBinding);
+        Assert.Equal("Ctrl+A", row.CustomGesture);
+
+        vm.ClearHotkeyCommand.Execute(row);
+
+        Assert.False(row.HasCustomBinding);
+        Assert.Empty(row.CustomGesture);
+    }
+
+    [Fact]
+    public void HotkeyRow_ToBinding_ReturnsCorrectBinding()
+    {
+        var configService = new StubConfigService();
+        var registry = new StubCommandRegistry();
+        registry.RegisterTestCommand("test.cmd", "Test", "Command");
+
+        var vm = new SettingsViewModel(configService, registry);
+        var row = vm.HotkeyRows[0];
+        row.SetCustomBinding(Key.S, ModifierKeys.Control | ModifierKeys.Shift);
+
+        var binding = row.ToBinding();
+
+        Assert.Equal("test.cmd", binding.CommandId);
+        Assert.Equal((int)Key.S, binding.Key);
+        Assert.Equal((int)(ModifierKeys.Control | ModifierKeys.Shift), binding.Modifiers);
+    }
+
+    [Fact]
+    public void LoadExistingHotkeys_PopulatesCustomBindings()
+    {
+        var configService = new StubConfigService();
+        var cfg = configService.Load();
+        cfg.CustomHotkeys = new List<HotkeyBinding>
+        {
+            new() { CommandId = "test.cmd", Key = (int)Key.G, Modifiers = (int)ModifierKeys.Control }
+        };
+        configService.Save(cfg);
+
+        var registry = new StubCommandRegistry();
+        registry.RegisterTestCommand("test.cmd", "Test", "Command");
+
+        var vm = new SettingsViewModel(configService, registry);
+
+        Assert.Single(vm.HotkeyRows);
+        var row = vm.HotkeyRows[0];
+        Assert.True(row.HasCustomBinding);
+        Assert.Equal("Ctrl+G", row.CustomGesture);
+    }
+}

--- a/QuickMail.Tests/SettingsViewModelTests.cs
+++ b/QuickMail.Tests/SettingsViewModelTests.cs
@@ -67,8 +67,7 @@ public class SettingsViewModelTests
         Assert.Single(loadedConfig.CustomHotkeys);
         var binding = loadedConfig.CustomHotkeys[0];
         Assert.Equal("test.cmd1", binding.CommandId);
-        Assert.Equal((int)Key.K, binding.Key);
-        Assert.Equal((int)(ModifierKeys.Control | ModifierKeys.Shift), binding.Modifiers);
+        Assert.Equal("Ctrl+Shift+K", binding.Gesture);
     }
 
     [Fact]
@@ -105,8 +104,7 @@ public class SettingsViewModelTests
         var binding = row.ToBinding();
 
         Assert.Equal("test.cmd", binding.CommandId);
-        Assert.Equal((int)Key.S, binding.Key);
-        Assert.Equal((int)(ModifierKeys.Control | ModifierKeys.Shift), binding.Modifiers);
+        Assert.Equal("Ctrl+Shift+S", binding.Gesture);
     }
 
     [Fact]
@@ -116,7 +114,7 @@ public class SettingsViewModelTests
         var cfg = configService.Load();
         cfg.CustomHotkeys = new List<HotkeyBinding>
         {
-            new() { CommandId = "test.cmd", Key = (int)Key.G, Modifiers = (int)ModifierKeys.Control }
+            new() { CommandId = "test.cmd", Gesture = "Ctrl+G" }
         };
         configService.Save(cfg);
 

--- a/QuickMail.Tests/StubServices.cs
+++ b/QuickMail.Tests/StubServices.cs
@@ -104,15 +104,35 @@ sealed class StubSyncService : ISyncService
 
 sealed class StubCommandRegistry : ICommandRegistry
 {
-    public void Register(CommandDefinition command) { }
-    public IReadOnlyList<CommandDefinition> GetAll() => [];
-    public CommandDefinition? FindById(string id) => null;
-    public CommandDefinition? FindByGesture(Key key, ModifierKeys modifiers) => null;
+    private readonly Dictionary<string, CommandDefinition> _commands = [];
+
+    public void Register(CommandDefinition command)
+        => _commands[command.Id] = command;
+
+    public IReadOnlyList<CommandDefinition> GetAll()
+        => _commands.Values.OrderBy(c => c.Category).ThenBy(c => c.Title).ToList();
+
+    public CommandDefinition? FindById(string id)
+        => _commands.TryGetValue(id, out var cmd) ? cmd : null;
+
+    public CommandDefinition? FindByGesture(Key key, ModifierKeys modifiers)
+        => _commands.Values.FirstOrDefault(c => c.DefaultKey == key && c.DefaultModifiers == modifiers);
+
     public void ApplyUserOverrides(IEnumerable<HotkeyBinding> overrides) { }
+
+    // Test helpers
+    public void RegisterTestCommand(string id, string category, string title)
+    {
+        Register(new CommandDefinition(id, category, title, () => { }));
+    }
 }
 
 sealed class StubConfigService : IConfigService
 {
-    public ConfigModel Load() => new();
-    public void Save(ConfigModel config) { }
+    private ConfigModel _config = new();
+
+    public ConfigModel Load() => _config;
+
+    public void Save(ConfigModel config)
+        => _config = config;
 }

--- a/QuickMail.Tests/UnitTest1.cs
+++ b/QuickMail.Tests/UnitTest1.cs
@@ -117,7 +117,7 @@ public class XamlParseTests
         var vm = new MainViewModel(imap, accounts, creds, store, sync, config, registry);
         // Constructing MainWindow triggers InitializeComponent() which is the real XAML parse.
         var window = new MainWindow(vm, new StubSmtpService(), accounts, creds, imap,
-            new StubOAuthService(), registry, contacts);
+            new StubOAuthService(), registry, contacts, config);
         Assert.NotNull(window);
         window.Close();
     }

--- a/QuickMail/App.xaml.cs
+++ b/QuickMail/App.xaml.cs
@@ -39,7 +39,7 @@ public partial class App : Application
             imapService, accountService, credentialService, localStore, syncService, configService, commandRegistry);
         mainVm.LoadAccountList();
 
-        var mainWindow = new MainWindow(mainVm, smtpService, accountService, credentialService, imapService, oauthService, commandRegistry, contactService);
+        var mainWindow = new MainWindow(mainVm, smtpService, accountService, credentialService, imapService, oauthService, commandRegistry, contactService, configService);
         mainWindow.Show();
     }
 }

--- a/QuickMail/Helpers/GestureHelper.cs
+++ b/QuickMail/Helpers/GestureHelper.cs
@@ -25,6 +25,16 @@ public static class GestureHelper
         return string.Join("+", parts);
     }
 
+    /// <summary>
+    /// Converts legacy integer-format hotkey fields to a gesture string.
+    /// Returns null when <paramref name="key"/> is 0 (no binding stored).
+    /// </summary>
+    public static string? MigrateFromLegacyIntegers(int key, int modifiers)
+    {
+        if (key == 0) return null;
+        return Format((Key)key, (ModifierKeys)modifiers);
+    }
+
     public static bool TryParse(string gesture, out Key key, out ModifierKeys modifiers)
     {
         key = Key.None;
@@ -65,10 +75,10 @@ public static class GestureHelper
         var d = new Dictionary<Key, string>();
         for (int i = 0; i <= 9; i++) d[(Key)((int)Key.D0 + i)] = i.ToString();
         for (int i = 0; i <= 9; i++) d[(Key)((int)Key.NumPad0 + i)] = $"Num{i}";
-        d[Key.Add]      = "Num+";
-        d[Key.Subtract] = "Num-";
-        d[Key.Multiply] = "Num*";
-        d[Key.Divide]   = "Num/";
+        d[Key.Add]      = "NumAdd";
+        d[Key.Subtract] = "NumSub";
+        d[Key.Multiply] = "NumMul";
+        d[Key.Divide]   = "NumDiv";
         d[Key.Decimal]  = "Num.";
         d[Key.Space]    = "Space";
         d[Key.Return]   = "Enter";
@@ -93,10 +103,10 @@ public static class GestureHelper
         var d = new Dictionary<string, Key>(StringComparer.OrdinalIgnoreCase);
         for (int i = 0; i <= 9; i++) d[i.ToString()] = (Key)((int)Key.D0 + i);
         for (int i = 0; i <= 9; i++) d[$"Num{i}"] = (Key)((int)Key.NumPad0 + i);
-        d["Num+"]      = Key.Add;
-        d["Num-"]      = Key.Subtract;
-        d["Num*"]      = Key.Multiply;
-        d["Num/"]      = Key.Divide;
+        d["NumAdd"]    = Key.Add;
+        d["NumSub"]    = Key.Subtract;
+        d["NumMul"]    = Key.Multiply;
+        d["NumDiv"]    = Key.Divide;
         d["Num."]      = Key.Decimal;
         d["Space"]     = Key.Space;
         d["Enter"]     = Key.Return;

--- a/QuickMail/Helpers/GestureHelper.cs
+++ b/QuickMail/Helpers/GestureHelper.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using System.Windows.Input;
+
+namespace QuickMail.Helpers;
+
+/// <summary>
+/// Converts between Key+ModifierKeys and human-readable gesture strings like "Ctrl+Shift+8".
+/// Centralizes the formatting logic used by the settings UI, key capture dialog, and file I/O.
+/// </summary>
+public static class GestureHelper
+{
+    private static readonly Dictionary<Key, string> _keyToName = BuildKeyToName();
+    private static readonly Dictionary<string, Key> _nameToKey = BuildNameToKey();
+
+    public static string Format(Key key, ModifierKeys modifiers)
+    {
+        if (key == Key.None) return string.Empty;
+        var parts = new List<string>(4);
+        if ((modifiers & ModifierKeys.Control) != 0) parts.Add("Ctrl");
+        if ((modifiers & ModifierKeys.Shift)   != 0) parts.Add("Shift");
+        if ((modifiers & ModifierKeys.Alt)     != 0) parts.Add("Alt");
+        if ((modifiers & ModifierKeys.Windows) != 0) parts.Add("Win");
+        parts.Add(_keyToName.TryGetValue(key, out var name) ? name : key.ToString());
+        return string.Join("+", parts);
+    }
+
+    public static bool TryParse(string gesture, out Key key, out ModifierKeys modifiers)
+    {
+        key = Key.None;
+        modifiers = ModifierKeys.None;
+
+        if (string.IsNullOrWhiteSpace(gesture)) return false;
+
+        var parts = gesture.Split('+');
+        if (parts.Length < 2) return false;
+
+        for (int i = 0; i < parts.Length - 1; i++)
+        {
+            switch (parts[i].Trim())
+            {
+                case "Ctrl":  modifiers |= ModifierKeys.Control; break;
+                case "Shift": modifiers |= ModifierKeys.Shift;   break;
+                case "Alt":   modifiers |= ModifierKeys.Alt;     break;
+                case "Win":   modifiers |= ModifierKeys.Windows; break;
+                default: return false;
+            }
+        }
+
+        if (modifiers == ModifierKeys.None) return false;
+
+        var keyPart = parts[^1].Trim();
+        if (_nameToKey.TryGetValue(keyPart, out key)) return true;
+
+        // Fallback: try the enum name directly (covers F1–F24, letter keys, etc.)
+        if (Enum.TryParse(keyPart, ignoreCase: true, out key) && key != Key.None) return true;
+
+        key = Key.None;
+        modifiers = ModifierKeys.None;
+        return false;
+    }
+
+    private static Dictionary<Key, string> BuildKeyToName()
+    {
+        var d = new Dictionary<Key, string>();
+        for (int i = 0; i <= 9; i++) d[(Key)((int)Key.D0 + i)] = i.ToString();
+        for (int i = 0; i <= 9; i++) d[(Key)((int)Key.NumPad0 + i)] = $"Num{i}";
+        d[Key.Add]      = "Num+";
+        d[Key.Subtract] = "Num-";
+        d[Key.Multiply] = "Num*";
+        d[Key.Divide]   = "Num/";
+        d[Key.Decimal]  = "Num.";
+        d[Key.Space]    = "Space";
+        d[Key.Return]   = "Enter";
+        d[Key.Escape]   = "Escape";
+        d[Key.Tab]      = "Tab";
+        d[Key.Delete]   = "Delete";
+        d[Key.Back]     = "Backspace";
+        d[Key.Insert]   = "Insert";
+        d[Key.Home]     = "Home";
+        d[Key.End]      = "End";
+        d[Key.Prior]    = "PageUp";
+        d[Key.Next]     = "PageDown";
+        d[Key.Up]       = "Up";
+        d[Key.Down]     = "Down";
+        d[Key.Left]     = "Left";
+        d[Key.Right]    = "Right";
+        return d;
+    }
+
+    private static Dictionary<string, Key> BuildNameToKey()
+    {
+        var d = new Dictionary<string, Key>(StringComparer.OrdinalIgnoreCase);
+        for (int i = 0; i <= 9; i++) d[i.ToString()] = (Key)((int)Key.D0 + i);
+        for (int i = 0; i <= 9; i++) d[$"Num{i}"] = (Key)((int)Key.NumPad0 + i);
+        d["Num+"]      = Key.Add;
+        d["Num-"]      = Key.Subtract;
+        d["Num*"]      = Key.Multiply;
+        d["Num/"]      = Key.Divide;
+        d["Num."]      = Key.Decimal;
+        d["Space"]     = Key.Space;
+        d["Enter"]     = Key.Return;
+        d["Return"]    = Key.Return;
+        d["Escape"]    = Key.Escape;
+        d["Esc"]       = Key.Escape;
+        d["Tab"]       = Key.Tab;
+        d["Delete"]    = Key.Delete;
+        d["Del"]       = Key.Delete;
+        d["Backspace"] = Key.Back;
+        d["Insert"]    = Key.Insert;
+        d["Home"]      = Key.Home;
+        d["End"]       = Key.End;
+        d["PageUp"]    = Key.Prior;
+        d["PageDown"]  = Key.Next;
+        d["Up"]        = Key.Up;
+        d["Down"]      = Key.Down;
+        d["Left"]      = Key.Left;
+        d["Right"]     = Key.Right;
+        return d;
+    }
+}

--- a/QuickMail/Models/CommandDefinition.cs
+++ b/QuickMail/Models/CommandDefinition.cs
@@ -1,6 +1,6 @@
 using System;
-using System.Collections.Generic;
 using System.Windows.Input;
+using QuickMail.Helpers;
 
 namespace QuickMail.Models;
 
@@ -40,21 +40,5 @@ public sealed class CommandDefinition
     }
 
     /// <summary>Human-readable shortcut string, e.g. "Ctrl+N" or "Delete".</summary>
-    public string GestureText
-    {
-        get
-        {
-            if (DefaultKey == Key.None) return string.Empty;
-            var parts = new List<string>();
-            if ((DefaultModifiers & ModifierKeys.Control) != 0) parts.Add("Ctrl");
-            if ((DefaultModifiers & ModifierKeys.Shift)   != 0) parts.Add("Shift");
-            if ((DefaultModifiers & ModifierKeys.Alt)     != 0) parts.Add("Alt");
-            var keyStr = DefaultKey.ToString();
-            // Key.D0–Key.D9 stringify as "D0"–"D9"; show just the digit.
-            if (keyStr.Length == 2 && keyStr[0] == 'D' && char.IsDigit(keyStr[1]))
-                keyStr = keyStr[1..];
-            parts.Add(keyStr);
-            return string.Join("+", parts);
-        }
-    }
+    public string GestureText => GestureHelper.Format(DefaultKey, DefaultModifiers);
 }

--- a/QuickMail/Models/HotkeyBinding.cs
+++ b/QuickMail/Models/HotkeyBinding.cs
@@ -1,18 +1,25 @@
-using System.Windows.Input;
+using System.Text.Json.Serialization;
 
 namespace QuickMail.Models;
 
 /// <summary>
 /// A user-defined override that maps a keyboard shortcut to a command by ID.
-/// Stored in hotkeys.json.
+/// Stored in hotkeys.json. The <see cref="Gesture"/> field is the authoritative format,
+/// e.g. "Ctrl+Shift+8". The legacy integer fields below are read-only for migration
+/// and are never written by current code.
 /// </summary>
 public sealed class HotkeyBinding
 {
     public string CommandId { get; set; } = string.Empty;
 
-    /// <summary>Integer value of <see cref="System.Windows.Input.Key"/>.</summary>
+    /// <summary>Human-readable gesture, e.g. "Ctrl+Shift+8" or "Ctrl+Alt+F5".</summary>
+    public string Gesture { get; set; } = string.Empty;
+
+    // Legacy fields kept for migrating old hotkeys.json files that stored raw integers.
+    // JsonIgnore(WhenWritingDefault) means these are never written when saving (value stays 0).
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public int Key { get; set; }
 
-    /// <summary>Integer value of <see cref="System.Windows.Input.ModifierKeys"/>.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public int Modifiers { get; set; }
 }

--- a/QuickMail/QuickMail.csproj
+++ b/QuickMail/QuickMail.csproj
@@ -6,9 +6,9 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
-    <Version>0.5.1</Version>
-    <AssemblyVersion>0.5.1.0</AssemblyVersion>
-    <FileVersion>0.5.1.0</FileVersion>
+    <Version>0.5.7</Version>
+    <AssemblyVersion>0.5.7.0</AssemblyVersion>
+    <FileVersion>0.5.7.0</FileVersion>
     <!-- Single-file publish: native DLLs (WebView2Loader, SQLite) extract to temp on first run -->
     <PublishSingleFile>true</PublishSingleFile>
     <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>

--- a/QuickMail/Services/ConfigService.cs
+++ b/QuickMail/Services/ConfigService.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Text.Json;
-using System.Windows.Input;
 using QuickMail.Helpers;
 using QuickMail.Models;
 
@@ -101,7 +100,7 @@ public class ConfigService : IConfigService
 
             // Migrate old integer format: if Gesture is absent but Key int is set, convert it
             if (string.IsNullOrEmpty(h.Gesture) && h.Key != 0)
-                h.Gesture = GestureHelper.Format((Key)h.Key, (ModifierKeys)h.Modifiers);
+                h.Gesture = GestureHelper.MigrateFromLegacyIntegers(h.Key, h.Modifiers) ?? string.Empty;
 
             // Skip entries whose gesture string can't be parsed into a valid key combination
             if (!GestureHelper.TryParse(h.Gesture, out _, out _))

--- a/QuickMail/Services/ConfigService.cs
+++ b/QuickMail/Services/ConfigService.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Text.Json;
+using System.Windows.Input;
+using QuickMail.Helpers;
 using QuickMail.Models;
 
 namespace QuickMail.Services;
@@ -63,7 +65,7 @@ public class ConfigService : IConfigService
             {
                 var hotkeys = JsonSerializer.Deserialize<List<HotkeyBinding>>(File.ReadAllText(HotkeysFile));
                 if (hotkeys != null)
-                    _cached.CustomHotkeys = hotkeys;
+                    _cached.CustomHotkeys = ValidateAndMigrateHotkeys(hotkeys);
             }
             catch { /* malformed hotkeys.json — ignore and use defaults */ }
         }
@@ -82,6 +84,33 @@ public class ConfigService : IConfigService
             File.WriteAllText(HotkeysFile, JsonSerializer.Serialize(config.CustomHotkeys, JsonOptions), Encoding.UTF8);
         else if (File.Exists(HotkeysFile))
             File.Delete(HotkeysFile);
+    }
+
+    // ── Hotkey helpers ────────────────────────────────────────────────────────────
+
+    private static List<HotkeyBinding> ValidateAndMigrateHotkeys(List<HotkeyBinding> raw)
+    {
+        var result = new List<HotkeyBinding>(raw.Count);
+        var seen   = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var h in raw)
+        {
+            // Skip entries with no command id or duplicate command ids
+            if (string.IsNullOrWhiteSpace(h.CommandId) || !seen.Add(h.CommandId))
+                continue;
+
+            // Migrate old integer format: if Gesture is absent but Key int is set, convert it
+            if (string.IsNullOrEmpty(h.Gesture) && h.Key != 0)
+                h.Gesture = GestureHelper.Format((Key)h.Key, (ModifierKeys)h.Modifiers);
+
+            // Skip entries whose gesture string can't be parsed into a valid key combination
+            if (!GestureHelper.TryParse(h.Gesture, out _, out _))
+                continue;
+
+            result.Add(h);
+        }
+
+        return result;
     }
 
     // ── Parser ────────────────────────────────────────────────────────────────────

--- a/QuickMail/Services/ImapService.cs
+++ b/QuickMail/Services/ImapService.cs
@@ -83,74 +83,74 @@ public class ImapService : IImapService
 
     // ── Folder list ──────────────────────────────────────────────────────────────
 
-    public async Task<List<MailFolderModel>> GetFoldersAsync(Guid accountId, CancellationToken ct = default)
-    {
-        var client = await GetOrReconnectAsync(accountId, ct);
-        var result = new List<MailFolderModel>();
-
-        // Always put INBOX first — many servers don't return it via GetFoldersAsync
-        try
+    public Task<List<MailFolderModel>> GetFoldersAsync(Guid accountId, CancellationToken ct = default)
+        => ExecuteWithRetryAsync(accountId, ct, async client =>
         {
-            var inbox = client.Inbox!;
-            await inbox.OpenAsync(FolderAccess.ReadOnly, ct);
-            LogService.Log($"INBOX: FullName={inbox.FullName} Count={inbox.Count} Unread={inbox.Unread}");
-            result.Add(new MailFolderModel
-            {
-                FullName    = inbox.FullName,
-                DisplayName = "Inbox",
-                UnreadCount = inbox.Unread,
-                AccountId   = accountId,
-                Kind        = SpecialFolderKind.Inbox
-            });
-            await inbox.CloseAsync(false, ct);
-        }
-        catch (Exception ex) { LogService.Log("GetFolders/Inbox", ex); }
+            var result = new List<MailFolderModel>();
 
-        var folders = await client.GetFoldersAsync(client.PersonalNamespaces[0], cancellationToken: ct);
-        LogService.Log($"GetFoldersAsync returned {folders.Count} folders");
-
-        foreach (var folder in folders)
-        {
-            if ((folder.Attributes & FolderAttributes.NonExistent) != 0) continue;
-            if ((folder.Attributes & FolderAttributes.NoSelect)    != 0) continue;
-            if (folder.FullName == client.Inbox!.FullName)              continue;
-
+            // Always put INBOX first — many servers don't return it via GetFoldersAsync
             try
             {
-                await folder.OpenAsync(FolderAccess.ReadOnly, ct);
-                LogService.Log($"  Folder: {folder.FullName} Count={folder.Count} Unread={folder.Unread}");
-                var unread   = folder.Unread;
-                var excluded = IsExcludedFromAllMail(folder.Attributes);
-                var kind     = GetSpecialFolderKind(folder.Attributes);
-                await folder.CloseAsync(false, ct);
+                var inbox = client.Inbox!;
+                await inbox.OpenAsync(FolderAccess.ReadOnly, ct);
+                LogService.Log($"INBOX: FullName={inbox.FullName} Count={inbox.Count} Unread={inbox.Unread}");
                 result.Add(new MailFolderModel
                 {
-                    FullName           = folder.FullName,
-                    DisplayName        = folder.Name,
-                    UnreadCount        = unread,
-                    AccountId          = accountId,
-                    ExcludeFromAllMail = excluded,
-                    Kind               = kind
+                    FullName    = inbox.FullName,
+                    DisplayName = "Inbox",
+                    UnreadCount = inbox.Unread,
+                    AccountId   = accountId,
+                    Kind        = SpecialFolderKind.Inbox
                 });
+                await inbox.CloseAsync(false, ct);
             }
-            catch (Exception ex)
-            {
-                LogService.Log($"  Cannot open folder {folder.FullName}: {ex.Message}");
-                result.Add(new MailFolderModel
-                {
-                    FullName           = folder.FullName,
-                    DisplayName        = folder.Name,
-                    UnreadCount        = 0,
-                    AccountId          = accountId,
-                    ExcludeFromAllMail = IsExcludedFromAllMail(folder.Attributes),
-                    Kind               = GetSpecialFolderKind(folder.Attributes)
-                });
-            }
-        }
+            catch (Exception ex) { LogService.Log("GetFolders/Inbox", ex); }
 
-        LogService.Log($"GetFoldersAsync: returning {result.Count} folders");
-        return result;
-    }
+            var folders = await client.GetFoldersAsync(client.PersonalNamespaces[0], cancellationToken: ct);
+            LogService.Log($"GetFoldersAsync returned {folders.Count} folders");
+
+            foreach (var folder in folders)
+            {
+                if ((folder.Attributes & FolderAttributes.NonExistent) != 0) continue;
+                if ((folder.Attributes & FolderAttributes.NoSelect)    != 0) continue;
+                if (folder.FullName == client.Inbox!.FullName)              continue;
+
+                try
+                {
+                    await folder.OpenAsync(FolderAccess.ReadOnly, ct);
+                    LogService.Log($"  Folder: {folder.FullName} Count={folder.Count} Unread={folder.Unread}");
+                    var unread   = folder.Unread;
+                    var excluded = IsExcludedFromAllMail(folder.Attributes);
+                    var kind     = GetSpecialFolderKind(folder.Attributes);
+                    await folder.CloseAsync(false, ct);
+                    result.Add(new MailFolderModel
+                    {
+                        FullName           = folder.FullName,
+                        DisplayName        = folder.Name,
+                        UnreadCount        = unread,
+                        AccountId          = accountId,
+                        ExcludeFromAllMail = excluded,
+                        Kind               = kind
+                    });
+                }
+                catch (Exception ex)
+                {
+                    LogService.Log($"  Cannot open folder {folder.FullName}: {ex.Message}");
+                    result.Add(new MailFolderModel
+                    {
+                        FullName           = folder.FullName,
+                        DisplayName        = folder.Name,
+                        UnreadCount        = 0,
+                        AccountId          = accountId,
+                        ExcludeFromAllMail = IsExcludedFromAllMail(folder.Attributes),
+                        Kind               = GetSpecialFolderKind(folder.Attributes)
+                    });
+                }
+            }
+
+            LogService.Log($"GetFoldersAsync: returning {result.Count} folders");
+            return result;
+        });
 
     // ── Message lists ────────────────────────────────────────────────────────────
 
@@ -317,14 +317,14 @@ public class ImapService : IImapService
 
     // ── Mutations ────────────────────────────────────────────────────────────────
 
-    public async Task MarkReadAsync(Guid accountId, string folderName, uint uid, CancellationToken ct = default)
-    {
-        var client = await GetOrReconnectAsync(accountId, ct);
-        var folder = await client.GetFolderAsync(folderName, ct);
-        await folder.OpenAsync(FolderAccess.ReadWrite, ct);
-        try   { await folder.AddFlagsAsync(new UniqueId(uid), MessageFlags.Seen, true, ct); }
-        finally { await folder.CloseAsync(false, ct); }
-    }
+    public Task MarkReadAsync(Guid accountId, string folderName, uint uid, CancellationToken ct = default)
+        => ExecuteWithRetryAsync(accountId, ct, async client =>
+        {
+            var folder = await client.GetFolderAsync(folderName, ct);
+            await folder.OpenAsync(FolderAccess.ReadWrite, ct);
+            try   { await folder.AddFlagsAsync(new UniqueId(uid), MessageFlags.Seen, true, ct); }
+            finally { await folder.CloseAsync(false, ct); }
+        });
 
     public Task MoveToTrashBatchAsync(Guid accountId, string folderName, IList<uint> uids, CancellationToken ct = default)
         => ExecuteWithRetryAsync<bool>(accountId, ct, async client =>
@@ -342,131 +342,128 @@ public class ImapService : IImapService
             finally { await folder.CloseAsync(false, ct); }
         });
 
-    public async Task MoveToTrashAsync(Guid accountId, string folderName, uint uid, CancellationToken ct = default)
-    {
-        var client = await GetOrReconnectAsync(accountId, ct);
-        var folder = await client.GetFolderAsync(folderName, ct);
-        await folder.OpenAsync(FolderAccess.ReadWrite, ct);
-        try
+    public Task MoveToTrashAsync(Guid accountId, string folderName, uint uid, CancellationToken ct = default)
+        => ExecuteWithRetryAsync(accountId, ct, async client =>
         {
-            var trash = FindSpecialFolder(client, SpecialFolder.Trash, SpecialFolder.Junk);
-            if (trash != null) await folder.MoveToAsync(new UniqueId(uid), trash, ct);
-            else               await folder.AddFlagsAsync(new UniqueId(uid), MessageFlags.Deleted, true, ct);
-        }
-        finally { await folder.CloseAsync(false, ct); }
-    }
+            var folder = await client.GetFolderAsync(folderName, ct);
+            await folder.OpenAsync(FolderAccess.ReadWrite, ct);
+            try
+            {
+                var trash = FindSpecialFolder(client, SpecialFolder.Trash, SpecialFolder.Junk);
+                if (trash != null) await folder.MoveToAsync(new UniqueId(uid), trash, ct);
+                else               await folder.AddFlagsAsync(new UniqueId(uid), MessageFlags.Deleted, true, ct);
+            }
+            finally { await folder.CloseAsync(false, ct); }
+        });
 
     // ── Drafts ───────────────────────────────────────────────────────────────────
 
-    public async Task<string?> FindDraftsFolderNameAsync(Guid accountId, CancellationToken ct = default)
-    {
-        var client = await GetOrReconnectAsync(accountId, ct);
-        var drafts = FindSpecialFolder(client, SpecialFolder.Drafts);
-        return drafts?.FullName;
-    }
+    public Task<string?> FindDraftsFolderNameAsync(Guid accountId, CancellationToken ct = default)
+        => ExecuteWithRetryAsync(accountId, ct, client =>
+            Task.FromResult(FindSpecialFolder(client, SpecialFolder.Drafts)?.FullName));
 
-    public async Task<uint> AppendDraftAsync(
+    public Task<uint> AppendDraftAsync(
         Guid accountId, ComposeModel draft, uint? replaceUid, CancellationToken ct = default)
-    {
-        var client  = await GetOrReconnectAsync(accountId, ct);
-        var account = _accounts[accountId];
-
-        var draftsFolder = FindSpecialFolder(client, SpecialFolder.Drafts)
-            ?? throw new InvalidOperationException("No Drafts folder found for this account.");
-
-        var msg = MimeMessageBuilder.Build(draft, account);
-
-        // Delete the old draft revision before appending the new one
-        if (replaceUid.HasValue)
+        => ExecuteWithRetryAsync(accountId, ct, async client =>
         {
+            var account = _accounts[accountId];
+
+            var draftsFolder = FindSpecialFolder(client, SpecialFolder.Drafts)
+                ?? throw new InvalidOperationException("No Drafts folder found for this account.");
+
+            var msg = MimeMessageBuilder.Build(draft, account);
+
+            if (replaceUid.HasValue)
+            {
+                await draftsFolder.OpenAsync(FolderAccess.ReadWrite, ct);
+                try
+                {
+                    await draftsFolder.AddFlagsAsync(new UniqueId(replaceUid.Value), MessageFlags.Deleted, true, ct);
+                    await draftsFolder.ExpungeAsync(ct);
+                }
+                finally { await draftsFolder.CloseAsync(false, ct); }
+            }
+
             await draftsFolder.OpenAsync(FolderAccess.ReadWrite, ct);
             try
             {
-                await draftsFolder.AddFlagsAsync(new UniqueId(replaceUid.Value), MessageFlags.Deleted, true, ct);
-                await draftsFolder.ExpungeAsync(ct);
+                var newUid = await draftsFolder.AppendAsync(msg, MessageFlags.Draft, ct);
+                LogService.Log($"AppendDraft: saved draft to {draftsFolder.FullName} UID={newUid?.Id}");
+                return newUid?.Id ?? 0;
             }
             finally { await draftsFolder.CloseAsync(false, ct); }
-        }
-
-        // Append the new draft and return its server-assigned UID
-        await draftsFolder.OpenAsync(FolderAccess.ReadWrite, ct);
-        try
-        {
-            var newUid = await draftsFolder.AppendAsync(msg, MessageFlags.Draft, ct);
-            LogService.Log($"AppendDraft: saved draft to {draftsFolder.FullName} UID={newUid?.Id}");
-            return newUid?.Id ?? 0;
-        }
-        finally { await draftsFolder.CloseAsync(false, ct); }
-    }
+        });
 
     // ── Copy / Move messages ─────────────────────────────────────────────────────
 
-    public async Task CopyMessagesAsync(Guid accountId, string folderName, IList<uint> uids, string destinationFolder, CancellationToken ct = default)
-    {
-        var client = await GetOrReconnectAsync(accountId, ct);
-        var folder = await client.GetFolderAsync(folderName, ct);
-        var dest   = await client.GetFolderAsync(destinationFolder, ct);
-        await folder.OpenAsync(FolderAccess.ReadOnly, ct);
-        try   { await folder.CopyToAsync(uids.Select(u => new UniqueId(u)).ToList(), dest, ct); }
-        finally { await folder.CloseAsync(false, ct); }
-    }
+    public Task CopyMessagesAsync(Guid accountId, string folderName, IList<uint> uids, string destinationFolder, CancellationToken ct = default)
+        => ExecuteWithRetryAsync(accountId, ct, async client =>
+        {
+            var folder = await client.GetFolderAsync(folderName, ct);
+            var dest   = await client.GetFolderAsync(destinationFolder, ct);
+            await folder.OpenAsync(FolderAccess.ReadOnly, ct);
+            try   { await folder.CopyToAsync(uids.Select(u => new UniqueId(u)).ToList(), dest, ct); }
+            finally { await folder.CloseAsync(false, ct); }
+        });
 
-    public async Task MoveMessagesAsync(Guid accountId, string folderName, IList<uint> uids, string destinationFolder, CancellationToken ct = default)
-    {
-        var client = await GetOrReconnectAsync(accountId, ct);
-        var folder = await client.GetFolderAsync(folderName, ct);
-        var dest   = await client.GetFolderAsync(destinationFolder, ct);
-        await folder.OpenAsync(FolderAccess.ReadWrite, ct);
-        try   { await folder.MoveToAsync(uids.Select(u => new UniqueId(u)).ToList(), dest, ct); }
-        finally { await folder.CloseAsync(false, ct); }
-    }
+    public Task MoveMessagesAsync(Guid accountId, string folderName, IList<uint> uids, string destinationFolder, CancellationToken ct = default)
+        => ExecuteWithRetryAsync(accountId, ct, async client =>
+        {
+            var folder = await client.GetFolderAsync(folderName, ct);
+            var dest   = await client.GetFolderAsync(destinationFolder, ct);
+            await folder.OpenAsync(FolderAccess.ReadWrite, ct);
+            try   { await folder.MoveToAsync(uids.Select(u => new UniqueId(u)).ToList(), dest, ct); }
+            finally { await folder.CloseAsync(false, ct); }
+        });
 
     // ── Folder CRUD ──────────────────────────────────────────────────────────────
 
-    public async Task CreateFolderAsync(Guid accountId, string? parentFolderName, string name, CancellationToken ct = default)
-    {
-        var client = await GetOrReconnectAsync(accountId, ct);
-        IMailFolder parent = string.IsNullOrEmpty(parentFolderName)
-            ? client.GetFolder(client.PersonalNamespaces[0])
-            : await client.GetFolderAsync(parentFolderName, ct);
-        await parent.CreateAsync(name, true, ct);
-    }
-
-    public async Task DeleteFolderAsync(Guid accountId, string folderName, CancellationToken ct = default)
-    {
-        var client = await GetOrReconnectAsync(accountId, ct);
-        var folder = await client.GetFolderAsync(folderName, ct);
-
-        // Move all messages to Trash first so no mail is hard-deleted
-        await folder.OpenAsync(FolderAccess.ReadWrite, ct);
-        try
+    public Task CreateFolderAsync(Guid accountId, string? parentFolderName, string name, CancellationToken ct = default)
+        => ExecuteWithRetryAsync(accountId, ct, async client =>
         {
-            var uids = await folder.SearchAsync(SearchQuery.All, ct);
-            if (uids.Count > 0)
+            IMailFolder parent = string.IsNullOrEmpty(parentFolderName)
+                ? client.GetFolder(client.PersonalNamespaces[0])
+                : await client.GetFolderAsync(parentFolderName, ct);
+            await parent.CreateAsync(name, true, ct);
+        });
+
+    public Task DeleteFolderAsync(Guid accountId, string folderName, CancellationToken ct = default)
+        => ExecuteWithRetryAsync(accountId, ct, async client =>
+        {
+            var folder = await client.GetFolderAsync(folderName, ct);
+
+            await folder.OpenAsync(FolderAccess.ReadWrite, ct);
+            try
             {
-                var trash = FindSpecialFolder(client, SpecialFolder.Trash);
-                if (trash != null) await folder.MoveToAsync(uids, trash, ct);
-                else               await folder.AddFlagsAsync(uids, MessageFlags.Deleted, true, ct);
+                var uids = await folder.SearchAsync(SearchQuery.All, ct);
+                if (uids.Count > 0)
+                {
+                    var trash = FindSpecialFolder(client, SpecialFolder.Trash);
+                    if (trash != null) await folder.MoveToAsync(uids, trash, ct);
+                    else               await folder.AddFlagsAsync(uids, MessageFlags.Deleted, true, ct);
+                }
             }
-        }
-        finally { await folder.CloseAsync(false, ct); }
+            finally { await folder.CloseAsync(false, ct); }
 
-        await folder.DeleteAsync(ct);
-    }
+            await folder.DeleteAsync(ct);
+        });
 
-    public async Task RenameFolderAsync(Guid accountId, string folderName, string newName, string? newParentFolderName, CancellationToken ct = default)
+    public Task RenameFolderAsync(Guid accountId, string folderName, string newName, string? newParentFolderName, CancellationToken ct = default)
+        => ExecuteWithRetryAsync(accountId, ct, async client =>
+        {
+            var folder = await client.GetFolderAsync(folderName, ct);
+            IMailFolder parent = string.IsNullOrEmpty(newParentFolderName)
+                ? client.GetFolder(client.PersonalNamespaces[0])
+                : await client.GetFolderAsync(newParentFolderName, ct);
+            await folder.RenameAsync(parent, newName, ct);
+        });
+
+    public Task CopyFolderAsync(Guid accountId, string folderName, string? destinationParentName, CancellationToken ct = default)
+        => ExecuteWithRetryAsync(accountId, ct, client =>
+            CopyFolderCoreAsync(client, folderName, destinationParentName, ct));
+
+    private async Task CopyFolderCoreAsync(ImapClient client, string folderName, string? destinationParentName, CancellationToken ct)
     {
-        var client = await GetOrReconnectAsync(accountId, ct);
-        var folder = await client.GetFolderAsync(folderName, ct);
-        IMailFolder parent = string.IsNullOrEmpty(newParentFolderName)
-            ? client.GetFolder(client.PersonalNamespaces[0])
-            : await client.GetFolderAsync(newParentFolderName, ct);
-        await folder.RenameAsync(parent, newName, ct);
-    }
-
-    public async Task CopyFolderAsync(Guid accountId, string folderName, string? destinationParentName, CancellationToken ct = default)
-    {
-        var client    = await GetOrReconnectAsync(accountId, ct);
         var srcFolder = await client.GetFolderAsync(folderName, ct);
 
         IMailFolder destParent = string.IsNullOrEmpty(destinationParentName)
@@ -488,35 +485,34 @@ public class ImapService : IImapService
         }
         finally { await srcFolder.CloseAsync(false, ct); }
 
-        // Recurse into subfolders
         var subfolders = await srcFolder.GetSubfoldersAsync(false, ct);
         foreach (var sub in subfolders)
-            await CopyFolderAsync(accountId, sub.FullName, newFolder.FullName, ct);
+            await CopyFolderCoreAsync(client, sub.FullName, newFolder.FullName, ct);
     }
 
-    public async Task<int> EmptyTrashAsync(Guid accountId, CancellationToken ct = default)
-    {
-        var client = await GetOrReconnectAsync(accountId, ct);
-        var trash  = FindSpecialFolder(client, SpecialFolder.Trash, SpecialFolder.Junk);
-
-        if (trash == null)
+    public Task<int> EmptyTrashAsync(Guid accountId, CancellationToken ct = default)
+        => ExecuteWithRetryAsync(accountId, ct, async client =>
         {
-            LogService.Log($"EmptyTrash: no Trash folder found for account {accountId}");
-            return 0;
-        }
+            var trash = FindSpecialFolder(client, SpecialFolder.Trash, SpecialFolder.Junk);
 
-        await trash.OpenAsync(FolderAccess.ReadWrite, ct);
-        try
-        {
-            var uids = await trash.SearchAsync(SearchQuery.All, ct);
-            if (uids.Count == 0) return 0;
-            LogService.Log($"EmptyTrash: expunging {uids.Count} messages from {trash.FullName}");
-            await trash.AddFlagsAsync(uids, MessageFlags.Deleted, true, ct);
-            await trash.ExpungeAsync(ct);
-            return uids.Count;
-        }
-        finally { await trash.CloseAsync(false, ct); }
-    }
+            if (trash == null)
+            {
+                LogService.Log($"EmptyTrash: no Trash folder found for account {accountId}");
+                return 0;
+            }
+
+            await trash.OpenAsync(FolderAccess.ReadWrite, ct);
+            try
+            {
+                var uids = await trash.SearchAsync(SearchQuery.All, ct);
+                if (uids.Count == 0) return 0;
+                LogService.Log($"EmptyTrash: expunging {uids.Count} messages from {trash.FullName}");
+                await trash.AddFlagsAsync(uids, MessageFlags.Deleted, true, ct);
+                await trash.ExpungeAsync(ct);
+                return uids.Count;
+            }
+            finally { await trash.CloseAsync(false, ct); }
+        });
 
     // ── UID queries ──────────────────────────────────────────────────────────────
 
@@ -536,92 +532,95 @@ public class ImapService : IImapService
 
     // ── Body-download preview fallback (used when server lacks IMAP PREVIEW) ────
 
-    public async Task<IReadOnlyDictionary<uint, string>> FetchPreviewsAsync(
+    public Task<IReadOnlyDictionary<uint, string>> FetchPreviewsAsync(
         Guid accountId, string folderName, IList<uint> uids,
         int maxLines, CancellationToken ct = default)
     {
-        var result = new Dictionary<uint, string>();
-        if (uids.Count == 0 || maxLines <= 0) return result;
+        if (uids.Count == 0 || maxLines <= 0)
+            return Task.FromResult<IReadOnlyDictionary<uint, string>>(new Dictionary<uint, string>());
 
-        var client = await GetOrReconnectAsync(accountId, ct);
-        var folder = await client.GetFolderAsync(folderName, ct);
-        await folder.OpenAsync(FolderAccess.ReadOnly, ct);
-        try
+        return ExecuteWithRetryAsync(accountId, ct, async client =>
         {
-            var mailKitUids = uids.Select(u => new UniqueId(u)).ToList();
-            var summaries   = await folder.FetchAsync(
-                mailKitUids,
-                MessageSummaryItems.UniqueId | MessageSummaryItems.BodyStructure,
-                ct);
-
-            foreach (var s in summaries)
+            var result = new Dictionary<uint, string>();
+            var folder = await client.GetFolderAsync(folderName, ct);
+            await folder.OpenAsync(FolderAccess.ReadOnly, ct);
+            try
             {
-                ct.ThrowIfCancellationRequested();
-                try
+                var mailKitUids = uids.Select(u => new UniqueId(u)).ToList();
+                var summaries   = await folder.FetchAsync(
+                    mailKitUids,
+                    MessageSummaryItems.UniqueId | MessageSummaryItems.BodyStructure,
+                    ct);
+
+                foreach (var s in summaries)
                 {
-                    string text = string.Empty;
-                    if (s.TextBody != null)
+                    ct.ThrowIfCancellationRequested();
+                    try
                     {
-                        var part = await folder.GetBodyPartAsync(s.UniqueId, s.TextBody, ct);
-                        if (part is TextPart tp) text = tp.Text ?? string.Empty;
-                    }
-                    else if (s.HtmlBody != null)
-                    {
-                        var part = await folder.GetBodyPartAsync(s.UniqueId, s.HtmlBody, ct);
-                        if (part is TextPart tp) text = StripHtml(tp.Text ?? string.Empty);
-                    }
+                        string text = string.Empty;
+                        if (s.TextBody != null)
+                        {
+                            var part = await folder.GetBodyPartAsync(s.UniqueId, s.TextBody, ct);
+                            if (part is TextPart tp) text = tp.Text ?? string.Empty;
+                        }
+                        else if (s.HtmlBody != null)
+                        {
+                            var part = await folder.GetBodyPartAsync(s.UniqueId, s.HtmlBody, ct);
+                            if (part is TextPart tp) text = StripHtml(tp.Text ?? string.Empty);
+                        }
 
-                    var preview = ExtractPreviewLines(text, maxLines);
-                    if (!string.IsNullOrEmpty(preview)) result[s.UniqueId.Id] = preview;
+                        var preview = ExtractPreviewLines(text, maxLines);
+                        if (!string.IsNullOrEmpty(preview)) result[s.UniqueId.Id] = preview;
+                    }
+                    catch (OperationCanceledException) { throw; }
+                    catch (Exception ex) { LogService.Log($"FetchPreview/{s.UniqueId}", ex); }
                 }
-                catch (OperationCanceledException) { throw; }
-                catch (Exception ex) { LogService.Log($"FetchPreview/{s.UniqueId}", ex); }
             }
-        }
-        finally { await folder.CloseAsync(false, ct); }
-        return result;
+            finally { await folder.CloseAsync(false, ct); }
+            return (IReadOnlyDictionary<uint, string>)result;
+        });
     }
 
-    public async Task<int> PollAsync(Guid accountId, string folderName, CancellationToken ct = default)
-    {
-        var client = await GetOrReconnectAsync(accountId, ct);
-        var folder = await client.GetFolderAsync(folderName, ct);
-        await folder.OpenAsync(FolderAccess.ReadOnly, ct);
-        try   { await folder.CheckAsync(ct); return folder.Unread; }
-        finally { await folder.CloseAsync(false, ct); }
-    }
+    public Task<int> PollAsync(Guid accountId, string folderName, CancellationToken ct = default)
+        => ExecuteWithRetryAsync(accountId, ct, async client =>
+        {
+            var folder = await client.GetFolderAsync(folderName, ct);
+            await folder.OpenAsync(FolderAccess.ReadOnly, ct);
+            try   { await folder.CheckAsync(ct); return folder.Unread; }
+            finally { await folder.CloseAsync(false, ct); }
+        });
 
     // ── Attachment download ───────────────────────────────────────────────────────
 
-    public async Task<byte[]> DownloadAttachmentAsync(
+    public Task<byte[]> DownloadAttachmentAsync(
         Guid accountId, string folderName, uint uid, string partSpecifier, CancellationToken ct = default)
-    {
-        var client = await GetOrReconnectAsync(accountId, ct);
-        var folder = await client.GetFolderAsync(folderName, ct);
-        await folder.OpenAsync(FolderAccess.ReadOnly, ct);
-        try
+        => ExecuteWithRetryAsync(accountId, ct, async client =>
         {
-            var mailKitUid = new UniqueId(uid);
-            var summaries  = await folder.FetchAsync(
-                new[] { mailKitUid },
-                MessageSummaryItems.UniqueId | MessageSummaryItems.BodyStructure,
-                ct);
+            var folder = await client.GetFolderAsync(folderName, ct);
+            await folder.OpenAsync(FolderAccess.ReadOnly, ct);
+            try
+            {
+                var mailKitUid = new UniqueId(uid);
+                var summaries  = await folder.FetchAsync(
+                    new[] { mailKitUid },
+                    MessageSummaryItems.UniqueId | MessageSummaryItems.BodyStructure,
+                    ct);
 
-            var s        = summaries.FirstOrDefault()
-                ?? throw new InvalidOperationException($"Message UID {uid} not found.");
-            var bodyPart = FindBodyPartBySpecifier(s.Body, partSpecifier)
-                ?? throw new InvalidOperationException($"Body part '{partSpecifier}' not found.");
+                var s        = summaries.FirstOrDefault()
+                    ?? throw new InvalidOperationException($"Message UID {uid} not found.");
+                var bodyPart = FindBodyPartBySpecifier(s.Body, partSpecifier)
+                    ?? throw new InvalidOperationException($"Body part '{partSpecifier}' not found.");
 
-            var decoded = await folder.GetBodyPartAsync(mailKitUid, bodyPart, ct);
-            using var stream = new MemoryStream();
-            if (decoded is MimePart mp)
-                mp.Content!.DecodeTo(stream);
-            else if (decoded is MessagePart msgPart)
-                await msgPart.Message!.WriteToAsync(stream, ct);
-            return stream.ToArray();
-        }
-        finally { await folder.CloseAsync(false, ct); }
-    }
+                var decoded = await folder.GetBodyPartAsync(mailKitUid, bodyPart, ct);
+                using var stream = new MemoryStream();
+                if (decoded is MimePart mp)
+                    mp.Content!.DecodeTo(stream);
+                else if (decoded is MessagePart msgPart)
+                    await msgPart.Message!.WriteToAsync(stream, ct);
+                return stream.ToArray();
+            }
+            finally { await folder.CloseAsync(false, ct); }
+        });
 
     // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -793,12 +792,20 @@ public class ImapService : IImapService
     public async Task NoOpAsync(Guid accountId, CancellationToken ct = default)
     {
         if (!_clients.TryGetValue(accountId, out var client) || !client.IsConnected) return;
-        try   { await client.NoOpAsync(ct); }
-        catch (Exception ex) when (IsTransientConnectionError(ex))
+
+        // Skip if another operation already holds the lock — NoOp is just a keepalive.
+        var sem = _locks.GetOrAdd(accountId, _ => new SemaphoreSlim(1, 1));
+        if (!await sem.WaitAsync(0, ct)) return;
+        try
         {
-            LogService.Log($"NoOp failed for {accountId}, discarding stale connection: {ex.GetType().Name}");
-            ForceDisconnect(accountId);
+            try   { await client.NoOpAsync(ct); }
+            catch (Exception ex) when (IsTransientConnectionError(ex))
+            {
+                LogService.Log($"NoOp failed for {accountId}, discarding stale connection: {ex.GetType().Name}");
+                ForceDisconnect(accountId);
+            }
         }
+        finally { sem.Release(); }
     }
 
     // ── Connection retry helpers ─────────────────────────────────────────────────
@@ -816,6 +823,9 @@ public class ImapService : IImapService
             try { stale.Dispose(); } catch { /* best effort */ }
         }
     }
+
+    private Task ExecuteWithRetryAsync(Guid accountId, CancellationToken ct, Func<ImapClient, Task> operation)
+        => ExecuteWithRetryAsync<bool>(accountId, ct, async client => { await operation(client); return true; });
 
     /// <summary>
     /// Runs <paramref name="operation"/> with an authenticated client.

--- a/QuickMail/ViewModels/ComposeViewModel.cs
+++ b/QuickMail/ViewModels/ComposeViewModel.cs
@@ -317,8 +317,12 @@ public partial class ComposeViewModel : ObservableObject
         var model = CreateReply(detail, accountId);
 
         // Merge original To + Cc, excluding the sender's own address, into the new Cc.
-        var recipients = InternetAddressList.Parse(detail.To ?? string.Empty)
-            .Concat(InternetAddressList.Parse(detail.Cc ?? string.Empty))
+        // Use TryParse so that empty or malformed address strings (e.g. when Cc is absent)
+        // return an empty list rather than throwing MimeKit.ParseException.
+        InternetAddressList.TryParse(detail.To ?? string.Empty, out var toList);
+        InternetAddressList.TryParse(detail.Cc ?? string.Empty, out var ccList);
+        var recipients = (toList ?? [])
+            .Concat(ccList ?? [])
             .OfType<MailboxAddress>()
             .Where(a => !string.Equals(a.Address, ownAddress, StringComparison.OrdinalIgnoreCase))
             .Distinct()

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -261,6 +261,28 @@ public partial class MainViewModel : ObservableObject
         Accounts = new ObservableCollection<AccountModel>(_accountService.LoadAccounts());
     }
 
+    internal void ApplySettings(ConfigModel cfg)
+    {
+        ShowMessageStatus = cfg.ShowMessageStatus;
+
+        var newMode = cfg.ViewMode switch
+        {
+            "conversations" => ViewMode.Conversations,
+            "from"          => ViewMode.From,
+            "to"            => ViewMode.To,
+            _               => ViewMode.Messages,
+        };
+        ViewMode = newMode;
+
+        _syncDays = cfg.SyncDays;
+        OnPropertyChanged(nameof(IsSyncDays7));
+        OnPropertyChanged(nameof(IsSyncDays30));
+        OnPropertyChanged(nameof(IsSyncDays180));
+        OnPropertyChanged(nameof(IsSyncDays365));
+        OnPropertyChanged(nameof(IsSyncDaysAll));
+        OnPropertyChanged(nameof(SyncRangeLabel));
+    }
+
     private void RegisterCommands(ICommandRegistry registry)
     {
         registry.Register(new CommandDefinition(

--- a/QuickMail/ViewModels/SettingsViewModel.cs
+++ b/QuickMail/ViewModels/SettingsViewModel.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Windows.Input;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using QuickMail.Models;
+using QuickMail.Services;
+
+namespace QuickMail.ViewModels;
+
+public partial class SettingsViewModel : ObservableObject
+{
+    private readonly IConfigService _configService;
+
+    [ObservableProperty]
+    private int _previewLines;
+
+    [ObservableProperty]
+    private bool _showMessageStatus;
+
+    [ObservableProperty]
+    private string _viewMode = "messages";
+
+    [ObservableProperty]
+    private int _syncDays;
+
+    [ObservableProperty]
+    private int _initialSyncCount;
+
+    public ObservableCollection<HotkeyRowViewModel> HotkeyRows { get; } = [];
+
+    [ObservableProperty]
+    private HotkeyRowViewModel? _selectedHotkey;
+
+    public SettingsViewModel(IConfigService configService, ICommandRegistry registry)
+    {
+        _configService = configService;
+        var cfg = configService.Load();
+
+        PreviewLines = cfg.PreviewLines;
+        ShowMessageStatus = cfg.ShowMessageStatus;
+        ViewMode = cfg.ViewMode;
+        SyncDays = cfg.SyncDays;
+        InitialSyncCount = cfg.InitialSyncCount;
+
+        foreach (var cmd in registry.GetAll())
+        {
+            var row = new HotkeyRowViewModel(cmd);
+            var customBinding = cfg.CustomHotkeys.FirstOrDefault(h => h.CommandId == cmd.Id);
+            if (customBinding != null)
+            {
+                row.SetCustomBinding((Key)customBinding.Key, (ModifierKeys)customBinding.Modifiers);
+            }
+            HotkeyRows.Add(row);
+        }
+    }
+
+    [RelayCommand]
+    private void Save()
+    {
+        var cfg = _configService.Load();
+
+        cfg.PreviewLines = PreviewLines;
+        cfg.ShowMessageStatus = ShowMessageStatus;
+        cfg.ViewMode = ViewMode;
+        cfg.SyncDays = SyncDays;
+        cfg.InitialSyncCount = InitialSyncCount;
+
+        cfg.CustomHotkeys = HotkeyRows
+            .Where(r => r.HasCustomBinding)
+            .Select(r => r.ToBinding())
+            .ToList();
+
+        _configService.Save(cfg);
+    }
+
+    [RelayCommand]
+    private void ClearHotkey(HotkeyRowViewModel? row)
+    {
+        if (row != null)
+        {
+            row.ClearCustomBinding();
+        }
+    }
+
+    // ── HotkeyRowViewModel ─────────────────────────────────────────────────────────
+
+    public partial class HotkeyRowViewModel : ObservableObject
+    {
+        private readonly CommandDefinition _command;
+        private Key _customKey = Key.None;
+        private ModifierKeys _customModifiers = ModifierKeys.None;
+
+        public string CommandId => _command.Id;
+        public string Category => _command.Category;
+        public string Title => _command.Title;
+
+        public string DefaultGesture => _command.GestureText;
+
+        [ObservableProperty]
+        private string _customGesture = string.Empty;
+
+        public bool HasCustomBinding => _customKey != Key.None;
+
+        public HotkeyRowViewModel(CommandDefinition command)
+        {
+            _command = command;
+        }
+
+        public void SetCustomBinding(Key key, ModifierKeys modifiers)
+        {
+            _customKey = key;
+            _customModifiers = modifiers;
+            UpdateCustomGesture();
+        }
+
+        public void ClearCustomBinding()
+        {
+            _customKey = Key.None;
+            _customModifiers = ModifierKeys.None;
+            CustomGesture = string.Empty;
+        }
+
+        public HotkeyBinding ToBinding() => new()
+        {
+            CommandId = CommandId,
+            Key = (int)_customKey,
+            Modifiers = (int)_customModifiers,
+        };
+
+        private void UpdateCustomGesture()
+        {
+            if (_customKey == Key.None)
+            {
+                CustomGesture = string.Empty;
+                return;
+            }
+
+            var parts = new List<string>();
+            if ((_customModifiers & ModifierKeys.Control) != 0) parts.Add("Ctrl");
+            if ((_customModifiers & ModifierKeys.Shift) != 0) parts.Add("Shift");
+            if ((_customModifiers & ModifierKeys.Alt) != 0) parts.Add("Alt");
+
+            var keyStr = _customKey.ToString();
+            if (keyStr.Length == 2 && keyStr[0] == 'D' && char.IsDigit(keyStr[1]))
+                keyStr = keyStr[1..];
+
+            parts.Add(keyStr);
+            CustomGesture = string.Join("+", parts);
+        }
+    }
+}

--- a/QuickMail/ViewModels/SettingsViewModel.cs
+++ b/QuickMail/ViewModels/SettingsViewModel.cs
@@ -85,6 +85,13 @@ public partial class SettingsViewModel : ObservableObject
         }
     }
 
+    internal HotkeyRowViewModel? FindConflict(Key key, ModifierKeys modifiers)
+    {
+        if (key == Key.None) return null;
+
+        return HotkeyRows.FirstOrDefault(r => r.HasCustomBinding && r.MatchesBinding(key, modifiers));
+    }
+
     // ── HotkeyRowViewModel ─────────────────────────────────────────────────────────
 
     public partial class HotkeyRowViewModel : ObservableObject
@@ -150,5 +157,8 @@ public partial class SettingsViewModel : ObservableObject
             parts.Add(keyStr);
             CustomGesture = string.Join("+", parts);
         }
+
+        internal bool MatchesBinding(Key key, ModifierKeys modifiers)
+            => _customKey == key && _customModifiers == modifiers;
     }
 }

--- a/QuickMail/ViewModels/SettingsViewModel.cs
+++ b/QuickMail/ViewModels/SettingsViewModel.cs
@@ -1,10 +1,9 @@
-using System;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Windows.Input;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using QuickMail.Helpers;
 using QuickMail.Models;
 using QuickMail.Services;
 
@@ -49,9 +48,10 @@ public partial class SettingsViewModel : ObservableObject
         {
             var row = new HotkeyRowViewModel(cmd);
             var customBinding = cfg.CustomHotkeys.FirstOrDefault(h => h.CommandId == cmd.Id);
-            if (customBinding != null)
+            if (customBinding != null &&
+                GestureHelper.TryParse(customBinding.Gesture, out var key, out var mods))
             {
-                row.SetCustomBinding((Key)customBinding.Key, (ModifierKeys)customBinding.Modifiers);
+                row.SetCustomBinding(key, mods);
             }
             HotkeyRows.Add(row);
         }
@@ -79,16 +79,12 @@ public partial class SettingsViewModel : ObservableObject
     [RelayCommand]
     private void ClearHotkey(HotkeyRowViewModel? row)
     {
-        if (row != null)
-        {
-            row.ClearCustomBinding();
-        }
+        row?.ClearCustomBinding();
     }
 
     internal HotkeyRowViewModel? FindConflict(Key key, ModifierKeys modifiers)
     {
         if (key == Key.None) return null;
-
         return HotkeyRows.FirstOrDefault(r => r.HasCustomBinding && r.MatchesBinding(key, modifiers));
     }
 
@@ -101,13 +97,17 @@ public partial class SettingsViewModel : ObservableObject
         private ModifierKeys _customModifiers = ModifierKeys.None;
 
         public string CommandId => _command.Id;
-        public string Category => _command.Category;
-        public string Title => _command.Title;
+        public string Category  => _command.Category;
+        public string Title     => _command.Title;
 
         public string DefaultGesture => _command.GestureText;
 
         [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(ActiveGesture))]
         private string _customGesture = string.Empty;
+
+        /// <summary>The binding currently in effect — custom if set, otherwise the default.</summary>
+        public string ActiveGesture => HasCustomBinding ? CustomGesture : DefaultGesture;
 
         public bool HasCustomBinding => _customKey != Key.None;
 
@@ -118,44 +118,31 @@ public partial class SettingsViewModel : ObservableObject
 
         public void SetCustomBinding(Key key, ModifierKeys modifiers)
         {
-            _customKey = key;
+            _customKey      = key;
             _customModifiers = modifiers;
             UpdateCustomGesture();
+            OnPropertyChanged(nameof(HasCustomBinding));
+            OnPropertyChanged(nameof(ActiveGesture));
         }
 
         public void ClearCustomBinding()
         {
-            _customKey = Key.None;
+            _customKey      = Key.None;
             _customModifiers = ModifierKeys.None;
-            CustomGesture = string.Empty;
+            CustomGesture   = string.Empty;
+            OnPropertyChanged(nameof(HasCustomBinding));
+            OnPropertyChanged(nameof(ActiveGesture));
         }
 
         public HotkeyBinding ToBinding() => new()
         {
             CommandId = CommandId,
-            Key = (int)_customKey,
-            Modifiers = (int)_customModifiers,
+            Gesture   = GestureHelper.Format(_customKey, _customModifiers),
         };
 
         private void UpdateCustomGesture()
         {
-            if (_customKey == Key.None)
-            {
-                CustomGesture = string.Empty;
-                return;
-            }
-
-            var parts = new List<string>();
-            if ((_customModifiers & ModifierKeys.Control) != 0) parts.Add("Ctrl");
-            if ((_customModifiers & ModifierKeys.Shift) != 0) parts.Add("Shift");
-            if ((_customModifiers & ModifierKeys.Alt) != 0) parts.Add("Alt");
-
-            var keyStr = _customKey.ToString();
-            if (keyStr.Length == 2 && keyStr[0] == 'D' && char.IsDigit(keyStr[1]))
-                keyStr = keyStr[1..];
-
-            parts.Add(keyStr);
-            CustomGesture = string.Join("+", parts);
+            CustomGesture = GestureHelper.Format(_customKey, _customModifiers);
         }
 
         internal bool MatchesBinding(Key key, ModifierKeys modifiers)

--- a/QuickMail/Views/AccessibilityHelper.cs
+++ b/QuickMail/Views/AccessibilityHelper.cs
@@ -1,6 +1,7 @@
 using System.Windows;
 using System.Windows.Automation.Peers;
 using System.Windows.Automation;
+using QuickMail.Services;
 
 namespace QuickMail.Views;
 
@@ -29,18 +30,33 @@ internal static class AccessibilityHelper
     {
         if (string.IsNullOrEmpty(text)) return;
 
-        var peer = UIElementAutomationPeer.FromElement(element)
-                   ?? UIElementAutomationPeer.CreatePeerForElement(element);
-        if (peer == null) return;
+        var fromElement = UIElementAutomationPeer.FromElement(element);
+        var peer        = fromElement ?? UIElementAutomationPeer.CreatePeerForElement(element);
+
+        LogService.Debug($"[UIA] Announce: element={element?.GetType().Name} fromElement={fromElement != null} peer={peer?.GetType().Name ?? "null"} text='{text}'");
+
+        if (peer == null)
+        {
+            LogService.Debug("[UIA] Announce: peer is null — notification skipped");
+            return;
+        }
 
         var processing = interrupt
             ? AutomationNotificationProcessing.ImportantMostRecent
             : AutomationNotificationProcessing.MostRecent;
 
-        peer.RaiseNotificationEvent(
-            AutomationNotificationKind.Other,
-            processing,
-            text,
-            ActivityId);
+        try
+        {
+            peer.RaiseNotificationEvent(
+                AutomationNotificationKind.Other,
+                processing,
+                text,
+                ActivityId);
+            LogService.Debug("[UIA] Announce: RaiseNotificationEvent completed");
+        }
+        catch (Exception ex)
+        {
+            LogService.Log("[UIA] Announce RaiseNotificationEvent", ex);
+        }
     }
 }

--- a/QuickMail/Views/ComposeWindow.xaml
+++ b/QuickMail/Views/ComposeWindow.xaml
@@ -199,7 +199,7 @@
                      AutomationProperties.Name="Message body. Alt+U for Subject, Alt+M for From, Alt+S to send."
                      AcceptsReturn="True" AcceptsTab="True"
                      TextWrapping="Wrap"
-                     SpellCheck.IsEnabled="True"
+                     SpellCheck.IsEnabled="False"
                      VerticalScrollBarVisibility="Auto"
                      FontFamily="Segoe UI"
                      Margin="0,4" TabIndex="7"

--- a/QuickMail/Views/ConflictDialog.xaml
+++ b/QuickMail/Views/ConflictDialog.xaml
@@ -1,0 +1,65 @@
+<Window x:Class="QuickMail.Views.ConflictDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        mc:Ignorable="d"
+        Title="Shortcut Conflict"
+        Height="200" Width="420"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="NoResize"
+        WindowStyle="ToolWindow"
+        ShowInTaskbar="False"
+        AutomationProperties.Name="Keyboard shortcut conflict warning">
+
+    <Grid Margin="20">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Warning Icon and Message -->
+        <TextBlock Grid.Row="0"
+                   Text="⚠ This shortcut is already assigned"
+                   FontSize="14"
+                   FontWeight="SemiBold"
+                   Foreground="#D32F2F"
+                   Margin="0,0,0,8"/>
+
+        <!-- Conflicting Command Info -->
+        <StackPanel Grid.Row="1" Margin="0,0,0,16">
+            <TextBlock Text="Assigned to:" Foreground="DimGray" FontSize="12"/>
+            <TextBlock x:Name="ConflictingCommandText"
+                       Text="(command name)"
+                       FontSize="12"
+                       Foreground="#1976D2"
+                       Margin="0,2,0,0"/>
+        </StackPanel>
+
+        <!-- Instructions -->
+        <TextBlock Grid.Row="2"
+                   Text="Select 'Choose Another' to try a different shortcut, or 'Cancel' to keep the previous binding."
+                   TextWrapping="Wrap"
+                   Foreground="DimGray"
+                   FontSize="12"
+                   Margin="0,0,0,16"/>
+
+        <!-- Buttons -->
+        <StackPanel Grid.Row="3"
+                    Orientation="Horizontal"
+                    HorizontalAlignment="Right">
+            <Button x:Name="RetryButton"
+                    Content="Choose _Another"
+                    Click="RetryButton_Click"
+                    MinWidth="100"
+                    Margin="0,0,8,0"
+                    AutomationProperties.Name="Try another shortcut"/>
+            <Button Content="_Cancel"
+                    IsCancel="True"
+                    MinWidth="75"
+                    AutomationProperties.Name="Cancel and keep previous binding"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/QuickMail/Views/ConflictDialog.xaml.cs
+++ b/QuickMail/Views/ConflictDialog.xaml.cs
@@ -1,0 +1,18 @@
+using System.Windows;
+
+namespace QuickMail.Views;
+
+public partial class ConflictDialog : Window
+{
+    public ConflictDialog(string conflictingCommandTitle)
+    {
+        InitializeComponent();
+        ConflictingCommandText.Text = conflictingCommandTitle;
+    }
+
+    private void RetryButton_Click(object sender, RoutedEventArgs e)
+    {
+        DialogResult = true; // "Try Again"
+        Close();
+    }
+}

--- a/QuickMail/Views/KeyCaptureDialog.xaml
+++ b/QuickMail/Views/KeyCaptureDialog.xaml
@@ -10,10 +10,12 @@
         ResizeMode="NoResize"
         WindowStyle="ToolWindow"
         ShowInTaskbar="False"
+        Loaded="Window_Loaded"
+        KeyDown="Window_KeyDown"
         PreviewKeyDown="Window_PreviewKeyDown"
         AutomationProperties.Name="Assign keyboard shortcut dialog">
 
-    <Grid Margin="20">
+    <Grid Margin="20" Focusable="True" x:Name="MainGrid" KeyDown="Grid_KeyDown">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>

--- a/QuickMail/Views/KeyCaptureDialog.xaml
+++ b/QuickMail/Views/KeyCaptureDialog.xaml
@@ -11,11 +11,10 @@
         WindowStyle="ToolWindow"
         ShowInTaskbar="False"
         Loaded="Window_Loaded"
-        KeyDown="Window_KeyDown"
         PreviewKeyDown="Window_PreviewKeyDown"
         AutomationProperties.Name="Assign keyboard shortcut dialog">
 
-    <Grid Margin="20" Focusable="True" x:Name="MainGrid" KeyDown="Grid_KeyDown">
+    <Grid Margin="20" Focusable="True" x:Name="MainGrid">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>

--- a/QuickMail/Views/KeyCaptureDialog.xaml
+++ b/QuickMail/Views/KeyCaptureDialog.xaml
@@ -1,0 +1,71 @@
+<Window x:Class="QuickMail.Views.KeyCaptureDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        mc:Ignorable="d"
+        Title="Assign Shortcut"
+        Height="180" Width="400"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="NoResize"
+        WindowStyle="ToolWindow"
+        ShowInTaskbar="False"
+        PreviewKeyDown="Window_PreviewKeyDown"
+        AutomationProperties.Name="Assign keyboard shortcut dialog">
+
+    <Grid Margin="20">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Instructions -->
+        <TextBlock Grid.Row="0"
+                   Text="Press your desired key combination"
+                   FontSize="14"
+                   FontWeight="SemiBold"
+                   Margin="0,0,0,4"/>
+        <TextBlock Grid.Row="1"
+                   Text="(with Ctrl, Shift, or Alt)"
+                   FontSize="12"
+                   Foreground="DimGray"
+                   Margin="0,0,0,16"/>
+
+        <!-- Captured Key Display -->
+        <Border Grid.Row="2"
+                BorderThickness="1"
+                BorderBrush="LightGray"
+                Background="#F5F5F5"
+                Padding="12"
+                Margin="0,0,0,16"
+                CornerRadius="2">
+            <TextBlock x:Name="CapturedKeyText"
+                       Text="(waiting for input...)"
+                       FontSize="13"
+                       Foreground="DimGray"
+                       TextAlignment="Center"
+                       AutomationProperties.Name="Captured key combination"/>
+        </Border>
+
+        <!-- Buttons -->
+        <StackPanel Grid.Row="4"
+                    Orientation="Horizontal"
+                    HorizontalAlignment="Right">
+            <Button x:Name="OkButton"
+                    Content="_OK"
+                    IsDefault="True"
+                    Click="OkButton_Click"
+                    MinWidth="75"
+                    IsEnabled="False"
+                    Margin="0,0,8,0"
+                    AutomationProperties.Name="Accept the captured shortcut"/>
+            <Button Content="_Cancel"
+                    IsCancel="True"
+                    MinWidth="75"
+                    AutomationProperties.Name="Cancel and close without saving"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/QuickMail/Views/KeyCaptureDialog.xaml.cs
+++ b/QuickMail/Views/KeyCaptureDialog.xaml.cs
@@ -24,8 +24,6 @@ public partial class KeyCaptureDialog : Window
     }
 
     private void Window_PreviewKeyDown(object sender, KeyEventArgs e) => CaptureKey(e);
-    private void Grid_KeyDown(object sender, KeyEventArgs e)          => CaptureKey(e);
-    private void Window_KeyDown(object sender, KeyEventArgs e)        => CaptureKey(e);
 
     private void CaptureKey(KeyEventArgs e)
     {

--- a/QuickMail/Views/KeyCaptureDialog.xaml.cs
+++ b/QuickMail/Views/KeyCaptureDialog.xaml.cs
@@ -16,11 +16,32 @@ public partial class KeyCaptureDialog : Window
         InitializeComponent();
     }
 
+    private void Window_Loaded(object sender, RoutedEventArgs e)
+    {
+        MainGrid.Focus();
+        Keyboard.Focus(MainGrid);
+    }
+
     private void Window_PreviewKeyDown(object sender, KeyEventArgs e)
+    {
+        CaptureKey(e);
+    }
+
+    private void Grid_KeyDown(object sender, KeyEventArgs e)
+    {
+        CaptureKey(e);
+    }
+
+    private void Window_KeyDown(object sender, KeyEventArgs e)
+    {
+        CaptureKey(e);
+    }
+
+    private void CaptureKey(KeyEventArgs e)
     {
         // Ignore modifier-only keys
         if (e.Key is Key.LeftCtrl or Key.RightCtrl or Key.LeftAlt or Key.RightAlt
-            or Key.LeftShift or Key.RightShift)
+            or Key.LeftShift or Key.RightShift or Key.LWin or Key.RWin)
         {
             return;
         }

--- a/QuickMail/Views/KeyCaptureDialog.xaml.cs
+++ b/QuickMail/Views/KeyCaptureDialog.xaml.cs
@@ -1,0 +1,66 @@
+using System.Windows;
+using System.Windows.Input;
+
+namespace QuickMail.Views;
+
+public partial class KeyCaptureDialog : Window
+{
+    private Key _capturedKey = Key.None;
+    private ModifierKeys _capturedModifiers = ModifierKeys.None;
+
+    public Key CapturedKey => _capturedKey;
+    public ModifierKeys CapturedModifiers => _capturedModifiers;
+
+    public KeyCaptureDialog()
+    {
+        InitializeComponent();
+    }
+
+    private void Window_PreviewKeyDown(object sender, KeyEventArgs e)
+    {
+        // Ignore modifier-only keys
+        if (e.Key is Key.LeftCtrl or Key.RightCtrl or Key.LeftAlt or Key.RightAlt
+            or Key.LeftShift or Key.RightShift)
+        {
+            return;
+        }
+
+        // Require at least one modifier
+        var modifiers = Keyboard.Modifiers;
+        if (modifiers == ModifierKeys.None)
+        {
+            return;
+        }
+
+        // Capture the key
+        _capturedKey = e.Key;
+        _capturedModifiers = modifiers;
+
+        // Update display
+        UpdateCapturedKeyDisplay();
+        OkButton.IsEnabled = true;
+
+        e.Handled = true;
+    }
+
+    private void UpdateCapturedKeyDisplay()
+    {
+        var parts = new System.Collections.Generic.List<string>();
+        if ((_capturedModifiers & ModifierKeys.Control) != 0) parts.Add("Ctrl");
+        if ((_capturedModifiers & ModifierKeys.Shift) != 0) parts.Add("Shift");
+        if ((_capturedModifiers & ModifierKeys.Alt) != 0) parts.Add("Alt");
+
+        var keyStr = _capturedKey.ToString();
+        if (keyStr.Length == 2 && keyStr[0] == 'D' && char.IsDigit(keyStr[1]))
+            keyStr = keyStr[1..];
+
+        parts.Add(keyStr);
+        CapturedKeyText.Text = string.Join("+", parts);
+    }
+
+    private void OkButton_Click(object sender, RoutedEventArgs e)
+    {
+        DialogResult = true;
+        Close();
+    }
+}

--- a/QuickMail/Views/KeyCaptureDialog.xaml.cs
+++ b/QuickMail/Views/KeyCaptureDialog.xaml.cs
@@ -1,5 +1,6 @@
 using System.Windows;
 using System.Windows.Input;
+using QuickMail.Helpers;
 
 namespace QuickMail.Views;
 
@@ -8,7 +9,7 @@ public partial class KeyCaptureDialog : Window
     private Key _capturedKey = Key.None;
     private ModifierKeys _capturedModifiers = ModifierKeys.None;
 
-    public Key CapturedKey => _capturedKey;
+    public Key CapturedKey      => _capturedKey;
     public ModifierKeys CapturedModifiers => _capturedModifiers;
 
     public KeyCaptureDialog()
@@ -22,61 +23,30 @@ public partial class KeyCaptureDialog : Window
         Keyboard.Focus(MainGrid);
     }
 
-    private void Window_PreviewKeyDown(object sender, KeyEventArgs e)
-    {
-        CaptureKey(e);
-    }
-
-    private void Grid_KeyDown(object sender, KeyEventArgs e)
-    {
-        CaptureKey(e);
-    }
-
-    private void Window_KeyDown(object sender, KeyEventArgs e)
-    {
-        CaptureKey(e);
-    }
+    private void Window_PreviewKeyDown(object sender, KeyEventArgs e) => CaptureKey(e);
+    private void Grid_KeyDown(object sender, KeyEventArgs e)          => CaptureKey(e);
+    private void Window_KeyDown(object sender, KeyEventArgs e)        => CaptureKey(e);
 
     private void CaptureKey(KeyEventArgs e)
     {
         // Ignore modifier-only keys
         if (e.Key is Key.LeftCtrl or Key.RightCtrl or Key.LeftAlt or Key.RightAlt
             or Key.LeftShift or Key.RightShift or Key.LWin or Key.RWin)
-        {
             return;
-        }
 
-        // Require at least one modifier
         var modifiers = Keyboard.Modifiers;
-        if (modifiers == ModifierKeys.None)
-        {
-            return;
-        }
+        if (modifiers == ModifierKeys.None) return;
 
-        // Capture the key
-        _capturedKey = e.Key;
+        _capturedKey       = e.Key;
         _capturedModifiers = modifiers;
 
-        // Update display
-        UpdateCapturedKeyDisplay();
-        OkButton.IsEnabled = true;
+        var gesture = GestureHelper.Format(_capturedKey, _capturedModifiers);
+        CapturedKeyText.Text = gesture;
+        OkButton.IsEnabled   = true;
+
+        AccessibilityHelper.Announce(MainGrid, gesture);
 
         e.Handled = true;
-    }
-
-    private void UpdateCapturedKeyDisplay()
-    {
-        var parts = new System.Collections.Generic.List<string>();
-        if ((_capturedModifiers & ModifierKeys.Control) != 0) parts.Add("Ctrl");
-        if ((_capturedModifiers & ModifierKeys.Shift) != 0) parts.Add("Shift");
-        if ((_capturedModifiers & ModifierKeys.Alt) != 0) parts.Add("Alt");
-
-        var keyStr = _capturedKey.ToString();
-        if (keyStr.Length == 2 && keyStr[0] == 'D' && char.IsDigit(keyStr[1]))
-            keyStr = keyStr[1..];
-
-        parts.Add(keyStr);
-        CapturedKeyText.Text = string.Join("+", parts);
     }
 
     private void OkButton_Click(object sender, RoutedEventArgs e)

--- a/QuickMail/Views/MainWindow.xaml
+++ b/QuickMail/Views/MainWindow.xaml
@@ -220,6 +220,10 @@
                           Click="MenuAddressBook_Click"
                           InputGestureText="Ctrl+Shift+B"/>
                 <Separator/>
+                <MenuItem Header="S_ettings…"
+                          Click="MenuSettings_Click"
+                          InputGestureText="Ctrl+,"/>
+                <Separator/>
                 <MenuItem Header="E_xit"
                           Command="{Binding ExitCommand}"/>
             </MenuItem>

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -75,6 +75,7 @@ public partial class MainWindow : Window
     private object? _typeAheadScope;
 
     private readonly IContactService _contactService;
+    private readonly IConfigService _configService;
 
     public MainWindow(
         MainViewModel vm,
@@ -84,7 +85,8 @@ public partial class MainWindow : Window
         IImapService imap,
         IOAuthService oauth,
         ICommandRegistry registry,
-        IContactService contactService)
+        IContactService contactService,
+        IConfigService configService)
     {
         _vm = vm;
         _smtp = smtp;
@@ -94,6 +96,7 @@ public partial class MainWindow : Window
         _oauth = oauth;
         _registry = registry;
         _contactService = contactService;
+        _configService = configService;
 
         InitializeComponent();
         DataContext = vm;
@@ -1936,6 +1939,18 @@ public partial class MainWindow : Window
         var vm  = new AddressBookViewModel(_contactService);
         var win = new AddressBookWindow(vm) { Owner = this };
         win.ShowDialog();
+    }
+
+    private void MenuSettings_Click(object sender, RoutedEventArgs e)
+    {
+        var vm = new SettingsViewModel(_configService, _registry);
+        var dialog = new SettingsDialog(vm) { Owner = this };
+        if (dialog.ShowDialog() == true)
+        {
+            var cfg = _configService.Load();
+            _vm.ApplySettings(cfg);
+            _registry.ApplyUserOverrides(cfg.CustomHotkeys);
+        }
     }
 
     private void MenuGrabAddresses_Click(object sender, RoutedEventArgs e)

--- a/QuickMail/Views/SettingsDialog.xaml
+++ b/QuickMail/Views/SettingsDialog.xaml
@@ -3,19 +3,13 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:local="clr-namespace:QuickMail.Views"
         mc:Ignorable="d"
         Title="Settings"
         Height="560" Width="520"
         WindowStartupLocation="CenterOwner"
         ResizeMode="CanResizeWithGrip"
         Background="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"
-        PreviewKeyDown="Window_PreviewKeyDown"
         Loaded="Window_Loaded">
-
-    <Window.Resources>
-        <local:EmptyStringToDashConverter x:Key="EmptyStringToDashConverter"/>
-    </Window.Resources>
 
     <Grid Margin="10">
         <Grid.RowDefinitions>
@@ -49,6 +43,10 @@
                                         <ComboBoxItem Tag="4" Content="4 lines"/>
                                         <ComboBoxItem Tag="5" Content="5 lines"/>
                                     </ComboBox>
+                                    <TextBlock Text="Takes effect after reopening a folder."
+                                               Foreground="DimGray"
+                                               FontSize="11"
+                                               Margin="0,4,0,0"/>
                                 </StackPanel>
 
                                 <!-- Show Message Status -->

--- a/QuickMail/Views/SettingsDialog.xaml
+++ b/QuickMail/Views/SettingsDialog.xaml
@@ -1,0 +1,195 @@
+<Window x:Class="QuickMail.Views.SettingsDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:QuickMail.Views"
+        mc:Ignorable="d"
+        Title="Settings"
+        Height="560" Width="520"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="CanResizeWithGrip"
+        Background="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"
+        PreviewKeyDown="Window_PreviewKeyDown">
+
+    <Window.Resources>
+        <local:EmptyStringToDashConverter x:Key="EmptyStringToDashConverter"/>
+    </Window.Resources>
+
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Tabs -->
+        <TabControl Grid.Row="0" Margin="0,0,0,10">
+            <!-- General Settings Tab -->
+            <TabItem Header="_General" AutomationProperties.Name="General settings tab">
+                <ScrollViewer VerticalScrollBarVisibility="Auto">
+                    <StackPanel Margin="10" >
+                        <!-- Message List Group -->
+                        <GroupBox Header="Message _List" Padding="10" Margin="0,0,0,15" AutomationProperties.Name="Message list settings">
+                            <StackPanel>
+                                <!-- Preview Lines -->
+                                <StackPanel>
+                                    <Label x:Name="PreviewLinesLabel"
+                                           Content="Preview _lines:"
+                                           Target="{Binding ElementName=PreviewLinesCombo}"
+                                           FontWeight="SemiBold"/>
+                                    <ComboBox x:Name="PreviewLinesCombo"
+                                              SelectedValue="{Binding PreviewLines, Mode=TwoWay}"
+                                              SelectedValuePath="Tag"
+                                              AutomationProperties.LabeledBy="{Binding ElementName=PreviewLinesLabel}">
+                                        <ComboBoxItem Tag="0" Content="Disabled"/>
+                                        <ComboBoxItem Tag="1" Content="1 line"/>
+                                        <ComboBoxItem Tag="2" Content="2 lines"/>
+                                        <ComboBoxItem Tag="3" Content="3 lines"/>
+                                        <ComboBoxItem Tag="4" Content="4 lines"/>
+                                        <ComboBoxItem Tag="5" Content="5 lines"/>
+                                    </ComboBox>
+                                </StackPanel>
+
+                                <!-- Show Message Status -->
+                                <CheckBox Content="Show message _status column"
+                                          IsChecked="{Binding ShowMessageStatus, Mode=TwoWay}"
+                                          Margin="0,8,0,0"
+                                          AutomationProperties.Name="Show message status column in message list"/>
+                            </StackPanel>
+                        </GroupBox>
+
+                        <!-- View Group -->
+                        <GroupBox Header="_View" Padding="10" Margin="0,0,0,15" AutomationProperties.Name="View settings">
+                            <StackPanel>
+                                <!-- View Mode -->
+                                <StackPanel>
+                                    <Label x:Name="ViewModeLabel"
+                                           Content="Display mode:"
+                                           Target="{Binding ElementName=ViewModeCombo}"
+                                           FontWeight="SemiBold"/>
+                                    <ComboBox x:Name="ViewModeCombo"
+                                              SelectedValue="{Binding ViewMode, Mode=TwoWay}"
+                                              SelectedValuePath="Tag"
+                                              AutomationProperties.LabeledBy="{Binding ElementName=ViewModeLabel}">
+                                        <ComboBoxItem Tag="messages" Content="Messages (flat list)"/>
+                                        <ComboBoxItem Tag="conversations" Content="Conversations (grouped by subject)"/>
+                                        <ComboBoxItem Tag="from" Content="By Sender"/>
+                                        <ComboBoxItem Tag="to" Content="By Recipient"/>
+                                    </ComboBox>
+                                </StackPanel>
+                            </StackPanel>
+                        </GroupBox>
+
+                        <!-- Sync Group -->
+                        <GroupBox Header="_Sync" Padding="10" AutomationProperties.Name="Synchronization settings">
+                            <StackPanel>
+                                <!-- Sync Days -->
+                                <StackPanel>
+                                    <Label x:Name="SyncDaysLabel" Margin="0,0,0,0"
+                                           Content="Sync _range:"
+                                           Target="{Binding ElementName=SyncDaysCombo}"
+                                           FontWeight="SemiBold"/>
+                                    <ComboBox x:Name="SyncDaysCombo"
+                                              SelectedValue="{Binding SyncDays, Mode=TwoWay}"
+                                              SelectedValuePath="Tag"
+                                              AutomationProperties.LabeledBy="{Binding ElementName=SyncDaysLabel}">
+                                        <ComboBoxItem Tag="7" Content="7 days"/>
+                                        <ComboBoxItem Tag="30" Content="30 days"/>
+                                        <ComboBoxItem Tag="180" Content="6 months"/>
+                                        <ComboBoxItem Tag="365" Content="1 year"/>
+                                        <ComboBoxItem Tag="0" Content="All mail"/>
+                                    </ComboBox>
+                                </StackPanel>
+
+                                <!-- Initial Sync Count -->
+                                <StackPanel Margin="0,8,0,0">
+                                    <Label x:Name="InitialSyncLabel"
+                                           Content="Initial fetch _count:"
+                                           Target="{Binding ElementName=InitialSyncCombo}"
+                                           FontWeight="SemiBold"/>
+                                    <ComboBox x:Name="InitialSyncCombo"
+                                              SelectedValue="{Binding InitialSyncCount, Mode=TwoWay}"
+                                              SelectedValuePath="Tag"
+                                              AutomationProperties.LabeledBy="{Binding ElementName=InitialSyncLabel}">
+                                        <ComboBoxItem Tag="100" Content="100 messages"/>
+                                        <ComboBoxItem Tag="250" Content="250 messages"/>
+                                        <ComboBoxItem Tag="500" Content="500 messages"/>
+                                        <ComboBoxItem Tag="1000" Content="1,000 messages"/>
+                                        <ComboBoxItem Tag="0" Content="All messages"/>
+                                    </ComboBox>
+                                </StackPanel>
+                            </StackPanel>
+                        </GroupBox>
+                    </StackPanel>
+                </ScrollViewer>
+            </TabItem>
+
+            <!-- Keyboard Shortcuts Tab -->
+            <TabItem Header="_Keyboard Shortcuts" AutomationProperties.Name="Keyboard shortcuts tab">
+                <DockPanel Margin="10">
+                    <!-- Helper text -->
+                    <TextBlock DockPanel.Dock="Top"
+                               Text="Select a command and press your desired key combination (with Ctrl, Shift, or Alt)."
+                               TextWrapping="Wrap"
+                               Margin="0,0,0,10"
+                               Foreground="DimGray"/>
+
+                    <!-- Hotkeys ListView -->
+                    <ListView x:Name="HotkeyListView"
+                              DockPanel.Dock="Top"
+                              ItemsSource="{Binding HotkeyRows}"
+                              SelectedItem="{Binding SelectedHotkey, Mode=TwoWay}"
+                              SelectionMode="Single"
+                              BorderThickness="1"
+                              Margin="0,0,0,10"
+                              PreviewKeyDown="HotkeyListView_PreviewKeyDown"
+                              SelectionChanged="HotkeyListView_SelectionChanged"
+                              AutomationProperties.Name="Keyboard shortcuts list">
+                        <ListView.View>
+                            <GridView>
+                                <GridViewColumn Header="Category" DisplayMemberBinding="{Binding Category}" Width="100"/>
+                                <GridViewColumn Header="Command" DisplayMemberBinding="{Binding Title}" Width="150"/>
+                                <GridViewColumn Header="Default" DisplayMemberBinding="{Binding DefaultGesture}" Width="80"/>
+                                <GridViewColumn Header="Custom" Width="100">
+                                    <GridViewColumn.CellTemplate>
+                                        <DataTemplate>
+                                            <TextBlock Text="{Binding CustomGesture, Converter={StaticResource EmptyStringToDashConverter}}"/>
+                                        </DataTemplate>
+                                    </GridViewColumn.CellTemplate>
+                                </GridViewColumn>
+                            </GridView>
+                        </ListView.View>
+                    </ListView>
+
+                    <!-- Clear Button -->
+                    <Button x:Name="ClearButton"
+                            DockPanel.Dock="Bottom"
+                            Content="_Clear Shortcut"
+                            Command="{Binding ClearHotkeyCommand}"
+                            CommandParameter="{Binding SelectedHotkey}"
+                            MinWidth="100"
+                            Margin="0,0,0,10"
+                            HorizontalAlignment="Left"
+                            AutomationProperties.Name="Clear the selected shortcut"/>
+                </DockPanel>
+            </TabItem>
+        </TabControl>
+
+        <!-- Buttons -->
+        <StackPanel Grid.Row="1"
+                    Orientation="Horizontal"
+                    HorizontalAlignment="Right"
+                    >
+            <Button x:Name="SaveButton"
+                    Content="_Save"
+                    IsDefault="True"
+                    Click="SaveButton_Click"
+                    MinWidth="75"
+                    AutomationProperties.Name="Save settings"/>
+            <Button Content="_Cancel"
+                    IsCancel="True"
+                    MinWidth="75"
+                    AutomationProperties.Name="Cancel and close without saving"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/QuickMail/Views/SettingsDialog.xaml
+++ b/QuickMail/Views/SettingsDialog.xaml
@@ -129,7 +129,7 @@
                 <DockPanel Margin="10">
                     <!-- Helper text -->
                     <TextBlock DockPanel.Dock="Top"
-                               Text="Select a command and press your desired key combination (with Ctrl, Shift, or Alt)."
+                               Text="Select a command row. Use Right arrow to focus the 'Set Shortcut' button, then press Space to assign a key combination."
                                TextWrapping="Wrap"
                                Margin="0,0,0,10"
                                Foreground="DimGray"/>
@@ -142,18 +142,43 @@
                               SelectionMode="Single"
                               BorderThickness="1"
                               Margin="0,0,0,10"
-                              PreviewKeyDown="HotkeyListView_PreviewKeyDown"
                               SelectionChanged="HotkeyListView_SelectionChanged"
                               AutomationProperties.Name="Keyboard shortcuts list">
                         <ListView.View>
                             <GridView>
-                                <GridViewColumn Header="Category" DisplayMemberBinding="{Binding Category}" Width="100"/>
-                                <GridViewColumn Header="Command" DisplayMemberBinding="{Binding Title}" Width="150"/>
-                                <GridViewColumn Header="Default" DisplayMemberBinding="{Binding DefaultGesture}" Width="80"/>
-                                <GridViewColumn Header="Custom" Width="100">
+                                <GridViewColumn Header="Category" DisplayMemberBinding="{Binding Category}" Width="90"/>
+                                <GridViewColumn Header="Command" DisplayMemberBinding="{Binding Title}" Width="130"/>
+                                <GridViewColumn Header="Default" DisplayMemberBinding="{Binding DefaultGesture}" Width="70"/>
+                                <GridViewColumn Header="Custom" Width="80">
                                     <GridViewColumn.CellTemplate>
                                         <DataTemplate>
-                                            <TextBlock Text="{Binding CustomGesture, Converter={StaticResource EmptyStringToDashConverter}}"/>
+                                            <TextBlock Text="{Binding CustomGesture, Converter={StaticResource EmptyStringToDashConverter}}"
+                                                       VerticalAlignment="Center"/>
+                                        </DataTemplate>
+                                    </GridViewColumn.CellTemplate>
+                                </GridViewColumn>
+                                <GridViewColumn Header="Set" Width="60">
+                                    <GridViewColumn.CellTemplate>
+                                        <DataTemplate>
+                                            <Button x:Name="SetButton"
+                                                    Content="Set…"
+                                                    Click="SetShortcutButton_Click"
+                                                    Padding="4,2"
+                                                    FontSize="11"
+                                                    AutomationProperties.Name="Set shortcut for this command"/>
+                                        </DataTemplate>
+                                    </GridViewColumn.CellTemplate>
+                                </GridViewColumn>
+                                <GridViewColumn Header="Restore" Width="65">
+                                    <GridViewColumn.CellTemplate>
+                                        <DataTemplate>
+                                            <Button x:Name="RestoreButton"
+                                                    Content="Default"
+                                                    Click="RestoreDefaultButton_Click"
+                                                    Padding="4,2"
+                                                    FontSize="11"
+                                                    IsEnabled="{Binding HasCustomBinding}"
+                                                    AutomationProperties.Name="Restore default shortcut"/>
                                         </DataTemplate>
                                     </GridViewColumn.CellTemplate>
                                 </GridViewColumn>
@@ -161,16 +186,6 @@
                         </ListView.View>
                     </ListView>
 
-                    <!-- Clear Button -->
-                    <Button x:Name="ClearButton"
-                            DockPanel.Dock="Bottom"
-                            Content="_Clear Shortcut"
-                            Command="{Binding ClearHotkeyCommand}"
-                            CommandParameter="{Binding SelectedHotkey}"
-                            MinWidth="100"
-                            Margin="0,0,0,10"
-                            HorizontalAlignment="Left"
-                            AutomationProperties.Name="Clear the selected shortcut"/>
                 </DockPanel>
             </TabItem>
         </TabControl>

--- a/QuickMail/Views/SettingsDialog.xaml
+++ b/QuickMail/Views/SettingsDialog.xaml
@@ -10,7 +10,8 @@
         WindowStartupLocation="CenterOwner"
         ResizeMode="CanResizeWithGrip"
         Background="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"
-        PreviewKeyDown="Window_PreviewKeyDown">
+        PreviewKeyDown="Window_PreviewKeyDown"
+        Loaded="Window_Loaded">
 
     <Window.Resources>
         <local:EmptyStringToDashConverter x:Key="EmptyStringToDashConverter"/>
@@ -126,67 +127,59 @@
 
             <!-- Keyboard Shortcuts Tab -->
             <TabItem Header="_Keyboard Shortcuts" AutomationProperties.Name="Keyboard shortcuts tab">
-                <DockPanel Margin="10">
+                <Grid Margin="10">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+
                     <!-- Helper text -->
-                    <TextBlock DockPanel.Dock="Top"
-                               Text="Select a command row. Use Right arrow to focus the 'Set Shortcut' button, then press Space to assign a key combination."
+                    <TextBlock Grid.Row="0"
+                               Text="Arrow to a command, then press Enter to assign a shortcut or Delete to restore the default."
                                TextWrapping="Wrap"
                                Margin="0,0,0,10"
                                Foreground="DimGray"/>
 
                     <!-- Hotkeys ListView -->
-                    <ListView x:Name="HotkeyListView"
-                              DockPanel.Dock="Top"
+                    <ListView Grid.Row="1"
+                              x:Name="HotkeyListView"
                               ItemsSource="{Binding HotkeyRows}"
                               SelectedItem="{Binding SelectedHotkey, Mode=TwoWay}"
                               SelectionMode="Single"
                               BorderThickness="1"
-                              Margin="0,0,0,10"
+                              Margin="0,0,0,6"
+                              KeyDown="HotkeyListView_KeyDown"
                               SelectionChanged="HotkeyListView_SelectionChanged"
                               AutomationProperties.Name="Keyboard shortcuts list">
                         <ListView.View>
                             <GridView>
                                 <GridViewColumn Header="Category" DisplayMemberBinding="{Binding Category}" Width="90"/>
-                                <GridViewColumn Header="Command" DisplayMemberBinding="{Binding Title}" Width="130"/>
-                                <GridViewColumn Header="Default" DisplayMemberBinding="{Binding DefaultGesture}" Width="70"/>
-                                <GridViewColumn Header="Custom" Width="80">
-                                    <GridViewColumn.CellTemplate>
-                                        <DataTemplate>
-                                            <TextBlock Text="{Binding CustomGesture, Converter={StaticResource EmptyStringToDashConverter}}"
-                                                       VerticalAlignment="Center"/>
-                                        </DataTemplate>
-                                    </GridViewColumn.CellTemplate>
-                                </GridViewColumn>
-                                <GridViewColumn Header="Set" Width="60">
-                                    <GridViewColumn.CellTemplate>
-                                        <DataTemplate>
-                                            <Button x:Name="SetButton"
-                                                    Content="Set…"
-                                                    Click="SetShortcutButton_Click"
-                                                    Padding="4,2"
-                                                    FontSize="11"
-                                                    AutomationProperties.Name="Set shortcut for this command"/>
-                                        </DataTemplate>
-                                    </GridViewColumn.CellTemplate>
-                                </GridViewColumn>
-                                <GridViewColumn Header="Restore" Width="65">
-                                    <GridViewColumn.CellTemplate>
-                                        <DataTemplate>
-                                            <Button x:Name="RestoreButton"
-                                                    Content="Default"
-                                                    Click="RestoreDefaultButton_Click"
-                                                    Padding="4,2"
-                                                    FontSize="11"
-                                                    IsEnabled="{Binding HasCustomBinding}"
-                                                    AutomationProperties.Name="Restore default shortcut"/>
-                                        </DataTemplate>
-                                    </GridViewColumn.CellTemplate>
-                                </GridViewColumn>
+                                <GridViewColumn Header="Command" DisplayMemberBinding="{Binding Title}" Width="200"/>
+                                <GridViewColumn Header="Shortcut" DisplayMemberBinding="{Binding ActiveGesture}" Width="130"/>
                             </GridView>
                         </ListView.View>
                     </ListView>
 
-                </DockPanel>
+                    <!-- Action buttons — Grid.Row="2" so Tab flows: list → Set → Restore → Save/Cancel -->
+                    <StackPanel Grid.Row="2"
+                                Orientation="Horizontal">
+                        <Button x:Name="SetShortcutButton"
+                                Content="Set Shortcut…"
+                                Click="SetShortcutButton_Click"
+                                IsEnabled="False"
+                                Padding="6,3"
+                                Margin="0,0,8,0"
+                                AutomationProperties.Name="Set shortcut for selected command"/>
+                        <Button x:Name="RestoreDefaultButton"
+                                Content="Restore Default"
+                                Click="RestoreDefaultButton_Click"
+                                IsEnabled="False"
+                                Padding="6,3"
+                                AutomationProperties.Name="Restore default shortcut for selected command"/>
+                    </StackPanel>
+
+                </Grid>
             </TabItem>
         </TabControl>
 
@@ -206,5 +199,6 @@
                     MinWidth="75"
                     AutomationProperties.Name="Cancel and close without saving"/>
         </StackPanel>
+
     </Grid>
 </Window>

--- a/QuickMail/Views/SettingsDialog.xaml.cs
+++ b/QuickMail/Views/SettingsDialog.xaml.cs
@@ -1,7 +1,5 @@
 using System;
-using System.Globalization;
 using System.Windows;
-using System.Windows.Data;
 using System.Windows.Input;
 using System.Windows.Threading;
 using QuickMail.Helpers;
@@ -9,23 +7,6 @@ using QuickMail.Services;
 using QuickMail.ViewModels;
 
 namespace QuickMail.Views;
-
-/// <summary>
-/// Converts an empty string to "—" (dash) for display purposes.
-/// </summary>
-public class EmptyStringToDashConverter : IValueConverter
-{
-    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
-    {
-        var str = value as string;
-        return string.IsNullOrEmpty(str) ? "—" : str;
-    }
-
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
-    {
-        throw new NotSupportedException();
-    }
-}
 
 public partial class SettingsDialog : Window
 {
@@ -49,16 +30,6 @@ public partial class SettingsDialog : Window
         _vm.SaveCommand.Execute(null);
         DialogResult = true;
         Close();
-    }
-
-    private void Window_PreviewKeyDown(object sender, KeyEventArgs e)
-    {
-        if (e.Key == Key.Escape)
-        {
-            DialogResult = false;
-            Close();
-            e.Handled = true;
-        }
     }
 
     private void HotkeyListView_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)

--- a/QuickMail/Views/SettingsDialog.xaml.cs
+++ b/QuickMail/Views/SettingsDialog.xaml.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+using System.Windows.Input;
+using QuickMail.ViewModels;
+
+namespace QuickMail.Views;
+
+/// <summary>
+/// Converts an empty string to "—" (dash) for display purposes.
+/// </summary>
+public class EmptyStringToDashConverter : IValueConverter
+{
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        var str = value as string;
+        return string.IsNullOrEmpty(str) ? "—" : str;
+    }
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        throw new NotSupportedException();
+    }
+}
+
+public partial class SettingsDialog : Window
+{
+    private readonly SettingsViewModel _vm;
+
+    public SettingsDialog(SettingsViewModel vm)
+    {
+        _vm = vm;
+        InitializeComponent();
+        DataContext = vm;
+    }
+
+    private void SaveButton_Click(object sender, RoutedEventArgs e)
+    {
+        _vm.SaveCommand.Execute(null);
+        DialogResult = true;
+        Close();
+    }
+
+    private void Window_PreviewKeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            DialogResult = false;
+            Close();
+            e.Handled = true;
+        }
+    }
+
+    private void HotkeyListView_PreviewKeyDown(object sender, KeyEventArgs e)
+    {
+        if (_vm.SelectedHotkey == null)
+        {
+            return;
+        }
+
+        // Allow navigation keys to work normally
+        if (e.Key is Key.Up or Key.Down or Key.Left or Key.Right or Key.Home or Key.End
+            or Key.PageUp or Key.PageDown or Key.Tab)
+        {
+            return;
+        }
+
+        // Require at least one modifier key (Ctrl, Alt, or Shift)
+        var modifiers = Keyboard.Modifiers;
+        if (modifiers == ModifierKeys.None)
+        {
+            return;
+        }
+
+        // Ignore modifier-only key presses
+        if (e.Key is Key.LeftCtrl or Key.RightCtrl or Key.LeftAlt or Key.RightAlt
+            or Key.LeftShift or Key.RightShift)
+        {
+            return;
+        }
+
+        _vm.SelectedHotkey.SetCustomBinding(e.Key, modifiers);
+        e.Handled = true;
+
+        // Update Clear button state
+        ClearButton.IsEnabled = _vm.SelectedHotkey.HasCustomBinding;
+    }
+
+    private void HotkeyListView_SelectionChanged(object sender, object e)
+    {
+        ClearButton.IsEnabled = _vm.SelectedHotkey != null && _vm.SelectedHotkey.HasCustomBinding;
+    }
+}

--- a/QuickMail/Views/SettingsDialog.xaml.cs
+++ b/QuickMail/Views/SettingsDialog.xaml.cs
@@ -59,7 +59,10 @@ public partial class SettingsDialog : Window
 
     private void SetShortcutButton_Click(object sender, RoutedEventArgs e)
     {
-        if (_vm.SelectedHotkey == null) return;
+        // Get the HotkeyRowViewModel from the button's DataContext (the row it's in)
+        var button = sender as System.Windows.Controls.Button;
+        if (button?.DataContext is not SettingsViewModel.HotkeyRowViewModel row)
+            return;
 
         while (true)
         {
@@ -88,14 +91,18 @@ public partial class SettingsDialog : Window
                 }
             }
 
-            _vm.SelectedHotkey.SetCustomBinding(key, modifiers);
+            row.SetCustomBinding(key, modifiers);
             break;
         }
     }
 
     private void RestoreDefaultButton_Click(object sender, RoutedEventArgs e)
     {
-        if (_vm.SelectedHotkey == null) return;
-        _vm.SelectedHotkey.ClearCustomBinding();
+        // Get the HotkeyRowViewModel from the button's DataContext (the row it's in)
+        var button = sender as System.Windows.Controls.Button;
+        if (button?.DataContext is SettingsViewModel.HotkeyRowViewModel row)
+        {
+            row.ClearCustomBinding();
+        }
     }
 }

--- a/QuickMail/Views/SettingsDialog.xaml.cs
+++ b/QuickMail/Views/SettingsDialog.xaml.cs
@@ -3,6 +3,9 @@ using System.Globalization;
 using System.Windows;
 using System.Windows.Data;
 using System.Windows.Input;
+using System.Windows.Threading;
+using QuickMail.Helpers;
+using QuickMail.Services;
 using QuickMail.ViewModels;
 
 namespace QuickMail.Views;
@@ -35,6 +38,12 @@ public partial class SettingsDialog : Window
         DataContext = vm;
     }
 
+    private void Window_Loaded(object sender, RoutedEventArgs e)
+    {
+        // Defer focus until after the window is activated so the screen reader picks it up.
+        Dispatcher.InvokeAsync(() => PreviewLinesCombo.Focus(), DispatcherPriority.Input);
+    }
+
     private void SaveButton_Click(object sender, RoutedEventArgs e)
     {
         _vm.SaveCommand.Execute(null);
@@ -52,57 +61,103 @@ public partial class SettingsDialog : Window
         }
     }
 
-    private void HotkeyListView_SelectionChanged(object sender, object e)
+    private void HotkeyListView_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
     {
-        // Selection changed; buttons will handle enable state binding
+        UpdateActionButtons();
+    }
+
+    private void HotkeyListView_KeyDown(object sender, KeyEventArgs e)
+    {
+        if (_vm.SelectedHotkey == null) return;
+
+        if (e.Key == Key.Return)
+        {
+            OpenSetShortcutDialog(_vm.SelectedHotkey);
+            e.Handled = true;
+        }
+        else if (e.Key == Key.Delete && _vm.SelectedHotkey.HasCustomBinding)
+        {
+            _vm.SelectedHotkey.ClearCustomBinding();
+            UpdateActionButtons();
+            e.Handled = true;
+        }
     }
 
     private void SetShortcutButton_Click(object sender, RoutedEventArgs e)
     {
-        // Get the HotkeyRowViewModel from the button's DataContext (the row it's in)
-        var button = sender as System.Windows.Controls.Button;
-        if (button?.DataContext is not SettingsViewModel.HotkeyRowViewModel row)
-            return;
+        if (_vm.SelectedHotkey != null)
+            OpenSetShortcutDialog(_vm.SelectedHotkey);
+    }
+
+    private void OpenSetShortcutDialog(SettingsViewModel.HotkeyRowViewModel row)
+    {
+        LogService.Debug($"[Settings] Opening capture dialog for '{row.CommandId}'");
 
         while (true)
         {
             var captureDialog = new KeyCaptureDialog { Owner = this };
             if (captureDialog.ShowDialog() != true)
             {
+                LogService.Debug("[Settings] Key capture cancelled");
                 return;
             }
 
-            var key = captureDialog.CapturedKey;
+            var key      = captureDialog.CapturedKey;
             var modifiers = captureDialog.CapturedModifiers;
+            var gesture  = GestureHelper.Format(key, modifiers);
+            LogService.Debug($"[Settings] Captured: key={key} modifiers={modifiers} gesture='{gesture}'");
 
             var conflict = _vm.FindConflict(key, modifiers);
-            if (conflict != null)
+            if (conflict != null && conflict != row)
             {
+                LogService.Debug($"[Settings] Conflict with '{conflict.CommandId}'");
                 var conflictDialog = new ConflictDialog(conflict.Title) { Owner = this };
                 if (conflictDialog.ShowDialog() == true)
-                {
-                    // "Choose Another" — loop back to capture dialog
                     continue;
-                }
                 else
                 {
-                    // "Cancel" — exit without saving
+                    LogService.Debug("[Settings] Conflict cancelled");
                     return;
                 }
             }
 
             row.SetCustomBinding(key, modifiers);
+            UpdateActionButtons();
+            LogService.Debug($"[Settings] Assigned '{gesture}' to '{row.Title}' — announcing");
+            AnnounceAssignment(gesture, row.Title);
             break;
+        }
+    }
+
+    private void AnnounceAssignment(string gesture, string commandTitle)
+    {
+        var source = Keyboard.FocusedElement as UIElement ?? this;
+        var text   = $"{gesture} assigned to {commandTitle}";
+
+        LogService.Debug($"[Settings] Announce: source={source.GetType().Name} text='{text}'");
+
+        try
+        {
+            AccessibilityHelper.Announce(source, text, interrupt: true);
+            LogService.Debug("[Settings] Announce returned OK");
+        }
+        catch (Exception ex)
+        {
+            LogService.Log("[Settings] Announce failed", ex);
         }
     }
 
     private void RestoreDefaultButton_Click(object sender, RoutedEventArgs e)
     {
-        // Get the HotkeyRowViewModel from the button's DataContext (the row it's in)
-        var button = sender as System.Windows.Controls.Button;
-        if (button?.DataContext is SettingsViewModel.HotkeyRowViewModel row)
-        {
-            row.ClearCustomBinding();
-        }
+        if (_vm.SelectedHotkey == null) return;
+        _vm.SelectedHotkey.ClearCustomBinding();
+        UpdateActionButtons();
+    }
+
+    private void UpdateActionButtons()
+    {
+        var row = _vm.SelectedHotkey;
+        SetShortcutButton.IsEnabled    = row != null;
+        RestoreDefaultButton.IsEnabled = row?.HasCustomBinding == true;
     }
 }

--- a/QuickMail/Views/SettingsDialog.xaml.cs
+++ b/QuickMail/Views/SettingsDialog.xaml.cs
@@ -52,43 +52,50 @@ public partial class SettingsDialog : Window
         }
     }
 
-    private void HotkeyListView_PreviewKeyDown(object sender, KeyEventArgs e)
-    {
-        if (_vm.SelectedHotkey == null)
-        {
-            return;
-        }
-
-        // Allow navigation keys to work normally
-        if (e.Key is Key.Up or Key.Down or Key.Left or Key.Right or Key.Home or Key.End
-            or Key.PageUp or Key.PageDown or Key.Tab)
-        {
-            return;
-        }
-
-        // Require at least one modifier key (Ctrl, Alt, or Shift)
-        var modifiers = Keyboard.Modifiers;
-        if (modifiers == ModifierKeys.None)
-        {
-            return;
-        }
-
-        // Ignore modifier-only key presses
-        if (e.Key is Key.LeftCtrl or Key.RightCtrl or Key.LeftAlt or Key.RightAlt
-            or Key.LeftShift or Key.RightShift)
-        {
-            return;
-        }
-
-        _vm.SelectedHotkey.SetCustomBinding(e.Key, modifiers);
-        e.Handled = true;
-
-        // Update Clear button state
-        ClearButton.IsEnabled = _vm.SelectedHotkey.HasCustomBinding;
-    }
-
     private void HotkeyListView_SelectionChanged(object sender, object e)
     {
-        ClearButton.IsEnabled = _vm.SelectedHotkey != null && _vm.SelectedHotkey.HasCustomBinding;
+        // Selection changed; buttons will handle enable state binding
+    }
+
+    private void SetShortcutButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (_vm.SelectedHotkey == null) return;
+
+        while (true)
+        {
+            var captureDialog = new KeyCaptureDialog { Owner = this };
+            if (captureDialog.ShowDialog() != true)
+            {
+                return;
+            }
+
+            var key = captureDialog.CapturedKey;
+            var modifiers = captureDialog.CapturedModifiers;
+
+            var conflict = _vm.FindConflict(key, modifiers);
+            if (conflict != null)
+            {
+                var conflictDialog = new ConflictDialog(conflict.Title) { Owner = this };
+                if (conflictDialog.ShowDialog() == true)
+                {
+                    // "Choose Another" — loop back to capture dialog
+                    continue;
+                }
+                else
+                {
+                    // "Cancel" — exit without saving
+                    return;
+                }
+            }
+
+            _vm.SelectedHotkey.SetCustomBinding(key, modifiers);
+            break;
+        }
+    }
+
+    private void RestoreDefaultButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (_vm.SelectedHotkey == null) return;
+        _vm.SelectedHotkey.ClearCustomBinding();
     }
 }


### PR DESCRIPTION
## Summary

- **Keyboard shortcuts UI**: the settings dialog now shows the active (custom or default) shortcut in a single column; the old two-column layout caused screen readers to announce two different keys with no context. Pressing a key in the capture dialog now fires a UIA `RaiseNotificationEvent` immediately (instant audio feedback), and a second announcement fires after assignment (e.g. \"Ctrl+Shift+8 assigned to View Status Bar\").
- **Hotkeys.json format**: switched from raw integers (`\"key\": 42, \"modifiers\": 6`) to human-readable gesture strings (`\"gesture\": \"Ctrl+Shift+8\"`). Old files are migrated automatically on load. `ConfigService` also validates entries on load (skips duplicates, empty IDs, unparseable gestures).
- **Focus and tab order**: settings dialog focuses the first General tab control on open; the Keyboard Shortcuts tab uses a Grid layout so tab order flows naturally: list → Set Shortcut → Restore Default → Save/Cancel.
- **Spell-check crash**: disabled `SpellCheck.IsEnabled` in ComposeWindow to fix an `AccessViolationException` in self-contained .NET 8 builds where the WinRT spell-check backend cannot load `System.Linq.Expressions`.
- **IMAP concurrency**: all public `ImapService` methods now serialize through `ExecuteWithRetryAsync` / the per-account `SemaphoreSlim`. Previously ~14 methods bypassed the lock by calling `GetOrReconnectAsync` directly, which could race with background sync and produce \"ImapClient is currently busy\" errors across every folder.

## What changed

| Area | Files |
|------|-------|
| New helper | `Helpers/GestureHelper.cs` — centralises key ↔ gesture-string conversion |
| Model | `Models/HotkeyBinding.cs` — `Gesture string` replaces int fields |
| Config | `Services/ConfigService.cs` — migration + validation on load |
| IMAP | `Services/ImapService.cs` — all methods through `ExecuteWithRetryAsync`; non-generic overload added; `CopyFolderAsync` split for safe recursion; `NoOpAsync` try-acquire |
| ViewModel | `ViewModels/SettingsViewModel.cs` — `ActiveGesture` property, `GestureHelper` usage |
| UI | `Views/SettingsDialog.xaml` / `.cs` — Grid layout, single shortcut column, action buttons, UIA announce |
| UI | `Views/KeyCaptureDialog.xaml.cs` — immediate UIA announce on key press |
| UI | `Views/AccessibilityHelper.cs` — debug logging added |
| UI | `Views/ComposeWindow.xaml` — spell check disabled |

## Test plan

- [ ] Change a keyboard shortcut in Settings; confirm the new gesture appears in the list immediately and the screen reader announces the assignment
- [ ] Close and reopen the app; confirm the custom shortcut is loaded from hotkeys.json (now stored as a readable string)
- [ ] Open a pre-existing hotkeys.json with integer format; confirm it is migrated transparently
- [ ] Compose and send an email; confirm no crash
- [ ] With multiple accounts configured, perform a delete + background sync simultaneously; confirm no \"ImapClient is currently busy\" errors in the log

🤖 Generated with [Claude Code](https://claude.com/claude-code)