### PR TITLE
Graph backend groundwork: specs + IMailService rename

### DIFF
--- a/QuickMail.Tests/ComposeViewModelTemplateTests.cs
+++ b/QuickMail.Tests/ComposeViewModelTemplateTests.cs
@@ -28,7 +28,7 @@ public class ComposeViewModelTemplateTests
             new StubSmtpService(),
             new StubAccountService(),
             new StubCredentialService(),
-            new StubImapService(),
+            new StubImapMailService(),
             templates);
         return (vm, templates);
     }

--- a/QuickMail.Tests/MessageFilterTests.cs
+++ b/QuickMail.Tests/MessageFilterTests.cs
@@ -64,7 +64,7 @@ public class MessageFilterTests
     {
         var store = new FilterableStore(messages);
         return new MainViewModel(
-            new StubImapService(), new StubAccountService(), new StubCredentialService(),
+            new StubImapMailService(), new StubAccountService(), new StubCredentialService(),
             store, new StubOAuthService(), new StubSyncService(), new StubConfigService(),
             new StubCommandRegistry(), new StubViewService(), new StubRuleService(), new StubSmtpService());
     }

--- a/QuickMail.Tests/RuleServiceTests.cs
+++ b/QuickMail.Tests/RuleServiceTests.cs
@@ -42,7 +42,7 @@ public class RuleServiceTests
 
     private static RuleService CreateService(string dataDir)
     {
-        return new RuleService(new StubImapService(), new StubLocalStoreService(), dataDir);
+        return new RuleService(new StubImapMailService(), new StubLocalStoreService(), dataDir);
     }
 
     // ── Load / Save tests ───────────────────────────────────────────────────

--- a/QuickMail.Tests/RulesManagerViewModelTests.cs
+++ b/QuickMail.Tests/RulesManagerViewModelTests.cs
@@ -293,7 +293,7 @@ public class RulesManagerViewModelTests
         var dir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), Guid.NewGuid().ToString());
         try
         {
-            var realService = new RuleService(new StubImapService(), new StubLocalStoreService(), dir);
+            var realService = new RuleService(new StubImapMailService(), new StubLocalStoreService(), dir);
             var msg = MakeMsg(from: "alice@example.com");
             var vm = new RulesManagerViewModel(realService, accounts: [], selectedMessagesForTest: [msg]);
             vm.NewRuleCommand.Execute(null);
@@ -313,7 +313,7 @@ public class RulesManagerViewModelTests
         var dir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), Guid.NewGuid().ToString());
         try
         {
-            var realService = new RuleService(new StubImapService(), new StubLocalStoreService(), dir);
+            var realService = new RuleService(new StubImapMailService(), new StubLocalStoreService(), dir);
             var msg = MakeMsg(from: "bob@example.com");
             var vm = new RulesManagerViewModel(realService, accounts: [], selectedMessagesForTest: [msg]);
             vm.NewRuleCommand.Execute(null);

--- a/QuickMail.Tests/SavedViewsTests.cs
+++ b/QuickMail.Tests/SavedViewsTests.cs
@@ -287,7 +287,7 @@ public class SavedViewsMainViewModelTests
     // -- Factory -------------------------------------------------------------
 
     private static MainViewModel MakeVm(IEnumerable<SavedView>? views = null)
-        => new(new StubImapService(),
+        => new(new StubImapMailService(),
                new StubAccountService(),
                new StubCredentialService(),
                new StubLocalStoreService(),
@@ -775,7 +775,7 @@ public class SavedViewsMainViewModelTests
     // Regression test: persisting DaysOfMail and setting ActiveDayLimit isn't
     // enough — Messages must also be filtered when the view is applied.
 
-    sealed class DatedImap : IImapService
+    sealed class DatedImap : IMailService
     {
         private readonly List<MailMessageSummary> _messages;
         public DatedImap(IEnumerable<MailMessageSummary> messages) => _messages = new(messages);
@@ -838,8 +838,8 @@ public class SavedViewsMainViewModelTests
         public Task<HashSet<uint>> GetAllUidsAsync(Guid accountId, string folderName) => Task.FromResult(new HashSet<uint>());
     }
 
-    private static MainViewModel MakeVmWithStore(IEnumerable<SavedView> views, ILocalStoreService store, IImapService? imap = null)
-        => new(imap ?? new StubImapService(),
+    private static MainViewModel MakeVmWithStore(IEnumerable<SavedView> views, ILocalStoreService store, IMailService? imap = null)
+        => new(imap ?? new StubImapMailService(),
                new StubAccountService(),
                new StubCredentialService(),
                store,

--- a/QuickMail.Tests/SavedViewsTests.cs
+++ b/QuickMail.Tests/SavedViewsTests.cs
@@ -775,10 +775,10 @@ public class SavedViewsMainViewModelTests
     // Regression test: persisting DaysOfMail and setting ActiveDayLimit isn't
     // enough — Messages must also be filtered when the view is applied.
 
-    sealed class DatedImap : IMailService
+    sealed class DatedMailService : IMailService
     {
         private readonly List<MailMessageSummary> _messages;
-        public DatedImap(IEnumerable<MailMessageSummary> messages) => _messages = new(messages);
+        public DatedMailService(IEnumerable<MailMessageSummary> messages) => _messages = new(messages);
         public Task ConnectAsync(AccountModel account, string? password = null, CancellationToken ct = default) => Task.CompletedTask;
         public Task DisconnectAsync(Guid accountId, CancellationToken ct = default) => Task.CompletedTask;
         public Task<List<MailFolderModel>> GetFoldersAsync(Guid accountId, CancellationToken ct = default) => Task.FromResult(new List<MailFolderModel>());
@@ -885,7 +885,7 @@ public class SavedViewsMainViewModelTests
         // Local store is empty so Phase 1 contributes nothing — every visible
         // message has to survive Phase 2's incremental insert path.
         var store  = new DatedStore([]);
-        var imap   = new DatedImap([recent, older]);
+        var imap   = new DatedMailService([recent, older]);
 
         var view = MakeVirtualView("AllMail");
         view.DaysOfMail = 7;
@@ -914,7 +914,7 @@ public class SavedViewsMainViewModelTests
         var view = MakeRealFolderView(acctId, "INBOX");
         view.DaysOfMail = 7;
 
-        var imap = new DatedImap([recent, older]);
+        var imap = new DatedMailService([recent, older]);
         var vm = MakeVmWithStore([view], store, imap);
         // Match the AccountId on the live Folders collection so ApplyViewAsync's
         // single-folder branch finds the real folder.

--- a/QuickMail.Tests/SessionFeaturesTests.cs
+++ b/QuickMail.Tests/SessionFeaturesTests.cs
@@ -114,7 +114,7 @@ public class PreviewSuppressionTests
     {
         var store = new PreviewStore(MessagesWithPreviews);
         var vm = new MainViewModel(
-            new StubImapService(), new StubAccountService(), new StubCredentialService(),
+            new StubImapMailService(), new StubAccountService(), new StubCredentialService(),
             store, new StubOAuthService(), new StubSyncService(), new ZeroPreviewConfig(),
             new StubCommandRegistry(), new StubViewService(), new StubRuleService(), new StubSmtpService());
 
@@ -129,7 +129,7 @@ public class PreviewSuppressionTests
         // Default StubConfigService returns PreviewLines = 3 (from ConfigModel defaults).
         var store = new PreviewStore(MessagesWithPreviews);
         var vm = new MainViewModel(
-            new StubImapService(), new StubAccountService(), new StubCredentialService(),
+            new StubImapMailService(), new StubAccountService(), new StubCredentialService(),
             store, new StubOAuthService(), new StubSyncService(), new StubConfigService(),
             new StubCommandRegistry(), new StubViewService(), new StubRuleService(), new StubSmtpService());
 
@@ -147,7 +147,7 @@ public class OnlineModeTests
 {
     private static MainViewModel MakeVm(bool onlineMode = false) =>
         new MainViewModel(
-            new StubImapService(), new StubAccountService(), new StubCredentialService(),
+            new StubImapMailService(), new StubAccountService(), new StubCredentialService(),
             new StubLocalStoreService(), new StubOAuthService(), new StubSyncService(),
             new StubConfigService(), new StubCommandRegistry(), new StubViewService(),
             new StubRuleService(), new StubSmtpService(), onlineMode: onlineMode);
@@ -180,10 +180,10 @@ public class OnlineModeTests
 
 public class IdleNewMailTests
 {
-    sealed class FireableImapService : IImapService
+    sealed class FireableImapMailService : IMailService
     {
         private readonly Guid _accountId;
-        public FireableImapService(Guid accountId) => _accountId = accountId;
+        public FireableImapMailService(Guid accountId) => _accountId = accountId;
 
         public event Action<Guid>? InboxNewMailDetected;
         public void FireNewMail() => InboxNewMailDetected?.Invoke(_accountId);
@@ -260,7 +260,7 @@ public class IdleNewMailTests
     public async Task NewMailDetected_TriggersSyncForMatchingInbox()
     {
         var accountId = Guid.NewGuid();
-        var imap = new FireableImapService(accountId);
+        var imap = new FireableImapMailService(accountId);
         var sync = new SpySyncService();
         var account = new AccountModel
         {
@@ -293,7 +293,7 @@ public class IdleNewMailTests
     public async Task NewMailDetected_OnlineMode_CallsSyncOneFolderOnline()
     {
         var accountId = Guid.NewGuid();
-        var imap = new FireableImapService(accountId);
+        var imap = new FireableImapMailService(accountId);
         var sync = new SpySyncService();
         var account = new AccountModel
         {

--- a/QuickMail.Tests/SessionFeaturesTests.cs
+++ b/QuickMail.Tests/SessionFeaturesTests.cs
@@ -180,10 +180,10 @@ public class OnlineModeTests
 
 public class IdleNewMailTests
 {
-    sealed class FireableImapMailService : IMailService
+    sealed class FireableMailService : IMailService
     {
         private readonly Guid _accountId;
-        public FireableImapMailService(Guid accountId) => _accountId = accountId;
+        public FireableMailService(Guid accountId) => _accountId = accountId;
 
         public event Action<Guid>? InboxNewMailDetected;
         public void FireNewMail() => InboxNewMailDetected?.Invoke(_accountId);
@@ -260,7 +260,7 @@ public class IdleNewMailTests
     public async Task NewMailDetected_TriggersSyncForMatchingInbox()
     {
         var accountId = Guid.NewGuid();
-        var imap = new FireableImapMailService(accountId);
+        var imap = new FireableMailService(accountId);
         var sync = new SpySyncService();
         var account = new AccountModel
         {
@@ -293,7 +293,7 @@ public class IdleNewMailTests
     public async Task NewMailDetected_OnlineMode_CallsSyncOneFolderOnline()
     {
         var accountId = Guid.NewGuid();
-        var imap = new FireableImapMailService(accountId);
+        var imap = new FireableMailService(accountId);
         var sync = new SpySyncService();
         var account = new AccountModel
         {

--- a/QuickMail.Tests/StubServices.cs
+++ b/QuickMail.Tests/StubServices.cs
@@ -12,7 +12,7 @@ using QuickMail.Services;
 
 namespace QuickMail.Tests;
 
-sealed class StubImapService : IImapService
+sealed class StubImapMailService : IMailService
 {
     public Task ConnectAsync(AccountModel account, string? password = null, CancellationToken ct = default) => Task.CompletedTask;
     public Task DisconnectAsync(Guid accountId, CancellationToken ct = default) => Task.CompletedTask;

--- a/QuickMail.Tests/UnitTest1.cs
+++ b/QuickMail.Tests/UnitTest1.cs
@@ -23,12 +23,12 @@ namespace QuickMail.Tests;
 /// </summary>
 public class ViewModelConstructionTests
 {
-    private static (StubImapService imap, StubAccountService accounts, StubCredentialService creds,
+    private static (StubImapMailService imap, StubAccountService accounts, StubCredentialService creds,
         StubLocalStoreService store, StubSyncService sync, StubConfigService config,
         StubCommandRegistry registry, StubContactService contacts, StubTemplateService templates)
         MakeServices()
     {
-        return (new StubImapService(), new StubAccountService(), new StubCredentialService(),
+        return (new StubImapMailService(), new StubAccountService(), new StubCredentialService(),
             new StubLocalStoreService(), new StubSyncService(), new StubConfigService(),
             new StubCommandRegistry(), new StubContactService(), new StubTemplateService());
     }
@@ -329,12 +329,12 @@ public class XamlParseTests
         window.Close();
     }
 
-    private static (StubImapService imap, StubAccountService accounts, StubCredentialService creds,
+    private static (StubImapMailService imap, StubAccountService accounts, StubCredentialService creds,
         StubLocalStoreService store, StubSyncService sync, StubConfigService config,
         StubCommandRegistry registry, StubContactService contacts, StubTemplateService templates)
         MakeServices()
     {
-        return (new StubImapService(), new StubAccountService(), new StubCredentialService(),
+        return (new StubImapMailService(), new StubAccountService(), new StubCredentialService(),
             new StubLocalStoreService(), new StubSyncService(), new StubConfigService(),
             new StubCommandRegistry(), new StubContactService(), new StubTemplateService());
     }

--- a/QuickMail/App.xaml.cs
+++ b/QuickMail/App.xaml.cs
@@ -72,7 +72,7 @@ public partial class App : Application
             var credentialService = new CredentialService();
             var oauthService      = new OAuthService(profile);
             var configService     = new ConfigService(profile);
-            var imapService       = new ImapService(oauthService, configService);
+            var mailService       = new ImapMailService(oauthService, configService);
             var smtpService       = new SmtpService(oauthService);
 
             var localStore = new LocalStoreService(profile);
@@ -81,8 +81,8 @@ public partial class App : Application
 
             var contactService = new ContactService(profile);
             var templateService = new TemplateService(profile);
-            var ruleService = new RuleService(imapService, localStore, profile.ProfileDir);
-            var syncService = new SyncService(imapService, localStore, configService, ruleService);
+            var ruleService = new RuleService(mailService, localStore, profile.ProfileDir);
+            var syncService = new SyncService(mailService, localStore, configService, ruleService);
 
             var startupCfg = configService.Load();
             Views.AccessibilityHelper.Configure(startupCfg);
@@ -94,11 +94,11 @@ public partial class App : Application
             var viewService = new ViewService(profile);
 
             var mainVm = new MainViewModel(
-                imapService, accountService, credentialService, localStore, oauthService, syncService, configService, commandRegistry, viewService, ruleService, smtpService,
+                mailService, accountService, credentialService, localStore, oauthService, syncService, configService, commandRegistry, viewService, ruleService, smtpService,
                 onlineMode: onlineMode);
             mainVm.LoadAccountList();
 
-            var mainWindow = new MainWindow(mainVm, smtpService, accountService, credentialService, imapService, oauthService, commandRegistry, contactService, configService, localStore, viewService, ruleService, templateService);
+            var mainWindow = new MainWindow(mainVm, smtpService, accountService, credentialService, mailService, oauthService, commandRegistry, contactService, configService, localStore, viewService, ruleService, templateService);
             mainWindow.Show();
         }
         catch (Exception ex)

--- a/QuickMail/Services/IMailService.cs
+++ b/QuickMail/Services/IMailService.cs
@@ -6,7 +6,7 @@ using QuickMail.Models;
 
 namespace QuickMail.Services;
 
-public interface IImapService : IDisposable
+public interface IMailService : IDisposable
 {
     Task ConnectAsync(AccountModel account, string? password = null, CancellationToken ct = default);
     Task DisconnectAsync(Guid accountId, CancellationToken ct = default);

--- a/QuickMail/Services/ImapMailService.cs
+++ b/QuickMail/Services/ImapMailService.cs
@@ -15,7 +15,7 @@ using QuickMail.Models;
 
 namespace QuickMail.Services;
 
-public class ImapService : IImapService
+public class ImapMailService : IMailService
 {
     private const int DefaultMaxConnectionsPerAccount = 6;
     private const int AbsoluteMaxConnectionsPerAccount = 15;
@@ -32,7 +32,7 @@ public class ImapService : IImapService
 
     public event Action<Guid>? InboxNewMailDetected;
 
-    public ImapService(IOAuthService oauth, IConfigService? config = null)
+    public ImapMailService(IOAuthService oauth, IConfigService? config = null)
     {
         _oauth  = oauth;
         _config = config;
@@ -353,7 +353,7 @@ public class ImapService : IImapService
                 }
                 catch (Exception ex)
                 {
-                    LogService.Log($"ImapService: failed to parse calendar part for UID {uid}: {ex.Message}");
+                    LogService.Log($"ImapMailService: failed to parse calendar part for UID {uid}: {ex.Message}");
                 }
             }
 
@@ -926,7 +926,7 @@ public class ImapService : IImapService
     private void ThrowIfDisposed()
     {
         if (_disposed)
-            throw new ObjectDisposedException(nameof(ImapService));
+            throw new ObjectDisposedException(nameof(ImapMailService));
     }
 
     private static bool SameConnectionSettings(AccountModel left, AccountModel right) =>
@@ -1003,7 +1003,7 @@ public class ImapService : IImapService
 
     private sealed class AccountConnectionPool : IDisposable
     {
-        private readonly ImapService _owner;
+        private readonly ImapMailService _owner;
         private readonly SemaphoreSlim _slots;
         private readonly SemaphoreSlim _backgroundSlots;
         private readonly object _gate = new();
@@ -1012,7 +1012,7 @@ public class ImapService : IImapService
         private bool _disposed;
 
         public AccountConnectionPool(
-            ImapService owner, AccountModel account, string? password, int maxConnections)
+            ImapMailService owner, AccountModel account, string? password, int maxConnections)
         {
             _owner = owner;
             Account = CloneAccount(account);

--- a/QuickMail/Services/MimeMessageBuilder.cs
+++ b/QuickMail/Services/MimeMessageBuilder.cs
@@ -8,7 +8,7 @@ namespace QuickMail.Services;
 /// <summary>
 /// Builds a <see cref="MimeMessage"/> from a <see cref="ComposeModel"/> and
 /// <see cref="AccountModel"/>, shared by <see cref="SmtpService"/> and
-/// <see cref="ImapService"/> (draft saving).
+/// <see cref="ImapMailService"/> (draft saving).
 /// </summary>
 public static class MimeMessageBuilder
 {

--- a/QuickMail/Services/RuleService.cs
+++ b/QuickMail/Services/RuleService.cs
@@ -12,14 +12,14 @@ namespace QuickMail.Services;
 public class RuleService : IRuleService
 {
     private readonly string _filePath;
-    private readonly IImapService _imap;
+    private readonly IMailService _imap;
     private readonly ILocalStoreService _store;
     private List<MailRule> _cache = [];
     private bool _loaded;
 
     private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
 
-    public RuleService(IImapService imap, ILocalStoreService store, string? dataDirectory = null)
+    public RuleService(IMailService imap, ILocalStoreService store, string? dataDirectory = null)
     {
         _imap = imap;
         _store = store;
@@ -220,7 +220,7 @@ public class RuleService : IRuleService
             ct.ThrowIfCancellationRequested();
             try
             {
-                // ImapService doesn't have a dedicated MarkUnreadAsync — we update
+                // ImapMailService doesn't have a dedicated MarkUnreadAsync — we update
                 // the local store only. Full IMAP unread will be added in a follow-up.
                 msg.IsRead = false;
                 await _store.UpdateIsReadAsync(msg.AccountId, msg.FolderName, msg.UniqueId, false);

--- a/QuickMail/Services/RuleService.cs
+++ b/QuickMail/Services/RuleService.cs
@@ -220,8 +220,8 @@ public class RuleService : IRuleService
             ct.ThrowIfCancellationRequested();
             try
             {
-                // ImapMailService doesn't have a dedicated MarkUnreadAsync — we update
-                // the local store only. Full IMAP unread will be added in a follow-up.
+                // IMailService has no MarkUnreadAsync yet — we update the local store
+                // only. Full server-side unread will be added in a follow-up.
                 msg.IsRead = false;
                 await _store.UpdateIsReadAsync(msg.AccountId, msg.FolderName, msg.UniqueId, false);
             }

--- a/QuickMail/Services/SyncService.cs
+++ b/QuickMail/Services/SyncService.cs
@@ -10,12 +10,12 @@ namespace QuickMail.Services;
 
 public class SyncService : ISyncService
 {
-    private readonly IImapService _imap;
+    private readonly IMailService _imap;
     private readonly ILocalStoreService _store;
     private readonly IConfigService _config;
     private readonly IRuleService _rules;
 
-    public SyncService(IImapService imap, ILocalStoreService store, IConfigService config, IRuleService rules)
+    public SyncService(IMailService imap, ILocalStoreService store, IConfigService config, IRuleService rules)
     {
         _imap   = imap;
         _store  = store;

--- a/QuickMail/ViewModels/AccountEditorViewModel.cs
+++ b/QuickMail/ViewModels/AccountEditorViewModel.cs
@@ -14,7 +14,7 @@ namespace QuickMail.ViewModels;
 /// </summary>
 public abstract partial class AccountEditorViewModel : ObservableObject
 {
-    protected readonly IImapService ImapService;
+    protected readonly IMailService ImapMailService;
     protected readonly IOAuthService OAuthService;
 
     [ObservableProperty] private string _accountName = string.Empty;
@@ -49,9 +49,9 @@ public abstract partial class AccountEditorViewModel : ObservableObject
         set => AuthType = value == 0 ? AuthType.Password : AuthType.OAuth2Microsoft;
     }
 
-    protected AccountEditorViewModel(IImapService imap, IOAuthService oauth)
+    protected AccountEditorViewModel(IMailService imap, IOAuthService oauth)
     {
-        ImapService = imap;
+        ImapMailService = imap;
         OAuthService = oauth;
     }
 
@@ -111,8 +111,8 @@ public abstract partial class AccountEditorViewModel : ObservableObject
             };
             using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
             var pwd = IsPasswordAuth ? Password : null;
-            await ImapService.ConnectAsync(testAccount, pwd, cts.Token);
-            await ImapService.DisconnectAsync(testAccount.Id, cts.Token);
+            await ImapMailService.ConnectAsync(testAccount, pwd, cts.Token);
+            await ImapMailService.DisconnectAsync(testAccount.Id, cts.Token);
             StatusText = "Connection successful!";
         }
         catch (Exception ex)

--- a/QuickMail/ViewModels/AccountEditorViewModel.cs
+++ b/QuickMail/ViewModels/AccountEditorViewModel.cs
@@ -14,7 +14,7 @@ namespace QuickMail.ViewModels;
 /// </summary>
 public abstract partial class AccountEditorViewModel : ObservableObject
 {
-    protected readonly IMailService ImapMailService;
+    protected readonly IMailService MailService;
     protected readonly IOAuthService OAuthService;
 
     [ObservableProperty] private string _accountName = string.Empty;
@@ -49,9 +49,9 @@ public abstract partial class AccountEditorViewModel : ObservableObject
         set => AuthType = value == 0 ? AuthType.Password : AuthType.OAuth2Microsoft;
     }
 
-    protected AccountEditorViewModel(IMailService imap, IOAuthService oauth)
+    protected AccountEditorViewModel(IMailService mailService, IOAuthService oauth)
     {
-        ImapMailService = imap;
+        MailService = mailService;
         OAuthService = oauth;
     }
 
@@ -111,8 +111,8 @@ public abstract partial class AccountEditorViewModel : ObservableObject
             };
             using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
             var pwd = IsPasswordAuth ? Password : null;
-            await ImapMailService.ConnectAsync(testAccount, pwd, cts.Token);
-            await ImapMailService.DisconnectAsync(testAccount.Id, cts.Token);
+            await MailService.ConnectAsync(testAccount, pwd, cts.Token);
+            await MailService.DisconnectAsync(testAccount.Id, cts.Token);
             StatusText = "Connection successful!";
         }
         catch (Exception ex)

--- a/QuickMail/ViewModels/AccountManagerViewModel.cs
+++ b/QuickMail/ViewModels/AccountManagerViewModel.cs
@@ -29,7 +29,7 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
     public AccountManagerViewModel(
         IAccountService accountService,
         ICredentialService credentials,
-        IImapService imap,
+        IMailService imap,
         IOAuthService oauth,
         ILocalStoreService localStore,
         IConfigService configService)
@@ -65,7 +65,7 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
         StatusText = string.Empty;
     }
 
-    public AddAccountViewModel CreateAddAccountViewModel() => new(ImapService, OAuthService);
+    public AddAccountViewModel CreateAddAccountViewModel() => new(ImapMailService, OAuthService);
 
     public void CommitNewAccount(AccountModel account, string password)
     {

--- a/QuickMail/ViewModels/AccountManagerViewModel.cs
+++ b/QuickMail/ViewModels/AccountManagerViewModel.cs
@@ -65,7 +65,7 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
         StatusText = string.Empty;
     }
 
-    public AddAccountViewModel CreateAddAccountViewModel() => new(ImapMailService, OAuthService);
+    public AddAccountViewModel CreateAddAccountViewModel() => new(MailService, OAuthService);
 
     public void CommitNewAccount(AccountModel account, string password)
     {

--- a/QuickMail/ViewModels/AddAccountViewModel.cs
+++ b/QuickMail/ViewModels/AddAccountViewModel.cs
@@ -7,8 +7,8 @@ namespace QuickMail.ViewModels;
 
 public partial class AddAccountViewModel : AccountEditorViewModel
 {
-    public AddAccountViewModel(IMailService imap, IOAuthService oauth)
-        : base(imap, oauth) { }
+    public AddAccountViewModel(IMailService mailService, IOAuthService oauth)
+        : base(mailService, oauth) { }
 
     protected override void OnAuthTypeChangedInternal(AuthType value)
     {

--- a/QuickMail/ViewModels/AddAccountViewModel.cs
+++ b/QuickMail/ViewModels/AddAccountViewModel.cs
@@ -7,7 +7,7 @@ namespace QuickMail.ViewModels;
 
 public partial class AddAccountViewModel : AccountEditorViewModel
 {
-    public AddAccountViewModel(IImapService imap, IOAuthService oauth)
+    public AddAccountViewModel(IMailService imap, IOAuthService oauth)
         : base(imap, oauth) { }
 
     protected override void OnAuthTypeChangedInternal(AuthType value)

--- a/QuickMail/ViewModels/ComposeViewModel.cs
+++ b/QuickMail/ViewModels/ComposeViewModel.cs
@@ -19,7 +19,7 @@ public partial class ComposeViewModel : ObservableObject
     private readonly ISmtpService _smtp;
     private readonly IAccountService _accountService;
     private readonly ICredentialService _credentials;
-    private readonly IImapService _imap;
+    private readonly IMailService _imap;
     private readonly ITemplateService _templateService;
 
     [ObservableProperty] private string _to = string.Empty;
@@ -51,7 +51,7 @@ public partial class ComposeViewModel : ObservableObject
     /// </summary>
     public Func<string, string, bool>? ConfirmationRequested { get; set; }
 
-    public ComposeViewModel(ISmtpService smtp, IAccountService accountService, ICredentialService credentials, IImapService imap, ITemplateService templateService)
+    public ComposeViewModel(ISmtpService smtp, IAccountService accountService, ICredentialService credentials, IMailService imap, ITemplateService templateService)
     {
         _smtp = smtp;
         _accountService = accountService;

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -19,7 +19,7 @@ namespace QuickMail.ViewModels;
 
 public partial class MainViewModel : ObservableObject
 {
-    private readonly IImapService _imap;
+    private readonly IMailService _imap;
     private readonly IAccountService _accountService;
     private readonly ICredentialService _credentials;
     private readonly ILocalStoreService _localStore;
@@ -419,7 +419,7 @@ public partial class MainViewModel : ObservableObject
     public bool OnlineMode { get; }
 
     public MainViewModel(
-        IImapService imap,
+        IMailService imap,
         IAccountService accountService,
         ICredentialService credentials,
         ILocalStoreService localStore,

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -70,7 +70,7 @@ public partial class MainWindow : Window
     private readonly ISmtpService _smtp;
     private readonly IAccountService _accountService;
     private readonly ICredentialService _credentials;
-    private readonly IImapService _imap;
+    private readonly IMailService _imap;
     private readonly IOAuthService _oauth;
     private readonly ICommandRegistry _registry;
     private bool _webViewReady;
@@ -131,7 +131,7 @@ public partial class MainWindow : Window
         ISmtpService smtp,
         IAccountService accountService,
         ICredentialService credentials,
-        IImapService imap,
+        IMailService imap,
         IOAuthService oauth,
         ICommandRegistry registry,
         IContactService contactService,

--- a/docs/planning/graph-backend-dev-spec.md
+++ b/docs/planning/graph-backend-dev-spec.md
@@ -196,6 +196,8 @@ Strict ordering. Each PR is mergeable on its own and leaves the app behaviorally
     - Gate off (default): combo not visible / shows only one option, IMAP account creation works identically to today.
     - Gate on (`config.ini` has `[features]\nGraphBackend=true`, or `--feature GraphBackend`): two options in combo, IMAP path still works identically.
 
+**`TestConnectionAsync` for Graph accounts:** `AccountEditorViewModel.TestConnectionAsync` is currently IMAP-specific — it guards on `ImapHost`, builds an `AccountModel` with IMAP fields, and calls `ConnectAsync`. For a `MicrosoftGraph` account those fields are empty. Make it a `virtual` method on the base `AccountEditorViewModel` that branches on `BackendKind` before the IMAP path: for `MicrosoftGraph`, skip the IMAP host/port validation and let `ConnectAsync` (routed to `GraphMailService` by `MailServiceRouter`) exercise the Graph `GET /me` probe, surfacing success/failure through the same `StatusText`. Because Graph `ConnectAsync` is not implemented until PR 4, a Graph "test connection" in PR 3 reports "not yet implemented" — consistent with step 15, keeping PR 3 a pure refactor + UI scaffold. A future Graph-specific editor can override the virtual cleanly.
+
 ### PR 4 — Graph read path (4-6 evenings)
 
 1. `Graph/GraphClient.cs`: thin `HttpClient` wrapper. Holds `IOAuthService`. Methods: `GetAsync<T>`, `PostAsync<T>`, `PatchAsync<T>`, `DeleteAsync`. Honors `Retry-After` on 429. Auto-pages on `@odata.nextLink`. Adds `Authorization: Bearer {token}` from `OAuthService.GetAccessTokenAsync(account, GraphScopes)`.
@@ -243,7 +245,7 @@ Strict ordering. Each PR is mergeable on its own and leaves the app behaviorally
 
 1. `IChangeNotifier.cs`: defines `event Action<Guid>? InboxNewMailDetected; void StartWatchers(IReadOnlyList<AccountModel> accounts, CancellationToken ct); void StopWatchers();`.
 2. `ImapMailService`: remove `StartIdleWatchers`, `StopIdleWatchers`, `InboxNewMailDetected` from `IMailService`. Move those into `ImapChangeNotifier`, which holds the existing IDLE pool logic.
-3. `GraphChangeNotifier`: one polling `Task` per Graph account. Each tick: `GET /mailFolders/Inbox/messages/delta?$skipToken={stored}`. If response contains ≥1 message, raise `InboxNewMailDetected(accountId)`; persist new `@odata.deltaLink` skip token to `DeltaToken` table.
+3. `GraphChangeNotifier`: one polling `Task` per Graph account. Each tick: request the stored `@odata.deltaLink` URL (or start a fresh `…/messages/delta` enumeration on the first run), following `@odata.nextLink` to the end of the page set. If any page contains ≥1 message, raise `InboxNewMailDetected(accountId)`; persist the final page's `@odata.deltaLink` URL to the `DeltaToken` table as the cursor for the next tick. The within-tick `@odata.nextLink`/`$skipToken` paging cursor is never persisted (see §6.12).
 4. Poll interval: 60s default, configurable via `config.ini` as `GraphPollSeconds` (clamped 30-600).
 5. `App.xaml.cs`: wire a `ChangeNotifierRouter` (or inline both notifiers and start both).
 6. `MainViewModel.StartIdleWatchers` call site: rename to `StartChangeWatchers`.
@@ -414,6 +416,8 @@ public string MessageId { get; set; } = string.Empty;
 Everything else unchanged. `MailMessageDetail : MailMessageSummary` inherits.
 
 **Sort behavior note:** when sorting messages by `MessageId` for backend-internal purposes (e.g. IMAP `GetMaxMessageKeyAsync`), the IMAP impl returns the zero-padded UID (`uid.ToString("D10")`) so string comparison preserves numeric order. Graph never compares IDs — it uses the delta token instead.
+
+**`GetMessagesSinceAsync` backend contract (resolves the PR 2 semantic gap):** after PR 2 the signature becomes `GetMessagesSinceAsync(Guid accountId, string folderName, string messageId, int initialCount, …)`. The `messageId` argument is meaningful **only** to the IMAP backend, which parses it back to a `uint` UID and requests `UID > messageId`. **`GraphMailService` ignores `messageId` entirely** and instead reads the folder's stored `@odata.deltaLink` cursor (see §6.12) to perform an incremental delta enumeration; an empty/`"0"` argument requests a first/full sync on both backends. This difference is invisible at the call site by design — `SyncService` passes the value it has and lets each backend interpret it. PR 4 implementers: do **not** attempt to honor `messageId` in `GraphMailService`; treating it as a UID range there is a bug.
 
 ### 6.6 `LocalStoreService.cs` — Schema Migration v2
 
@@ -886,20 +890,36 @@ public class GraphChangeNotifier : IChangeNotifier
         {
             try
             {
-                var token = await _store.GetDeltaTokenAsync(account.Id, "Inbox");
-                var url = string.IsNullOrEmpty(token)
+                // The stored cursor is a full @odata.deltaLink URL captured at the end of
+                // the previous tick (null on the very first poll → start a fresh delta
+                // enumeration). IMPORTANT: @odata.deltaLink (persisted; drives the NEXT
+                // tick) and @odata.nextLink/$skipToken (paging WITHIN this tick) are two
+                // different cursors. Only the deltaLink is ever persisted.
+                var deltaLink = await _store.GetDeltaTokenAsync(account.Id, "Inbox");
+                var url = string.IsNullOrEmpty(deltaLink)
                     ? "/me/mailFolders/Inbox/messages/delta?$select=id"
-                    : $"/me/mailFolders/Inbox/messages/delta?$skipToken={Uri.EscapeDataString(token)}";
+                    : deltaLink; // request the stored deltaLink URL verbatim
 
-                var resp = await _client.GetAsync<GraphDeltaResponse>(account.Id, url, ct);
-                if (resp?.Value?.Length > 0)
+                var sawMessages = false;
+                string? nextDeltaLink = null;
+
+                // Drain this tick's pages: follow @odata.nextLink to exhaustion, then keep
+                // the final page's @odata.deltaLink as the cursor for the next tick.
+                while (!string.IsNullOrEmpty(url))
+                {
+                    var resp = await _client.GetAsync<GraphDeltaResponse>(account.Id, url, ct);
+                    if (resp?.Value?.Length > 0)
+                        sawMessages = true;
+
+                    nextDeltaLink = resp?.DeltaLink ?? nextDeltaLink; // set only on the final page
+                    url = resp?.NextLink;                             // null on the final page
+                }
+
+                if (sawMessages)
                     InboxNewMailDetected?.Invoke(account.Id);
 
-                if (!string.IsNullOrEmpty(resp?.DeltaLink))
-                {
-                    var newToken = ExtractSkipToken(resp.DeltaLink);
-                    await _store.SetDeltaTokenAsync(account.Id, "Inbox", newToken);
-                }
+                if (!string.IsNullOrEmpty(nextDeltaLink))
+                    await _store.SetDeltaTokenAsync(account.Id, "Inbox", nextDeltaLink);
             }
             catch (OperationCanceledException) { return; }
             catch (Exception ex) { LogService.Log($"GraphChangeNotifier {account.AccountLabel}", ex); }
@@ -917,6 +937,18 @@ public class GraphChangeNotifier : IChangeNotifier
     }
 }
 ```
+
+`GraphDeltaResponse` exposes both cursors so the loop above can tell them apart:
+```csharp
+public class GraphDeltaResponse
+{
+    [JsonPropertyName("value")]            public GraphMessage[]? Value { get; set; }
+    [JsonPropertyName("@odata.nextLink")]  public string? NextLink { get; set; }  // within-tick paging; transient
+    [JsonPropertyName("@odata.deltaLink")] public string? DeltaLink { get; set; } // next-tick cursor; persist this
+}
+```
+
+The value persisted via `SetDeltaTokenAsync` is the **full `@odata.deltaLink` URL**, requested verbatim on the next tick — there is no `ExtractSkipToken` step. (The `folderId`/`deltaToken` parameter names below are historical; the stored string is a URL, not a bare token.)
 
 `ILocalStoreService` grows two methods:
 ```csharp
@@ -1082,7 +1114,7 @@ The existing INI parser already iterates sections. Add a case for `[features]` t
 **Consumer pattern in `AddAccountViewModel`:**
 
 ```csharp
-public AddAccountViewModel(IFeatureGate gate, IImapService imap, IOAuthService oauth) : base(imap, oauth)
+public AddAccountViewModel(IFeatureGate gate, IMailService mailService, IOAuthService oauth) : base(mailService, oauth)
 {
     var backends = new List<BackendKindOption>
     {
@@ -1295,7 +1327,7 @@ After every PR lands, before merge, the contributor runs this checklist on the d
 | `accounts.json` from old version has no `backendKind` | System.Text.Json defaults to `ImapSmtp` — backward compatible |
 | User adds Graph account but tenant has no Exchange Online mailbox | `/me` returns 200 but `GET /mailFolders` returns 404; surface: "No Exchange mailbox is associated with this account." |
 | Schema migration fails partway | Wrapped in transaction; rollback leaves v1 intact; backup file is the safety net |
-| Delta token expires (rare; Graph occasionally invalidates) | `GET delta?$skipToken=...` returns 410 Gone; clear the stored token and re-poll without it (full resync of changes) |
+| Stored deltaLink expires (rare; Graph occasionally invalidates) | requesting the stored `@odata.deltaLink` returns 410 Gone; clear the stored cursor and re-poll from a fresh `…/messages/delta` enumeration (full resync of changes) |
 | Long-running attachment download cancelled by user | Existing `CancellationToken` path applies; cancel propagates to `HttpClient` |
 
 ---

--- a/docs/planning/graph-backend-dev-spec.md
+++ b/docs/planning/graph-backend-dev-spec.md
@@ -1,0 +1,1367 @@
+# Microsoft Graph Backend — Development Specification
+
+**Status:** Proposed
+**Version:** 0.2 (incorporates maintainer feedback on feature gating)
+**Date:** 2026-05-24
+**Based on:** `graph-backend-pm-spec.md` v0.2 (Proposed)
+**Target:** AI coding agent or human contributor implementation
+
+**Changelog from v0.1:**
+- §2, §3, §4: added `IFeatureGate` + `ConfigFeatureGate` + `FeatureFlag` enum to files-to-create.
+- §5: PR 3 implementation order grows to include the feature gate.
+- §6: new §6.14 detailing `IFeatureGate` design.
+- §7: added gate-state tests to PR 8.
+- §8: PR 3 manual smoke checklist explicitly verifies gate-on and gate-off behavior.
+
+---
+
+## Table of Contents
+
+1. [Overview](#1-overview)
+2. [Phasing & PR Plan](#2-phasing--pr-plan)
+3. [Files to Create](#3-files-to-create)
+4. [Files to Modify](#4-files-to-modify)
+5. [Implementation Order](#5-implementation-order)
+6. [Detailed File Specifications](#6-detailed-file-specifications)
+   - [6.1 `BackendKind.cs` — Enum](#61-backendkindcs--enum)
+   - [6.2 `IMailService.cs` — Renamed Interface](#62-imailservicecs--renamed-interface)
+   - [6.3 `ImapMailService.cs` — Renamed Class](#63-imapmailservicecs--renamed-class)
+   - [6.4 `MailServiceRouter.cs` — Per-Account Dispatcher](#64-mailserviceroutercs--per-account-dispatcher)
+   - [6.5 `MailMessageSummary.cs` — string MessageId](#65-mailmessagesummarycs--string-messageid)
+   - [6.6 `LocalStoreService.cs` — Schema Migration v2](#66-localstoreservicecs--schema-migration-v2)
+   - [6.7 `AccountModel.cs` — BackendKind & TenantId](#67-accountmodelcs--backendkind--tenantid)
+   - [6.8 `OAuthService.cs` — Per-Call Scopes](#68-oauthservicecs--per-call-scopes)
+   - [6.9 `AddAccountViewModel.cs` & Dialog — Account Type Combo](#69-addaccountviewmodelcs--dialog--account-type-combo)
+   - [6.10 `GraphMailService.cs` — Read Path](#610-graphmailservicecs--read-path)
+   - [6.11 `GraphSmtpService.cs` — Send Path](#611-graphsmtpservicecs--send-path)
+   - [6.12 `GraphChangeNotifier.cs` — Delta Polling](#612-graphchangenotifiercs--delta-polling)
+   - [6.13 `App.xaml.cs` — DI Wiring](#613-appxamlcs--di-wiring)
+7. [Tests](#7-tests)
+8. [Per-PR Manual Smoke Checklist](#8-per-pr-manual-smoke-checklist)
+9. [Edge Cases & Error Handling](#9-edge-cases--error-handling)
+10. [Accessibility Checklist](#10-accessibility-checklist)
+11. [Build Verification](#11-build-verification)
+
+---
+
+## 1. Overview
+
+This spec implements the [Microsoft Graph Backend PM spec](graph-backend-pm-spec.md). The implementation is staged across eight PRs over two release cycles (v0.7 refactor, v0.8 Graph backend).
+
+**Key constraints from the codebase (from CLAUDE.md):**
+
+- MVVM strictly enforced — no `MessageBox`, `Window`, or `Dispatcher` in ViewModels
+- All keyboard shortcuts registered in `CommandRegistry`
+- All screen-reader announcements through `AccessibilityHelper.Announce()` with explicit `AnnouncementCategory`
+- Manual DI in `App.xaml.cs` — no container
+- Services follow the existing pattern (interface + class, constructor injection)
+- Passwords never in JSON; OAuth tokens in DPAPI-encrypted MSAL cache
+- New backend must respect the existing IMAP-pool philosophy: foreground operations get priority over background work
+
+**Existing infrastructure that this spec reuses without change:**
+
+- `OAuthService` / MSAL token cache (modified only to accept per-call scopes)
+- `MimeMessageBuilder` (Graph `/sendMail` accepts MIME)
+- `LocalStoreService` SQLite schema (modified for `unique_id` type change; otherwise same shape)
+- `ConversationBuilder`, `SenderGroupBuilder`, `FolderTreeBuilder` (all backend-agnostic)
+- `AccessibilityHelper`, `CommandRegistry`, `ViewService`, `RuleService` (zero changes)
+- `WebView2` HTML rendering (zero changes — Graph delivers the same HTML)
+
+---
+
+## 2. Phasing & PR Plan
+
+| PR | Title | v target | Approx LOC |
+|---|---|---|---|
+| 0 | This spec + PM spec, merged as draft | — | — |
+| 1 | Rename `IImapService` → `IMailService`, `ImapService` → `ImapMailService` | v0.7 | ~150 |
+| 2 | `uint UniqueId` → `string MessageId`; SQLite schema migration v2 | v0.7 | ~800 |
+| 3 | `BackendKind` + `MailServiceRouter` + **`IFeatureGate` infrastructure** + Add Account UI combo (Microsoft 365 option visible only when `FeatureFlag.GraphBackend` is on) | v0.7 | ~500 |
+| 4 | `GraphMailService` read path + `OAuthService` per-call scopes | v0.8 | ~600 |
+| 5 | `GraphSmtpService` send path | v0.8 | ~150 |
+| 6 | Graph attachments, folder CRUD, move/copy/delete | v0.8 | ~400 |
+| 7 | `IChangeNotifier`, `ImapChangeNotifier` (extracted), `GraphChangeNotifier` (delta polling) | v0.8 | ~300 |
+| 8 | Tests: `GraphMailServiceTests`, `MailServiceRouterTests`, `FeatureGateTests`, migration round-trip | v0.8 | ~450 |
+| **GA** | One-line PR flipping `FeatureFlag.GraphBackend` default `false` → `true`. Requires explicit maintainer approval. No fixed release. | TBD | <10 |
+
+Total: ~3100 LOC across ~27 files touched.
+
+---
+
+## 3. Files to Create
+
+| # | File | Phase | Purpose |
+|---|---|---|---|
+| 1 | `QuickMail/Models/BackendKind.cs` | 3 | Enum |
+| 2 | `QuickMail/Models/FeatureFlag.cs` | 3 | Enum of feature-gate keys (initially: `GraphBackend`) |
+| 3 | `QuickMail/Services/IFeatureGate.cs` | 3 | Feature-gate interface |
+| 4 | `QuickMail/Services/ConfigFeatureGate.cs` | 3 | Reads `[features]` from config.ini + CLI `--feature` flags |
+| 5 | `QuickMail/Services/IMailService.cs` | 1 | Renamed interface (file move from `IImapService.cs`) |
+| 6 | `QuickMail/Services/ImapMailService.cs` | 1 | Renamed class (file move from `ImapService.cs`) |
+| 7 | `QuickMail/Services/MailServiceRouter.cs` | 3 | Per-account `IMailService` dispatcher |
+| 8 | `QuickMail/Services/GraphMailService.cs` | 4 | Graph backend |
+| 9 | `QuickMail/Services/GraphSmtpService.cs` | 5 | Graph send via `/me/sendMail` |
+| 10 | `QuickMail/Services/IChangeNotifier.cs` | 7 | Abstraction over IDLE / delta polling |
+| 11 | `QuickMail/Services/ImapChangeNotifier.cs` | 7 | Extracted from `ImapMailService.StartIdleWatchers` |
+| 12 | `QuickMail/Services/GraphChangeNotifier.cs` | 7 | Delta polling loop |
+| 13 | `QuickMail/Services/Graph/GraphClient.cs` | 4 | Thin HttpClient wrapper with auth, throttling, paging |
+| 14 | `QuickMail/Services/Graph/GraphMessage.cs` | 4 | DTO for `/me/messages` response |
+| 15 | `QuickMail/Services/Graph/GraphMailFolder.cs` | 4 | DTO for `/me/mailFolders` |
+| 16 | `QuickMail/Services/Graph/GraphAttachment.cs` | 6 | DTO for `/messages/{id}/attachments` |
+| 17 | `QuickMail/Services/Graph/GraphDeltaResponse.cs` | 7 | DTO for delta envelope |
+| 18 | `QuickMail.Tests/FeatureGateTests.cs` | 3 | Gate-resolution tests (config + CLI + defaults) |
+| 19 | `QuickMail.Tests/GraphMailServiceTests.cs` | 8 | Tests against `HttpMessageHandler` stub |
+| 20 | `QuickMail.Tests/MailServiceRouterTests.cs` | 8 | Routing logic tests |
+| 21 | `QuickMail.Tests/LocalStoreServiceMigrationTests.cs` | 2 | Schema v1 → v2 round-trip |
+
+---
+
+## 4. Files to Modify
+
+| # | File | Phase | Change |
+|---|---|---|---|
+| 1 | `QuickMail/Services/IImapService.cs` (delete) | 1 | Replaced by `IMailService.cs` |
+| 2 | `QuickMail/Services/ImapService.cs` (delete) | 1 | Replaced by `ImapMailService.cs` |
+| 3 | `QuickMail/Models/MailMessageSummary.cs` | 2 | `uint UniqueId` → `string MessageId` |
+| 4 | `QuickMail/Models/MailMessageDetail.cs` | 2 | Inherits change (no own field change) |
+| 5 | `QuickMail/Models/AttachmentModel.cs` | 6 | Rename `PartSpecifier` → `AttachmentRef` |
+| 6 | `QuickMail/Models/AccountModel.cs` | 3 | Add `BackendKind BackendKind`, `string? TenantId` |
+| 7 | `QuickMail/Services/ILocalStoreService.cs` | 2 | All `uint uid` → `string messageId` |
+| 8 | `QuickMail/Services/LocalStoreService.cs` | 2 | Schema migration v2 (see §6.6) |
+| 9 | `QuickMail/Services/OAuthService.cs` | 4 | Accept `string[] scopes` per call (overload retains existing default for callers not ready) |
+| 10 | `QuickMail/Services/SyncService.cs` | 2 + 3 | `string` IDs; talks to `IMailService` |
+| 11 | `QuickMail/Services/RuleService.cs` | 2 | `string` IDs |
+| 12 | `QuickMail/ViewModels/MainViewModel.cs` | 2 + 3 | `string` IDs (44 call sites); injects `IMailService` (was `IImapService`) |
+| 13 | `QuickMail/ViewModels/AddAccountViewModel.cs` | 3 | `BackendKind` property; conditional defaults; consults `IFeatureGate` to populate combo options |
+| 14 | `QuickMail/ViewModels/AccountEditorViewModel.cs` | 3 | Read-only `BackendKind` (set at construction, never edited) |
+| 15 | `QuickMail/Views/AddAccountDialog.xaml` | 3 | New combo at top (single option when gate off; two options when gate on); conditional visibility on IMAP/SMTP groups |
+| 16 | `QuickMail/Views/AddAccountDialog.xaml.cs` | 3 | Announce field-set changes on backend type change |
+| 17 | `QuickMail/Views/AccountManagerDialog.xaml` | 3 | Display (read-only) account type column |
+| 17a | `QuickMail/Models/ConfigModel.cs` | 3 | Add `Dictionary<string, string> Features` for `[features]` section parsing |
+| 17b | `QuickMail/Services/ConfigService.cs` | 3 | Parse `[features]` INI section into `ConfigModel.Features` |
+| 18 | `QuickMail/App.xaml.cs` | 1, 3, 4 | Each PR updates DI wiring incrementally |
+| 19 | `QuickMail.Tests/StubServices.cs` | 1, 3, 4 | Rename stubs in PR 1; add `StubGraphMailService` in PR 4 |
+| 20 | `QuickMail/QuickMail.csproj` | 4 | No new packages (raw HttpClient choice per PM spec §9.6) |
+| 21 | `CLAUDE.md` | 3 | Document the router pattern in the Architecture section |
+| 22 | `USERGUIDE.md` | 4 | Add "Microsoft 365 accounts" section |
+
+---
+
+## 5. Implementation Order
+
+Strict ordering. Each PR is mergeable on its own and leaves the app behaviorally identical to the previous PR (with the exception of the Add Account UI in PR 3, which adds a combo box, and the Graph user-facing functionality in PR 4+).
+
+### PR 1 — Interface rename (1-2 evenings)
+
+1. Copy `IImapService.cs` to `IMailService.cs`; change `interface IImapService` → `interface IMailService`. Delete `IImapService.cs`.
+2. Copy `ImapService.cs` to `ImapMailService.cs`; change `class ImapService` → `class ImapMailService : IMailService`. Delete `ImapService.cs`.
+3. Update every consumer's constructor parameter: `IImapService` → `IMailService`. Visual Studio "Find All References" + bulk replace.
+4. Update `StubServices.cs`: `StubImapService` → `StubImapMailService` implementing `IMailService`.
+5. Update `App.xaml.cs`: `var imapService = new ImapService(...)` → `var mailService = new ImapMailService(...)`. Rename local variable everywhere it appears.
+6. Build, test suite, manual smoke (any IMAP account).
+
+### PR 2 — UID → string (3-5 evenings)
+
+1. `MailMessageSummary.UniqueId: uint` → `MessageId: string`.
+2. `AttachmentModel.PartSpecifier` keeps its type (still `string?`) — no change in PR 2; renamed in PR 6.
+3. `IMailService`: every `uint uid` → `string messageId`; every `IList<uint> uids` → `IList<string> messageIds`; `GetMaxUidAsync` → `GetMaxMessageKeyAsync` (returns `string` — IMAP impl returns zero-padded UID; Graph impl returns the delta token).
+4. `ILocalStoreService`: same changes.
+5. `LocalStoreService`: rewrite schema migration logic. Bump `CurrentSchemaVersion` to 2. Migration SQL per PM spec Appendix C.
+6. `LocalStoreService.Initialize`: pre-migration backup of `mail.db` → `mail.db.pre-v2` if `user_version < 2`.
+7. `ImapMailService`: every `client.Uid` → `client.Uid.ToString(CultureInfo.InvariantCulture)`. Every internal `uint` becomes `string`. Where `uint.Parse` is needed (e.g. for IMAP UID arithmetic), parse on entry.
+8. `SyncService`: `maxUid` (`uint`) → `maxKey` (`string`); IMAP backend interprets, Graph backend ignores.
+9. `RuleService`: 12 occurrences of `UniqueId` → `MessageId`.
+10. `MainViewModel`: 44 occurrences. The compiler is your friend — `uint` → `string` won't compile until every site is updated.
+11. Migration test: `LocalStoreServiceMigrationTests` — seed a v1 schema with 1000 rows, run migration, assert all rows survive with correct text IDs.
+12. Full test suite, manual smoke on a Gmail account: open app, fetch mail, read a message, mark unread, move to folder, send a reply, delete. Compare with pre-PR behavior.
+
+### PR 3 — Backend kind + router + feature gate (2-3 evenings)
+
+1. `BackendKind.cs`: enum with `ImapSmtp`, `MicrosoftGraph`.
+2. `FeatureFlag.cs`: enum with `GraphBackend` (others added by future PRs).
+3. `IFeatureGate.cs`: `bool IsEnabled(FeatureFlag flag);`.
+4. `ConfigFeatureGate.cs`: reads `[features]` section from `ConfigModel.Features` and merges CLI `--feature` flags from `App.xaml.cs`. Defaults: every flag is `false` unless explicitly enabled.
+5. `ConfigModel.cs`: add `Dictionary<string, string> Features { get; set; } = new();`.
+6. `ConfigService.cs`: extend INI parser to read `[features]` section into `ConfigModel.Features`.
+7. `App.xaml.cs`: parse `--feature` CLI flags (multiple allowed); construct `ConfigFeatureGate(configService.Load(), cliFlags)`; pass to `AddAccountViewModel`.
+8. `AccountModel`: add `BackendKind BackendKind { get; set; } = BackendKind.ImapSmtp;` and `string? TenantId { get; set; }`.
+9. `MailServiceRouter.cs`: implements `IMailService`. Holds `Dictionary<Guid, IMailService> _byAccount`. Each method looks up by accountId and delegates. Events are aggregated from all underlying services.
+10. `App.xaml.cs`: change `mainVm = new MainViewModel(mailService, ...)` to `mainVm = new MainViewModel(router, ...)` where `router = new MailServiceRouter(...)`. For every account, the router registers `ImapMailService` (Graph backend wired in PR 4).
+11. `AccountEditorViewModel`: expose `BackendKind` as a read-only property when editing (set at construction, displayed but not editable).
+12. `AddAccountViewModel`: accept `IFeatureGate` in constructor. Expose `BackendKind` as a writable property with bindable default `ImapSmtp`. When set to `MicrosoftGraph`: clear IMAP/SMTP fields, force `AuthType = OAuth2Microsoft`. Expose `IReadOnlyList<BackendKindOption> AvailableBackends` derived from gate state: always includes `ImapSmtp`; includes `MicrosoftGraph` only when `gate.IsEnabled(FeatureFlag.GraphBackend)`.
+13. `AddAccountDialog.xaml`: add a `ComboBox` at the top bound to `BackendKind`, items source bound to `AvailableBackends`. When `AvailableBackends.Count == 1`, the dialog renders the combo as a static label ("Standard IMAP/SMTP") to reduce visual clutter for the default user. Add `Visibility` triggers on the IMAP and SMTP group boxes that collapse them when `BackendKind == MicrosoftGraph`.
+14. `AddAccountDialog.xaml.cs`: on `BackendKind` change, call `AccessibilityHelper.Announce(...)` with the appropriate `Hint` message.
+15. Until PR 4 lands: even with the gate on, selecting "Microsoft 365" produces a dialog warning ("Graph backend not yet implemented") on Save. This keeps PR 3 a pure refactor + UI scaffold + gate infrastructure.
+16. Build, test, smoke. **Verify both gate states:**
+    - Gate off (default): combo not visible / shows only one option, IMAP account creation works identically to today.
+    - Gate on (`config.ini` has `[features]\nGraphBackend=true`, or `--feature GraphBackend`): two options in combo, IMAP path still works identically.
+
+### PR 4 — Graph read path (4-6 evenings)
+
+1. `Graph/GraphClient.cs`: thin `HttpClient` wrapper. Holds `IOAuthService`. Methods: `GetAsync<T>`, `PostAsync<T>`, `PatchAsync<T>`, `DeleteAsync`. Honors `Retry-After` on 429. Auto-pages on `@odata.nextLink`. Adds `Authorization: Bearer {token}` from `OAuthService.GetAccessTokenAsync(account, GraphScopes)`.
+2. `Graph/GraphMessage.cs`, `Graph/GraphMailFolder.cs`: DTOs matching Graph v1.0 response shape. Use `JsonPropertyName` attributes for camelCase mapping.
+3. `OAuthService.cs`: add overload `GetAccessTokenAsync(AccountModel account, string[] scopes, CancellationToken ct = default)`. Existing zero-scope-arg overload calls the new one with IMAP scopes.
+4. `GraphMailService.cs`: implements `IMailService`. Reads only — `MarkReadAsync`, `MoveMessagesAsync`, etc. throw `NotImplementedException` (lit up in PRs 5-6). Implements:
+   - `ConnectAsync` — `GET /me?$select=id,userPrincipalName`; populates `account.Username` on success.
+   - `GetFoldersAsync` — `GET /mailFolders?$top=100`; paginate via `@odata.nextLink`; map to `MailFolderModel` with `FullName = folder.id`, `DisplayName = folder.displayName`. Folder tree built by existing `FolderTreeBuilder` using `parentFolderId`.
+   - `GetMessageSummariesAsync` — `GET /mailFolders/{id}/messages?$top={N}&$orderby=receivedDateTime desc&$select=...`. Map to `MailMessageSummary` with `MessageId = msg.id`.
+   - `GetMessageDetailAsync` — `GET /messages/{id}?$select=...&$expand=attachments`. Map body, recipients, attachments.
+   - `MarkReadAsync` — `PATCH /messages/{id}` with `{ "isRead": true }`.
+   - `GetInboxStatusAsync` — `GET /mailFolders/Inbox?$select=totalItemCount,unreadItemCount`.
+   - `FindDraftsFolderNameAsync` — return well-known `"Drafts"` (Graph well-known folder name; works as folder ID).
+   - All other methods: `throw new NotImplementedException("Wired in PR 5/6")`.
+5. `App.xaml.cs`: when an account has `BackendKind == MicrosoftGraph`, register `GraphMailService` in the router instead of `ImapMailService`.
+6. `AddAccountDialog.xaml`: enable the "Microsoft 365 / Outlook.com" combo option.
+7. `AddAccountViewModel`: on `BackendKind = MicrosoftGraph`, the **Sign in** button (existing OAuth flow) uses Graph scopes via the overload.
+8. **Maintainer coordination required**: MSAL app registration needs Graph scopes added in Azure portal before this PR can be tested end-to-end.
+9. Smoke test on a real M365 account: create account, fetch inbox, read a message.
+
+### PR 5 — Graph send (1-2 evenings)
+
+1. `GraphSmtpService.cs`: implements `ISmtpService`. `SendAsync` posts the MIME from `MimeMessageBuilder` to `POST /me/sendMail` with `Content-Type: text/plain` and base64-encoded MIME body. Graph auto-saves to Sent — `AppendToSentAsync` becomes a no-op for Graph.
+2. `App.xaml.cs`: SMTP service is a router too — `SmtpServiceRouter` (simpler than mail; one method). Or: the existing `SmtpService` checks `account.BackendKind` and delegates. Simpler — go with the second.
+3. Modify `SmtpService.SendAsync`: at the top, `if (account.BackendKind == BackendKind.MicrosoftGraph) { await _graphSmtp.SendAsync(...); return; }`.
+4. Smoke: compose and send from an M365 account; verify it appears in Sent.
+
+### PR 6 — Graph mutations (3-5 evenings)
+
+1. `GraphMailService`: implement the rest of `IMailService`:
+   - `MoveMessagesAsync` — `POST /messages/{id}/move` per message; consider `$batch` for >5 messages.
+   - `MoveToTrashBatchAsync` — same, target = Deleted Items well-known folder.
+   - `PermanentlyDeleteBatchAsync` — `DELETE /messages/{id}` per message.
+   - `CopyMessagesAsync` — `POST /messages/{id}/copy`.
+   - `DownloadAttachmentAsync` — `GET /messages/{messageId}/attachments/{attachmentId}/$value`.
+   - `CreateFolderAsync` / `DeleteFolderAsync` / `RenameFolderAsync` / `CopyFolderAsync` — `mailFolders` endpoints per appendix A.
+   - `AppendDraftAsync` — `POST /messages`; if `replaceMessageId` is provided, `DELETE` it first.
+   - `EmptyTrashAsync` — list + bulk delete (preview `permanentlyDelete` may be available; check at impl time).
+2. `AttachmentModel.PartSpecifier` rename to `AttachmentRef`. Find-replace across 4 files.
+3. `FetchPreviewsAsync` becomes a no-op for Graph (`bodyPreview` already populated in summaries).
+4. `NoOpAsync` becomes a no-op for Graph (HTTP is stateless).
+5. Smoke: full mutate cycle on M365 — move, copy, delete, attach a file, save draft, edit draft, send.
+
+### PR 7 — Change notifications (3-4 evenings)
+
+1. `IChangeNotifier.cs`: defines `event Action<Guid>? InboxNewMailDetected; void StartWatchers(IReadOnlyList<AccountModel> accounts, CancellationToken ct); void StopWatchers();`.
+2. `ImapMailService`: remove `StartIdleWatchers`, `StopIdleWatchers`, `InboxNewMailDetected` from `IMailService`. Move those into `ImapChangeNotifier`, which holds the existing IDLE pool logic.
+3. `GraphChangeNotifier`: one polling `Task` per Graph account. Each tick: `GET /mailFolders/Inbox/messages/delta?$skipToken={stored}`. If response contains ≥1 message, raise `InboxNewMailDetected(accountId)`; persist new `@odata.deltaLink` skip token to `DeltaToken` table.
+4. Poll interval: 60s default, configurable via `config.ini` as `GraphPollSeconds` (clamped 30-600).
+5. `App.xaml.cs`: wire a `ChangeNotifierRouter` (or inline both notifiers and start both).
+6. `MainViewModel.StartIdleWatchers` call site: rename to `StartChangeWatchers`.
+7. Smoke: send a message to the M365 account from another mailbox; verify QuickMail notices within 60s.
+
+### PR 8 — Tests (2-3 evenings)
+
+1. `GraphMailServiceTests`: use `HttpMessageHandler` stub. Test each endpoint mapping. Test 429 backoff. Test pagination via `@odata.nextLink`. Test delta token persistence.
+2. `MailServiceRouterTests`: register a fake `IMailService` for two accounts; assert calls route correctly; assert events from both backends are surfaced.
+3. `LocalStoreServiceMigrationTests` (already added in PR 2): no change.
+4. Update `StubServices.cs` with a `StubGraphMailService` that does nothing — used by VM construction tests.
+
+---
+
+## 6. Detailed File Specifications
+
+### 6.1 `BackendKind.cs` — Enum
+
+**Path:** `QuickMail/Models/BackendKind.cs`
+
+```csharp
+namespace QuickMail.Models;
+
+/// <summary>
+/// Which protocol stack this account uses. Selected when the account is added
+/// and fixed for its lifetime. To switch, delete and re-add the account.
+/// </summary>
+public enum BackendKind
+{
+    /// <summary>Standard IMAP for receive + SMTP for send (default for all existing accounts).</summary>
+    ImapSmtp,
+
+    /// <summary>Microsoft Graph for receive + send. Used for M365 / Outlook.com.</summary>
+    MicrosoftGraph,
+}
+```
+
+### 6.2 `IMailService.cs` — Renamed Interface
+
+**Path:** `QuickMail/Services/IMailService.cs`
+
+**Phase 1: byte-identical to `IImapService.cs` except:**
+- Filename
+- Interface name (`IMailService`)
+
+**Phase 2 (within PR 2):** every `uint uid` → `string messageId`, every `IList<uint>` → `IList<string>`, `GetMaxUidAsync` → `GetMaxMessageKeyAsync`.
+
+**Phase 7 (PR 7):** remove `event Action<Guid>? InboxNewMailDetected; StartIdleWatchers; StopIdleWatchers;` — moved to `IChangeNotifier`.
+
+No other changes.
+
+### 6.3 `ImapMailService.cs` — Renamed Class
+
+**Path:** `QuickMail/Services/ImapMailService.cs`
+
+Identical contents to `ImapService.cs` after rename. Class name `ImapMailService`. The class continues to use MailKit and the existing per-account connection pool. The only logical changes happen in later PRs:
+
+- PR 2: `client.Uid` → `client.Uid.ToString(CultureInfo.InvariantCulture)`; internal `uint`s become `string`. UID parsing happens at the IMAP boundary only.
+- PR 7: IDLE logic moves to `ImapChangeNotifier`; `ImapMailService.StartIdleWatchers` becomes a thin wrapper that delegates (kept for compile compatibility, then removed).
+
+### 6.4 `MailServiceRouter.cs` — Per-Account Dispatcher
+
+**Path:** `QuickMail/Services/MailServiceRouter.cs`
+
+```csharp
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using QuickMail.Models;
+
+namespace QuickMail.Services;
+
+/// <summary>
+/// IMailService implementation that holds one backend per account and dispatches
+/// every call to the right backend based on accountId. Consumers see a single
+/// IMailService surface.
+/// </summary>
+public class MailServiceRouter : IMailService
+{
+    private readonly ConcurrentDictionary<Guid, IMailService> _byAccount = new();
+    private readonly IReadOnlyList<IMailService> _allBackends; // ordered, for event aggregation
+
+    public MailServiceRouter(IEnumerable<IMailService> backends)
+    {
+        _allBackends = backends.ToList();
+        // Subscribe to each backend's events and re-raise on this router.
+        foreach (var b in _allBackends)
+            b.InboxNewMailDetected += OnInnerInboxNewMail;
+    }
+
+    /// <summary>
+    /// Bind an account to a specific backend. Called once at account-load time
+    /// and once per Add Account.
+    /// </summary>
+    public void RegisterAccount(Guid accountId, IMailService backend)
+        => _byAccount[accountId] = backend;
+
+    public void UnregisterAccount(Guid accountId)
+        => _byAccount.TryRemove(accountId, out _);
+
+    private IMailService For(Guid accountId)
+        => _byAccount.TryGetValue(accountId, out var b)
+           ? b
+           : throw new InvalidOperationException($"No backend registered for account {accountId}");
+
+    private IMailService For(AccountModel account)
+    {
+        if (!_byAccount.TryGetValue(account.Id, out var b))
+        {
+            // Lazy registration on first Connect — useful for first-time account adds.
+            // The host (App.xaml.cs) is responsible for choosing the right backend.
+            throw new InvalidOperationException(
+                $"No backend registered for account {account.Id} ({account.AccountLabel}). " +
+                "Call RegisterAccount before any IMailService method.");
+        }
+        return b;
+    }
+
+    private void OnInnerInboxNewMail(Guid accountId) => InboxNewMailDetected?.Invoke(accountId);
+    public event Action<Guid>? InboxNewMailDetected;
+
+    // ── Every method delegates ───────────────────────────────────────────────
+
+    public Task ConnectAsync(AccountModel account, string? password = null, CancellationToken ct = default)
+        => For(account).ConnectAsync(account, password, ct);
+
+    public Task DisconnectAsync(Guid accountId, CancellationToken ct = default)
+        => For(accountId).DisconnectAsync(accountId, ct);
+
+    public Task<List<MailFolderModel>> GetFoldersAsync(Guid accountId, CancellationToken ct = default)
+        => For(accountId).GetFoldersAsync(accountId, ct);
+
+    // ... and so on for every method on IMailService ...
+
+    public void Dispose()
+    {
+        foreach (var b in _allBackends)
+        {
+            b.InboxNewMailDetected -= OnInnerInboxNewMail;
+            b.Dispose();
+        }
+    }
+}
+```
+
+**Notes:**
+- Router itself implements `IMailService` so `MainViewModel`, `SyncService`, `RuleService` are unchanged — they always saw `IMailService`.
+- Backends are constructed once in `App.xaml.cs` and registered per-account at account load.
+- `RegisterAccount` is idempotent — re-registration replaces the binding.
+
+### 6.5 `MailMessageSummary.cs` — string MessageId
+
+**Path:** `QuickMail/Models/MailMessageSummary.cs`
+
+Change:
+
+```csharp
+// before:
+public uint UniqueId { get; set; }
+
+// after:
+public string MessageId { get; set; } = string.Empty;
+```
+
+Everything else unchanged. `MailMessageDetail : MailMessageSummary` inherits.
+
+**Sort behavior note:** when sorting messages by `MessageId` for backend-internal purposes (e.g. IMAP `GetMaxMessageKeyAsync`), the IMAP impl returns the zero-padded UID (`uid.ToString("D10")`) so string comparison preserves numeric order. Graph never compares IDs — it uses the delta token instead.
+
+### 6.6 `LocalStoreService.cs` — Schema Migration v2
+
+**Path:** `QuickMail/Services/LocalStoreService.cs`
+
+Migration logic added at top of `Initialize`:
+
+```csharp
+public void Initialize()
+{
+    // Pre-migration backup: if we're upgrading from v1, copy mail.db to mail.db.pre-v2.
+    var dbPath = Path.Combine(_profileDir, "mail.db");
+    if (File.Exists(dbPath))
+    {
+        using (var probe = new SqliteConnection($"Data Source={dbPath};Mode=ReadOnly;"))
+        {
+            probe.Open();
+            using var pragma = probe.CreateCommand();
+            pragma.CommandText = "PRAGMA user_version;";
+            var ver = Convert.ToInt32(pragma.ExecuteScalar());
+            if (ver < 2)
+            {
+                var backupPath = dbPath + ".pre-v2";
+                File.Copy(dbPath, backupPath, overwrite: true);
+                LogService.Log($"LocalStoreService: backed up mail.db to {backupPath} before v2 migration");
+            }
+        }
+    }
+
+    using var conn = Open();
+    using var cmd = conn.CreateCommand();
+    cmd.CommandText = """
+        PRAGMA journal_mode=WAL;
+        -- (CREATE TABLE statements with TEXT unique_id from PM spec Appendix C)
+        """;
+    cmd.ExecuteNonQuery();
+
+    RunMigration(conn, /* existing v1 ALTER TABLEs */);
+    RunDataMigrations(conn);
+}
+
+private const int CurrentSchemaVersion = 2;
+
+private static void RunDataMigrations(SqliteConnection conn)
+{
+    var version = GetUserVersion(conn);
+    if (version >= CurrentSchemaVersion) return;
+
+    if (version < 1)
+    {
+        // existing v1 backfill (unchanged)
+    }
+
+    if (version < 2)
+    {
+        // PM spec Appendix C — change unique_id from INTEGER to TEXT, add DeltaToken table.
+        using var migrateCmd = conn.CreateCommand();
+        migrateCmd.CommandText = @"
+            CREATE TABLE MessageSummary_v2 (
+                unique_id    TEXT    NOT NULL,
+                /* ... */
+            );
+            INSERT INTO MessageSummary_v2
+            SELECT CAST(unique_id AS TEXT), /* ... */ FROM MessageSummary;
+            DROP TABLE MessageSummary;
+            ALTER TABLE MessageSummary_v2 RENAME TO MessageSummary;
+            /* ... same for MessageDetail ... */
+            CREATE TABLE DeltaToken (
+                account_id   TEXT NOT NULL,
+                folder_id    TEXT NOT NULL,
+                delta_token  TEXT NOT NULL,
+                updated_utc  INTEGER NOT NULL,
+                PRIMARY KEY (account_id, folder_id)
+            );
+        ";
+        migrateCmd.ExecuteNonQuery();
+    }
+
+    SetUserVersion(conn, CurrentSchemaVersion);
+}
+```
+
+All other method signatures in `ILocalStoreService` and `LocalStoreService` change `uint uniqueId` → `string messageId`. SQL parameter bindings change from `AddWithValue("@unique_id", uid)` to `AddWithValue("@unique_id", messageId)`.
+
+### 6.7 `AccountModel.cs` — BackendKind & TenantId
+
+**Path:** `QuickMail/Models/AccountModel.cs`
+
+Add two fields after the existing persistent fields:
+
+```csharp
+public AuthType AuthType { get; set; } = AuthType.Password;
+
+// NEW:
+/// <summary>Which protocol stack this account uses. Fixed at account creation.</summary>
+public BackendKind BackendKind { get; set; } = BackendKind.ImapSmtp;
+
+/// <summary>Optional Azure AD tenant ID for Graph accounts. Null = "common" authority.</summary>
+public string? TenantId { get; set; }
+```
+
+No code changes elsewhere in `AccountModel`. The new fields serialize/deserialize via System.Text.Json defaults; existing `accounts.json` files lack these fields and get the defaults (`ImapSmtp`, `null`) on load.
+
+### 6.8 `OAuthService.cs` — Per-Call Scopes
+
+**Path:** `QuickMail/Services/OAuthService.cs`
+
+Add a new overload that accepts scopes; keep existing overload for backward compatibility during refactor:
+
+```csharp
+// Existing scope constants (unchanged):
+public static readonly string[] ImapSmtpScopes =
+[
+    "https://outlook.office.com/IMAP.AccessAsUser.All",
+    "https://outlook.office.com/SMTP.Send",
+    "offline_access",
+];
+
+// NEW:
+public static readonly string[] GraphMailScopes =
+[
+    "https://graph.microsoft.com/Mail.ReadWrite",
+    "https://graph.microsoft.com/Mail.Send",
+    "https://graph.microsoft.com/MailboxSettings.Read",
+    "offline_access",
+];
+
+// Existing methods become wrappers around new scope-aware overloads:
+public Task<string> GetAccessTokenAsync(AccountModel account, CancellationToken ct = default)
+    => GetAccessTokenAsync(account, DefaultScopesFor(account), ct);
+
+// NEW:
+public async Task<string> GetAccessTokenAsync(AccountModel account, string[] scopes, CancellationToken ct = default)
+{
+    // existing silent-then-interactive logic, with `scopes` parameter passed to MSAL
+    // instead of the hardcoded `Scopes` static field
+}
+
+private static string[] DefaultScopesFor(AccountModel account)
+    => account.BackendKind == BackendKind.MicrosoftGraph
+        ? GraphMailScopes
+        : ImapSmtpScopes;
+```
+
+`ImapMailService.ConnectAsync` continues to call `_oauth.GetAccessTokenAsync(account, ct)` — the default-scope path picks `ImapSmtpScopes`. `GraphMailService.ConnectAsync` calls `_oauth.GetAccessTokenAsync(account, GraphMailScopes, ct)` explicitly. After all consumers are updated, the no-scopes-arg overload can stay as a convenience.
+
+### 6.9 `AddAccountViewModel.cs` & Dialog — Account Type Combo
+
+**`AddAccountViewModel.cs` additions:**
+
+```csharp
+public partial class AddAccountViewModel : AccountEditorViewModel
+{
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsImapFieldsVisible))]
+    private BackendKind _backendKind = BackendKind.ImapSmtp;
+
+    public bool IsImapFieldsVisible => BackendKind == BackendKind.ImapSmtp;
+
+    partial void OnBackendKindChanged(BackendKind value)
+    {
+        if (value == BackendKind.MicrosoftGraph)
+        {
+            // Force OAuth — no password option for Graph
+            AuthType = AuthType.OAuth2Microsoft;
+            // Clear IMAP/SMTP fields (they'll be hidden)
+            ImapHost = SmtpHost = string.Empty;
+            ImapPort = 993; SmtpPort = 587;
+            ImapUseSsl = true; SmtpUseSsl = false;
+        }
+        else
+        {
+            // Restore IMAP defaults (existing logic in OnAuthTypeChangedInternal)
+            OnAuthTypeChangedInternal(AuthType);
+        }
+    }
+
+    public AccountModel ToAccountModel() => new()
+    {
+        AccountName = AccountName,
+        DisplayName = DisplayName,
+        Username = Username,
+        AuthType = AuthType,
+        BackendKind = BackendKind,        // NEW
+        TenantId = null,                  // NEW — v1 always common
+        ImapHost = ImapHost,
+        // ... rest unchanged ...
+    };
+}
+```
+
+**`AddAccountDialog.xaml` additions:**
+
+Add at the top of the form, before existing fields:
+
+```xml
+<StackPanel Orientation="Vertical" Margin="0,0,0,12">
+    <TextBlock Text="Account type:" />
+    <ComboBox x:Name="BackendKindCombo"
+              SelectedIndex="0"
+              SelectedItem="{Binding BackendKind, Mode=TwoWay, Converter={StaticResource BackendKindStringConverter}}"
+              AutomationProperties.Name="Account type">
+        <ComboBoxItem Content="Standard IMAP/SMTP" Tag="ImapSmtp" />
+        <ComboBoxItem Content="Microsoft 365 / Outlook.com" Tag="MicrosoftGraph" />
+    </ComboBox>
+</StackPanel>
+```
+
+Wrap the IMAP and SMTP groups with `Visibility="{Binding IsImapFieldsVisible, Converter={StaticResource BoolToVisibilityConverter}}"`.
+
+**`AddAccountDialog.xaml.cs` additions:**
+
+```csharp
+public AddAccountDialog(AddAccountViewModel vm)
+{
+    InitializeComponent();
+    DataContext = vm;
+    vm.PropertyChanged += OnVmPropertyChanged;
+}
+
+private void OnVmPropertyChanged(object? sender, PropertyChangedEventArgs e)
+{
+    if (e.PropertyName == nameof(AddAccountViewModel.BackendKind))
+    {
+        var vm = (AddAccountViewModel)DataContext;
+        if (vm.BackendKind == BackendKind.MicrosoftGraph)
+            AccessibilityHelper.Announce(
+                "Switched to Microsoft 365. IMAP and SMTP fields are not needed for this account type.",
+                AnnouncementCategory.Hint);
+        else
+            AccessibilityHelper.Announce(
+                "Switched to standard IMAP and SMTP. Enter your server settings below.",
+                AnnouncementCategory.Hint);
+    }
+}
+```
+
+### 6.10 `GraphMailService.cs` — Read Path
+
+**Path:** `QuickMail/Services/GraphMailService.cs`
+
+Skeleton (full method bodies for the read path; mutations and notifications come in PR 6 and 7):
+
+```csharp
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using QuickMail.Models;
+using QuickMail.Services.Graph;
+
+namespace QuickMail.Services;
+
+public class GraphMailService : IMailService
+{
+    private readonly GraphClient _client;
+    private readonly IConfigService? _config;
+
+    public GraphMailService(IOAuthService oauth, IConfigService? config = null)
+    {
+        _client = new GraphClient(oauth);
+        _config = config;
+    }
+
+    public event Action<Guid>? InboxNewMailDetected; // wired by GraphChangeNotifier in PR 7
+
+    public async Task ConnectAsync(AccountModel account, string? password = null, CancellationToken ct = default)
+    {
+        // Validate the token by calling /me. No persistent connection.
+        var me = await _client.GetAsync<GraphMe>(account, "/me?$select=id,userPrincipalName", ct);
+        if (string.IsNullOrEmpty(me?.UserPrincipalName))
+            throw new InvalidOperationException("Graph /me returned no userPrincipalName");
+        if (!string.Equals(account.Username, me.UserPrincipalName, StringComparison.OrdinalIgnoreCase))
+        {
+            LogService.Log($"GraphMailService: token UPN {me.UserPrincipalName} differs from account.Username {account.Username}; updating");
+            account.Username = me.UserPrincipalName;
+        }
+        LogService.Log($"GraphMailService: connected for {account.AccountLabel} ({account.Username})");
+    }
+
+    public Task DisconnectAsync(Guid accountId, CancellationToken ct = default) => Task.CompletedTask;
+
+    public async Task<List<MailFolderModel>> GetFoldersAsync(Guid accountId, CancellationToken ct = default)
+    {
+        // Graph paginates; GraphClient.GetAllPagesAsync handles @odata.nextLink.
+        var folders = await _client.GetAllPagesAsync<GraphMailFolder>(
+            accountId, "/me/mailFolders?$top=100&$select=id,displayName,parentFolderId,totalItemCount,unreadItemCount", ct);
+
+        return folders.Select(f => new MailFolderModel
+        {
+            AccountId = accountId,
+            FullName = f.Id,                       // Graph uses opaque IDs as "folder names"
+            DisplayName = f.DisplayName,
+            UnreadCount = f.UnreadItemCount,
+            MessageCount = f.TotalItemCount,
+            Kind = MapWellKnownFolder(f.DisplayName),
+            ExcludeFromAllMail = ShouldExcludeFromAll(f.DisplayName),
+        }).ToList();
+    }
+
+    public async Task<List<MailMessageSummary>> GetMessageSummariesAsync(
+        Guid accountId, string folderName, int maxMessages, CancellationToken ct = default)
+    {
+        var path = $"/me/mailFolders/{folderName}/messages" +
+                   $"?$top={Math.Min(maxMessages, 999)}" +
+                   "&$orderby=receivedDateTime desc" +
+                   "&$select=id,subject,from,toRecipients,receivedDateTime,isRead,bodyPreview,hasAttachments";
+        var msgs = await _client.GetAllPagesAsync<GraphMessage>(accountId, path, ct);
+        return msgs.Select(m => MapToSummary(m, accountId, folderName)).ToList();
+    }
+
+    public async Task<MailMessageDetail> GetMessageDetailAsync(
+        Guid accountId, string folderName, string messageId, CancellationToken ct = default)
+    {
+        var path = $"/me/messages/{messageId}" +
+                   "?$select=id,subject,body,from,toRecipients,ccRecipients,internetMessageId,receivedDateTime,isRead,hasAttachments" +
+                   "&$expand=attachments($select=id,name,contentType,size,isInline)";
+        var msg = await _client.GetAsync<GraphMessage>(accountId, path, ct);
+        return MapToDetail(msg!, accountId, folderName);
+    }
+
+    public async Task MarkReadAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default)
+    {
+        await _client.PatchAsync(accountId, $"/me/messages/{messageId}", new { isRead = true }, ct);
+    }
+
+    // PR 5 hook
+    public Task<(int Total, int Unread)> GetInboxStatusAsync(Guid accountId, CancellationToken ct = default)
+        => _client.GetAsync<GraphMailFolder>(accountId, "/me/mailFolders/Inbox?$select=totalItemCount,unreadItemCount", ct)
+            .ContinueWith(t => (t.Result!.TotalItemCount, t.Result.UnreadItemCount), ct);
+
+    public Task<string?> FindDraftsFolderNameAsync(Guid accountId, CancellationToken ct = default)
+        => Task.FromResult<string?>("Drafts"); // Graph well-known name
+
+    public Task NoOpAsync(Guid accountId, CancellationToken ct = default) => Task.CompletedTask;
+
+    public Task<IReadOnlyDictionary<string, string>> FetchPreviewsAsync(
+        Guid accountId, string folderName, IList<string> messageIds, int maxLines, CancellationToken ct = default)
+        => Task.FromResult<IReadOnlyDictionary<string, string>>(
+            new Dictionary<string, string>()); // No-op: Graph fills bodyPreview natively
+
+    // ── PR 6 stubs ──
+    public Task MoveToTrashAsync(...) => throw new NotImplementedException("PR 6");
+    public Task MoveToTrashBatchAsync(...) => throw new NotImplementedException("PR 6");
+    public Task PermanentlyDeleteBatchAsync(...) => throw new NotImplementedException("PR 6");
+    // ... etc ...
+
+    // ── PR 7 stubs ──
+    public void StartIdleWatchers(IReadOnlyList<AccountModel> accounts, CancellationToken ct = default)
+        => throw new InvalidOperationException("StartIdleWatchers removed in PR 7; use IChangeNotifier instead");
+
+    // Helpers
+    private static MailMessageSummary MapToSummary(GraphMessage m, Guid accountId, string folderName) => new()
+    {
+        MessageId = m.Id,
+        AccountId = accountId,
+        FolderName = folderName,
+        From = m.From?.EmailAddress?.AsHeaderString() ?? string.Empty,
+        To = string.Join(", ", m.ToRecipients?.Select(r => r.EmailAddress.AsHeaderString()) ?? []),
+        Subject = m.Subject ?? string.Empty,
+        Date = m.ReceivedDateTime,
+        IsRead = m.IsRead,
+        Preview = m.BodyPreview ?? string.Empty,
+        HasAttachments = m.HasAttachments,
+    };
+
+    // (MapToDetail similar; populates body, cc, attachments)
+
+    public void Dispose() => _client.Dispose();
+}
+```
+
+### 6.11 `GraphSmtpService.cs` — Send Path
+
+**Path:** `QuickMail/Services/GraphSmtpService.cs`
+
+```csharp
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using QuickMail.Models;
+using QuickMail.Services.Graph;
+
+namespace QuickMail.Services;
+
+public class GraphSmtpService : ISmtpService
+{
+    private readonly GraphClient _client;
+    private static readonly string UserAgent =
+        "QuickMail/" + (Assembly.GetExecutingAssembly().GetName().Version?.ToString(3) ?? "0");
+
+    public GraphSmtpService(IOAuthService oauth) => _client = new GraphClient(oauth);
+
+    public async Task SendAsync(ComposeModel compose, AccountModel account, string? password, CancellationToken ct = default)
+    {
+        // Graph /sendMail accepts MIME directly when Content-Type is text/plain and the body is the raw MIME.
+        var mime = MimeMessageBuilder.Build(compose, account, UserAgent);
+        using var ms = new MemoryStream();
+        await mime.WriteToAsync(ms, ct);
+        var mimeBytes = ms.ToArray();
+
+        using var content = new ByteArrayContent(mimeBytes);
+        content.Headers.ContentType = new MediaTypeHeaderValue("text/plain");
+
+        LogService.Log($"GraphSmtpService: sending {mimeBytes.Length} bytes via /me/sendMail");
+        await _client.PostRawAsync(account.Id, "/me/sendMail", content, ct);
+        LogService.Log("GraphSmtpService: send complete");
+    }
+}
+```
+
+`SmtpService.SendAsync` dispatches by `BackendKind`:
+
+```csharp
+public async Task SendAsync(ComposeModel compose, AccountModel account, string? password, CancellationToken ct = default)
+{
+    if (account.BackendKind == BackendKind.MicrosoftGraph)
+    {
+        await _graphSmtp.SendAsync(compose, account, password, ct);
+        return;
+    }
+    // existing MailKit SmtpClient logic
+}
+```
+
+### 6.12 `GraphChangeNotifier.cs` — Delta Polling
+
+**Path:** `QuickMail/Services/GraphChangeNotifier.cs`
+
+```csharp
+public class GraphChangeNotifier : IChangeNotifier
+{
+    private readonly GraphClient _client;
+    private readonly ILocalStoreService _store; // for delta-token persistence
+    private readonly IConfigService? _config;
+    private readonly Dictionary<Guid, Task> _watchers = new();
+    private CancellationTokenSource? _cts;
+
+    public event Action<Guid>? InboxNewMailDetected;
+
+    public GraphChangeNotifier(GraphClient client, ILocalStoreService store, IConfigService? config = null)
+    {
+        _client = client; _store = store; _config = config;
+    }
+
+    public void StartWatchers(IReadOnlyList<AccountModel> accounts, CancellationToken ct)
+    {
+        StopWatchers();
+        _cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+
+        foreach (var account in accounts.Where(a => a.BackendKind == BackendKind.MicrosoftGraph))
+        {
+            _watchers[account.Id] = Task.Run(() => PollLoopAsync(account, _cts.Token), _cts.Token);
+        }
+    }
+
+    private async Task PollLoopAsync(AccountModel account, CancellationToken ct)
+    {
+        var intervalSec = _config?.Load().GraphPollSeconds ?? 60;
+        intervalSec = Math.Clamp(intervalSec, 30, 600);
+
+        while (!ct.IsCancellationRequested)
+        {
+            try
+            {
+                var token = await _store.GetDeltaTokenAsync(account.Id, "Inbox");
+                var url = string.IsNullOrEmpty(token)
+                    ? "/me/mailFolders/Inbox/messages/delta?$select=id"
+                    : $"/me/mailFolders/Inbox/messages/delta?$skipToken={Uri.EscapeDataString(token)}";
+
+                var resp = await _client.GetAsync<GraphDeltaResponse>(account.Id, url, ct);
+                if (resp?.Value?.Length > 0)
+                    InboxNewMailDetected?.Invoke(account.Id);
+
+                if (!string.IsNullOrEmpty(resp?.DeltaLink))
+                {
+                    var newToken = ExtractSkipToken(resp.DeltaLink);
+                    await _store.SetDeltaTokenAsync(account.Id, "Inbox", newToken);
+                }
+            }
+            catch (OperationCanceledException) { return; }
+            catch (Exception ex) { LogService.Log($"GraphChangeNotifier {account.AccountLabel}", ex); }
+
+            try { await Task.Delay(TimeSpan.FromSeconds(intervalSec), ct); }
+            catch (OperationCanceledException) { return; }
+        }
+    }
+
+    public void StopWatchers()
+    {
+        _cts?.Cancel();
+        _watchers.Clear();
+        _cts = null;
+    }
+}
+```
+
+`ILocalStoreService` grows two methods:
+```csharp
+Task<string?> GetDeltaTokenAsync(Guid accountId, string folderId);
+Task SetDeltaTokenAsync(Guid accountId, string folderId, string deltaToken);
+```
+
+### 6.13 `App.xaml.cs` — DI Wiring
+
+Per-PR changes to the composition root. The final shape (after PR 7):
+
+```csharp
+var oauthService = new OAuthService(profile);
+var configService = new ConfigService(profile);
+
+// Both backends constructed once:
+var imapBackend = new ImapMailService(oauthService, configService);
+var graphBackend = new GraphMailService(oauthService, configService);
+
+var mailRouter = new MailServiceRouter(new IMailService[] { imapBackend, graphBackend });
+
+// Register every account to its backend:
+foreach (var account in accountService.LoadAccounts())
+{
+    mailRouter.RegisterAccount(account.Id,
+        account.BackendKind == BackendKind.MicrosoftGraph ? graphBackend : imapBackend);
+}
+
+// SMTP — single service that delegates internally:
+var graphSmtpService = new GraphSmtpService(oauthService);
+var smtpService = new SmtpService(oauthService, graphSmtpService);
+
+// Change notifier — composite over both backends:
+var imapNotifier = new ImapChangeNotifier(imapBackend);
+var graphNotifier = new GraphChangeNotifier(graphBackend.Client, localStore, configService);
+var changeNotifier = new ChangeNotifierRouter(new IChangeNotifier[] { imapNotifier, graphNotifier });
+
+// Rest of wiring uses mailRouter wherever IMailService is needed:
+var ruleService = new RuleService(mailRouter, localStore, profile.ProfileDir);
+var syncService = new SyncService(mailRouter, localStore, configService, ruleService);
+
+var mainVm = new MainViewModel(
+    mailRouter, accountService, credentialService, localStore, oauthService,
+    syncService, configService, commandRegistry, viewService, ruleService,
+    changeNotifier,
+    onlineMode: onlineMode);
+```
+
+When a new account is added at runtime, the caller (`MainViewModel.AddAccountAsync`) must call `mailRouter.RegisterAccount(account.Id, backendForKind(account.BackendKind))` before the first IMailService method runs against that account.
+
+### 6.14 `IFeatureGate.cs` and `ConfigFeatureGate.cs` — Feature Gate
+
+**Path:** `QuickMail/Services/IFeatureGate.cs`
+
+```csharp
+using QuickMail.Models;
+
+namespace QuickMail.Services;
+
+/// <summary>
+/// Runtime feature gate. Code paths and UI surfaces check this before exposing
+/// experimental functionality. Defaults are baked into ConfigFeatureGate and
+/// overridable via config.ini [features] section or --feature CLI flags.
+/// </summary>
+public interface IFeatureGate
+{
+    bool IsEnabled(FeatureFlag flag);
+}
+```
+
+**Path:** `QuickMail/Models/FeatureFlag.cs`
+
+```csharp
+namespace QuickMail.Models;
+
+/// <summary>
+/// Feature-gate keys. Adding a new gate is one enum value here plus an entry
+/// in ConfigFeatureGate.Defaults.
+/// </summary>
+public enum FeatureFlag
+{
+    /// <summary>
+    /// Enables Microsoft Graph as a mail-backend option in the Add Account dialog.
+    /// Default: false. Flip default to true via a future joint-decision PR.
+    /// </summary>
+    GraphBackend,
+}
+```
+
+**Path:** `QuickMail/Services/ConfigFeatureGate.cs`
+
+```csharp
+using System;
+using System.Collections.Generic;
+using QuickMail.Models;
+
+namespace QuickMail.Services;
+
+/// <summary>
+/// Resolves feature flags from (in order of precedence, highest first):
+///   1. CLI --feature flags passed at startup
+///   2. config.ini [features] section
+///   3. Built-in defaults
+/// </summary>
+public class ConfigFeatureGate : IFeatureGate
+{
+    /// <summary>Built-in defaults. Every flag MUST appear here.</summary>
+    private static readonly IReadOnlyDictionary<FeatureFlag, bool> Defaults = new Dictionary<FeatureFlag, bool>
+    {
+        [FeatureFlag.GraphBackend] = false,
+    };
+
+    private readonly IReadOnlyDictionary<string, string> _configFlags;
+    private readonly IReadOnlySet<string> _cliFlags;
+
+    public ConfigFeatureGate(ConfigModel config, IEnumerable<string> cliFlags)
+    {
+        _configFlags = config.Features ?? new Dictionary<string, string>();
+        _cliFlags = new HashSet<string>(cliFlags ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
+    }
+
+    public bool IsEnabled(FeatureFlag flag)
+    {
+        var name = flag.ToString();
+
+        // 1. CLI override
+        if (_cliFlags.Contains(name)) return true;
+
+        // 2. config.ini
+        if (_configFlags.TryGetValue(name, out var raw)
+            && bool.TryParse(raw, out var configValue))
+            return configValue;
+
+        // 3. Default
+        return Defaults[flag];
+    }
+}
+```
+
+**Parsing `--feature` in `App.xaml.cs`:**
+
+```csharp
+// Multiple --feature flags are supported. Each takes the next arg as its value.
+//   QuickMail.exe --feature GraphBackend --feature SomethingElse
+static IEnumerable<string> ParseFeatureFlags(string[] args)
+{
+    for (int i = 0; i < args.Length - 1; i++)
+    {
+        if (args[i].Equals("--feature", StringComparison.OrdinalIgnoreCase))
+            yield return args[i + 1];
+    }
+}
+
+// In OnStartup, after configService is loaded:
+var cliFlags = ParseFeatureFlags(e.Args).ToList();
+var featureGate = new ConfigFeatureGate(configService.Load(), cliFlags);
+```
+
+**`ConfigService.cs` extension:**
+
+The existing INI parser already iterates sections. Add a case for `[features]` that copies all key/value pairs into `ConfigModel.Features`. No new file, ~10 lines added.
+
+**Consumer pattern in `AddAccountViewModel`:**
+
+```csharp
+public AddAccountViewModel(IFeatureGate gate, IImapService imap, IOAuthService oauth) : base(imap, oauth)
+{
+    var backends = new List<BackendKindOption>
+    {
+        new(BackendKind.ImapSmtp, "Standard IMAP/SMTP"),
+    };
+    if (gate.IsEnabled(FeatureFlag.GraphBackend))
+        backends.Add(new(BackendKind.MicrosoftGraph, "Microsoft 365 / Outlook.com"));
+
+    AvailableBackends = backends;
+}
+
+public IReadOnlyList<BackendKindOption> AvailableBackends { get; }
+```
+
+**`StubFeatureGate` for tests** (added to `QuickMail.Tests/StubServices.cs`):
+
+```csharp
+public class StubFeatureGate : IFeatureGate
+{
+    private readonly Dictionary<FeatureFlag, bool> _flags = new();
+    public bool this[FeatureFlag flag] { set => _flags[flag] = value; }
+    public bool IsEnabled(FeatureFlag flag) => _flags.TryGetValue(flag, out var v) && v;
+}
+```
+
+Usage in tests:
+
+```csharp
+[Fact]
+public void AddAccountViewModel_GateOff_OnlyShowsImap()
+{
+    var gate = new StubFeatureGate();
+    var vm = new AddAccountViewModel(gate, stubImap, stubOauth);
+    Assert.Single(vm.AvailableBackends);
+    Assert.Equal(BackendKind.ImapSmtp, vm.AvailableBackends[0].Kind);
+}
+
+[Fact]
+public void AddAccountViewModel_GateOn_ShowsGraphOption()
+{
+    var gate = new StubFeatureGate { [FeatureFlag.GraphBackend] = true };
+    var vm = new AddAccountViewModel(gate, stubImap, stubOauth);
+    Assert.Equal(2, vm.AvailableBackends.Count);
+    Assert.Contains(vm.AvailableBackends, b => b.Kind == BackendKind.MicrosoftGraph);
+}
+```
+
+---
+
+## 7. Tests
+
+### 7.1 Per-PR test additions
+
+| PR | Tests added |
+|---|---|
+| 1 | None (rename only); existing tests prove no regression. |
+| 2 | `LocalStoreServiceMigrationTests.cs`: seed v1 schema with 1000 rows; run init; assert 1000 rows survive with text IDs matching original UIDs. |
+| 3 | `FeatureGateTests.cs` (CLI overrides config; config overrides default; defaults are honored when neither overrides); `MailServiceRouterTests.cs` (router dispatch — fake backends); `AddAccountViewModelTests.cs` (BackendKind change clears IMAP fields; **gate state controls which backends appear in `AvailableBackends`**). |
+| 4 | `GraphMailServiceTests.cs` for read endpoints; `OAuthServiceScopesTests.cs` (per-call scope selection). |
+| 5 | Extend `GraphMailServiceTests` with send tests. |
+| 6 | Extend `GraphMailServiceTests` with mutation endpoint tests. |
+| 7 | `GraphChangeNotifierTests.cs` (delta token persistence; new-mail event raising). |
+| 8 | Coverage round-up: any missing integration test; verify CI runs both gate-on and gate-off variants of `AddAccountViewModelTests`. |
+
+### 7.2 GraphMailServiceTests pattern
+
+Use `HttpMessageHandler` stub to inject canned Graph responses:
+
+```csharp
+public class GraphMailServiceTests
+{
+    private readonly HttpMessageHandler _handler;
+    private readonly GraphMailService _service;
+
+    public GraphMailServiceTests()
+    {
+        _handler = new StubHandler();
+        var oauth = new StubOAuthService("fake-token");
+        _service = new GraphMailService(oauth, config: null);
+        // Inject _handler into GraphClient via test seam
+    }
+
+    [Fact]
+    public async Task GetMessageSummariesAsync_ParsesGraphResponse()
+    {
+        StubHandler.WhenGet("/me/mailFolders/Inbox/messages")
+            .ReturnsJson(new { value = new[] { new { id = "ABC=", subject = "Hi", /* ... */ } } });
+
+        var summaries = await _service.GetMessageSummariesAsync(Guid.NewGuid(), "Inbox", 50);
+
+        Assert.Single(summaries);
+        Assert.Equal("ABC=", summaries[0].MessageId);
+        Assert.Equal("Hi", summaries[0].Subject);
+    }
+
+    [Fact]
+    public async Task GetAllPagesAsync_FollowsODataNextLink()
+    {
+        // First page returns 100 items + @odata.nextLink
+        // Second page returns 50 items, no nextLink
+        // Assert: total 150 items returned
+    }
+
+    [Fact]
+    public async Task GetAsync_Respects429RetryAfter()
+    {
+        // First response: 429 with Retry-After: 1
+        // Second response: 200 with the data
+        // Assert: total ~1s wall time, returns data
+    }
+}
+```
+
+### 7.3 Integration test (manual, per PR)
+
+The retro from the mail-rules feature called for explicit manual checklists. See §8.
+
+---
+
+## 8. Per-PR Manual Smoke Checklist
+
+After every PR lands, before merge, the contributor runs this checklist on the dev branch.
+
+### After PR 1 (rename)
+
+- [ ] Build succeeds: `dotnet build QuickMail.sln -nologo`
+- [ ] All tests pass: `dotnet test QuickMail.Tests/QuickMail.Tests.csproj -c Release`
+- [ ] App launches; existing IMAP account connects, folders load, messages display
+- [ ] Send a test message; verify it arrives in another inbox
+
+### After PR 2 (UID → string)
+
+- [ ] Backup mail.db.pre-v2 is created on first launch (verify file exists)
+- [ ] App launches; existing IMAP account: folders load, messages display, no missing messages
+- [ ] Pre-PR Sent folder still contains all previous Sent messages (verifies migration)
+- [ ] Mark message read/unread persists across restart
+- [ ] Delete a message; verify it goes to Trash and is no longer in Inbox
+- [ ] Reply to a message; verify it sends and appears in Sent
+- [ ] Stop and re-launch; verify Sent message persisted via SQLite
+
+### After PR 3 (router + UI + feature gate)
+
+**Gate OFF (default — no config.ini override, no CLI flag):**
+- [ ] Add Account dialog: "Microsoft 365 / Outlook.com" option is **not** present in the account-type combo (or the combo is rendered as a static label showing only "Standard IMAP/SMTP")
+- [ ] Existing IMAP account still connects and works identically
+- [ ] No visible difference from pre-PR-3 behavior for end users
+- [ ] `--feature SomeOtherFlag` (a flag that doesn't exist) doesn't crash; logs a warning
+
+**Gate ON (set `[features]\nGraphBackend=true` in config.ini, OR pass `--feature GraphBackend`):**
+- [ ] Account-type combo appears with two options, accessible by Tab
+- [ ] Selecting "Microsoft 365" disables IMAP/SMTP fields (visually + tab-stops)
+- [ ] Selecting "Standard IMAP/SMTP" re-enables them
+- [ ] Screen reader announces field-set changes (manually verified with one screen reader)
+- [ ] Attempting to save a "Microsoft 365" account produces the documented "Graph backend not yet implemented" message (until PR 4 lands)
+- [ ] IMAP account creation works identically to gate-off mode
+
+**Both modes:**
+- [ ] Build succeeds: `dotnet build QuickMail.sln -nologo`
+- [ ] All tests pass: `dotnet test QuickMail.Tests/QuickMail.Tests.csproj -c Release`
+- [ ] `FeatureGateTests` verifies CLI > config > default precedence
+
+### After PR 4 (Graph read)
+
+- [ ] **Maintainer has added Graph scopes to MSAL app registration in Azure portal**
+- [ ] Add Account → Microsoft 365: OAuth flow opens, completes, account is saved
+- [ ] Folder tree populates from Graph
+- [ ] Inbox messages display with correct subject, sender, date, preview
+- [ ] Open a message: body renders (HTML if present, plain text otherwise)
+- [ ] Mark message read; verify it persists on next refresh
+- [ ] IMAP account still works (no regression)
+
+### After PR 5 (Graph send)
+
+- [ ] Compose new message from M365 account; send to a Gmail address; verify arrival
+- [ ] Reply to an M365 message; verify it sends and appears in Sent (auto-saved by Graph)
+- [ ] Forward an M365 message with an attachment; verify the attachment is included
+
+### After PR 6 (Graph mutations)
+
+- [ ] Move a message to another folder; verify it appears in the destination
+- [ ] Copy a message; verify a copy exists in both folders
+- [ ] Delete a message; verify it appears in Deleted Items
+- [ ] Empty trash; verify Deleted Items is empty
+- [ ] Download an attachment; verify the file opens correctly
+- [ ] Save a draft; verify it appears in Drafts; edit it; verify changes persist
+- [ ] Create, rename, delete a folder; verify each in the folder tree
+
+### After PR 7 (notifications)
+
+- [ ] M365 account: send a message to it from another mailbox; verify QuickMail notices within 60s
+- [ ] IMAP account: same test using IDLE; verify no regression
+
+### After PR 8 (tests)
+
+- [ ] `dotnet test` reports >90% pass on Graph-related tests
+- [ ] Integration test recipe documented in `CLAUDE.md`
+
+---
+
+## 9. Edge Cases & Error Handling
+
+| Scenario | Handling |
+|---|---|
+| Tenant denies Graph scopes during sign-in | MSAL throws `MsalServiceException` with `AADSTS65001` or similar; surface user-facing message: "Your organization's Microsoft 365 settings do not permit this app to read mail. Contact your administrator." |
+| Conditional access requires a managed device | MSAL throws with `AADSTS50158`; user-facing message about device compliance |
+| Token expired between calls | MSAL silent refresh transparent to caller |
+| Network drops mid-Graph-request | `HttpClient` throws `HttpRequestException`; backend retries once, then surfaces to UI via existing exception path |
+| Graph returns 429 with `Retry-After: N` | `GraphClient` waits N seconds, retries once; if still 429, surfaces error |
+| Graph returns 5xx | Retry with exponential backoff up to 3 times; surface on persistent failure |
+| `accounts.json` from old version has no `backendKind` | System.Text.Json defaults to `ImapSmtp` — backward compatible |
+| User adds Graph account but tenant has no Exchange Online mailbox | `/me` returns 200 but `GET /mailFolders` returns 404; surface: "No Exchange mailbox is associated with this account." |
+| Schema migration fails partway | Wrapped in transaction; rollback leaves v1 intact; backup file is the safety net |
+| Delta token expires (rare; Graph occasionally invalidates) | `GET delta?$skipToken=...` returns 410 Gone; clear the stored token and re-poll without it (full resync of changes) |
+| Long-running attachment download cancelled by user | Existing `CancellationToken` path applies; cancel propagates to `HttpClient` |
+
+---
+
+## 10. Accessibility Checklist
+
+Performed manually after PR 3 lands and again after PR 4 lands.
+
+### Add Account dialog (new combo)
+
+- [ ] `AutomationProperties.Name` on combo: "Account type"
+- [ ] Combo announces selected option when changed
+- [ ] Field-set change announcement plays via `AccessibilityHelper.Announce(category: Hint)`
+- [ ] Hidden IMAP/SMTP fields are removed from tab order when M365 selected
+- [ ] Focus moves to the next visible field, not lost
+- [ ] No layout shift causes focus reset on field hide
+- [ ] Contrast on combo dropdown ≥ 4.5:1
+
+### Account list (no change)
+
+- [ ] Existing account list unchanged; no regression test required beyond visual inspection
+
+### Connect / sign-in flow
+
+- [ ] "Opening Microsoft sign-in in your browser" announced (Status)
+- [ ] On success: "Signed in as {Username}. Microsoft 365 account ready." announced (Result)
+- [ ] On tenant denial: user-facing message announced (Result), not silent
+
+### Error states
+
+- [ ] Throttling notice in status bar uses appropriate category (Status, silenced by default)
+- [ ] Permanent errors (tenant denial, mailbox missing) use Result category and are not silenced
+
+---
+
+## 11. Build Verification
+
+### Per-PR build
+
+```bat
+build.bat clean
+build.bat
+dotnet test QuickMail.Tests/QuickMail.Tests.csproj -c Release
+build.bat smoke
+```
+
+### Pre-merge publish check
+
+```bat
+build.bat publish
+```
+
+Verify `publish/QuickMail.exe` runs end-to-end against a real M365 account (after PR 4+).
+
+### CI
+
+The existing `.github/workflows/quickmail.yml` GitHub Actions workflow handles per-PR build and artifact upload. No CI changes are required for this work — Graph integration tests are gated to `[Trait("Category", "RequiresTenant")]` and skipped by default.
+
+---
+
+## Appendix: Open code decisions (deferred to implementation)
+
+These are choices that don't change the spec but need to be made by the implementer:
+
+1. **Graph client retry policy:** how many retries on 5xx? **Recommendation: 3, exponential backoff starting at 1s.**
+2. **Batch via `$batch`?** For mutations that touch >5 messages, Graph supports a JSON-batch endpoint. **Recommendation: defer to PR 6; ship single-call first, batch as a follow-up if perf matters.**
+3. **Body content-type negotiation:** Graph can return body as HTML or text via `Prefer: outlook.body-content-type="text"` header. **Recommendation: request HTML (current default); fall back to text only if body is empty.**
+4. **Folder display-name vs Graph well-known names:** Graph supports `/me/mailFolders/Inbox` (well-known), `/me/mailFolders/{id}` (specific ID). **Recommendation: use the ID for everything except the very first connection (use well-known to find Inbox/Drafts/SentItems/DeletedItems).**
+5. **Delta token storage:** in `mail.db` (proposed) or separate file? **Recommendation: in mail.db for transactional consistency with summaries.**

--- a/docs/planning/graph-backend-pm-spec.md
+++ b/docs/planning/graph-backend-pm-spec.md
@@ -1,0 +1,811 @@
+# Microsoft Graph Backend — Product Management Specification
+
+**Status:** Proposed
+**Version:** 0.2 (incorporates maintainer feedback on feature gating)
+**Date:** 2026-05-24
+**Author:** Tim Spaulding (proposing contributor)
+**Target release:** v0.7 (refactor PRs 1-3), v0.8+ (Graph backend PRs 4-8, gated)
+**Implementation:** Not started
+
+**Changelog from v0.1:**
+- §5, §9.7, §10, §12: added Feature Gate mechanism per maintainer request. Graph backend code ships disabled by default; flip is a future joint-decision PR independent of any release version.
+
+---
+
+## Table of Contents
+
+1. [Executive Summary](#1-executive-summary)
+2. [User Problem & Opportunity](#2-user-problem--opportunity)
+3. [Competitive Landscape](#3-competitive-landscape)
+4. [Design Principles](#4-design-principles)
+5. [Feature Scope](#5-feature-scope)
+6. [Data Model Changes](#6-data-model-changes)
+7. [User Experience Design](#7-user-experience-design)
+8. [Accessibility (WCAG 2.2)](#8-accessibility-wcag-22)
+9. [Technical Architecture](#9-technical-architecture)
+10. [Implementation Phases](#10-implementation-phases)
+11. [Success Metrics](#11-success-metrics)
+12. [Open Questions & Risks](#12-open-questions--risks)
+
+---
+
+## 1. Executive Summary
+
+QuickMail today speaks IMAP and SMTP. Microsoft 365 mailboxes are reachable via that path — `OAuthService` already authenticates against `login.microsoftonline.com` with `IMAP.AccessAsUser.All` and `SMTP.Send` scopes, and `ImapService` uses `SaslMechanismOAuth2` for those accounts. For the **default** M365 tenant configuration, QuickMail already works.
+
+What QuickMail cannot do today is connect to an M365 mailbox where the tenant administrator has **disabled the IMAP and SMTP services** at the org level. This is an increasingly common enterprise security baseline. For users on those tenants, QuickMail is unreachable — there is no fallback. They are forced to use Outlook (with its known accessibility friction) or a web client.
+
+This spec proposes adding **Microsoft Graph** as a second mail backend alongside the existing IMAP/SMTP stack. A new account type ("Microsoft 365") is offered in the Add Account dialog; selecting it routes that account through a new `GraphMailService` instead of `ImapService`. Existing IMAP/SMTP accounts are untouched.
+
+The work is sequenced into nine PRs over two release cycles, with the first three landing as pure refactor (no behavior change) so that risk is decoupled from the new Graph code.
+
+---
+
+## 2. User Problem & Opportunity
+
+### Current state
+
+Microsoft has spent the last three years steering Exchange Online customers away from IMAP and SMTP:
+
+- **Basic Auth** for IMAP/SMTP was disabled across most tenants in late 2023.
+- **OAuth-based** IMAP/SMTP works, but Microsoft now permits tenant admins to disable those protocols entirely via the org-level `Set-CASMailbox -ImapEnabled $false` / `-SmtpClientAuthenticationDisabled $true` controls.
+- The Microsoft 365 documentation now positions Graph as the only long-term API for mail.
+
+The practical effect for QuickMail: a user whose company has hardened its tenant cannot connect, regardless of whether QuickMail supports OAuth. The connection succeeds at the TCP/TLS layer, the OAuth handshake completes, and the IMAP `LOGIN` returns `AUTHENTICATIONFAILED` with no recourse from the client side.
+
+### Target personas
+
+| Persona | Need |
+|---|---|
+| **Accessibility-first user on a hardened M365 tenant** | Their company disabled IMAP. Outlook is the only option; Outlook's accessibility is uneven. QuickMail's accessibility is a known good. They need a backend that works. |
+| **Power user managing both work (M365) and personal (Gmail/Fastmail) mail** | Wants one client for everything. Today they must keep Outlook open just for work mail. |
+| **Privacy-conscious user with a personal Outlook.com account** | Already works today via IMAP/OAuth, but Graph is faster (no IDLE connection pool to manage) and exposes richer features over time. |
+| **System administrator evaluating QuickMail for org-wide deployment** | Needs the client to work without enabling legacy protocols on the tenant. IMAP being a hard requirement is a non-starter for many security baselines. |
+
+### Opportunity
+
+There is no Windows-first, accessibility-first, free, open-source desktop mail client that speaks Microsoft Graph natively. The accessible-on-M365 options today are:
+
+1. **Outlook** (free / paid) — full Graph, full features, well-known accessibility friction (focus management, virtualization of large message lists, modal dialog patterns)
+2. **Web Outlook** — better than desktop Outlook on some axes; worse on others; tied to the browser
+3. **Thunderbird** — IMAP only; if your tenant disabled IMAP, you cannot use it
+4. **eM Client** — IMAP + EWS; no Graph; paid; closed source
+
+Adding Graph to QuickMail makes it the only entrant in the "accessible Windows client that works on a locked-down M365 tenant" category.
+
+---
+
+## 3. Competitive Landscape
+
+| Product | M365 protocol | IMAP-disabled tenant? | Accessibility | License |
+|---|---|---|---|---|
+| **Outlook (Win32)** | Graph + MAPI | Yes | Known friction | Paid (M365) |
+| **Outlook (new / web)** | Graph | Yes | Mixed | Paid (M365) |
+| **Thunderbird** | IMAP/SMTP | **No** | Decent | Free |
+| **eM Client** | IMAP + EWS | Partial (EWS) | Limited | Paid |
+| **Mailspring** | IMAP only | **No** | Limited | Free + paid |
+| **Apple Mail** | IMAP + EWS | Partial (EWS) | Good | macOS only |
+| **QuickMail (today)** | IMAP/SMTP | **No** | Excellent | Free, MIT |
+| **QuickMail + Graph (proposed)** | IMAP/SMTP + Graph | **Yes** | Excellent | Free, MIT |
+
+### QuickMail's positioning
+
+The proposal does not chase Outlook on feature breadth (categories, focused inbox, mailbox-settings UI, Teams hand-off). The goal is **functional parity** with the existing IMAP backend, but reachable on tenants where IMAP isn't. Feature breadth is a follow-up.
+
+| Dimension | QuickMail target |
+|---|---|
+| Connect to IMAP-disabled M365 tenant | Yes |
+| Send and receive mail | Yes |
+| Folders, move, copy, delete | Yes |
+| Drafts, attachments, conversation grouping | Yes |
+| New-mail notifications | Yes (Graph `delta` polling, not webhooks) |
+| Categories, focused inbox, mailbox settings | Future |
+| Calendar, Contacts | Out of scope (QuickMail is mail-only) |
+| EWS / on-prem Exchange | Out of scope (Microsoft removing EWS Oct 2026) |
+
+---
+
+## 4. Design Principles
+
+1. **Protocol invisible to users.** The Add Account dialog offers "Microsoft 365" as an account type. Nowhere else in the UI does the word "Graph" or "IMAP" appear unless the user opens Settings → Advanced. Account list rows look identical regardless of backend.
+
+2. **No regression for existing accounts.** IMAP users see no UI change, no behavior change, no startup-time change. The router has a fast path for the single-backend case.
+
+3. **Per-account backend, fixed at creation.** An account's backend is selected when the account is added. You cannot migrate an IMAP account to a Graph account; you re-add it. This avoids a class of dual-state bugs and matches the user's mental model ("I'm setting up an account").
+
+4. **Refactor first, feature second.** The first three PRs are pure mechanical refactor that leave the IMAP backend identical in behavior. The Graph backend lands in later PRs. Risk is staged.
+
+5. **Reuse, do not duplicate.** OAuth/MSAL, the SQLite cache, `MimeMessageBuilder`, `ConversationBuilder`, every ViewModel, every dialog, every accessibility helper — all unchanged. Only the protocol layer is new.
+
+6. **Polling, not webhooks.** Graph supports webhook subscriptions for change notifications, but webhooks require a publicly reachable callback URL — impractical for a desktop client. QuickMail polls the Graph `delta` endpoint instead. Same UX as IMAP IDLE; different mechanism.
+
+7. **Accessibility unchanged.** The Add Account dialog grows one control. All other UI is untouched. WCAG 2.2 AA is preserved.
+
+---
+
+## 5. Feature Scope
+
+### In scope (v0.7 refactor + v0.8 Graph backend)
+
+**v0.7 — Refactor + feature-gate infrastructure (no user-visible change):**
+- Rename `IImapService` → `IMailService` (no signature changes initially)
+- Migrate `uint UniqueId` to `string MessageId` across models, services, SQLite schema
+- Introduce `BackendKind` enum on `AccountModel`
+- Introduce `MailServiceRouter` that dispatches per-account
+- **Introduce `IFeatureGate` infrastructure** — `[features]` section in `config.ini` + `--feature` CLI flag; enum-keyed `FeatureFlag` so new flags don't change the interface. Lands in PR 3 alongside the first consumer (the Add Account combo).
+
+**v0.8+ — Graph backend (gated, opt-in):**
+- "Microsoft 365" option in Add Account dialog (**only visible when `FeatureFlag.GraphBackend` is enabled**)
+- Full `GraphMailService` implementation: connect, list folders, list messages, get message detail, mark read/unread, move/copy, delete (to Trash), download attachments
+- `GraphSmtpService`: send via `/me/sendMail` (accepts MIME from `MimeMessageBuilder`)
+- Drafts: append/replace/delete via `/me/messages`
+- Folder CRUD: create/rename/delete/move folders via `/me/mailFolders`
+- New-mail notifications via `delta` polling (replacing IDLE for Graph accounts)
+- OAuth scopes added: `Mail.ReadWrite`, `Mail.Send`, `MailboxSettings.Read`, `offline_access`
+- Default gate state: **OFF**. Adventurous users enable it manually in `config.ini`. Default flips to ON via a future joint-decision PR (see §12).
+
+### Out of scope (future)
+
+- **EWS / on-prem Exchange Server.** Microsoft is removing EWS from Exchange Online in October 2026. New EWS code in 2026 is building on quicksand.
+- **MAPI / RPC.** Proprietary, not viable for a third-party client.
+- **Mixed-mode accounts** (same mailbox accessed via both IMAP and Graph). Pick one at creation; re-add to change.
+- **Migrating an existing IMAP account to Graph in place.** User re-adds; the local cache for the old account remains until the account is deleted.
+- **Categories, focused inbox, mailbox-settings UI.** Graph-only features that have no IMAP analogue. Worth their own future spec.
+- **Webhook-based change notifications.** Requires a public callback URL or relay. Polling is sufficient for v1.
+- **Shared mailboxes, delegate access, on-behalf-of send.** Future; not part of v1 parity.
+- **Calendar, Contacts, Tasks.** QuickMail is a mail client; expanding scope is a separate product decision.
+- **Per-tenant client app registration.** v1 uses the existing MSAL client ID with `common` authority, same as the current IMAP/OAuth path.
+
+---
+
+## 6. Data Model Changes
+
+### 6.1 New: `BackendKind` enum
+
+```csharp
+namespace QuickMail.Models;
+
+public enum BackendKind
+{
+    /// <summary>Standard IMAP for receive + SMTP for send. Default for all existing accounts.</summary>
+    ImapSmtp,
+
+    /// <summary>Microsoft Graph for receive + send. Used for M365 / Outlook.com when IMAP/SMTP is unavailable.</summary>
+    MicrosoftGraph,
+}
+```
+
+### 6.2 Modified: `AccountModel`
+
+Adds two fields. All existing fields remain. IMAP-specific fields are unused when `BackendKind == MicrosoftGraph` but kept on the model to avoid a polymorphic JSON shape.
+
+```csharp
+public BackendKind BackendKind { get; set; } = BackendKind.ImapSmtp;
+
+/// <summary>
+/// Azure AD tenant for Graph accounts. Null = "common" authority (default).
+/// Used only when BackendKind == MicrosoftGraph; ignored otherwise.
+/// </summary>
+public string? TenantId { get; set; }
+```
+
+**Migration:** existing `accounts.json` files have no `backendKind` field. `System.Text.Json` will use the default (`ImapSmtp`) on read — backwards-compatible without code changes.
+
+### 6.3 Modified: `MailMessageSummary.UniqueId` (uint → string)
+
+The IMAP `uint` UID does not fit Graph's opaque string IDs (e.g. `AAMkAGI2T...==`, ~150 chars). The whole pipeline migrates.
+
+| Old | New |
+|---|---|
+| `public uint UniqueId { get; set; }` | `public string MessageId { get; set; } = string.Empty;` |
+| SQLite: `unique_id INTEGER NOT NULL` | `unique_id TEXT NOT NULL` |
+| IMAP impl writes `client.Uid` | IMAP impl writes `client.Uid.ToString(CultureInfo.InvariantCulture)` |
+| Graph impl writes | message.Id directly |
+
+**Schema migration:** one-time on first launch of v0.7. New `CurrentSchemaVersion = 2`. Migration converts `unique_id INTEGER` to `unique_id TEXT` for both `MessageSummary` and `MessageDetail` tables. Existing values become `CAST(unique_id AS TEXT)`.
+
+**Sort behavior:** IMAP code relied on `MAX(unique_id)` for incremental sync (`GetMaxUidAsync`). For Graph this is replaced by a per-folder `delta_token` column. For IMAP, the impl issues `MAX(CAST(unique_id AS INTEGER))` to preserve numeric sort. Spec'd in §6.5.
+
+### 6.4 Modified: `AttachmentModel.PartSpecifier`
+
+Rename to `AttachmentRef` (string, opaque per backend):
+
+- IMAP: stores the body-part specifier (`"2"`, `"2.1"`)
+- Graph: stores the attachment ID returned by `/messages/{id}/attachments`
+
+Type and nullability unchanged.
+
+### 6.5 New: per-folder delta tokens for Graph
+
+A new column on `MailFolderModel` (in-memory only, persisted in a small new SQLite table):
+
+```sql
+CREATE TABLE IF NOT EXISTS DeltaToken (
+    account_id   TEXT NOT NULL,
+    folder_id    TEXT NOT NULL,
+    delta_token  TEXT NOT NULL,
+    updated_utc  INTEGER NOT NULL,
+    PRIMARY KEY (account_id, folder_id)
+);
+```
+
+Used only by Graph backend. IMAP rows never exist here.
+
+---
+
+## 7. User Experience Design
+
+### 7.1 Add Account dialog
+
+One new control at the top of the dialog: an "Account type" combo box.
+
+```
+┌──────────────────────────────────────────────────────┐
+│ Add Account                                  [✕]    │
+├──────────────────────────────────────────────────────┤
+│ Account type:  [Standard IMAP/SMTP            ▾]   │
+│                                                      │
+│ Account name:  [_______________________]            │
+│ Display name:  [_______________________]            │
+│ Email address: [_______________________]            │
+│                                                      │
+│ Authentication: ( ) Password  (•) OAuth (Microsoft) │
+│                                                      │
+│ ── IMAP ──────────────────────────────────────────── │
+│ Host: [_______________]  Port: [993]  [✓] SSL       │
+│                                                      │
+│ ── SMTP ──────────────────────────────────────────── │
+│ Host: [_______________]  Port: [587]  [ ] SSL       │
+│                                                      │
+│ [Sign in]  [Test connection]                         │
+│                                                      │
+│                              [Cancel]  [Save]        │
+└──────────────────────────────────────────────────────┘
+```
+
+When **Account type** is "Microsoft 365 / Outlook.com":
+
+```
+┌──────────────────────────────────────────────────────┐
+│ Add Account                                  [✕]    │
+├──────────────────────────────────────────────────────┤
+│ Account type:  [Microsoft 365 / Outlook.com   ▾]   │
+│                                                      │
+│ Account name:  [_______________________]            │
+│ Display name:  [_______________________]            │
+│ Email address: [_______________________]            │
+│                                                      │
+│ Authentication: OAuth (Microsoft) — required        │
+│                                                      │
+│ Selecting this account type will sign you in with   │
+│ your Microsoft 365 or personal Outlook.com account. │
+│ Mail will be accessed via Microsoft Graph.          │
+│                                                      │
+│ [Sign in]                                            │
+│                                                      │
+│                              [Cancel]  [Save]        │
+└──────────────────────────────────────────────────────┘
+```
+
+The IMAP and SMTP host/port fields are collapsed (not visible) when Microsoft 365 is selected. The Authentication radio group is hidden because OAuth is the only option.
+
+**Rationale:** the user does not need to know what protocol they're picking. They pick "their account type" and the right thing happens.
+
+### 7.2 Account type combo options
+
+| Display value | Backend | Auth options | Visible when |
+|---|---|---|---|
+| "Standard IMAP/SMTP" (default) | `ImapSmtp` | Password, OAuth (Microsoft) | Always |
+| "Microsoft 365 / Outlook.com" | `MicrosoftGraph` | OAuth (Microsoft) only | `FeatureFlag.GraphBackend == true` |
+
+Account type is **fixed after creation** — the field is read-only when editing an existing account. To switch, delete and re-add.
+
+**When the gate is off** (the default state shipped to all users), the combo contains only one option ("Standard IMAP/SMTP") and may be rendered as a static label rather than a combo. See §9.7 for the gate mechanism.
+
+### 7.3 Account list
+
+No visible change for IMAP accounts. M365 accounts look identical in the list — same name, same unread badge, same status text. Behind the scenes, every operation routes through `GraphMailService` instead of `ImapMailService`.
+
+The account's accessible name (`AutomationProperties.Name`) is unchanged — no "Microsoft 365" suffix. Users who care can read it in the Account Manager dialog.
+
+### 7.4 Sign-in flow for new M365 accounts
+
+Identical to the existing OAuth flow:
+
+1. User selects "Microsoft 365 / Outlook.com" account type.
+2. User enters email address and clicks **Sign in**.
+3. System browser opens to `login.microsoftonline.com`.
+4. User completes Microsoft sign-in (password, MFA, conditional access).
+5. Browser redirects to `http://localhost:<port>` — MSAL captures the token.
+6. Account is saved. Connection test runs in the background. UI confirms "Connected".
+
+**Difference from existing IMAP/OAuth flow:** the scopes requested are `Mail.ReadWrite`, `Mail.Send`, `MailboxSettings.Read`, `offline_access` instead of `IMAP.AccessAsUser.All`, `SMTP.Send`, `offline_access`.
+
+### 7.5 Error states unique to Graph
+
+| Error | User-facing message |
+|---|---|
+| Tenant policy denies Graph access | "Your organization's Microsoft 365 settings do not permit this app to read mail. Contact your administrator." |
+| Conditional access blocks sign-in | "Microsoft sign-in was blocked by your organization's security policy. Try again from a managed device, or contact your administrator." |
+| Throttled (429 Too Many Requests) | Transparent — backoff and retry. Status bar: "Microsoft 365 is rate-limiting. Retrying…" |
+| Mailbox not found | "No mailbox is associated with this account. If you signed in with a different account than intended, sign out and try again." |
+
+All messages routed through `AccessibilityHelper.Announce(category: Result)`.
+
+---
+
+## 8. Accessibility (WCAG 2.2)
+
+The user-visible surface change is **one new combo box** in the Add Account dialog. The accessibility burden is small but non-zero.
+
+### 8.1 Compliance targets
+
+WCAG 2.2 Level AA for the new combo and the conditional field visibility.
+
+| SC | Description | How we meet it |
+|---|---|---|
+| 1.3.1 Info and Relationships | Hidden fields are not exposed to AT | When fields collapse on backend change, they are `Visibility="Collapsed"` (not `Hidden`), removing them from the tab order and the UIA tree |
+| 1.3.2 Meaningful Sequence | Tab order is logical | Account type combo is first in tab order; remaining fields follow in visual order |
+| 2.4.3 Focus Order | Focus moves meaningfully when fields change | When user switches from IMAP to M365 and hidden fields lose focus, focus moves to the next visible field, not lost |
+| 4.1.2 Name, Role, Value | Combo has correct UIA role | Standard WPF `ComboBox` exposes `UIA.ControlType.ComboBox` natively |
+| 4.1.3 Status Messages | Field-set change is announced | `AccessibilityHelper.Announce("Switched to Microsoft 365 account. IMAP and SMTP fields are no longer required.", AnnouncementCategory.Hint)` when the user changes backend type |
+
+### 8.2 Screen-reader announcements
+
+| Event | Announcement | Category |
+|---|---|---|
+| User switches account type to "Microsoft 365" | "Switched to Microsoft 365. IMAP and SMTP fields are not needed for this account type." | `Hint` |
+| User switches account type back to "Standard IMAP/SMTP" | "Switched to standard IMAP and SMTP. Enter your server settings below." | `Hint` |
+| OAuth sign-in started | "Opening Microsoft sign-in in your browser." | `Status` |
+| Sign-in succeeded (Graph) | "Signed in as {Username}. Microsoft 365 account ready." | `Result` |
+| Tenant denies scopes | "Your organization's Microsoft 365 settings do not permit this app to read mail." | `Result` |
+
+### 8.3 Keyboard navigation
+
+No new shortcuts. The Add Account dialog already supports Tab, Enter, and Escape; the new combo participates in the existing flow.
+
+---
+
+## 9. Technical Architecture
+
+### 9.1 Target architecture
+
+```
+                          ┌─────────────────────────────────┐
+   MainViewModel ─────→   │       IMailService              │  ←── per-account dispatch
+   SyncService    ─────→  │  (was IImapService, renamed)    │       on BackendKind
+   RuleService    ─────→  └────────────────┬────────────────┘
+                                            │
+                          ┌─────────────────┴─────────────────┐
+                          │                                   │
+                ┌─────────▼──────────┐              ┌─────────▼──────────┐
+                │  ImapMailService   │              │  GraphMailService  │
+                │  (existing logic)  │              │       (new)        │
+                └─────────┬──────────┘              └─────────┬──────────┘
+                          │                                   │
+                       MailKit                       Microsoft.Graph or
+                                                     raw HttpClient
+                ─────────────────────────────────────────────────────
+                                            │
+                          ┌─────────────────┴─────────────────┐
+                          │       MailServiceRouter           │
+                          │  Dictionary<Guid, IMailService>   │
+                          └───────────────────────────────────┘
+```
+
+`MailServiceRouter` itself implements `IMailService`. Every method takes an `accountId` (or `AccountModel`) — the router looks up the right backend instance and delegates. Consumers don't know two backends exist.
+
+For events that don't take an account ID (e.g. `event Action<Guid>? InboxNewMailDetected`), the router multiplexes events from all underlying backends.
+
+### 9.2 Data-flow diagram — incoming message
+
+This diagram traces a single new message from arrival to UI render. **Both** backends produce the same shape at the `MailMessageSummary` boundary; everything downstream is backend-agnostic.
+
+```
+                IMAP path                                 Graph path
+                ─────────                                 ──────────
+
+  ImapClient IDLE detects new INBOX msg         GraphChangeNotifier delta-poll tick
+              │                                              │
+              │ event InboxNewMailDetected(accountId)        │
+              └──────────────────────┬───────────────────────┘
+                                     │
+                                     ▼
+                        MainViewModel.OnInboxNewMailDetected
+                                     │
+                                     ▼
+                     SyncService.SyncOneFolderOnlineAsync
+                                     │
+                          IMailService.GetMessagesSinceAsync   ← router dispatches
+                                     │
+                  ┌──────────────────┴──────────────────┐
+                  │                                     │
+        ImapMailService                       GraphMailService
+        IMAP UID FETCH range            GET /me/mailFolders/{id}/messages/delta
+                  │                                     │
+                  │   List<MailMessageSummary>          │
+                  └──────────────────┬──────────────────┘
+                                     ▼
+                  ILocalStoreService.UpsertSummariesAsync
+                       (SQLite, string PK on MessageId)
+                                     │
+                                     ▼
+                      IRuleService.ApplyRulesAsync
+                       (matches against summary fields)
+                                     │
+                                     ▼
+                       SyncService.FolderSynced event
+                                     │
+                                     ▼
+                  MainViewModel merges into Messages collection
+                                     │
+                                     ▼
+                            ListBox renders
+                  AccessibilityHelper.Announce(Status)
+                  "New message from {Sender}: {Subject}"
+```
+
+**Boundary contract:** both backends MUST return `MailMessageSummary` with `MessageId` (string, non-empty), `AccountId` (Guid), `FolderName` (Graph: folder ID; IMAP: full IMAP name), `From`, `Subject`, `Date`, and where available `Preview`, `IsRead`, `HasAttachments`. Anything else can be empty.
+
+### 9.3 Authentication
+
+The MSAL infrastructure stays. `OAuthService.GetAccessTokenAsync` already handles silent-then-interactive with a DPAPI-encrypted cache.
+
+What changes: `OAuthService` accepts scopes per call instead of hardcoding the IMAP scopes. The caller passes the right scopes for the backend.
+
+```csharp
+// before:
+private static readonly string[] Scopes =
+[
+    "https://outlook.office.com/IMAP.AccessAsUser.All",
+    "https://outlook.office.com/SMTP.Send",
+    "offline_access"
+];
+
+// after — scopes selected by caller:
+public Task<string> GetAccessTokenAsync(AccountModel account, string[] scopes, CancellationToken ct = default);
+
+// IMAP caller passes the IMAP scopes (above)
+// Graph caller passes:
+//   ["https://graph.microsoft.com/Mail.ReadWrite",
+//    "https://graph.microsoft.com/Mail.Send",
+//    "https://graph.microsoft.com/MailboxSettings.Read",
+//    "offline_access"]
+```
+
+The MSAL token cache stores tokens per-scope automatically — no token-cache collision between an account that has both IMAP and Graph scopes.
+
+**App registration:** the existing MSAL `ClientId = "bcdc84f1-d37c-4581-b14a-a01f7b3a1312"` must have `Mail.ReadWrite`, `Mail.Send`, `MailboxSettings.Read` added as delegated permissions in its Azure registration. Maintainer action required before PR 4 lands.
+
+### 9.4 New-mail notifications: polling, not webhooks
+
+IMAP uses IDLE — a persistent TCP connection that the server pushes notifications onto. Graph offers two notification mechanisms:
+
+1. **Webhook subscriptions** — Microsoft POSTs to a URL when mail arrives. Requires a publicly reachable HTTPS URL. **Not viable for a desktop app** without a relay service.
+
+2. **Delta queries** — client polls `GET /me/mailFolders/{id}/messages/delta?$skipToken=…`, server returns only changes since the last token. **Right choice for a desktop app.**
+
+`GraphChangeNotifier` polls every account's INBOX delta endpoint on a 60-second cadence (configurable in `config.ini`). When the delta returns ≥1 new message, it raises `InboxNewMailDetected(accountId)` — the same event consumers already handle.
+
+Polling is slower than IDLE (60s worst case vs near-instant) but adequate for a mail client. If users complain, webhook-via-relay is a future feature.
+
+### 9.5 Throttling
+
+Graph throttles per user (~10,000 requests / 10 min for most endpoints) and returns `429 Too Many Requests` with a `Retry-After` header when exceeded. `GraphMailService` honors `Retry-After`. Background sync respects throttling and surfaces a "Rate-limited, retrying in {N}s" status to the user.
+
+### 9.6 Dependency choice: SDK vs raw HttpClient
+
+Two options for the Graph layer:
+
+| Option | Pros | Cons |
+|---|---|---|
+| **`Microsoft.Graph` 5.x SDK** | Strongly-typed model objects, fluent request builder, automatic retry/throttling | +~10MB to published exe, brings Azure Identity transitive deps |
+| **Raw `HttpClient`** | Minimal dep footprint, full control over wire format | More code to write; we re-implement model classes for messages, folders, attachments |
+
+**Recommendation: raw `HttpClient`.** QuickMail is small (one solo dev, published size matters for accessibility users on metered connections), and the Graph mail surface is narrow — maybe 12 endpoints. The SDK's value is on Graph's huge surface area; we use a sliver. Hand-rolled DTOs are ~200 lines.
+
+This is the v1 decision; the SDK can be adopted later if the dep footprint stops mattering.
+
+### 9.7 Feature gate
+
+Per maintainer request, the Graph backend (and any future user-facing surface that ships before it's broadly ready) sits behind a runtime feature gate. The gate mechanism is **new infrastructure** introduced by this work and intended to be reused for future experimental features.
+
+**Design:**
+
+```csharp
+// Models/FeatureFlag.cs
+public enum FeatureFlag
+{
+    GraphBackend,
+    // Future flags add an enum value here.
+}
+
+// Services/IFeatureGate.cs
+public interface IFeatureGate
+{
+    bool IsEnabled(FeatureFlag flag);
+}
+
+// Services/ConfigFeatureGate.cs
+// Reads [features] section of config.ini; merges --feature CLI flags from App.xaml.cs.
+public class ConfigFeatureGate : IFeatureGate { /* impl */ }
+```
+
+**Storage:** new `[features]` section in `%APPDATA%\QuickMail\config.ini`:
+
+```ini
+[features]
+GraphBackend=true
+```
+
+The file is human-editable; `ConfigService` already parses INI, so the addition is small.
+
+**CLI override:** `QuickMail.exe --feature GraphBackend` enables the flag for one launch without writing to disk. Useful for quick dev iteration. Multiple flags: `--feature GraphBackend --feature OtherFlag`. CLI flags take precedence over `config.ini`.
+
+**Defaults:** every flag defaults to `false` until explicitly enabled. The defaults table lives in `ConfigFeatureGate` and is updated by future PRs when a feature graduates. For `FeatureFlag.GraphBackend`, the default stays `false` for the duration of v0.7 and v0.8 — adventurous users opt in by editing `config.ini`.
+
+**Default-flip decision:** changing the in-code default from `false` to `true` is a one-line PR that requires explicit maintainer approval. It is independent of any specific release version — the code can sit dormant across multiple v0.x releases until both contributor and maintainer agree the feature is GA-ready. See §12 question 5.
+
+**What the gate controls (and doesn't):**
+
+| Surface | Gated? |
+|---|---|
+| "Microsoft 365 / Outlook.com" option in Add Account combo | **Yes** — hidden when gate is off |
+| `BackendKind` enum existence | No — internal type, always present |
+| `MailServiceRouter` construction | No — cheap; routes IMAP traffic correctly with no Graph accounts present |
+| `GraphMailService` instantiation in DI | No — instantiated but never called when no Graph accounts exist |
+| Existing Graph-backed accounts (after a flag flip) | No — once an account exists, it remains functional regardless of the flag |
+| Graph endpoint network calls | No direct gate — but no Graph accounts means no calls happen |
+
+The single gated surface is the **Add Account combo option**. Everything else is internal plumbing that has no observable behavior absent a Graph account, which can't be created with the gate off.
+
+**Testing:** unit tests inject `StubFeatureGate` with explicit per-test state. CI runs both gate-on and gate-off variants of relevant tests so we never ship a regression in the off path. Documented in dev spec §7.
+
+**Future:** a "Lab / Preview features" tab in the Settings dialog is out of scope for this work but explicitly anticipated. The enum-keyed design makes it a future enhancement without breaking the existing call sites.
+
+### 9.8 Files
+
+**New files:**
+
+| File | Purpose |
+|---|---|
+| `QuickMail/Models/BackendKind.cs` | Enum: ImapSmtp \| MicrosoftGraph |
+| `QuickMail/Models/FeatureFlag.cs` | Enum for feature-gate keys |
+| `QuickMail/Services/IFeatureGate.cs` | Feature-gate interface |
+| `QuickMail/Services/ConfigFeatureGate.cs` | Config-file + CLI implementation |
+| `QuickMail/Services/IMailService.cs` | Renamed `IImapService`, identical surface initially |
+| `QuickMail/Services/ImapMailService.cs` | Renamed `ImapService` |
+| `QuickMail/Services/MailServiceRouter.cs` | Per-account dispatcher implementing `IMailService` |
+| `QuickMail/Services/GraphMailService.cs` | New Graph backend |
+| `QuickMail/Services/GraphSmtpService.cs` | New Graph send (via `/me/sendMail`) |
+| `QuickMail/Services/IChangeNotifier.cs` | Abstraction over IDLE / delta polling |
+| `QuickMail/Services/ImapChangeNotifier.cs` | Extracted from `ImapService.StartIdleWatchers` |
+| `QuickMail/Services/GraphChangeNotifier.cs` | Delta polling loop |
+| `QuickMail/Services/Graph/*.cs` | DTOs for Graph wire format (Message, MessageBody, MailFolder, FileAttachment, etc.) |
+
+**Modified files (high level):**
+
+| File | Change |
+|---|---|
+| `QuickMail/Models/AccountModel.cs` | Add `BackendKind`, `TenantId` |
+| `QuickMail/Models/MailMessageSummary.cs` | `UniqueId: uint` → `MessageId: string` |
+| `QuickMail/Models/AttachmentModel.cs` | `PartSpecifier` → `AttachmentRef` |
+| `QuickMail/Models/ConfigModel.cs` | Add `Features` dictionary (parsed `[features]` section) |
+| `QuickMail/Services/ConfigService.cs` | Parse `[features]` section into `ConfigModel.Features` |
+| `QuickMail/Services/ILocalStoreService.cs` | All `uint uid` → `string messageId` |
+| `QuickMail/Services/LocalStoreService.cs` | Schema migration v2: `unique_id INTEGER` → `TEXT`; add `DeltaToken` table |
+| `QuickMail/Services/OAuthService.cs` | Accept scopes per call, not hardcoded |
+| `QuickMail/Services/SyncService.cs` | Talks to `IMailService` (was `IImapService`) |
+| `QuickMail/Services/RuleService.cs` | string IDs |
+| `QuickMail/ViewModels/MainViewModel.cs` | string IDs (44 call sites) |
+| `QuickMail/ViewModels/AddAccountViewModel.cs` | `BackendKind` property + conditional defaults; consults `IFeatureGate` to populate combo |
+| `QuickMail/Views/AddAccountDialog.xaml` | New combo (one-option fallback when gate is off); conditional field visibility |
+| `QuickMail/App.xaml.cs` | Parse `--feature` CLI flags; wire `MailServiceRouter` and `ConfigFeatureGate` |
+| `QuickMail/QuickMail.csproj` | No new packages if raw HttpClient |
+| `QuickMail.Tests/StubServices.cs` | `StubGraphMailService`, `StubFeatureGate` |
+
+---
+
+## 10. Implementation Phases
+
+Sequenced so that each phase is independently mergeable and reversible until the schema migration in Phase 2 lands. After Phase 2, downgrade requires a SQLite restore from backup.
+
+| Phase | Title | Behavior change | Estimated effort (solo, evenings) |
+|---|---|---|---|
+| 0 | This PM spec + matching dev spec, opened as a draft PR for maintainer review | None | 1 |
+| 1 | Interface rename — `IImapService` → `IMailService`, `ImapService` → `ImapMailService`. Pure rename. | None | 1-2 |
+| 2 | `uint UniqueId` → `string MessageId`. SQLite schema migration v2. | None (behavioral parity verified by full test suite + manual smoke) | **3-5** (the painful one) |
+| 3 | `BackendKind` enum + `MailServiceRouter` + `IFeatureGate` infrastructure + Add Account UI combo (Microsoft 365 option present but gated off by default) | New UI element when gate is on; no functional change when gate is off (default) | 2-3 |
+| 4 | `GraphMailService` read path: connect, GetFolders, GetMessageSummaries, GetMessagesSince*, GetMessageDetail, MarkRead | First end-to-end Graph read (only reachable when gate is on) | 4-6 |
+| 5 | `GraphSmtpService`: send via `/me/sendMail`. `AppendToSent` is no-op for Graph. | First Graph send | 1-2 |
+| 6 | Attachments + folder CRUD + move/copy/delete on Graph | Feature parity for daily use | 3-5 |
+| 7 | `GraphChangeNotifier`: delta polling + `IChangeNotifier` abstraction; extract `ImapChangeNotifier` from existing IDLE code | New-mail notifications for Graph accounts | 3-4 |
+| 8 | Tests: `GraphMailServiceTests` with `HttpMessageHandler` stub, `MailServiceRouterTests`, `FeatureGateTests`, migration round-trip test | None (coverage) | 2-3 |
+| **Future** | One-line PR flipping `FeatureFlag.GraphBackend` default to `true`. Requires explicit maintainer approval and release-notes entry. Independent of any specific release version. | Graph backend becomes generally available | <1 |
+
+**Total: 20-30 evenings of focused work.**
+
+Phases 1-3 ship as v0.7 (no user-visible Graph; gate present but defaulted off). Phases 4-8 ship as v0.8 or later — Graph code is in the binary but unreachable from the UI without the user flipping the gate. The GA flip is a separate PR with no fixed schedule.
+
+---
+
+## 11. Success Metrics
+
+| Metric | Target | Measurement |
+|---|---|---|
+| **Reach** — users on IMAP-disabled M365 tenants can now connect | Manual verification on a test tenant where `Set-CASMailbox -ImapEnabled $false` is applied | One-time |
+| **Functional parity** — every IMAP operation has a working Graph equivalent | 100% of `IMailService` methods covered by `GraphMailService` | Test matrix at PR 6 |
+| **No regression** — existing IMAP users see identical behavior | All existing tests pass; `MainViewModel` smoke test on a Gmail account passes pre/post each PR | Per PR |
+| **Startup time** — no measurable regression for IMAP-only users | < 5% increase in time-to-first-folder-render with one IMAP account | Manual benchmark on PR 3 and PR 7 |
+| **Schema migration safety** — no data loss on first launch of v0.7 | Migration tested on a 500MB mail.db with 100k messages; all rows present after migration | Test in Phase 2 |
+| **Graph throttling handled gracefully** — 429 responses don't crash sync | Stress test: fire 200 message-detail requests in 10s, verify backoff and eventual completion | Test in Phase 4 |
+| **Accessibility** — zero new a11y bugs in Add Account dialog | Screen-reader pass on the new combo and conditional fields | Manual in Phase 3 |
+
+---
+
+## 12. Open Questions & Risks
+
+### Open questions for the maintainer
+
+Questions 1, 6, 7 resolved in v0.2 per Kelly's Issue #24 response (2026-05-24). Remaining open:
+
+1. ~~Take this on at all?~~ **Resolved (v0.2):** Kelly approved direction; pending detailed doc review.
+
+2. **MSAL app registration:** the existing `ClientId = "bcdc84f1-d37c-4581-b14a-a01f7b3a1312"` is owned by Kelly. Graph scopes (`Mail.ReadWrite`, `Mail.Send`, `MailboxSettings.Read`) must be added in its Azure portal registration. Who does it? Coordinate timing with Phase 4.
+
+3. **Tenant authority:** stay on `common` (personal + work/school)? Or expose a per-account tenant ID field for organizations that require it? **Proposed: stay on `common` for v1.** Per-tenant authority is a follow-up.
+
+4. **Microsoft.Graph SDK vs raw HttpClient:** §9.6 recommends raw HttpClient (~10MB smaller binary, narrower surface). Maintainer override welcomed.
+
+5. **GA flip — when does `FeatureFlag.GraphBackend` default to `true`?** **Proposed (v0.2):** the in-code default stays `false` for the lifetime of v0.7 and v0.8. The flip is a one-line PR opened by the contributor and merged only with explicit maintainer approval. No specific release version is committed; the flip happens when both parties agree the feature is GA-ready based on real-world testing. Until the flip, adventurous users enable it in `config.ini`.
+
+6. ~~EWS / on-prem Exchange?~~ **Resolved (v0.2):** confirmed out of scope.
+
+7. ~~Per-feature spec docs first?~~ **Resolved (v0.1):** confirmed; this PR *is* the spec.
+
+8. **One-way schema migration:** unique_id INTEGER → TEXT is one-way without a SQLite backup. The plan includes a pre-migration backup of `mail.db` to `mail.db.pre-v2`. Comfortable with that, or do we need additional protection (e.g. a settings toggle to defer migration)?
+
+### Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Tenant policy denies the requested Graph scopes for some users | Medium | Affected users cannot use Graph backend | Clear error message routing user to admin; document required scopes in USERGUIDE.md |
+| Throttling under heavy initial sync of a large mailbox (50k+ messages) | Medium | First-time sync is slow | Honor `Retry-After`; surface "Rate-limited, retrying" in status bar; throttle initial fetch batch size |
+| Schema migration corrupts an existing mail.db | Low | Data loss; users must re-sync | Migration is wrapped in a transaction; pre-migration backup of mail.db → mail.db.pre-v2; recover script documented |
+| MSAL token cache collision between IMAP-scope and Graph-scope tokens for the same user | Low | User gets unexpected sign-in prompts | MSAL stores tokens per scope-set; no collision in normal use; explicitly tested |
+| 44 call sites in MainViewModel = high blast radius for the UID→string refactor | High | Regressions slip in | Full test suite + manual smoke on Gmail account after every PR in Phase 2; lean on the compiler — `uint` → `string` is a compile-time-enforced change |
+| Graph SDK / wire format changes between draft and merge | Low | Need to update DTOs | Pin to Graph v1.0 endpoint (not beta); test against the published OpenAPI spec |
+| Webhook expectations from power users | Low | Users want instant notifications | Polling cadence is configurable; webhook-via-relay is a documented future feature |
+| Maintainer rejects the proposal | Medium | All work wasted | **Open as a GitHub issue first, draft PR second, code only after thumbs-up** |
+
+---
+
+## Appendix A: Graph endpoint map
+
+Reference for Phase 4-6 implementers. All endpoints are `https://graph.microsoft.com/v1.0/me/...`.
+
+| `IMailService` method | Graph endpoint(s) |
+|---|---|
+| `ConnectAsync` | `GET /me?$select=id,userPrincipalName` (validates token; no real connection) |
+| `GetFoldersAsync` | `GET /mailFolders?$top=100&$select=id,displayName,parentFolderId,totalItemCount,unreadItemCount` (paginated; flattens to existing tree) |
+| `GetMessageSummariesAsync` | `GET /mailFolders/{id}/messages?$top={N}&$orderby=receivedDateTime desc&$select=id,subject,from,toRecipients,receivedDateTime,isRead,bodyPreview,hasAttachments` |
+| `GetMessagesSinceAsync` | `GET /mailFolders/{id}/messages/delta?$skipToken={token}` (first call: no skipToken) |
+| `GetMessagesSinceDateAsync` | `GET /mailFolders/{id}/messages?$filter=receivedDateTime ge {iso}&$top=1000` |
+| `GetMessageDetailAsync` | `GET /messages/{id}?$select=id,subject,body,from,toRecipients,ccRecipients,internetMessageId,attachments&$expand=attachments($select=id,name,contentType,size,isInline)` |
+| `MarkReadAsync` | `PATCH /messages/{id}` with `{ "isRead": true }` |
+| `MoveMessagesAsync` | `POST /messages/{id}/move` with `{ "destinationId": "{folderId}" }` (one call per message; consider batch via `$batch`) |
+| `MoveToTrashBatchAsync` | Same as Move, target = Deleted Items folder ID |
+| `PermanentlyDeleteBatchAsync` | `DELETE /messages/{id}` |
+| `CopyMessagesAsync` | `POST /messages/{id}/copy` |
+| `DownloadAttachmentAsync` | `GET /messages/{messageId}/attachments/{attachmentId}/$value` (returns raw bytes) |
+| `FetchPreviewsAsync` | No-op for Graph — `bodyPreview` already in summary response |
+| `CreateFolderAsync` | `POST /mailFolders/{parentId}/childFolders` (root: `POST /mailFolders`) |
+| `DeleteFolderAsync` | `DELETE /mailFolders/{id}` |
+| `RenameFolderAsync` | `PATCH /mailFolders/{id}` with `{ "displayName": "..." }` |
+| `CopyFolderAsync` | `POST /mailFolders/{id}/copy` |
+| `AppendDraftAsync` | `POST /messages` with full draft body; if `replaceUid`: `DELETE` old then `POST` new |
+| `AppendToSentAsync` | No-op for Graph — `/sendMail` automatically saves to Sent |
+| `EmptyTrashAsync` | `POST /mailFolders/{deletedItemsId}/messages` listing + `DELETE` each, or `POST /mailFolders/{id}/permanentlyDelete` (preview-only at writing) |
+| `GetInboxStatusAsync` | `GET /mailFolders/Inbox?$select=totalItemCount,unreadItemCount` |
+| `FindDraftsFolderNameAsync` | `GET /mailFolders/Drafts?$select=id` (Graph well-known name) |
+| `NoOpAsync` | No-op for Graph (HTTP is stateless) |
+| `SendAsync` (SMTP path) | `POST /me/sendMail` with `{ "message": { ... }, "saveToSentItems": true }` (accepts MIME via `Content-Type: text/plain` body with base64-encoded MIME) |
+
+## Appendix B: Scope comparison
+
+| Today (IMAP/OAuth) | Proposed (Graph) |
+|---|---|
+| `https://outlook.office.com/IMAP.AccessAsUser.All` | `https://graph.microsoft.com/Mail.ReadWrite` |
+| `https://outlook.office.com/SMTP.Send` | `https://graph.microsoft.com/Mail.Send` |
+| (none) | `https://graph.microsoft.com/MailboxSettings.Read` (used to discover well-known folder IDs) |
+| `offline_access` | `offline_access` |
+
+## Appendix C: Schema migration SQL
+
+```sql
+-- v2: change unique_id from INTEGER to TEXT
+-- Run inside a single transaction. On failure, rollback leaves v1 intact.
+
+BEGIN;
+
+-- MessageSummary
+CREATE TABLE MessageSummary_v2 (
+    unique_id    TEXT    NOT NULL,
+    account_id   TEXT    NOT NULL,
+    folder_name  TEXT    NOT NULL,
+    from_disp    TEXT    NOT NULL DEFAULT '',
+    to_addr      TEXT    NOT NULL DEFAULT '',
+    subject      TEXT    NOT NULL DEFAULT '',
+    date_ticks   INTEGER NOT NULL,
+    is_read      INTEGER NOT NULL DEFAULT 0,
+    preview_text TEXT    NOT NULL DEFAULT '',
+    is_replied   INTEGER NOT NULL DEFAULT 0,
+    is_forwarded INTEGER NOT NULL DEFAULT 0,
+    has_attachments INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (unique_id, account_id, folder_name)
+);
+
+INSERT INTO MessageSummary_v2
+SELECT CAST(unique_id AS TEXT), account_id, folder_name, from_disp, to_addr,
+       subject, date_ticks, is_read, preview_text, is_replied, is_forwarded,
+       has_attachments
+FROM MessageSummary;
+
+DROP TABLE MessageSummary;
+ALTER TABLE MessageSummary_v2 RENAME TO MessageSummary;
+
+CREATE INDEX idx_summary_date ON MessageSummary(date_ticks DESC);
+
+-- MessageDetail (parallel migration)
+CREATE TABLE MessageDetail_v2 (
+    unique_id   TEXT NOT NULL,
+    account_id  TEXT NOT NULL,
+    folder_name TEXT NOT NULL,
+    to_addr     TEXT NOT NULL DEFAULT '',
+    cc          TEXT NOT NULL DEFAULT '',
+    reply_to    TEXT NOT NULL DEFAULT '',
+    plain_body  TEXT NOT NULL DEFAULT '',
+    html_body   TEXT NOT NULL DEFAULT '',
+    attachments_json TEXT DEFAULT NULL,
+    PRIMARY KEY (unique_id, account_id, folder_name)
+);
+
+INSERT INTO MessageDetail_v2
+SELECT CAST(unique_id AS TEXT), account_id, folder_name, to_addr, cc,
+       reply_to, plain_body, html_body, attachments_json
+FROM MessageDetail;
+
+DROP TABLE MessageDetail;
+ALTER TABLE MessageDetail_v2 RENAME TO MessageDetail;
+
+-- New table for Graph delta tokens
+CREATE TABLE DeltaToken (
+    account_id   TEXT NOT NULL,
+    folder_id    TEXT NOT NULL,
+    delta_token  TEXT NOT NULL,
+    updated_utc  INTEGER NOT NULL,
+    PRIMARY KEY (account_id, folder_id)
+);
+
+PRAGMA user_version = 2;
+
+COMMIT;
+```
+
+**Pre-migration backup:** `LocalStoreService.Initialize` copies `mail.db` to `mail.db.pre-v2` before opening the connection if `user_version < 2`. Backup is preserved indefinitely; user can manually delete after they're confident the migration is good.
+
+## Appendix D: Comparison to mail-rules feature retrospective
+
+The mail-rules retrospective ([mail-rules-pm-spec.md §Appendix D](../docs/planning/mail-rules-pm-spec.md)) identified four bugs that all lived at component boundaries. The fix was: data-flow diagrams, integration tests, manual test checklists.
+
+This proposal includes:
+
+| Lesson from mail-rules | Where it appears here |
+|---|---|
+| Data-flow diagram required | §9.2 — single diagram covering both backends |
+| Integration test specified | §11 — "no regression" smoke test on a Gmail account between every PR; "schema migration safety" test on a real-sized DB |
+| Manual test checklist | Dev spec §6 (forthcoming) will include the per-PR manual smoke list |
+| Different agent for spec review vs implementation | This document is the proposal; the maintainer (or an independent agent) reviews; a third agent (or the contributor) implements |
+| Existing-data path explicit | §6.3 — schema migration is one-way and explicit; existing IMAP rows become text via CAST |
+
+The same retrospective noted: "**specs describe structure; bugs live in flow.**" Phase 2 (the UID → string migration) is where this proposal is most exposed to that risk — the change is mechanical but touches 12 files and 128 sites. The per-PR smoke test on a real Gmail account is the primary mitigation; the compiler is the secondary.


### PR DESCRIPTION
Groundwork for the optional Microsoft Graph mail backend proposed in #24. Two commits, reviewable independently:

**1. Docs** — adds the PM and developer specs under `docs/planning/` (`graph-backend-pm-spec.md`, `graph-backend-dev-spec.md`, v0.2), matching the existing `mail-rules-*-spec.md` format. No code; this is the artifact for the detailed design read.

**2. Interface rename** — PR 1 from the dev spec. Pure mechanical rename, **no behavior change**:
- `IImapService` → `IMailService`
- `ImapService` → `ImapMailService` (unchanged MailKit implementation + per-account connection pool)
- all consumers, the `App.xaml.cs` composition root, and the test stub (`StubImapMailService`) updated

This establishes the backend-agnostic seam a future Graph backend implements. Everything Graph-specific lands in later PRs, gated off by default.

**Verification:** `dotnet build -c Release` clean (0 warnings, 0 errors); full test suite green (341 passed, 0 failed).

Happy to split this into two separate PRs (docs vs refactor) if you'd prefer to review them apart.
