### PR TITLE
Fix: exclude toolbar from Tab navigation sequence

### DIFF
--- a/QuickMail/Views/MainWindow.xaml
+++ b/QuickMail/Views/MainWindow.xaml
@@ -335,10 +335,11 @@
 
         </Menu>
 
-        <!-- ── Toolbar — one tab stop; Arrow keys navigate between buttons ── -->
+        <!-- ── Toolbar — Ctrl+0 only; excluded from Tab sequence ── -->
         <ToolBar x:Name="MainToolbar"
                  Grid.Row="1"
                  AutomationProperties.Name="Main toolbar"
+                 KeyboardNavigation.TabNavigation="None"
                  KeyboardNavigation.DirectionalNavigation="Cycle"
                  PreviewKeyDown="Toolbar_PreviewKeyDown">
             <Button x:Name="ToolbarFirstButton"


### PR DESCRIPTION
## Summary
- `KeyboardNavigation.TabNavigation="None"` added to the `ToolBar`, mirroring the same fix applied to the menu bar in #15
- Tab can no longer land on the toolbar — it is only reachable via Ctrl+0
- Tab cycle is now strictly: AccountList → FolderList → MessageList → wrap

## Test plan
- [ ] Focus the message list (Ctrl+3 or Tab into it)
- [ ] Press Tab — verify focus wraps back to the account list, skipping the toolbar
- [ ] Press Ctrl+0 — verify focus still lands on the toolbar
- [ ] While in toolbar, press Tab — verify focus exits the toolbar cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)