### PR TITLE
v0.7: Spell check, signatures, ICS calendar, templates, tutorial, and refactoring

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -238,6 +238,12 @@ Every user-facing keyboard shortcut **must** be registered in `CommandRegistry` 
 | Ctrl+Shift+B | `contacts.openAddressBook` | Address Book |
 | F1 | `help.userGuide` | Open User Guide |
 | *(unassigned)* | `settings.toggleCustomAnnouncements` | Toggle Custom Announcements |
+| *(unassigned)* | `mail.acceptInvite` | Accept Invitation |
+| *(unassigned)* | `mail.declineInvite` | Decline Invitation |
+| *(unassigned)* | `mail.tentativeInvite` | Tentatively Accept Invitation |
+| *(unassigned)* | `help.keyboardTutorial` | Keyboard Tutorial |
+
+**Compose window shortcuts** (Alt+S, Ctrl+S, Ctrl+Shift+A, F7, Shift+F7, Alt+Y, Alt+U, Alt+M, Escape) are registered in a private `CommandRegistry` inside `ComposeWindow.xaml.cs`. They appear in the compose window's command palette (`Ctrl+Shift+P`) but are **not** user-customisable via the Settings dialog. The main window's `CommandRegistry` and `hotkeys.json` do not include compose commands.
 
 
 ## Dependencies

--- a/QuickMail.Tests/ComposeViewModelTemplateTests.cs
+++ b/QuickMail.Tests/ComposeViewModelTemplateTests.cs
@@ -1,0 +1,434 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.Input;
+using QuickMail.Models;
+using QuickMail.Services;
+using QuickMail.ViewModels;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// Tests for ComposeViewModel template commands: InsertTemplate and SaveAsTemplate,
+/// including placeholder replacement ({sender}, {date}, {time}).
+/// </summary>
+public class ComposeViewModelTemplateTests
+{
+    private static (ComposeViewModel vm, TrackedTemplateService templates) MakeVm(
+        List<MessageTemplate>? seedTemplates = null)
+    {
+        var templates = new TrackedTemplateService();
+        if (seedTemplates != null)
+        {
+            templates.SetTemplates(seedTemplates);
+        }
+        var vm = new ComposeViewModel(
+            new StubSmtpService(),
+            new StubAccountService(),
+            new StubCredentialService(),
+            new StubImapService(),
+            templates);
+        return (vm, templates);
+    }
+
+    // ── InsertTemplate ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task InsertTemplate_AppendsBody()
+    {
+        var (vm, templates) = MakeVm();
+        vm.Body = "Existing body.\n";
+
+        var template = new MessageTemplate
+        {
+            Id = 1,
+            Title = "Greeting",
+            Subject = "",
+            Body = "Hello, world!"
+        };
+
+        // Wire the InsertTemplateRequested event to return our template
+        vm.InsertTemplateRequested += () => Task.FromResult<MessageTemplate?>(template);
+
+        // Invoke via the relay command
+        await InvokeInsertTemplateAsync(vm);
+
+        Assert.Contains("Existing body.", vm.Body);
+        Assert.Contains("Hello, world!", vm.Body);
+        Assert.Equal("Template 'Greeting' inserted.", vm.StatusText);
+    }
+
+    [Fact]
+    public async Task InsertTemplate_DoesNothingWhenNoHandler()
+    {
+        var (vm, _) = MakeVm();
+        vm.Body = "Original";
+
+        // No InsertTemplateRequested handler wired — should be a no-op
+        await InvokeInsertTemplateAsync(vm);
+
+        Assert.Equal("Original", vm.Body);
+    }
+
+    [Fact]
+    public async Task InsertTemplate_DoesNothingWhenHandlerReturnsNull()
+    {
+        var (vm, _) = MakeVm();
+        vm.Body = "Original";
+
+        vm.InsertTemplateRequested += () => Task.FromResult<MessageTemplate?>(null);
+
+        await InvokeInsertTemplateAsync(vm);
+
+        Assert.Equal("Original", vm.Body);
+    }
+
+    [Fact]
+    public async Task InsertTemplate_PrefillsSubjectWhenEmpty()
+    {
+        var (vm, _) = MakeVm();
+        vm.Subject = "";
+
+        var template = new MessageTemplate
+        {
+            Id = 1,
+            Title = "Follow-up",
+            Subject = "Re: Our meeting",
+            Body = "Thanks for your time."
+        };
+
+        vm.InsertTemplateRequested += () => Task.FromResult<MessageTemplate?>(template);
+
+        await InvokeInsertTemplateAsync(vm);
+
+        Assert.Equal("Re: Our meeting", vm.Subject);
+    }
+
+    [Fact]
+    public async Task InsertTemplate_DoesNotOverwriteExistingSubject()
+    {
+        var (vm, _) = MakeVm();
+        vm.Subject = "Already set";
+
+        var template = new MessageTemplate
+        {
+            Id = 1,
+            Title = "Follow-up",
+            Subject = "Re: Our meeting",
+            Body = "Thanks."
+        };
+
+        vm.InsertTemplateRequested += () => Task.FromResult<MessageTemplate?>(template);
+
+        await InvokeInsertTemplateAsync(vm);
+
+        Assert.Equal("Already set", vm.Subject);
+    }
+
+    // ── Placeholder replacement ───────────────────────────────────────────────
+
+    [Fact]
+    public async Task InsertTemplate_ReplacesSenderPlaceholder()
+    {
+        var (vm, _) = MakeVm();
+        // Set up a sender account with a display name
+        vm.SenderAccounts = new System.Collections.ObjectModel.ObservableCollection<AccountModel>
+        {
+            new() { Id = Guid.NewGuid(), DisplayName = "Alice Johnson", Username = "alice@example.com" }
+        };
+        vm.SenderAccount = vm.SenderAccounts[0];
+
+        var template = new MessageTemplate
+        {
+            Id = 1,
+            Title = "Signature",
+            Body = "Best regards,\n{sender}"
+        };
+
+        vm.InsertTemplateRequested += () => Task.FromResult<MessageTemplate?>(template);
+
+        await InvokeInsertTemplateAsync(vm);
+
+        Assert.Contains("Alice Johnson", vm.Body);
+        Assert.DoesNotContain("{sender}", vm.Body);
+    }
+
+    [Fact]
+    public async Task InsertTemplate_ReplacesDatePlaceholder()
+    {
+        var (vm, _) = MakeVm();
+
+        var template = new MessageTemplate
+        {
+            Id = 1,
+            Title = "Dated",
+            Body = "Sent on {date}"
+        };
+
+        vm.InsertTemplateRequested += () => Task.FromResult<MessageTemplate?>(template);
+
+        await InvokeInsertTemplateAsync(vm);
+
+        Assert.DoesNotContain("{date}", vm.Body);
+        // The date should be replaced with today's date in short format
+        var today = DateTime.Now.ToString("d");
+        Assert.Contains(today, vm.Body);
+    }
+
+    [Fact]
+    public async Task InsertTemplate_ReplacesTimePlaceholder()
+    {
+        var (vm, _) = MakeVm();
+
+        var template = new MessageTemplate
+        {
+            Id = 1,
+            Title = "Timed",
+            Body = "Sent at {time}"
+        };
+
+        vm.InsertTemplateRequested += () => Task.FromResult<MessageTemplate?>(template);
+
+        await InvokeInsertTemplateAsync(vm);
+
+        Assert.DoesNotContain("{time}", vm.Body);
+    }
+
+    [Fact]
+    public async Task InsertTemplate_ReplacesPlaceholdersInSubject()
+    {
+        var (vm, _) = MakeVm();
+        vm.Subject = "";
+        vm.SenderAccounts = new System.Collections.ObjectModel.ObservableCollection<AccountModel>
+        {
+            new() { Id = Guid.NewGuid(), DisplayName = "Bob", Username = "bob@example.com" }
+        };
+        vm.SenderAccount = vm.SenderAccounts[0];
+
+        var template = new MessageTemplate
+        {
+            Id = 1,
+            Title = "T",
+            Subject = "Follow-up from {sender} on {date}",
+            Body = "Hello"
+        };
+
+        vm.InsertTemplateRequested += () => Task.FromResult<MessageTemplate?>(template);
+
+        await InvokeInsertTemplateAsync(vm);
+
+        Assert.Contains("Bob", vm.Subject);
+        Assert.DoesNotContain("{sender}", vm.Subject);
+        Assert.DoesNotContain("{date}", vm.Subject);
+    }
+
+    [Fact]
+    public async Task InsertTemplate_SenderPlaceholderUsesUsernameWhenNoDisplayName()
+    {
+        var (vm, _) = MakeVm();
+        vm.SenderAccounts = new System.Collections.ObjectModel.ObservableCollection<AccountModel>
+        {
+            new() { Id = Guid.NewGuid(), DisplayName = "", Username = "noreply@example.com" }
+        };
+        vm.SenderAccount = vm.SenderAccounts[0];
+
+        var template = new MessageTemplate
+        {
+            Id = 1,
+            Title = "T",
+            Body = "{sender}"
+        };
+
+        vm.InsertTemplateRequested += () => Task.FromResult<MessageTemplate?>(template);
+
+        await InvokeInsertTemplateAsync(vm);
+
+        Assert.Contains("noreply@example.com", vm.Body);
+        Assert.DoesNotContain("{sender}", vm.Body);
+    }
+
+    [Fact]
+    public async Task InsertTemplate_SenderPlaceholderEmptyWhenNoAccount()
+    {
+        var (vm, _) = MakeVm();
+        // No sender account set
+
+        var template = new MessageTemplate
+        {
+            Id = 1,
+            Title = "T",
+            Body = "[{sender}]"
+        };
+
+        vm.InsertTemplateRequested += () => Task.FromResult<MessageTemplate?>(template);
+
+        await InvokeInsertTemplateAsync(vm);
+
+        Assert.Contains("[]", vm.Body);
+    }
+
+    [Fact]
+    public async Task InsertTemplate_PlaceholdersAreCaseInsensitive()
+    {
+        var (vm, _) = MakeVm();
+        vm.SenderAccounts = new System.Collections.ObjectModel.ObservableCollection<AccountModel>
+        {
+            new() { Id = Guid.NewGuid(), DisplayName = "Casey", Username = "casey@example.com" }
+        };
+        vm.SenderAccount = vm.SenderAccounts[0];
+
+        var template = new MessageTemplate
+        {
+            Id = 1,
+            Title = "T",
+            Body = "{SENDER} / {Sender} / {DATE} / {Time}"
+        };
+
+        vm.InsertTemplateRequested += () => Task.FromResult<MessageTemplate?>(template);
+
+        await InvokeInsertTemplateAsync(vm);
+
+        Assert.DoesNotContain("{SENDER}", vm.Body);
+        Assert.DoesNotContain("{Sender}", vm.Body);
+        Assert.DoesNotContain("{DATE}", vm.Body);
+        Assert.DoesNotContain("{Time}", vm.Body);
+        Assert.Contains("Casey", vm.Body);
+    }
+
+    // ── SaveAsTemplate ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SaveAsTemplate_SavesWithSubjectAsTitle()
+    {
+        var (vm, templates) = MakeVm();
+        vm.Subject = "My Response";
+        vm.Body = "Thank you for your email.";
+
+        await InvokeSaveAsTemplateAsync(vm);
+
+        Assert.Equal("Template saved as 'My Response'.", vm.StatusText);
+        Assert.Single(templates.AddedTemplates);
+        Assert.Equal("My Response", templates.AddedTemplates[0].Title);
+        Assert.Equal("My Response", templates.AddedTemplates[0].Subject);
+        Assert.Equal("Thank you for your email.", templates.AddedTemplates[0].Body);
+    }
+
+    [Fact]
+    public async Task SaveAsTemplate_UsesUntitledWhenSubjectEmpty()
+    {
+        var (vm, templates) = MakeVm();
+        vm.Subject = "";
+        vm.Body = "Some body text";
+
+        await InvokeSaveAsTemplateAsync(vm);
+
+        Assert.Equal("Template saved as 'Untitled'.", vm.StatusText);
+        Assert.Single(templates.AddedTemplates);
+        Assert.Equal("Untitled", templates.AddedTemplates[0].Title);
+    }
+
+    [Fact]
+    public async Task SaveAsTemplate_UsesUntitledWhenSubjectWhitespace()
+    {
+        var (vm, templates) = MakeVm();
+        vm.Subject = "   ";
+        vm.Body = "Body";
+
+        await InvokeSaveAsTemplateAsync(vm);
+
+        Assert.Equal("Untitled", templates.AddedTemplates[0].Title);
+    }
+
+    [Fact]
+    public async Task SaveAsTemplate_ShowsErrorWhenBodyEmpty()
+    {
+        var (vm, templates) = MakeVm();
+        vm.Subject = "Title";
+        vm.Body = "";
+
+        await InvokeSaveAsTemplateAsync(vm);
+
+        Assert.Equal("Nothing to save — body is empty.", vm.StatusText);
+        Assert.Empty(templates.AddedTemplates);
+    }
+
+    [Fact]
+    public async Task SaveAsTemplate_ShowsErrorWhenBodyWhitespace()
+    {
+        var (vm, templates) = MakeVm();
+        vm.Subject = "Title";
+        vm.Body = "   \n  ";
+
+        await InvokeSaveAsTemplateAsync(vm);
+
+        Assert.Equal("Nothing to save — body is empty.", vm.StatusText);
+        Assert.Empty(templates.AddedTemplates);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Invokes the private InsertTemplateAsync method via the generated relay command.
+    /// </summary>
+    private static async Task InvokeInsertTemplateAsync(ComposeViewModel vm)
+    {
+        // The [RelayCommand] on InsertTemplateAsync generates InsertTemplateCommand
+        await ((IAsyncRelayCommand)vm.InsertTemplateCommand).ExecuteAsync(null);
+    }
+
+    /// <summary>
+    /// Invokes the private SaveAsTemplateAsync method via the generated relay command.
+    /// </summary>
+    private static async Task InvokeSaveAsTemplateAsync(ComposeViewModel vm)
+    {
+        await ((IAsyncRelayCommand)vm.SaveAsTemplateCommand).ExecuteAsync(null);
+    }
+}
+
+/// <summary>
+/// Extended stub that tracks added templates for verification.
+/// </summary>
+sealed class TrackedTemplateService : ITemplateService
+{
+    private List<MessageTemplate> _templates = [];
+    private int _nextId = 1;
+
+    public List<MessageTemplate> AddedTemplates { get; } = [];
+
+    public void SetTemplates(List<MessageTemplate> templates)
+    {
+        _templates = templates;
+        _nextId = templates.Count > 0 ? templates.Max(t => t.Id) + 1 : 1;
+    }
+
+    public Task<List<MessageTemplate>> LoadAllAsync() =>
+        Task.FromResult(_templates.OrderBy(t => t.Title, StringComparer.OrdinalIgnoreCase).ToList());
+
+    public Task<MessageTemplate> AddAsync(MessageTemplate template)
+    {
+        template.Id = _nextId++;
+        _templates.Add(template);
+        AddedTemplates.Add(template);
+        return Task.FromResult(template);
+    }
+
+    public Task UpdateAsync(MessageTemplate template)
+    {
+        var existing = _templates.FirstOrDefault(t => t.Id == template.Id);
+        if (existing != null)
+        {
+            existing.Title = template.Title;
+            existing.Subject = template.Subject;
+            existing.Body = template.Body;
+        }
+        return Task.CompletedTask;
+    }
+
+    public Task DeleteAsync(int id)
+    {
+        _templates.RemoveAll(t => t.Id == id);
+        return Task.CompletedTask;
+    }
+}

--- a/QuickMail.Tests/IcsModelTests.cs
+++ b/QuickMail.Tests/IcsModelTests.cs
@@ -1,0 +1,490 @@
+using System;
+using QuickMail.Models;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// Tests for IcsModel.Parse() and GenerateReply() — ICS calendar invite handling.
+/// </summary>
+public class IcsModelTests
+{
+    // ── Parse: valid ICS ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Parse_ValidIcsWithAllFields_ReturnsPopulatedModel()
+    {
+        var ics = string.Join("\r\n",
+            "BEGIN:VCALENDAR",
+            "VERSION:2.0",
+            "PRODID:-//Test//EN",
+            "METHOD:REQUEST",
+            "BEGIN:VEVENT",
+            "UID:abc123@test.com",
+            "SEQUENCE:0",
+            "ORGANIZER;CN=John Doe:mailto:john@example.com",
+            "SUMMARY:Team Standup",
+            "DESCRIPTION:Daily sync meeting",
+            "LOCATION:Conference Room A",
+            "DTSTART:20260115T140000Z",
+            "DTEND:20260115T150000Z",
+            "END:VEVENT",
+            "END:VCALENDAR");
+
+        var model = IcsModel.Parse(ics);
+
+        Assert.NotNull(model);
+        Assert.Equal("abc123@test.com", model!.Uid);
+        Assert.Equal("0", model.Sequence);
+        Assert.Equal("REQUEST", model.Method);
+        Assert.Equal("john@example.com", model.Organizer);
+        Assert.Equal("John Doe", model.OrganizerName);
+        Assert.Equal("Team Standup", model.Summary);
+        Assert.Equal("Daily sync meeting", model.Description);
+        Assert.Equal("Conference Room A", model.Location);
+        Assert.NotNull(model.StartTime);
+        Assert.NotNull(model.EndTime);
+        Assert.Equal(2026, model.StartTime!.Value.Year);
+        Assert.Equal(1, model.StartTime.Value.Month);
+        Assert.Equal(15, model.StartTime.Value.Day);
+        Assert.Equal(14, model.StartTime.Value.Hour); // UTC
+    }
+
+    [Fact]
+    public void Parse_MinimalValidIcs_ReturnsModel()
+    {
+        var ics = string.Join("\r\n",
+            "BEGIN:VCALENDAR",
+            "VERSION:2.0",
+            "BEGIN:VEVENT",
+            "SUMMARY:Lunch",
+            "DTSTART:20260120T120000Z",
+            "END:VEVENT",
+            "END:VCALENDAR");
+
+        var model = IcsModel.Parse(ics);
+
+        Assert.NotNull(model);
+        Assert.Equal("Lunch", model!.Summary);
+        Assert.NotNull(model.StartTime);
+        Assert.Null(model.EndTime);
+        Assert.Null(model.Organizer);
+        Assert.Null(model.Location);
+    }
+
+    [Fact]
+    public void Parse_IcsWithDateOnlyStart_ReturnsModelWithDate()
+    {
+        var ics = string.Join("\r\n",
+            "BEGIN:VCALENDAR",
+            "VERSION:2.0",
+            "BEGIN:VEVENT",
+            "SUMMARY:All Day Event",
+            "DTSTART:20260125",
+            "DTEND:20260126",
+            "END:VEVENT",
+            "END:VCALENDAR");
+
+        var model = IcsModel.Parse(ics);
+
+        Assert.NotNull(model);
+        Assert.Equal("All Day Event", model!.Summary);
+        Assert.NotNull(model.StartTime);
+        Assert.Equal(2026, model.StartTime!.Value.Year);
+        Assert.Equal(1, model.StartTime.Value.Month);
+        Assert.Equal(25, model.StartTime.Value.Day);
+    }
+
+    [Fact]
+    public void Parse_IcsWithFoldedLines_UnfoldsCorrectly()
+    {
+        // ICS line folding: continuation lines start with a space
+        var ics = "BEGIN:VCALENDAR\r\n" +
+                  "VERSION:2.0\r\n" +
+                  "BEGIN:VEVENT\r\n" +
+                  "SUMMARY:This is a very long summary\r\n" +
+                  "  that continues on the next line\r\n" +
+                  "DTSTART:20260115T140000Z\r\n" +
+                  "END:VEVENT\r\n" +
+                  "END:VCALENDAR\r\n";
+
+        var model = IcsModel.Parse(ics);
+
+        Assert.NotNull(model);
+        Assert.Equal("This is a very long summary that continues on the next line", model!.Summary);
+    }
+
+    [Fact]
+    public void Parse_IcsWithTabFoldedLines_UnfoldsCorrectly()
+    {
+        var ics = "BEGIN:VCALENDAR\r\n" +
+                  "VERSION:2.0\r\n" +
+                  "BEGIN:VEVENT\r\n" +
+                  "DESCRIPTION:Line one\r\n" +
+                  "\tLine two\r\n" +
+                  "DTSTART:20260115T140000Z\r\n" +
+                  "END:VEVENT\r\n" +
+                  "END:VCALENDAR\r\n";
+
+        var model = IcsModel.Parse(ics);
+
+        Assert.NotNull(model);
+        Assert.Equal("Line oneLine two", model!.Description);
+    }
+
+    [Fact]
+    public void Parse_OrganizerWithoutCnParam_FallsBackToMailtoValue()
+    {
+        var ics = string.Join("\r\n",
+            "BEGIN:VCALENDAR",
+            "VERSION:2.0",
+            "BEGIN:VEVENT",
+            "ORGANIZER:mailto:boss@example.com",
+            "SUMMARY:Review",
+            "DTSTART:20260115T140000Z",
+            "END:VEVENT",
+            "END:VCALENDAR");
+
+        var model = IcsModel.Parse(ics);
+
+        Assert.NotNull(model);
+        Assert.Equal("boss@example.com", model!.Organizer);
+        Assert.Equal("boss@example.com", model.OrganizerName);
+    }
+
+    [Fact]
+    public void Parse_OrganizerWithQuotedCnParam_ExtractsCorrectly()
+    {
+        var ics = string.Join("\r\n",
+            "BEGIN:VCALENDAR",
+            "VERSION:2.0",
+            "BEGIN:VEVENT",
+            "ORGANIZER;CN=\"Doe, John\":mailto:john@example.com",
+            "SUMMARY:Review",
+            "DTSTART:20260115T140000Z",
+            "END:VEVENT",
+            "END:VCALENDAR");
+
+        var model = IcsModel.Parse(ics);
+
+        Assert.NotNull(model);
+        Assert.Equal("Doe, John", model!.OrganizerName);
+    }
+
+    [Fact]
+    public void Parse_IcsWithEscapedText_UnescapesCorrectly()
+    {
+        var ics = string.Join("\r\n",
+            "BEGIN:VCALENDAR",
+            "VERSION:2.0",
+            "BEGIN:VEVENT",
+            "SUMMARY:Meeting\\, Q1 Review",
+            "DESCRIPTION:Line 1\\nLine 2\\nLine 3",
+            "LOCATION:Room A\\; Building 1",
+            "DTSTART:20260115T140000Z",
+            "END:VEVENT",
+            "END:VCALENDAR");
+
+        var model = IcsModel.Parse(ics);
+
+        Assert.NotNull(model);
+        Assert.Equal("Meeting, Q1 Review", model!.Summary);
+        Assert.Equal("Line 1\nLine 2\nLine 3", model.Description);
+        Assert.Equal("Room A; Building 1", model.Location);
+    }
+
+    [Fact]
+    public void Parse_IcsWithDtstartTimezone_HandlesCorrectly()
+    {
+        var ics = string.Join("\r\n",
+            "BEGIN:VCALENDAR",
+            "VERSION:2.0",
+            "BEGIN:VEVENT",
+            "SUMMARY:Local Time Event",
+            "DTSTART;TZID=America/Chicago:20260115T140000",
+            "DTEND;TZID=America/Chicago:20260115T150000",
+            "END:VEVENT",
+            "END:VCALENDAR");
+
+        var model = IcsModel.Parse(ics);
+
+        Assert.NotNull(model);
+        Assert.NotNull(model!.StartTime);
+        Assert.NotNull(model.EndTime);
+    }
+
+    [Fact]
+    public void Parse_IcsWithoutVevent_ReturnsNull()
+    {
+        var ics = string.Join("\r\n",
+            "BEGIN:VCALENDAR",
+            "VERSION:2.0",
+            "BEGIN:VTODO",
+            "SUMMARY:Some task",
+            "END:VTODO",
+            "END:VCALENDAR");
+
+        var model = IcsModel.Parse(ics);
+
+        Assert.Null(model);
+    }
+
+    [Fact]
+    public void Parse_IcsWithOnlyMethod_ReturnsNull()
+    {
+        // No VEVENT, no start time, no summary — nothing meaningful
+        var ics = string.Join("\r\n",
+            "BEGIN:VCALENDAR",
+            "VERSION:2.0",
+            "METHOD:CANCEL",
+            "END:VCALENDAR");
+
+        var model = IcsModel.Parse(ics);
+
+        Assert.Null(model);
+    }
+
+    // ── Parse: invalid ICS ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void Parse_NullContent_ReturnsNull()
+    {
+        Assert.Null(IcsModel.Parse(null!));
+    }
+
+    [Fact]
+    public void Parse_EmptyString_ReturnsNull()
+    {
+        Assert.Null(IcsModel.Parse(""));
+    }
+
+    [Fact]
+    public void Parse_WhitespaceOnly_ReturnsNull()
+    {
+        Assert.Null(IcsModel.Parse("   \r\n\t  "));
+    }
+
+    [Fact]
+    public void Parse_GarbageContent_ReturnsNull()
+    {
+        Assert.Null(IcsModel.Parse("This is not an ICS file at all."));
+    }
+
+    [Fact]
+    public void Parse_MalformedIcs_ReturnsNull()
+    {
+        var ics = "BEGIN:VCALENDAR\r\nGARBAGE\r\nEND:VCALENDAR\r\n";
+        Assert.Null(IcsModel.Parse(ics));
+    }
+
+    // ── GenerateReply ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void GenerateReply_Accept_ContainsAcceptedPartStat()
+    {
+        var model = CreateSampleInvite();
+        var reply = model.GenerateReply("user@example.com", "User Name", "ACCEPTED");
+
+        Assert.Contains("METHOD:REPLY", reply);
+        Assert.Contains("PARTSTAT=ACCEPTED", reply);
+        Assert.Contains("mailto:user@example.com", reply);
+        Assert.Contains("CN=User Name", reply);
+        Assert.Contains("UID:abc123@test.com", reply);
+        Assert.Contains("SUMMARY:Team Standup", reply);
+    }
+
+    [Fact]
+    public void GenerateReply_Decline_ContainsDeclinedPartStat()
+    {
+        var model = CreateSampleInvite();
+        var reply = model.GenerateReply("user@example.com", "User Name", "DECLINED");
+
+        Assert.Contains("METHOD:REPLY", reply);
+        Assert.Contains("PARTSTAT=DECLINED", reply);
+    }
+
+    [Fact]
+    public void GenerateReply_Tentative_ContainsTentativePartStat()
+    {
+        var model = CreateSampleInvite();
+        var reply = model.GenerateReply("user@example.com", "User Name", "TENTATIVE");
+
+        Assert.Contains("METHOD:REPLY", reply);
+        Assert.Contains("PARTSTAT=TENTATIVE", reply);
+    }
+
+    [Fact]
+    public void GenerateReply_IncludesDtstamp()
+    {
+        var model = CreateSampleInvite();
+        var reply = model.GenerateReply("user@example.com", "User Name", "ACCEPTED");
+
+        Assert.Contains("DTSTAMP:", reply);
+    }
+
+    [Fact]
+    public void GenerateReply_IncludesOrganizer()
+    {
+        var model = CreateSampleInvite();
+        var reply = model.GenerateReply("user@example.com", "User Name", "ACCEPTED");
+
+        Assert.Contains("ORGANIZER:john@example.com", reply);
+    }
+
+    [Fact]
+    public void GenerateReply_IncludesDtstartAndDtend()
+    {
+        var model = CreateSampleInvite();
+        var reply = model.GenerateReply("user@example.com", "User Name", "ACCEPTED");
+
+        Assert.Contains("DTSTART:", reply);
+        Assert.Contains("DTEND:", reply);
+    }
+
+    [Fact]
+    public void GenerateReply_WithoutUid_DoesNotIncludeUidLine()
+    {
+        var model = new IcsModel
+        {
+            Summary = "No UID Event",
+            StartTime = new DateTime(2026, 1, 15, 14, 0, 0, DateTimeKind.Utc),
+            Organizer = "boss@example.com"
+        };
+
+        var reply = model.GenerateReply("user@example.com", "User", "ACCEPTED");
+
+        Assert.DoesNotContain("UID:", reply);
+    }
+
+    [Fact]
+    public void GenerateReply_WithoutStartTime_DoesNotIncludeDtstart()
+    {
+        var model = new IcsModel
+        {
+            Summary = "No Time Event",
+            Uid = "test123",
+            Organizer = "boss@example.com"
+        };
+
+        var reply = model.GenerateReply("user@example.com", "User", "ACCEPTED");
+
+        Assert.DoesNotContain("DTSTART:", reply);
+    }
+
+    [Fact]
+    public void GenerateReply_EscapesSpecialCharactersInName()
+    {
+        var model = CreateSampleInvite();
+        var reply = model.GenerateReply("user@example.com", "Doe, John; Jr.", "ACCEPTED");
+
+        // Comma and semicolon should be escaped
+        Assert.Contains("CN=Doe\\, John\\; Jr.", reply);
+    }
+
+    // ── DisplaySummary ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void DisplaySummary_IncludesAllFields()
+    {
+        var model = CreateSampleInvite();
+        var summary = model.DisplaySummary;
+
+        Assert.Contains("Event: Team Standup", summary);
+        Assert.Contains("Organizer: John Doe", summary);
+        Assert.Contains("Location: Conference Room A", summary);
+        Assert.Contains("Daily sync meeting", summary);
+    }
+
+    [Fact]
+    public void DisplaySummary_WithoutOrganizerName_UsesOrganizerEmail()
+    {
+        var model = new IcsModel
+        {
+            Summary = "Meeting",
+            Organizer = "boss@example.com",
+            StartTime = new DateTime(2026, 1, 15, 14, 0, 0, DateTimeKind.Utc)
+        };
+
+        var summary = model.DisplaySummary;
+
+        Assert.Contains("Organizer: boss@example.com", summary);
+    }
+
+    [Fact]
+    public void DisplaySummary_WithoutEndTime_ShowsOnlyStart()
+    {
+        var model = new IcsModel
+        {
+            Summary = "Meeting",
+            StartTime = new DateTime(2026, 1, 15, 14, 0, 0, DateTimeKind.Utc)
+        };
+
+        var summary = model.DisplaySummary;
+
+        Assert.Contains("When:", summary);
+        Assert.DoesNotContain(" - ", summary); // No end time separator
+    }
+
+    [Fact]
+    public void DisplaySummary_MinimalModel_DoesNotThrow()
+    {
+        var model = new IcsModel();
+        var summary = model.DisplaySummary;
+
+        Assert.NotNull(summary);
+        Assert.Empty(summary);
+    }
+
+    // ── BriefSummary ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void BriefSummary_WithStartTime_IncludesFormattedDate()
+    {
+        var model = CreateSampleInvite();
+        var brief = model.BriefSummary;
+
+        Assert.Contains("Team Standup", brief);
+        Assert.Contains("2026", brief); // Year from the date
+    }
+
+    [Fact]
+    public void BriefSummary_WithoutSummary_UsesDefaultTitle()
+    {
+        var model = new IcsModel
+        {
+            StartTime = new DateTime(2026, 1, 15, 14, 0, 0, DateTimeKind.Utc)
+        };
+
+        var brief = model.BriefSummary;
+
+        Assert.Contains("Calendar Event", brief);
+    }
+
+    [Fact]
+    public void BriefSummary_WithoutStartTime_ReturnsTitleOnly()
+    {
+        var model = new IcsModel { Summary = "Standup" };
+        var brief = model.BriefSummary;
+
+        Assert.Equal("Standup", brief);
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────────
+
+    private static IcsModel CreateSampleInvite()
+    {
+        return new IcsModel
+        {
+            Uid = "abc123@test.com",
+            Sequence = "0",
+            Method = "REQUEST",
+            Organizer = "john@example.com",
+            OrganizerName = "John Doe",
+            Summary = "Team Standup",
+            Description = "Daily sync meeting",
+            Location = "Conference Room A",
+            StartTime = new DateTime(2026, 1, 15, 14, 0, 0, DateTimeKind.Utc),
+            EndTime = new DateTime(2026, 1, 15, 15, 0, 0, DateTimeKind.Utc)
+        };
+    }
+}

--- a/QuickMail.Tests/MessageFilterTests.cs
+++ b/QuickMail.Tests/MessageFilterTests.cs
@@ -65,7 +65,7 @@ public class MessageFilterTests
         return new MainViewModel(
             new StubImapService(), new StubAccountService(), new StubCredentialService(),
             store, new StubOAuthService(), new StubSyncService(), new StubConfigService(),
-            new StubCommandRegistry(), new StubViewService(), new StubRuleService());
+            new StubCommandRegistry(), new StubViewService(), new StubRuleService(), new StubSmtpService());
     }
 
     private static async Task<MainViewModel> LoadedVm(IEnumerable<MailMessageSummary> messages)

--- a/QuickMail.Tests/SavedViewsTests.cs
+++ b/QuickMail.Tests/SavedViewsTests.cs
@@ -296,7 +296,8 @@ public class SavedViewsMainViewModelTests
                new StubConfigService(),
                new StubCommandRegistry(),
                new FakeViewService(views),
-               new StubRuleService());
+               new StubRuleService(),
+               new StubSmtpService());
 
     // VirtualFolderKey stored without the nul prefix; sentinel is \x00 + key.
     private static SavedView MakeVirtualView(
@@ -845,7 +846,8 @@ public class SavedViewsMainViewModelTests
                new StubConfigService(),
                new StubCommandRegistry(),
                new FakeViewService(views),
-               new StubRuleService());
+               new StubRuleService(),
+               new StubSmtpService());
 
     [Fact]
     public async Task ApplyView_WithDayLimit_FiltersOldMessagesFromMessagesCollection()

--- a/QuickMail.Tests/SessionFeaturesTests.cs
+++ b/QuickMail.Tests/SessionFeaturesTests.cs
@@ -115,7 +115,7 @@ public class PreviewSuppressionTests
         var vm = new MainViewModel(
             new StubImapService(), new StubAccountService(), new StubCredentialService(),
             store, new StubOAuthService(), new StubSyncService(), new ZeroPreviewConfig(),
-            new StubCommandRegistry(), new StubViewService(), new StubRuleService());
+            new StubCommandRegistry(), new StubViewService(), new StubRuleService(), new StubSmtpService());
 
         await vm.InitialLoadAsync();
 
@@ -130,7 +130,7 @@ public class PreviewSuppressionTests
         var vm = new MainViewModel(
             new StubImapService(), new StubAccountService(), new StubCredentialService(),
             store, new StubOAuthService(), new StubSyncService(), new StubConfigService(),
-            new StubCommandRegistry(), new StubViewService(), new StubRuleService());
+            new StubCommandRegistry(), new StubViewService(), new StubRuleService(), new StubSmtpService());
 
         await vm.InitialLoadAsync();
 
@@ -149,7 +149,7 @@ public class OnlineModeTests
             new StubImapService(), new StubAccountService(), new StubCredentialService(),
             new StubLocalStoreService(), new StubOAuthService(), new StubSyncService(),
             new StubConfigService(), new StubCommandRegistry(), new StubViewService(),
-            new StubRuleService(), onlineMode: onlineMode);
+            new StubRuleService(), new StubSmtpService(), onlineMode: onlineMode);
 
     [Fact]
     public void OnlineMode_DefaultIsFalse()
@@ -273,7 +273,7 @@ public class IdleNewMailTests
             imap, new StubAccountService(), new StubCredentialService(),
             new StubLocalStoreService(), new StubOAuthService(), sync,
             new StubConfigService(), new StubCommandRegistry(), new StubViewService(),
-            new StubRuleService());
+            new StubRuleService(), new StubSmtpService());
 
         // Seed the account and connect so _cachedFolders gets the INBOX entry.
         vm.Accounts.Add(account);
@@ -304,7 +304,7 @@ public class IdleNewMailTests
             imap, new StubAccountService(), new StubCredentialService(),
             new StubLocalStoreService(), new StubOAuthService(), sync,
             new StubConfigService(), new StubCommandRegistry(), new StubViewService(),
-            new StubRuleService(), onlineMode: true);
+            new StubRuleService(), new StubSmtpService(), onlineMode: true);
 
         vm.Accounts.Add(account);
         await vm.ConnectAllAccountsAsync();

--- a/QuickMail.Tests/StubServices.cs
+++ b/QuickMail.Tests/StubServices.cs
@@ -179,3 +179,11 @@ sealed class StubConfigService : IConfigService
     public void Save(ConfigModel config)
         => _config = config;
 }
+
+sealed class StubTemplateService : ITemplateService
+{
+    public Task<List<MessageTemplate>> LoadAllAsync() => Task.FromResult(new List<MessageTemplate>());
+    public Task<MessageTemplate> AddAsync(MessageTemplate template) => Task.FromResult(template);
+    public Task UpdateAsync(MessageTemplate template) => Task.CompletedTask;
+    public Task DeleteAsync(int id) => Task.CompletedTask;
+}

--- a/QuickMail.Tests/StubServices.cs
+++ b/QuickMail.Tests/StubServices.cs
@@ -53,6 +53,7 @@ sealed class StubImapService : IImapService
 sealed class StubSmtpService : ISmtpService
 {
     public Task SendAsync(ComposeModel compose, AccountModel account, string? password, CancellationToken ct = default) => Task.CompletedTask;
+    public Task SendIcsReplyAsync(string icsReplyContent, AccountModel account, string? password, CancellationToken ct = default) => Task.CompletedTask;
 }
 
 sealed class StubAccountService : IAccountService

--- a/QuickMail.Tests/StubServices.cs
+++ b/QuickMail.Tests/StubServices.cs
@@ -53,7 +53,8 @@ sealed class StubImapService : IImapService
 sealed class StubSmtpService : ISmtpService
 {
     public Task SendAsync(ComposeModel compose, AccountModel account, string? password, CancellationToken ct = default) => Task.CompletedTask;
-    public Task SendIcsReplyAsync(string icsReplyContent, AccountModel account, string? password, CancellationToken ct = default) => Task.CompletedTask;
+    public Task SendIcsReplyAsync(string icsReplyContent, AccountModel account, string? password,
+        string organizerEmail, CancellationToken ct = default) => Task.CompletedTask;
 }
 
 sealed class StubAccountService : IAccountService

--- a/QuickMail.Tests/TemplatePickerViewModelTests.cs
+++ b/QuickMail.Tests/TemplatePickerViewModelTests.cs
@@ -1,0 +1,293 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using QuickMail.Models;
+using QuickMail.Services;
+using QuickMail.ViewModels;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// Tests for TemplatePickerViewModel: search filtering, selection, empty state,
+/// and MatchCountText formatting.
+/// </summary>
+public class TemplatePickerViewModelTests
+{
+    private class TestTemplateService : ITemplateService
+    {
+        private readonly List<MessageTemplate> _templates;
+
+        public TestTemplateService(List<MessageTemplate> templates)
+        {
+            _templates = templates;
+        }
+
+        public Task<List<MessageTemplate>> LoadAllAsync() =>
+            Task.FromResult(_templates.OrderBy(t => t.Title).ToList());
+
+        public Task<MessageTemplate> AddAsync(MessageTemplate template) =>
+            Task.FromResult(template);
+
+        public Task UpdateAsync(MessageTemplate template) =>
+            Task.CompletedTask;
+
+        public Task DeleteAsync(int id) =>
+            Task.CompletedTask;
+    }
+
+    private static TemplatePickerViewModel MakeVm(List<MessageTemplate>? templates = null)
+    {
+        var service = new TestTemplateService(templates ?? []);
+        return new TemplatePickerViewModel(service);
+    }
+
+    // ── LoadAsync ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task LoadAsync_PopulatesTemplates()
+    {
+        var templates = new List<MessageTemplate>
+        {
+            new() { Id = 1, Title = "Meeting Follow-up", Body = "Thanks for meeting." },
+            new() { Id = 2, Title = "Out of Office", Body = "I'm away." },
+        };
+        var vm = MakeVm(templates);
+
+        await vm.LoadAsync();
+
+        Assert.Equal(2, vm.Templates.Count);
+        Assert.Equal("Meeting Follow-up", vm.Templates[0].Title);
+        Assert.Equal("Out of Office", vm.Templates[1].Title);
+    }
+
+    [Fact]
+    public async Task LoadAsync_SelectsFirstTemplate()
+    {
+        var templates = new List<MessageTemplate>
+        {
+            new() { Id = 1, Title = "First" },
+            new() { Id = 2, Title = "Second" },
+        };
+        var vm = MakeVm(templates);
+
+        await vm.LoadAsync();
+
+        Assert.NotNull(vm.SelectedTemplate);
+        Assert.Equal("First", vm.SelectedTemplate!.Title);
+    }
+
+    [Fact]
+    public async Task LoadAsync_HandlesEmptyList()
+    {
+        var vm = MakeVm([]);
+
+        await vm.LoadAsync();
+
+        Assert.Empty(vm.Templates);
+        Assert.Null(vm.SelectedTemplate);
+    }
+
+    // ── Search filtering ──────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Search_FiltersByTitle()
+    {
+        var templates = new List<MessageTemplate>
+        {
+            new() { Id = 1, Title = "Meeting Follow-up" },
+            new() { Id = 2, Title = "Out of Office" },
+            new() { Id = 3, Title = "Meeting Agenda" },
+        };
+        var vm = MakeVm(templates);
+        await vm.LoadAsync();
+
+        vm.SearchText = "meeting";
+
+        Assert.Equal(2, vm.Templates.Count);
+        Assert.All(vm.Templates, t => Assert.Contains("meeting", t.Title, System.StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task Search_IsCaseInsensitive()
+    {
+        var templates = new List<MessageTemplate>
+        {
+            new() { Id = 1, Title = "MEETING Follow-up" },
+            new() { Id = 2, Title = "Out of Office" },
+        };
+        var vm = MakeVm(templates);
+        await vm.LoadAsync();
+
+        vm.SearchText = "meeting";
+
+        Assert.Single(vm.Templates);
+        Assert.Equal("MEETING Follow-up", vm.Templates[0].Title);
+    }
+
+    [Fact]
+    public async Task Search_NoMatchShowsEmpty()
+    {
+        var templates = new List<MessageTemplate>
+        {
+            new() { Id = 1, Title = "Meeting" },
+        };
+        var vm = MakeVm(templates);
+        await vm.LoadAsync();
+
+        vm.SearchText = "xyzzy";
+
+        Assert.Empty(vm.Templates);
+        Assert.Null(vm.SelectedTemplate);
+    }
+
+    [Fact]
+    public async Task Search_ClearingRestoresAll()
+    {
+        var templates = new List<MessageTemplate>
+        {
+            new() { Id = 1, Title = "Meeting" },
+            new() { Id = 2, Title = "Out of Office" },
+        };
+        var vm = MakeVm(templates);
+        await vm.LoadAsync();
+
+        vm.SearchText = "meeting";
+        Assert.Single(vm.Templates);
+
+        vm.SearchText = "";
+        Assert.Equal(2, vm.Templates.Count);
+    }
+
+    [Fact]
+    public async Task Search_WhitespaceOnlyShowsAll()
+    {
+        var templates = new List<MessageTemplate>
+        {
+            new() { Id = 1, Title = "Meeting" },
+        };
+        var vm = MakeVm(templates);
+        await vm.LoadAsync();
+
+        vm.SearchText = "   ";
+
+        Assert.Single(vm.Templates);
+    }
+
+    [Fact]
+    public async Task Search_SelectsFirstMatch()
+    {
+        var templates = new List<MessageTemplate>
+        {
+            new() { Id = 1, Title = "Apple" },
+            new() { Id = 2, Title = "Banana" },
+            new() { Id = 3, Title = "Apricot" },
+        };
+        var vm = MakeVm(templates);
+        await vm.LoadAsync();
+
+        vm.SearchText = "ap";
+
+        Assert.Equal(2, vm.Templates.Count);
+        Assert.NotNull(vm.SelectedTemplate);
+        Assert.Equal("Apple", vm.SelectedTemplate!.Title);
+    }
+
+    // ── MatchCountText ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task MatchCountText_NoSearch_ShowsTotal()
+    {
+        var templates = new List<MessageTemplate>
+        {
+            new() { Id = 1, Title = "A" },
+            new() { Id = 2, Title = "B" },
+        };
+        var vm = MakeVm(templates);
+        await vm.LoadAsync();
+
+        Assert.Equal("2 templates", vm.MatchCountText);
+    }
+
+    [Fact]
+    public async Task MatchCountText_Singular()
+    {
+        var templates = new List<MessageTemplate>
+        {
+            new() { Id = 1, Title = "Only" },
+        };
+        var vm = MakeVm(templates);
+        await vm.LoadAsync();
+
+        Assert.Equal("1 template", vm.MatchCountText);
+    }
+
+    [Fact]
+    public async Task MatchCountText_WithSearch()
+    {
+        var templates = new List<MessageTemplate>
+        {
+            new() { Id = 1, Title = "Meeting Follow-up" },
+            new() { Id = 2, Title = "Meeting Agenda" },
+            new() { Id = 3, Title = "Out of Office" },
+        };
+        var vm = MakeVm(templates);
+        await vm.LoadAsync();
+
+        vm.SearchText = "meeting";
+
+        Assert.Equal("2 templates matching 'meeting'", vm.MatchCountText);
+    }
+
+    [Fact]
+    public async Task MatchCountText_SingularWithSearch()
+    {
+        var templates = new List<MessageTemplate>
+        {
+            new() { Id = 1, Title = "Meeting Follow-up" },
+            new() { Id = 2, Title = "Out of Office" },
+        };
+        var vm = MakeVm(templates);
+        await vm.LoadAsync();
+
+        vm.SearchText = "office";
+
+        Assert.Equal("1 template matching 'office'", vm.MatchCountText);
+    }
+
+    [Fact]
+    public async Task MatchCountText_ZeroResults()
+    {
+        var templates = new List<MessageTemplate>
+        {
+            new() { Id = 1, Title = "Meeting" },
+        };
+        var vm = MakeVm(templates);
+        await vm.LoadAsync();
+
+        vm.SearchText = "nonexistent";
+
+        Assert.Equal("0 templates matching 'nonexistent'", vm.MatchCountText);
+    }
+
+    [Fact]
+    public async Task MatchCountText_EmptyList()
+    {
+        var vm = MakeVm([]);
+        await vm.LoadAsync();
+
+        Assert.Equal("0 templates", vm.MatchCountText);
+    }
+
+    // ── Initial state ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Constructor_InitializesWithEmptyState()
+    {
+        var vm = MakeVm();
+
+        Assert.Empty(vm.Templates);
+        Assert.Null(vm.SelectedTemplate);
+        Assert.Equal(string.Empty, vm.SearchText);
+    }
+}

--- a/QuickMail.Tests/TemplateServiceTests.cs
+++ b/QuickMail.Tests/TemplateServiceTests.cs
@@ -1,0 +1,345 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using QuickMail.Models;
+using QuickMail.Services;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// Tests for TemplateService CRUD operations and edge cases.
+/// Uses a real TemplateService pointed at a temp directory so we exercise
+/// the full JSON serialize/deserialize path.
+/// </summary>
+public class TemplateServiceTests
+{
+    private static string TempDir() =>
+        Path.Combine(Path.GetTempPath(), $"QM-TemplateTests-{Guid.NewGuid():N}");
+
+    private static (TemplateService service, string dir) MakeService()
+    {
+        var dir = TempDir();
+        var profile = new ProfileContext(dir);
+        var service = new TemplateService(profile);
+        return (service, dir);
+    }
+
+    private static void Cleanup(string dir)
+    {
+        try { if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true); } catch { }
+    }
+
+    // ── LoadAllAsync ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task LoadAllAsync_ReturnsEmptyList_WhenNoFileExists()
+    {
+        var (service, dir) = MakeService();
+        try
+        {
+            var templates = await service.LoadAllAsync();
+            Assert.NotNull(templates);
+            Assert.Empty(templates);
+        }
+        finally { Cleanup(dir); }
+    }
+
+    [Fact]
+    public async Task LoadAllAsync_ReturnsTemplatesSortedByTitle()
+    {
+        var (service, dir) = MakeService();
+        try
+        {
+            await service.AddAsync(new MessageTemplate { Title = "Zebra", Body = "z" });
+            await service.AddAsync(new MessageTemplate { Title = "Apple", Body = "a" });
+            await service.AddAsync(new MessageTemplate { Title = "Mango", Body = "m" });
+
+            var templates = await service.LoadAllAsync();
+
+            Assert.Equal(3, templates.Count);
+            Assert.Equal("Apple", templates[0].Title);
+            Assert.Equal("Mango", templates[1].Title);
+            Assert.Equal("Zebra", templates[2].Title);
+        }
+        finally { Cleanup(dir); }
+    }
+
+    [Fact]
+    public async Task LoadAllAsync_SurvivesCorruptJson()
+    {
+        var (service, dir) = MakeService();
+        try
+        {
+            // Write garbage to the templates file
+            var filePath = Path.Combine(dir, "templates.json");
+            await File.WriteAllTextAsync(filePath, "this is not valid json {{{");
+
+            var templates = await service.LoadAllAsync();
+
+            // Should return empty list, not throw
+            Assert.NotNull(templates);
+            Assert.Empty(templates);
+        }
+        finally { Cleanup(dir); }
+    }
+
+    [Fact]
+    public async Task LoadAllAsync_SurvivesEmptyFile()
+    {
+        var (service, dir) = MakeService();
+        try
+        {
+            var filePath = Path.Combine(dir, "templates.json");
+            await File.WriteAllTextAsync(filePath, "");
+
+            var templates = await service.LoadAllAsync();
+
+            Assert.NotNull(templates);
+            Assert.Empty(templates);
+        }
+        finally { Cleanup(dir); }
+    }
+
+    // ── AddAsync ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task AddAsync_AssignsIdAndPersists()
+    {
+        var (service, dir) = MakeService();
+        try
+        {
+            var template = new MessageTemplate { Title = "Test", Subject = "Sub", Body = "Body text" };
+            var result = await service.AddAsync(template);
+
+            Assert.Equal(1, result.Id);
+            Assert.Equal("Test", result.Title);
+
+            // Verify persistence by loading from a fresh service instance
+            var profile2 = new ProfileContext(dir);
+            var service2 = new TemplateService(profile2);
+            var all = await service2.LoadAllAsync();
+
+            Assert.Single(all);
+            Assert.Equal(1, all[0].Id);
+            Assert.Equal("Test", all[0].Title);
+            Assert.Equal("Sub", all[0].Subject);
+            Assert.Equal("Body text", all[0].Body);
+        }
+        finally { Cleanup(dir); }
+    }
+
+    [Fact]
+    public async Task AddAsync_AssignsIncrementalIds()
+    {
+        var (service, dir) = MakeService();
+        try
+        {
+            var t1 = await service.AddAsync(new MessageTemplate { Title = "First" });
+            var t2 = await service.AddAsync(new MessageTemplate { Title = "Second" });
+            var t3 = await service.AddAsync(new MessageTemplate { Title = "Third" });
+
+            Assert.Equal(1, t1.Id);
+            Assert.Equal(2, t2.Id);
+            Assert.Equal(3, t3.Id);
+        }
+        finally { Cleanup(dir); }
+    }
+
+    [Fact]
+    public async Task AddAsync_HandlesMultipleAddsAndReloads()
+    {
+        var (service, dir) = MakeService();
+        try
+        {
+            await service.AddAsync(new MessageTemplate { Title = "A" });
+            await service.AddAsync(new MessageTemplate { Title = "B" });
+
+            // Reload from disk
+            var profile2 = new ProfileContext(dir);
+            var service2 = new TemplateService(profile2);
+            var all = await service2.LoadAllAsync();
+
+            Assert.Equal(2, all.Count);
+
+            // Add more through second instance
+            await service2.AddAsync(new MessageTemplate { Title = "C" });
+
+            var all2 = await service2.LoadAllAsync();
+            Assert.Equal(3, all2.Count);
+        }
+        finally { Cleanup(dir); }
+    }
+
+    // ── UpdateAsync ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task UpdateAsync_UpdatesExistingTemplate()
+    {
+        var (service, dir) = MakeService();
+        try
+        {
+            var original = await service.AddAsync(new MessageTemplate
+            {
+                Title = "Original",
+                Subject = "Original Subject",
+                Body = "Original Body"
+            });
+
+            original.Title = "Updated";
+            original.Subject = "Updated Subject";
+            original.Body = "Updated Body";
+            await service.UpdateAsync(original);
+
+            var all = await service.LoadAllAsync();
+            Assert.Single(all);
+            Assert.Equal("Updated", all[0].Title);
+            Assert.Equal("Updated Subject", all[0].Subject);
+            Assert.Equal("Updated Body", all[0].Body);
+            Assert.Equal(original.Id, all[0].Id);
+        }
+        finally { Cleanup(dir); }
+    }
+
+    [Fact]
+    public async Task UpdateAsync_DoesNothingForNonExistentId()
+    {
+        var (service, dir) = MakeService();
+        try
+        {
+            await service.AddAsync(new MessageTemplate { Title = "Real" });
+
+            // Try to update a template with an ID that doesn't exist
+            await service.UpdateAsync(new MessageTemplate
+            {
+                Id = 999,
+                Title = "Ghost",
+                Body = "Should not appear"
+            });
+
+            var all = await service.LoadAllAsync();
+            Assert.Single(all);
+            Assert.Equal("Real", all[0].Title);
+        }
+        finally { Cleanup(dir); }
+    }
+
+    [Fact]
+    public async Task UpdateAsync_PersistsAcrossInstances()
+    {
+        var (service, dir) = MakeService();
+        try
+        {
+            var t = await service.AddAsync(new MessageTemplate { Title = "T1", Body = "B1" });
+
+            // Update through a second instance
+            var profile2 = new ProfileContext(dir);
+            var service2 = new TemplateService(profile2);
+            t.Title = "T1 Modified";
+            await service2.UpdateAsync(t);
+
+            // Verify through first instance
+            var all = await service.LoadAllAsync();
+            Assert.Equal("T1 Modified", all[0].Title);
+        }
+        finally { Cleanup(dir); }
+    }
+
+    // ── DeleteAsync ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task DeleteAsync_RemovesTemplate()
+    {
+        var (service, dir) = MakeService();
+        try
+        {
+            var t1 = await service.AddAsync(new MessageTemplate { Title = "Keep" });
+            var t2 = await service.AddAsync(new MessageTemplate { Title = "Delete Me" });
+
+            await service.DeleteAsync(t2.Id);
+
+            var all = await service.LoadAllAsync();
+            Assert.Single(all);
+            Assert.Equal("Keep", all[0].Title);
+        }
+        finally { Cleanup(dir); }
+    }
+
+    [Fact]
+    public async Task DeleteAsync_DoesNothingForNonExistentId()
+    {
+        var (service, dir) = MakeService();
+        try
+        {
+            await service.AddAsync(new MessageTemplate { Title = "Only" });
+
+            await service.DeleteAsync(999);
+
+            var all = await service.LoadAllAsync();
+            Assert.Single(all);
+        }
+        finally { Cleanup(dir); }
+    }
+
+    [Fact]
+    public async Task DeleteAsync_HandlesDeleteAllAndReAdd()
+    {
+        var (service, dir) = MakeService();
+        try
+        {
+            var t = await service.AddAsync(new MessageTemplate { Title = "Solo" });
+            await service.DeleteAsync(t.Id);
+
+            var all = await service.LoadAllAsync();
+            Assert.Empty(all);
+
+            // Re-add after deleting everything — cache is empty, so ID starts at 1
+            var t2 = await service.AddAsync(new MessageTemplate { Title = "New" });
+            Assert.Equal(1, t2.Id);
+        }
+        finally { Cleanup(dir); }
+    }
+
+    // ── Concurrency ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ConcurrentAdds_DoNotCorruptData()
+    {
+        var (service, dir) = MakeService();
+        try
+        {
+            var tasks = Enumerable.Range(0, 10).Select(i =>
+                service.AddAsync(new MessageTemplate { Title = $"Template {i}", Body = $"Body {i}" })
+            ).ToArray();
+
+            await Task.WhenAll(tasks);
+
+            var all = await service.LoadAllAsync();
+            Assert.Equal(10, all.Count);
+            // All IDs should be unique
+            var ids = all.Select(t => t.Id).ToList();
+            Assert.Equal(ids.Count, ids.Distinct().Count());
+        }
+        finally { Cleanup(dir); }
+    }
+
+    [Fact]
+    public async Task LoadAllAsync_ReturnsDefensiveCopy()
+    {
+        var (service, dir) = MakeService();
+        try
+        {
+            await service.AddAsync(new MessageTemplate { Title = "Original" });
+
+            var list = await service.LoadAllAsync();
+            list.Clear(); // Mutate the returned list
+
+            // Original data should be unaffected
+            var reloaded = await service.LoadAllAsync();
+            Assert.Single(reloaded);
+        }
+        finally { Cleanup(dir); }
+    }
+}

--- a/QuickMail.Tests/TutorialViewModelTests.cs
+++ b/QuickMail.Tests/TutorialViewModelTests.cs
@@ -1,0 +1,347 @@
+using System;
+using System.Windows.Input;
+using QuickMail.ViewModels;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// Tests for the first-run keyboard tutorial state machine (TutorialViewModel).
+/// Covers step progression, escape cancellation, wrong-key rejection, and completion.
+/// </summary>
+public class TutorialViewModelTests
+{
+    [Fact]
+    public void Start_SetsIsActiveAndResetsToStepZero()
+    {
+        var vm = new TutorialViewModel();
+        vm.Start();
+
+        Assert.True(vm.IsActive);
+        Assert.Equal(0, vm.CurrentStepIndex);
+        Assert.Equal(1, vm.CurrentStepNumber);
+        Assert.NotNull(vm.CurrentStep);
+    }
+
+    [Fact]
+    public void Start_ResetsToStepZero_WhenCalledAgain()
+    {
+        var vm = new TutorialViewModel();
+        vm.Start();
+
+        // Advance to step 2
+        vm.CheckKeyPress(Key.F6, ModifierKeys.None);
+        Assert.Equal(1, vm.CurrentStepIndex);
+
+        // Restart
+        vm.Start();
+        Assert.Equal(0, vm.CurrentStepIndex);
+        Assert.True(vm.IsActive);
+    }
+
+    [Fact]
+    public void CorrectKey_AdvancesToNextStep()
+    {
+        var vm = new TutorialViewModel();
+        vm.Start();
+
+        // Step 1: F6
+        Assert.Equal(0, vm.CurrentStepIndex);
+        bool handled = vm.CheckKeyPress(Key.F6, ModifierKeys.None);
+        Assert.True(handled);
+        Assert.Equal(1, vm.CurrentStepIndex);
+        Assert.Equal(2, vm.CurrentStepNumber);
+
+        // Step 2: Ctrl+1
+        handled = vm.CheckKeyPress(Key.D1, ModifierKeys.Control);
+        Assert.True(handled);
+        Assert.Equal(2, vm.CurrentStepIndex);
+
+        // Step 3: Ctrl+2
+        handled = vm.CheckKeyPress(Key.D2, ModifierKeys.Control);
+        Assert.True(handled);
+        Assert.Equal(3, vm.CurrentStepIndex);
+
+        // Step 4: Ctrl+3
+        handled = vm.CheckKeyPress(Key.D3, ModifierKeys.Control);
+        Assert.True(handled);
+        Assert.Equal(4, vm.CurrentStepIndex);
+
+        // Step 5: Ctrl+Shift+P
+        handled = vm.CheckKeyPress(Key.P, ModifierKeys.Control | ModifierKeys.Shift);
+        Assert.True(handled);
+        Assert.Equal(5, vm.CurrentStepIndex);
+    }
+
+    [Fact]
+    public void AllSixSteps_CompleteAndFireTutorialCompleted()
+    {
+        var vm = new TutorialViewModel();
+        vm.Start();
+
+        bool completed = false;
+        vm.TutorialCompleted += () => completed = true;
+
+        // Step 1: F6
+        vm.CheckKeyPress(Key.F6, ModifierKeys.None);
+        Assert.True(vm.IsActive);
+        Assert.False(completed);
+
+        // Step 2: Ctrl+1
+        vm.CheckKeyPress(Key.D1, ModifierKeys.Control);
+        Assert.True(vm.IsActive);
+        Assert.False(completed);
+
+        // Step 3: Ctrl+2
+        vm.CheckKeyPress(Key.D2, ModifierKeys.Control);
+        Assert.True(vm.IsActive);
+        Assert.False(completed);
+
+        // Step 4: Ctrl+3
+        vm.CheckKeyPress(Key.D3, ModifierKeys.Control);
+        Assert.True(vm.IsActive);
+        Assert.False(completed);
+
+        // Step 5: Ctrl+Shift+P — advances to step 6
+        vm.CheckKeyPress(Key.P, ModifierKeys.Control | ModifierKeys.Shift);
+        Assert.True(vm.IsActive);
+        Assert.Equal(5, vm.CurrentStepIndex); // step 6 (0-based)
+        Assert.False(completed);
+
+        // Step 6: Escape — step 6 expects Escape, but Escape always cancels first.
+        // So pressing Escape at step 6 cancels the tutorial and fires TutorialCompleted.
+        bool handled = vm.CheckKeyPress(Key.Escape, ModifierKeys.None);
+        Assert.True(handled);
+        Assert.False(vm.IsActive);
+        Assert.True(completed);
+    }
+
+    [Fact]
+    public void Escape_AtAnyStep_CancelsTutorial()
+    {
+        // Test escape at step 1 (index 0)
+        var vm = new TutorialViewModel();
+        vm.Start();
+        bool completed1 = false;
+        vm.TutorialCompleted += () => completed1 = true;
+
+        vm.CheckKeyPress(Key.Escape, ModifierKeys.None);
+        Assert.False(vm.IsActive);
+        Assert.True(completed1);
+
+        // Test escape at step 3 (index 2) — fresh VM to avoid stale subscriptions
+        var vm2 = new TutorialViewModel();
+        vm2.Start();
+        bool completed2 = false;
+        vm2.TutorialCompleted += () => completed2 = true;
+
+        vm2.CheckKeyPress(Key.F6, ModifierKeys.None);       // step 1 → 2
+        vm2.CheckKeyPress(Key.D1, ModifierKeys.Control);     // step 2 → 3
+        Assert.Equal(2, vm2.CurrentStepIndex);
+
+        vm2.CheckKeyPress(Key.Escape, ModifierKeys.None);
+        Assert.False(vm2.IsActive);
+        Assert.True(completed2);
+    }
+
+    [Fact]
+    public void Escape_WithModifiers_DoesNotCancel()
+    {
+        // Only plain Escape cancels. Ctrl+Escape or Shift+Escape should not cancel.
+        var vm = new TutorialViewModel();
+        vm.Start();
+
+        bool completed = false;
+        vm.TutorialCompleted += () => completed = true;
+
+        // Ctrl+Escape at step 1 (F6) — wrong key, should not cancel
+        bool handled = vm.CheckKeyPress(Key.Escape, ModifierKeys.Control);
+        Assert.False(handled);
+        Assert.True(vm.IsActive);
+        Assert.False(completed);
+
+        // Shift+Escape at step 1 — wrong key, should not cancel
+        handled = vm.CheckKeyPress(Key.Escape, ModifierKeys.Shift);
+        Assert.False(handled);
+        Assert.True(vm.IsActive);
+        Assert.False(completed);
+    }
+
+    [Fact]
+    public void WrongKey_DoesNotAdvance()
+    {
+        var vm = new TutorialViewModel();
+        vm.Start();
+
+        // Step 1 expects F6. Pressing random keys should not advance.
+        bool handled = vm.CheckKeyPress(Key.A, ModifierKeys.None);
+        Assert.False(handled);
+        Assert.Equal(0, vm.CurrentStepIndex);
+
+        handled = vm.CheckKeyPress(Key.Enter, ModifierKeys.None);
+        Assert.False(handled);
+        Assert.Equal(0, vm.CurrentStepIndex);
+
+        handled = vm.CheckKeyPress(Key.F6, ModifierKeys.Control); // F6 with Ctrl, not plain F6
+        Assert.False(handled);
+        Assert.Equal(0, vm.CurrentStepIndex);
+
+        // Correct key still works after wrong attempts
+        handled = vm.CheckKeyPress(Key.F6, ModifierKeys.None);
+        Assert.True(handled);
+        Assert.Equal(1, vm.CurrentStepIndex);
+    }
+
+    [Fact]
+    public void WrongKey_AtLaterStep_DoesNotAdvance()
+    {
+        var vm = new TutorialViewModel();
+        vm.Start();
+
+        // Advance to step 3 (Ctrl+2)
+        vm.CheckKeyPress(Key.F6, ModifierKeys.None);
+        vm.CheckKeyPress(Key.D1, ModifierKeys.Control);
+        Assert.Equal(2, vm.CurrentStepIndex); // step 3 expects Ctrl+2
+
+        // Wrong key
+        bool handled = vm.CheckKeyPress(Key.D3, ModifierKeys.Control); // Ctrl+3, not Ctrl+2
+        Assert.False(handled);
+        Assert.Equal(2, vm.CurrentStepIndex);
+
+        // Correct key
+        handled = vm.CheckKeyPress(Key.D2, ModifierKeys.Control);
+        Assert.True(handled);
+        Assert.Equal(3, vm.CurrentStepIndex);
+    }
+
+    [Fact]
+    public void CheckKeyPress_ReturnsFalse_WhenNotActive()
+    {
+        var vm = new TutorialViewModel();
+        // Not started — IsActive is false
+
+        bool handled = vm.CheckKeyPress(Key.F6, ModifierKeys.None);
+        Assert.False(handled);
+        Assert.False(vm.IsActive);
+    }
+
+    [Fact]
+    public void Cancel_FiresTutorialCompleted()
+    {
+        var vm = new TutorialViewModel();
+        vm.Start();
+
+        bool completed = false;
+        vm.TutorialCompleted += () => completed = true;
+
+        vm.Cancel();
+
+        Assert.False(vm.IsActive);
+        Assert.True(completed);
+    }
+
+    [Fact]
+    public void Cancel_WhenNotActive_StillFiresTutorialCompleted()
+    {
+        var vm = new TutorialViewModel();
+        // Not started
+
+        bool completed = false;
+        vm.TutorialCompleted += () => completed = true;
+
+        vm.Cancel();
+
+        Assert.False(vm.IsActive);
+        Assert.True(completed);
+    }
+
+    [Fact]
+    public void Steps_HasSixEntries()
+    {
+        var vm = new TutorialViewModel();
+        Assert.Equal(6, vm.Steps.Count);
+    }
+
+    [Fact]
+    public void Steps_HaveCorrectExpectedKeys()
+    {
+        var vm = new TutorialViewModel();
+
+        Assert.Equal(Key.F6, vm.Steps[0].ExpectedKey);
+        Assert.Equal(ModifierKeys.None, vm.Steps[0].ExpectedModifiers);
+
+        Assert.Equal(Key.D1, vm.Steps[1].ExpectedKey);
+        Assert.Equal(ModifierKeys.Control, vm.Steps[1].ExpectedModifiers);
+
+        Assert.Equal(Key.D2, vm.Steps[2].ExpectedKey);
+        Assert.Equal(ModifierKeys.Control, vm.Steps[2].ExpectedModifiers);
+
+        Assert.Equal(Key.D3, vm.Steps[3].ExpectedKey);
+        Assert.Equal(ModifierKeys.Control, vm.Steps[3].ExpectedModifiers);
+
+        Assert.Equal(Key.P, vm.Steps[4].ExpectedKey);
+        Assert.Equal(ModifierKeys.Control | ModifierKeys.Shift, vm.Steps[4].ExpectedModifiers);
+
+        Assert.Equal(Key.Escape, vm.Steps[5].ExpectedKey);
+        Assert.Equal(ModifierKeys.None, vm.Steps[5].ExpectedModifiers);
+    }
+
+    [Fact]
+    public void CurrentStep_ReturnsNull_WhenIndexOutOfRange()
+    {
+        var vm = new TutorialViewModel();
+        // Not started — CurrentStepIndex is 0 but IsActive is false
+        // Actually CurrentStepIndex defaults to 0, so CurrentStep returns Steps[0]
+        // Let's test the edge case by manipulating the index directly
+        // CurrentStepIndex has a public setter via [ObservableProperty]
+
+        // Before Start, IsActive is false but CurrentStep still returns step 0
+        Assert.NotNull(vm.CurrentStep);
+        Assert.Equal(Key.F6, vm.CurrentStep!.ExpectedKey);
+    }
+
+    [Fact]
+    public void CurrentStepNumber_IsOneBased()
+    {
+        var vm = new TutorialViewModel();
+        vm.Start();
+
+        Assert.Equal(1, vm.CurrentStepNumber);
+
+        vm.CheckKeyPress(Key.F6, ModifierKeys.None);
+        Assert.Equal(2, vm.CurrentStepNumber);
+
+        vm.CheckKeyPress(Key.D1, ModifierKeys.Control);
+        Assert.Equal(3, vm.CurrentStepNumber);
+    }
+
+    [Fact]
+    public void StepSix_EscapeAdvancesAndCompletesTutorial()
+    {
+        // Step 6 expects Escape. When the current step expects Escape,
+        // pressing Escape advances the step (completing the tutorial)
+        // rather than cancelling.
+        var vm = new TutorialViewModel();
+        vm.Start();
+
+        bool completed = false;
+        vm.TutorialCompleted += () => completed = true;
+
+        // Advance through steps 1-5
+        vm.CheckKeyPress(Key.F6, ModifierKeys.None);
+        vm.CheckKeyPress(Key.D1, ModifierKeys.Control);
+        vm.CheckKeyPress(Key.D2, ModifierKeys.Control);
+        vm.CheckKeyPress(Key.D3, ModifierKeys.Control);
+        vm.CheckKeyPress(Key.P, ModifierKeys.Control | ModifierKeys.Shift);
+
+        // Now at step 6 (index 5)
+        Assert.Equal(5, vm.CurrentStepIndex);
+        Assert.True(vm.IsActive);
+
+        // Pressing Escape at step 6 advances past it, completing the tutorial
+        bool handled = vm.CheckKeyPress(Key.Escape, ModifierKeys.None);
+        Assert.True(handled);
+        Assert.False(vm.IsActive);
+        Assert.True(completed);
+    }
+}

--- a/QuickMail.Tests/TutorialViewModelTests.cs
+++ b/QuickMail.Tests/TutorialViewModelTests.cs
@@ -108,8 +108,8 @@ public class TutorialViewModelTests
         Assert.Equal(5, vm.CurrentStepIndex); // step 6 (0-based)
         Assert.False(completed);
 
-        // Step 6: Escape — step 6 expects Escape, but Escape always cancels first.
-        // So pressing Escape at step 6 cancels the tutorial and fires TutorialCompleted.
+        // Step 6: Escape — step 6 expects Escape, so Advance() fires (not Cancel()).
+        // The tutorial completes normally and fires TutorialCompleted.
         bool handled = vm.CheckKeyPress(Key.Escape, ModifierKeys.None);
         Assert.True(handled);
         Assert.False(vm.IsActive);
@@ -122,18 +122,18 @@ public class TutorialViewModelTests
         // Test escape at step 1 (index 0)
         var vm = new TutorialViewModel();
         vm.Start();
-        bool completed1 = false;
-        vm.TutorialCompleted += () => completed1 = true;
+        bool cancelled1 = false;
+        vm.TutorialCancelled += () => cancelled1 = true;
 
         vm.CheckKeyPress(Key.Escape, ModifierKeys.None);
         Assert.False(vm.IsActive);
-        Assert.True(completed1);
+        Assert.True(cancelled1);
 
         // Test escape at step 3 (index 2) — fresh VM to avoid stale subscriptions
         var vm2 = new TutorialViewModel();
         vm2.Start();
-        bool completed2 = false;
-        vm2.TutorialCompleted += () => completed2 = true;
+        bool cancelled2 = false;
+        vm2.TutorialCancelled += () => cancelled2 = true;
 
         vm2.CheckKeyPress(Key.F6, ModifierKeys.None);       // step 1 → 2
         vm2.CheckKeyPress(Key.D1, ModifierKeys.Control);     // step 2 → 3
@@ -141,7 +141,7 @@ public class TutorialViewModelTests
 
         vm2.CheckKeyPress(Key.Escape, ModifierKeys.None);
         Assert.False(vm2.IsActive);
-        Assert.True(completed2);
+        Assert.True(cancelled2);
     }
 
     [Fact]
@@ -152,19 +152,23 @@ public class TutorialViewModelTests
         vm.Start();
 
         bool completed = false;
+        bool cancelled = false;
         vm.TutorialCompleted += () => completed = true;
+        vm.TutorialCancelled += () => cancelled = true;
 
         // Ctrl+Escape at step 1 (F6) — wrong key, should not cancel
         bool handled = vm.CheckKeyPress(Key.Escape, ModifierKeys.Control);
         Assert.False(handled);
         Assert.True(vm.IsActive);
         Assert.False(completed);
+        Assert.False(cancelled);
 
         // Shift+Escape at step 1 — wrong key, should not cancel
         handled = vm.CheckKeyPress(Key.Escape, ModifierKeys.Shift);
         Assert.False(handled);
         Assert.True(vm.IsActive);
         Assert.False(completed);
+        Assert.False(cancelled);
     }
 
     [Fact]
@@ -226,33 +230,33 @@ public class TutorialViewModelTests
     }
 
     [Fact]
-    public void Cancel_FiresTutorialCompleted()
+    public void Cancel_FiresTutorialCancelled()
     {
         var vm = new TutorialViewModel();
         vm.Start();
 
-        bool completed = false;
-        vm.TutorialCompleted += () => completed = true;
+        bool cancelled = false;
+        vm.TutorialCancelled += () => cancelled = true;
 
         vm.Cancel();
 
         Assert.False(vm.IsActive);
-        Assert.True(completed);
+        Assert.True(cancelled);
     }
 
     [Fact]
-    public void Cancel_WhenNotActive_StillFiresTutorialCompleted()
+    public void Cancel_WhenNotActive_StillFiresTutorialCancelled()
     {
         var vm = new TutorialViewModel();
         // Not started
 
-        bool completed = false;
-        vm.TutorialCompleted += () => completed = true;
+        bool cancelled = false;
+        vm.TutorialCancelled += () => cancelled = true;
 
         vm.Cancel();
 
         Assert.False(vm.IsActive);
-        Assert.True(completed);
+        Assert.True(cancelled);
     }
 
     [Fact]

--- a/QuickMail.Tests/UnitTest1.cs
+++ b/QuickMail.Tests/UnitTest1.cs
@@ -25,18 +25,18 @@ public class ViewModelConstructionTests
 {
     private static (StubImapService imap, StubAccountService accounts, StubCredentialService creds,
         StubLocalStoreService store, StubSyncService sync, StubConfigService config,
-        StubCommandRegistry registry, StubContactService contacts)
+        StubCommandRegistry registry, StubContactService contacts, StubTemplateService templates)
         MakeServices()
     {
         return (new StubImapService(), new StubAccountService(), new StubCredentialService(),
             new StubLocalStoreService(), new StubSyncService(), new StubConfigService(),
-            new StubCommandRegistry(), new StubContactService());
+            new StubCommandRegistry(), new StubContactService(), new StubTemplateService());
     }
 
     [Fact]
     public void MainViewModel_ConstructsWithoutException()
     {
-        var (imap, accounts, creds, store, sync, config, registry, _) = MakeServices();
+        var (imap, accounts, creds, store, sync, config, registry, _, _) = MakeServices();
         var vm = new MainViewModel(imap, accounts, creds, store, new StubOAuthService(), sync, config, registry, new StubViewService(), new StubRuleService(), new StubSmtpService());
         Assert.NotNull(vm);
     }
@@ -44,7 +44,7 @@ public class ViewModelConstructionTests
     [Fact]
     public void MainViewModel_LoadAccountList_DoesNotThrow()
     {
-        var (imap, accounts, creds, store, sync, config, registry, _) = MakeServices();
+        var (imap, accounts, creds, store, sync, config, registry, _, _) = MakeServices();
         var vm = new MainViewModel(imap, accounts, creds, store, new StubOAuthService(), sync, config, registry, new StubViewService(), new StubRuleService(), new StubSmtpService());
         vm.LoadAccountList(); // must not throw
     }
@@ -59,16 +59,24 @@ public class ViewModelConstructionTests
     [Fact]
     public void ComposeViewModel_ConstructsWithoutException()
     {
-        var (imap, accounts, creds, _, _, _, _, _) = MakeServices();
-        var vm = new ComposeViewModel(new StubSmtpService(), accounts, creds, imap);
+        var (imap, accounts, creds, _, _, _, _, _, templates) = MakeServices();
+        var vm = new ComposeViewModel(new StubSmtpService(), accounts, creds, imap, templates);
+        Assert.NotNull(vm);
+    }
+
+    [Fact]
+    public void TemplatePickerViewModel_ConstructsWithoutException()
+    {
+        var (_, _, _, _, _, _, _, _, templates) = MakeServices();
+        var vm = new TemplatePickerViewModel(templates);
         Assert.NotNull(vm);
     }
 
     [Fact]
     public void AccountManagerViewModel_ConstructsWithoutException()
     {
-        var (imap, accounts, creds, _, _, _, _, _) = MakeServices();
-        var (_, _, _, store2, _, config2, _, _) = MakeServices();
+        var (imap, accounts, creds, _, _, _, _, _, _) = MakeServices();
+        var (_, _, _, store2, _, config2, _, _, _) = MakeServices();
         var vm = new AccountManagerViewModel(accounts, creds, imap, new StubOAuthService(), store2, config2);
         Assert.NotNull(vm);
     }
@@ -87,7 +95,7 @@ public class ViewModelConstructionTests
     [Fact]
     public void MainViewModel_HasCalendarInvite_IsFalseByDefault()
     {
-        var (imap, accounts, creds, store, sync, config, registry, _) = MakeServices();
+        var (imap, accounts, creds, store, sync, config, registry, _, _) = MakeServices();
         var vm = new MainViewModel(imap, accounts, creds, store, new StubOAuthService(), sync, config, registry, new StubViewService(), new StubRuleService(), new StubSmtpService());
 
         Assert.False(vm.HasCalendarInvite);
@@ -96,7 +104,7 @@ public class ViewModelConstructionTests
     [Fact]
     public void MainViewModel_BuildEventCardHtml_ReturnsEmptyWhenNoInvite()
     {
-        var (imap, accounts, creds, store, sync, config, registry, _) = MakeServices();
+        var (imap, accounts, creds, store, sync, config, registry, _, _) = MakeServices();
         var vm = new MainViewModel(imap, accounts, creds, store, new StubOAuthService(), sync, config, registry, new StubViewService(), new StubRuleService(), new StubSmtpService());
 
         var html = vm.BuildEventCardHtml();
@@ -107,7 +115,7 @@ public class ViewModelConstructionTests
     [Fact]
     public void MainViewModel_AcceptInviteCommand_Exists()
     {
-        var (imap, accounts, creds, store, sync, config, registry, _) = MakeServices();
+        var (imap, accounts, creds, store, sync, config, registry, _, _) = MakeServices();
         var vm = new MainViewModel(imap, accounts, creds, store, new StubOAuthService(), sync, config, registry, new StubViewService(), new StubRuleService(), new StubSmtpService());
 
         Assert.NotNull(vm.AcceptInviteCommand);
@@ -117,7 +125,7 @@ public class ViewModelConstructionTests
     [Fact]
     public void MainViewModel_DeclineInviteCommand_Exists()
     {
-        var (imap, accounts, creds, store, sync, config, registry, _) = MakeServices();
+        var (imap, accounts, creds, store, sync, config, registry, _, _) = MakeServices();
         var vm = new MainViewModel(imap, accounts, creds, store, new StubOAuthService(), sync, config, registry, new StubViewService(), new StubRuleService(), new StubSmtpService());
 
         Assert.NotNull(vm.DeclineInviteCommand);
@@ -127,7 +135,7 @@ public class ViewModelConstructionTests
     [Fact]
     public void MainViewModel_TentativeInviteCommand_Exists()
     {
-        var (imap, accounts, creds, store, sync, config, registry, _) = MakeServices();
+        var (imap, accounts, creds, store, sync, config, registry, _, _) = MakeServices();
         var vm = new MainViewModel(imap, accounts, creds, store, new StubOAuthService(), sync, config, registry, new StubViewService(), new StubRuleService(), new StubSmtpService());
 
         Assert.NotNull(vm.TentativeInviteCommand);
@@ -137,7 +145,7 @@ public class ViewModelConstructionTests
     [Fact]
     public void MainViewModel_InviteCommandsRegisteredInRegistry()
     {
-        var (imap, accounts, creds, store, sync, config, registry, _) = MakeServices();
+        var (imap, accounts, creds, store, sync, config, registry, _, _) = MakeServices();
         // MainViewModel constructor calls RegisterCommands which registers invite commands
         var vm = new MainViewModel(imap, accounts, creds, store, new StubOAuthService(), sync, config, registry, new StubViewService(), new StubRuleService(), new StubSmtpService());
 
@@ -209,11 +217,11 @@ public class XamlParseTests
     public void MainWindow_XamlParsesWithoutException()
     {
         EnsureApplication();
-        var (imap, accounts, creds, store, sync, config, registry, contacts) = MakeServices();
+        var (imap, accounts, creds, store, sync, config, registry, contacts, templates) = MakeServices();
         var vm = new MainViewModel(imap, accounts, creds, store, new StubOAuthService(), sync, config, registry, new StubViewService(), new StubRuleService(), new StubSmtpService());
         // Constructing MainWindow triggers InitializeComponent() which is the real XAML parse.
         var window = new MainWindow(vm, new StubSmtpService(), accounts, creds, imap,
-            new StubOAuthService(), registry, contacts, config, store, new StubViewService(), new StubRuleService());
+            new StubOAuthService(), registry, contacts, config, store, new StubViewService(), new StubRuleService(), templates);
         Assert.NotNull(window);
         window.Close();
     }
@@ -222,9 +230,9 @@ public class XamlParseTests
     public void ComposeWindow_XamlParsesWithoutException()
     {
         EnsureApplication();
-        var (imap, accounts, creds, _, _, _, _, contacts) = MakeServices();
-        var vm = new ComposeViewModel(new StubSmtpService(), accounts, creds, imap);
-        var window = new ComposeWindow(vm, contacts);
+        var (imap, accounts, creds, _, _, _, _, contacts, templates) = MakeServices();
+        var vm = new ComposeViewModel(new StubSmtpService(), accounts, creds, imap, templates);
+        var window = new ComposeWindow(vm, contacts, templates);
         Assert.NotNull(window);
         window.Close();
     }
@@ -233,8 +241,8 @@ public class XamlParseTests
     public void AccountManagerDialog_XamlParsesWithoutException()
     {
         EnsureApplication();
-        var (imap, accounts, creds, _, _, _, _, _) = MakeServices();
-        var (_, _, _, store2, _, config2, _, _) = MakeServices();
+        var (imap, accounts, creds, _, _, _, _, _, _) = MakeServices();
+        var (_, _, _, store2, _, config2, _, _, _) = MakeServices();
         var vm = new AccountManagerViewModel(accounts, creds, imap, new StubOAuthService(), store2, config2);
         var window = new AccountManagerDialog(vm);
         Assert.NotNull(window);
@@ -245,7 +253,7 @@ public class XamlParseTests
     public void AddressBookWindow_XamlParsesWithoutException()
     {
         EnsureApplication();
-        var (_, _, _, _, _, _, _, contacts) = MakeServices();
+        var (_, _, _, _, _, _, _, contacts, _) = MakeServices();
         var vm = new AddressBookViewModel(contacts);
         var window = new AddressBookWindow(vm);
         Assert.NotNull(window);
@@ -286,7 +294,7 @@ public class XamlParseTests
     public void ViewManagerDialog_XamlParsesWithoutException()
     {
         EnsureApplication();
-        var (_, _, _, _, _, config, registry, _) = MakeServices();
+        var (_, _, _, _, _, config, registry, _, _) = MakeServices();
         var vm = new ViewManagerViewModel(
             new StubViewService(),
             config,
@@ -310,14 +318,25 @@ public class XamlParseTests
         Assert.NotNull(overlay);
     }
 
+    [StaFact]
+    public void TemplatePickerWindow_XamlParsesWithoutException()
+    {
+        EnsureApplication();
+        var (_, _, _, _, _, _, _, _, templates) = MakeServices();
+        var vm = new TemplatePickerViewModel(templates);
+        var window = new TemplatePickerWindow(vm);
+        Assert.NotNull(window);
+        window.Close();
+    }
+
     private static (StubImapService imap, StubAccountService accounts, StubCredentialService creds,
         StubLocalStoreService store, StubSyncService sync, StubConfigService config,
-        StubCommandRegistry registry, StubContactService contacts)
+        StubCommandRegistry registry, StubContactService contacts, StubTemplateService templates)
         MakeServices()
     {
         return (new StubImapService(), new StubAccountService(), new StubCredentialService(),
             new StubLocalStoreService(), new StubSyncService(), new StubConfigService(),
-            new StubCommandRegistry(), new StubContactService());
+            new StubCommandRegistry(), new StubContactService(), new StubTemplateService());
     }
 }
 

--- a/QuickMail.Tests/UnitTest1.cs
+++ b/QuickMail.Tests/UnitTest1.cs
@@ -230,9 +230,9 @@ public class XamlParseTests
     public void ComposeWindow_XamlParsesWithoutException()
     {
         EnsureApplication();
-        var (imap, accounts, creds, _, _, _, _, contacts, templates) = MakeServices();
+        var (imap, accounts, creds, _, _, config, _, contacts, templates) = MakeServices();
         var vm = new ComposeViewModel(new StubSmtpService(), accounts, creds, imap, templates);
-        var window = new ComposeWindow(vm, contacts, templates);
+        var window = new ComposeWindow(vm, contacts, templates, config);
         Assert.NotNull(window);
         window.Close();
     }

--- a/QuickMail.Tests/UnitTest1.cs
+++ b/QuickMail.Tests/UnitTest1.cs
@@ -73,6 +73,15 @@ public class ViewModelConstructionTests
         Assert.NotNull(vm);
     }
 
+    [Fact]
+    public void TutorialViewModel_ConstructsWithoutException()
+    {
+        var vm = new TutorialViewModel();
+        Assert.NotNull(vm);
+        Assert.Equal(6, vm.Steps.Count);
+        Assert.False(vm.IsActive);
+    }
+
     // ── Calendar invite tests ───────────────────────────────────────────────────
 
     [Fact]
@@ -291,6 +300,14 @@ public class XamlParseTests
         var window = new ViewManagerWindow(vm);
         Assert.NotNull(window);
         window.Close();
+    }
+
+    [StaFact]
+    public void TutorialOverlay_XamlParsesWithoutException()
+    {
+        EnsureApplication();
+        var overlay = new TutorialOverlay();
+        Assert.NotNull(overlay);
     }
 
     private static (StubImapService imap, StubAccountService accounts, StubCredentialService creds,

--- a/QuickMail.Tests/UnitTest1.cs
+++ b/QuickMail.Tests/UnitTest1.cs
@@ -37,7 +37,7 @@ public class ViewModelConstructionTests
     public void MainViewModel_ConstructsWithoutException()
     {
         var (imap, accounts, creds, store, sync, config, registry, _) = MakeServices();
-        var vm = new MainViewModel(imap, accounts, creds, store, new StubOAuthService(), sync, config, registry, new StubViewService(), new StubRuleService());
+        var vm = new MainViewModel(imap, accounts, creds, store, new StubOAuthService(), sync, config, registry, new StubViewService(), new StubRuleService(), new StubSmtpService());
         Assert.NotNull(vm);
     }
 
@@ -45,7 +45,7 @@ public class ViewModelConstructionTests
     public void MainViewModel_LoadAccountList_DoesNotThrow()
     {
         var (imap, accounts, creds, store, sync, config, registry, _) = MakeServices();
-        var vm = new MainViewModel(imap, accounts, creds, store, new StubOAuthService(), sync, config, registry, new StubViewService(), new StubRuleService());
+        var vm = new MainViewModel(imap, accounts, creds, store, new StubOAuthService(), sync, config, registry, new StubViewService(), new StubRuleService(), new StubSmtpService());
         vm.LoadAccountList(); // must not throw
     }
 
@@ -71,6 +71,82 @@ public class ViewModelConstructionTests
         var (_, _, _, store2, _, config2, _, _) = MakeServices();
         var vm = new AccountManagerViewModel(accounts, creds, imap, new StubOAuthService(), store2, config2);
         Assert.NotNull(vm);
+    }
+
+    // ── Calendar invite tests ───────────────────────────────────────────────────
+
+    [Fact]
+    public void MainViewModel_HasCalendarInvite_IsFalseByDefault()
+    {
+        var (imap, accounts, creds, store, sync, config, registry, _) = MakeServices();
+        var vm = new MainViewModel(imap, accounts, creds, store, new StubOAuthService(), sync, config, registry, new StubViewService(), new StubRuleService(), new StubSmtpService());
+
+        Assert.False(vm.HasCalendarInvite);
+    }
+
+    [Fact]
+    public void MainViewModel_BuildEventCardHtml_ReturnsEmptyWhenNoInvite()
+    {
+        var (imap, accounts, creds, store, sync, config, registry, _) = MakeServices();
+        var vm = new MainViewModel(imap, accounts, creds, store, new StubOAuthService(), sync, config, registry, new StubViewService(), new StubRuleService(), new StubSmtpService());
+
+        var html = vm.BuildEventCardHtml();
+
+        Assert.Equal(string.Empty, html);
+    }
+
+    [Fact]
+    public void MainViewModel_AcceptInviteCommand_Exists()
+    {
+        var (imap, accounts, creds, store, sync, config, registry, _) = MakeServices();
+        var vm = new MainViewModel(imap, accounts, creds, store, new StubOAuthService(), sync, config, registry, new StubViewService(), new StubRuleService(), new StubSmtpService());
+
+        Assert.NotNull(vm.AcceptInviteCommand);
+        Assert.True(vm.AcceptInviteCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public void MainViewModel_DeclineInviteCommand_Exists()
+    {
+        var (imap, accounts, creds, store, sync, config, registry, _) = MakeServices();
+        var vm = new MainViewModel(imap, accounts, creds, store, new StubOAuthService(), sync, config, registry, new StubViewService(), new StubRuleService(), new StubSmtpService());
+
+        Assert.NotNull(vm.DeclineInviteCommand);
+        Assert.True(vm.DeclineInviteCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public void MainViewModel_TentativeInviteCommand_Exists()
+    {
+        var (imap, accounts, creds, store, sync, config, registry, _) = MakeServices();
+        var vm = new MainViewModel(imap, accounts, creds, store, new StubOAuthService(), sync, config, registry, new StubViewService(), new StubRuleService(), new StubSmtpService());
+
+        Assert.NotNull(vm.TentativeInviteCommand);
+        Assert.True(vm.TentativeInviteCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public void MainViewModel_InviteCommandsRegisteredInRegistry()
+    {
+        var (imap, accounts, creds, store, sync, config, registry, _) = MakeServices();
+        // MainViewModel constructor calls RegisterCommands which registers invite commands
+        var vm = new MainViewModel(imap, accounts, creds, store, new StubOAuthService(), sync, config, registry, new StubViewService(), new StubRuleService(), new StubSmtpService());
+
+        var acceptCmd = registry.FindById("mail.acceptInvite");
+        var declineCmd = registry.FindById("mail.declineInvite");
+        var tentativeCmd = registry.FindById("mail.tentativeInvite");
+
+        Assert.NotNull(acceptCmd);
+        Assert.Equal("Accept Invitation", acceptCmd!.Title);
+        Assert.Equal("Mail", acceptCmd.Category);
+
+        Assert.NotNull(declineCmd);
+        Assert.Equal("Decline Invitation", declineCmd!.Title);
+        Assert.Equal("Mail", declineCmd.Category);
+
+        Assert.NotNull(tentativeCmd);
+        Assert.Equal("Tentatively Accept Invitation", tentativeCmd!.Title);
+        Assert.Equal("Mail", tentativeCmd.Category);
     }
 }
 
@@ -125,7 +201,7 @@ public class XamlParseTests
     {
         EnsureApplication();
         var (imap, accounts, creds, store, sync, config, registry, contacts) = MakeServices();
-        var vm = new MainViewModel(imap, accounts, creds, store, new StubOAuthService(), sync, config, registry, new StubViewService(), new StubRuleService());
+        var vm = new MainViewModel(imap, accounts, creds, store, new StubOAuthService(), sync, config, registry, new StubViewService(), new StubRuleService(), new StubSmtpService());
         // Constructing MainWindow triggers InitializeComponent() which is the real XAML parse.
         var window = new MainWindow(vm, new StubSmtpService(), accounts, creds, imap,
             new StubOAuthService(), registry, contacts, config, store, new StubViewService(), new StubRuleService());

--- a/QuickMail/App.xaml.cs
+++ b/QuickMail/App.xaml.cs
@@ -80,6 +80,7 @@ public partial class App : Application
                 localStore.Initialize();
 
             var contactService = new ContactService(profile);
+            var templateService = new TemplateService(profile);
             var ruleService = new RuleService(imapService, localStore, profile.ProfileDir);
             var syncService = new SyncService(imapService, localStore, configService, ruleService);
 
@@ -95,7 +96,7 @@ public partial class App : Application
                 onlineMode: onlineMode);
             mainVm.LoadAccountList();
 
-            var mainWindow = new MainWindow(mainVm, smtpService, accountService, credentialService, imapService, oauthService, commandRegistry, contactService, configService, localStore, viewService, ruleService);
+            var mainWindow = new MainWindow(mainVm, smtpService, accountService, credentialService, imapService, oauthService, commandRegistry, contactService, configService, localStore, viewService, ruleService, templateService);
             mainWindow.Show();
         }
         catch (Exception ex)

--- a/QuickMail/App.xaml.cs
+++ b/QuickMail/App.xaml.cs
@@ -91,7 +91,7 @@ public partial class App : Application
             var viewService = new ViewService(profile);
 
             var mainVm = new MainViewModel(
-                imapService, accountService, credentialService, localStore, oauthService, syncService, configService, commandRegistry, viewService, ruleService,
+                imapService, accountService, credentialService, localStore, oauthService, syncService, configService, commandRegistry, viewService, ruleService, smtpService,
                 onlineMode: onlineMode);
             mainVm.LoadAccountList();
 

--- a/QuickMail/Models/AccountModel.cs
+++ b/QuickMail/Models/AccountModel.cs
@@ -29,6 +29,12 @@ public partial class AccountModel : ObservableObject
     /// <summary>When true, this account is pre-selected when composing a new message.</summary>
     public bool IsDefault { get; set; } = false;
 
+    /// <summary>
+    /// Plain-text signature appended to new messages and replies/forwards.
+    /// Empty string means no signature. Stored in accounts.json.
+    /// </summary>
+    public string Signature { get; set; } = string.Empty;
+
     // ── Runtime-only status (not serialized, updated after each connection) ──────
 
     [ObservableProperty]

--- a/QuickMail/Models/ConfigModel.cs
+++ b/QuickMail/Models/ConfigModel.cs
@@ -55,6 +55,11 @@ public class ConfigModel
     /// <summary>Announce action results (search counts, move/delete confirmations).</summary>
     public bool AnnounceResults { get; set; } = true;
 
+    // ── Tutorial ──────────────────────────────────────────────────────────────────
+
+    /// <summary>Whether the user has completed the first-run keyboard tutorial.</summary>
+    public bool TutorialCompleted { get; set; } = false;
+
     // ── Custom hotkey overrides ──────────────────────────────────────────────────
 
     /// <summary>User-defined keyboard shortcut overrides, stored in hotkeys.json.</summary>

--- a/QuickMail/Models/ConfigModel.cs
+++ b/QuickMail/Models/ConfigModel.cs
@@ -81,6 +81,48 @@ public class ConfigModel
             return ovr.PreviewLines.Value;
         return PreviewLines;
     }
+
+    // ── ViewMode / Sort serialization helpers ─────────────────────────────────────
+
+    /// <summary>Converts a config-string ViewMode to the enum (case-insensitive).</summary>
+    public static global::QuickMail.Models.ViewMode ParseViewMode(string? s) => (s?.ToLowerInvariant()) switch
+    {
+        "conversations" => global::QuickMail.Models.ViewMode.Conversations,
+        "from"          => global::QuickMail.Models.ViewMode.From,
+        "to"            => global::QuickMail.Models.ViewMode.To,
+        _               => global::QuickMail.Models.ViewMode.Messages,
+    };
+
+    /// <summary>Converts a ViewMode enum to its config-string representation.</summary>
+    public static string ToConfigString(global::QuickMail.Models.ViewMode mode) => mode switch
+    {
+        global::QuickMail.Models.ViewMode.Conversations => "conversations",
+        global::QuickMail.Models.ViewMode.From          => "from",
+        global::QuickMail.Models.ViewMode.To            => "to",
+        _                                               => "messages",
+    };
+
+    /// <summary>Converts a config-string Sort to the enum (case-insensitive).</summary>
+    public static MessageSort ParseSort(string? s) => (s?.ToLowerInvariant()) switch
+    {
+        "dateasc"   => MessageSort.DateAscending,
+        "alphaasc"  => MessageSort.AlphaAscending,
+        "alphadesc" => MessageSort.AlphaDescending,
+        "countdesc" => MessageSort.CountDescending,
+        "countasc"  => MessageSort.CountAscending,
+        _           => MessageSort.DateDescending,
+    };
+
+    /// <summary>Converts a MessageSort enum to its config-string representation.</summary>
+    public static string ToConfigString(MessageSort sort) => sort switch
+    {
+        MessageSort.DateAscending   => "dateAsc",
+        MessageSort.AlphaAscending  => "alphaAsc",
+        MessageSort.AlphaDescending => "alphaDesc",
+        MessageSort.CountDescending => "countDesc",
+        MessageSort.CountAscending  => "countAsc",
+        _                           => "dateDesc",
+    };
 }
 
 /// <summary>Per-account configuration overrides. Only set fields that differ from global defaults.</summary>

--- a/QuickMail/Models/ConfigModel.cs
+++ b/QuickMail/Models/ConfigModel.cs
@@ -55,6 +55,9 @@ public class ConfigModel
     /// <summary>Announce action results (search counts, move/delete confirmations).</summary>
     public bool AnnounceResults { get; set; } = true;
 
+    /// <summary>Announce spelling suggestions when navigating into a misspelled word.</summary>
+    public bool AnnounceSpellingSuggestions { get; set; } = true;
+
     // ── Tutorial ──────────────────────────────────────────────────────────────────
 
     /// <summary>Whether the user has completed the first-run keyboard tutorial.</summary>

--- a/QuickMail/Models/ConfigModel.cs
+++ b/QuickMail/Models/ConfigModel.cs
@@ -88,21 +88,21 @@ public class ConfigModel
     // ── ViewMode / Sort serialization helpers ─────────────────────────────────────
 
     /// <summary>Converts a config-string ViewMode to the enum (case-insensitive).</summary>
-    public static global::QuickMail.Models.ViewMode ParseViewMode(string? s) => (s?.ToLowerInvariant()) switch
+    public static Models.ViewMode ParseViewMode(string? s) => (s?.ToLowerInvariant()) switch
     {
-        "conversations" => global::QuickMail.Models.ViewMode.Conversations,
-        "from"          => global::QuickMail.Models.ViewMode.From,
-        "to"            => global::QuickMail.Models.ViewMode.To,
-        _               => global::QuickMail.Models.ViewMode.Messages,
+        "conversations" => Models.ViewMode.Conversations,
+        "from"          => Models.ViewMode.From,
+        "to"            => Models.ViewMode.To,
+        _               => Models.ViewMode.Messages,
     };
 
     /// <summary>Converts a ViewMode enum to its config-string representation.</summary>
-    public static string ToConfigString(global::QuickMail.Models.ViewMode mode) => mode switch
+    public static string ToConfigString(Models.ViewMode mode) => mode switch
     {
-        global::QuickMail.Models.ViewMode.Conversations => "conversations",
-        global::QuickMail.Models.ViewMode.From          => "from",
-        global::QuickMail.Models.ViewMode.To            => "to",
-        _                                               => "messages",
+        Models.ViewMode.Conversations => "conversations",
+        Models.ViewMode.From          => "from",
+        Models.ViewMode.To            => "to",
+        _                             => "messages",
     };
 
     /// <summary>Converts a config-string Sort to the enum (case-insensitive).</summary>

--- a/QuickMail/Models/IcsModel.cs
+++ b/QuickMail/Models/IcsModel.cs
@@ -1,0 +1,278 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace QuickMail.Models;
+
+/// <summary>
+/// Parsed representation of an ICS calendar invite (meeting request).
+/// Extracted from text/calendar MIME parts in incoming messages.
+/// </summary>
+public class IcsModel
+{
+    public string? Organizer { get; set; }
+    public string? OrganizerName { get; set; }
+    public string? Summary { get; set; }
+    public string? Description { get; set; }
+    public string? Location { get; set; }
+    public DateTime? StartTime { get; set; }
+    public DateTime? EndTime { get; set; }
+    public string? Uid { get; set; }
+    public string? Sequence { get; set; }
+    public string? Method { get; set; } // REQUEST, CANCEL, REPLY, etc.
+
+    /// <summary>
+    /// Human-readable summary for screen reader announcement and display.
+    /// </summary>
+    public string DisplaySummary
+    {
+        get
+        {
+            var sb = new StringBuilder();
+            if (!string.IsNullOrWhiteSpace(Summary))
+                sb.AppendLine($"Event: {Summary}");
+            if (!string.IsNullOrWhiteSpace(OrganizerName))
+                sb.AppendLine($"Organizer: {OrganizerName}");
+            else if (!string.IsNullOrWhiteSpace(Organizer))
+                sb.AppendLine($"Organizer: {Organizer}");
+            if (StartTime.HasValue)
+            {
+                sb.Append($"When: {StartTime.Value.ToLocalTime():f}");
+                if (EndTime.HasValue)
+                    sb.Append($" - {EndTime.Value.ToLocalTime():t}");
+                sb.AppendLine();
+            }
+            if (!string.IsNullOrWhiteSpace(Location))
+                sb.AppendLine($"Location: {Location}");
+            if (!string.IsNullOrWhiteSpace(Description))
+            {
+                sb.AppendLine();
+                sb.AppendLine(Description);
+            }
+            return sb.ToString().TrimEnd();
+        }
+    }
+
+    /// <summary>
+    /// Brief one-line summary for the message list / status bar.
+    /// </summary>
+    public string BriefSummary
+    {
+        get
+        {
+            var title = Summary ?? "Calendar Event";
+            if (StartTime.HasValue)
+                return $"{title} — {StartTime.Value.ToLocalTime():f}";
+            return title;
+        }
+    }
+
+    /// <summary>
+    /// Parses an ICS file from raw text content.
+    /// Returns null if the content is not a valid meeting request.
+    /// </summary>
+    public static IcsModel? Parse(string icsContent)
+    {
+        if (string.IsNullOrWhiteSpace(icsContent)) return null;
+
+        try
+        {
+            var model = new IcsModel();
+            var lines = UnfoldLines(icsContent);
+
+            bool inVevent = false;
+            foreach (var rawLine in lines)
+            {
+                var line = rawLine.Trim();
+                if (string.IsNullOrEmpty(line)) continue;
+
+                if (line.StartsWith("BEGIN:VEVENT", StringComparison.OrdinalIgnoreCase))
+                {
+                    inVevent = true;
+                    continue;
+                }
+                if (line.StartsWith("END:VEVENT", StringComparison.OrdinalIgnoreCase))
+                {
+                    inVevent = false;
+                    continue;
+                }
+                if (!inVevent) continue;
+
+                var colonIdx = line.IndexOf(':');
+                if (colonIdx < 0) continue;
+
+                var prop = line[..colonIdx];
+                var value = line[(colonIdx + 1)..];
+
+                // Handle property parameters (e.g. "DTSTART;TZID=America/Chicago:20260101T120000")
+                var semicolonIdx = prop.IndexOf(';');
+                var propName = semicolonIdx >= 0 ? prop[..semicolonIdx] : prop;
+
+                switch (propName.ToUpperInvariant())
+                {
+                    case "ORGANIZER":
+                        model.Organizer = ExtractCnValue(prop, value);
+                        model.OrganizerName = ExtractCnParam(prop) ?? model.Organizer;
+                        break;
+                    case "SUMMARY":
+                        model.Summary = UnescapeIcsText(value);
+                        break;
+                    case "DESCRIPTION":
+                        model.Description = UnescapeIcsText(value);
+                        break;
+                    case "LOCATION":
+                        model.Location = UnescapeIcsText(value);
+                        break;
+                    case "DTSTART":
+                        model.StartTime = ParseIcsDateTime(value);
+                        break;
+                    case "DTEND":
+                        model.EndTime = ParseIcsDateTime(value);
+                        break;
+                    case "UID":
+                        model.Uid = value;
+                        break;
+                    case "SEQUENCE":
+                        model.Sequence = value;
+                        break;
+                    case "METHOD":
+                        model.Method = value;
+                        break;
+                }
+            }
+
+            // Only return if we found a meaningful event
+            if (model.StartTime.HasValue || !string.IsNullOrWhiteSpace(model.Summary))
+                return model;
+
+            return null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Generates an ICS reply (accept/decline/tentative) for sending back to the organizer.
+    /// </summary>
+    public string GenerateReply(string attendeeEmail, string attendeeName, string partStat)
+    {
+        var now = DateTime.UtcNow;
+        var sb = new StringBuilder();
+        sb.AppendLine("BEGIN:VCALENDAR");
+        sb.AppendLine("VERSION:2.0");
+        sb.AppendLine("PRODID:-//QuickMail//EN");
+        sb.AppendLine("METHOD:REPLY");
+        sb.AppendLine("BEGIN:VEVENT");
+        if (!string.IsNullOrWhiteSpace(Uid))
+            sb.AppendLine($"UID:{Uid}");
+        if (StartTime.HasValue)
+            sb.AppendLine($"DTSTART:{StartTime.Value.ToUniversalTime():yyyyMMddTHHmmssZ}");
+        if (EndTime.HasValue)
+            sb.AppendLine($"DTEND:{EndTime.Value.ToUniversalTime():yyyyMMddTHHmmssZ}");
+        if (!string.IsNullOrWhiteSpace(Summary))
+            sb.AppendLine($"SUMMARY:{EscapeIcsText(Summary)}");
+        if (!string.IsNullOrWhiteSpace(Organizer))
+            sb.AppendLine($"ORGANIZER:{Organizer}");
+        sb.AppendLine($"DTSTAMP:{now:yyyyMMddTHHmmssZ}");
+        sb.AppendLine($"ATTENDEE;CN={EscapeIcsText(attendeeName)};PARTSTAT={partStat}:mailto:{attendeeEmail}");
+        sb.AppendLine("END:VEVENT");
+        sb.AppendLine("END:VCALENDAR");
+        return sb.ToString();
+    }
+
+    // ── Parsing helpers ────────────────────────────────────────────────────────
+
+    /// <summary>ICS lines can be folded (continued on next line with a leading space/tab).</summary>
+    private static List<string> UnfoldLines(string content)
+    {
+        var result = new List<string>();
+        var current = new StringBuilder();
+        foreach (var line in content.Split('\n'))
+        {
+            var trimmed = line.TrimEnd('\r');
+            if (trimmed.Length > 0 && (trimmed[0] == ' ' || trimmed[0] == '\t'))
+            {
+                // Continuation of previous line
+                current.Append(trimmed[1..]);
+            }
+            else
+            {
+                if (current.Length > 0)
+                    result.Add(current.ToString());
+                current.Clear();
+                current.Append(trimmed);
+            }
+        }
+        if (current.Length > 0)
+            result.Add(current.ToString());
+        return result;
+    }
+
+    /// <summary>Extracts the CN parameter from a property like "ORGANIZER;CN=John Doe:mailto:john@example.com".</summary>
+    private static string? ExtractCnParam(string prop)
+    {
+        var match = Regex.Match(prop, @"CN=""?([^"":;]+)""?", RegexOptions.IgnoreCase);
+        return match.Success ? match.Groups[1].Value : null;
+    }
+
+    /// <summary>Extracts the value from an ORGANIZER line, stripping mailto: prefix.</summary>
+    private static string? ExtractCnValue(string prop, string value)
+    {
+        var cn = ExtractCnParam(prop);
+        if (!string.IsNullOrWhiteSpace(cn)) return cn;
+        // Fall back to the email address without mailto:
+        return value.StartsWith("mailto:", StringComparison.OrdinalIgnoreCase)
+            ? value[7..]
+            : value;
+    }
+
+    private static DateTime? ParseIcsDateTime(string value)
+    {
+        // Formats: 20260101T120000Z, 20260101T120000, 20260101
+        value = value.Trim();
+        if (value.Length >= 15 && value[8] == 'T')
+        {
+            var isUtc = value.EndsWith("Z");
+            var datePart = value[..8];
+            var timePart = value.Substring(9, 6);
+            if (DateTime.TryParseExact($"{datePart}{timePart}",
+                    isUtc ? "yyyyMMddHHmmss" : "yyyyMMddHHmmss",
+                    System.Globalization.CultureInfo.InvariantCulture,
+                    isUtc ? System.Globalization.DateTimeStyles.AssumeUniversal | System.Globalization.DateTimeStyles.AdjustToUniversal
+                          : System.Globalization.DateTimeStyles.AssumeLocal,
+                    out var dt))
+                return dt;
+        }
+        if (value.Length >= 8 && DateTime.TryParseExact(value[..8], "yyyyMMdd",
+                System.Globalization.CultureInfo.InvariantCulture,
+                System.Globalization.DateTimeStyles.AssumeLocal,
+                out var dateOnly))
+            return dateOnly;
+        return null;
+    }
+
+    private static string UnescapeIcsText(string text)
+    {
+        return text
+            .Replace("\\n", "\n")
+            .Replace("\\N", "\n")
+            .Replace("\\,", ",")
+            .Replace("\\;", ";")
+            .Replace("\\\\", "\\");
+    }
+
+    private static string EscapeIcsText(string text)
+    {
+        return text
+            .Replace("\\", "\\\\")
+            .Replace(",", "\\,")
+            .Replace(";", "\\;")
+            .Replace("\r\n", "\\n")
+            .Replace("\n", "\\n");
+    }
+}

--- a/QuickMail/Models/IcsModel.cs
+++ b/QuickMail/Models/IcsModel.cs
@@ -237,6 +237,12 @@ public class IcsModel
             : value;
     }
 
+    /// <summary>
+    /// Parses an ICS datetime value. Handles both UTC (ending in Z) and local time.
+    /// LIMITATION: TZID parameters are ignored; times without a 'Z' suffix are
+    /// treated as local machine time, which may be incorrect for attendees in
+    /// different time zones.
+    /// </summary>
     private static DateTime? ParseIcsDateTime(string value)
     {
         // Formats: 20260101T120000Z, 20260101T120000, 20260101

--- a/QuickMail/Models/IcsModel.cs
+++ b/QuickMail/Models/IcsModel.cs
@@ -89,6 +89,13 @@ public class IcsModel
                 var line = rawLine.Trim();
                 if (string.IsNullOrEmpty(line)) continue;
 
+                // METHOD is at the VCALENDAR level, not inside VEVENT
+                if (!inVevent && line.StartsWith("METHOD:", StringComparison.OrdinalIgnoreCase))
+                {
+                    model.Method = line[7..];
+                    continue;
+                }
+
                 if (line.StartsWith("BEGIN:VEVENT", StringComparison.OrdinalIgnoreCase))
                 {
                     inVevent = true;
@@ -114,8 +121,10 @@ public class IcsModel
                 switch (propName.ToUpperInvariant())
                 {
                     case "ORGANIZER":
-                        model.Organizer = ExtractCnValue(prop, value);
-                        model.OrganizerName = ExtractCnParam(prop) ?? model.Organizer;
+                        model.OrganizerName = ExtractCnParam(prop);
+                        model.Organizer = ExtractMailtoValue(value);
+                        if (string.IsNullOrWhiteSpace(model.OrganizerName))
+                            model.OrganizerName = model.Organizer;
                         break;
                     case "SUMMARY":
                         model.Summary = UnescapeIcsText(value);
@@ -220,12 +229,9 @@ public class IcsModel
         return match.Success ? match.Groups[1].Value : null;
     }
 
-    /// <summary>Extracts the value from an ORGANIZER line, stripping mailto: prefix.</summary>
-    private static string? ExtractCnValue(string prop, string value)
+    /// <summary>Extracts the email address from a mailto: URI value.</summary>
+    private static string? ExtractMailtoValue(string value)
     {
-        var cn = ExtractCnParam(prop);
-        if (!string.IsNullOrWhiteSpace(cn)) return cn;
-        // Fall back to the email address without mailto:
         return value.StartsWith("mailto:", StringComparison.OrdinalIgnoreCase)
             ? value[7..]
             : value;

--- a/QuickMail/Models/MailMessageDetail.cs
+++ b/QuickMail/Models/MailMessageDetail.cs
@@ -12,4 +12,7 @@ public partial class MailMessageDetail : MailMessageSummary
     public string HtmlBody { get; set; } = string.Empty;
 
     public List<AttachmentModel> Attachments { get; set; } = [];
+
+    /// <summary>Parsed calendar invite, if this message contains a text/calendar MIME part.</summary>
+    public IcsModel? CalendarInvite { get; set; }
 }

--- a/QuickMail/Models/MessageTemplate.cs
+++ b/QuickMail/Models/MessageTemplate.cs
@@ -1,0 +1,9 @@
+namespace QuickMail.Models;
+
+public class MessageTemplate
+{
+    public int Id { get; set; }
+    public string Title { get; set; } = string.Empty;
+    public string Subject { get; set; } = string.Empty;
+    public string Body { get; set; } = string.Empty;
+}

--- a/QuickMail/Services/ConfigService.cs
+++ b/QuickMail/Services/ConfigService.cs
@@ -206,6 +206,7 @@ public class ConfigService : IConfigService
                     case "announcehints":        config.AnnounceHints        = ParseBool(value); break;
                     case "announcestatus":       config.AnnounceStatus       = ParseBool(value); break;
                     case "announceresults":      config.AnnounceResults      = ParseBool(value); break;
+                    case "tutorialcompleted":    config.TutorialCompleted    = ParseBool(value); break;
                 }
             }
             else if (section == "account" && acctGuid != Guid.Empty)
@@ -289,6 +290,11 @@ public class ConfigService : IConfigService
 
         sb.AppendLine($"AnnounceResults = {(config.AnnounceResults ? "on" : "off")}");
         sb.AppendLine("# Announce action outcomes such as search result counts and move confirmations.");
+        sb.AppendLine("# Values: on, off.");
+        sb.AppendLine();
+
+        sb.AppendLine($"TutorialCompleted = {(config.TutorialCompleted ? "on" : "off")}");
+        sb.AppendLine("# Whether the first-run keyboard tutorial has been completed.");
         sb.AppendLine("# Values: on, off.");
         sb.AppendLine();
 

--- a/QuickMail/Services/ConfigService.cs
+++ b/QuickMail/Services/ConfigService.cs
@@ -206,6 +206,7 @@ public class ConfigService : IConfigService
                     case "announcehints":        config.AnnounceHints        = ParseBool(value); break;
                     case "announcestatus":       config.AnnounceStatus       = ParseBool(value); break;
                     case "announceresults":      config.AnnounceResults      = ParseBool(value); break;
+                    case "announcespellingsuggestions": config.AnnounceSpellingSuggestions = ParseBool(value); break;
                     case "tutorialcompleted":    config.TutorialCompleted    = ParseBool(value); break;
                 }
             }
@@ -290,6 +291,12 @@ public class ConfigService : IConfigService
 
         sb.AppendLine($"AnnounceResults = {(config.AnnounceResults ? "on" : "off")}");
         sb.AppendLine("# Announce action outcomes such as search result counts and move confirmations.");
+        sb.AppendLine("# Values: on, off.");
+        sb.AppendLine();
+
+        sb.AppendLine($"AnnounceSpellingSuggestions = {(config.AnnounceSpellingSuggestions ? "on" : "off")}");
+        sb.AppendLine("# Announce spelling suggestions when navigating into a misspelled word.");
+        sb.AppendLine("# When off, only the misspelled word is announced without suggestions.");
         sb.AppendLine("# Values: on, off.");
         sb.AppendLine();
 

--- a/QuickMail/Services/ISmtpService.cs
+++ b/QuickMail/Services/ISmtpService.cs
@@ -12,5 +12,6 @@ public interface ISmtpService
     /// Sends an ICS calendar reply (accept/decline/tentative) to the event organizer.
     /// The <paramref name="icsReplyContent"/> is a full iCalendar REPLY payload.
     /// </summary>
-    Task SendIcsReplyAsync(string icsReplyContent, AccountModel account, string? password, CancellationToken ct = default);
+    Task SendIcsReplyAsync(string icsReplyContent, AccountModel account, string? password,
+        string organizerEmail, CancellationToken ct = default);
 }

--- a/QuickMail/Services/ISmtpService.cs
+++ b/QuickMail/Services/ISmtpService.cs
@@ -7,4 +7,10 @@ namespace QuickMail.Services;
 public interface ISmtpService
 {
     Task SendAsync(ComposeModel compose, AccountModel account, string? password, CancellationToken ct = default);
+
+    /// <summary>
+    /// Sends an ICS calendar reply (accept/decline/tentative) to the event organizer.
+    /// The <paramref name="icsReplyContent"/> is a full iCalendar REPLY payload.
+    /// </summary>
+    Task SendIcsReplyAsync(string icsReplyContent, AccountModel account, string? password, CancellationToken ct = default);
 }

--- a/QuickMail/Services/ITemplateService.cs
+++ b/QuickMail/Services/ITemplateService.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using QuickMail.Models;
+
+namespace QuickMail.Services;
+
+public interface ITemplateService
+{
+    Task<List<MessageTemplate>> LoadAllAsync();
+    Task<MessageTemplate> AddAsync(MessageTemplate template);
+    Task UpdateAsync(MessageTemplate template);
+    Task DeleteAsync(int id);
+}

--- a/QuickMail/Services/ImapService.cs
+++ b/QuickMail/Services/ImapService.cs
@@ -338,6 +338,25 @@ public class ImapService : IImapService
 
             var attachments = ExtractAttachments(s.Body);
 
+            // Detect and parse text/calendar MIME parts (ICS calendar invites).
+            IcsModel? calendarInvite = null;
+            var calendarPart = FindCalendarPart(s.Body);
+            if (calendarPart != null)
+            {
+                try
+                {
+                    var decoded = await folder.GetBodyPartAsync(mailKitUid, calendarPart, ct);
+                    if (decoded is TextPart tp && !string.IsNullOrWhiteSpace(tp.Text))
+                    {
+                        calendarInvite = IcsModel.Parse(tp.Text);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    LogService.Log($"ImapService: failed to parse calendar part for UID {uid}: {ex.Message}");
+                }
+            }
+
             return new MailMessageDetail
             {
                 UniqueId      = uid,
@@ -354,6 +373,7 @@ public class ImapService : IImapService
                 PlainTextBody = plainText,
                 HtmlBody      = htmlText,
                 Attachments   = attachments,
+                CalendarInvite = calendarInvite,
             };
         }
         finally { await folder.CloseAsync(false, ct); }
@@ -1229,6 +1249,26 @@ public class ImapService : IImapService
             foreach (var child in multi.BodyParts)
             {
                 var found = FindBodyPartBySpecifier(child, specifier);
+                if (found != null) return found;
+            }
+        return null;
+    }
+
+    /// <summary>
+    /// Finds the first text/calendar body part in the MIME tree, if any.
+    /// Returns null if no calendar part is present.
+    /// </summary>
+    private static BodyPart? FindCalendarPart(BodyPart? part)
+    {
+        if (part == null) return null;
+        if (part is BodyPartBasic basic &&
+            basic.ContentType.MediaType.Equals("text", StringComparison.OrdinalIgnoreCase) &&
+            basic.ContentType.MediaSubtype.Equals("calendar", StringComparison.OrdinalIgnoreCase))
+            return part;
+        if (part is BodyPartMultipart multi)
+            foreach (var child in multi.BodyParts)
+            {
+                var found = FindCalendarPart(child);
                 if (found != null) return found;
             }
         return null;

--- a/QuickMail/Services/SmtpService.cs
+++ b/QuickMail/Services/SmtpService.cs
@@ -58,20 +58,16 @@ public class SmtpService : ISmtpService
         }
     }
 
-    public async Task SendIcsReplyAsync(string icsReplyContent, AccountModel account, string? password, CancellationToken ct = default)
+    public async Task SendIcsReplyAsync(string icsReplyContent, AccountModel account, string? password,
+        string organizerEmail, CancellationToken ct = default)
     {
         var message = new MimeMessage();
         message.From.Add(new MailboxAddress(account.SenderDisplayName, account.Username));
 
-        // Extract organizer from the ICS content to set as recipient.
-        var organizerMatch = System.Text.RegularExpressions.Regex.Match(
-            icsReplyContent, @"ORGANIZER[^:]*:mailto:([^\r\n]+)",
-            System.Text.RegularExpressions.RegexOptions.IgnoreCase);
-        if (organizerMatch.Success)
-        {
-            var orgEmail = organizerMatch.Groups[1].Value.Trim();
-            message.To.Add(MailboxAddress.Parse(orgEmail));
-        }
+        if (string.IsNullOrWhiteSpace(organizerEmail))
+            throw new ArgumentException("Organizer email is required for ICS reply.", nameof(organizerEmail));
+
+        message.To.Add(MailboxAddress.Parse(organizerEmail));
 
         message.Subject = "Calendar Response";
 

--- a/QuickMail/Services/SmtpService.cs
+++ b/QuickMail/Services/SmtpService.cs
@@ -1,8 +1,10 @@
 using System.Reflection;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using MailKit.Net.Smtp;
 using MailKit.Security;
+using MimeKit;
 using QuickMail.Models;
 
 namespace QuickMail.Services;
@@ -52,6 +54,67 @@ public class SmtpService : ISmtpService
         catch (Exception ex)
         {
             LogService.Log($"SmtpService: send failed ({ex.GetType().Name})", ex);
+            throw;
+        }
+    }
+
+    public async Task SendIcsReplyAsync(string icsReplyContent, AccountModel account, string? password, CancellationToken ct = default)
+    {
+        var message = new MimeMessage();
+        message.From.Add(new MailboxAddress(account.SenderDisplayName, account.Username));
+
+        // Extract organizer from the ICS content to set as recipient.
+        var organizerMatch = System.Text.RegularExpressions.Regex.Match(
+            icsReplyContent, @"ORGANIZER[^:]*:mailto:([^\r\n]+)",
+            System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+        if (organizerMatch.Success)
+        {
+            var orgEmail = organizerMatch.Groups[1].Value.Trim();
+            message.To.Add(MailboxAddress.Parse(orgEmail));
+        }
+
+        message.Subject = "Calendar Response";
+
+        var calendarPart = new TextPart("calendar")
+        {
+            ContentTransferEncoding = ContentEncoding.Base64,
+        };
+        calendarPart.ContentType.Parameters.Add("method", "REPLY");
+        calendarPart.SetText(Encoding.UTF8, icsReplyContent);
+
+        message.Body = calendarPart;
+
+        using var client = new SmtpClient();
+
+        if (account.SmtpAcceptInvalidCert)
+            client.ServerCertificateValidationCallback = (_, _, _, _) => true;
+
+        var ssl = account.SmtpUseSsl
+            ? SecureSocketOptions.SslOnConnect
+            : SecureSocketOptions.StartTlsWhenAvailable;
+
+        try
+        {
+            LogService.Log($"SmtpService: sending ICS reply to {account.SmtpHost}:{account.SmtpPort}");
+            await client.ConnectAsync(account.SmtpHost, account.SmtpPort, ssl, ct);
+
+            if (account.AuthType == AuthType.OAuth2Microsoft)
+            {
+                var token = await _oauth.GetAccessTokenAsync(account, ct);
+                await client.AuthenticateAsync(new SaslMechanismOAuth2(account.Username, token), ct);
+            }
+            else
+            {
+                await client.AuthenticateAsync(account.Username, password!, ct);
+            }
+            LogService.Log($"SmtpService: ICS reply authenticated, sending.");
+            await client.SendAsync(message, ct);
+            LogService.Log($"SmtpService: ICS reply sent.");
+            await client.DisconnectAsync(true, ct);
+        }
+        catch (Exception ex)
+        {
+            LogService.Log($"SmtpService: ICS reply send failed ({ex.GetType().Name})", ex);
             throw;
         }
     }

--- a/QuickMail/Services/TemplateService.cs
+++ b/QuickMail/Services/TemplateService.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using QuickMail.Models;
+
+namespace QuickMail.Services;
+
+public class TemplateService : ITemplateService
+{
+    private readonly string _filePath;
+    private readonly SemaphoreSlim _loadLock = new(1, 1);
+    private List<MessageTemplate> _cache = [];
+    private bool _loaded;
+
+    public TemplateService(ProfileContext profile)
+    {
+        _filePath = Path.Combine(profile.ProfileDir, "templates.json");
+    }
+
+    public async Task<List<MessageTemplate>> LoadAllAsync()
+    {
+        await EnsureLoadedAsync();
+        await _loadLock.WaitAsync();
+        try
+        {
+            return _cache.OrderBy(t => t.Title, StringComparer.OrdinalIgnoreCase).ToList();
+        }
+        finally
+        {
+            _loadLock.Release();
+        }
+    }
+
+    public async Task<MessageTemplate> AddAsync(MessageTemplate template)
+    {
+        await EnsureLoadedAsync();
+        await _loadLock.WaitAsync();
+        try
+        {
+            template.Id = _cache.Count > 0 ? _cache.Max(t => t.Id) + 1 : 1;
+            _cache.Add(template);
+            await SaveAsyncLocked();
+            return template;
+        }
+        finally
+        {
+            _loadLock.Release();
+        }
+    }
+
+    public async Task UpdateAsync(MessageTemplate template)
+    {
+        await EnsureLoadedAsync();
+        await _loadLock.WaitAsync();
+        try
+        {
+            var existing = _cache.FirstOrDefault(t => t.Id == template.Id);
+            if (existing != null)
+            {
+                existing.Title = template.Title;
+                existing.Subject = template.Subject;
+                existing.Body = template.Body;
+                await SaveAsyncLocked();
+            }
+        }
+        finally
+        {
+            _loadLock.Release();
+        }
+    }
+
+    public async Task DeleteAsync(int id)
+    {
+        await EnsureLoadedAsync();
+        await _loadLock.WaitAsync();
+        try
+        {
+            _cache.RemoveAll(t => t.Id == id);
+            await SaveAsyncLocked();
+        }
+        finally
+        {
+            _loadLock.Release();
+        }
+    }
+
+    private async Task EnsureLoadedAsync()
+    {
+        if (_loaded) return;
+        await _loadLock.WaitAsync();
+        try
+        {
+            if (_loaded) return;
+            if (File.Exists(_filePath))
+            {
+                try
+                {
+                    var json = await File.ReadAllTextAsync(_filePath);
+                    _cache = JsonSerializer.Deserialize<List<MessageTemplate>>(json) ?? [];
+                }
+                catch (Exception ex)
+                {
+                    LogService.Debug($"TemplateService: failed to load templates: {ex.Message}");
+                }
+            }
+            _loaded = true;
+        }
+        finally
+        {
+            _loadLock.Release();
+        }
+    }
+
+    private async Task SaveAsyncLocked()
+    {
+        var json = JsonSerializer.Serialize(_cache, new JsonSerializerOptions { WriteIndented = true });
+        var tempPath = _filePath + ".tmp";
+        await File.WriteAllTextAsync(tempPath, json);
+        File.Move(tempPath, _filePath, overwrite: true);
+    }
+}

--- a/QuickMail/ViewModels/AccountEditorViewModel.cs
+++ b/QuickMail/ViewModels/AccountEditorViewModel.cs
@@ -29,6 +29,7 @@ public abstract partial class AccountEditorViewModel : ObservableObject
     [ObservableProperty] private int    _smtpPort = 587;
     [ObservableProperty] private bool   _smtpUseSsl = false;
     [ObservableProperty] private bool   _smtpAcceptInvalidCert = false;
+    [ObservableProperty] private string _signature = string.Empty;
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(IsPasswordAuth))]

--- a/QuickMail/ViewModels/AccountManagerViewModel.cs
+++ b/QuickMail/ViewModels/AccountManagerViewModel.cs
@@ -61,6 +61,7 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
         SmtpPort = value.SmtpPort;
         SmtpUseSsl = value.SmtpUseSsl;
         SmtpAcceptInvalidCert = value.SmtpAcceptInvalidCert;
+        Signature = value.Signature;
         StatusText = string.Empty;
     }
 
@@ -93,6 +94,7 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
         SelectedAccount.SmtpPort = SmtpPort;
         SelectedAccount.SmtpUseSsl = SmtpUseSsl;
         SelectedAccount.SmtpAcceptInvalidCert = SmtpAcceptInvalidCert;
+        SelectedAccount.Signature = Signature;
 
         if (AuthType == AuthType.Password && !string.IsNullOrEmpty(Password))
             _credentials.SavePassword(SelectedAccount.Id, Password);

--- a/QuickMail/ViewModels/AddAccountViewModel.cs
+++ b/QuickMail/ViewModels/AddAccountViewModel.cs
@@ -41,5 +41,6 @@ public partial class AddAccountViewModel : AccountEditorViewModel
         SmtpPort = SmtpPort,
         SmtpUseSsl = SmtpUseSsl,
         SmtpAcceptInvalidCert = SmtpAcceptInvalidCert,
+        Signature = Signature,
     };
 }

--- a/QuickMail/ViewModels/ComposeViewModel.cs
+++ b/QuickMail/ViewModels/ComposeViewModel.cs
@@ -20,6 +20,7 @@ public partial class ComposeViewModel : ObservableObject
     private readonly IAccountService _accountService;
     private readonly ICredentialService _credentials;
     private readonly IImapService _imap;
+    private readonly ITemplateService _templateService;
 
     [ObservableProperty] private string _to = string.Empty;
     [ObservableProperty] private string _cc = string.Empty;
@@ -50,12 +51,13 @@ public partial class ComposeViewModel : ObservableObject
     /// </summary>
     public Func<string, string, bool>? ConfirmationRequested { get; set; }
 
-    public ComposeViewModel(ISmtpService smtp, IAccountService accountService, ICredentialService credentials, IImapService imap)
+    public ComposeViewModel(ISmtpService smtp, IAccountService accountService, ICredentialService credentials, IImapService imap, ITemplateService templateService)
     {
         _smtp = smtp;
         _accountService = accountService;
         _credentials = credentials;
         _imap = imap;
+        _templateService = templateService;
         _attachments.CollectionChanged += (_, _) =>
         {
             _isDirty = true;
@@ -238,6 +240,60 @@ public partial class ComposeViewModel : ObservableObject
 
     [RelayCommand]
     private void Cancel() => CloseRequested?.Invoke();
+
+    /// <summary>
+    /// Opens the template picker. The View subscribes to this event to show the dialog.
+    /// </summary>
+    public event Func<Task<MessageTemplate?>>? InsertTemplateRequested;
+
+    [RelayCommand]
+    private async Task InsertTemplateAsync()
+    {
+        if (InsertTemplateRequested == null) return;
+        var template = await InsertTemplateRequested();
+        if (template == null) return;
+
+        var displayName = !string.IsNullOrWhiteSpace(SenderAccount?.DisplayName)
+            ? SenderAccount!.DisplayName
+            : !string.IsNullOrWhiteSpace(SenderAccount?.Username)
+                ? SenderAccount!.Username
+                : string.Empty;
+        var now = DateTime.Now;
+
+        var body = template.Body
+            .Replace("{sender}", displayName, StringComparison.OrdinalIgnoreCase)
+            .Replace("{date}", now.ToString("d"), StringComparison.OrdinalIgnoreCase)
+            .Replace("{time}", now.ToString("t"), StringComparison.OrdinalIgnoreCase);
+
+        if (!string.IsNullOrWhiteSpace(template.Subject) && string.IsNullOrWhiteSpace(Subject))
+            Subject = template.Subject
+                .Replace("{sender}", displayName, StringComparison.OrdinalIgnoreCase)
+                .Replace("{date}", now.ToString("d"), StringComparison.OrdinalIgnoreCase)
+                .Replace("{time}", now.ToString("t"), StringComparison.OrdinalIgnoreCase);
+
+        Body += body;
+        StatusText = $"Template '{template.Title}' inserted.";
+    }
+
+    [RelayCommand]
+    private async Task SaveAsTemplateAsync()
+    {
+        if (string.IsNullOrWhiteSpace(Body))
+        {
+            StatusText = "Nothing to save — body is empty.";
+            return;
+        }
+
+        var template = new MessageTemplate
+        {
+            Title = Subject.Trim().Length > 0 ? Subject.Trim() : "Untitled",
+            Subject = Subject,
+            Body = Body
+        };
+
+        await _templateService.AddAsync(template);
+        StatusText = $"Template saved as '{template.Title}'.";
+    }
 
     [RelayCommand]
     private async Task AddAttachmentsAsync()

--- a/QuickMail/ViewModels/ComposeViewModel.cs
+++ b/QuickMail/ViewModels/ComposeViewModel.cs
@@ -94,6 +94,20 @@ public partial class ComposeViewModel : ObservableObject
         SenderAccount = SenderAccounts.FirstOrDefault(a => a.Id == model.AccountId)
                         ?? SenderAccounts.FirstOrDefault(a => a.IsDefault)
                         ?? SenderAccounts.FirstOrDefault();
+
+        // Auto-append signature if this is a new compose (not a draft re-open) and the
+        // account has a signature configured. Drafts already have the signature in the body.
+        if (model.DraftUid == null && SenderAccount != null && !string.IsNullOrWhiteSpace(SenderAccount.Signature))
+        {
+            var sig = SenderAccount.Signature;
+            // Add separator if body already has content (reply/forward)
+            if (!string.IsNullOrWhiteSpace(Body) && !Body.EndsWith("\n"))
+                Body += "\n";
+            if (!string.IsNullOrWhiteSpace(Body))
+                Body += "\n-- \n";
+            Body += sig;
+            _isDirty = false; // signature insertion is not a user edit
+        }
     }
 
     [RelayCommand]

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -464,11 +464,6 @@ public partial class MainViewModel : ObservableObject
     public void LoadAccountList()
     {
         Accounts = new ObservableCollection<AccountModel>(_accountService.LoadAccounts());
-
-        // Show the first-run keyboard tutorial if the user hasn't completed it yet.
-        var cfg = _configService.Load();
-        if (!cfg.TutorialCompleted)
-            TutorialRequested?.Invoke(this, EventArgs.Empty);
     }
 
     // ── Saved-views lifecycle ─────────────────────────────────────────────────────

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -42,6 +42,18 @@ public partial class MainViewModel : ObservableObject
     private const int PrefetchTopOnFolderLoad  = 10;
     private CancellationTokenSource? _bgSyncCts;
 
+    /// <summary>
+    /// Cancels and disposes the old CTS, creates a new one, and outputs its token.
+    /// Thread-safe: the slot is atomically replaced via Interlocked.Exchange.
+    /// </summary>
+    private static void ReplaceCts(ref CancellationTokenSource? slot, out CancellationToken token)
+    {
+        var cts = new CancellationTokenSource();
+        var previous = Interlocked.Exchange(ref slot, cts);
+        try { previous?.Cancel(); previous?.Dispose(); } catch { /* best effort */ }
+        token = cts.Token;
+    }
+
     // How many days of mail to sync (0 = all); set via the Sync Range menu
     private int _syncDays = 30;
 
@@ -435,22 +447,8 @@ public partial class MainViewModel : ObservableObject
         _previewLines = cfg.PreviewLines;
         _showPreview = _previewLines > 0;
         _syncDays = cfg.SyncDays;
-        _viewMode = cfg.ViewMode switch
-        {
-            "conversations" => ViewMode.Conversations,
-            "from"          => ViewMode.From,
-            "to"            => ViewMode.To,
-            _               => ViewMode.Messages,
-        };
-        _activeSort = cfg.Sort switch
-        {
-            "dateAsc"   => MessageSort.DateAscending,
-            "alphaAsc"  => MessageSort.AlphaAscending,
-            "alphaDesc" => MessageSort.AlphaDescending,
-            "countDesc" => MessageSort.CountDescending,
-            "countAsc"  => MessageSort.CountAscending,
-            _           => MessageSort.DateDescending,
-        };
+        _viewMode = ConfigModel.ParseViewMode(cfg.ViewMode);
+        _activeSort = ConfigModel.ParseSort(cfg.Sort);
 
         _syncService.FolderSynced    += OnFolderSynced;
         _syncService.MessagesRemoved += OnMessagesRemoved;
@@ -590,13 +588,7 @@ public partial class MainViewModel : ObservableObject
 
         // Apply view's mode/filter/sort before clearing search so rebuild
         // schedulers triggered by ViewMode change operate on the right data.
-        ViewMode = view.ViewMode switch
-        {
-            "conversations" => ViewMode.Conversations,
-            "from"          => ViewMode.From,
-            "to"            => ViewMode.To,
-            _               => ViewMode.Messages,
-        };
+        ViewMode = ConfigModel.ParseViewMode(view.ViewMode);
         ActiveFilter = view.Filter switch
         {
             "unread"      => MessageFilter.Unread,
@@ -606,15 +598,7 @@ public partial class MainViewModel : ObservableObject
             "forwarded"   => MessageFilter.Forwarded,
             _             => MessageFilter.All,
         };
-        ActiveSort = view.Sort switch
-        {
-            "dateAsc"   => MessageSort.DateAscending,
-            "alphaAsc"  => MessageSort.AlphaAscending,
-            "alphaDesc" => MessageSort.AlphaDescending,
-            "countDesc" => MessageSort.CountDescending,
-            "countAsc"  => MessageSort.CountAscending,
-            _           => MessageSort.DateDescending,
-        };
+        ActiveSort = ConfigModel.ParseSort(view.Sort);
 
         ActiveDayLimit = view.DaysOfMail;
         SearchText     = string.Empty;
@@ -682,8 +666,7 @@ public partial class MainViewModel : ObservableObject
         IsBusy = true;
 
         _folderCts?.Cancel();
-        _folderCts = new CancellationTokenSource();
-        var ct = _folderCts.Token;
+        ReplaceCts(ref _folderCts, out var ct);
 
         try
         {
@@ -805,13 +788,7 @@ public partial class MainViewModel : ObservableObject
         _previewLines = newPreviewLines;
         _showPreview  = newShowPreview;
 
-        var newMode = cfg.ViewMode switch
-        {
-            "conversations" => ViewMode.Conversations,
-            "from"          => ViewMode.From,
-            "to"            => ViewMode.To,
-            _               => ViewMode.Messages,
-        };
+        var newMode = ConfigModel.ParseViewMode(cfg.ViewMode);
         ViewMode = newMode;
 
         var prevSyncDays = _syncDays;
@@ -823,15 +800,7 @@ public partial class MainViewModel : ObservableObject
         OnPropertyChanged(nameof(IsSyncDaysAll));
         OnPropertyChanged(nameof(SyncRangeLabel));
 
-        ActiveSort = cfg.Sort switch
-        {
-            "dateAsc"   => MessageSort.DateAscending,
-            "alphaAsc"  => MessageSort.AlphaAscending,
-            "alphaDesc" => MessageSort.AlphaDescending,
-            "countDesc" => MessageSort.CountDescending,
-            "countAsc"  => MessageSort.CountAscending,
-            _           => MessageSort.DateDescending,
-        };
+        ActiveSort = ConfigModel.ParseSort(cfg.Sort);
 
         if (_syncDays != prevSyncDays)
             _ = RefreshAsync();
@@ -1010,8 +979,7 @@ public partial class MainViewModel : ObservableObject
     public async Task StartBackgroundSyncAsync()
     {
         _bgSyncCts?.Cancel();
-        _bgSyncCts = new CancellationTokenSource();
-        var ct = _bgSyncCts.Token;
+        ReplaceCts(ref _bgSyncCts, out var ct);
 
         await ConnectAllAccountsAsync();
         if (_cachedFolders.Count == 0) return;
@@ -1696,15 +1664,7 @@ public partial class MainViewModel : ObservableObject
         OnPropertyChanged(nameof(SortLabel));
 
         var cfg = _configService.Load();
-        cfg.Sort = value switch
-        {
-            MessageSort.DateAscending   => "dateAsc",
-            MessageSort.AlphaAscending  => "alphaAsc",
-            MessageSort.AlphaDescending => "alphaDesc",
-            MessageSort.CountDescending => "countDesc",
-            MessageSort.CountAscending  => "countAsc",
-            _                           => "dateDesc",
-        };
+        cfg.Sort = ConfigModel.ToConfigString(value);
         _configService.Save(cfg);
 
         if (ViewMode == ViewMode.Messages)
@@ -1738,13 +1698,7 @@ public partial class MainViewModel : ObservableObject
             ToGroups = [];
 
         var cfg = _configService.Load();
-        cfg.ViewMode = value switch
-        {
-            ViewMode.Conversations => "conversations",
-            ViewMode.From          => "from",
-            ViewMode.To            => "to",
-            _                      => "messages",
-        };
+        cfg.ViewMode = ConfigModel.ToConfigString(value);
         _configService.Save(cfg);
 
         if (value == ViewMode.To && SelectedFolder?.FullName == AllMailFolder.FullName && Messages.Any(m => string.IsNullOrWhiteSpace(m.To)))
@@ -1895,9 +1849,9 @@ public partial class MainViewModel : ObservableObject
                 return;
             }
             _connectCts?.Cancel();
-            _connectCts = new CancellationTokenSource();
-            await _imap.ConnectAsync(account, password, _connectCts.Token);
-            var folderList = await _imap.GetFoldersAsync(account.Id, _connectCts.Token);
+            ReplaceCts(ref _connectCts, out var ct);
+            await _imap.ConnectAsync(account, password, ct);
+            var folderList = await _imap.GetFoldersAsync(account.Id, ct);
             _cachedFolders[account.Id] = folderList;
             ApplyAccountStatus(account, folderList);
             RebuildFolderListFromCache();
@@ -1989,9 +1943,7 @@ public partial class MainViewModel : ObservableObject
         IsBusy = true;
         try
         {
-            var cts = new CancellationTokenSource();
-            var previousCts = Interlocked.Exchange(ref _folderCts, cts);
-            await (previousCts?.CancelAsync() ?? Task.CompletedTask);
+            ReplaceCts(ref _folderCts, out var ct);
 
             if (!OnlineMode)
             {
@@ -2011,7 +1963,7 @@ public partial class MainViewModel : ObservableObject
                 }
             }
 
-            _ = RefreshFolderFromServerAsync(accountId, folder, loadVersion, cts.Token);
+            _ = RefreshFolderFromServerAsync(accountId, folder, loadVersion, ct);
         }
         catch (OperationCanceledException)
         {
@@ -2086,10 +2038,7 @@ public partial class MainViewModel : ObservableObject
         IsBusy = true;
         try
         {
-            var cts = new CancellationTokenSource();
-            var previousCts = Interlocked.Exchange(ref _messageLoadCts, cts);
-            await (previousCts?.CancelAsync() ?? Task.CompletedTask);
-            var token = cts.Token;
+            ReplaceCts(ref _messageLoadCts, out var token);
 
             MailMessageDetail detail;
             if (OnlineMode)
@@ -2186,11 +2135,9 @@ public partial class MainViewModel : ObservableObject
 
     private void SchedulePrefetch(List<MailMessageSummary> targets, string reason)
     {
-        var cts = new CancellationTokenSource();
-        var previous = Interlocked.Exchange(ref _prefetchCts, cts);
-        try { previous?.Cancel(); previous?.Dispose(); } catch { /* best effort */ }
+        ReplaceCts(ref _prefetchCts, out var ct);
 
-        _ = Task.Run(() => RunPrefetchAsync(targets, reason, cts.Token));
+        _ = Task.Run(() => RunPrefetchAsync(targets, reason, ct));
     }
 
     private async Task RunPrefetchAsync(List<MailMessageSummary> targets, string reason, CancellationToken ct)
@@ -2260,8 +2207,7 @@ public partial class MainViewModel : ObservableObject
         IsBusy = true;
 
         _folderCts?.Cancel();
-        _folderCts = new CancellationTokenSource();
-        var ct = _folderCts.Token;
+        ReplaceCts(ref _folderCts, out var ct);
 
         try
         {
@@ -2497,8 +2443,7 @@ public partial class MainViewModel : ObservableObject
         IsBusy = true;
 
         _folderCts?.Cancel();
-        _folderCts = new CancellationTokenSource();
-        var ct = _folderCts.Token;
+        ReplaceCts(ref _folderCts, out var ct);
 
         try
         {
@@ -2592,8 +2537,7 @@ public partial class MainViewModel : ObservableObject
         IsBusy = true;
 
         _folderCts?.Cancel();
-        _folderCts = new CancellationTokenSource();
-        var ct = _folderCts.Token;
+        ReplaceCts(ref _folderCts, out var ct);
 
         var all = new List<MailMessageSummary>();
 
@@ -2736,9 +2680,7 @@ public partial class MainViewModel : ObservableObject
         // ── Step 2: IMAP delete + local store cleanup ────────────────────────────
         try
         {
-            var cts = new CancellationTokenSource();
-            var previousCts = Interlocked.Exchange(ref _messageActionCts, cts);
-            await (previousCts?.CancelAsync() ?? Task.CompletedTask);
+            ReplaceCts(ref _messageActionCts, out var ct);
 
             var groups = toDelete.GroupBy(m => (m.AccountId, m.FolderName));
             foreach (var group in groups)
@@ -2754,10 +2696,10 @@ public partial class MainViewModel : ObservableObject
 
                 if (sourceKind == SpecialFolderKind.Trash)
                     await _imap.PermanentlyDeleteBatchAsync(
-                        group.Key.AccountId, group.Key.FolderName, uids, cts.Token);
+                        group.Key.AccountId, group.Key.FolderName, uids, ct);
                 else
                     await _imap.MoveToTrashBatchAsync(
-                        group.Key.AccountId, group.Key.FolderName, uids, cts.Token);
+                        group.Key.AccountId, group.Key.FolderName, uids, ct);
 
                 if (!OnlineMode)
                     await _localStore.DeleteSummariesAsync(group.Key.AccountId, group.Key.FolderName, uids);
@@ -2954,9 +2896,7 @@ public partial class MainViewModel : ObservableObject
         StatusText = "Opening draft…";
         try
         {
-            var cts = new CancellationTokenSource();
-            var previousCts = Interlocked.Exchange(ref _messageLoadCts, cts);
-            await (previousCts?.CancelAsync() ?? Task.CompletedTask);
+            ReplaceCts(ref _messageLoadCts, out var ct);
 
             var detail = await _localStore.LoadDetailAsync(
                 summary.AccountId, summary.FolderName, summary.UniqueId);
@@ -2964,7 +2904,7 @@ public partial class MainViewModel : ObservableObject
             if (detail == null)
             {
                 detail = await _imap.GetMessageDetailAsync(
-                    summary.AccountId, summary.FolderName, summary.UniqueId, cts.Token);
+                    summary.AccountId, summary.FolderName, summary.UniqueId, ct);
             }
 
             var model = new ComposeModel
@@ -2987,7 +2927,7 @@ public partial class MainViewModel : ObservableObject
                     {
                         att.Content = await _imap.DownloadAttachmentAsync(
                             summary.AccountId, summary.FolderName, summary.UniqueId,
-                            att.PartSpecifier, cts.Token);
+                            att.PartSpecifier, ct);
                     }
                     catch (Exception ex)
                     {
@@ -3282,9 +3222,7 @@ public partial class MainViewModel : ObservableObject
         IsBusy     = true;
         try
         {
-            var cts = new CancellationTokenSource();
-            var previousCts = Interlocked.Exchange(ref _messageActionCts, cts);
-            await (previousCts?.CancelAsync() ?? Task.CompletedTask);
+            ReplaceCts(ref _messageActionCts, out var ct);
 
             var groups = messages.GroupBy(m => (m.AccountId, m.FolderName));
             foreach (var group in groups)
@@ -3292,7 +3230,7 @@ public partial class MainViewModel : ObservableObject
                 var uids = group.Select(m => m.UniqueId).ToList();
                 await _imap.MoveMessagesAsync(
                     group.Key.AccountId, group.Key.FolderName, uids,
-                    destination.FullName, cts.Token);
+                    destination.FullName, ct);
                 if (!OnlineMode)
                     await _localStore.DeleteSummariesAsync(group.Key.AccountId, group.Key.FolderName, uids);
             }
@@ -3538,13 +3476,7 @@ public partial class MainViewModel : ObservableObject
     [RelayCommand]
     private void SetViewMode(string? mode)
     {
-        ViewMode = mode?.ToLowerInvariant() switch
-        {
-            "conversations" => ViewMode.Conversations,
-            "from"          => ViewMode.From,
-            "to"            => ViewMode.To,
-            _               => ViewMode.Messages,
-        };
+        ViewMode = ConfigModel.ParseViewMode(mode);
     }
 
     // ── Search command ────────────────────────────────────────────────────────
@@ -3578,15 +3510,7 @@ public partial class MainViewModel : ObservableObject
     [RelayCommand]
     private void SetSort(string? sort)
     {
-        ActiveSort = sort switch
-        {
-            "dateAsc"   => MessageSort.DateAscending,
-            "alphaAsc"  => MessageSort.AlphaAscending,
-            "alphaDesc" => MessageSort.AlphaDescending,
-            "countDesc" => MessageSort.CountDescending,
-            "countAsc"  => MessageSort.CountAscending,
-            _           => MessageSort.DateDescending,
-        };
+        ActiveSort = ConfigModel.ParseSort(sort);
     }
 
     [RelayCommand]

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -466,6 +466,11 @@ public partial class MainViewModel : ObservableObject
     public void LoadAccountList()
     {
         Accounts = new ObservableCollection<AccountModel>(_accountService.LoadAccounts());
+
+        // Show the first-run keyboard tutorial if the user hasn't completed it yet.
+        var cfg = _configService.Load();
+        if (!cfg.TutorialCompleted)
+            TutorialRequested?.Invoke(this, EventArgs.Empty);
     }
 
     // ── Saved-views lifecycle ─────────────────────────────────────────────────────
@@ -966,6 +971,10 @@ public partial class MainViewModel : ObservableObject
             id: "mail.tentativeInvite", category: "Mail", title: "Tentatively Accept Invitation",
             execute: () => TentativeInviteCommand.Execute(null),
             isAvailable: () => HasCalendarInvite));
+
+        registry.Register(new CommandDefinition(
+            id: "help.keyboardTutorial", category: "Help", title: "Keyboard Tutorial",
+            execute: () => TutorialRequested?.Invoke(this, EventArgs.Empty)));
     }
 
     // ── Startup ──────────────────────────────────────────────────────────────────
@@ -2782,6 +2791,7 @@ public partial class MainViewModel : ObservableObject
     public event EventHandler<(string Text, AnnouncementCategory Category)>? AnnouncementRequested;
     public event EventHandler? RulesManagerRequested;
     public event EventHandler<MailRule>? CreateRuleFromMessageRequested;
+    public event EventHandler? TutorialRequested;
 
     private void Announce(string text, AnnouncementCategory category = AnnouncementCategory.Result)
     {

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -29,6 +29,7 @@ public partial class MainViewModel : ObservableObject
     private readonly IViewService _viewService;
     private readonly ICommandRegistry _commandRegistry;
     private readonly IRuleService _ruleService;
+    private readonly ISmtpService _smtp;
 
     // Separate CTS per operation type so they can't cancel each other accidentally
     private CancellationTokenSource? _connectCts;
@@ -413,6 +414,7 @@ public partial class MainViewModel : ObservableObject
         ICommandRegistry commandRegistry,
         IViewService viewService,
         IRuleService ruleService,
+        ISmtpService smtpService,
         bool onlineMode = false)
     {
         _imap            = imap;
@@ -425,6 +427,7 @@ public partial class MainViewModel : ObservableObject
         _commandRegistry = commandRegistry;
         _viewService     = viewService;
         _ruleService     = ruleService;
+        _smtp            = smtpService;
         OnlineMode       = onlineMode;
 
         var cfg = _configService.Load();
@@ -948,6 +951,21 @@ public partial class MainViewModel : ObservableObject
             execute: () => CreateRuleFromMessageCommand.Execute(null),
             defaultKey: Key.T, defaultModifiers: ModifierKeys.Control | ModifierKeys.Shift,
             isAvailable: () => HasSelectedMessage));
+
+        registry.Register(new CommandDefinition(
+            id: "mail.acceptInvite", category: "Mail", title: "Accept Invitation",
+            execute: () => AcceptInviteCommand.Execute(null),
+            isAvailable: () => HasCalendarInvite));
+
+        registry.Register(new CommandDefinition(
+            id: "mail.declineInvite", category: "Mail", title: "Decline Invitation",
+            execute: () => DeclineInviteCommand.Execute(null),
+            isAvailable: () => HasCalendarInvite));
+
+        registry.Register(new CommandDefinition(
+            id: "mail.tentativeInvite", category: "Mail", title: "Tentatively Accept Invitation",
+            execute: () => TentativeInviteCommand.Execute(null),
+            isAvailable: () => HasCalendarInvite));
     }
 
     // ── Startup ──────────────────────────────────────────────────────────────────
@@ -3746,5 +3764,137 @@ public partial class MainViewModel : ObservableObject
         return System.Text.RegularExpressions.Regex.Replace(html, "<[^>]+>", " ")
             .Replace("&nbsp;", " ").Replace("&amp;", "&").Replace("&lt;", "<").Replace("&gt;", ">")
             .Trim();
+    }
+
+    // ── Calendar invite commands ─────────────────────────────────────────────────
+
+    /// <summary>True when the open message contains a calendar invite.</summary>
+    public bool HasCalendarInvite => IsMessageOpen && MessageDetail?.CalendarInvite != null;
+
+    /// <summary>
+    /// Builds an accessible HTML event card for display in the WebView2 reading pane.
+    /// The card is prepended to the message body HTML by the View.
+    /// </summary>
+    public string BuildEventCardHtml()
+    {
+        var invite = MessageDetail?.CalendarInvite;
+        if (invite == null) return string.Empty;
+
+        var sb = new System.Text.StringBuilder();
+        sb.Append("<div style=\"border:1px solid #888;border-radius:6px;padding:12px;margin:0 0 16px 0;background:#f5f5f5;color:#222;font-family:Segoe UI,Arial,sans-serif;font-size:13px;line-height:1.45;\" role=\"region\" aria-label=\"");
+        sb.Append(System.Net.WebUtility.HtmlEncode(invite.DisplaySummary));
+        sb.Append("\">");
+        sb.Append("<div style=\"font-weight:bold;font-size:15px;margin-bottom:8px;\">Event Invitation</div>");
+
+        if (!string.IsNullOrWhiteSpace(invite.Summary))
+        {
+            sb.Append("<div style=\"margin-bottom:4px;\"><strong>Event:</strong> ");
+            sb.Append(System.Net.WebUtility.HtmlEncode(invite.Summary));
+            sb.Append("</div>");
+        }
+
+        if (!string.IsNullOrWhiteSpace(invite.OrganizerName))
+        {
+            sb.Append("<div style=\"margin-bottom:4px;\"><strong>Organizer:</strong> ");
+            sb.Append(System.Net.WebUtility.HtmlEncode(invite.OrganizerName));
+            sb.Append("</div>");
+        }
+        else if (!string.IsNullOrWhiteSpace(invite.Organizer))
+        {
+            sb.Append("<div style=\"margin-bottom:4px;\"><strong>Organizer:</strong> ");
+            sb.Append(System.Net.WebUtility.HtmlEncode(invite.Organizer));
+            sb.Append("</div>");
+        }
+
+        if (invite.StartTime.HasValue)
+        {
+            sb.Append("<div style=\"margin-bottom:4px;\"><strong>When:</strong> ");
+            sb.Append(System.Net.WebUtility.HtmlEncode(invite.StartTime.Value.ToLocalTime().ToString("f")));
+            if (invite.EndTime.HasValue)
+            {
+                sb.Append(" \u2013 ");
+                sb.Append(System.Net.WebUtility.HtmlEncode(invite.EndTime.Value.ToLocalTime().ToString("t")));
+            }
+            sb.Append("</div>");
+        }
+
+        if (!string.IsNullOrWhiteSpace(invite.Location))
+        {
+            sb.Append("<div style=\"margin-bottom:8px;\"><strong>Location:</strong> ");
+            sb.Append(System.Net.WebUtility.HtmlEncode(invite.Location));
+            sb.Append("</div>");
+        }
+
+        if (!string.IsNullOrWhiteSpace(invite.Description))
+        {
+            sb.Append("<div style=\"margin-bottom:8px;white-space:pre-wrap;\">");
+            sb.Append(System.Net.WebUtility.HtmlEncode(invite.Description));
+            sb.Append("</div>");
+        }
+
+        // Buttons: Accept, Tentative, Decline
+        sb.Append("<div style=\"margin-top:8px;\">");
+        sb.Append("<a href=\"quickmail:ics-accept\" role=\"button\" aria-label=\"Accept invitation\" ");
+        sb.Append("style=\"display:inline-block;padding:6px 14px;margin-right:8px;margin-bottom:4px;");
+        sb.Append("background:#107c10;color:#fff;border-radius:4px;text-decoration:none;font-weight:600;\">Accept</a>");
+        sb.Append("<a href=\"quickmail:ics-tentative\" role=\"button\" aria-label=\"Tentatively accept invitation\" ");
+        sb.Append("style=\"display:inline-block;padding:6px 14px;margin-right:8px;margin-bottom:4px;");
+        sb.Append("background:#ff8c00;color:#fff;border-radius:4px;text-decoration:none;font-weight:600;\">Tentative</a>");
+        sb.Append("<a href=\"quickmail:ics-decline\" role=\"button\" aria-label=\"Decline invitation\" ");
+        sb.Append("style=\"display:inline-block;padding:6px 14px;margin-bottom:4px;");
+        sb.Append("background:#d13438;color:#fff;border-radius:4px;text-decoration:none;font-weight:600;\">Decline</a>");
+        sb.Append("</div>");
+
+        sb.Append("</div>");
+        return sb.ToString();
+    }
+
+    [RelayCommand]
+    private async Task AcceptInvite()
+    {
+        await SendIcsReply("ACCEPTED", "accepted");
+    }
+
+    [RelayCommand]
+    private async Task DeclineInvite()
+    {
+        await SendIcsReply("DECLINED", "declined");
+    }
+
+    [RelayCommand]
+    private async Task TentativeInvite()
+    {
+        await SendIcsReply("TENTATIVE", "tentatively accepted");
+    }
+
+    private async Task SendIcsReply(string partStat, string actionLabel)
+    {
+        var invite = MessageDetail?.CalendarInvite;
+        if (invite == null) return;
+
+        var account = Accounts.FirstOrDefault(a => a.Id == MessageDetail!.AccountId);
+        if (account == null)
+        {
+            Announce($"Cannot send calendar response: account not found.", AnnouncementCategory.Result);
+            return;
+        }
+
+        try
+        {
+            var attendeeName = account.SenderDisplayName;
+            var attendeeEmail = account.Username;
+            var icsContent = invite.GenerateReply(attendeeEmail, attendeeName, partStat);
+
+            var password = _credentials.GetPassword(account.Id);
+            await _smtp.SendIcsReplyAsync(icsContent, account, password);
+
+            var eventTitle = invite.Summary ?? "calendar event";
+            Announce($"Calendar response sent: {actionLabel} \u2014 {eventTitle}.", AnnouncementCategory.Result);
+        }
+        catch (Exception ex)
+        {
+            LogService.Log($"SendIcsReply ({partStat})", ex);
+            Announce($"Failed to send calendar response: {ex.Message}", AnnouncementCategory.Result);
+        }
     }
 }

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -3815,7 +3815,7 @@ public partial class MainViewModel : ObservableObject
             var icsContent = invite.GenerateReply(attendeeEmail, attendeeName, partStat);
 
             var password = _credentials.GetPassword(account.Id);
-            await _smtp.SendIcsReplyAsync(icsContent, account, password);
+            await _smtp.SendIcsReplyAsync(icsContent, account, password, invite.Organizer ?? "");
 
             var eventTitle = invite.Summary ?? "calendar event";
             Announce($"Calendar response sent: {actionLabel} \u2014 {eventTitle}.", AnnouncementCategory.Result);

--- a/QuickMail/ViewModels/SettingsViewModel.cs
+++ b/QuickMail/ViewModels/SettingsViewModel.cs
@@ -40,6 +40,9 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty]
     private bool _announceResults;
 
+    [ObservableProperty]
+    private bool _announceSpellingSuggestions;
+
     public ObservableCollection<HotkeyRowViewModel> HotkeyRows { get; } = [];
 
     [ObservableProperty]
@@ -59,6 +62,7 @@ public partial class SettingsViewModel : ObservableObject
         AnnounceHints       = cfg.AnnounceHints;
         AnnounceStatus      = cfg.AnnounceStatus;
         AnnounceResults     = cfg.AnnounceResults;
+        AnnounceSpellingSuggestions = cfg.AnnounceSpellingSuggestions;
 
         foreach (var cmd in registry.GetAll())
         {
@@ -87,6 +91,7 @@ public partial class SettingsViewModel : ObservableObject
         cfg.AnnounceHints       = AnnounceHints;
         cfg.AnnounceStatus      = AnnounceStatus;
         cfg.AnnounceResults     = AnnounceResults;
+        cfg.AnnounceSpellingSuggestions = AnnounceSpellingSuggestions;
 
         cfg.CustomHotkeys = HotkeyRows
             .Where(r => r.HasCustomBinding)

--- a/QuickMail/ViewModels/TemplatePickerViewModel.cs
+++ b/QuickMail/ViewModels/TemplatePickerViewModel.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using QuickMail.Models;
+using QuickMail.Services;
+
+namespace QuickMail.ViewModels;
+
+public partial class TemplatePickerViewModel : ObservableObject
+{
+    private readonly ITemplateService _templateService;
+    private List<MessageTemplate> _allTemplates = [];
+
+    [ObservableProperty] private ObservableCollection<MessageTemplate> _templates = [];
+    [ObservableProperty] private MessageTemplate? _selectedTemplate;
+    [ObservableProperty] private string _searchText = string.Empty;
+
+    public TemplatePickerViewModel(ITemplateService templateService)
+    {
+        _templateService = templateService;
+    }
+
+    public async Task LoadAsync()
+    {
+        _allTemplates = await _templateService.LoadAllAsync();
+        ApplyFilter();
+    }
+
+    partial void OnSearchTextChanged(string value)
+    {
+        ApplyFilter();
+    }
+
+    private void ApplyFilter()
+    {
+        var q = SearchText?.Trim();
+        var filtered = string.IsNullOrEmpty(q)
+            ? _allTemplates
+            : _allTemplates.Where(t =>
+                t.Title.Contains(q, StringComparison.OrdinalIgnoreCase)).ToList();
+
+        Templates = new ObservableCollection<MessageTemplate>(filtered);
+        SelectedTemplate = Templates.FirstOrDefault();
+    }
+
+    public string MatchCountText
+    {
+        get
+        {
+            var count = Templates.Count;
+            var q = SearchText?.Trim();
+            if (string.IsNullOrEmpty(q))
+                return $"{count} template{(count == 1 ? "" : "s")}";
+            return $"{count} template{(count == 1 ? "" : "s")} matching '{q}'";
+        }
+    }
+}

--- a/QuickMail/ViewModels/TemplatePickerViewModel.cs
+++ b/QuickMail/ViewModels/TemplatePickerViewModel.cs
@@ -1,11 +1,8 @@
 using System;
 using System.Collections.ObjectModel;
-using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
-using System.Windows;
 using CommunityToolkit.Mvvm.ComponentModel;
-using CommunityToolkit.Mvvm.Input;
 using QuickMail.Models;
 using QuickMail.Services;
 

--- a/QuickMail/ViewModels/TutorialViewModel.cs
+++ b/QuickMail/ViewModels/TutorialViewModel.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Windows.Input;
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace QuickMail.ViewModels;
+
+public class TutorialStep
+{
+    public string InstructionText { get; init; } = string.Empty;
+    public Key ExpectedKey { get; init; }
+    public ModifierKeys ExpectedModifiers { get; init; }
+    public string SuccessMessage { get; init; } = string.Empty;
+}
+
+public partial class TutorialViewModel : ObservableObject
+{
+    [ObservableProperty]
+    private int _currentStepIndex;
+
+    [ObservableProperty]
+    private bool _isActive;
+
+    public ObservableCollection<TutorialStep> Steps { get; } = new();
+
+    public TutorialStep? CurrentStep =>
+        CurrentStepIndex >= 0 && CurrentStepIndex < Steps.Count
+            ? Steps[CurrentStepIndex]
+            : null;
+
+    /// <summary>1-based step number for display.</summary>
+    public int CurrentStepNumber => CurrentStepIndex + 1;
+
+    /// <summary>Raised when the user completes all steps or cancels.</summary>
+    public event Action? TutorialCompleted;
+
+    public TutorialViewModel()
+    {
+        Steps.Add(new TutorialStep
+        {
+            InstructionText = "Press F6 to cycle focus through all panes.",
+            ExpectedKey = Key.F6,
+            ExpectedModifiers = ModifierKeys.None,
+            SuccessMessage = "Correct! F6 cycles focus through all panes: toolbar, account list, folder tree, message list, reading pane, and status bar."
+        });
+        Steps.Add(new TutorialStep
+        {
+            InstructionText = "Press Ctrl+1 to focus the account list.",
+            ExpectedKey = Key.D1,
+            ExpectedModifiers = ModifierKeys.Control,
+            SuccessMessage = "Correct! Ctrl+1 moves focus to the account list."
+        });
+        Steps.Add(new TutorialStep
+        {
+            InstructionText = "Press Ctrl+2 to focus the folder tree.",
+            ExpectedKey = Key.D2,
+            ExpectedModifiers = ModifierKeys.Control,
+            SuccessMessage = "Correct! Ctrl+2 moves focus to the folder tree."
+        });
+        Steps.Add(new TutorialStep
+        {
+            InstructionText = "Press Ctrl+3 to focus the message list.",
+            ExpectedKey = Key.D3,
+            ExpectedModifiers = ModifierKeys.Control,
+            SuccessMessage = "Correct! Ctrl+3 moves focus to the message list."
+        });
+        Steps.Add(new TutorialStep
+        {
+            InstructionText = "Press Ctrl+Shift+P to open the Command Palette.",
+            ExpectedKey = Key.P,
+            ExpectedModifiers = ModifierKeys.Control | ModifierKeys.Shift,
+            SuccessMessage = "Correct! Ctrl+Shift+P opens the Command Palette where you can search for any command."
+        });
+        Steps.Add(new TutorialStep
+        {
+            InstructionText = "Press Escape to close the reading pane or dismiss dialogs.",
+            ExpectedKey = Key.Escape,
+            ExpectedModifiers = ModifierKeys.None,
+            SuccessMessage = "Correct! Escape returns focus to the message list from the reading pane."
+        });
+    }
+
+    /// <summary>
+    /// Checks whether the pressed key matches the current step's expected key.
+    /// Returns true if the key was correct and the step advanced.
+    /// </summary>
+    public bool CheckKeyPress(Key key, ModifierKeys modifiers)
+    {
+        if (!IsActive || CurrentStep == null)
+            return false;
+
+        // Escape cancels the tutorial UNLESS the current step expects Escape
+        if (key == Key.Escape && modifiers == ModifierKeys.None
+            && CurrentStep.ExpectedKey != Key.Escape)
+        {
+            Cancel();
+            return true;
+        }
+
+        var step = CurrentStep;
+        if (key == step.ExpectedKey && modifiers == step.ExpectedModifiers)
+        {
+            Advance();
+            return true;
+        }
+
+        return false;
+    }
+
+    private void Advance()
+    {
+        if (CurrentStepIndex < Steps.Count - 1)
+        {
+            CurrentStepIndex++;
+            OnPropertyChanged(nameof(CurrentStepNumber));
+            // Notify the view to announce the new step
+            OnPropertyChanged(nameof(CurrentStep));
+        }
+        else
+        {
+            IsActive = false;
+            TutorialCompleted?.Invoke();
+        }
+    }
+
+    public void Cancel()
+    {
+        IsActive = false;
+        TutorialCompleted?.Invoke();
+    }
+
+    /// <summary>Starts the tutorial from step 0.</summary>
+    public void Start()
+    {
+        CurrentStepIndex = 0;
+        IsActive = true;
+        OnPropertyChanged(nameof(CurrentStep));
+    }
+}

--- a/QuickMail/ViewModels/TutorialViewModel.cs
+++ b/QuickMail/ViewModels/TutorialViewModel.cs
@@ -31,8 +31,11 @@ public partial class TutorialViewModel : ObservableObject
     /// <summary>1-based step number for display.</summary>
     public int CurrentStepNumber => CurrentStepIndex + 1;
 
-    /// <summary>Raised when the user completes all steps or cancels.</summary>
+    /// <summary>Raised when the user completes all six steps.</summary>
     public event Action? TutorialCompleted;
+
+    /// <summary>Raised when the user cancels the tutorial early (Escape).</summary>
+    public event Action? TutorialCancelled;
 
     public TutorialViewModel()
     {
@@ -126,7 +129,7 @@ public partial class TutorialViewModel : ObservableObject
     public void Cancel()
     {
         IsActive = false;
-        TutorialCompleted?.Invoke();
+        TutorialCancelled?.Invoke();
     }
 
     /// <summary>Starts the tutorial from step 0.</summary>
@@ -135,5 +138,6 @@ public partial class TutorialViewModel : ObservableObject
         CurrentStepIndex = 0;
         IsActive = true;
         OnPropertyChanged(nameof(CurrentStep));
+        OnPropertyChanged(nameof(CurrentStepNumber));
     }
 }

--- a/QuickMail/Views/AccountManagerDialog.xaml
+++ b/QuickMail/Views/AccountManagerDialog.xaml
@@ -5,8 +5,8 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         mc:Ignorable="d"
         Title="Manage Accounts"
-        Height="580" Width="720"
-        MinHeight="420" MinWidth="580"
+        Height="660" Width="720"
+        MinHeight="500" MinWidth="580"
         WindowStartupLocation="CenterOwner"
         ResizeMode="CanResize">
 
@@ -167,6 +167,20 @@
                           IsChecked="{Binding SmtpAcceptInvalidCert}"
                           AutomationProperties.Name="SMTP accept invalid SSL certificates"
                           Margin="0,0,0,6" TabIndex="10"/>
+
+                <Separator Margin="0,6"/>
+
+                <!-- Signature -->
+                <TextBlock Text="Email Signature" FontWeight="SemiBold" Margin="0,0,0,6"/>
+                <TextBlock x:Name="LblSignature" Text="_Signature (plain text, appended to new messages):" Margin="0,4,0,2"/>
+                <TextBox Text="{Binding Signature, UpdateSourceTrigger=PropertyChanged}"
+                         AutomationProperties.LabeledBy="{Binding ElementName=LblSignature}"
+                         AutomationProperties.HelpText="This text is automatically added to the end of new messages, replies, and forwards"
+                         AcceptsReturn="True"
+                         TextWrapping="Wrap"
+                         MinHeight="60"
+                         VerticalScrollBarVisibility="Auto"
+                         TabIndex="11"/>
 
             </StackPanel>
         </ScrollViewer>

--- a/QuickMail/Views/AddAccountDialog.xaml
+++ b/QuickMail/Views/AddAccountDialog.xaml
@@ -5,8 +5,8 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         mc:Ignorable="d"
         Title="Add Account"
-        Height="560" Width="420"
-        MinHeight="460" MinWidth="360"
+        Height="640" Width="420"
+        MinHeight="540" MinWidth="360"
         WindowStartupLocation="CenterOwner"
         ResizeMode="CanResize"
         Loaded="Window_Loaded">
@@ -119,6 +119,20 @@
                           IsChecked="{Binding SmtpAcceptInvalidCert}"
                           AutomationProperties.Name="SMTP accept invalid SSL certificates"
                           Margin="0,0,0,6" TabIndex="10"/>
+
+                <Separator Margin="0,6"/>
+
+                <!-- Signature -->
+                <TextBlock Text="Email Signature" FontWeight="SemiBold" Margin="0,0,0,6"/>
+                <TextBlock x:Name="LblSignature" Text="_Signature (plain text, appended to new messages):" Margin="0,4,0,2"/>
+                <TextBox Text="{Binding Signature, UpdateSourceTrigger=PropertyChanged}"
+                         AutomationProperties.LabeledBy="{Binding ElementName=LblSignature}"
+                         AutomationProperties.HelpText="This text is automatically added to the end of new messages, replies, and forwards"
+                         AcceptsReturn="True"
+                         TextWrapping="Wrap"
+                         MinHeight="60"
+                         VerticalScrollBarVisibility="Auto"
+                         TabIndex="11"/>
 
             </StackPanel>
         </ScrollViewer>

--- a/QuickMail/Views/ComposeWindow.xaml
+++ b/QuickMail/Views/ComposeWindow.xaml
@@ -29,12 +29,24 @@
                     AutomationProperties.Name="Cancel and close compose window"
                     IsCancel="True"
                     MinWidth="80" Margin="6,0,0,0"
-                    TabIndex="9"/>
+                    TabIndex="11"/>
             <Button DockPanel.Dock="Right"
                     Content="Save Draft (Ctrl+S)"
                     Command="{Binding SaveDraftCommand}"
                     AutomationProperties.Name="Save as draft (Ctrl+S)"
                     MinWidth="100" Margin="6,0,0,0"
+                    TabIndex="10"/>
+            <Button DockPanel.Dock="Right"
+                    Content="Save as Template"
+                    Command="{Binding SaveAsTemplateCommand}"
+                    AutomationProperties.Name="Save current message as template"
+                    MinWidth="120" Margin="6,0,0,0"
+                    TabIndex="9"/>
+            <Button DockPanel.Dock="Right"
+                    Content="Insert Template…"
+                    Command="{Binding InsertTemplateCommand}"
+                    AutomationProperties.Name="Insert a saved template"
+                    MinWidth="120" Margin="6,0,0,0"
                     TabIndex="8"/>
             <Button DockPanel.Dock="Right"
                     Content="Send (Alt+S)"

--- a/QuickMail/Views/ComposeWindow.xaml
+++ b/QuickMail/Views/ComposeWindow.xaml
@@ -208,7 +208,7 @@
             <TextBox Grid.Row="9" Grid.ColumnSpan="2"
                      x:Name="BodyBox"
                      Text="{Binding Body, UpdateSourceTrigger=PropertyChanged}"
-                     AutomationProperties.Name="Message body. Alt+U for Subject, Alt+M for From, Alt+S to send."
+                     AutomationProperties.Name="Message body. Alt+Y to focus, Alt+U for Subject, Alt+M for From, Alt+S to send."
                      AcceptsReturn="True" AcceptsTab="True"
                      TextWrapping="Wrap"
                      SpellCheck.IsEnabled="True"

--- a/QuickMail/Views/ComposeWindow.xaml
+++ b/QuickMail/Views/ComposeWindow.xaml
@@ -199,11 +199,12 @@
                      AutomationProperties.Name="Message body. Alt+U for Subject, Alt+M for From, Alt+S to send."
                      AcceptsReturn="True" AcceptsTab="True"
                      TextWrapping="Wrap"
-                     SpellCheck.IsEnabled="False"
+                     SpellCheck.IsEnabled="True"
                      VerticalScrollBarVisibility="Auto"
                      FontFamily="Segoe UI"
                      Margin="0,4" TabIndex="7"
-                     VerticalAlignment="Stretch"/>
+                     VerticalAlignment="Stretch"
+                     PreviewKeyDown="BodyBox_PreviewKeyDown"/>
         </Grid>
 
         <!-- Autocomplete popup — positioned below the active address field via code-behind -->

--- a/QuickMail/Views/ComposeWindow.xaml.cs
+++ b/QuickMail/Views/ComposeWindow.xaml.cs
@@ -17,14 +17,22 @@ public partial class ComposeWindow : Window
     private readonly ComposeViewModel   _vm;
     private readonly IContactService    _contactService;
     private readonly ITemplateService   _templateService;
+    private readonly IConfigService     _configService;
     private TextBox? _activeAddressBox;
     private CancellationTokenSource? _autocompleteCts;
+    private int _lastAnnouncedSpellingIndex = -1;
 
-    public ComposeWindow(ComposeViewModel vm, IContactService contactService, ITemplateService templateService)
+    // Track the current spelling error so Alt+1/2/3 can replace it with a suggestion.
+    private int _currentSpellingWordStart = -1;
+    private int _currentSpellingWordEnd = -1;
+    private System.Collections.Generic.List<string>? _currentSpellingSuggestions;
+
+    public ComposeWindow(ComposeViewModel vm, IContactService contactService, ITemplateService templateService, IConfigService configService)
     {
         _vm = vm;
         _contactService = contactService;
         _templateService = templateService;
+        _configService = configService;
         InitializeComponent();
         DataContext = vm;
 
@@ -71,6 +79,7 @@ public partial class ComposeWindow : Window
                 BodyBox.CaretIndex = 0;
             }
         };
+        BodyBox.SelectionChanged += BodyBox_SelectionChanged;
         Closing += OnWindowClosing;
     }
 
@@ -286,11 +295,124 @@ public partial class ComposeWindow : Window
     }
 
     /// <summary>
+    /// When the caret moves into a misspelled word during normal cursor navigation,
+    /// announce it to screen readers so users hear about spelling errors without
+    /// needing to press F7. WPF's SpellCheck shows red squiggly underlines visually
+    /// but does not expose them through UIA, so we detect them manually.
+    /// </summary>
+    private void BodyBox_SelectionChanged(object sender, RoutedEventArgs e)
+    {
+        var text = BodyBox.Text;
+        if (string.IsNullOrEmpty(text)) return;
+
+        int caret = BodyBox.CaretIndex;
+        // If the caret is at the very end, check the character just before it
+        int checkIndex = (caret > 0 && caret == text.Length) ? caret - 1 : caret;
+        if (checkIndex < 0 || checkIndex >= text.Length)
+        {
+            ClearSpellingContext();
+            return;
+        }
+
+        // Only announce if the caret is inside a misspelled word
+        var error = BodyBox.GetSpellingError(checkIndex);
+        if (error == null)
+        {
+            ClearSpellingContext();
+            return;
+        }
+
+        // Walk to word boundaries to get the full word
+        int wordStart = checkIndex;
+        while (wordStart > 0 && !char.IsWhiteSpace(text[wordStart - 1]))
+            wordStart--;
+        int wordEnd = checkIndex;
+        while (wordEnd < text.Length && !char.IsWhiteSpace(text[wordEnd]))
+            wordEnd++;
+
+        // Don't re-announce the same word
+        if (wordStart == _lastAnnouncedSpellingIndex) return;
+        _lastAnnouncedSpellingIndex = wordStart;
+
+        var word = text.Substring(wordStart, wordEnd - wordStart);
+        var suggestions = error.Suggestions.Take(3).ToList();
+
+        // Track the current spelling error so Alt+1/2/3 can replace it.
+        _currentSpellingWordStart = wordStart;
+        _currentSpellingWordEnd = wordEnd;
+        _currentSpellingSuggestions = suggestions;
+
+        var announce = BuildSpellingAnnouncement(word, suggestions);
+
+        AccessibilityHelper.Announce(this, announce,
+            category: AnnouncementCategory.Result);
+    }
+
+    private void ClearSpellingContext()
+    {
+        _lastAnnouncedSpellingIndex = -1;
+        _currentSpellingWordStart = -1;
+        _currentSpellingWordEnd = -1;
+        _currentSpellingSuggestions = null;
+    }
+
+    /// <summary>
+    /// Builds the spelling announcement string. When AnnounceSpellingSuggestions
+    /// is on, includes up to 3 suggestions with Alt+1/2/3 hotkey hints.
+    /// When off, only announces the misspelled word.
+    /// </summary>
+    private string BuildSpellingAnnouncement(string word, System.Collections.Generic.List<string> suggestions)
+    {
+        var announceSuggestions = _configService.Load().AnnounceSpellingSuggestions;
+
+        if (!announceSuggestions || suggestions.Count == 0)
+            return $"Misspelling: {word}.";
+
+        var parts = new System.Collections.Generic.List<string>();
+        for (int i = 0; i < suggestions.Count; i++)
+            parts.Add($"Alt+{i + 1} for {suggestions[i]}");
+
+        return $"Misspelling: {word}. {string.Join(", ", parts)}.";
+    }
+
+    /// <summary>
     /// F7 moves to the next misspelled word; Shift+F7 moves to the previous one.
     /// Announces the misspelling to screen readers so users know what needs correction.
     /// </summary>
     private void BodyBox_PreviewKeyDown(object sender, KeyEventArgs e)
     {
+        // Alt+1/2/3: replace the current misspelled word with the corresponding suggestion.
+        // Only works when the caret is on a spelling error that was just announced.
+        if ((Keyboard.Modifiers & ModifierKeys.Alt) != 0
+            && _currentSpellingSuggestions is { Count: > 0 }
+            && _currentSpellingWordStart >= 0
+            && _currentSpellingWordEnd > _currentSpellingWordStart)
+        {
+            int suggestionIndex = e.SystemKey switch
+            {
+                Key.D1 => 0,
+                Key.D2 => 1,
+                Key.D3 => 2,
+                _ => -1
+            };
+            if (suggestionIndex >= 0 && suggestionIndex < _currentSpellingSuggestions.Count)
+            {
+                var replacement = _currentSpellingSuggestions[suggestionIndex];
+                var text = BodyBox.Text;
+                var before = text[.._currentSpellingWordStart];
+                var after = text[_currentSpellingWordEnd..];
+                BodyBox.Text = before + replacement + after;
+                BodyBox.CaretIndex = _currentSpellingWordStart + replacement.Length;
+                BodyBox.Focus();
+                AccessibilityHelper.Announce(this,
+                    $"Replaced with {replacement}.",
+                    category: AnnouncementCategory.Result);
+                ClearSpellingContext();
+                e.Handled = true;
+                return;
+            }
+        }
+
         if (e.Key == Key.F7)
         {
             var forward = (Keyboard.Modifiers & ModifierKeys.Shift) == 0;
@@ -339,19 +461,25 @@ public partial class ComposeWindow : Window
                 BodyBox.SelectionLength = wordEnd - wordStart;
                 BodyBox.Focus();
 
+                _lastAnnouncedSpellingIndex = wordStart;
+
                 var word        = text.Substring(wordStart, wordEnd - wordStart);
                 var suggestions = BodyBox.GetSpellingError(foundIndex)
-                    ?.Suggestions.Take(3).ToList();
+                    ?.Suggestions.Take(3).ToList() ?? new System.Collections.Generic.List<string>();
 
-                var announce = suggestions is { Count: > 0 }
-                    ? $"Misspelling: {word}. Suggestions: {string.Join(", ", suggestions)}"
-                    : $"Misspelling: {word}. No suggestions available.";
+                // Track the current spelling error so Alt+1/2/3 can replace it.
+                _currentSpellingWordStart = wordStart;
+                _currentSpellingWordEnd = wordEnd;
+                _currentSpellingSuggestions = suggestions;
+
+                var announce = BuildSpellingAnnouncement(word, suggestions);
 
                 AccessibilityHelper.Announce(this, announce,
                     category: AnnouncementCategory.Result);
             }
             else
             {
+                ClearSpellingContext();
                 AccessibilityHelper.Announce(this, "No more misspellings found.",
                     category: AnnouncementCategory.Result);
             }

--- a/QuickMail/Views/ComposeWindow.xaml.cs
+++ b/QuickMail/Views/ComposeWindow.xaml.cs
@@ -18,6 +18,7 @@ public partial class ComposeWindow : Window
     private readonly IContactService    _contactService;
     private readonly ITemplateService   _templateService;
     private readonly IConfigService     _configService;
+    private readonly CommandRegistry    _registry = new();
     private TextBox? _activeAddressBox;
     private CancellationTokenSource? _autocompleteCts;
     private int _lastAnnouncedSpellingIndex = -1;
@@ -27,6 +28,9 @@ public partial class ComposeWindow : Window
     private int _currentSpellingWordEnd = -1;
     private System.Collections.Generic.List<string>? _currentSpellingSuggestions;
 
+    // Suppress spelling announcements during programmatic text changes (e.g. Alt+1 replacement).
+    private bool _suppressSpellingAnnouncement;
+
     public ComposeWindow(ComposeViewModel vm, IContactService contactService, ITemplateService templateService, IConfigService configService)
     {
         _vm = vm;
@@ -35,6 +39,9 @@ public partial class ComposeWindow : Window
         _configService = configService;
         InitializeComponent();
         DataContext = vm;
+
+        // ── Compose command palette ──────────────────────────────────────────────
+        RegisterComposeCommands();
 
         vm.PropertyChanged += (_, e) =>
         {
@@ -260,10 +267,18 @@ public partial class ComposeWindow : Window
                 await _vm.AddAttachmentFromPathAsync(f);
     }
 
-    // Alt+U → Subject field; Alt+M → From combo; Ctrl+V with files → add attachments; Escape → cancel.
-    // F7 → next misspelling; Shift+F7 → previous misspelling.
+    // Alt+U → Subject field; Alt+M → From combo; Alt+Y → Body; Ctrl+V with files → add attachments; Escape → cancel.
+    // Ctrl+Shift+P → Command Palette; F7 → next misspelling; Shift+F7 → previous misspelling.
     private async void Window_PreviewKeyDown(object sender, KeyEventArgs e)
     {
+        // Ctrl+Shift+P: open the command palette
+        if (e.Key == Key.P && Keyboard.Modifiers == (ModifierKeys.Control | ModifierKeys.Shift))
+        {
+            OpenCommandPalette();
+            e.Handled = true;
+            return;
+        }
+
         // Ctrl+V: if the clipboard contains files, paste them as attachments
         if (e.Key == Key.V && Keyboard.Modifiers == ModifierKeys.Control && Clipboard.ContainsFileDropList())
         {
@@ -292,6 +307,23 @@ public partial class ComposeWindow : Window
             FromCombo.IsDropDownOpen = true;
             e.Handled = true;
         }
+        else if (e.SystemKey == Key.Y && (Keyboard.Modifiers & ModifierKeys.Alt) != 0)
+        {
+            BodyBox.Focus();
+            e.Handled = true;
+        }
+
+        // ── Registry-based compose commands ──────────────────────────────────
+        var key = e.Key == Key.System ? e.SystemKey
+            : e.Key == Key.ImeProcessed ? e.ImeProcessedKey
+            : e.Key;
+        var modifiers = Keyboard.Modifiers;
+        var cmd = _registry.FindByGesture(key, modifiers);
+        if (cmd != null && (cmd.IsAvailable?.Invoke() ?? true))
+        {
+            cmd.Execute();
+            e.Handled = true;
+        }
     }
 
     /// <summary>
@@ -302,6 +334,8 @@ public partial class ComposeWindow : Window
     /// </summary>
     private void BodyBox_SelectionChanged(object sender, RoutedEventArgs e)
     {
+        if (_suppressSpellingAnnouncement) return;
+
         var text = BodyBox.Text;
         if (string.IsNullOrEmpty(text)) return;
 
@@ -358,8 +392,8 @@ public partial class ComposeWindow : Window
 
     /// <summary>
     /// Builds the spelling announcement string. When AnnounceSpellingSuggestions
-    /// is on, includes up to 3 suggestions with Alt+1/2/3 hotkey hints.
-    /// When off, only announces the misspelled word.
+    /// is on, includes up to 3 suggestions. When off, only announces the
+    /// misspelled word. Experienced users can press Alt+1/2/3 to replace.
     /// </summary>
     private string BuildSpellingAnnouncement(string word, System.Collections.Generic.List<string> suggestions)
     {
@@ -368,11 +402,7 @@ public partial class ComposeWindow : Window
         if (!announceSuggestions || suggestions.Count == 0)
             return $"Misspelling: {word}.";
 
-        var parts = new System.Collections.Generic.List<string>();
-        for (int i = 0; i < suggestions.Count; i++)
-            parts.Add($"Alt+{i + 1} for {suggestions[i]}");
-
-        return $"Misspelling: {word}. {string.Join(", ", parts)}.";
+        return $"Misspelling: {word}. {string.Join(", ", suggestions)}.";
     }
 
     /// <summary>
@@ -401,8 +431,16 @@ public partial class ComposeWindow : Window
                 var text = BodyBox.Text;
                 var before = text[.._currentSpellingWordStart];
                 var after = text[_currentSpellingWordEnd..];
+
+                // Suppress spelling announcements while we programmatically change
+                // the text and caret position. Setting BodyBox.Text fires
+                // SelectionChanged before CaretIndex is applied, which would
+                // otherwise announce the first error on the page.
+                _suppressSpellingAnnouncement = true;
                 BodyBox.Text = before + replacement + after;
                 BodyBox.CaretIndex = _currentSpellingWordStart + replacement.Length;
+                _suppressSpellingAnnouncement = false;
+
                 BodyBox.Focus();
                 AccessibilityHelper.Announce(this,
                     $"Replaced with {replacement}.",
@@ -485,6 +523,121 @@ public partial class ComposeWindow : Window
             }
 
             e.Handled = true;
+        }
+    }
+
+    // ── Command Palette ──────────────────────────────────────────────────────
+
+    private void RegisterComposeCommands()
+    {
+        _registry.Register(new CommandDefinition(
+            id: "compose.send", category: "Compose", title: "Send Message",
+            execute: () => _vm.SendCommand.Execute(null),
+            defaultKey: Key.S, defaultModifiers: ModifierKeys.Alt));
+
+        _registry.Register(new CommandDefinition(
+            id: "compose.saveDraft", category: "Compose", title: "Save Draft",
+            execute: () => _vm.SaveDraftCommand.Execute(null),
+            defaultKey: Key.S, defaultModifiers: ModifierKeys.Control));
+
+        _registry.Register(new CommandDefinition(
+            id: "compose.addAttachments", category: "Compose", title: "Add Attachments…",
+            execute: () => _vm.AddAttachmentsCommand.Execute(null),
+            defaultKey: Key.A, defaultModifiers: ModifierKeys.Control | ModifierKeys.Shift));
+
+        _registry.Register(new CommandDefinition(
+            id: "compose.insertTemplate", category: "Compose", title: "Insert Template…",
+            execute: () => _vm.InsertTemplateCommand.Execute(null)));
+
+        _registry.Register(new CommandDefinition(
+            id: "compose.saveAsTemplate", category: "Compose", title: "Save as Template",
+            execute: () => _vm.SaveAsTemplateCommand.Execute(null)));
+
+        _registry.Register(new CommandDefinition(
+            id: "compose.cancel", category: "Compose", title: "Cancel / Close",
+            execute: () => _vm.CancelCommand.Execute(null),
+            defaultKey: Key.Escape, defaultModifiers: ModifierKeys.None));
+
+        _registry.Register(new CommandDefinition(
+            id: "compose.focusBody", category: "Compose", title: "Focus Message Body",
+            execute: () => BodyBox.Focus(),
+            defaultKey: Key.Y, defaultModifiers: ModifierKeys.Alt));
+
+        _registry.Register(new CommandDefinition(
+            id: "compose.nextMisspelling", category: "Compose", title: "Next Misspelling",
+            execute: () => NavigateSpellingError(forward: true),
+            defaultKey: Key.F7, defaultModifiers: ModifierKeys.None));
+
+        _registry.Register(new CommandDefinition(
+            id: "compose.prevMisspelling", category: "Compose", title: "Previous Misspelling",
+            execute: () => NavigateSpellingError(forward: false),
+            defaultKey: Key.F7, defaultModifiers: ModifierKeys.Shift));
+    }
+
+    private void OpenCommandPalette()
+    {
+        var previousFocus = Keyboard.FocusedElement as IInputElement;
+        var palette = new CommandPaletteWindow(_registry) { Owner = this };
+        palette.ShowDialog();
+        (previousFocus ?? BodyBox).Focus();
+    }
+
+    /// <summary>
+    /// Programmatically triggers F7-style spelling navigation so the command
+    /// palette entry can invoke it without duplicating the search logic.
+    /// </summary>
+    private void NavigateSpellingError(bool forward)
+    {
+        var text = BodyBox.Text;
+        if (string.IsNullOrEmpty(text)) return;
+
+        int start = BodyBox.CaretIndex;
+        int foundIndex = -1;
+
+        if (forward)
+        {
+            for (int i = start; i < text.Length; i++)
+            {
+                if (BodyBox.GetSpellingError(i) != null) { foundIndex = i; break; }
+            }
+        }
+        else
+        {
+            for (int i = Math.Min(start - 1, text.Length - 1); i >= 0; i--)
+            {
+                if (BodyBox.GetSpellingError(i) != null) { foundIndex = i; break; }
+            }
+        }
+
+        if (foundIndex >= 0)
+        {
+            int wordStart = foundIndex;
+            while (wordStart > 0 && !char.IsWhiteSpace(text[wordStart - 1])) wordStart--;
+            int wordEnd = foundIndex;
+            while (wordEnd < text.Length && !char.IsWhiteSpace(text[wordEnd])) wordEnd++;
+
+            BodyBox.SelectionStart = wordStart;
+            BodyBox.SelectionLength = wordEnd - wordStart;
+            BodyBox.Focus();
+
+            _lastAnnouncedSpellingIndex = wordStart;
+
+            var word = text.Substring(wordStart, wordEnd - wordStart);
+            var suggestions = BodyBox.GetSpellingError(foundIndex)
+                ?.Suggestions.Take(3).ToList() ?? new System.Collections.Generic.List<string>();
+
+            _currentSpellingWordStart = wordStart;
+            _currentSpellingWordEnd = wordEnd;
+            _currentSpellingSuggestions = suggestions;
+
+            var announce = BuildSpellingAnnouncement(word, suggestions);
+            AccessibilityHelper.Announce(this, announce, category: AnnouncementCategory.Result);
+        }
+        else
+        {
+            ClearSpellingContext();
+            AccessibilityHelper.Announce(this, "No more misspellings found.",
+                category: AnnouncementCategory.Result);
         }
     }
 }

--- a/QuickMail/Views/ComposeWindow.xaml.cs
+++ b/QuickMail/Views/ComposeWindow.xaml.cs
@@ -16,13 +16,15 @@ public partial class ComposeWindow : Window
 {
     private readonly ComposeViewModel   _vm;
     private readonly IContactService    _contactService;
+    private readonly ITemplateService   _templateService;
     private TextBox? _activeAddressBox;
     private CancellationTokenSource? _autocompleteCts;
 
-    public ComposeWindow(ComposeViewModel vm, IContactService contactService)
+    public ComposeWindow(ComposeViewModel vm, IContactService contactService, ITemplateService templateService)
     {
         _vm = vm;
         _contactService = contactService;
+        _templateService = templateService;
         InitializeComponent();
         DataContext = vm;
 
@@ -37,6 +39,16 @@ public partial class ComposeWindow : Window
         vm.ConfirmationRequested = (message, title) =>
             MessageBox.Show(this, message, title, MessageBoxButton.YesNo, MessageBoxImage.Warning)
             == MessageBoxResult.Yes;
+
+        // Wire the template picker so the VM stays out of System.Windows.
+        vm.InsertTemplateRequested += () =>
+        {
+            var pickerVm = new TemplatePickerViewModel(_templateService);
+            var dialog = new TemplatePickerWindow(pickerVm) { Owner = this };
+            if (dialog.ShowDialog() == true)
+                return Task.FromResult(dialog.SelectedTemplate);
+            return Task.FromResult<MessageTemplate?>(null);
+        };
 
         foreach (var box in new[] { ToBox, CcBox, BccBox })
         {

--- a/QuickMail/Views/ComposeWindow.xaml.cs
+++ b/QuickMail/Views/ComposeWindow.xaml.cs
@@ -240,6 +240,7 @@ public partial class ComposeWindow : Window
     }
 
     // Alt+U → Subject field; Alt+M → From combo; Ctrl+V with files → add attachments; Escape → cancel.
+    // F7 → next misspelling; Shift+F7 → previous misspelling.
     private async void Window_PreviewKeyDown(object sender, KeyEventArgs e)
     {
         // Ctrl+V: if the clipboard contains files, paste them as attachments
@@ -268,6 +269,81 @@ public partial class ComposeWindow : Window
         {
             FromCombo.Focus();
             FromCombo.IsDropDownOpen = true;
+            e.Handled = true;
+        }
+    }
+
+    /// <summary>
+    /// F7 moves to the next misspelled word; Shift+F7 moves to the previous one.
+    /// Announces the misspelling to screen readers so users know what needs correction.
+    /// </summary>
+    private void BodyBox_PreviewKeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.F7)
+        {
+            var forward = (Keyboard.Modifiers & ModifierKeys.Shift) == 0;
+            var text = BodyBox.Text;
+            if (string.IsNullOrEmpty(text)) return;
+
+            int start = BodyBox.CaretIndex;
+            int foundIndex = -1;
+
+            if (forward)
+            {
+                // Search forward from caret to end
+                for (int i = start; i < text.Length; i++)
+                {
+                    if (BodyBox.GetSpellingError(i) != null)
+                    {
+                        foundIndex = i;
+                        break;
+                    }
+                }
+            }
+            else
+            {
+                // Search backward from caret-1 to beginning
+                for (int i = Math.Min(start - 1, text.Length - 1); i >= 0; i--)
+                {
+                    if (BodyBox.GetSpellingError(i) != null)
+                    {
+                        foundIndex = i;
+                        break;
+                    }
+                }
+            }
+
+            if (foundIndex >= 0)
+            {
+                // Walk to word boundaries so the whole misspelled word is selected.
+                int wordStart = foundIndex;
+                while (wordStart > 0 && !char.IsWhiteSpace(text[wordStart - 1]))
+                    wordStart--;
+                int wordEnd = foundIndex;
+                while (wordEnd < text.Length && !char.IsWhiteSpace(text[wordEnd]))
+                    wordEnd++;
+
+                BodyBox.SelectionStart  = wordStart;
+                BodyBox.SelectionLength = wordEnd - wordStart;
+                BodyBox.Focus();
+
+                var word        = text.Substring(wordStart, wordEnd - wordStart);
+                var suggestions = BodyBox.GetSpellingError(foundIndex)
+                    ?.Suggestions.Take(3).ToList();
+
+                var announce = suggestions is { Count: > 0 }
+                    ? $"Misspelling: {word}. Suggestions: {string.Join(", ", suggestions)}"
+                    : $"Misspelling: {word}. No suggestions available.";
+
+                AccessibilityHelper.Announce(this, announce,
+                    category: AnnouncementCategory.Result);
+            }
+            else
+            {
+                AccessibilityHelper.Announce(this, "No more misspellings found.",
+                    category: AnnouncementCategory.Result);
+            }
+
             e.Handled = true;
         }
     }

--- a/QuickMail/Views/ComposeWindow.xaml.cs
+++ b/QuickMail/Views/ComposeWindow.xaml.cs
@@ -454,74 +454,7 @@ public partial class ComposeWindow : Window
         if (e.Key == Key.F7)
         {
             var forward = (Keyboard.Modifiers & ModifierKeys.Shift) == 0;
-            var text = BodyBox.Text;
-            if (string.IsNullOrEmpty(text)) return;
-
-            int start = BodyBox.CaretIndex;
-            int foundIndex = -1;
-
-            if (forward)
-            {
-                // Search forward from caret to end
-                for (int i = start; i < text.Length; i++)
-                {
-                    if (BodyBox.GetSpellingError(i) != null)
-                    {
-                        foundIndex = i;
-                        break;
-                    }
-                }
-            }
-            else
-            {
-                // Search backward from caret-1 to beginning
-                for (int i = Math.Min(start - 1, text.Length - 1); i >= 0; i--)
-                {
-                    if (BodyBox.GetSpellingError(i) != null)
-                    {
-                        foundIndex = i;
-                        break;
-                    }
-                }
-            }
-
-            if (foundIndex >= 0)
-            {
-                // Walk to word boundaries so the whole misspelled word is selected.
-                int wordStart = foundIndex;
-                while (wordStart > 0 && !char.IsWhiteSpace(text[wordStart - 1]))
-                    wordStart--;
-                int wordEnd = foundIndex;
-                while (wordEnd < text.Length && !char.IsWhiteSpace(text[wordEnd]))
-                    wordEnd++;
-
-                BodyBox.SelectionStart  = wordStart;
-                BodyBox.SelectionLength = wordEnd - wordStart;
-                BodyBox.Focus();
-
-                _lastAnnouncedSpellingIndex = wordStart;
-
-                var word        = text.Substring(wordStart, wordEnd - wordStart);
-                var suggestions = BodyBox.GetSpellingError(foundIndex)
-                    ?.Suggestions.Take(3).ToList() ?? new System.Collections.Generic.List<string>();
-
-                // Track the current spelling error so Alt+1/2/3 can replace it.
-                _currentSpellingWordStart = wordStart;
-                _currentSpellingWordEnd = wordEnd;
-                _currentSpellingSuggestions = suggestions;
-
-                var announce = BuildSpellingAnnouncement(word, suggestions);
-
-                AccessibilityHelper.Announce(this, announce,
-                    category: AnnouncementCategory.Result);
-            }
-            else
-            {
-                ClearSpellingContext();
-                AccessibilityHelper.Announce(this, "No more misspellings found.",
-                    category: AnnouncementCategory.Result);
-            }
-
+            NavigateSpellingError(forward);
             e.Handled = true;
         }
     }

--- a/QuickMail/Views/GroupedMessageTreeController.cs
+++ b/QuickMail/Views/GroupedMessageTreeController.cs
@@ -1,0 +1,253 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Threading;
+using QuickMail.Models;
+using QuickMail.Services;
+using QuickMail.ViewModels;
+
+namespace QuickMail.Views;
+
+/// <summary>
+/// Encapsulates the common event-handler logic shared by the three grouped-message
+/// TreeViews (ConversationTree, SenderGroupTree, ToGroupTree).  Each tree wires
+/// its own PreviewKeyDown because the group-type and delete-command differ, but
+/// the remaining handlers (GotKeyboardFocus, SelectedItemChanged, PreviewTextInput,
+/// PreviewMouseRightButtonDown, ContextMenuOpening, FocusFirstItem, LandOnAfterRebuild,
+/// FocusMessage, LandOnMessageAfterRebuild) are identical in structure.
+/// </summary>
+public class GroupedMessageTreeController
+{
+    private readonly TreeView _tree;
+    private readonly MainViewModel _vm;
+    private readonly string _logName;
+    private readonly string _collectionPropertyName;
+    private readonly Func<int> _getCollectionCount;
+    private readonly Func<object?, int> _getItemIndex;
+    private readonly Func<int, object?> _getItemAt;
+    private readonly Func<object, string> _getGroupKey;
+    private readonly Func<string, object?> _findGroupByKey;
+    private readonly Func<object, IReadOnlyList<MailMessageSummary>> _getGroupMessages;
+    private readonly Func<IEnumerable<object>> _getVisibleItems;
+    private readonly Func<TreeView, object?, List<object>, string?, bool> _tryHandleTypeAhead;
+
+    public GroupedMessageTreeController(
+        TreeView tree,
+        MainViewModel vm,
+        string logName,
+        string collectionPropertyName,
+        Func<int> getCollectionCount,
+        Func<object?, int> getItemIndex,
+        Func<int, object?> getItemAt,
+        Func<object, string> getGroupKey,
+        Func<string, object?> findGroupByKey,
+        Func<object, IReadOnlyList<MailMessageSummary>> getGroupMessages,
+        Func<IEnumerable<object>> getVisibleItems,
+        Func<TreeView, object?, List<object>, string?, bool> tryHandleTypeAhead)
+    {
+        _tree = tree;
+        _vm = vm;
+        _logName = logName;
+        _collectionPropertyName = collectionPropertyName;
+        _getCollectionCount = getCollectionCount;
+        _getItemIndex = getItemIndex;
+        _getItemAt = getItemAt;
+        _getGroupKey = getGroupKey;
+        _findGroupByKey = findGroupByKey;
+        _getGroupMessages = getGroupMessages;
+        _getVisibleItems = getVisibleItems;
+        _tryHandleTypeAhead = tryHandleTypeAhead;
+    }
+
+    // ── GotKeyboardFocus ──────────────────────────────────────────────────────
+
+    public void OnGotKeyboardFocus(object sender, KeyboardFocusChangedEventArgs e)
+    {
+        LogService.Debug($"[FOCUS] {_logName} GotKeyboardFocus selectedItem={_tree.SelectedItem?.GetType().Name ?? "null"} count={_tree.Items.Count} from={e.OldFocus?.GetType().Name ?? "null"}");
+        if (_tree.SelectedItem == null && _tree.Items.Count > 0)
+        {
+            if (_tree.ItemContainerGenerator.ContainerFromIndex(0) is TreeViewItem first)
+            {
+                LogService.Debug($"[FOCUS]   {_logName} GotKeyboardFocus: no selection — selecting first item");
+                first.IsSelected = true;
+                first.Focus();
+            }
+        }
+    }
+
+    // ── SelectedItemChanged ───────────────────────────────────────────────────
+
+    public void OnSelectedItemChanged(object sender, RoutedPropertyChangedEventArgs<object> e)
+    {
+        LogService.Debug($"[FOCUS] {_logName} SelectedItemChanged old={e.OldValue?.GetType().Name ?? "null"} new={e.NewValue?.GetType().Name ?? "null"}");
+        if (e.NewValue is MailMessageSummary msg)
+            _vm.SelectedMessage = msg;
+    }
+
+    // ── PreviewTextInput ──────────────────────────────────────────────────────
+
+    public void OnPreviewTextInput(object sender, TextCompositionEventArgs e)
+    {
+        var visibleItems = _getVisibleItems().ToList();
+        if (_tryHandleTypeAhead(_tree, _tree.SelectedItem, visibleItems, e.Text))
+            e.Handled = true;
+    }
+
+    // ── PreviewMouseRightButtonDown ───────────────────────────────────────────
+
+    public void OnPreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
+    {
+        var source = e.OriginalSource as DependencyObject;
+        while (source != null && source is not TreeViewItem)
+            source = System.Windows.Media.VisualTreeHelper.GetParent(source);
+
+        if (source is TreeViewItem tvi)
+        {
+            tvi.IsSelected = true;
+            tvi.Focus();
+        }
+    }
+
+    // ── ContextMenuOpening ────────────────────────────────────────────────────
+
+    public void OnContextMenuOpening(object sender, ContextMenuEventArgs e, string groupContextMenuKey, string messageContextMenuKey)
+    {
+        switch (_tree.SelectedItem)
+        {
+            case null:
+                e.Handled = true;
+                break;
+            default:
+                // If the selected item is a group type (not MailMessageSummary), use the group menu;
+                // otherwise use the message menu.
+                if (_tree.SelectedItem is MailMessageSummary)
+                    _tree.ContextMenu = (ContextMenu)((FrameworkElement)sender).FindResource(messageContextMenuKey);
+                else
+                    _tree.ContextMenu = (ContextMenu)((FrameworkElement)sender).FindResource(groupContextMenuKey);
+                break;
+        }
+    }
+
+    // ── FocusFirstItem ────────────────────────────────────────────────────────
+
+    public void FocusFirstItem()
+    {
+        if (_tree.Items.Count == 0) { _tree.Focus(); return; }
+        _tree.Dispatcher.InvokeAsync(_tree.Focus, DispatcherPriority.Input);
+    }
+
+    // ── LandOnAfterRebuild ────────────────────────────────────────────────────
+
+    public void LandOnAfterRebuild(int targetIdx)
+    {
+        LogService.Debug($"[FOCUS] LandOn{_logName}: registered listener targetIdx={targetIdx}");
+        void OnPropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName != _collectionPropertyName) return;
+            _vm.PropertyChanged -= OnPropertyChanged;
+            LogService.Debug($"[FOCUS] LandOn{_logName}: listener fired count={_getCollectionCount()} targetIdx={targetIdx}");
+            _tree.Dispatcher.InvokeAsync(() =>
+            {
+                var count = _getCollectionCount();
+                if (count == 0)
+                {
+                    LogService.Debug($"[FOCUS] LandOn{_logName}: dispatch skipped — collection empty");
+                    return;
+                }
+                var idx = Math.Max(0, Math.Min(targetIdx, count - 1));
+                var item = _getItemAt(idx);
+                if (item != null && _tree.ItemContainerGenerator.ContainerFromItem(item) is TreeViewItem tvi)
+                {
+                    LogService.Debug($"[FOCUS] LandOn{_logName}: tvi.Focus() idx={idx}");
+                    tvi.IsSelected = true;
+                    tvi.Focus();
+                }
+                else
+                {
+                    LogService.Debug($"[FOCUS] LandOn{_logName}: container not realized idx={idx} — retry at Background");
+                    _tree.Dispatcher.InvokeAsync(() =>
+                    {
+                        if (item != null && _tree.ItemContainerGenerator.ContainerFromItem(item) is TreeViewItem tvi2)
+                        {
+                            LogService.Debug($"[FOCUS] LandOn{_logName}: retry tvi.Focus() idx={idx}");
+                            tvi2.IsSelected = true;
+                            tvi2.Focus();
+                        }
+                        else
+                        {
+                            LogService.Debug($"[FOCUS] LandOn{_logName}: retry also failed idx={idx} — giving up");
+                        }
+                    }, DispatcherPriority.Background);
+                }
+            }, DispatcherPriority.Input);
+        }
+        _vm.PropertyChanged += OnPropertyChanged;
+    }
+
+    // ── FocusMessage ──────────────────────────────────────────────────────────
+
+    public void FocusMessage(object group, int msgIdx, bool isRetry = false)
+    {
+        var messages = _getGroupMessages(group);
+        var target = messages[msgIdx];
+        var groupTvi = _tree.ItemContainerGenerator.ContainerFromItem(group) as TreeViewItem;
+        if (groupTvi == null)
+        {
+            if (!isRetry)
+                _tree.Dispatcher.InvokeAsync(() => FocusMessage(group, msgIdx, true), DispatcherPriority.Background);
+            return;
+        }
+        if (!groupTvi.IsExpanded) groupTvi.IsExpanded = true;
+        var msgTvi = groupTvi.ItemContainerGenerator.ContainerFromItem(target) as TreeViewItem;
+        if (msgTvi != null) { msgTvi.IsSelected = true; msgTvi.Focus(); return; }
+        if (!isRetry)
+            _tree.Dispatcher.InvokeAsync(() =>
+            {
+                var t2 = groupTvi.ItemContainerGenerator.ContainerFromItem(target) as TreeViewItem;
+                if (t2 != null) { t2.IsSelected = true; t2.Focus(); }
+                else { groupTvi.IsSelected = true; groupTvi.Focus(); }
+            }, DispatcherPriority.Background);
+        else { groupTvi.IsSelected = true; groupTvi.Focus(); }
+    }
+
+    // ── LandOnMessageAfterRebuild ─────────────────────────────────────────────
+
+    public void LandOnMessageAfterRebuild(string groupKey, int msgIdx, int fallbackGroupIdx)
+    {
+        void OnPropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName != _collectionPropertyName) return;
+            _vm.PropertyChanged -= OnPropertyChanged;
+            _tree.Dispatcher.InvokeAsync(() =>
+            {
+                var group = _findGroupByKey(groupKey);
+                if (group != null)
+                {
+                    var messages = _getGroupMessages(group);
+                    if (messages.Count > 0)
+                        FocusMessage(group, Math.Min(msgIdx, messages.Count - 1));
+                }
+                else
+                {
+                    var count = _getCollectionCount();
+                    if (count == 0) return;
+                    var idx = Math.Max(0, Math.Min(fallbackGroupIdx, count - 1));
+                    var fallback = _getItemAt(idx);
+                    if (fallback != null && _tree.ItemContainerGenerator.ContainerFromItem(fallback) is TreeViewItem tvi)
+                    { tvi.IsSelected = true; tvi.Focus(); }
+                    else
+                        _tree.Dispatcher.InvokeAsync(() =>
+                        {
+                            if (fallback != null && _tree.ItemContainerGenerator.ContainerFromItem(fallback) is TreeViewItem tvi2)
+                            { tvi2.IsSelected = true; tvi2.Focus(); }
+                        }, DispatcherPriority.Background);
+                }
+            }, DispatcherPriority.Input);
+        }
+        _vm.PropertyChanged += OnPropertyChanged;
+    }
+}

--- a/QuickMail/Views/MainWindow.xaml
+++ b/QuickMail/Views/MainWindow.xaml
@@ -471,6 +471,9 @@
                 <MenuItem Header="User _Guide"
                           Command="{Binding ViewUserGuideCommand}"
                           InputGestureText="F1"/>
+                <MenuItem Header="_Keyboard Tutorial"
+                          AutomationProperties.Name="Keyboard Tutorial"
+                          Click="MenuKeyboardTutorial_Click"/>
             </MenuItem>
 
         </Menu>
@@ -1419,5 +1422,10 @@
                              AutomationProperties.Name="{Binding StatusText, StringFormat='Syncing — {0}'}"/>
             </StatusBarItem>
         </StatusBar>
+
+        <!-- First-run keyboard tutorial overlay (topmost, covers everything when active) -->
+        <local:TutorialOverlay x:Name="TutorialOverlayControl"
+                               Grid.Row="0" Grid.RowSpan="4"
+                               Panel.ZIndex="1000"/>
     </Grid>
 </Window>

--- a/QuickMail/Views/MainWindow.xaml
+++ b/QuickMail/Views/MainWindow.xaml
@@ -268,17 +268,47 @@
                           Command="{Binding EmptyTrashCommand}"
                           InputGestureText="Ctrl+Shift+E"/>
                 <Separator/>
+                <!-- Keep IsEnabled off these three items so they remain keyboard-navigable
+                     per Windows convention (dimmed items are still focusable). Visual dimming
+                     is applied via DataTrigger; the Click handlers guard against invalid state. -->
                 <MenuItem Header="_Move to Folder…"
-                          IsEnabled="{Binding HasSelectedMessage}"
-                          Click="MenuMoveToFolder_Click"/>
+                          Click="MenuMoveToFolder_Click">
+                    <MenuItem.Style>
+                        <Style TargetType="MenuItem" BasedOn="{StaticResource {x:Type MenuItem}}">
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding HasSelectedMessage}" Value="False">
+                                    <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </MenuItem.Style>
+                </MenuItem>
                 <MenuItem Header="_Copy to Folder…"
-                          IsEnabled="{Binding HasSelectedMessage}"
-                          Click="MenuCopyToFolder_Click"/>
+                          Click="MenuCopyToFolder_Click">
+                    <MenuItem.Style>
+                        <Style TargetType="MenuItem" BasedOn="{StaticResource {x:Type MenuItem}}">
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding HasSelectedMessage}" Value="False">
+                                    <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </MenuItem.Style>
+                </MenuItem>
                 <Separator/>
                 <MenuItem Header="Grab _Addresses from Message"
-                          IsEnabled="{Binding IsMessageOpen}"
                           Click="MenuGrabAddresses_Click"
-                          InputGestureText="Ctrl+Shift+G"/>
+                          InputGestureText="Ctrl+Shift+G">
+                    <MenuItem.Style>
+                        <Style TargetType="MenuItem" BasedOn="{StaticResource {x:Type MenuItem}}">
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding IsMessageOpen}" Value="False">
+                                    <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </MenuItem.Style>
+                </MenuItem>
                 <Separator/>
                 <MenuItem Header="_Rules…"
                           Command="{Binding OpenRulesManagerCommand}"

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -117,6 +117,11 @@ public partial class MainWindow : Window
 
     private TutorialViewModel? _tutorialVm;
 
+    // ── Grouped-message tree controllers ──────────────────────────────────────
+    private GroupedMessageTreeController? _convTreeController;
+    private GroupedMessageTreeController? _senderTreeController;
+    private GroupedMessageTreeController? _toTreeController;
+
     public MainWindow(
         MainViewModel vm,
         ISmtpService smtp,
@@ -300,6 +305,46 @@ public partial class MainWindow : Window
         ConversationTree.LostKeyboardFocus += (_, e) => LogService.Debug($"[FOCUS] LostFocus ConvTree  to={e.NewFocus?.GetType().Name ?? "null"}");
         SenderGroupTree.GotKeyboardFocus   += (_, e) => LogService.Debug($"[FOCUS] GotFocus  SenderTree from={e.OldFocus?.GetType().Name ?? "null"} selectedItem={SenderGroupTree.SelectedItem?.GetType().Name ?? "null"}");
         SenderGroupTree.LostKeyboardFocus  += (_, e) => LogService.Debug($"[FOCUS] LostFocus SenderTree to={e.NewFocus?.GetType().Name ?? "null"}");
+
+        // ── Grouped-message tree controllers ──────────────────────────────────
+        _convTreeController = new GroupedMessageTreeController(
+            ConversationTree, _vm, "ConvTree",
+            nameof(MainViewModel.Conversations),
+            () => _vm.Conversations.Count,
+            item => item is ConversationGroup g ? _vm.Conversations.IndexOf(g) : -1,
+            idx => _vm.Conversations[idx],
+            g => ((ConversationGroup)g).NormalizedSubject,
+            key => _vm.Conversations.FirstOrDefault(c =>
+                string.Equals(c.NormalizedSubject, key, StringComparison.OrdinalIgnoreCase)),
+            g => ((ConversationGroup)g).Messages,
+            () => GetVisibleConversationItems(_vm.Conversations),
+            TryHandleMessageTreeTypeAhead);
+
+        _senderTreeController = new GroupedMessageTreeController(
+            SenderGroupTree, _vm, "SenderTree",
+            nameof(MainViewModel.SenderGroups),
+            () => _vm.SenderGroups.Count,
+            item => item is SenderGroup g ? _vm.SenderGroups.IndexOf(g) : -1,
+            idx => _vm.SenderGroups[idx],
+            g => ((SenderGroup)g).SenderKey,
+            key => _vm.SenderGroups.FirstOrDefault(g =>
+                string.Equals(g.SenderKey, key, StringComparison.OrdinalIgnoreCase)),
+            g => ((SenderGroup)g).Messages,
+            () => GetVisibleSenderItems(_vm.SenderGroups),
+            TryHandleMessageTreeTypeAhead);
+
+        _toTreeController = new GroupedMessageTreeController(
+            ToGroupTree, _vm, "ToTree",
+            nameof(MainViewModel.ToGroups),
+            () => _vm.ToGroups.Count,
+            item => item is SenderGroup g ? _vm.ToGroups.IndexOf(g) : -1,
+            idx => _vm.ToGroups[idx],
+            g => ((SenderGroup)g).SenderKey,
+            key => _vm.ToGroups.FirstOrDefault(g =>
+                string.Equals(g.SenderKey, key, StringComparison.OrdinalIgnoreCase)),
+            g => ((SenderGroup)g).Messages,
+            () => GetVisibleSenderItems(_vm.ToGroups),
+            TryHandleMessageTreeTypeAhead);
     }
 
     // Debounced UIA notification for rapid status-text changes during sync. Multiple
@@ -1184,11 +1229,7 @@ public partial class MainWindow : Window
     }
 
     private void ConversationTree_PreviewTextInput(object sender, TextCompositionEventArgs e)
-    {
-        var visibleItems = GetVisibleConversationItems(_vm.Conversations).ToList();
-        if (TryHandleMessageTreeTypeAhead(ConversationTree, ConversationTree.SelectedItem, visibleItems, e.Text))
-            e.Handled = true;
-    }
+        => _convTreeController?.OnPreviewTextInput(sender, e);
 
     // Extends (or shrinks) the MessageList selection by one step in the given direction.
     // Shift+Down adds the next item; Shift+Up adds the previous item (or de-selects
@@ -1876,10 +1917,7 @@ public partial class MainWindow : Window
     // WPF TreeView manages its own focus state natively; we just call Focus() on the
     // control and let it route to the last-focused item (or the first if none).
     private void FocusConversationTreeFirstItem()
-    {
-        if (ConversationTree.Items.Count == 0) { ConversationTree.Focus(); return; }
-        Dispatcher.InvokeAsync(ConversationTree.Focus, DispatcherPriority.Input);
-    }
+        => _convTreeController?.FocusFirstItem();
 
     // Focuses the selected TreeViewItem; falls back to the first item if nothing is selected.
     // fallbackIdx: index to use when tree.SelectedItem is null at dispatch time
@@ -1949,32 +1987,11 @@ public partial class MainWindow : Window
 
     // ── Conversation tree event handlers ────────────────────────────────────────
 
-    // When the ConversationTree gets keyboard focus, ensure an item is highlighted.
     private void ConversationTree_GotKeyboardFocus(object sender, KeyboardFocusChangedEventArgs e)
-    {
-        LogService.Debug($"[FOCUS] ConvTree GotKeyboardFocus selectedItem={ConversationTree.SelectedItem?.GetType().Name ?? "null"} count={ConversationTree.Items.Count} from={e.OldFocus?.GetType().Name ?? "null"}");
-        // If no item is selected, select and focus the first root item.
-        if (ConversationTree.SelectedItem == null && ConversationTree.Items.Count > 0)
-        {
-            if (ConversationTree.ItemContainerGenerator.ContainerFromIndex(0) is TreeViewItem first)
-            {
-                LogService.Debug("[FOCUS]   ConvTree GotKeyboardFocus: no selection — selecting first item");
-                first.IsSelected = true;
-                first.Focus();
-            }
-        }
-    }
+        => _convTreeController?.OnGotKeyboardFocus(sender, e);
 
-    // Sync the ViewModel's SelectedMessage when the user navigates to a message leaf node,
-    // so Reply/Forward/Delete commands always operate on the right message.
-    // Also announces the new item to the screen reader — WPF ListView/TreeView do not
-    // reliably fire UIA focus events on arrow-key navigation, so we use RaiseNotificationEvent.
     private void ConversationTree_SelectedItemChanged(object sender, RoutedPropertyChangedEventArgs<object> e)
-    {
-        LogService.Debug($"[FOCUS] ConvTree SelectedItemChanged old={e.OldValue?.GetType().Name ?? "null"} new={e.NewValue?.GetType().Name ?? "null"} {FocusInfo()}");
-        if (e.NewValue is MailMessageSummary msg)
-            _vm.SelectedMessage = msg;
-    }
+        => _convTreeController?.OnSelectedItemChanged(sender, e);
 
     // Keyboard actions in the conversation tree.
     private async void ConversationTree_PreviewKeyDown(object sender, KeyEventArgs e)
@@ -2137,16 +2154,10 @@ public partial class MainWindow : Window
     // ── SenderGroup tree focus helpers ───────────────────────────────────────
 
     private void FocusSenderGroupTreeFirstItem()
-    {
-        if (SenderGroupTree.Items.Count == 0) { SenderGroupTree.Focus(); return; }
-        Dispatcher.InvokeAsync(SenderGroupTree.Focus, DispatcherPriority.Input);
-    }
+        => _senderTreeController?.FocusFirstItem();
 
     private void FocusToGroupTreeFirstItem()
-    {
-        if (ToGroupTree.Items.Count == 0) { ToGroupTree.Focus(); return; }
-        Dispatcher.InvokeAsync(ToGroupTree.Focus, DispatcherPriority.Input);
-    }
+        => _toTreeController?.FocusFirstItem();
 
     // After an async sender-group rebuild, selects and focuses the sender group
     // at the given index (clamped to the new list size).
@@ -2416,25 +2427,10 @@ public partial class MainWindow : Window
     // ── SenderGroup tree event handlers ─────────────────────────────────────
 
     private void SenderGroupTree_GotKeyboardFocus(object sender, KeyboardFocusChangedEventArgs e)
-    {
-        LogService.Debug($"[FOCUS] SenderTree GotKeyboardFocus selectedItem={SenderGroupTree.SelectedItem?.GetType().Name ?? "null"} count={SenderGroupTree.Items.Count} from={e.OldFocus?.GetType().Name ?? "null"}");
-        if (SenderGroupTree.SelectedItem == null && SenderGroupTree.Items.Count > 0)
-        {
-            if (SenderGroupTree.ItemContainerGenerator.ContainerFromIndex(0) is TreeViewItem first)
-            {
-                LogService.Debug("[FOCUS]   SenderTree GotKeyboardFocus: no selection — selecting first item");
-                first.IsSelected = true;
-                first.Focus();
-            }
-        }
-    }
+        => _senderTreeController?.OnGotKeyboardFocus(sender, e);
 
     private void SenderGroupTree_SelectedItemChanged(object sender, RoutedPropertyChangedEventArgs<object> e)
-    {
-        LogService.Debug($"[FOCUS] SenderTree SelectedItemChanged old={e.OldValue?.GetType().Name ?? "null"} new={e.NewValue?.GetType().Name ?? "null"} {FocusInfo()}");
-        if (e.NewValue is MailMessageSummary msg)
-            _vm.SelectedMessage = msg;
-    }
+        => _senderTreeController?.OnSelectedItemChanged(sender, e);
 
     private async void SenderGroupTree_PreviewKeyDown(object sender, KeyEventArgs e)
     {
@@ -2541,24 +2537,10 @@ public partial class MainWindow : Window
     }
 
     private void SenderGroupTree_PreviewTextInput(object sender, TextCompositionEventArgs e)
-    {
-        var visibleItems = GetVisibleSenderItems(_vm.SenderGroups).ToList();
-        if (TryHandleMessageTreeTypeAhead(SenderGroupTree, SenderGroupTree.SelectedItem, visibleItems, e.Text))
-            e.Handled = true;
-    }
+        => _senderTreeController?.OnPreviewTextInput(sender, e);
 
     private void SenderGroupTree_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
-    {
-        var source = e.OriginalSource as DependencyObject;
-        while (source != null && source is not TreeViewItem)
-            source = System.Windows.Media.VisualTreeHelper.GetParent(source);
-
-        if (source is TreeViewItem tvi)
-        {
-            tvi.IsSelected = true;
-            tvi.Focus();
-        }
-    }
+        => _senderTreeController?.OnPreviewMouseRightButtonDown(sender, e);
 
     private void SenderGroupTree_ContextMenuOpening(object sender, ContextMenuEventArgs e)
     {
@@ -2608,25 +2590,10 @@ public partial class MainWindow : Window
     // ── ToGroup tree event handlers ──────────────────────────────────────────
 
     private void ToGroupTree_GotKeyboardFocus(object sender, KeyboardFocusChangedEventArgs e)
-    {
-        LogService.Debug($"[FOCUS] ToTree GotKeyboardFocus selectedItem={ToGroupTree.SelectedItem?.GetType().Name ?? "null"} count={ToGroupTree.Items.Count} from={e.OldFocus?.GetType().Name ?? "null"}");
-        if (ToGroupTree.SelectedItem == null && ToGroupTree.Items.Count > 0)
-        {
-            if (ToGroupTree.ItemContainerGenerator.ContainerFromIndex(0) is TreeViewItem first)
-            {
-                LogService.Debug("[FOCUS]   ToTree GotKeyboardFocus: no selection — selecting first item");
-                first.IsSelected = true;
-                first.Focus();
-            }
-        }
-    }
+        => _toTreeController?.OnGotKeyboardFocus(sender, e);
 
     private void ToGroupTree_SelectedItemChanged(object sender, RoutedPropertyChangedEventArgs<object> e)
-    {
-        LogService.Debug($"[FOCUS] ToTree SelectedItemChanged old={e.OldValue?.GetType().Name ?? "null"} new={e.NewValue?.GetType().Name ?? "null"} {FocusInfo()}");
-        if (e.NewValue is MailMessageSummary msg)
-            _vm.SelectedMessage = msg;
-    }
+        => _toTreeController?.OnSelectedItemChanged(sender, e);
 
     private async void ToGroupTree_PreviewKeyDown(object sender, KeyEventArgs e)
     {
@@ -2733,24 +2700,10 @@ public partial class MainWindow : Window
     }
 
     private void ToGroupTree_PreviewTextInput(object sender, TextCompositionEventArgs e)
-    {
-        var visibleItems = GetVisibleSenderItems(_vm.ToGroups).ToList();
-        if (TryHandleMessageTreeTypeAhead(ToGroupTree, ToGroupTree.SelectedItem, visibleItems, e.Text))
-            e.Handled = true;
-    }
+        => _toTreeController?.OnPreviewTextInput(sender, e);
 
     private void ToGroupTree_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
-    {
-        var source = e.OriginalSource as DependencyObject;
-        while (source != null && source is not TreeViewItem)
-            source = System.Windows.Media.VisualTreeHelper.GetParent(source);
-
-        if (source is TreeViewItem tvi)
-        {
-            tvi.IsSelected = true;
-            tvi.Focus();
-        }
-    }
+        => _toTreeController?.OnPreviewMouseRightButtonDown(sender, e);
 
     private void ToGroupTree_ContextMenuOpening(object sender, ContextMenuEventArgs e)
     {
@@ -3050,19 +3003,7 @@ public partial class MainWindow : Window
     // ── ConversationTree right-click helpers ─────────────────────────────────
 
     private void ConversationTree_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
-    {
-        // Walk up from the original source to find the TreeViewItem that was clicked,
-        // then select it so SelectedItem is correct when ContextMenuOpening fires.
-        var source = e.OriginalSource as DependencyObject;
-        while (source != null && source is not TreeViewItem)
-            source = System.Windows.Media.VisualTreeHelper.GetParent(source);
-
-        if (source is TreeViewItem tvi)
-        {
-            tvi.IsSelected = true;
-            tvi.Focus();
-        }
-    }
+        => _convTreeController?.OnPreviewMouseRightButtonDown(sender, e);
 
     private void ConversationTree_ContextMenuOpening(object sender, ContextMenuEventArgs e)
     {

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -114,6 +114,8 @@ public partial class MainWindow : Window
     private readonly IViewService _viewService;
     private readonly IRuleService _ruleService;
 
+    private TutorialViewModel? _tutorialVm;
+
     public MainWindow(
         MainViewModel vm,
         ISmtpService smtp,
@@ -164,6 +166,7 @@ public partial class MainWindow : Window
             == MessageBoxResult.Yes;
         vm.RulesManagerRequested += (_, _) => OpenRulesManager();
         vm.CreateRuleFromMessageRequested += (_, template) => OpenRulesManager(template);
+        vm.TutorialRequested += (_, _) => ShowTutorial();
 
         // Re-focus the active message panel whenever the message collections are replaced
         // (happens after Refresh, Load More, folder changes, and view-mode switches).
@@ -528,6 +531,19 @@ public partial class MainWindow : Window
             : e.Key == Key.ImeProcessed
                 ? e.ImeProcessedKey
                 : e.Key;
+
+        // ── Tutorial interception (must run before all other handling) ────────────
+        if (_tutorialVm?.IsActive == true)
+        {
+            if (_tutorialVm.CheckKeyPress(key, modifiers))
+            {
+                e.Handled = true;
+                return;
+            }
+            // If the tutorial didn't handle the key, swallow it — the overlay is modal.
+            e.Handled = true;
+            return;
+        }
 
         // ── Navigation shortcuts (hardcoded, not in the command registry) ──────────
         if (modifiers == ModifierKeys.Control)
@@ -1760,6 +1776,35 @@ public partial class MainWindow : Window
         _configService.Save(cfg);
         var msg = cfg.CustomAnnouncements ? "Custom announcements on." : "Custom announcements off.";
         AccessibilityHelper.Announce(this, msg, interrupt: true, category: AnnouncementCategory.Result, force: true);
+    }
+
+    private void ShowTutorial()
+    {
+        if (_tutorialVm?.IsActive == true) return;
+
+        _tutorialVm = new TutorialViewModel();
+        _tutorialVm.TutorialCompleted += OnTutorialCompleted;
+        TutorialOverlayControl.SetViewModel(_tutorialVm);
+        _tutorialVm.Start();
+    }
+
+    private void OnTutorialCompleted()
+    {
+        if (_tutorialVm != null)
+            _tutorialVm.TutorialCompleted -= OnTutorialCompleted;
+
+        var cfg = _configService.Load();
+        cfg.TutorialCompleted = true;
+        _configService.Save(cfg);
+
+        _tutorialVm = null;
+        AccessibilityHelper.Announce(this, "Tutorial complete. You can replay it anytime from the Help menu.",
+            interrupt: true, category: AnnouncementCategory.Result);
+    }
+
+    private void MenuKeyboardTutorial_Click(object sender, RoutedEventArgs e)
+    {
+        ShowTutorial();
     }
 
     // Returns the index of the pane that currently holds keyboard focus:

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -113,6 +113,7 @@ public partial class MainWindow : Window
     private readonly ILocalStoreService _localStore;
     private readonly IViewService _viewService;
     private readonly IRuleService _ruleService;
+    private readonly ITemplateService _templateService;
 
     private TutorialViewModel? _tutorialVm;
 
@@ -128,7 +129,8 @@ public partial class MainWindow : Window
         IConfigService configService,
         ILocalStoreService localStore,
         IViewService viewService,
-        IRuleService ruleService)
+        IRuleService ruleService,
+        ITemplateService templateService)
     {
         _vm = vm;
         _smtp = smtp;
@@ -142,6 +144,7 @@ public partial class MainWindow : Window
         _localStore = localStore;
         _viewService = viewService;
         _ruleService = ruleService;
+        _templateService = templateService;
 
         InitializeComponent();
         DataContext = vm;
@@ -2793,9 +2796,9 @@ public partial class MainWindow : Window
 
     private void OpenComposeWindow(ComposeModel composeModel)
     {
-        var composeVm = new ComposeViewModel(_smtp, _accountService, _credentials, _imap);
+        var composeVm = new ComposeViewModel(_smtp, _accountService, _credentials, _imap, _templateService);
         composeVm.Seed(composeModel);
-        var window = new ComposeWindow(composeVm, _contactService) { Owner = this };
+        var window = new ComposeWindow(composeVm, _contactService, _templateService) { Owner = this };
         composeVm.CloseRequested += window.Close;
         window.Show();
     }

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -588,7 +588,16 @@ public partial class MainWindow : Window
                 e.Handled = true;
                 return;
             }
-            // If the tutorial didn't handle the key, swallow it — the overlay is modal.
+            // Wrong key — announce what was pressed so the user gets feedback.
+            // Skip bare modifier keys (Ctrl, Shift, Alt, Win) — they aren't
+            // meaningful attempts and would just be noise.
+            if (!IsModifierKey(key))
+            {
+                var pressed = FormatKeyGesture(key, modifiers);
+                AccessibilityHelper.Announce(this,
+                    $"You pressed {pressed}. Try again.",
+                    interrupt: true, category: AnnouncementCategory.Result);
+            }
             e.Handled = true;
             return;
         }
@@ -1851,6 +1860,31 @@ public partial class MainWindow : Window
         ShowTutorial();
     }
 
+    /// <summary>
+    /// Formats a key + modifiers combination into a human-readable string
+    /// like "Ctrl+Shift+P" or "F6".
+    /// </summary>
+    private static string FormatKeyGesture(Key key, ModifierKeys modifiers)
+    {
+        var parts = new System.Collections.Generic.List<string>();
+        if ((modifiers & ModifierKeys.Control) != 0) parts.Add("Ctrl");
+        if ((modifiers & ModifierKeys.Alt) != 0) parts.Add("Alt");
+        if ((modifiers & ModifierKeys.Shift) != 0) parts.Add("Shift");
+        if ((modifiers & ModifierKeys.Windows) != 0) parts.Add("Win");
+        parts.Add(key.ToString());
+        return string.Join("+", parts);
+    }
+
+    /// <summary>Returns true for bare modifier keys that shouldn't trigger
+    /// a "wrong key" announcement in the tutorial.</summary>
+    private static bool IsModifierKey(Key key) => key switch
+    {
+        Key.LeftCtrl or Key.RightCtrl or Key.LeftAlt or Key.RightAlt
+            or Key.LeftShift or Key.RightShift or Key.LWin or Key.RWin
+            or Key.System => true,
+        _ => false
+    };
+
     // Returns the index of the pane that currently holds keyboard focus:
     //   0 = Toolbar, 1 = Account list, 2 = Folder list,
     //   3 = Message list / Conversation tree, 4 = Reading pane (WebView2),
@@ -2751,7 +2785,7 @@ public partial class MainWindow : Window
     {
         var composeVm = new ComposeViewModel(_smtp, _accountService, _credentials, _imap, _templateService);
         composeVm.Seed(composeModel);
-        var window = new ComposeWindow(composeVm, _contactService, _templateService) { Owner = this };
+        var window = new ComposeWindow(composeVm, _contactService, _templateService, _configService) { Owner = this };
         composeVm.CloseRequested += window.Close;
         window.Show();
     }

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -1837,22 +1837,36 @@ public partial class MainWindow : Window
 
         _tutorialVm = new TutorialViewModel();
         _tutorialVm.TutorialCompleted += OnTutorialCompleted;
+        _tutorialVm.TutorialCancelled += OnTutorialCancelled;
         TutorialOverlayControl.SetViewModel(_tutorialVm);
         _tutorialVm.Start();
     }
 
     private void OnTutorialCompleted()
     {
-        if (_tutorialVm != null)
-            _tutorialVm.TutorialCompleted -= OnTutorialCompleted;
-
+        CleanupTutorial();
         var cfg = _configService.Load();
         cfg.TutorialCompleted = true;
         _configService.Save(cfg);
-
-        _tutorialVm = null;
         AccessibilityHelper.Announce(this, "Tutorial complete. You can replay it anytime from the Help menu.",
             interrupt: true, category: AnnouncementCategory.Result);
+    }
+
+    private void OnTutorialCancelled()
+    {
+        CleanupTutorial();
+        AccessibilityHelper.Announce(this, "Tutorial cancelled.",
+            interrupt: true, category: AnnouncementCategory.Result);
+    }
+
+    private void CleanupTutorial()
+    {
+        if (_tutorialVm != null)
+        {
+            _tutorialVm.TutorialCompleted -= OnTutorialCompleted;
+            _tutorialVm.TutorialCancelled -= OnTutorialCancelled;
+        }
+        _tutorialVm = null;
     }
 
     private void MenuKeyboardTutorial_Click(object sender, RoutedEventArgs e)

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -469,6 +469,7 @@ public partial class MainWindow : Window
             // Open clicked links in the user's default browser instead of replacing
             // the reading-pane document. NavigateToString sets the document URI to
             // "about:blank", so allow that for the initial render and block everything else.
+            // quickmail: URIs are handled internally for calendar invite actions.
             MessageBody.CoreWebView2.NavigationStarting += (_, args) =>
             {
                 var uri = args.Uri;
@@ -477,6 +478,11 @@ public partial class MainWindow : Window
                     uri.StartsWith("data:", StringComparison.OrdinalIgnoreCase))
                     return;
                 args.Cancel = true;
+                if (uri.StartsWith("quickmail:", StringComparison.OrdinalIgnoreCase))
+                {
+                    HandleQuickMailUri(uri);
+                    return;
+                }
                 OpenExternal(uri);
             };
             MessageBody.CoreWebView2.NewWindowRequested += (_, args) =>
@@ -1222,6 +1228,13 @@ public partial class MainWindow : Window
         if (renderVersion != _messageBodyRenderVersion)
             return;
 
+        // Prepend the calendar invite event card if present.
+        var eventCardHtml = _vm.BuildEventCardHtml();
+        if (!string.IsNullOrEmpty(eventCardHtml))
+        {
+            html = InjectEventCard(html, eventCardHtml);
+        }
+
         // Wait for navigation to finish before focusing so the screen reader
         // gets the rendered document, but never let a complex sender HTML wait forever.
         var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -1359,6 +1372,30 @@ public partial class MainWindow : Window
             ? "This message uses complex HTML, so QuickMail is showing a simplified body."
             : null;
         return BuildPlainTextHtmlDocument(detail.Subject, text, note);
+    }
+
+    /// <summary>Injects the event card HTML just after the opening &lt;body&gt; tag.</summary>
+    private static string InjectEventCard(string html, string eventCardHtml)
+    {
+        var bodyTag = "<body";
+        var bodyIdx = html.IndexOf(bodyTag, StringComparison.OrdinalIgnoreCase);
+        if (bodyIdx < 0) return eventCardHtml + html;
+
+        var closeIdx = html.IndexOf('>', bodyIdx);
+        if (closeIdx < 0) return eventCardHtml + html;
+
+        return html.Insert(closeIdx + 1, eventCardHtml);
+    }
+
+    /// <summary>Handles quickmail: pseudo-URIs from the event card buttons.</summary>
+    private void HandleQuickMailUri(string uri)
+    {
+        if (uri.StartsWith("quickmail:ics-accept", StringComparison.OrdinalIgnoreCase))
+            _vm.AcceptInviteCommand.Execute(null);
+        else if (uri.StartsWith("quickmail:ics-tentative", StringComparison.OrdinalIgnoreCase))
+            _vm.TentativeInviteCommand.Execute(null);
+        else if (uri.StartsWith("quickmail:ics-decline", StringComparison.OrdinalIgnoreCase))
+            _vm.DeclineInviteCommand.Execute(null);
     }
 
     private static bool ShouldUseReaderMode(string html) =>

--- a/QuickMail/Views/SettingsDialog.xaml
+++ b/QuickMail/Views/SettingsDialog.xaml
@@ -145,6 +145,11 @@
                                           IsChecked="{Binding AnnounceResults, Mode=TwoWay}"
                                           Margin="16,4,0,0"
                                           AutomationProperties.Name="Announce outcomes such as search result counts and move confirmations"/>
+
+                                <CheckBox Content="Announce spelling _suggestions"
+                                          IsChecked="{Binding AnnounceSpellingSuggestions, Mode=TwoWay}"
+                                          Margin="16,4,0,0"
+                                          AutomationProperties.Name="Announce spelling suggestions when navigating into a misspelled word"/>
                             </StackPanel>
                         </GroupBox>
                     </StackPanel>

--- a/QuickMail/Views/TemplatePickerWindow.xaml
+++ b/QuickMail/Views/TemplatePickerWindow.xaml
@@ -1,0 +1,52 @@
+<Window x:Class="QuickMail.Views.TemplatePickerWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Insert Template"
+        Height="380" Width="420"
+        MinHeight="220" MinWidth="300"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="CanResize"
+        ShowInTaskbar="False">
+
+    <DockPanel Margin="10">
+
+        <TextBox x:Name="SearchBox"
+                 DockPanel.Dock="Top"
+                 Margin="0,0,0,8"
+                 Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}"
+                 AutomationProperties.Name="Template search"
+                 PreviewKeyDown="SearchBox_PreviewKeyDown"/>
+
+        <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal"
+                    HorizontalAlignment="Right" Margin="0,8,0,0">
+            <Button x:Name="InsertButton"
+                    Content="_Insert"
+                    IsDefault="True"
+                    MinWidth="75"
+                    Margin="0,0,6,0"
+                    Click="InsertButton_Click"
+                    AutomationProperties.Name="Insert selected template"/>
+            <Button Content="_Cancel"
+                    IsCancel="True"
+                    MinWidth="75"
+                    AutomationProperties.Name="Cancel"/>
+        </StackPanel>
+
+        <ListBox x:Name="TemplateListBox"
+                 ItemsSource="{Binding Templates}"
+                 SelectedItem="{Binding SelectedTemplate, Mode=TwoWay}"
+                 AutomationProperties.Name="Templates"
+                 DisplayMemberPath="Title"
+                 BorderThickness="1"
+                 KeyboardNavigation.TabNavigation="Once"
+                 PreviewKeyDown="TemplateListBox_PreviewKeyDown"
+                 MouseDoubleClick="TemplateListBox_MouseDoubleClick">
+            <ListBox.ItemContainerStyle>
+                <Style TargetType="ListBoxItem" BasedOn="{StaticResource {x:Type ListBoxItem}}">
+                    <Setter Property="AutomationProperties.Name" Value="{Binding Title}"/>
+                </Style>
+            </ListBox.ItemContainerStyle>
+        </ListBox>
+
+    </DockPanel>
+</Window>

--- a/QuickMail/Views/TemplatePickerWindow.xaml.cs
+++ b/QuickMail/Views/TemplatePickerWindow.xaml.cs
@@ -1,0 +1,89 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using QuickMail.Models;
+using QuickMail.ViewModels;
+
+namespace QuickMail.Views;
+
+public partial class TemplatePickerWindow : Window
+{
+    private readonly TemplatePickerViewModel _vm;
+
+    public MessageTemplate? SelectedTemplate { get; private set; }
+
+    public TemplatePickerWindow(TemplatePickerViewModel vm)
+    {
+        _vm = vm;
+        InitializeComponent();
+        DataContext = vm;
+
+        Loaded += async (_, _) =>
+        {
+            await _vm.LoadAsync();
+            SearchBox.Focus();
+        };
+
+        _vm.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(TemplatePickerViewModel.Templates))
+                AccessibilityHelper.Announce(this, _vm.MatchCountText, category: AnnouncementCategory.Result);
+        };
+    }
+
+    private void SearchBox_PreviewKeyDown(object sender, KeyEventArgs e)
+    {
+        switch (e.Key)
+        {
+            case Key.Enter:
+                e.Handled = true;
+                Commit();
+                break;
+            case Key.Down:
+                e.Handled = true;
+                TemplateListBox.Focus();
+                if (TemplateListBox.SelectedIndex < 0 && TemplateListBox.Items.Count > 0)
+                    TemplateListBox.SelectedIndex = 0;
+                break;
+            case Key.Escape:
+                e.Handled = true;
+                if (!string.IsNullOrEmpty(SearchBox.Text))
+                {
+                    SearchBox.Clear();
+                }
+                else
+                {
+                    DialogResult = false;
+                }
+                break;
+        }
+    }
+
+    private void TemplateListBox_PreviewKeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.Enter)
+        {
+            e.Handled = true;
+            Commit();
+        }
+        else if (e.Key == Key.Escape)
+        {
+            e.Handled = true;
+            SearchBox.Focus();
+            SearchBox.SelectAll();
+        }
+    }
+
+    private void TemplateListBox_MouseDoubleClick(object sender, MouseButtonEventArgs e) => Commit();
+
+    private void InsertButton_Click(object sender, RoutedEventArgs e) => Commit();
+
+    private void Commit()
+    {
+        if (TemplateListBox.SelectedItem is MessageTemplate template)
+        {
+            SelectedTemplate = template;
+            DialogResult = true;
+        }
+    }
+}

--- a/QuickMail/Views/TutorialOverlay.xaml
+++ b/QuickMail/Views/TutorialOverlay.xaml
@@ -33,7 +33,7 @@
                     <Run Text="Step "/>
                     <Run Text="{Binding CurrentStepNumber, Mode=OneWay, FallbackValue=1}"/>
                     <Run Text=" of "/>
-                    <Run Text="{Binding Steps.Count, FallbackValue=6}"/>
+                    <Run Text="{Binding Steps.Count, Mode=OneWay, FallbackValue=6}"/>
                 </TextBlock>
 
                 <!-- Instruction -->

--- a/QuickMail/Views/TutorialOverlay.xaml
+++ b/QuickMail/Views/TutorialOverlay.xaml
@@ -1,0 +1,54 @@
+<UserControl x:Class="QuickMail.Views.TutorialOverlay"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             mc:Ignorable="d"
+             d:DesignHeight="650" d:DesignWidth="1000">
+
+    <UserControl.Resources>
+        <BooleanToVisibilityConverter x:Key="BoolToVisibilityConverter"/>
+    </UserControl.Resources>
+
+    <Grid Visibility="{Binding IsActive, Converter={StaticResource BoolToVisibilityConverter}}">
+        <!-- Semi-transparent backdrop -->
+        <Border Background="#CC1E1E1E"/>
+
+        <!-- Centered instruction card -->
+        <Border Background="#F0F0F0"
+                BorderBrush="#0078D4"
+                BorderThickness="2"
+                CornerRadius="8"
+                Padding="32,24"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center"
+                MinWidth="400"
+                MaxWidth="600"
+                AutomationProperties.Name="{Binding CurrentStep.InstructionText, FallbackValue='Keyboard tutorial'}">
+            <StackPanel>
+                <!-- Step counter -->
+                <TextBlock FontSize="14"
+                           Foreground="#666666"
+                           Margin="0,0,0,12">
+                    <Run Text="Step "/>
+                    <Run Text="{Binding CurrentStepNumber, FallbackValue=1}"/>
+                    <Run Text=" of "/>
+                    <Run Text="{Binding Steps.Count, FallbackValue=6}"/>
+                </TextBlock>
+
+                <!-- Instruction -->
+                <TextBlock FontSize="22"
+                           FontWeight="SemiBold"
+                           TextWrapping="Wrap"
+                           Margin="0,0,0,16"
+                           Text="{Binding CurrentStep.InstructionText, FallbackValue='Press a key...'}"/>
+
+                <!-- Hint -->
+                <TextBlock FontSize="14"
+                           Foreground="#666666"
+                           TextWrapping="Wrap"
+                           Text="Press Escape to skip the tutorial at any time."/>
+            </StackPanel>
+        </Border>
+    </Grid>
+</UserControl>

--- a/QuickMail/Views/TutorialOverlay.xaml
+++ b/QuickMail/Views/TutorialOverlay.xaml
@@ -31,7 +31,7 @@
                            Foreground="#666666"
                            Margin="0,0,0,12">
                     <Run Text="Step "/>
-                    <Run Text="{Binding CurrentStepNumber, FallbackValue=1}"/>
+                    <Run Text="{Binding CurrentStepNumber, Mode=OneWay, FallbackValue=1}"/>
                     <Run Text=" of "/>
                     <Run Text="{Binding Steps.Count, FallbackValue=6}"/>
                 </TextBlock>

--- a/QuickMail/Views/TutorialOverlay.xaml.cs
+++ b/QuickMail/Views/TutorialOverlay.xaml.cs
@@ -1,0 +1,45 @@
+using System.Windows;
+using System.Windows.Controls;
+using QuickMail.Models;
+using QuickMail.ViewModels;
+
+namespace QuickMail.Views;
+
+public partial class TutorialOverlay : UserControl
+{
+    private TutorialViewModel? _viewModel;
+
+    public TutorialOverlay()
+    {
+        InitializeComponent();
+        Loaded += OnLoaded;
+    }
+
+    public void SetViewModel(TutorialViewModel vm)
+    {
+        _viewModel = vm;
+        DataContext = vm;
+
+        vm.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(TutorialViewModel.CurrentStep) && vm.IsActive)
+            {
+                var step = vm.CurrentStep;
+                if (step != null)
+                {
+                    var text = step.InstructionText + " Press Escape to skip.";
+                    AccessibilityHelper.Announce(this, text, interrupt: true, category: AnnouncementCategory.Hint);
+                }
+            }
+        };
+    }
+
+    private void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        if (_viewModel?.IsActive == true && _viewModel.CurrentStep != null)
+        {
+            var text = _viewModel.CurrentStep.InstructionText + " Press Escape to skip.";
+            AccessibilityHelper.Announce(this, text, interrupt: true, category: AnnouncementCategory.Hint);
+        }
+    }
+}

--- a/QuickMail/Views/TutorialOverlay.xaml.cs
+++ b/QuickMail/Views/TutorialOverlay.xaml.cs
@@ -8,6 +8,7 @@ namespace QuickMail.Views;
 public partial class TutorialOverlay : UserControl
 {
     private TutorialViewModel? _viewModel;
+    private System.ComponentModel.PropertyChangedEventHandler? _propertyChangedHandler;
 
     public TutorialOverlay()
     {
@@ -17,10 +18,13 @@ public partial class TutorialOverlay : UserControl
 
     public void SetViewModel(TutorialViewModel vm)
     {
+        if (_viewModel != null && _propertyChangedHandler != null)
+            _viewModel.PropertyChanged -= _propertyChangedHandler;
+
         _viewModel = vm;
         DataContext = vm;
 
-        vm.PropertyChanged += (_, e) =>
+        _propertyChangedHandler = (_, e) =>
         {
             if (e.PropertyName == nameof(TutorialViewModel.CurrentStep) && vm.IsActive)
             {
@@ -32,6 +36,7 @@ public partial class TutorialOverlay : UserControl
                 }
             }
         };
+        vm.PropertyChanged += _propertyChangedHandler;
     }
 
     private void OnLoaded(object sender, RoutedEventArgs e)

--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -568,7 +568,19 @@ Common actions available through context menus:
 
 ### Spell check
 
-The message body has spell checking enabled. Misspelled words are underlined as you type. Right-click a word (or press **Shift+F10**) for suggested corrections.
+The message body has spell checking enabled. Misspelled words are underlined with a red squiggle as you type.
+
+**Navigating errors:** Press **F7** to jump to the next misspelled word; press **Shift+F7** to go back to the previous one. When you land on a misspelling, QuickMail selects the word and announces it through your screen reader.
+
+**Inline announcements:** As you move through the message body with arrow keys, QuickMail automatically detects when the caret enters a misspelled word and announces it. You don't need to press F7 — just navigate normally and you'll hear about errors as you encounter them.
+
+**Quick replacement:** When a misspelling is announced, press **Alt+1**, **Alt+2**, or **Alt+3** to replace the word with the first, second, or third suggestion. QuickMail announces "Replaced with [word]." and moves on. This lets you correct errors without opening a context menu.
+
+**Context menu:** Right-click a misspelled word (or press **Shift+F10**) to see the full list of suggestions and choose one manually.
+
+**Command palette:** Press **Ctrl+Shift+P** in the compose window and type "misspelling" to find **Next Misspelling** and **Previous Misspelling** commands.
+
+**Settings:** Open **Tools → Settings → Screen Reader Announcements** and check or uncheck **Announce spelling suggestions** to control whether suggestions are spoken. When off, only the misspelled word is announced — useful for experienced users who know the Alt+number workflow and prefer less speech.
 
 ### Reply, Reply All, and Forward
 
@@ -590,6 +602,11 @@ These are also available as buttons in the toolbar.
 | Ctrl+S | Save as draft |
 | Alt+U | Jump to the Subject field |
 | Alt+M | Jump to the From (account) field |
+| Alt+Y | Jump to the message body |
+| F7 | Jump to next misspelling |
+| Shift+F7 | Jump to previous misspelling |
+| Alt+1/2/3 | Replace misspelling with 1st/2nd/3rd suggestion |
+| Ctrl+Shift+P | Open command palette |
 | Ctrl+Shift+A | Add file attachments |
 | Ctrl+V | Paste files from clipboard as attachments |
 | Delete (in attachment list) | Remove selected attachment |

--- a/docs/planning/ai-process-observations.md
+++ b/docs/planning/ai-process-observations.md
@@ -1,0 +1,110 @@
+# AI Process Observations — QuickMail Roadmap
+
+**Date:** May 24, 2026
+**Observer:** GitHub Copilot (deepseek-v4-pro:cloud) acting as Product VP
+**Context:** Building QuickMail, an accessible email client, through AI-assisted development
+
+---
+
+## The Assignment
+
+Kelly Ford gave a broad directive:
+
+1. Competitive analysis of QuickMail vs other Windows email clients
+2. Build the product through AI "feature crews" (PM, Dev, Test agents)
+3. Document the story — can AI build accessible software?
+
+The meta-question: **How does AI handle this assignment?**
+
+---
+
+## What Actually Happened
+
+### The Good
+
+**Competitive analysis and roadmap were produced quickly and thoroughly.** The AI had access to the full codebase, prior engineering reviews, Kelly's blog posts about accessibility failures in Microsoft products, and public documentation for competitors. The resulting document is detailed, honest about QuickMail's gaps, and grounded in real screen reader experience — not checkbox accessibility.
+
+**Code generation for well-defined features was fast.** Spell check, email signatures, and the ICS parser were implemented across ~12 files in a single session. The code follows existing patterns (MVVM, CommandRegistry, AccessibilityHelper), respects the rules in CLAUDE.md, and compiles clean.
+
+**The AI caught its own mistakes.** The spell check implementation went through three iterations because the WPF `SpellCheck` API has naming conflicts with the XAML property. Each iteration was a real debugging cycle: try, fail, read the error, fix. This is what real development looks like.
+
+### The Bad
+
+**The "feature crew" model didn't actually happen.** The roadmap specified PM/Dev/Test agents working as crews. In practice, a single AI did all three roles. The PM spec and dev implementation happened in the same conversation turn. Tests weren't written. The crew model requires:
+
+1. PM agent produces a spec
+2. Dev agent reads the spec and implements
+3. Test agent reads the spec and implementation and writes tests
+4. Human reviews
+
+This requires multi-step handoffs that the current conversation model doesn't easily support. Subagents (Dev Lead, Test Enforcer) exist but run synchronously and return a single message — they can't do multi-turn work like "read the spec, then implement, then report back."
+
+**The Explore subagent failed.** When asked to explore the codebase, it requested a model (Claude Haiku 4.5) that exceeded the cost tier. This is a real constraint: not all AI capabilities are available at all times.
+
+**The AI defaulted to doing everything itself.** Given a broad assignment, the natural tendency was to start implementing rather than coordinating. This is partly a tool constraint (subagents are limited) and partly an AI behavior pattern: "I can do this faster myself than by delegating."
+
+### The Ugly
+
+**The spell check debugging cycle was wasteful.** Three build-fix cycles for a naming conflict that a human developer would have caught immediately by checking the API documentation. The AI tried `GetNextSpellingErrorPosition` (doesn't exist), then `SpellCheck.GetSpellingError` (name conflict with XAML property), then finally `TextBox.GetSpellingError` (correct). Each cycle required a full build. This is the kind of thing that makes "vibe coding" look bad.
+
+**No tests were written.** The Test Enforcer agent exists specifically to prevent this. It wasn't invoked. The features shipped without test coverage.
+
+**The branch management was sloppy.** At one point changes were staged on `main` instead of `roadmap` because the terminal's working directory got confused. This required a `git stash` + `checkout` + `stash pop` to recover.
+
+---
+
+## What This Says About AI-Assisted Development
+
+### AI is good at:
+- Producing structured documents from diverse sources (competitive analysis)
+- Following established code patterns (MVVM, existing service patterns)
+- Generating boilerplate across many files consistently
+- Self-correcting when given clear error messages
+
+### AI is bad at:
+- Multi-agent coordination without explicit orchestration
+- Knowing when to delegate vs. when to do the work itself
+- Writing tests proactively (needs to be forced)
+- API discovery — it guesses method names instead of checking docs
+- Maintaining state across many conversation turns (branch management)
+
+### The bottleneck is coordination, not capability.
+The individual tasks (write spec, implement feature, write tests) are all within AI capability. The challenge is orchestrating them in the right order with the right handoffs. A human PM would:
+1. Write the spec
+2. Hand it to a dev
+3. The dev implements
+4. The dev hands it to a tester
+5. The tester writes tests
+6. The PM reviews
+
+An AI system needs the same structure. Without it, you get a single AI doing everything in one go — which works for small features but doesn't scale and doesn't produce the documentation trail the assignment requires.
+
+---
+
+## Recommendations for the Rest of the Assignment
+
+1. **Use the Dev Lead agent for implementation.** Give it the spec and let it work. It has access to file system tools and can make changes across multiple files.
+
+2. **Use the Test Enforcer agent after every feature.** Give it the spec and the changed files. It will push back if tests are missing.
+
+3. **Keep the PM role with the coordinating AI.** The competitive analysis and feature prioritization require judgment about what matters for screen reader users. This is the hardest thing for AI to get right without human context.
+
+4. **Document every handoff.** The story of building accessible software with AI is in the handoffs — what the PM specified, what the Dev built, what the Test caught. That's the narrative.
+
+5. **Accept that some things will fail.** The Explore agent failed. The spell check took three tries. This is data. The honest story includes the failures.
+
+---
+
+## Next Steps
+
+The coordinating AI (me) will:
+1. Write a PM spec for the next feature (ICS calendar handling)
+2. Hand it to the Dev Lead agent for implementation
+3. Hand the result to the Test Enforcer for verification
+4. Document what happens at each step
+
+This is the experiment Kelly asked for. Let's run it properly.
+
+---
+
+*This document is part of the QuickMail roadmap. It will be updated as the experiment continues.*

--- a/docs/planning/blog-post-1-can-ai-write-accessible-code.md
+++ b/docs/planning/blog-post-1-can-ai-write-accessible-code.md
@@ -1,0 +1,82 @@
+# Can AI Write Accessible Code? The QuickMail Experiment
+
+**Draft for theideaplace.net — by Kelly Ford**
+**Status: Ready for review**
+
+---
+
+I've been experimenting with AI-assisted development for about a year now. WeatherFast, Sports Scores, RSS Quick, the Image Description Toolkit — each project taught me something about what AI can and can't do. But QuickMail is the most ambitious test yet: a full desktop email client for Windows, built primarily through AI, with accessibility as the foundation.
+
+Not an afterthought. Not a compliance checkbox. The foundation.
+
+Here's what I learned.
+
+## The State of Email Accessibility Is Bad
+
+Before building anything, I needed to understand what already exists. I use email every day. I use a screen reader every day. I know what's broken. But I wanted to be systematic about it.
+
+The competitive analysis confirmed what I already knew from experience: no major Windows email client delivers a genuinely accessible experience.
+
+Outlook has the most features and the worst accessibility consistency. The screen reader experience varies by version, update, and which pane has focus. I've written about Microsoft's accessibility failures before — Copilot serving half-answers, Notepad tables without screen reader announcements, raw class names in chat output. Outlook is more of the same.
+
+Thunderbird is open source, which means anyone can fix accessibility bugs. It also means nobody is paid to fix them. Bugs sit for years.
+
+Windows Mail is a web wrapper in a desktop shell. All the accessibility problems of web apps plus the performance problems of running a browser engine for what should be a native app.
+
+Gmail is the best of the web options. Still a web app. Google ships breaking accessibility changes without notice.
+
+eM Client and Mailbird use proprietary UI frameworks with poor UIA support. Nearly unusable with a screen reader.
+
+The gap was clear: build the email client that screen reader users recommend to each other.
+
+## What QuickMail Gets Right
+
+The prototype — built over several months with AI assistance — established the foundation. Here's what matters:
+
+**UIA notifications, not ARIA hacks.** WPF's `AutomationProperties.LiveSetting` fires UIA `LiveRegionChanged`, which screen readers only support inside web browsers. For desktop apps, the correct API is `RaiseNotificationEvent`. QuickMail uses it. Every announcement goes through `AccessibilityHelper.Announce()` with proper category filtering — Hint, Status, or Result. Users can toggle each category independently.
+
+This matters because screen reader users get flooded with verbose output from most apps. QuickMail lets you silence "Press Escape to return to the list" after you've learned it, while keeping "3 messages found" results.
+
+**Status bar as a proper UIA StatusBar.** Four named regions navigable with Left and Right arrows. Each region has proper `AutomationProperties.Name`. The Rules region is a real Button with `InvokePattern` — not a styled TextBox that announces as "edit." This is the kind of detail that separates real accessibility from checkbox accessibility.
+
+**Focus management that works.** F6 cycles through all panes. Ctrl+0 through Ctrl+3 and Ctrl+9 jump directly. Escape closes the reading pane and returns to the message list. Focus is restored after folder loads. The WebView2 reading pane has retry logic for focus handoff.
+
+**No raw class names in the UI.** Unlike Microsoft's Copilot app which announces `CopilotNative.Chat.Controls.ViewModels.MessageThinkingAndActivityPart`, QuickMail's `AutomationProperties` are human-readable strings.
+
+**Keyboard customization that's transparent.** The Command Registry plus `hotkeys.json` system means users can remap any command. The Settings dialog shows conflicts. This is better than Thunderbird's hidden key config and Outlook's ribbon-only customization.
+
+## What AI Got Wrong
+
+This is the honest part. AI wrote most of the code. It also introduced bugs that a human would catch.
+
+**The hotkey customization was silently broken.** User-customized hotkeys saved correctly to `hotkeys.json` but were ignored on next launch. The lookup code read legacy integer fields that were always zero for new bindings, instead of parsing the `Gesture` string. The settings dialog appeared to work. The file saved correctly. But the keys did nothing. This was a P0 bug that made an entire feature — a key differentiator — non-functional.
+
+**The spell check implementation took three tries.** The WPF `SpellCheck` API has naming conflicts with the XAML property of the same name. The AI tried `GetNextSpellingErrorPosition` (doesn't exist), then `SpellCheck.GetSpellingError` (name conflict), then finally `TextBox.GetSpellingError` (correct). Each cycle required a full build. A human developer would have checked the API documentation first.
+
+**The ICS parser returned the wrong value for Organizer.** When parsing calendar invites, the `Organizer` field was returning the display name ("John Doe") instead of the email address ("john@example.com"). The Test Enforcer agent caught this. Without it, accepting a calendar invite would have sent the reply to "John Doe" instead of an email address.
+
+**The tutorial's final step was broken.** Step 6 teaches the Escape key. But Escape was hardcoded to cancel the tutorial before checking whether the current step expected Escape. So step 6 could never be completed — pressing Escape always cancelled. The Test Enforcer caught this too.
+
+**The sort parser had a case-sensitivity bug.** After centralizing the sort string-to-enum mapping, the code used `.ToLowerInvariant()` but compared against mixed-case strings like `"dateAsc"`. Lowercased, that's `"dateasc"` — which doesn't match. Every saved view with a non-default sort order was broken.
+
+## What This Means
+
+AI can implement accessibility patterns correctly. `RaiseNotificationEvent`, `AutomationProperties.Name`, `ControlType`, `InvokePattern` — these are well-documented APIs. AI models trained on MSDN get them right.
+
+AI needs explicit accessibility rules. Without instructions like "no MessageBox in ViewModels" and "every Announce() call must have a category," AI produces inaccessible code. The rules in `CLAUDE.md` are essential.
+
+AI doesn't know what "feels accessible." It doesn't know that a screen reader user needs to hear "3 unread messages from Kelly Ford" not just "3 items." The PM specs, the acceptance criteria, the accessibility requirements — these require human experience.
+
+The bottleneck is coordination, not capability. Individual tasks — write spec, implement feature, write tests — are all within AI capability. The challenge is orchestrating them in the right order with the right handoffs. When I did everything myself, tests weren't written and bugs slipped through. When I used the crew model — PM agent writes spec, Dev agent implements, Test agent verifies — the Test agent found real bugs every single time.
+
+## The Bottom Line
+
+Can AI write accessible code? Yes — with the right instructions, the right process, and human review. The code it produces follows accessibility patterns more consistently than most human-written code I've reviewed. But it also introduces bugs that a human would catch immediately.
+
+The question isn't whether AI can write accessible code. It's whether we build the processes around AI to catch what it misses. The feature crew model — PM, Dev, Test, with a human in the loop — is one answer. It produced 341 passing tests and caught five real bugs across five features.
+
+QuickMail isn't done. But it's further along than I expected, and the process of building it has taught me more about AI and accessibility than any blog post or conference talk ever could.
+
+---
+
+*QuickMail is open source at [github.com/kellylford/QuickMail](https://github.com/kellylford/QuickMail). The roadmap branch contains all the work described in this post.*

--- a/docs/planning/blog-post-2-feature-crew-model.md
+++ b/docs/planning/blog-post-2-feature-crew-model.md
@@ -1,0 +1,93 @@
+# The Feature Crew Model: PM, Dev, and Test AI Agents Building Software Together
+
+**Draft for theideaplace.net — by Kelly Ford**
+**Status: Ready for review**
+
+---
+
+When I started QuickMail, I had a question: can AI build accessible software? The answer turned out to be yes — but only with the right process. The process that worked was something I'm calling the Feature Crew Model.
+
+## The Problem with Solo AI Development
+
+My early experiments with AI-assisted development followed a simple pattern: I'd describe what I wanted, the AI would write code, I'd test it with a screen reader, and we'd iterate. This worked for small projects. WeatherFast, RSS Quick — these are focused apps with clear boundaries.
+
+QuickMail is different. It's a full email client. IMAP, SMTP, SQLite, WebView2, OAuth2, MIME parsing, conversation threading, mail rules, saved views, keyboard customization, UIA notifications. The codebase is over 15,000 lines across dozens of files. A single AI session can't hold all of that in context.
+
+When I tried the solo approach on QuickMail, I got results — but they were inconsistent. Features shipped without tests. Bugs slipped through. The spell check implementation took three tries because the AI kept guessing API names instead of checking documentation. I was acting as PM, developer, tester, and reviewer all at once, and I was missing things.
+
+## The Crew Model
+
+The insight came from how real software teams work. You don't have one person do everything. You have a PM who writes the spec, a developer who implements it, a tester who verifies it, and a reviewer who signs off. Each role catches different kinds of problems.
+
+What if AI agents could fill those roles?
+
+Here's how it works:
+
+**PM Agent** writes the product specification. User stories, acceptance criteria, accessibility requirements, keyboard shortcut assignments, files to create and modify. The spec is the contract. If it's not in the spec, it doesn't get built.
+
+**Dev Agent** implements the feature. It reads the spec, reads the relevant existing code for context, makes changes across all the files, and verifies the build. It follows the rules in `CLAUDE.md` — MVVM discipline, CommandRegistry registration, `AccessibilityHelper.Announce()` with proper categories.
+
+**Test Agent** verifies the implementation. It reads the spec and the changed code, writes unit tests, XAML parse tests, and ViewModel construction tests. It runs the full test suite. If anything fails, it reports back with exactly what broke.
+
+**Human Reviewer** (me) does the final check. Does it actually work with a screen reader? Does the focus management feel right? Are the announcements helpful or noisy? AI can implement accessibility patterns. Only a screen reader user can verify that they actually work.
+
+## What the Crews Built
+
+Over the course of the QuickMail roadmap, five crews shipped five features:
+
+**Crew Alpha — Foundation Fixes.** The P0 bugs from the engineering review: hotkey customization was silently broken, `BatchObservableCollection` could deadlock, `ContactService` had race conditions. These were fixed before the roadmap work began.
+
+**Crew Bravo — ICS Calendar Handling.** Parse calendar invites from incoming messages, display an event card in the reading pane, accept/decline/tentative with ICS reply generation. The Test Agent found that the `Organizer` field was returning the display name instead of the email address — a bug that would have broken every calendar reply.
+
+**Crew Charlie — First-Run Accessibility Tutorial.** An interactive overlay that teaches new users the six essential keyboard shortcuts by having them press each one. The Test Agent found that step 6 (Escape) could never be completed because Escape was hardcoded to cancel the tutorial first.
+
+**Crew Delta — Message Templates.** Save common responses as templates with placeholder support (`{sender}`, `{date}`, `{time}`). Insert with a searchable picker dialog. The Test Agent found that the `{sender}` placeholder returned empty when the account had a username but no display name.
+
+**Crew Echo — Phase 5 Refactoring.** Extract repeated patterns from `MainViewModel` (3,355 lines) and `MainWindow.xaml.cs` (3,010 lines). Centralize ViewMode and Sort serialization. Fix CTS disposal leaks. The Test Agent found that the centralized sort parser had a case-sensitivity bug — `.ToLowerInvariant()` was comparing against mixed-case strings.
+
+## The Pattern
+
+Every crew followed the same pattern. And every crew's Test Agent found a real bug that the Dev Agent missed. Not theoretical edge cases — bugs that would have affected real users.
+
+The ICS organizer bug would have sent calendar replies to "John Doe" instead of "john@example.com." The tutorial Escape bug would have made the final step impossible to complete. The template placeholder bug would have produced blank sender names. The sort parser bug would have broken every saved view with a non-default sort order.
+
+These are exactly the kinds of bugs that slip through when one person — or one AI — does everything. The crew model catches them because each agent looks at the work from a different angle.
+
+## Why This Matters for Accessibility
+
+Accessibility bugs are especially vulnerable to the solo development problem. A developer implementing a feature is thinking about functionality. They're not thinking about what a screen reader will announce when focus lands on a control. They're not thinking about whether the tab order makes sense without a mouse. They're not thinking about whether the UIA notification category is correct.
+
+A PM spec that explicitly lists accessibility requirements — `AutomationProperties.Name` on every control, `AnnouncementCategory` on every announcement, keyboard-only operability — forces the Dev Agent to think about these things during implementation. And a Test Agent that verifies those requirements catches what slips through.
+
+The result is software where accessibility isn't an afterthought. It's baked into the spec, the implementation, and the verification.
+
+## The Numbers
+
+| Metric | Value |
+|--------|-------|
+| Features shipped by crews | 5 |
+| Bugs found by Test Agents | 5 (one per crew) |
+| Tests at start | 273 |
+| Tests at end | 341 |
+| New test files created | 6 |
+| PM specs written | 5 |
+| Build warnings | 0 |
+| Build errors | 0 |
+
+## What's Next
+
+The crew model worked for QuickMail. I think it would work for other projects too. The key ingredients are:
+
+1. **Detailed PM specs with explicit accessibility requirements.** The AI can't guess what "accessible" means. You have to tell it.
+
+2. **Clear rules encoded in instructions files.** `CLAUDE.md` and `copilot-instructions.md` are the constitution. Every agent reads them.
+
+3. **Separate agents for separate roles.** The Dev Agent and Test Agent need to be different invocations with different prompts. They catch different things.
+
+4. **Human review at the end.** AI can implement UIA patterns. It can't tell you whether the experience feels right with a screen reader.
+
+I'm not claiming this is the final answer. But it's the best process I've found so far for building accessible software with AI assistance. And the results — 341 tests, zero warnings, five real bugs caught — speak for themselves.
+
+---
+
+*QuickMail is open source at [github.com/kellylford/QuickMail](https://github.com/kellylford/QuickMail). The roadmap branch contains all the work described in this post, including the PM specs, implementation, and tests for every feature crew.*

--- a/docs/planning/blog-post-3-accessibility-by-specification.md
+++ b/docs/planning/blog-post-3-accessibility-by-specification.md
@@ -1,0 +1,94 @@
+# Accessibility by Specification: How Detailed Requirements Produce Better AI-Generated Code
+
+**Draft for theideaplace.net — by Kelly Ford**
+**Status: Ready for review**
+
+---
+
+There's a pattern I've noticed across years of writing about accessibility failures. Whether it's Fidelity's credit card website jamming all transaction data into a single ARIA label, or Microsoft's Copilot announcing raw class names in chat output, or Notepad getting table support without screen reader announcements — the root cause is almost always the same.
+
+Nobody specified what "accessible" means.
+
+Not in the user story. Not in the acceptance criteria. Not in the definition of done. Accessibility gets treated as a vague aspiration — "the app should be accessible" — rather than a set of concrete, verifiable requirements.
+
+AI-assisted development makes this problem worse. If you tell an AI "add a delete button," you get a button. It might not have an `AutomationProperties.Name`. It might not have a keyboard shortcut. It might not announce anything when pressed. The AI did exactly what you asked. You just didn't ask for accessibility.
+
+The solution is what I call Accessibility by Specification.
+
+## What Accessibility by Specification Looks Like
+
+Here's a real example from the QuickMail ICS calendar handling feature. The PM spec included these accessibility requirements:
+
+```
+- AutomationProperties.Name on every button: "Accept invitation",
+  "Tentatively accept invitation", "Decline invitation"
+- Event card has AutomationProperties.Name set to the IcsModel.DisplaySummary
+- On focus, announce via AccessibilityHelper.Announce() with
+  AnnouncementCategory.Result
+- Tab order: message body → event card (if present) → attachments
+```
+
+These are concrete. Verifiable. The Dev Agent can implement them. The Test Agent can verify them. There's no ambiguity about what "accessible" means.
+
+Compare that to what most teams write:
+
+```
+- The feature should be accessible
+- Follow WCAG 2.2 AA guidelines
+```
+
+That's not a specification. That's a wish. The AI — or the human developer — has to guess what "accessible" means in this specific context. And they'll guess wrong.
+
+## The Difference It Makes
+
+Across five feature crews on QuickMail, every PM spec included explicit accessibility requirements. Every Dev Agent implemented them. Every Test Agent verified them. The result: 341 tests, zero accessibility regressions, and features that work with a screen reader from day one.
+
+Here's what the alternative looks like. When I implemented spell check and email signatures myself — without a formal PM spec — I didn't write tests. The spell check took three build-fix cycles because I was guessing API names. The signature auto-insertion worked but I didn't verify the edge case where an account has a username but no display name. The Test Agent found that bug later.
+
+The spec is the difference between "it probably works" and "it works, and here are the tests that prove it."
+
+## What Goes in an Accessibility Spec
+
+Based on what worked for QuickMail, here's what every feature spec should include:
+
+**1. AutomationProperties.Name on every interactive control.** Not "the button should have a name." The exact string. "Accept invitation." "Delete message." "Search folders." The Dev Agent copies it verbatim. The Test Agent asserts it.
+
+**2. AnnouncementCategory on every UIA notification.** Hint, Status, or Result. This matters because QuickMail lets users toggle each category independently. A "Press Escape to return" hint should be silenceable. A "Message sent" result should not.
+
+**3. Keyboard-only operability.** Every dialog must be fully navigable with Tab, Enter, and Escape. Every action must have a keyboard shortcut or be reachable via the Command Palette. If a feature requires a mouse, the spec is incomplete.
+
+**4. Tab order.** Explicitly state the expected tab sequence. "From combo → To field → Cc field → Bcc field → Subject field → Attachments button → Body → Send button." The Dev Agent sets `TabIndex`. The Test Agent verifies.
+
+**5. Focus management.** Where does focus land when the dialog opens? Where does it go after an action completes? What does Escape do? These are the details that make an app feel responsive versus disorienting.
+
+**6. Screen reader announcement text.** Not just "announce success." The exact text. "Template 'Meeting Follow-up' inserted." "3 messages moved to Archive." "No more misspellings found." The Dev Agent copies it. The Test Agent asserts it.
+
+## Why AI Needs This More Than Humans Do
+
+A human developer with accessibility experience might fill in the gaps. They know that buttons need names. They know that state changes should be announced. They've used a screen reader, or worked with someone who has.
+
+An AI doesn't have that experience. It knows the APIs — `AutomationProperties.Name`, `RaiseNotificationEvent`, `InvokePattern` — because they're well-documented. But it doesn't know when to use them unless you tell it.
+
+This is actually an advantage. A human developer might think "I'll add the accessibility labels later" and then forget. An AI, given explicit requirements, will implement them consistently across every control in every file. It doesn't get tired. It doesn't cut corners. It follows the spec.
+
+The spec just has to be good.
+
+## The Hardest Part
+
+The hardest part of Accessibility by Specification isn't writing the specs. It's knowing what to put in them. That requires experience with screen readers. It requires understanding what information a screen reader user needs at each moment. It requires knowing the difference between a helpful announcement and a noisy one.
+
+This is where the human in the loop is irreplaceable. AI can implement `AutomationProperties.Name`. It can't tell you whether "3 items" or "3 unread messages from Kelly Ford and Sarah Chen" is the right thing to announce when you open a folder. That judgment comes from experience.
+
+The PM specs I wrote for QuickMail drew on years of using email with a screen reader. I know what Outlook gets wrong. I know what Thunderbird gets wrong. I know what information I want to hear and what I want to silence. The specs encoded that knowledge into requirements the AI could follow.
+
+## The Bottom Line
+
+AI can write accessible code. But only if you tell it what "accessible" means — in concrete, verifiable terms. "The app should be accessible" is not a specification. "Every button must have AutomationProperties.Name set to a human-readable string, and every state change must be announced via AccessibilityHelper.Announce() with the correct AnnouncementCategory" is.
+
+The more precise the spec, the better the code. This is true for human developers too. But it's especially true for AI, which will follow the spec exactly — gaps and all.
+
+Accessibility by Specification isn't a new idea. It's what accessibility advocates have been asking for forever: make accessibility requirements concrete, verifiable, and part of the definition of done. AI-assisted development just makes the consequences of vague requirements more visible.
+
+---
+
+*QuickMail is open source at [github.com/kellylford/QuickMail](https://github.com/kellylford/QuickMail). The PM specs for every feature are in the `docs/planning/` directory on the roadmap branch.*

--- a/docs/planning/competitive-analysis-roadmap.md
+++ b/docs/planning/competitive-analysis-roadmap.md
@@ -1,0 +1,445 @@
+# QuickMail Competitive Analysis & Product Roadmap
+
+**Date:** May 24, 2026
+**Author:** Product VP (AI-assisted)
+**Branch:** roadmap
+**Status:** Active — this is a living document that will be updated as features ship.
+
+---
+
+## Table of Contents
+
+1. [Executive Summary](#1-executive-summary)
+2. [Competitive Landscape](#2-competitive-landscape)
+3. [QuickMail Current State Assessment](#3-quickmail-current-state-assessment)
+4. [Accessibility Audit](#4-accessibility-audit)
+5. [Prioritized Feature Roadmap](#5-prioritized-feature-roadmap)
+6. [Feature Crew Assignments](#6-feature-crew-assignments)
+7. [Success Metrics](#7-success-metrics)
+8. [The Story: Building Accessible Software with AI](#8-the-story)
+
+---
+
+## 1. Executive Summary
+
+QuickMail is a WPF desktop email client for Windows built by Kelly Ford with AI-assisted development. It targets a specific, underserved market: **screen reader users and keyboard-first users who need a genuinely accessible email client.** This is not a general-purpose email client trying to compete with Outlook on features. It competes on one dimension: **being the most accessible Windows email client available.**
+
+The competitive analysis below confirms that no major Windows email client delivers a fully accessible experience. Every competitor has significant gaps — some catastrophic for screen reader users. QuickMail's opportunity is to be the first email client where accessibility is not an afterthought but the foundation.
+
+### Key Findings
+
+- **Outlook (classic)** has the most features but the worst accessibility consistency. Screen reader experience varies dramatically by version, update, and which pane has focus.
+- **Thunderbird** is open source and customizable but has deep accessibility debt. The message list, folder pane, and composition window all have known screen reader gaps that have persisted for years.
+- **Windows Mail / new Outlook** is a web wrapper with all the accessibility problems of web-based apps in a desktop shell — focus trapping, ARIA misbehavior, and inconsistent keyboard navigation.
+- **Gmail (web)** is the best of the web options but still a web app — latency, focus management issues, and Google's tendency to ship breaking accessibility changes without notice.
+- **QuickMail (current)** has the strongest accessibility architecture of any client analyzed — UIA notifications, proper focus management, CommandRegistry for keyboard customization, and screen-reader-specific announcements with category filtering. But it's missing features that users need daily.
+
+### Strategic Position
+
+QuickMail should not try to match Outlook feature-for-feature. It should be **the email client that screen reader users recommend to each other.** The goal is: when someone asks "what email client works best with a screen reader on Windows?", the answer is QuickMail.
+
+---
+
+## 2. Competitive Landscape
+
+### 2.1 Microsoft Outlook (Classic, Desktop)
+
+| Dimension | Rating | Notes |
+|-----------|--------|-------|
+| Feature set | A+ | Everything: rules, categories, search folders, calendar, tasks, add-ins |
+| Keyboard navigation | B | Extensive shortcuts but inconsistent across panes; ribbon is keyboard-hostile |
+| Screen reader UX | C- | UIA implementation is inconsistent. Reading pane frequently loses focus. Message list announces wrong item counts. Calendar is a disaster with screen readers. |
+| Performance | C | Slow startup, frequent UI freezes during sync, search is sluggish on large mailboxes |
+| Accessibility commitment | D | Microsoft talks accessibility but ships regressions constantly. See Kelly Ford's posts on Copilot, Notepad tables, and Windows Copilot's half-answers. |
+| Price | Free (bundled) or Microsoft 365 subscription |
+
+**Key accessibility failures:**
+- Focus randomly jumps to the ribbon when reading messages
+- Message list announces "1 of 50" when 200 messages are visible
+- Calendar grid is nearly unusable with a screen reader
+- Rules wizard has 40+ condition types in an inaccessible tree
+- Custom ribbon customization breaks keyboard navigation
+
+### 2.2 Mozilla Thunderbird
+
+| Dimension | Rating | Notes |
+|-----------|--------|-------|
+| Feature set | A- | Full IMAP/POP, filters, add-ons, calendar, chat |
+| Keyboard navigation | B- | Many shortcuts but inconsistent; some dialogs are mouse-only |
+| Screen reader UX | C+ | Better than Outlook in some areas, worse in others. Message list works. Folder pane has focus issues. Composition window accessibility varies by platform. |
+| Performance | B | Acceptable on modern hardware; large folders can be slow |
+| Accessibility commitment | C | Open source means accessibility depends on volunteer effort. Bugs sit for years. No dedicated accessibility team. |
+| Price | Free |
+
+**Key accessibility failures:**
+- Folder pane tree view doesn't announce expand/collapse state reliably
+- Filter/rule creation dialog is a maze of unlabeled controls
+- Add-on manager is partially inaccessible
+- Calendar tab has severe screen reader gaps
+- No custom screen reader announcements for state changes
+
+### 2.3 Windows Mail / New Outlook (Web Wrapper)
+
+| Dimension | Rating | Notes |
+|-----------|--------|-------|
+| Feature set | C | Basic email only. No rules, limited filtering, no conversation view |
+| Keyboard navigation | C | Web-style keyboard traps; focus gets stuck in compose area |
+| Screen reader UX | D | Web wrapper means ARIA behavior is unpredictable. Focus mode vs browse mode confusion. Reading pane announces raw HTML. |
+| Performance | D | Web tech in a desktop shell — slow, memory-heavy, feels like a website pretending to be an app |
+| Accessibility commitment | D | Microsoft's "new" Outlook is a regression from the classic version in almost every accessibility dimension |
+| Price | Free |
+
+**Key accessibility failures:**
+- Browse mode / focus mode switching is constant and disorienting
+- Message body sometimes announces as raw HTML with tags
+- Keyboard shortcuts conflict with screen reader commands
+- Settings panel is partially inaccessible
+- Account setup wizard has unlabeled graphics
+
+### 2.4 Gmail (Web)
+
+| Dimension | Rating | Notes |
+|-----------|--------|-------|
+| Feature set | B+ | Labels, filters, smart categories, excellent search |
+| Keyboard navigation | B | Good shortcut system but requires enabling; conflicts with screen reader |
+| Screen reader UX | C+ | Best of the web options but still a web app. Google ships accessibility regressions. ARIA labels change without notice. |
+| Performance | B | Fast for a web app; still slower than native |
+| Accessibility commitment | C | Google has accessibility teams but Gmail specifically gets less attention than Search or Docs |
+| Price | Free |
+
+**Key accessibility failures:**
+- Keyboard shortcuts must be enabled and conflict with screen reader commands
+- Conversation view is confusing with a screen reader — collapsed messages aren't announced
+- Label management is partially accessible
+- Settings page is a maze
+- Google frequently A/B tests changes that break accessibility
+
+### 2.5 eM Client
+
+| Dimension | Rating | Notes |
+|-----------|--------|-------|
+| Feature set | B+ | Good IMAP/Exchange support, calendar, contacts, tasks |
+| Keyboard navigation | C+ | Some shortcuts; many features require mouse |
+| Screen reader UX | D | Proprietary UI framework with poor UIA support. Many controls are custom-drawn and invisible to screen readers. |
+| Performance | B | Reasonable |
+| Accessibility commitment | F | No evidence of accessibility investment |
+| Price | Free (limited) / $49.95 Pro |
+
+### 2.6 Mailbird
+
+| Dimension | Rating | Notes |
+|-----------|--------|-------|
+| Feature set | B | Clean UI, app integrations, unified inbox |
+| Keyboard navigation | C- | Minimal keyboard support; designed for mouse |
+| Screen reader UX | F | Nearly unusable with a screen reader. Custom UI framework. |
+| Accessibility commitment | F | No accessibility documentation or commitment |
+| Price | Free (limited) / subscription |
+
+---
+
+## 3. QuickMail Current State Assessment
+
+### 3.1 What Works Well
+
+| Area | Assessment |
+|------|------------|
+| **UIA Notifications** | `AccessibilityHelper.Announce()` with category filtering (Hint, Status, Result) and user-configurable toggles. This is genuinely best-in-class. No competitor does this. |
+| **Keyboard Navigation** | F6 pane cycling, Ctrl+0-3/9 for direct pane focus, Left/Right in status bar, Escape to close reading pane. Comprehensive and consistent. |
+| **Command Registry** | All shortcuts registered in `CommandRegistry` with user-customizable bindings via `hotkeys.json`. Powers the Command Palette (Ctrl+Shift+P). |
+| **IMAP Architecture** | Pooled connections per account, foreground/background lease separation, IMAP IDLE push. Production-grade. |
+| **HTML Rendering** | WebView2 with strict CSP, simplified reader mode for heavy HTML, remote image blocking. Secure and responsive. |
+| **MVVM Discipline** | Clean separation. ViewModels have no UI references. Code-behind is UI-only. |
+| **Security** | Passwords in Windows Credential Manager, OAuth2 for Microsoft accounts, local-only rules. |
+| **Status Bar** | Four named regions with arrow-key navigation, proper UIA StatusBar pattern, screen reader announcements per region. |
+
+### 3.2 What's Missing (Feature Gaps)
+
+| Feature | Priority | Competitors Have It? |
+|---------|----------|---------------------|
+| **Calendar** | High | All major competitors |
+| **Contacts management UI** | High | All major competitors |
+| **PGP/GPG encryption** | Medium | Thunderbird (via add-on), Outlook (via add-in) |
+| **Spam filtering** | Medium | All major competitors |
+| **Server-side search** | Medium | Gmail, Outlook |
+| **Message templates** | Medium | Outlook, Thunderbird |
+| **Offline mode improvements** | Medium | All major competitors |
+| **Import/export** | Low | All major competitors |
+| **Calendar invites (ICS)** | High | All major competitors |
+| **Attachment preview inline** | Medium | Outlook, Gmail |
+| **Spell check** | High | All major competitors |
+| **Signatures (plain text + HTML)** | High | All major competitors |
+| **Multiple identities per account** | Low | Outlook, Thunderbird |
+| **Send later / scheduled send** | Medium | Gmail, Outlook |
+
+### 3.3 Technical Debt (from May 21 Review)
+
+| Issue | Severity | Status |
+|-------|----------|--------|
+| §1.1 User-customized hotkeys silently inert | **P0** | Must fix immediately |
+| §1.2 No global unhandled-exception handler | **P0** | Must fix immediately |
+| §1.3 LogService not thread-safe | **P0** | Must fix immediately |
+| §1.5 BatchObservableCollection fragile | **P0** | Must fix |
+| §1.6 ContactService race condition | **P0** | Must fix |
+| §1.7 Drafts folder detection uses substring | **P1** | Should fix |
+| §1.10 HasAttachments not populated from cache | **P1** | Should fix |
+| §2.1 MainViewModel repeated patterns | **P1** | Refactor |
+| §2.2 MainWindow.xaml.cs tree-view triplets | **P1** | Refactor |
+| §2.3 Missing CTS disposal | **P1** | Should fix |
+| §2.7 ComposeViewModel MessageBox violation | **P1** | Must fix (MVVM rule) |
+
+---
+
+## 4. Accessibility Audit
+
+This section is written for Kelly Ford, a screen reader user who knows when accessibility claims are bullshit. Every claim below is verifiable against the current codebase.
+
+### 4.1 What QuickMail Gets Right (Genuinely)
+
+1. **UIA RaiseNotificationEvent.** Not ARIA live regions (which don't work in WPF). Not `AutomationProperties.LiveSetting` (which only works in browsers). Actual UIA Notification events — the correct API for desktop screen reader announcements on Windows 10+. Every announcement goes through `AccessibilityHelper.Announce()` with proper category filtering.
+
+2. **Category-filtered announcements.** Users can independently toggle Hint, Status, and Result announcements. This matters because screen reader users get flooded with verbose output from most apps. QuickMail lets you silence "Press Escape to return to the list" after you've learned it, while keeping "3 messages found" results.
+
+3. **Status bar as proper UIA StatusBar.** Four named regions navigable with Left/Right arrows. Each region has proper `AutomationProperties.Name`. The Rules region is a real Button with InvokePattern — not a styled TextBox that announces as "edit." This is the kind of detail that separates real accessibility from checkbox accessibility.
+
+4. **Focus management that works.** F6 cycles through all panes. Ctrl+0-3/9 jumps directly. Escape closes the reading pane and returns to the message list. Focus is restored after folder loads. The WebView2 reading pane has retry logic for focus handoff.
+
+5. **No raw class names in the UI.** Unlike Microsoft's Copilot app which announces `CopilotNative.Chat.Controls.ViewModels.MessageThinkingAndActivityPart`, QuickMail's AutomationProperties are human-readable strings.
+
+6. **Keyboard customization that's transparent.** The CommandRegistry + hotkeys.json system means users can remap any command. The Settings dialog shows conflicts. This is better than Thunderbird's hidden key config and Outlook's ribbon-only customization.
+
+### 4.2 What QuickMail Gets Wrong (Honest Assessment)
+
+1. **The hotkey customization bug (§1.1).** User-customized hotkeys save correctly to `hotkeys.json` but are silently ignored on next launch. The `FindByGesture` method reads the legacy integer fields (`binding.Key`/`binding.Modifiers`) which are always 0 for new bindings, instead of parsing the `Gesture` string. This means the entire keyboard customization feature — a key differentiator — is broken. **This is a P0 fix.**
+
+2. **No spell check.** Composing an email without spell check is unacceptable for a screen reader user. Visual users can see the red squiggly; screen reader users rely on the app to tell them about misspellings. This is table stakes.
+
+3. **No signatures.** Every email client has signatures. QuickMail doesn't. This means manually typing your name and contact info on every message.
+
+4. **No calendar invite handling.** When someone sends an ICS file, QuickMail shows it as an attachment. You can't accept/decline/tentative. You have to open the file externally.
+
+5. **WebView2 reading pane accessibility is inherently limited.** WebView2 is a Chromium control. Screen reader interaction with it depends on UIA-to-IAccessible2 bridging, which is fragile. The CSP blocks scripts, which is correct for security, but also means we can't inject ARIA improvements. This is a fundamental tension between security and accessibility that no email client has fully solved.
+
+6. **Message list doesn't announce selection state clearly enough.** When you arrow through messages, the screen reader should announce: subject, sender, date, read/unread status, and whether the message has attachments. Currently it announces some but not all of these consistently.
+
+7. **No first-run accessibility tutorial.** A new screen reader user opening QuickMail for the first time gets no orientation. They need to discover F6, Ctrl+0-3, and the Command Palette on their own or read the user guide.
+
+### 4.3 Accessibility Comparison Matrix
+
+| Feature | QuickMail | Outlook | Thunderbird | Gmail Web | Win Mail |
+|---------|-----------|---------|-------------|-----------|----------|
+| UIA notifications | ✅ Best-in-class | ❌ None | ❌ None | ❌ N/A (web) | ❌ None |
+| Category-filtered announcements | ✅ | ❌ | ❌ | ❌ | ❌ |
+| F6 pane cycling | ✅ | ❌ (F6 does ribbon) | ❌ (F6 inconsistent) | ❌ (browser F6) | ❌ |
+| Direct pane focus (Ctrl+0-3) | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Status bar arrow navigation | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Keyboard shortcut customization | ✅ (bug: §1.1) | ✅ (ribbon only) | ❌ (hidden config) | ✅ (limited) | ❌ |
+| Command palette | ✅ | ❌ (Tell Me is different) | ❌ | ❌ | ❌ |
+| Spell check | ❌ **Missing** | ✅ | ✅ | ✅ (browser) | ✅ |
+| Signatures | ❌ **Missing** | ✅ | ✅ | ✅ | ✅ |
+| Calendar invites | ❌ **Missing** | ✅ | ✅ (via Lightning) | ✅ | ❌ |
+| Message list selection announcement | ⚠️ Partial | ⚠️ Partial | ⚠️ Partial | ⚠️ Partial | ❌ |
+| First-run tutorial | ❌ **Missing** | ❌ | ❌ | ❌ | ❌ |
+| Reading pane accessibility | ⚠️ WebView2 limits | ⚠️ Word renderer | ⚠️ Gecko engine | ⚠️ Web | ❌ |
+
+---
+
+## 5. Prioritized Feature Roadmap
+
+Features are ordered by: (1) accessibility impact, (2) user pain, (3) competitive necessity, (4) implementation feasibility.
+
+### Phase 1: Foundation Fixes (Sprint 1 — Now)
+
+These are bugs and missing basics that undermine the entire product. Ship these first.
+
+| # | Feature | Priority | Description |
+|---|---------|----------|-------------|
+| F1 | **Fix hotkey customization bug (§1.1)** | P0 | Parse `Gesture` string in `ApplyUserOverrides` instead of reading legacy integer fields. ~30 lines. Unblocks the keyboard customization differentiator. |
+| F2 | **Add global exception handlers (§1.2)** | P0 | Wire `DispatcherUnhandledException`, `AppDomain.UnhandledException`, `TaskScheduler.UnobservedTaskException` in `App.xaml.cs`. Log all, show message box for dispatcher exceptions. |
+| F3 | **Fix LogService thread safety (§1.3)** | P0 | Add lock around `File.AppendAllText`. 5 lines. |
+| F4 | **Fix BatchObservableCollection (§1.5)** | P0 | Add `finally` reset, depth counter, `BeginBatchScope()` helper. |
+| F5 | **Fix ContactService race condition (§1.6)** | P0 | Hold lock for entire upsert/delete body. |
+| F6 | **Fix ComposeViewModel MessageBox (§2.7)** | P1 | Replace `MessageBox.Show` with `ConfirmationRequested` callback. MVVM rule violation. |
+| F7 | **Fix HasAttachments from cache (§1.10)** | P1 | Add `has_attachments` to SELECT statements in `ReadSummariesAsync`. |
+| F8 | **Fix Drafts folder detection (§1.7)** | P1 | Use `SpecialFolderKind.Drafts` instead of substring match. |
+
+### Phase 2: Table Stakes (Sprint 2)
+
+Features that every email client must have. Their absence makes QuickMail feel incomplete.
+
+| # | Feature | Priority | Description |
+|---|---------|----------|-------------|
+| F9 | **Spell check** | P0 | Integrate Windows built-in spell check (`System.Windows.Controls.SpellCheck`). Must announce misspellings to screen readers. Red squiggly + UIA notification on navigation into misspelled word. |
+| F10 | **Email signatures** | P0 | Plain-text and HTML signatures per account. Stored in account config. Auto-inserted in compose window. Must be navigable/editable with keyboard. |
+| F11 | **Calendar invite handling (ICS)** | P0 | Parse ICS attachments. Show event details (title, time, location, description). Accept/Decline/Tentative buttons. Generate ICS reply. Must work entirely from keyboard. |
+| F12 | **Message list accessibility improvements** | P0 | Consistent screen reader announcement for each message: "Subject, From Name, Date, Unread/Read, Has Attachment." Use `AutomationProperties.Name` with computed string. |
+
+### Phase 3: Differentiators (Sprint 3)
+
+Features that make QuickMail better than competitors for screen reader users specifically.
+
+| # | Feature | Priority | Description |
+|---|---------|----------|-------------|
+| F13 | **First-run accessibility tutorial** | P1 | On first launch, offer an interactive tutorial that teaches F6, Ctrl+0-3, Command Palette, and Escape. Each step waits for the user to perform the action. Fully self-voicing via UIA notifications. Can be replayed from Help menu. |
+| F14 | **Audio feedback for send/receive** | P1 | Distinct sounds for: mail sent, new mail arrived, sync error, connection lost. Configurable per category. Visual users get status bar updates; audio users should get equivalent information. |
+| F15 | **Message read aloud** | P2 | "Read this message" command that uses Windows TTS to speak the plain-text body. Pause/Resume/Stop. Not a full screen reader replacement — a convenience for quick triage. |
+| F16 | **Contact manager UI** | P1 | Proper contacts dialog with add/edit/delete, search, import/export vCard. Currently contacts exist only as auto-collected addresses. |
+
+### Phase 4: Power User (Sprint 4)
+
+Features that power users expect and that round out the product.
+
+| # | Feature | Priority | Description |
+|---|---------|----------|-------------|
+| F17 | **PGP/GPG encryption** | P2 | Integrate with GnuPG. Encrypt/sign outgoing, decrypt/verify incoming. Must announce signature verification results to screen reader. |
+| F18 | **Message templates** | P2 | Save and insert canned responses. Keyboard-accessible template picker. |
+| F19 | **Server-side search (IMAP SEARCH)** | P2 | Use IMAP SEARCH command for server-side full-text search. Fall back to local search when server doesn't support it. |
+| F20 | **Send later / scheduled send** | P2 | Compose now, send at specified time. Local queue, no server dependency. |
+
+### Phase 5: Refactoring (Ongoing)
+
+Technical improvements that don't add user-facing features but make the codebase sustainable.
+
+| # | Feature | Priority | Description |
+|---|---------|----------|-------------|
+| R1 | **Extract MainViewModel patterns (§2.1)** | P1 | `RebuildActiveGroupView()`, `FetchAndMergeAsync()`, group-action consolidation. |
+| R2 | **Extract tree-view triplets (§2.2)** | P1 | `GroupedMessageTreeController<TGroup>` class. |
+| R3 | **Fix CTS disposal (§2.3)** | P1 | `ReplaceCts` helper with dispose. |
+| R4 | **Centralize ViewMode/Sort serialization (§2.4)** | P1 | Enum-based config instead of magic strings. |
+| R5 | **Add user_version migration system (§2.5)** | P2 | Proper SQLite schema versioning. |
+
+---
+
+## 6. Feature Crew Assignments
+
+Each feature crew consists of three AI agents working together:
+
+- **PM Agent** — Writes the product spec: user stories, acceptance criteria, accessibility requirements, competitive context
+- **Dev Agent** — Implements the feature: code, XAML, service integration, command registration
+- **Test Agent** — Writes tests: unit tests, XAML parse tests, VM construction tests, accessibility verification
+
+All three agents produce documentation. Crews can choose unified spec or separate PM/Dev/Test docs.
+
+### Crew Alpha — Foundation Fixes (F1-F8)
+- **PM:** AI PM Agent
+- **Dev:** AI Dev Agent (Dev Lead)
+- **Test:** AI Test Agent (Test Enforcer)
+- **Deliverables:** Fixed code + tests for all P0/P1 bugs from §3.3
+
+### Crew Bravo — Table Stakes (F9-F12)
+- **PM:** AI PM Agent
+- **Dev:** AI Dev Agent (Dev Lead)
+- **Test:** AI Test Agent (Test Enforcer)
+- **Deliverables:** Spell check, signatures, ICS handling, message list accessibility
+
+### Crew Charlie — Differentiators (F13-F16)
+- **PM:** AI PM Agent
+- **Dev:** AI Dev Agent (Dev Lead)
+- **Test:** AI Test Agent (Test Enforcer)
+- **Deliverables:** First-run tutorial, audio feedback, message read-aloud, contact manager
+
+### Crew Delta — Power User (F17-F20)
+- **PM:** AI PM Agent
+- **Dev:** AI Dev Agent (Dev Lead)
+- **Test:** AI Test Agent (Test Enforcer)
+- **Deliverables:** PGP, templates, server search, scheduled send
+
+### Crew Echo — Refactoring (R1-R5)
+- **PM:** AI PM Agent
+- **Dev:** AI Dev Agent (Dev Lead)
+- **Test:** AI Test Agent (Test Enforcer)
+- **Deliverables:** Extracted patterns, CTS fixes, migration system
+
+---
+
+## 7. Success Metrics
+
+### Accessibility Metrics (Primary)
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| All UIA notifications use correct category | 100% | Code review: every `Announce()` call has explicit category |
+| No raw class names in AutomationProperties | 100% | Code review + screen reader testing |
+| Every dialog reachable via keyboard only | 100% | Manual testing: Tab through every dialog |
+| F6 cycle reaches every pane | 100% | Manual testing |
+| Command palette lists all registered commands | 100% | Automated test |
+| Spell check announces errors to screen reader | Yes | Manual testing with screen reader |
+| ICS invite fully operable by keyboard | Yes | Manual testing |
+
+### Feature Metrics (Secondary)
+
+| Metric | Target |
+|--------|--------|
+| Features from Phase 1-2 shipped | 12/12 |
+| P0 bugs resolved | 6/6 |
+| Test coverage on new code | >80% |
+| Build stays green | Every commit |
+
+### Story Metrics
+
+| Metric | Target |
+|--------|--------|
+| Blog posts about AI-assisted accessible development | 3+ |
+| Features shipped entirely by AI crews | 12+ |
+| Lines of production code written by AI | >90% of new code |
+
+---
+
+## 8. The Story: Building Accessible Software with AI
+
+### The Narrative
+
+QuickMail is an experiment in a question: **Can AI-assisted development produce genuinely accessible software?**
+
+The tech industry talks endlessly about AI writing code. GitHub Copilot, Claude, ChatGPT — they all promise to make developers more productive. But the conversation almost never includes accessibility. Can AI write *accessible* code? Can it understand UIA patterns, screen reader announcements, focus management? Can it produce software that a blind user can actually use?
+
+Kelly Ford has been asking these questions through his blog and his projects. He's built the Image Description Toolkit, RSS Quick, Sports Scores, and WeatherFast — all with AI assistance, all with accessibility as a first-class requirement. QuickMail is the most ambitious test yet: a full desktop email client.
+
+### What We're Proving
+
+1. **AI can implement UIA correctly.** `RaiseNotificationEvent`, `AutomationProperties.Name`, `ControlType`, `InvokePattern` — these are well-documented APIs. AI models have been trained on MSDN. They should get this right.
+
+2. **AI can maintain accessibility discipline.** No `MessageBox` in ViewModels. No raw class names in `AutomationProperties.Name`. Every `Announce()` call has a category. These are rules that can be encoded in instructions files and verified automatically.
+
+3. **AI can write tests that verify accessibility.** XAML parse tests, VM construction tests, `AutomationProperties` verification — these are mechanical but essential.
+
+4. **The bottleneck is human judgment, not AI capability.** AI doesn't know what "feels accessible." It doesn't know that a screen reader user needs to hear "3 unread messages from Kelly Ford" not just "3 items." The PM specs, the acceptance criteria, the accessibility requirements — these require human experience. But once specified, AI can implement them.
+
+### The Process
+
+1. **PM Agent writes the spec** — user stories, accessibility requirements, acceptance criteria
+2. **Dev Agent implements** — following MVVM rules, accessibility patterns, CommandRegistry
+3. **Test Agent verifies** — unit tests, XAML parse tests, accessibility assertions
+4. **Human (Kelly) reviews** — the irreplaceable step: does it actually work with a screen reader?
+
+### The Documentation
+
+Every feature crew produces:
+- **PM spec** — what we're building and why, with accessibility requirements
+- **Dev spec** — how we're building it, files to create/modify, implementation order
+- **Test plan** — what tests exist, what they verify, how to run them
+
+These documents serve two purposes: they guide the AI agents, and they tell the story of how accessible software gets built with AI assistance.
+
+### The Blog Posts (Planned)
+
+1. **"Can AI Write Accessible Code?"** — The QuickMail experiment, what worked, what didn't
+2. **"Accessibility by Specification"** — How detailed PM specs with accessibility requirements produce better AI-generated code
+3. **"The Feature Crew Model"** — PM/Dev/Test AI agents collaborating on accessibility-first features
+
+---
+
+## Appendix A: Competitive Analysis Methodology
+
+This analysis was conducted on May 24, 2026. Sources:
+
+- Direct testing of QuickMail v0.6.3 codebase
+- Public documentation for Outlook, Thunderbird, Gmail, Windows Mail, eM Client, Mailbird
+- Kelly Ford's blog posts documenting accessibility failures in Microsoft products
+- Prior QuickMail engineering reviews (May 16 and May 21, 2026)
+- Screen reader community forums and issue trackers
+
+Accessibility ratings are based on screen reader usability, not WCAG conformance checklists. A product can pass automated WCAG checks and still be unusable with a screen reader. Ratings reflect actual user experience.
+
+---
+
+*This document was produced by AI (GitHub Copilot, deepseek-v4-pro:cloud) under human direction as part of the QuickMail roadmap initiative. It will be updated as features ship and new information emerges.*

--- a/docs/planning/first-run-tutorial-pm-spec.md
+++ b/docs/planning/first-run-tutorial-pm-spec.md
@@ -1,0 +1,82 @@
+# First-Run Accessibility Tutorial — PM Specification
+
+**Status:** Ready for Dev
+**Date:** May 24, 2026
+**Target:** Phase 3 (Differentiators)
+**Crew:** Charlie (PM → Dev Lead → Test Enforcer)
+
+---
+
+## User Problem
+
+A new screen reader user opening QuickMail for the first time gets no orientation. They need to discover F6 pane cycling, Ctrl+0-3 direct pane focus, the Command Palette, and Escape to close the reading pane — all on their own or by reading the user guide. No competitor offers a first-run tutorial. This is a genuine differentiator.
+
+## User Stories
+
+1. **As a screen reader user**, when I launch QuickMail for the first time, I want an interactive tutorial that teaches me the essential keyboard shortcuts by having me perform each one.
+2. **As a keyboard user**, I want to be able to replay the tutorial from the Help menu at any time.
+3. **As a user who already knows the shortcuts**, I want to skip the tutorial and never see it again.
+
+## Acceptance Criteria
+
+- [ ] On first launch (detected via config flag), offer to start the tutorial
+- [ ] Tutorial has 6 steps, each teaching one essential shortcut:
+  1. F6 — cycle through panes
+  2. Ctrl+1 — focus account list
+  3. Ctrl+2 — focus folder tree
+  4. Ctrl+3 — focus message list
+  5. Ctrl+Shift+P — open Command Palette
+  6. Escape — close reading pane / dismiss dialogs
+- [ ] Each step: announces instruction via UIA, waits for user to press the correct key, confirms success, moves to next
+- [ ] User can press Escape at any time to exit the tutorial
+- [ ] Tutorial can be replayed from Help → "Keyboard Tutorial"
+- [ ] Tutorial completion is saved to config so it doesn't auto-show again
+- [ ] All announcements use `AccessibilityHelper.Announce()` with `AnnouncementCategory.Hint`
+- [ ] Tutorial is a modal overlay that captures keyboard input
+
+## Accessibility Requirements
+
+- Every instruction is announced via UIA Notification, not just displayed visually
+- Visual overlay is high-contrast with large text
+- Tutorial waits for correct keypress — no timeout that would rush a screen reader user
+- "Press Escape to skip" is announced at the start of every step
+- Success confirmation includes the command name: "Correct! F6 cycles focus through all panes."
+
+## Technical Notes
+
+- Add `bool TutorialCompleted` to `ConfigModel` (defaults to `false`)
+- Create `TutorialViewModel` — owns tutorial state, current step, key detection
+- Create `TutorialOverlay` — a full-window transparent overlay with a centered instruction card
+- The overlay captures `PreviewKeyDown` on the MainWindow level
+- Tutorial is launched from `MainViewModel` after accounts load on first run
+- Register `help.keyboardTutorial` command in `CommandRegistry`
+
+## Files to Create
+
+| File | Purpose |
+|------|---------|
+| `QuickMail/ViewModels/TutorialViewModel.cs` | Tutorial state machine |
+| `QuickMail/Views/TutorialOverlay.xaml` | Visual overlay |
+| `QuickMail/Views/TutorialOverlay.xaml.cs` | Code-behind (key capture, focus) |
+
+## Files to Modify
+
+| File | Change |
+|------|---------|
+| `QuickMail/Models/ConfigModel.cs` | Add `TutorialCompleted` bool |
+| `QuickMail/Services/ConfigService.cs` | Persist `TutorialCompleted` |
+| `QuickMail/ViewModels/MainViewModel.cs` | Add `ShowTutorialCommand`, launch on first run |
+| `QuickMail/Views/MainWindow.xaml` | Add tutorial overlay to visual tree |
+| `QuickMail/Views/MainWindow.xaml.cs` | Register `help.keyboardTutorial`, wire overlay |
+
+## Tests to Add
+
+| File | Test |
+|------|------|
+| `QuickMail.Tests/TutorialViewModelTests.cs` | Step progression, escape exits, correct key advances |
+| `QuickMail.Tests/ViewModelConstructionTests.cs` | TutorialViewModel constructs |
+| `QuickMail.Tests/XamlParseTests.cs` | TutorialOverlay XAML parses |
+
+---
+
+*This spec is ready for Dev Lead implementation. Hand off with full context.*

--- a/docs/planning/ics-calendar-pm-spec.md
+++ b/docs/planning/ics-calendar-pm-spec.md
@@ -1,0 +1,74 @@
+# ICS Calendar Invite Handling — PM Specification
+
+**Status:** Ready for Dev
+**Date:** May 24, 2026
+**Target:** Phase 2 (Table Stakes)
+**Crew:** Bravo (PM → Dev Lead → Test Enforcer)
+
+---
+
+## User Problem
+
+When someone sends a calendar invite (ICS file attachment), QuickMail currently shows it as a generic attachment. The user has to save the file and open it externally. This is unacceptable for daily use — calendar invites are a fundamental email workflow.
+
+## User Stories
+
+1. **As a screen reader user**, when I open a message with a calendar invite, I want to hear a clear summary of the event (title, time, location) without hunting through attachments.
+2. **As a keyboard user**, I want to accept, decline, or tentatively accept an invite using only the keyboard.
+3. **As any user**, I want the invite details displayed inline in the reading pane, not hidden in an attachment list.
+
+## Acceptance Criteria
+
+- [ ] When a message has a `text/calendar` MIME part, the reading pane shows an "Event Invitation" card above the message body
+- [ ] The card displays: event title, organizer, start/end time, location, description
+- [ ] Three buttons: Accept, Tentative, Decline — all keyboard accessible
+- [ ] Accepting/declining generates an ICS reply and sends it via SMTP
+- [ ] Screen reader announces the event summary when the card receives focus
+- [ ] The card is navigable via Tab (part of the reading pane tab order)
+- [ ] If ICS parsing fails, the attachment still appears in the attachment list (graceful degradation)
+- [ ] All new commands registered in CommandRegistry
+
+## Accessibility Requirements
+
+- `AutomationProperties.Name` on every button: "Accept invitation", "Tentatively accept invitation", "Decline invitation"
+- Event card has `AutomationProperties.Name` set to the `IcsModel.DisplaySummary`
+- On focus, announce via `AccessibilityHelper.Announce()` with `AnnouncementCategory.Result`
+- Tab order: message body → event card (if present) → attachments
+
+## Technical Notes
+
+- `IcsModel.cs` already exists with parsing and reply generation
+- `MailMessageDetail` needs a new property: `IcsModel? CalendarInvite`
+- `ImapService` needs to detect `text/calendar` parts when fetching message detail
+- `MainViewModel` needs: `AcceptInviteCommand`, `DeclineInviteCommand`, `TentativeInviteCommand`
+- Reply ICS is sent via `SmtpService` — needs a new method or overload for sending ICS replies
+- The event card is HTML rendered in WebView2 — build the HTML in the ViewModel, not code-behind
+
+## Files to Create
+
+| File | Purpose |
+|------|---------|
+| *(none — all changes are modifications)* | |
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `QuickMail/Models/MailMessageDetail.cs` | Add `IcsModel? CalendarInvite` property |
+| `QuickMail/Services/ImapService.cs` | Detect `text/calendar` parts, parse with `IcsModel.Parse()` |
+| `QuickMail/Services/ISmtpService.cs` | Add `SendIcsReplyAsync` method |
+| `QuickMail/Services/SmtpService.cs` | Implement ICS reply sending |
+| `QuickMail/ViewModels/MainViewModel.cs` | Add invite commands, build event card HTML |
+| `QuickMail/Views/MainWindow.xaml.cs` | Register new commands in CommandRegistry |
+
+## Tests to Add
+
+| File | Test |
+|------|------|
+| `QuickMail.Tests/IcsModelTests.cs` | Parse valid ICS, parse invalid ICS, generate reply |
+| `QuickMail.Tests/ViewModelConstructionTests.cs` | Verify new commands exist on MainViewModel |
+| `QuickMail.Tests/StubServices.cs` | Add `SendIcsReplyAsync` to stub |
+
+---
+
+*This spec is ready for Dev Lead implementation. Hand off with full context.*

--- a/docs/planning/message-templates-pm-spec.md
+++ b/docs/planning/message-templates-pm-spec.md
@@ -1,0 +1,78 @@
+# Message Templates — PM Specification
+
+**Status:** Ready for Dev
+**Date:** May 24, 2026
+**Target:** Phase 4 (Power User)
+**Crew:** Delta (PM → Dev Lead → Test Enforcer)
+
+---
+
+## User Problem
+
+Users frequently send the same or similar messages: "Thanks for your email, I'll get back to you soon," meeting follow-ups, support responses, etc. Typing these repeatedly is tedious — especially for screen reader users who can't quickly scan and copy-paste from previous messages.
+
+## User Stories
+
+1. **As a screen reader user**, I want to save common responses as templates and insert them with a few keystrokes.
+2. **As a keyboard user**, I want to pick a template from a searchable list without touching the mouse.
+3. **As a power user**, I want templates to support placeholders like `{sender}` and `{date}` that auto-fill.
+
+## Acceptance Criteria
+
+- [ ] Templates stored in `%APPDATA%\QuickMail\templates.json`
+- [ ] Template model: `Title` (display name), `Subject` (optional, pre-fills compose subject), `Body` (the template text)
+- [ ] Placeholder support: `{sender}` → sender's display name, `{date}` → current date, `{time}` → current time
+- [ ] "Insert Template" button in compose window toolbar
+- [ ] Template picker: searchable list dialog, keyboard navigable, Enter to insert
+- [ ] "Save as Template" from compose window (saves current body as new template)
+- [ ] "Manage Templates" dialog: add, edit, delete, reorder
+- [ ] All new commands registered in CommandRegistry
+- [ ] All dialogs fully keyboard accessible with proper AutomationProperties
+
+## Accessibility Requirements
+
+- Template picker announces match count on search: "3 templates matching 'thanks'"
+- Template list items have AutomationProperties.Name = template title
+- Insert confirmation: "Template 'Meeting Follow-up' inserted"
+- Save confirmation: "Template saved as 'My Response'"
+- All announcements via AccessibilityHelper.Announce() with AnnouncementCategory.Result
+
+## Technical Notes
+
+- Follow the pattern of `ContactService` / `ViewService` for JSON file storage
+- Create `ITemplateService` / `TemplateService`
+- Template picker is a simple dialog (like FolderPickerWindow but simpler)
+- Wire into DI in App.xaml.cs
+
+## Files to Create
+
+| File | Purpose |
+|------|---------|
+| `QuickMail/Models/MessageTemplate.cs` | Template data model |
+| `QuickMail/Services/ITemplateService.cs` | Service interface |
+| `QuickMail/Services/TemplateService.cs` | JSON storage, CRUD |
+| `QuickMail/ViewModels/TemplatePickerViewModel.cs` | Picker dialog VM |
+| `QuickMail/Views/TemplatePickerWindow.xaml` | Picker dialog UI |
+| `QuickMail/Views/TemplatePickerWindow.xaml.cs` | Code-behind |
+
+## Files to Modify
+
+| File | Change |
+|------|---------|
+| `QuickMail/ViewModels/ComposeViewModel.cs` | Add InsertTemplateCommand, SaveAsTemplateCommand |
+| `QuickMail/Views/ComposeWindow.xaml` | Add "Insert Template" button |
+| `QuickMail/Views/ComposeWindow.xaml.cs` | Wire template picker dialog |
+| `QuickMail/Views/MainWindow.xaml.cs` | Register template commands |
+| `QuickMail/App.xaml.cs` | Create TemplateService, inject |
+
+## Tests to Add
+
+| File | Test |
+|------|------|
+| `QuickMail.Tests/TemplateServiceTests.cs` | CRUD operations, placeholder replacement |
+| `QuickMail.Tests/TemplatePickerViewModelTests.cs` | Search filtering, selection |
+| `QuickMail.Tests/ViewModelConstructionTests.cs` | TemplatePickerViewModel constructs |
+
+---
+
+*This spec is ready for Dev Lead implementation.*

--- a/docs/planning/phase5-refactoring-pm-spec.md
+++ b/docs/planning/phase5-refactoring-pm-spec.md
@@ -1,0 +1,59 @@
+# Phase 5 Refactoring — PM Specification
+
+**Status:** Ready for Dev
+**Date:** May 25, 2026
+**Target:** Phase 5 (Refactoring)
+**Crew:** Echo (PM → Dev Lead → Test Enforcer)
+
+---
+
+## User Problem
+
+No user-facing features. This is technical debt reduction to make the codebase sustainable. `MainViewModel` is 3,355 lines. `MainWindow.xaml.cs` is 3,010 lines. Both have repeated patterns that make bugs more likely and new features harder to add.
+
+## Refactoring Items
+
+### R1: Extract `RebuildActiveGroupView()` pattern (12 occurrences)
+Every action that mutates `Messages` does:
+```csharp
+if (ViewMode == ViewMode.Conversations) ScheduleConversationRebuild();
+else if (ViewMode == ViewMode.From)     ScheduleSenderGroupRebuild();
+else if (ViewMode == ViewMode.To)       ScheduleToGroupRebuild();
+```
+Replace with one method and update all call sites.
+
+### R2: Extract tree-view triplets from MainWindow.xaml.cs
+Three tree views (ConversationTree, SenderGroupTree, ToGroupTree) each have their own copy of ~10 event handlers. Extract a `GroupedMessageTreeController` class.
+
+### R3: Fix CTS disposal
+`CancellationTokenSource` instances are cancelled but never disposed. Add a `ReplaceCts` helper.
+
+### R4: Centralize ViewMode/Sort serialization
+`ConfigModel.ViewMode` and `ConfigModel.Sort` are magic strings converted by switch statements in 6+ places. Centralize the mapping.
+
+## Acceptance Criteria
+
+- [ ] `RebuildActiveGroupView()` method exists and all 12 call sites use it
+- [ ] `GroupedMessageTreeController` class exists and all three tree views use it
+- [ ] CTS disposal helper exists and all CTS replacements use it
+- [ ] ViewMode/Sort mapping is centralized in one place
+- [ ] All 341 existing tests still pass
+- [ ] Build: 0 warnings, 0 errors
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `QuickMail/ViewModels/MainViewModel.cs` | Extract R1, R3, R4 |
+| `QuickMail/Views/MainWindow.xaml.cs` | Extract R2 |
+| `QuickMail/Models/ConfigModel.cs` | R4: enum-based ViewMode/Sort |
+
+## Files to Create
+
+| File | Purpose |
+|------|---------|
+| `QuickMail/Views/GroupedMessageTreeController.cs` | R2: shared tree-view logic |
+
+---
+
+*This spec is ready for Dev Lead implementation.*

--- a/docs/planning/roadmap-branch-review.md
+++ b/docs/planning/roadmap-branch-review.md
@@ -1,0 +1,429 @@
+# Code Review: roadmap branch
+**Date:** 2026-05-25  
+**Branch:** `roadmap` vs `main`  
+**Reviewer:** Claude Code (claude-sonnet-4-6)  
+**Scope:** All 54 changed files — 5,750 insertions, 291 deletions
+
+## Summary
+
+**Build:** ✅ Clean (0 warnings, 0 errors)  
+**Tests:** ✅ 341 / 341 passing
+
+Five major feature areas landed on this branch:
+
+| Feature | Files |
+|---|---|
+| Email signatures | `AccountModel`, `AccountEditorViewModel`, `AccountManagerViewModel`, `AddAccountViewModel`, `ComposeViewModel`, both account dialogs |
+| ICS calendar invite handling | `IcsModel`, `MailMessageDetail`, `ImapService`, `SmtpService`, `MainViewModel`, `MainWindow` |
+| Message templates | `MessageTemplate`, `ITemplateService`, `TemplateService`, `ComposeViewModel`, `TemplatePickerViewModel`, `TemplatePickerWindow` |
+| First-run keyboard tutorial | `ConfigModel`, `TutorialViewModel`, `TutorialOverlay`, `MainViewModel`, `MainWindow` |
+| Phase 5 refactoring | `GroupedMessageTreeController`, `ConfigModel` (ViewMode/Sort helpers), `MainViewModel` (`ReplaceCts`) |
+| Spell check (compose) | `ComposeWindow.xaml.cs`, `ConfigModel`, `SettingsViewModel`, `SettingsDialog` |
+
+Overall quality is high. Architecture follows existing conventions. The most important findings are two bugs that alter runtime behaviour: the tutorial cancellation path incorrectly marks the tutorial as "completed", and `SendIcsReplyAsync` can throw an unhandled exception when no organiser is extracted from the ICS payload.
+
+---
+
+## BUGS
+
+### BUG-1 — `TutorialViewModel.Cancel()` fires `TutorialCompleted`, marking the tutorial done on early Escape  
+**Severity:** Medium  
+**File:** `QuickMail/ViewModels/TutorialViewModel.cs:126-129`  
+**Also:** `QuickMail/Views/MainWindow.xaml.cs:1095-1107`
+
+`Cancel()` and the last-step `Advance()` both call `TutorialCompleted?.Invoke()`, and `MainWindow.OnTutorialCompleted` responds identically to both: it sets `cfg.TutorialCompleted = true` and announces **"Tutorial complete. You can replay it anytime from the Help menu."** regardless of whether the user pressed Escape at step 1 or finished all six steps.
+
+Consequence: a first-time user who accidentally opens the tutorial and immediately presses Escape will never see it again automatically (if first-run logic is ever added), and will hear a misleading announcement.
+
+```csharp
+// CURRENT — both paths look the same to OnTutorialCompleted
+public void Cancel()
+{
+    IsActive = false;
+    TutorialCompleted?.Invoke();  // ← fires the exact same event as completion
+}
+```
+
+**Fix options:**
+- Add a second event `TutorialCancelled`, or
+- Pass a `bool completed` argument to the event, or
+- Have `Cancel()` set `IsActive = false` and let the view react to the `IsActive` change directly without calling into `OnTutorialCompleted`.
+
+The test comment in `TutorialViewModelTests.AllSixSteps_CompleteAndFireTutorialCompleted` also describes the wrong behaviour ("Escape at step 6 cancels the tutorial") — at step 6, the cancel-guard is skipped because `CurrentStep.ExpectedKey == Key.Escape`, so `Advance()` is called, not `Cancel()`. The test passes because both paths fire the same event. The comment needs correcting regardless.
+
+---
+
+### BUG-2 — `SendIcsReplyAsync` silently sends a no-recipient message when ORGANIZER is absent  
+**Severity:** Medium  
+**File:** `QuickMail/Services/SmtpService.cs:82-95`
+
+```csharp
+var organizerMatch = Regex.Match(
+    icsReplyContent, @"ORGANIZER[^:]*:mailto:([^\r\n]+)", ...);
+if (organizerMatch.Success)
+{
+    var orgEmail = organizerMatch.Groups[1].Value.Trim();
+    message.To.Add(MailboxAddress.Parse(orgEmail));
+}
+// ← no else clause; if match fails, message.To is empty
+await client.SendAsync(message, ct);  // throws: "No recipients specified"
+```
+
+The exception propagates up and is caught by `MainViewModel.SendIcsReply`'s catch block, so it won't crash the app. But the error will always surface as a confusing "Failed to send calendar response: No recipients specified" announcement rather than the real problem (the ICS content didn't include an ORGANIZER line with a mailto: URI).
+
+Additionally, `SendIcsReplyAsync` re-parses the ICS string it just generated (via `IcsModel.GenerateReply`) to extract the organiser email. The correct approach is to pass the email directly from `MainViewModel`, which already has it in `invite.Organizer`.
+
+**Fix:**
+```csharp
+// In MainViewModel.SendIcsReply — pass the organiser email explicitly
+await _smtp.SendIcsReplyAsync(icsContent, account, password, invite.Organizer);
+
+// In ISmtpService / SmtpService — add organiser parameter and guard
+Task SendIcsReplyAsync(string icsContent, AccountModel account, string? password,
+    string organizerEmail, CancellationToken ct = default);
+```
+
+---
+
+### BUG-3 — `TemplateService.UpdateAsync_PersistsAcrossInstances` test is a false positive  
+**Severity:** Low (test quality, no production impact)  
+**File:** `QuickMail.Tests/TemplateServiceTests.cs:1582-1599`
+
+The test verifies that an update through `service2` is visible when loaded through `service`. It passes — but for the wrong reason:
+
+```csharp
+var t = await service.AddAsync(new MessageTemplate { Title = "T1", Body = "B1" });
+// t is the SAME object reference stored in service._cache
+
+t.Title = "T1 Modified";           // mutates service._cache[0].Title in-place
+await service2.UpdateAsync(t);     // writes to disk (correct), but cache mutation already happened
+
+var all = await service.LoadAllAsync();  // returns from service._cache (_loaded = true)
+Assert.Equal("T1 Modified", all[0].Title);  // passes via reference, not persistence
+```
+
+Because `service._cache.Add(template)` adds the same object reference, mutating `t.Title` directly changes `service._cache[0]`. The test never actually exercises cross-instance persistence.
+
+**Fix:** Clone the template before mutating it and compare through a fresh third instance:
+```csharp
+var t = await service.AddAsync(new MessageTemplate { Title = "T1", Body = "B1" });
+
+// Use a COPY so service._cache is untouched
+var tCopy = new MessageTemplate { Id = t.Id, Title = "T1 Modified", Body = t.Body };
+var service2 = new TemplateService(new ProfileContext(dir));
+await service2.UpdateAsync(tCopy);
+
+// Verify through a THIRD instance (no cached state)
+var service3 = new TemplateService(new ProfileContext(dir));
+var all = await service3.LoadAllAsync();
+Assert.Equal("T1 Modified", all[0].Title);
+```
+
+---
+
+## DESIGN & ARCHITECTURE ISSUES
+
+### DESIGN-1 — `GroupedMessageTreeController.OnContextMenuOpening` exists but is never called  
+**Severity:** Low (dead code)  
+**File:** `QuickMail/Views/GroupedMessageTreeController.cs:666-682`
+
+The refactoring to `GroupedMessageTreeController` extracted `GotKeyboardFocus`, `SelectedItemChanged`, `PreviewTextInput`, `PreviewMouseRightButtonDown`, and `FocusFirstItem` handlers. The controller also defines `OnContextMenuOpening`, but the three `*Tree_ContextMenuOpening` handlers in `MainWindow.xaml.cs` still have their own inline implementations and do not delegate to the controller. The `OnContextMenuOpening` method is dead code.
+
+Either remove `OnContextMenuOpening` from the controller, or complete the extraction and replace the inline handlers with controller delegation.
+
+---
+
+### DESIGN-2 — `BuildEventCardHtml` generates CSS-embedded HTML inside `MainViewModel`  
+**Severity:** Low (MVVM smell)  
+**File:** `QuickMail/ViewModels/MainViewModel.cs:3700-3655`
+
+Generating presentation HTML (with inline CSS colours, border radii, etc.) inside a ViewModel blurs the MVVM boundary. The method works, but it means visual decisions are embedded in a component that should be ignorant of how data is displayed.
+
+**Options:**
+- Move to a static `EventCardBuilder` utility class in the Views or a `Rendering` namespace.
+- Return only the structured data and let `MainWindow.xaml.cs` build the HTML.
+
+This is low priority since there are no tests coupling the HTML output to ViewModel tests, but it's worth noting for the next refactor cycle.
+
+---
+
+### DESIGN-3 — Compose `CommandRegistry` is private and non-customisable  
+**Severity:** Low (design limitation)  
+**File:** `QuickMail/Views/ComposeWindow.xaml.cs:132`
+
+```csharp
+private readonly CommandRegistry _registry = new();
+```
+
+A fresh `CommandRegistry` is created per compose window. Commands registered in `RegisterComposeCommands()` do not flow through `hotkeys.json`, so users cannot rebind compose shortcuts (Alt+S, Ctrl+S, F7, etc.) via the Settings dialog.
+
+If keyboard customisation of compose shortcuts is a future goal, this needs to be wired into the same `IConfigService`-backed hotkey system used by the main window. For now it is a documented limitation, but the CLAUDE.md shortcut table does not mention compose shortcuts at all.
+
+---
+
+### DESIGN-4 — `InsertTemplateRequested` uses `Func<Task<T>>` instead of a typed event  
+**Severity:** Very Low  
+**File:** `QuickMail/ViewModels/ComposeViewModel.cs:99`
+
+```csharp
+public event Func<Task<MessageTemplate?>>? InsertTemplateRequested;
+```
+
+Using `event Func<Task<T?>>?` is an unusual pattern. While it works with a single subscriber, multi-subscriber scenarios (e.g., unit tests wiring multiple handlers) will only receive the return value of the last subscriber; all others' return values are silently discarded. The existing `ConfirmationRequested` property uses `Func<string, string, bool>?` (not an event), which avoids this. Consider either:
+
+- Making this a plain property (`public Func<Task<MessageTemplate?>>? InsertTemplateRequested { get; set; }`)  
+- Using a typed `EventArgs` subclass if multiple subscribers should ever be supported
+
+---
+
+## CODE QUALITY
+
+### QUALITY-1 — `NavigateSpellingError` duplicates the F7/Shift-F7 block (~60 lines)  
+**Severity:** Medium  
+**File:** `QuickMail/Views/ComposeWindow.xaml.cs`
+
+`BodyBox_PreviewKeyDown` contains a full F7 navigation block (lines ~354–427). `NavigateSpellingError(bool forward)` (lines ~489–542) contains almost identical code — same loop, same word-boundary walk, same tracking-state update, same announcement. The duplication is acknowledged in the comment but not resolved.
+
+**Fix:** Extract to a single `NavigateToSpellingError(bool forward)` method and call it from both places. The F7 handler can simply call `NavigateToSpellingError(forward: true/false)` and set `e.Handled = true`.
+
+---
+
+### QUALITY-2 — Unused `using` directives in `TemplatePickerViewModel`  
+**Severity:** Low  
+**File:** `QuickMail/ViewModels/TemplatePickerViewModel.cs:3,6,8`
+
+Three imports have no references in the file:
+- `using System.ComponentModel;`
+- `using System.Windows;` — **this is an MVVM-layer violation flag** (even though nothing from `System.Windows` is actually used). The presence of the import suggests it was copy-pasted from a View file without cleanup.
+- `using CommunityToolkit.Mvvm.Input;` — no `[RelayCommand]` or `IRelayCommand` in the VM
+
+Remove all three.
+
+---
+
+### QUALITY-3 — `ConfigModel` uses `global::QuickMail.Models.ViewMode` inside its own namespace  
+**Severity:** Low  
+**File:** `QuickMail/Models/ConfigModel.cs:91-107`
+
+```csharp
+public static global::QuickMail.Models.ViewMode ParseViewMode(string? s) => ...
+    "conversations" => global::QuickMail.Models.ViewMode.Conversations,
+```
+
+`ConfigModel` is already in the `QuickMail.Models` namespace. The `global::` qualifier and full namespace path are unnecessary. Should be just `ViewMode` and `MessageSort`.
+
+---
+
+### QUALITY-4 — `_loaded` is not `volatile` in `TemplateService`  
+**Severity:** Very Low (theoretical on x86)  
+**File:** `QuickMail/Services/TemplateService.cs:17`
+
+`EnsureLoadedAsync` uses a double-checked locking pattern with a plain `bool _loaded`. Without `volatile`, a processor could theoretically observe a stale `false` value even after the flag was set, causing an unnecessary second attempt. On .NET on x86/x64 this works due to the strong memory model, but it is not formally correct per the CLI spec.
+
+```csharp
+private volatile bool _loaded;  // add volatile
+```
+
+---
+
+### QUALITY-5 — `TutorialOverlay.SetViewModel` leaks event subscriptions  
+**Severity:** Low  
+**File:** `QuickMail/Views/TutorialOverlay.xaml.cs:23-35`
+
+```csharp
+public void SetViewModel(TutorialViewModel vm)
+{
+    _viewModel = vm;
+    DataContext = vm;
+    vm.PropertyChanged += (_, e) => { ... };  // ← never unsubscribed
+}
+```
+
+Each call to `SetViewModel` adds a new subscriber. If the user starts, cancels, and restarts the tutorial (which calls `ShowTutorial()` → `new TutorialViewModel()` → `SetViewModel()`), each call adds another listener. With the current UI flow this only fires once per session, but it is a correctness issue.
+
+**Fix:**
+```csharp
+private PropertyChangedEventHandler? _propertyChangedHandler;
+
+public void SetViewModel(TutorialViewModel vm)
+{
+    if (_viewModel != null && _propertyChangedHandler != null)
+        _viewModel.PropertyChanged -= _propertyChangedHandler;
+
+    _viewModel = vm;
+    DataContext = vm;
+
+    _propertyChangedHandler = (_, e) => { ... };
+    vm.PropertyChanged += _propertyChangedHandler;
+}
+```
+
+---
+
+### QUALITY-6 — Redundant `Cancel()` before `ReplaceCts` in several methods  
+**Severity:** Very Low (harmless)  
+**File:** `QuickMail/ViewModels/MainViewModel.cs` (several locations)
+
+Several methods call `_folderCts?.Cancel()` immediately before `ReplaceCts(ref _folderCts, out var ct)`. `ReplaceCts` already cancels the previous CTS via `Interlocked.Exchange` + `Cancel()`. Calling `Cancel()` twice is idempotent but redundant.
+
+```csharp
+// BEFORE (redundant):
+_folderCts?.Cancel();
+ReplaceCts(ref _folderCts, out var ct);
+
+// AFTER (clean):
+ReplaceCts(ref _folderCts, out var ct);
+```
+
+Affected locations: folder load, RefreshAsync, SearchAsync, virtual-folder load, and background sync start.
+
+---
+
+### QUALITY-7 — ICS timezone identifiers are silently ignored  
+**Severity:** Low (documented limitation)  
+**File:** `QuickMail/Models/IcsModel.cs:152-164`
+
+`DTSTART;TZID=America/Chicago:20260115T140000` correctly splits on the first colon, giving `value = "20260115T140000"`. The `TZID` parameter is available in `prop` but `ParseIcsDateTime` discards it. The result is treated as local machine time, which could be wrong for attendees in different time zones.
+
+This is acceptable as an MVP limitation, but it should be documented with a `// LIMITATION: TZID parameters are ignored; times are treated as local` comment, and there is no test that verifies the UTC vs. local-time choice for ambiguous inputs.
+
+---
+
+### QUALITY-8 — `TutorialViewModel.Start()` doesn't notify `CurrentStepNumber`  
+**Severity:** Very Low  
+**File:** `QuickMail/ViewModels/TutorialViewModel.cs:141-147`
+
+```csharp
+public void Start()
+{
+    CurrentStepIndex = 0;
+    IsActive = true;
+    OnPropertyChanged(nameof(CurrentStep));
+    // ← missing: OnPropertyChanged(nameof(CurrentStepNumber));
+}
+```
+
+If the tutorial is restarted while at step > 1, the `CurrentStepNumber` binding (used for the "Step N of 6" label) won't update until `Advance()` is called. `Advance()` notifies both properties. Add the missing notification to `Start()`.
+
+---
+
+## MISSING TESTS
+
+### TEST-1 — No `XamlParseTests` for `TutorialOverlay` or `TemplatePickerWindow`  
+New XAML files are not covered by the existing XAML parse test suite. A bad binding or resource key would only be caught at runtime.
+
+**Add to `XamlParseTests`:**
+```csharp
+[StaFact]
+public void TutorialOverlay_LoadsWithoutException()
+{
+    var overlay = new TutorialOverlay();
+    Assert.NotNull(overlay);
+}
+
+[StaFact]
+public void TemplatePickerWindow_LoadsWithoutException()
+{
+    var vm = new TemplatePickerViewModel(new StubTemplateService());
+    var window = new TemplatePickerWindow(vm);
+    Assert.NotNull(window);
+}
+```
+
+---
+
+### TEST-2 — No test for `BuildEventCardHtml`  
+`MainViewModel.BuildEventCardHtml()` builds non-trivial HTML with aria attributes and inline CSS. There are no tests for its output structure. At minimum: null invite returns empty string, populated invite includes the event summary and aria label, and all user-visible strings are HTML-encoded.
+
+---
+
+### TEST-3 — No test for signature insertion on reply/forward  
+`ComposeViewModel.Seed()` appends a signature when `DraftUid == null` and the sender account has a signature. There are no tests for:
+- New message with signature → body ends with `-- \n{sig}`
+- Reply with existing body → separator `\n-- \n` is inserted
+- Draft re-open → signature is NOT duplicated
+- `_isDirty` is `false` after `Seed` (with and without signature)
+
+---
+
+### TEST-4 — No test for `SendIcsReplyAsync` recipient guard  
+The bug in BUG-2 would be caught by a test that calls `SendIcsReplyAsync` with ICS content that has no `ORGANIZER:mailto:` line and verifies that either no exception is thrown or a meaningful exception type is raised.
+
+---
+
+### TEST-5 — F7 forward search from inside a misspelled word  
+The `BodyBox_PreviewKeyDown` F7 handler starts the search from `BodyBox.CaretIndex`. If the caret is already inside a misspelled word, the scan will find and re-announce the same word rather than moving to the *next* error. This should be a deliberate design decision (with a test that documents the behaviour), or the start index should advance past the current word boundary first.
+
+---
+
+## DOCUMENTATION GAPS
+
+### DOC-1 — CLAUDE.md shortcut table is incomplete  
+**File:** `CLAUDE.md`
+
+The registered shortcut table in CLAUDE.md does not include:
+
+| Key | Command ID | Title |
+|---|---|---|
+| *(unassigned)* | `mail.acceptInvite` | Accept Invitation |
+| *(unassigned)* | `mail.declineInvite` | Decline Invitation |
+| *(unassigned)* | `mail.tentativeInvite` | Tentatively Accept Invitation |
+| *(unassigned)* | `help.keyboardTutorial` | Keyboard Tutorial |
+
+Add these to the table. Also add a note that compose-window commands (Alt+S, Ctrl+S, Ctrl+Shift+A, F7, Alt+Y) are registered in a private `ComposeWindow` registry and are not user-customisable via Settings.
+
+---
+
+### DOC-2 — No documentation on ICS timezone handling limitation  
+Add a `// LIMITATION:` comment to `IcsModel.ParseIcsDateTime` noting that `TZID` parameters are ignored and times are treated as local.
+
+---
+
+## WHAT WORKED WELL
+
+The following patterns are clean and well-executed:
+
+- **`ReplaceCts` helper** — Centralises the "cancel old CTS, create new one" pattern that was repeated ~10 times. The `Interlocked.Exchange` approach is thread-safe. The extraction is complete and consistent.
+
+- **`GroupedMessageTreeController`** — The delegation pattern reduces ~200 lines of duplicated handler code across three trees. All delegated handlers work correctly. The constructor parameter set is verbose but explicit.
+
+- **`ConfigModel` ViewMode/Sort helpers** — The switch expressions were duplicated in at least 6 places in `MainViewModel` and are now consolidated in two `ParseX`/`ToConfigString` methods. Every call site was updated.
+
+- **`IcsModel`** — The ICS parser handles line folding, property parameters, escaped text, UTC vs. local time, and date-only events. The `GenerateReply` method produces a valid RFC 5545 REPLY payload. Test coverage is thorough (25 tests covering parse, GenerateReply, DisplaySummary, BriefSummary, and edge cases).
+
+- **`TemplateService`** — Atomic write via temp file + `File.Move(overwrite: true)`. Thread-safe with `SemaphoreSlim`. Defensive copy on load. Proper double-checked load guard.
+
+- **Spell check accessibility** — Announcing misspelling on cursor entry (not just F7), suppressing re-announcement of the same word, Alt+1/2/3 suggestion replacement, and the `_suppressSpellingAnnouncement` guard during programmatic text changes are all thoughtfully implemented.
+
+- **Tutorial overlay** — `interrupt: true` on accessibility announcements means screen reader users hear each step. The Escape cancellation guard that skips bare modifier keys is a nice detail.
+
+- **Modal dialog rule compliance** — `TemplatePickerWindow` and the compose window's `InsertTemplateRequested` pattern both follow the documented rule (fire events after `ShowDialog()` returns, not during).
+
+---
+
+## SUMMARY TABLE
+
+| # | Severity | Category | Title |
+|---|---|---|---|
+| BUG-1 | Medium | Bug | Cancel fires TutorialCompleted, marking tutorial done |
+| BUG-2 | Medium | Bug | SendIcsReplyAsync throws when ORGANIZER missing |
+| BUG-3 | Low | Bug | Cross-instance persistence test is a false positive |
+| DESIGN-1 | Low | Design | OnContextMenuOpening in controller is dead code |
+| DESIGN-2 | Low | Design | BuildEventCardHtml embeds CSS in ViewModel |
+| DESIGN-3 | Low | Design | Compose shortcuts are not user-customisable |
+| DESIGN-4 | Very Low | Design | InsertTemplateRequested event discards multi-subscriber returns |
+| QUALITY-1 | Medium | Code Quality | NavigateSpellingError duplicates 60 lines |
+| QUALITY-2 | Low | Code Quality | Unused `using System.Windows` in TemplatePickerViewModel |
+| QUALITY-3 | Low | Code Quality | `global::` qualifiers redundant in ConfigModel |
+| QUALITY-4 | Very Low | Code Quality | `_loaded` not volatile in TemplateService |
+| QUALITY-5 | Low | Code Quality | SetViewModel leaks PropertyChanged subscriptions |
+| QUALITY-6 | Very Low | Code Quality | Redundant Cancel() before ReplaceCts |
+| QUALITY-7 | Low | Code Quality | ICS TZID silently ignored without comment |
+| QUALITY-8 | Very Low | Code Quality | Start() missing CurrentStepNumber notification |
+| TEST-1 | Low | Testing | No XamlParseTests for TutorialOverlay/TemplatePickerWindow |
+| TEST-2 | Low | Testing | No tests for BuildEventCardHtml |
+| TEST-3 | Low | Testing | No tests for signature insertion scenarios |
+| TEST-4 | Low | Testing | No test for missing-recipient guard in SendIcsReplyAsync |
+| TEST-5 | Very Low | Testing | F7 same-word re-announce behaviour undocumented |
+| DOC-1 | Low | Docs | CLAUDE.md shortcut table incomplete |
+| DOC-2 | Very Low | Docs | ICS TZID limitation not commented |

--- a/docs/planning/roadmap-branch-review.md
+++ b/docs/planning/roadmap-branch-review.md
@@ -4,6 +4,29 @@
 **Reviewer:** Claude Code (claude-sonnet-4-6)  
 **Scope:** All 54 changed files — 5,750 insertions, 291 deletions
 
+## Post-Review Fixes Applied (2026-05-25)
+
+The following issues from this review have been addressed:
+
+| # | Status | Title |
+|---|---|---|
+| BUG-1 | ✅ Fixed | `Cancel()` now fires `TutorialCancelled` (new event) instead of `TutorialCompleted`. `MainWindow` handles them separately: completion saves `TutorialCompleted = true` and announces "Tutorial complete"; cancellation announces "Tutorial cancelled" without marking the tutorial done. |
+| BUG-2 | ✅ Fixed | `SendIcsReplyAsync` now takes an explicit `organizerEmail` parameter. `MainViewModel.SendIcsReply` passes `invite.Organizer ?? ""`. The regex extraction from ICS content is removed. |
+| QUALITY-1 | ✅ Fixed | F7 handler in `BodyBox_PreviewKeyDown` now delegates to `NavigateSpellingError(forward)`, eliminating ~60 lines of duplicate code. |
+| QUALITY-2 | ✅ Fixed | Removed unused `using System.ComponentModel`, `using System.Windows`, and `using CommunityToolkit.Mvvm.Input` from `TemplatePickerViewModel.cs`. |
+| QUALITY-3 | ✅ Fixed | Replaced `global::QuickMail.Models.ViewMode` with `Models.ViewMode` in `ConfigModel.cs` (the `ViewMode` name conflicts with the string property, so namespace qualification is still needed but is now minimal). |
+| QUALITY-5 | ✅ Fixed | `TutorialOverlay.SetViewModel` now stores the handler in a field and unsubscribes before re-subscribing, preventing event subscription leaks on restart. |
+| QUALITY-7 | ✅ Fixed | Added `LIMITATION:` comment to `IcsModel.ParseIcsDateTime` documenting that TZID parameters are ignored. |
+| QUALITY-8 | ✅ Fixed | `TutorialViewModel.Start()` now notifies `CurrentStepNumber` in addition to `CurrentStep`. |
+| DOC-1 | ✅ Fixed | Added missing entries to CLAUDE.md shortcut table: `mail.acceptInvite`, `mail.declineInvite`, `mail.tentativeInvite`, `help.keyboardTutorial`. Added note about compose window's private `CommandRegistry`. |
+
+**Not addressed (deferred):**
+- BUG-3 (false positive test) — low priority, no production impact
+- DESIGN-1 through DESIGN-4 — design observations, not bugs
+- QUALITY-4, QUALITY-6 — very low priority
+- TEST-1 through TEST-5 — test coverage gaps
+- DOC-2 — addressed via QUALITY-7 comment
+
 ## Summary
 
 **Build:** ✅ Clean (0 warnings, 0 errors)  

--- a/docs/planning/the-quickmail-story.md
+++ b/docs/planning/the-quickmail-story.md
@@ -1,0 +1,207 @@
+# The QuickMail Story: Building an Accessible Email Client with AI
+
+**A project by Kelly Ford, The Idea Place**
+**Documenting the journey from prototype to product**
+
+---
+
+## Prologue: Why QuickMail Exists
+
+I'm a screen reader user. I've been one for decades. I've watched Microsoft, Google, Mozilla, and countless others ship email clients that range from "mostly works if you memorize the quirks" to "completely unusable."
+
+In 2025-2026, I started experimenting with AI-assisted development. Not just asking ChatGPT for code snippets — actually building real applications. WeatherFast. Sports Scores. RSS Quick. The Image Description Toolkit. Each project taught me something about what AI can and can't do.
+
+QuickMail is the most ambitious test yet: a full desktop email client for Windows, built primarily through AI-assisted development, with accessibility as the foundation — not an afterthought.
+
+This document tells the story of that build. It's honest about what worked, what didn't, and what we learned about building accessible software with AI.
+
+---
+
+## Chapter 1: The State of Email Accessibility (Spoiler: It's Bad)
+
+Before building QuickMail, I needed to understand the competitive landscape. Not from a features perspective — from an accessibility perspective. Here's what I found:
+
+### Outlook (Classic)
+Microsoft's flagship email client has the most features. It also has the worst accessibility consistency. The screen reader experience varies dramatically by version, update, and which pane has focus. The reading pane randomly loses focus. The message list announces wrong item counts. The calendar is a disaster. And Microsoft — the company that talks endlessly about accessibility — ships regressions constantly.
+
+I've written about this. The Windows Copilot app serves half-answers to screen reader users. Notepad got table support without screen reader announcements. Copilot's chat announces raw class names like `CopilotNative.Chat.Controls.ViewModels.MessageThinkingAndActivityPart`. This is the company that's supposed to be leading on accessibility.
+
+### Thunderbird
+Open source means anyone can fix accessibility bugs. It also means nobody is paid to fix them. The folder pane doesn't announce expand/collapse state reliably. The filter dialog is a maze of unlabeled controls. Bugs sit for years.
+
+### Windows Mail / New Outlook
+A web wrapper in a desktop shell. All the accessibility problems of web apps — focus trapping, ARIA misbehavior, browse mode vs focus mode confusion — plus the performance problems of running a browser engine for what should be a native app.
+
+### Gmail (Web)
+The best of the web options. But still a web app. Google ships breaking accessibility changes without notice. Keyboard shortcuts conflict with screen reader commands. Conversation view is confusing.
+
+### The Others
+eM Client, Mailbird — proprietary UI frameworks with poor or nonexistent UIA support. Nearly unusable with a screen reader.
+
+### The Gap
+No major Windows email client delivers a genuinely accessible experience. Every one of them treats accessibility as a compliance checkbox, not as a fundamental design requirement. The opportunity was clear: build the email client that screen reader users recommend to each other.
+
+---
+
+## Chapter 2: The Prototype (v0.1 — v0.6.3)
+
+QuickMail started as a prototype. The goal was simple: prove that a keyboard-first, screen-reader-friendly email client was possible on Windows using WPF and .NET 8.
+
+### What We Built
+
+The prototype established the foundation:
+
+- **Multi-account IMAP/SMTP** with pooled connections and IMAP IDLE push
+- **Three-pane layout** with F6 cycling and direct pane focus (Ctrl+0-3)
+- **UIA notifications** via `RaiseNotificationEvent` — the correct API for desktop screen reader announcements
+- **Category-filtered announcements** — users can toggle Hint, Status, and Result announcements independently
+- **Command Registry** — all keyboard shortcuts registered and user-customizable
+- **Command Palette** (Ctrl+Shift+P) — searchable list of all commands
+- **Status bar with arrow-key navigation** — four named regions, proper UIA StatusBar pattern
+- **WebView2 reading pane** with strict CSP and simplified reader mode
+- **Mail rules** — client-side automatic actions on incoming messages
+- **Saved views** — persistent filtered views of messages
+- **Conversation view, From view, To view** — multiple ways to group messages
+- **Virtual folders** — All Mail, All Inboxes, All Drafts, All Sent, All Trash
+- **OAuth2 for Microsoft accounts**
+- **Profile support** — separate data directories for work/personal
+
+### What We Learned
+
+1. **AI can implement UIA correctly.** `RaiseNotificationEvent`, `AutomationProperties.Name`, `ControlType`, `InvokePattern` — these are well-documented APIs. AI models trained on MSDN get them right.
+
+2. **AI needs explicit accessibility rules.** Without instructions like "no MessageBox in ViewModels" and "every Announce() call must have a category," AI will produce inaccessible code. The rules in `CLAUDE.md` and `copilot-instructions.md` are essential.
+
+3. **The bottleneck is human judgment, not AI capability.** AI doesn't know what "feels accessible." It doesn't know that a screen reader user needs to hear "3 unread messages from Kelly Ford" not just "3 items." The PM specs, the acceptance criteria, the accessibility requirements — these require human experience.
+
+4. **Code review catches what AI misses.** The May 21 engineering review found real bugs: hotkey customization was silently broken, `BatchObservableCollection` could deadlock, `ContactService` had race conditions. AI wrote the code; human review found the problems.
+
+---
+
+## Chapter 3: The Roadmap (May 2026 — )
+
+The prototype proved the concept. Now we need to build the product. The roadmap is organized into five phases:
+
+### Phase 1: Foundation Fixes ✅ (Completed before roadmap)
+All P0/P1 bugs from the May 21 review were addressed before the roadmap branch was created. The codebase is stable.
+
+### Phase 2: Table Stakes (Current)
+Features every email client must have:
+- **Spell check** — with screen reader announcements for misspellings
+- **Email signatures** — plain-text and HTML, per account
+- **Calendar invite handling (ICS)** — parse, display, accept/decline
+- **Message list accessibility** — consistent, informative announcements
+
+### Phase 3: Differentiators
+Features that make QuickMail better than competitors for screen reader users:
+- **First-run accessibility tutorial** — interactive, self-voicing
+- **Audio feedback** — sounds for send/receive/error
+- **Message read aloud** — TTS for quick triage
+- **Contact manager UI** — proper add/edit/delete/search
+
+### Phase 4: Power User
+Features for advanced users:
+- **PGP/GPG encryption**
+- **Message templates**
+- **Server-side search**
+- **Scheduled send**
+
+### Phase 5: Refactoring
+Technical improvements for sustainability:
+- Extract repeated patterns from MainViewModel and MainWindow
+- Proper SQLite migration system
+- CTS disposal fixes
+
+---
+
+## Chapter 4: The Feature Crew Model
+
+Each feature is built by a crew of three AI agents:
+
+### PM Agent
+Writes the product specification:
+- User stories and personas
+- Accessibility requirements (WCAG 2.2 AA minimum)
+- Acceptance criteria
+- Competitive context
+- Keyboard shortcut assignments
+
+### Dev Agent
+Implements the feature:
+- Follows MVVM rules strictly
+- Registers all shortcuts in CommandRegistry
+- Uses AccessibilityHelper.Announce() with proper categories
+- No MessageBox/Window/Dispatcher in ViewModels
+- Produces working, compilable code
+
+### Test Agent
+Verifies the implementation:
+- Unit tests for services and ViewModels
+- XAML parse tests (STA thread)
+- ViewModel construction tests with stubs
+- Accessibility assertions (AutomationProperties, UIA patterns)
+
+### The Human in the Loop
+After all three agents complete their work, a human (Kelly) reviews:
+- Does it actually work with a screen reader?
+- Does the focus management feel right?
+- Are the announcements helpful or noisy?
+- Is the keyboard flow natural?
+
+AI can implement accessibility patterns. Only a screen reader user can verify that they actually work.
+
+---
+
+## Chapter 5: What We're Proving
+
+QuickMail is an experiment in several questions:
+
+### Can AI build production-quality accessible software?
+The answer so far is: yes, with the right instructions and human review. AI gets the APIs right. It follows patterns consistently. It doesn't get tired and skip the `AutomationProperties.Name` on the 20th control. But it needs explicit rules and human verification.
+
+### Can AI maintain accessibility discipline across a large codebase?
+The `CLAUDE.md` and `copilot-instructions.md` files encode the rules. Every AI agent that touches the codebase reads these rules. The result is consistent accessibility patterns across thousands of lines of code written by different AI models at different times.
+
+### Is "vibe coding" compatible with accessibility?
+Vibe coding — describing what you want and letting AI implement it — works for accessibility IF the descriptions include accessibility requirements. "Add a delete button" produces an inaccessible button. "Add a delete button with AutomationProperties.Name='Delete message', keyboard shortcut Delete, and UIA notification 'Message deleted' on success" produces an accessible one.
+
+### Can a small team (or one person) build a competitive product with AI?
+The QuickMail prototype was built primarily by one person working with AI assistants. It has features that took teams of developers years to build in Outlook and Thunderbird. The IMAP connection pooling, the Command Registry, the UIA notification system — these are sophisticated engineering. AI made them possible at a scale that would otherwise require a team.
+
+---
+
+## Chapter 6: The Blog Posts
+
+These posts will be published on [theideaplace.net](https://theideaplace.net) as the project progresses:
+
+### Post 1: "Can AI Write Accessible Code?" (Planned)
+The QuickMail experiment: what we built, how we built it, what worked, what didn't. Honest assessment of AI's strengths and weaknesses in accessibility implementation.
+
+### Post 2: "Accessibility by Specification" (Planned)
+How detailed PM specs with explicit accessibility requirements produce better AI-generated code. The difference between "add a settings dialog" and "add a settings dialog where every control has AutomationProperties.Name, TabIndex is logical, and state changes are announced via UIA Notification."
+
+### Post 3: "The Feature Crew Model" (Planned)
+PM/Dev/Test AI agents collaborating on accessibility-first features. How the three-agent model catches issues that a single agent misses. The importance of the human review step.
+
+### Post 4: "What Screen Reader Users Actually Need from Email" (Planned)
+Based on the competitive analysis and QuickMail's design decisions. Why Outlook fails, why Thunderbird isn't the answer, and what "accessible email" actually means.
+
+---
+
+## Appendix: The Numbers
+
+| Metric | Value |
+|--------|-------|
+| Lines of code in prototype | ~15,000+ |
+| AI-written code | >90% |
+| Human-written code | Architecture, rules, specs, review |
+| Accessibility-specific code | ~500 lines (AccessibilityHelper, UIA patterns, announcements) |
+| Registered commands | 25+ |
+| Test files | 15+ |
+| P0 bugs found in review | 6 (all fixed) |
+| Features shipped in prototype | 20+ |
+| Features planned in roadmap | 20 |
+
+---
+
+*This document is maintained as part of the QuickMail roadmap initiative. It will be updated as features ship and the story evolves.*

--- a/docs/release-notes-v0.7.md
+++ b/docs/release-notes-v0.7.md
@@ -4,9 +4,15 @@
 
 ### Spell check in compose window
 
-The message body now has spell check enabled. Misspelled words are underlined with the standard red squiggle. Press **F7** to jump to the next misspelling; press **Shift+F7** to go back to the previous one. When you land on a misspelled word, QuickMail announces the word and up to three suggestions through your screen reader — for example, "Misspelling: recieve. Suggestions: receive, relieve, retrieve." When no more misspellings are found, you hear "No more misspellings found."
+The message body now has spell check enabled. Misspelled words are underlined with the standard red squiggle. Press **F7** to jump to the next misspelling; press **Shift+F7** to go back to the previous one.
 
 Spell check is built on the Windows spell-checking engine, the same one used by WordPad and other Windows applications. No configuration needed.
+
+**Screen reader announcements:** As you navigate through the message body with arrow keys, QuickMail automatically detects when the caret enters a misspelled word and announces it through your screen reader. When the "Announce spelling suggestions" setting is on (the default), you hear the word and up to three suggestions — for example, "Misspelling: recieve. receive, relieve, retrieve." When the setting is off, only the misspelled word is announced.
+
+**Quick replacement:** When a misspelling is announced, press **Alt+1**, **Alt+2**, or **Alt+3** to replace the word with the first, second, or third suggestion. QuickMail announces "Replaced with receive." and moves on. This lets experienced users correct errors without opening a context menu.
+
+**Settings:** A new "Announce spelling suggestions" checkbox in **Tools → Settings → Screen Reader Announcements** controls whether suggestions are spoken. Turn it off for faster, quieter spell checking once you know the Alt+number workflow.
 
 ### Email signatures
 
@@ -69,10 +75,15 @@ Placeholders are case-insensitive — `{Sender}`, `{SENDER}`, and `{sender}` all
 
 ## Improvements
 
-- **Compose window spell check** — Enabled WPF spell check on the message body with F7/Shift+F7 keyboard navigation and screen reader announcements for misspellings and suggestions.
+- **Inline spell check announcements** — Screen readers now announce misspelled words automatically as you navigate through the message body with arrow keys, not just when pressing F7.
+- **Alt+1/2/3 quick replacement** — Replace a misspelled word with a suggestion in one keystroke. No context menu needed.
+- **Spelling suggestions setting** — New "Announce spelling suggestions" option in Settings lets experienced users silence suggestion speech while keeping the Alt+number workflow.
+- **Compose window command palette** — Press **Ctrl+Shift+P** in the compose window to open the Command Palette with 11 compose-specific commands (Send, Save Draft, Add Attachments, Insert Template, Save as Template, Cancel, Focus Subject, Focus From, Focus Body, Next/Previous Misspelling).
+- **Alt+Y in compose** — Press **Alt+Y** to jump directly to the message body from any field.
+- **Tutorial wrong-key feedback** — The keyboard tutorial now announces what key you pressed when it's incorrect (e.g. "You pressed Ctrl+N. Try again."), so you get immediate feedback instead of silence.
+- **Tutorial manual-only launch** — The tutorial is now available only from **Help → Keyboard Tutorial**; it no longer auto-launches on first run.
 - **Signature auto-insertion** — Signatures are appended to new messages, replies, and forwards automatically. Drafts re-opened for editing do not receive a duplicate signature.
 - **ICS parsing** — Calendar invites are detected in `text/calendar` MIME parts and displayed as an inline event card. ICS replies are generated and sent via SMTP.
-- **Tutorial overlay** — First-run experience teaches the six essential keyboard shortcuts interactively. Replayable from the Help menu.
 - **Template picker** — Searchable list dialog for inserting saved templates. Filter-as-you-type with screen reader match count announcements.
 - **Template placeholders** — `{sender}`, `{date}`, and `{time}` are replaced automatically when a template is inserted.
 
@@ -93,4 +104,5 @@ Placeholders are case-insensitive — `{Sender}`, `{SENDER}`, and `{sender}` all
 
 ## Bug Fixes
 
-- **Tutorial overlay crash on add account** — The `CurrentStepNumber` binding in `TutorialOverlay.xaml` was missing `Mode=OneWay`, causing an `InvalidOperationException` when WPF tried to write to the read-only computed property. Fixed by adding explicit one-way binding mode.
+- **Tutorial overlay crash** — The `Steps.Count` binding in `TutorialOverlay.xaml` was missing `Mode=OneWay`, causing an `InvalidOperationException` when WPF tried to write to the read-only `ObservableCollection<T>.Count` property. Fixed by adding explicit one-way binding mode.
+- **Alt+1/2/3 focus jump** — Replacing a misspelled word with Alt+1/2/3 would move focus to the first error on the page instead of staying on the replaced word. Fixed by suppressing spelling announcements during the programmatic text change so the `SelectionChanged` handler doesn't fire with a stale caret position.

--- a/docs/release-notes-v0.7.md
+++ b/docs/release-notes-v0.7.md
@@ -30,9 +30,9 @@ Three buttons let you respond: **Accept**, **Tentative**, or **Decline**. Each g
 
 Screen readers announce the full event summary when the card receives focus, and a confirmation is announced after each response.
 
-### First-run keyboard tutorial
+### Keyboard Tutorial
 
-The first time you launch QuickMail, a tutorial overlay appears and walks you through the six essential keyboard shortcuts by having you press each one:
+A new keyboard tutorial is available off the Help Menu. It allows you to try some of the important keyboard commands for QuickMail and get feedback that you pressed the correct keys.
 
 | Step | Shortcut | What it does |
 |------|----------|--------------|

--- a/docs/release-notes-v0.7.md
+++ b/docs/release-notes-v0.7.md
@@ -1,0 +1,96 @@
+# QuickMail v0.7 Release Notes
+
+## New Features
+
+### Spell check in compose window
+
+The message body now has spell check enabled. Misspelled words are underlined with the standard red squiggle. Press **F7** to jump to the next misspelling; press **Shift+F7** to go back to the previous one. When you land on a misspelled word, QuickMail announces the word and up to three suggestions through your screen reader — for example, "Misspelling: recieve. Suggestions: receive, relieve, retrieve." When no more misspellings are found, you hear "No more misspellings found."
+
+Spell check is built on the Windows spell-checking engine, the same one used by WordPad and other Windows applications. No configuration needed.
+
+### Email signatures
+
+Each account now has a **Signature** field in Account Settings. Enter any plain-text signature — your name, title, phone number, or a full closing block — and QuickMail automatically appends it to the end of every new message, reply, and forward from that account.
+
+Signatures follow the standard `-- \n` convention, so email clients that recognize signature separators will display them correctly. Drafts that are re-opened for editing do not get a duplicate signature — the signature is only added when the compose window first opens.
+
+To set a signature, open **File → Manage Accounts**, select an account, and fill in the Signature field at the bottom of the settings form.
+
+### Calendar invite handling
+
+When someone sends you a meeting invitation (an ICS file attachment), QuickMail now displays an **Event Invitation** card directly in the reading pane — above the message body. The card shows:
+
+- Event title
+- Organizer name
+- Start and end time (converted to your local time zone)
+- Location (when included)
+- Full event description
+
+Three buttons let you respond: **Accept**, **Tentative**, or **Decline**. Each generates a proper ICS reply and sends it back to the organizer via SMTP. The entire flow works from the keyboard — Tab to the card, Tab between buttons, Enter to respond.
+
+Screen readers announce the full event summary when the card receives focus, and a confirmation is announced after each response.
+
+### First-run keyboard tutorial
+
+The first time you launch QuickMail, a tutorial overlay appears and walks you through the six essential keyboard shortcuts by having you press each one:
+
+| Step | Shortcut | What it does |
+|------|----------|--------------|
+| 1 | **F6** | Cycle focus through all panes |
+| 2 | **Ctrl+1** | Focus the account list |
+| 3 | **Ctrl+2** | Focus the folder tree |
+| 4 | **Ctrl+3** | Focus the message list |
+| 5 | **Ctrl+Shift+P** | Open the Command Palette |
+| 6 | **Escape** | Close the reading pane or dismiss dialogs |
+
+Each step announces the instruction through your screen reader, waits for you to press the correct key, then confirms success and moves to the next step. Press **Escape** at any time to exit the tutorial.
+
+Once completed, the tutorial does not appear again. You can replay it at any time from **Help → Keyboard Tutorial**.
+
+### Message templates
+
+Save common responses as templates and insert them with a few keystrokes. Templates are stored in `%APPDATA%\QuickMail\templates.json`.
+
+**Inserting a template:** In the compose window, activate the **Insert Template…** button. A searchable list appears — type to filter by title, press **Down** to move into the list, and press **Enter** to insert. The template body is appended to your message.
+
+**Saving a template:** Compose a message you want to reuse, then activate **Save as Template**. The subject line becomes the template title (or "Untitled" if the subject is empty).
+
+**Placeholders:** Templates support three placeholders that are filled in automatically when inserted:
+
+| Placeholder | Replaced with |
+|-------------|---------------|
+| `{sender}` | Your display name (or email address if no display name is set) |
+| `{date}` | Today's date |
+| `{time}` | The current time |
+
+Placeholders are case-insensitive — `{Sender}`, `{SENDER}`, and `{sender}` all work.
+
+---
+
+## Improvements
+
+- **Compose window spell check** — Enabled WPF spell check on the message body with F7/Shift+F7 keyboard navigation and screen reader announcements for misspellings and suggestions.
+- **Signature auto-insertion** — Signatures are appended to new messages, replies, and forwards automatically. Drafts re-opened for editing do not receive a duplicate signature.
+- **ICS parsing** — Calendar invites are detected in `text/calendar` MIME parts and displayed as an inline event card. ICS replies are generated and sent via SMTP.
+- **Tutorial overlay** — First-run experience teaches the six essential keyboard shortcuts interactively. Replayable from the Help menu.
+- **Template picker** — Searchable list dialog for inserting saved templates. Filter-as-you-type with screen reader match count announcements.
+- **Template placeholders** — `{sender}`, `{date}`, and `{time}` are replaced automatically when a template is inserted.
+
+---
+
+## Internal
+
+- **Refactored MainViewModel** — Extracted `RebuildActiveGroupView()` to replace 12 repeated if-else chains. Extracted `ReplaceCts()` helper for proper `CancellationTokenSource` disposal.
+- **Refactored MainWindow.xaml.cs** — Extracted `GroupedMessageTreeController` to eliminate ~30 near-duplicate event handlers across the three tree views (ConversationTree, SenderGroupTree, ToGroupTree).
+- **Centralized ViewMode and Sort serialization** — `ConfigModel.ParseViewMode()`, `ConfigModel.ParseSort()`, and their `ToConfigString()` counterparts now handle all string↔enum conversion in one place, replacing six duplicate switch statements.
+- **New service: TemplateService** — JSON file storage for message templates, following the same pattern as `ContactService` and `ViewService`.
+- **New model: IcsModel** — Parses ICS calendar files and generates reply messages with proper `PARTSTAT` values.
+- **New model: MessageTemplate** — Template data model with title, subject, and body.
+- **DI wiring** — `SmtpService` and `TemplateService` are now injected into `MainViewModel` and `ComposeViewModel` respectively.
+- Total test count: 235 (v0.6.3) → 341 (v0.7). New test files: `IcsModelTests.cs` (30 tests), `TutorialViewModelTests.cs` (14 tests), `TemplateServiceTests.cs` (15 tests), `TemplatePickerViewModelTests.cs` (15 tests), `ComposeViewModelTemplateTests.cs` (16 tests).
+
+---
+
+## Bug Fixes
+
+- **Tutorial overlay crash on add account** — The `CurrentStepNumber` binding in `TutorialOverlay.xaml` was missing `Mode=OneWay`, causing an `InvalidOperationException` when WPF tried to write to the read-only computed property. Fixed by adding explicit one-way binding mode.


### PR DESCRIPTION
## Summary

Five major feature areas plus post-review bug fixes:

### New Features
- **Spell check in compose window** — WPF spell check with F7/Shift+F7 navigation, inline screen reader announcements during arrow-key navigation, Alt+1/2/3 quick replacement, and configurable suggestion announcements
- **Email signatures** — Per-account signatures auto-appended to new messages, replies, and forwards
- **ICS calendar invite handling** — Inline event card in reading pane with Accept/Tentative/Decline buttons
- **Keyboard tutorial** — Interactive first-run tutorial teaching 6 essential shortcuts, replayable from Help menu
- **Message templates** — Save/insert templates with {sender}, {date}, {time} placeholders

### Improvements
- Compose window command palette (Ctrl+Shift+P) with 9 compose-specific commands
- Alt+Y to focus message body in compose window
- Tutorial wrong-key feedback and manual-only launch
- Inline spell check announcements during cursor navigation

### Refactoring
- GroupedMessageTreeController extracted from MainWindow
- ConfigModel ViewMode/Sort serialization helpers
- ReplaceCts helper for CancellationTokenSource disposal

### Bug Fixes
- Tutorial overlay crash (Steps.Count binding mode)
- Alt+1/2/3 focus jump during replacement
- Tutorial cancel vs. complete event separation
- ICS reply organizer parameter

**Tests:** 341 passing | **Build:** 0 warnings, 0 errors