### PR TITLE
Fix: Tab from message list no longer lands on menu bar

### DIFF
--- a/QuickMail/Views/MainWindow.xaml
+++ b/QuickMail/Views/MainWindow.xaml
@@ -206,6 +206,7 @@
         <!-- ── Menu bar — Row 0 ── -->
         <Menu Grid.Row="0"
               IsTabStop="False"
+              KeyboardNavigation.TabNavigation="None"
               AutomationProperties.Name="Main menu">
 
             <!-- File -->


### PR DESCRIPTION
## Summary
- `IsTabStop="False"` on the `Menu` only excluded the container itself from tab navigation; the top-level `MenuItem` children were still reachable via Tab
- Added `KeyboardNavigation.TabNavigation="None"` to the `Menu` element so WPF's focus engine skips the entire menu subtree during Tab traversal
- Tab from the message list now correctly advances to the toolbar

## Test plan
- [ ] Focus the message list (Ctrl+3 or Tab into it)
- [ ] Press Tab — verify focus moves to the toolbar, not the menu bar
- [ ] Press Shift+Tab from the toolbar — verify focus returns to the message list
- [ ] Press Alt or F10 — verify the menu bar is still accessible via those keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)