### PR TITLE
PR 3: backend kind + router + feature gate

### DIFF
--- a/QuickMail.Tests/GraphBackendGateTests.cs
+++ b/QuickMail.Tests/GraphBackendGateTests.cs
@@ -114,7 +114,8 @@ public class MailServiceRouterTests
         public Task DeleteFolderAsync(Guid accountId, string folderName, CancellationToken ct = default) => Task.CompletedTask;
         public Task RenameFolderAsync(Guid accountId, string folderName, string newName, string? newParentFolderName, CancellationToken ct = default) => Task.CompletedTask;
         public Task CopyFolderAsync(Guid accountId, string folderName, string? destinationParentName, CancellationToken ct = default) => Task.CompletedTask;
-        public void StartIdleWatchers(IReadOnlyList<AccountModel> accounts, CancellationToken ct = default) { }
+        public IReadOnlyList<AccountModel>? LastIdleAccounts { get; private set; }
+        public void StartIdleWatchers(IReadOnlyList<AccountModel> accounts, CancellationToken ct = default) => LastIdleAccounts = accounts;
         public void StopIdleWatchers() { }
         public void Dispose() { }
     }
@@ -170,4 +171,64 @@ public class MailServiceRouterTests
     [Fact]
     public void EmptyBackends_Throws()
         => Assert.Throws<ArgumentException>(() => new MailServiceRouter(Array.Empty<IMailService>()));
+
+    [Fact]
+    public void StartIdleWatchers_PassesEachBackendOnlyItsAccounts()
+    {
+        var imap = new RecordingMailService();
+        var graph = new RecordingMailService();
+        var router = new MailServiceRouter(new IMailService[] { imap, graph });
+
+        var imapAcct = new AccountModel { Id = Guid.NewGuid() };
+        var graphAcct = new AccountModel { Id = Guid.NewGuid() };
+        router.RegisterAccount(imapAcct.Id, imap);
+        router.RegisterAccount(graphAcct.Id, graph);
+
+        router.StartIdleWatchers(new[] { imapAcct, graphAcct });
+
+        Assert.NotNull(imap.LastIdleAccounts);
+        Assert.NotNull(graph.LastIdleAccounts);
+        Assert.Equal(new[] { imapAcct.Id }, imap.LastIdleAccounts!.Select(a => a.Id));
+        Assert.Equal(new[] { graphAcct.Id }, graph.LastIdleAccounts!.Select(a => a.Id));
+    }
+}
+
+public class ConfigFeatureGateTests
+{
+    private static ConfigModel ConfigWith(string key, string value)
+    {
+        var c = new ConfigModel();
+        c.Features[key] = value;
+        return c;
+    }
+
+    [Fact]
+    public void Default_GraphBackendOff()
+        => Assert.False(new ConfigFeatureGate(new ConfigModel(), Array.Empty<string>())
+            .IsEnabled(FeatureFlag.GraphBackend));
+
+    [Fact]
+    public void Config_EnablesFlag()
+        => Assert.True(new ConfigFeatureGate(ConfigWith("GraphBackend", "true"), Array.Empty<string>())
+            .IsEnabled(FeatureFlag.GraphBackend));
+
+    [Fact]
+    public void Config_IsCaseInsensitive()
+        => Assert.True(new ConfigFeatureGate(ConfigWith("graphbackend", "true"), Array.Empty<string>())
+            .IsEnabled(FeatureFlag.GraphBackend));
+
+    [Fact]
+    public void CliEnable_OverridesDefault()
+        => Assert.True(new ConfigFeatureGate(new ConfigModel(), new[] { "GraphBackend" })
+            .IsEnabled(FeatureFlag.GraphBackend));
+
+    [Fact]
+    public void CliDisable_OverridesConfigEnabled()
+        => Assert.False(new ConfigFeatureGate(ConfigWith("GraphBackend", "true"), Array.Empty<string>(), new[] { "GraphBackend" })
+            .IsEnabled(FeatureFlag.GraphBackend));
+
+    [Fact]
+    public void CliDisable_WinsOverCliEnable()
+        => Assert.False(new ConfigFeatureGate(new ConfigModel(), new[] { "GraphBackend" }, new[] { "GraphBackend" })
+            .IsEnabled(FeatureFlag.GraphBackend));
 }

--- a/QuickMail.Tests/GraphBackendGateTests.cs
+++ b/QuickMail.Tests/GraphBackendGateTests.cs
@@ -1,0 +1,173 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using QuickMail.Models;
+using QuickMail.Services;
+using QuickMail.ViewModels;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+public class AddAccountViewModelGateTests
+{
+    private static AddAccountViewModel Make(bool graphEnabled)
+    {
+        var gate = new StubFeatureGate { [FeatureFlag.GraphBackend] = graphEnabled };
+        return new AddAccountViewModel(gate, new StubImapMailService(), new StubOAuthService());
+    }
+
+    [Fact]
+    public void GateOff_OffersOnlyImap()
+    {
+        var vm = Make(graphEnabled: false);
+        Assert.Single(vm.AvailableBackends);
+        Assert.Equal(BackendKind.ImapSmtp, vm.AvailableBackends[0].Kind);
+        Assert.False(vm.ShowBackendPicker);
+        Assert.Equal(BackendKind.ImapSmtp, vm.BackendKind);
+        Assert.True(vm.IsImapBackend);
+    }
+
+    [Fact]
+    public void GateOn_OffersBothBackends()
+    {
+        var vm = Make(graphEnabled: true);
+        Assert.Equal(2, vm.AvailableBackends.Count);
+        Assert.Contains(vm.AvailableBackends, b => b.Kind == BackendKind.MicrosoftGraph);
+        Assert.True(vm.ShowBackendPicker);
+        // Default selection is still IMAP.
+        Assert.Equal(BackendKind.ImapSmtp, vm.BackendKind);
+    }
+
+    [Fact]
+    public void SelectingGraph_ForcesOAuthAndClearsImapFields()
+    {
+        var vm = Make(graphEnabled: true);
+        vm.ImapHost = "imap.example.com";
+        vm.SmtpHost = "smtp.example.com";
+
+        vm.SelectedBackend = vm.AvailableBackends.First(b => b.Kind == BackendKind.MicrosoftGraph);
+
+        Assert.Equal(BackendKind.MicrosoftGraph, vm.BackendKind);
+        Assert.True(vm.IsGraphBackend);
+        Assert.False(vm.IsImapBackend);
+        Assert.Equal(AuthType.OAuth2Microsoft, vm.AuthType);
+        Assert.Equal(string.Empty, vm.ImapHost);
+        Assert.Equal(string.Empty, vm.SmtpHost);
+    }
+
+    [Fact]
+    public void ToAccountModel_CarriesBackendKind()
+    {
+        var vm = Make(graphEnabled: true);
+        vm.SelectedBackend = vm.AvailableBackends.First(b => b.Kind == BackendKind.MicrosoftGraph);
+        Assert.Equal(BackendKind.MicrosoftGraph, vm.ToAccountModel().BackendKind);
+
+        var imapVm = Make(graphEnabled: false);
+        Assert.Equal(BackendKind.ImapSmtp, imapVm.ToAccountModel().BackendKind);
+    }
+}
+
+public class MailServiceRouterTests
+{
+    /// <summary>Minimal recording backend: notes the last accountId routed to it and can raise the new-mail event.</summary>
+    private sealed class RecordingMailService : IMailService
+    {
+        public Guid? LastAccountId { get; private set; }
+        public void RaiseNewMail(Guid accountId) => InboxNewMailDetected?.Invoke(accountId);
+
+        public event Action<Guid>? InboxNewMailDetected;
+
+        public Task<List<MailFolderModel>> GetFoldersAsync(Guid accountId, CancellationToken ct = default)
+        {
+            LastAccountId = accountId;
+            return Task.FromResult(new List<MailFolderModel>());
+        }
+
+        // Remaining members are unused by these tests.
+        public Task ConnectAsync(AccountModel account, string? password = null, CancellationToken ct = default) => Task.CompletedTask;
+        public Task DisconnectAsync(Guid accountId, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<List<MailMessageSummary>> GetMessageSummariesAsync(Guid accountId, string folderName, int maxMessages, CancellationToken ct = default) => Task.FromResult(new List<MailMessageSummary>());
+        public Task<List<MailMessageSummary>> GetMessagesSinceDateAsync(Guid accountId, string folderName, DateTime since, CancellationToken ct = default) => Task.FromResult(new List<MailMessageSummary>());
+        public Task<List<MailMessageSummary>> GetMessagesSinceAsync(Guid accountId, string folderName, string sinceMessageId, int initialCount, CancellationToken ct = default) => Task.FromResult(new List<MailMessageSummary>());
+        public Task<MailMessageDetail> GetMessageDetailAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default) => Task.FromResult(new MailMessageDetail());
+        public Task<MailMessageDetail> PrefetchMessageDetailAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default) => Task.FromResult(new MailMessageDetail());
+        public Task MarkReadAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default) => Task.CompletedTask;
+        public Task MarkReadBatchAsync(Guid accountId, string folderName, IList<string> messageIds, CancellationToken ct = default) => Task.CompletedTask;
+        public Task MoveToTrashAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default) => Task.CompletedTask;
+        public Task MoveToTrashBatchAsync(Guid accountId, string folderName, IList<string> messageIds, CancellationToken ct = default) => Task.CompletedTask;
+        public Task PermanentlyDeleteBatchAsync(Guid accountId, string folderName, IList<string> messageIds, CancellationToken ct = default) => Task.CompletedTask;
+        public Task NoOpAsync(Guid accountId, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<int> EmptyTrashAsync(Guid accountId, CancellationToken ct = default) => Task.FromResult(0);
+        public Task<IList<string>> GetFolderMessageIdsAsync(Guid accountId, string folderName, CancellationToken ct = default) => Task.FromResult<IList<string>>(Array.Empty<string>());
+        public Task<IReadOnlyDictionary<string, string>> FetchPreviewsAsync(Guid accountId, string folderName, IList<string> messageIds, int maxLines, CancellationToken ct = default) => Task.FromResult<IReadOnlyDictionary<string, string>>(new Dictionary<string, string>());
+        public Task<int> PollAsync(Guid accountId, string folderName, CancellationToken ct = default) => Task.FromResult(0);
+        public Task<(int Total, int Unread)> GetInboxStatusAsync(Guid accountId, CancellationToken ct = default) => Task.FromResult((0, 0));
+        public Task<string?> FindDraftsFolderNameAsync(Guid accountId, CancellationToken ct = default) => Task.FromResult<string?>(null);
+        public Task<string> AppendDraftAsync(Guid accountId, ComposeModel draft, string? replaceMessageId, CancellationToken ct = default) => Task.FromResult(string.Empty);
+        public Task AppendToSentAsync(Guid accountId, ComposeModel sent, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<byte[]> DownloadAttachmentAsync(Guid accountId, string folderName, string messageId, string partSpecifier, CancellationToken ct = default) => Task.FromResult(Array.Empty<byte>());
+        public Task CopyMessagesAsync(Guid accountId, string folderName, IList<string> messageIds, string destinationFolder, CancellationToken ct = default) => Task.CompletedTask;
+        public Task MoveMessagesAsync(Guid accountId, string folderName, IList<string> messageIds, string destinationFolder, CancellationToken ct = default) => Task.CompletedTask;
+        public Task CreateFolderAsync(Guid accountId, string? parentFolderName, string name, CancellationToken ct = default) => Task.CompletedTask;
+        public Task DeleteFolderAsync(Guid accountId, string folderName, CancellationToken ct = default) => Task.CompletedTask;
+        public Task RenameFolderAsync(Guid accountId, string folderName, string newName, string? newParentFolderName, CancellationToken ct = default) => Task.CompletedTask;
+        public Task CopyFolderAsync(Guid accountId, string folderName, string? destinationParentName, CancellationToken ct = default) => Task.CompletedTask;
+        public void StartIdleWatchers(IReadOnlyList<AccountModel> accounts, CancellationToken ct = default) { }
+        public void StopIdleWatchers() { }
+        public void Dispose() { }
+    }
+
+    [Fact]
+    public async Task RoutesToRegisteredBackend()
+    {
+        var imap = new RecordingMailService();
+        var graph = new RecordingMailService();
+        var router = new MailServiceRouter(new IMailService[] { imap, graph });
+
+        var graphAcct = Guid.NewGuid();
+        router.RegisterAccount(graphAcct, graph);
+
+        await router.GetFoldersAsync(graphAcct);
+
+        Assert.Equal(graphAcct, graph.LastAccountId);
+        Assert.Null(imap.LastAccountId);
+    }
+
+    [Fact]
+    public async Task UnregisteredAccount_FallsBackToFirstBackend()
+    {
+        var imap = new RecordingMailService();
+        var graph = new RecordingMailService();
+        var router = new MailServiceRouter(new IMailService[] { imap, graph }); // imap is the default
+
+        var unknown = Guid.NewGuid();
+        await router.GetFoldersAsync(unknown);
+
+        Assert.Equal(unknown, imap.LastAccountId);
+        Assert.Null(graph.LastAccountId);
+    }
+
+    [Fact]
+    public void AggregatesInboxNewMailFromAllBackends()
+    {
+        var imap = new RecordingMailService();
+        var graph = new RecordingMailService();
+        var router = new MailServiceRouter(new IMailService[] { imap, graph });
+
+        var seen = new List<Guid>();
+        router.InboxNewMailDetected += seen.Add;
+
+        var a1 = Guid.NewGuid();
+        var a2 = Guid.NewGuid();
+        imap.RaiseNewMail(a1);
+        graph.RaiseNewMail(a2);
+
+        Assert.Equal(new[] { a1, a2 }, seen);
+    }
+
+    [Fact]
+    public void EmptyBackends_Throws()
+        => Assert.Throws<ArgumentException>(() => new MailServiceRouter(Array.Empty<IMailService>()));
+}

--- a/QuickMail.Tests/StubServices.cs
+++ b/QuickMail.Tests/StubServices.cs
@@ -204,3 +204,13 @@ sealed class StubTemplateService : ITemplateService
     public Task UpdateAsync(MessageTemplate template) => Task.CompletedTask;
     public Task DeleteAsync(int id) => Task.CompletedTask;
 }
+
+sealed class StubFeatureGate : IFeatureGate
+{
+    private readonly Dictionary<FeatureFlag, bool> _flags = new();
+
+    /// <summary>Enable/disable a flag for the test, e.g. <c>gate[FeatureFlag.GraphBackend] = true;</c></summary>
+    public bool this[FeatureFlag flag] { set => _flags[flag] = value; }
+
+    public bool IsEnabled(FeatureFlag flag) => _flags.TryGetValue(flag, out var v) && v;
+}

--- a/QuickMail.Tests/UnitTest1.cs
+++ b/QuickMail.Tests/UnitTest1.cs
@@ -77,7 +77,7 @@ public class ViewModelConstructionTests
     {
         var (imap, accounts, creds, _, _, _, _, _, _) = MakeServices();
         var (_, _, _, store2, _, config2, _, _, _) = MakeServices();
-        var vm = new AccountManagerViewModel(accounts, creds, imap, new StubOAuthService(), store2, config2);
+        var vm = new AccountManagerViewModel(accounts, creds, imap, new StubOAuthService(), store2, config2, new StubFeatureGate());
         Assert.NotNull(vm);
     }
 
@@ -242,7 +242,7 @@ public class XamlParseTests
         var vm = new MainViewModel(imap, accounts, creds, store, new StubOAuthService(), sync, config, registry, new StubViewService(), new StubRuleService(), new StubSmtpService());
         // Constructing MainWindow triggers InitializeComponent() which is the real XAML parse.
         var window = new MainWindow(vm, new StubSmtpService(), accounts, creds, imap,
-            new StubOAuthService(), registry, contacts, config, store, new StubViewService(), new StubRuleService(), templates);
+            new StubOAuthService(), registry, contacts, config, store, new StubViewService(), new StubRuleService(), templates, new StubFeatureGate());
         Assert.NotNull(window);
         window.Close();
     }
@@ -264,8 +264,22 @@ public class XamlParseTests
         EnsureApplication();
         var (imap, accounts, creds, _, _, _, _, _, _) = MakeServices();
         var (_, _, _, store2, _, config2, _, _, _) = MakeServices();
-        var vm = new AccountManagerViewModel(accounts, creds, imap, new StubOAuthService(), store2, config2);
+        var vm = new AccountManagerViewModel(accounts, creds, imap, new StubOAuthService(), store2, config2, new StubFeatureGate());
         var window = new AccountManagerDialog(vm);
+        Assert.NotNull(window);
+        window.Close();
+    }
+
+    [StaFact]
+    public void AddAccountDialog_XamlParsesWithoutException()
+    {
+        EnsureApplication();
+        var (imap, _, _, _, _, _, _, _, _) = MakeServices();
+        // Gate ON so the backend combo and its bindings (AvailableBackends / SelectedBackend /
+        // ShowBackendPicker / IsImapBackend) are exercised during the XAML parse.
+        var gate = new StubFeatureGate { [FeatureFlag.GraphBackend] = true };
+        var vm = new AddAccountViewModel(gate, imap, new StubOAuthService());
+        var window = new AddAccountDialog(vm);
         Assert.NotNull(window);
         window.Close();
     }

--- a/QuickMail/App.xaml.cs
+++ b/QuickMail/App.xaml.cs
@@ -72,8 +72,14 @@ public partial class App : Application
             var credentialService = new CredentialService();
             var oauthService      = new OAuthService(profile);
             var configService     = new ConfigService(profile);
-            var mailService       = new ImapMailService(oauthService, configService);
+            var imapBackend       = new ImapMailService(oauthService, configService);
             var smtpService       = new SmtpService(oauthService);
+
+            // Per-account mail backend router. v0.7 ships a single backend (IMAP); PR 4 adds Graph
+            // and routes Microsoft 365 accounts to it. Every existing account binds to IMAP here.
+            var mailRouter = new MailServiceRouter(new IMailService[] { imapBackend });
+            foreach (var account in accountService.LoadAccounts())
+                mailRouter.RegisterAccount(account.Id, imapBackend);
 
             var localStore = new LocalStoreService(profile);
             if (!onlineMode)
@@ -81,12 +87,15 @@ public partial class App : Application
 
             var contactService = new ContactService(profile);
             var templateService = new TemplateService(profile);
-            var ruleService = new RuleService(mailService, localStore, profile.ProfileDir);
-            var syncService = new SyncService(mailService, localStore, configService, ruleService);
+            var ruleService = new RuleService(mailRouter, localStore, profile.ProfileDir);
+            var syncService = new SyncService(mailRouter, localStore, configService, ruleService);
 
             var startupCfg = configService.Load();
             Views.AccessibilityHelper.Configure(startupCfg);
             LogService.Format = startupCfg.LogFormat;
+
+            // Feature gate: CLI --feature flags > config.ini [features] section > built-in defaults.
+            var featureGate = new ConfigFeatureGate(startupCfg, ParseFeatureFlags(e.Args));
 
             var commandRegistry = new CommandRegistry();
             commandRegistry.ApplyUserOverrides(startupCfg.CustomHotkeys);
@@ -94,11 +103,11 @@ public partial class App : Application
             var viewService = new ViewService(profile);
 
             var mainVm = new MainViewModel(
-                mailService, accountService, credentialService, localStore, oauthService, syncService, configService, commandRegistry, viewService, ruleService, smtpService,
+                mailRouter, accountService, credentialService, localStore, oauthService, syncService, configService, commandRegistry, viewService, ruleService, smtpService,
                 onlineMode: onlineMode);
             mainVm.LoadAccountList();
 
-            var mainWindow = new MainWindow(mainVm, smtpService, accountService, credentialService, mailService, oauthService, commandRegistry, contactService, configService, localStore, viewService, ruleService, templateService);
+            var mainWindow = new MainWindow(mainVm, smtpService, accountService, credentialService, mailRouter, oauthService, commandRegistry, contactService, configService, localStore, viewService, ruleService, templateService, featureGate);
             mainWindow.Show();
         }
         catch (Exception ex)
@@ -115,6 +124,17 @@ public partial class App : Application
     /// Parses --profileDir from args, validates the path, and returns a ProfileContext.
     /// Returns null (and shows an error dialog) if the path is unusable.
     /// </summary>
+    /// <summary>
+    /// Parses repeated <c>--feature &lt;Name&gt;</c> CLI flags. Each occurrence enables the named
+    /// feature gate for this run (highest precedence, above config.ini and built-in defaults).
+    /// </summary>
+    private static System.Collections.Generic.IEnumerable<string> ParseFeatureFlags(string[] args)
+    {
+        for (int i = 0; i < args.Length - 1; i++)
+            if (args[i].Equals("--feature", StringComparison.OrdinalIgnoreCase))
+                yield return args[i + 1];
+    }
+
     private static bool IsHelpRequest(string[] args)
     {
         var helpFlags = new[] { "--help", "-help", "-h", "/?" };

--- a/QuickMail/App.xaml.cs
+++ b/QuickMail/App.xaml.cs
@@ -76,14 +76,18 @@ public partial class App : Application
             var smtpService       = new SmtpService(oauthService);
 
             // Per-account mail backend router. v0.7 ships a single backend (IMAP); PR 4 adds Graph
-            // and routes Microsoft 365 accounts to it. Every existing account binds to IMAP here.
+            // and routes Microsoft 365 accounts to it.
             var mailRouter = new MailServiceRouter(new IMailService[] { imapBackend });
-            foreach (var account in accountService.LoadAccounts())
-                mailRouter.RegisterAccount(account.Id, imapBackend);
 
             var localStore = new LocalStoreService(profile);
             if (!onlineMode)
                 localStore.Initialize();
+
+            // Load accounts once — after the store is initialized — and reuse the list for both
+            // router registration and the view model, avoiding a second synchronous accounts.json read.
+            var accounts = accountService.LoadAccounts();
+            foreach (var account in accounts)
+                mailRouter.RegisterAccount(account.Id, imapBackend);
 
             var contactService = new ContactService(profile);
             var templateService = new TemplateService(profile);
@@ -94,8 +98,9 @@ public partial class App : Application
             Views.AccessibilityHelper.Configure(startupCfg);
             LogService.Format = startupCfg.LogFormat;
 
-            // Feature gate: CLI --feature flags > config.ini [features] section > built-in defaults.
-            var featureGate = new ConfigFeatureGate(startupCfg, ParseFeatureFlags(e.Args));
+            // Feature gate: CLI --feature/--no-feature > config.ini [features] section > built-in defaults.
+            var (enableFlags, disableFlags) = ParseFeatureFlags(e.Args);
+            var featureGate = new ConfigFeatureGate(startupCfg, enableFlags, disableFlags);
 
             var commandRegistry = new CommandRegistry();
             commandRegistry.ApplyUserOverrides(startupCfg.CustomHotkeys);
@@ -105,7 +110,7 @@ public partial class App : Application
             var mainVm = new MainViewModel(
                 mailRouter, accountService, credentialService, localStore, oauthService, syncService, configService, commandRegistry, viewService, ruleService, smtpService,
                 onlineMode: onlineMode);
-            mainVm.LoadAccountList();
+            mainVm.LoadAccountList(accounts);
 
             var mainWindow = new MainWindow(mainVm, smtpService, accountService, credentialService, mailRouter, oauthService, commandRegistry, contactService, configService, localStore, viewService, ruleService, templateService, featureGate);
             mainWindow.Show();
@@ -121,18 +126,22 @@ public partial class App : Application
     }
 
     /// <summary>
-    /// Parses --profileDir from args, validates the path, and returns a ProfileContext.
-    /// Returns null (and shows an error dialog) if the path is unusable.
+    /// Parses repeated <c>--feature &lt;Name&gt;</c> (force-on) and <c>--no-feature &lt;Name&gt;</c>
+    /// (force-off) CLI flags. CLI flags are the highest-precedence feature-gate source; for a given
+    /// flag an explicit <c>--no-feature</c> wins over <c>--feature</c>.
     /// </summary>
-    /// <summary>
-    /// Parses repeated <c>--feature &lt;Name&gt;</c> CLI flags. Each occurrence enables the named
-    /// feature gate for this run (highest precedence, above config.ini and built-in defaults).
-    /// </summary>
-    private static System.Collections.Generic.IEnumerable<string> ParseFeatureFlags(string[] args)
+    private static (List<string> Enable, List<string> Disable) ParseFeatureFlags(string[] args)
     {
+        var enable = new List<string>();
+        var disable = new List<string>();
         for (int i = 0; i < args.Length - 1; i++)
+        {
             if (args[i].Equals("--feature", StringComparison.OrdinalIgnoreCase))
-                yield return args[i + 1];
+                enable.Add(args[i + 1]);
+            else if (args[i].Equals("--no-feature", StringComparison.OrdinalIgnoreCase))
+                disable.Add(args[i + 1]);
+        }
+        return (enable, disable);
     }
 
     private static bool IsHelpRequest(string[] args)
@@ -145,6 +154,10 @@ public partial class App : Application
         return false;
     }
 
+    /// <summary>
+    /// Parses --profileDir from args, validates the path, and returns a ProfileContext.
+    /// Returns null (and shows an error dialog) if the path is unusable.
+    /// </summary>
     private static ProfileContext? ResolveProfile(string[] args)
     {
         var rawDir = ProfileContext.ParseProfileDir(args);

--- a/QuickMail/Models/AccountModel.cs
+++ b/QuickMail/Models/AccountModel.cs
@@ -14,6 +14,12 @@ public partial class AccountModel : ObservableObject
     public string Username { get; set; } = string.Empty;
     public AuthType AuthType { get; set; } = AuthType.Password;
 
+    /// <summary>Which protocol stack this account uses. Fixed at account creation.</summary>
+    public BackendKind BackendKind { get; set; } = BackendKind.ImapSmtp;
+
+    /// <summary>Optional Azure AD tenant ID for Graph accounts. Null = "common" authority.</summary>
+    public string? TenantId { get; set; }
+
     // IMAP
     public string ImapHost { get; set; } = string.Empty;
     public int ImapPort { get; set; } = 993;

--- a/QuickMail/Models/BackendKind.cs
+++ b/QuickMail/Models/BackendKind.cs
@@ -1,0 +1,14 @@
+namespace QuickMail.Models;
+
+/// <summary>
+/// Which protocol stack this account uses. Selected when the account is added
+/// and fixed for its lifetime. To switch, delete and re-add the account.
+/// </summary>
+public enum BackendKind
+{
+    /// <summary>Standard IMAP for receive + SMTP for send (default for all existing accounts).</summary>
+    ImapSmtp,
+
+    /// <summary>Microsoft Graph for receive + send. Used for M365 / Outlook.com.</summary>
+    MicrosoftGraph,
+}

--- a/QuickMail/Models/BackendKindOption.cs
+++ b/QuickMail/Models/BackendKindOption.cs
@@ -1,0 +1,11 @@
+namespace QuickMail.Models;
+
+/// <summary>
+/// A selectable backend option for the Add Account dialog's backend combo box.
+/// <see cref="Label"/> is the user-facing text; <see cref="ToString"/> returns it
+/// so the combo renders correctly without an explicit DisplayMemberPath.
+/// </summary>
+public record BackendKindOption(BackendKind Kind, string Label)
+{
+    public override string ToString() => Label;
+}

--- a/QuickMail/Models/ConfigModel.cs
+++ b/QuickMail/Models/ConfigModel.cs
@@ -86,6 +86,14 @@ public class ConfigModel
     /// <summary>User-defined keyboard shortcut overrides, stored in hotkeys.json.</summary>
     public List<HotkeyBinding> CustomHotkeys { get; set; } = [];
 
+    // ── Feature flags ─────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Raw key/value pairs from the config.ini [features] section (e.g. "GraphBackend" = "true").
+    /// Resolved through <see cref="QuickMail.Services.IFeatureGate"/>; absent keys fall back to built-in defaults.
+    /// </summary>
+    public Dictionary<string, string> Features { get; set; } = [];
+
     // ── Per-account overrides ─────────────────────────────────────────────────────
 
     public Dictionary<Guid, AccountOverrideConfig> Accounts { get; set; } = [];

--- a/QuickMail/Models/FeatureFlag.cs
+++ b/QuickMail/Models/FeatureFlag.cs
@@ -1,0 +1,14 @@
+namespace QuickMail.Models;
+
+/// <summary>
+/// Feature-gate keys. Adding a new gate is one enum value here plus an entry
+/// in ConfigFeatureGate.Defaults.
+/// </summary>
+public enum FeatureFlag
+{
+    /// <summary>
+    /// Enables Microsoft Graph as a mail-backend option in the Add Account dialog.
+    /// Default: false. Flip the default to true via a future joint-decision PR.
+    /// </summary>
+    GraphBackend,
+}

--- a/QuickMail/Services/ConfigFeatureGate.cs
+++ b/QuickMail/Services/ConfigFeatureGate.cs
@@ -19,22 +19,25 @@ public class ConfigFeatureGate : IFeatureGate
     };
 
     private readonly IReadOnlyDictionary<string, string> _configFlags;
-    private readonly IReadOnlySet<string> _cliFlags;
+    private readonly IReadOnlySet<string> _cliEnable;
+    private readonly IReadOnlySet<string> _cliDisable;
 
-    public ConfigFeatureGate(ConfigModel config, IEnumerable<string> cliFlags)
+    public ConfigFeatureGate(ConfigModel config, IEnumerable<string> cliEnable, IEnumerable<string>? cliDisable = null)
     {
         // Case-insensitive so "GraphBackend" / "graphbackend" in config.ini resolve identically.
         _configFlags = new Dictionary<string, string>(
             config.Features ?? new Dictionary<string, string>(), StringComparer.OrdinalIgnoreCase);
-        _cliFlags = new HashSet<string>(cliFlags ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
+        _cliEnable  = new HashSet<string>(cliEnable  ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
+        _cliDisable = new HashSet<string>(cliDisable ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
     }
 
     public bool IsEnabled(FeatureFlag flag)
     {
         var name = flag.ToString();
 
-        // 1. CLI override (presence of the flag name enables it).
-        if (_cliFlags.Contains(name)) return true;
+        // 1. CLI override (highest precedence). An explicit --no-feature wins over --feature.
+        if (_cliDisable.Contains(name)) return false;
+        if (_cliEnable.Contains(name)) return true;
 
         // 2. config.ini [features] section.
         if (_configFlags.TryGetValue(name, out var raw) && bool.TryParse(raw, out var configValue))

--- a/QuickMail/Services/ConfigFeatureGate.cs
+++ b/QuickMail/Services/ConfigFeatureGate.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using QuickMail.Models;
+
+namespace QuickMail.Services;
+
+/// <summary>
+/// Resolves feature flags from (in order of precedence, highest first):
+///   1. CLI --feature flags passed at startup
+///   2. config.ini [features] section
+///   3. Built-in defaults
+/// </summary>
+public class ConfigFeatureGate : IFeatureGate
+{
+    /// <summary>Built-in defaults. Every flag MUST appear here.</summary>
+    private static readonly IReadOnlyDictionary<FeatureFlag, bool> Defaults = new Dictionary<FeatureFlag, bool>
+    {
+        [FeatureFlag.GraphBackend] = false,
+    };
+
+    private readonly IReadOnlyDictionary<string, string> _configFlags;
+    private readonly IReadOnlySet<string> _cliFlags;
+
+    public ConfigFeatureGate(ConfigModel config, IEnumerable<string> cliFlags)
+    {
+        // Case-insensitive so "GraphBackend" / "graphbackend" in config.ini resolve identically.
+        _configFlags = new Dictionary<string, string>(
+            config.Features ?? new Dictionary<string, string>(), StringComparer.OrdinalIgnoreCase);
+        _cliFlags = new HashSet<string>(cliFlags ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
+    }
+
+    public bool IsEnabled(FeatureFlag flag)
+    {
+        var name = flag.ToString();
+
+        // 1. CLI override (presence of the flag name enables it).
+        if (_cliFlags.Contains(name)) return true;
+
+        // 2. config.ini [features] section.
+        if (_configFlags.TryGetValue(name, out var raw) && bool.TryParse(raw, out var configValue))
+            return configValue;
+
+        // 3. Built-in default.
+        return Defaults[flag];
+    }
+}

--- a/QuickMail/Services/ConfigService.cs
+++ b/QuickMail/Services/ConfigService.cs
@@ -159,6 +159,11 @@ public class ConfigService : IConfigService
                     if (!config.Accounts.ContainsKey(acctGuid))
                         config.Accounts[acctGuid] = new AccountOverrideConfig();
                 }
+                else if (header == "features")
+                {
+                    section  = "features";
+                    acctGuid = Guid.Empty;
+                }
                 else
                 {
                     section = null;
@@ -170,8 +175,9 @@ public class ConfigService : IConfigService
             var eq = line.IndexOf('=');
             if (eq < 0) continue;
 
-            var key   = line[..eq].Trim().ToLowerInvariant();
-            var value = line[(eq + 1)..].Trim();
+            var rawKey = line[..eq].Trim();
+            var key    = rawKey.ToLowerInvariant();
+            var value  = line[(eq + 1)..].Trim();
 
             if (section == "global")
             {
@@ -225,6 +231,11 @@ public class ConfigService : IConfigService
                         if (int.TryParse(value, out var pl)) ovr.PreviewLines = Math.Max(0, pl);
                         break;
                 }
+            }
+            else if (section == "features")
+            {
+                // Preserve the original key case so IFeatureGate matches FeatureFlag.ToString().
+                config.Features[rawKey] = value;
             }
         }
 
@@ -348,6 +359,18 @@ public class ConfigService : IConfigService
                 sb.AppendLine("# Override preview lines for this account. Remove to use global setting.");
                 sb.AppendLine();
             }
+        }
+
+        // ── [features] ─────────────────────────────────────────────────────────────
+        // Only written when at least one flag has been set, so the default config stays clean.
+        if (config.Features.Count > 0)
+        {
+            sb.AppendLine("[features]");
+            sb.AppendLine("# Experimental feature flags. Values: true, false.");
+            sb.AppendLine();
+            foreach (var (name, value) in config.Features)
+                sb.AppendLine($"{name} = {value}");
+            sb.AppendLine();
         }
 
         return sb.ToString();

--- a/QuickMail/Services/IFeatureGate.cs
+++ b/QuickMail/Services/IFeatureGate.cs
@@ -1,0 +1,13 @@
+using QuickMail.Models;
+
+namespace QuickMail.Services;
+
+/// <summary>
+/// Runtime feature gate. Code paths and UI surfaces check this before exposing
+/// experimental functionality. Defaults are baked into ConfigFeatureGate and
+/// overridable via the config.ini [features] section or --feature CLI flags.
+/// </summary>
+public interface IFeatureGate
+{
+    bool IsEnabled(FeatureFlag flag);
+}

--- a/QuickMail/Services/MailServiceRouter.cs
+++ b/QuickMail/Services/MailServiceRouter.cs
@@ -1,0 +1,167 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using QuickMail.Models;
+
+namespace QuickMail.Services;
+
+/// <summary>
+/// <see cref="IMailService"/> implementation that holds one backend per account and dispatches
+/// every call to the right backend based on accountId. Consumers (MainViewModel, SyncService,
+/// RuleService) see a single IMailService surface and are unaware that more than one backend exists.
+///
+/// In v0.7 (PR 3) the only backend is <see cref="ImapMailService"/>, so every account registers to
+/// it and behavior is identical to today. PR 4 adds a Graph backend and routes Graph accounts to it.
+/// </summary>
+public class MailServiceRouter : IMailService
+{
+    private readonly ConcurrentDictionary<Guid, IMailService> _byAccount = new();
+    private readonly IReadOnlyList<IMailService> _allBackends; // ordered, for event aggregation + fan-out
+    private readonly IMailService _defaultBackend;             // fallback for unregistered accounts
+
+    public MailServiceRouter(IEnumerable<IMailService> backends)
+    {
+        _allBackends = backends.ToList();
+        if (_allBackends.Count == 0)
+            throw new ArgumentException("MailServiceRouter requires at least one backend.", nameof(backends));
+        _defaultBackend = _allBackends[0];
+        foreach (var b in _allBackends)
+            b.InboxNewMailDetected += OnInnerInboxNewMail;
+    }
+
+    /// <summary>Bind an account to a specific backend. Called once at account-load time and once per Add Account. Idempotent.</summary>
+    public void RegisterAccount(Guid accountId, IMailService backend) => _byAccount[accountId] = backend;
+
+    public void UnregisterAccount(Guid accountId) => _byAccount.TryRemove(accountId, out _);
+
+    /// <summary>
+    /// Resolves the backend for an account. Explicitly-registered accounts use their bound backend;
+    /// anything else falls back to the first (default) backend. In v0.7 (PR 3) the only backend is
+    /// IMAP, so runtime-added accounts route correctly via the fallback without plumbing the router
+    /// through the VM layer. PR 4 (multiple backends) must call <see cref="RegisterAccount"/> for
+    /// Graph accounts at add time, since the fallback assumes IMAP.
+    /// </summary>
+    private IMailService For(Guid accountId)
+        => _byAccount.TryGetValue(accountId, out var b) ? b : _defaultBackend;
+
+    private IMailService For(AccountModel account) => For(account.Id);
+
+    // ── Event aggregation ────────────────────────────────────────────────────────
+    public event Action<Guid>? InboxNewMailDetected;
+    private void OnInnerInboxNewMail(Guid accountId) => InboxNewMailDetected?.Invoke(accountId);
+
+    // ── Per-account delegation ─────────────────────────────────────────────────────
+    public Task ConnectAsync(AccountModel account, string? password = null, CancellationToken ct = default)
+        => For(account).ConnectAsync(account, password, ct);
+
+    public Task DisconnectAsync(Guid accountId, CancellationToken ct = default)
+        => For(accountId).DisconnectAsync(accountId, ct);
+
+    public Task<List<MailFolderModel>> GetFoldersAsync(Guid accountId, CancellationToken ct = default)
+        => For(accountId).GetFoldersAsync(accountId, ct);
+
+    public Task<List<MailMessageSummary>> GetMessageSummariesAsync(Guid accountId, string folderName, int maxMessages, CancellationToken ct = default)
+        => For(accountId).GetMessageSummariesAsync(accountId, folderName, maxMessages, ct);
+
+    public Task<List<MailMessageSummary>> GetMessagesSinceDateAsync(Guid accountId, string folderName, DateTime since, CancellationToken ct = default)
+        => For(accountId).GetMessagesSinceDateAsync(accountId, folderName, since, ct);
+
+    public Task<List<MailMessageSummary>> GetMessagesSinceAsync(Guid accountId, string folderName, string sinceMessageId, int initialCount, CancellationToken ct = default)
+        => For(accountId).GetMessagesSinceAsync(accountId, folderName, sinceMessageId, initialCount, ct);
+
+    public Task<MailMessageDetail> GetMessageDetailAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default)
+        => For(accountId).GetMessageDetailAsync(accountId, folderName, messageId, ct);
+
+    public Task<MailMessageDetail> PrefetchMessageDetailAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default)
+        => For(accountId).PrefetchMessageDetailAsync(accountId, folderName, messageId, ct);
+
+    public Task MarkReadAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default)
+        => For(accountId).MarkReadAsync(accountId, folderName, messageId, ct);
+
+    public Task MarkReadBatchAsync(Guid accountId, string folderName, IList<string> messageIds, CancellationToken ct = default)
+        => For(accountId).MarkReadBatchAsync(accountId, folderName, messageIds, ct);
+
+    public Task MoveToTrashAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default)
+        => For(accountId).MoveToTrashAsync(accountId, folderName, messageId, ct);
+
+    public Task MoveToTrashBatchAsync(Guid accountId, string folderName, IList<string> messageIds, CancellationToken ct = default)
+        => For(accountId).MoveToTrashBatchAsync(accountId, folderName, messageIds, ct);
+
+    public Task PermanentlyDeleteBatchAsync(Guid accountId, string folderName, IList<string> messageIds, CancellationToken ct = default)
+        => For(accountId).PermanentlyDeleteBatchAsync(accountId, folderName, messageIds, ct);
+
+    public Task NoOpAsync(Guid accountId, CancellationToken ct = default)
+        => For(accountId).NoOpAsync(accountId, ct);
+
+    public Task<int> EmptyTrashAsync(Guid accountId, CancellationToken ct = default)
+        => For(accountId).EmptyTrashAsync(accountId, ct);
+
+    public Task<IList<string>> GetFolderMessageIdsAsync(Guid accountId, string folderName, CancellationToken ct = default)
+        => For(accountId).GetFolderMessageIdsAsync(accountId, folderName, ct);
+
+    public Task<IReadOnlyDictionary<string, string>> FetchPreviewsAsync(Guid accountId, string folderName, IList<string> messageIds, int maxLines, CancellationToken ct = default)
+        => For(accountId).FetchPreviewsAsync(accountId, folderName, messageIds, maxLines, ct);
+
+    public Task<int> PollAsync(Guid accountId, string folderName, CancellationToken ct = default)
+        => For(accountId).PollAsync(accountId, folderName, ct);
+
+    public Task<(int Total, int Unread)> GetInboxStatusAsync(Guid accountId, CancellationToken ct = default)
+        => For(accountId).GetInboxStatusAsync(accountId, ct);
+
+    public Task<string?> FindDraftsFolderNameAsync(Guid accountId, CancellationToken ct = default)
+        => For(accountId).FindDraftsFolderNameAsync(accountId, ct);
+
+    public Task<string> AppendDraftAsync(Guid accountId, ComposeModel draft, string? replaceMessageId, CancellationToken ct = default)
+        => For(accountId).AppendDraftAsync(accountId, draft, replaceMessageId, ct);
+
+    public Task AppendToSentAsync(Guid accountId, ComposeModel sent, CancellationToken ct = default)
+        => For(accountId).AppendToSentAsync(accountId, sent, ct);
+
+    public Task<byte[]> DownloadAttachmentAsync(Guid accountId, string folderName, string messageId, string partSpecifier, CancellationToken ct = default)
+        => For(accountId).DownloadAttachmentAsync(accountId, folderName, messageId, partSpecifier, ct);
+
+    public Task CopyMessagesAsync(Guid accountId, string folderName, IList<string> messageIds, string destinationFolder, CancellationToken ct = default)
+        => For(accountId).CopyMessagesAsync(accountId, folderName, messageIds, destinationFolder, ct);
+
+    public Task MoveMessagesAsync(Guid accountId, string folderName, IList<string> messageIds, string destinationFolder, CancellationToken ct = default)
+        => For(accountId).MoveMessagesAsync(accountId, folderName, messageIds, destinationFolder, ct);
+
+    public Task CreateFolderAsync(Guid accountId, string? parentFolderName, string name, CancellationToken ct = default)
+        => For(accountId).CreateFolderAsync(accountId, parentFolderName, name, ct);
+
+    public Task DeleteFolderAsync(Guid accountId, string folderName, CancellationToken ct = default)
+        => For(accountId).DeleteFolderAsync(accountId, folderName, ct);
+
+    public Task RenameFolderAsync(Guid accountId, string folderName, string newName, string? newParentFolderName, CancellationToken ct = default)
+        => For(accountId).RenameFolderAsync(accountId, folderName, newName, newParentFolderName, ct);
+
+    public Task CopyFolderAsync(Guid accountId, string folderName, string? destinationParentName, CancellationToken ct = default)
+        => For(accountId).CopyFolderAsync(accountId, folderName, destinationParentName, ct);
+
+    // ── Account-list-level operations: fan out to every backend ────────────────────
+    // Each backend starts watchers only for the accounts it can actually connect; passing the full
+    // list to all backends is correct because an account is only ever registered to one backend.
+    public void StartIdleWatchers(IReadOnlyList<AccountModel> accounts, CancellationToken ct = default)
+    {
+        foreach (var b in _allBackends)
+            b.StartIdleWatchers(accounts, ct);
+    }
+
+    public void StopIdleWatchers()
+    {
+        foreach (var b in _allBackends)
+            b.StopIdleWatchers();
+    }
+
+    public void Dispose()
+    {
+        foreach (var b in _allBackends)
+        {
+            b.InboxNewMailDetected -= OnInnerInboxNewMail;
+            b.Dispose();
+        }
+    }
+}

--- a/QuickMail/Services/MailServiceRouter.cs
+++ b/QuickMail/Services/MailServiceRouter.cs
@@ -146,8 +146,19 @@ public class MailServiceRouter : IMailService
     // list to all backends is correct because an account is only ever registered to one backend.
     public void StartIdleWatchers(IReadOnlyList<AccountModel> accounts, CancellationToken ct = default)
     {
+        // Give each backend only the accounts registered to it (unregistered accounts fall back to
+        // the default backend), so a backend never spins up watcher tasks for accounts it doesn't own.
+        var byBackend = new Dictionary<IMailService, List<AccountModel>>();
+        foreach (var account in accounts)
+        {
+            var backend = _byAccount.TryGetValue(account.Id, out var b) ? b : _defaultBackend;
+            if (!byBackend.TryGetValue(backend, out var list))
+                byBackend[backend] = list = new List<AccountModel>();
+            list.Add(account);
+        }
+
         foreach (var b in _allBackends)
-            b.StartIdleWatchers(accounts, ct);
+            b.StartIdleWatchers(byBackend.TryGetValue(b, out var list) ? list : new List<AccountModel>(), ct);
     }
 
     public void StopIdleWatchers()

--- a/QuickMail/ViewModels/AccountEditorViewModel.cs
+++ b/QuickMail/ViewModels/AccountEditorViewModel.cs
@@ -37,6 +37,17 @@ public abstract partial class AccountEditorViewModel : ObservableObject
     [NotifyPropertyChangedFor(nameof(AuthTypeIndex))]
     private AuthType _authType = AuthType.Password;
 
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsGraphBackend))]
+    [NotifyPropertyChangedFor(nameof(IsImapBackend))]
+    private BackendKind _backendKind = BackendKind.ImapSmtp;
+
+    /// <summary>True when this account uses the Microsoft Graph backend (drives IMAP/SMTP field visibility).</summary>
+    public bool IsGraphBackend => BackendKind == BackendKind.MicrosoftGraph;
+
+    /// <summary>True when this account uses the standard IMAP/SMTP backend.</summary>
+    public bool IsImapBackend => BackendKind == BackendKind.ImapSmtp;
+
     [ObservableProperty] private string _statusText = string.Empty;
     [ObservableProperty] private bool   _isBusy = false;
 
@@ -89,6 +100,14 @@ public abstract partial class AccountEditorViewModel : ObservableObject
     [RelayCommand]
     private async Task TestConnectionAsync()
     {
+        // Branch on backend before the IMAP-specific validation. Graph accounts have no IMAP
+        // host/port; their connectivity probe (GET /me) lands with the Graph backend in PR 4.
+        if (IsGraphBackend)
+        {
+            StatusText = "Connection testing for Microsoft 365 accounts is available once the Graph backend ships.";
+            return;
+        }
+
         if (string.IsNullOrWhiteSpace(ImapHost) || string.IsNullOrWhiteSpace(Username))
         {
             StatusText = "Fill in IMAP host and username first.";

--- a/QuickMail/ViewModels/AccountManagerViewModel.cs
+++ b/QuickMail/ViewModels/AccountManagerViewModel.cs
@@ -16,6 +16,7 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
     private readonly ILocalStoreService _localStore;
     private readonly IConfigService _configService;
     private readonly IOAuthService _oauth;
+    private readonly IFeatureGate _featureGate;
 
     [ObservableProperty]
     private ObservableCollection<AccountModel> _accounts = [];
@@ -32,7 +33,8 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
         IMailService imap,
         IOAuthService oauth,
         ILocalStoreService localStore,
-        IConfigService configService)
+        IConfigService configService,
+        IFeatureGate featureGate)
         : base(imap, oauth)
     {
         _accountService = accountService;
@@ -40,6 +42,7 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
         _oauth          = oauth;
         _localStore     = localStore;
         _configService  = configService;
+        _featureGate    = featureGate;
         Accounts = new ObservableCollection<AccountModel>(accountService.LoadAccounts());
     }
 
@@ -65,7 +68,7 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
         StatusText = string.Empty;
     }
 
-    public AddAccountViewModel CreateAddAccountViewModel() => new(MailService, OAuthService);
+    public AddAccountViewModel CreateAddAccountViewModel() => new(_featureGate, MailService, OAuthService);
 
     public void CommitNewAccount(AccountModel account, string password)
     {

--- a/QuickMail/ViewModels/AddAccountViewModel.cs
+++ b/QuickMail/ViewModels/AddAccountViewModel.cs
@@ -35,6 +35,10 @@ public partial class AddAccountViewModel : AccountEditorViewModel
 
     partial void OnSelectedBackendChanged(BackendKindOption value)
     {
+        // ORDER MATTERS: set BackendKind BEFORE AuthType. Assigning AuthType below triggers
+        // OnAuthTypeChangedInternal, which reads BackendKind to decide whether to auto-fill the
+        // Outlook.com IMAP/SMTP hosts. If AuthType were assigned first, a Graph account would
+        // wrongly receive IMAP host defaults.
         BackendKind = value?.Kind ?? BackendKind.ImapSmtp;
         if (BackendKind == BackendKind.MicrosoftGraph)
         {

--- a/QuickMail/ViewModels/AddAccountViewModel.cs
+++ b/QuickMail/ViewModels/AddAccountViewModel.cs
@@ -1,4 +1,4 @@
-using System;
+using System.Collections.Generic;
 using CommunityToolkit.Mvvm.ComponentModel;
 using QuickMail.Models;
 using QuickMail.Services;
@@ -7,23 +7,60 @@ namespace QuickMail.ViewModels;
 
 public partial class AddAccountViewModel : AccountEditorViewModel
 {
-    public AddAccountViewModel(IMailService mailService, IOAuthService oauth)
-        : base(mailService, oauth) { }
+    public AddAccountViewModel(IFeatureGate gate, IMailService mailService, IOAuthService oauth)
+        : base(mailService, oauth)
+    {
+        var backends = new List<BackendKindOption>
+        {
+            new(BackendKind.ImapSmtp, "Standard IMAP/SMTP"),
+        };
+        if (gate.IsEnabled(FeatureFlag.GraphBackend))
+            backends.Add(new(BackendKind.MicrosoftGraph, "Microsoft 365 / Outlook.com"));
+
+        AvailableBackends = backends;
+        _selectedBackend = backends[0];
+    }
+
+    /// <summary>Backend options offered in the dialog, derived from the feature gate.</summary>
+    public IReadOnlyList<BackendKindOption> AvailableBackends { get; }
+
+    /// <summary>
+    /// True when more than one backend is available — the dialog renders a combo box. When only
+    /// one option exists (the default), it renders a static label to reduce clutter.
+    /// </summary>
+    public bool ShowBackendPicker => AvailableBackends.Count > 1;
+
+    [ObservableProperty]
+    private BackendKindOption _selectedBackend;
+
+    partial void OnSelectedBackendChanged(BackendKindOption value)
+    {
+        BackendKind = value?.Kind ?? BackendKind.ImapSmtp;
+        if (BackendKind == BackendKind.MicrosoftGraph)
+        {
+            // Graph accounts authenticate via OAuth and need no IMAP/SMTP host configuration.
+            AuthType = AuthType.OAuth2Microsoft;
+            ImapHost = string.Empty;
+            SmtpHost = string.Empty;
+            Password = string.Empty;
+        }
+    }
 
     protected override void OnAuthTypeChangedInternal(AuthType value)
     {
-        if (value == AuthType.OAuth2Microsoft)
+        // Auto-fill personal Outlook.com IMAP/SMTP settings only for the IMAP backend — a Graph
+        // account also uses OAuth but must NOT get IMAP host defaults.
+        if (value == AuthType.OAuth2Microsoft && BackendKind == BackendKind.ImapSmtp)
         {
-            // Personal Outlook.com IMAP/SMTP server settings
-            ImapHost             = "outlook.office365.com";
-            ImapPort             = 993;
-            ImapUseSsl           = true;
+            ImapHost              = "outlook.office365.com";
+            ImapPort              = 993;
+            ImapUseSsl            = true;
             ImapAcceptInvalidCert = false;
-            SmtpHost             = "smtp-mail.outlook.com";
-            SmtpPort             = 587;
-            SmtpUseSsl           = false;
+            SmtpHost              = "smtp-mail.outlook.com";
+            SmtpPort              = 587;
+            SmtpUseSsl            = false;
             SmtpAcceptInvalidCert = false;
-            Password             = string.Empty;
+            Password              = string.Empty;
         }
     }
 
@@ -33,6 +70,7 @@ public partial class AddAccountViewModel : AccountEditorViewModel
         DisplayName = DisplayName,
         Username = Username,
         AuthType = AuthType,
+        BackendKind = BackendKind,
         ImapHost = ImapHost,
         ImapPort = ImapPort,
         ImapUseSsl = ImapUseSsl,

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -466,9 +466,9 @@ public partial class MainViewModel : ObservableObject
         UpdateRulesStatusText();
     }
 
-    public void LoadAccountList()
+    public void LoadAccountList(List<AccountModel>? preloaded = null)
     {
-        Accounts = new ObservableCollection<AccountModel>(_accountService.LoadAccounts());
+        Accounts = new ObservableCollection<AccountModel>(preloaded ?? _accountService.LoadAccounts());
     }
 
     // ── Saved-views lifecycle ─────────────────────────────────────────────────────

--- a/QuickMail/Views/AddAccountDialog.xaml
+++ b/QuickMail/Views/AddAccountDialog.xaml
@@ -25,6 +25,19 @@
         <ScrollViewer Grid.Row="0" VerticalScrollBarVisibility="Auto">
             <StackPanel>
 
+                <!-- Backend selector — shown only when the feature gate offers more than one backend.
+                     Default users (single backend) see no extra UI, identical to before. -->
+                <StackPanel Visibility="{Binding ShowBackendPicker, Converter={StaticResource BoolToVisibility}}">
+                    <TextBlock x:Name="LblBackend" Text="Account _Type:" Margin="0,0,0,2"/>
+                    <ComboBox x:Name="BackendComboBox"
+                              ItemsSource="{Binding AvailableBackends}"
+                              SelectedItem="{Binding SelectedBackend, Mode=TwoWay}"
+                              SelectionChanged="BackendComboBox_SelectionChanged"
+                              AutomationProperties.LabeledBy="{Binding ElementName=LblBackend}"
+                              AutomationProperties.Name="Account type"/>
+                    <Separator Margin="0,12"/>
+                </StackPanel>
+
                 <TextBlock Text="Account Details" FontWeight="SemiBold" FontSize="13" Margin="0,0,0,8"/>
 
                 <TextBlock x:Name="LblAccountName" Text="_Account Name:" Margin="0,4,0,2"/>
@@ -72,6 +85,9 @@
                             HorizontalAlignment="Left" MinWidth="200" TabIndex="5"/>
                 </StackPanel>
 
+                <!-- IMAP + SMTP server settings — collapsed for Microsoft Graph accounts,
+                     which authenticate via OAuth and need no host configuration. -->
+                <StackPanel Visibility="{Binding IsImapBackend, Converter={StaticResource BoolToVisibility}}">
                 <Separator Margin="0,12"/>
 
                 <TextBlock Text="Incoming Mail (IMAP)" FontWeight="SemiBold" Margin="0,0,0,6"/>
@@ -119,6 +135,7 @@
                           IsChecked="{Binding SmtpAcceptInvalidCert}"
                           AutomationProperties.Name="SMTP accept invalid SSL certificates"
                           Margin="0,0,0,6" TabIndex="10"/>
+                </StackPanel>
 
                 <Separator Margin="0,6"/>
 

--- a/QuickMail/Views/AddAccountDialog.xaml
+++ b/QuickMail/Views/AddAccountDialog.xaml
@@ -33,8 +33,7 @@
                               ItemsSource="{Binding AvailableBackends}"
                               SelectedItem="{Binding SelectedBackend, Mode=TwoWay}"
                               SelectionChanged="BackendComboBox_SelectionChanged"
-                              AutomationProperties.LabeledBy="{Binding ElementName=LblBackend}"
-                              AutomationProperties.Name="Account type"/>
+                              AutomationProperties.LabeledBy="{Binding ElementName=LblBackend}"/>
                     <Separator Margin="0,12"/>
                 </StackPanel>
 

--- a/QuickMail/Views/AddAccountDialog.xaml.cs
+++ b/QuickMail/Views/AddAccountDialog.xaml.cs
@@ -58,8 +58,34 @@ public partial class AddAccountDialog : Window
             _vm.Password = pb.Password;
     }
 
+    private void BackendComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        var label = _vm.SelectedBackend?.Label;
+        if (string.IsNullOrEmpty(label)) return;
+        AccessibilityHelper.Announce(
+            this,
+            _vm.IsGraphBackend
+                ? $"{label}. IMAP and SMTP settings are not required."
+                : $"{label}.",
+            category: AnnouncementCategory.Hint);
+    }
+
     private void AddButton_Click(object sender, RoutedEventArgs e)
     {
+        // PR 3 ships the Graph option behind the feature gate but not the backend itself.
+        // Selecting it and saving is blocked with a clear message until PR 4 lands.
+        if (_vm.SelectedBackend?.Kind == BackendKind.MicrosoftGraph)
+        {
+            MessageBox.Show(
+                this,
+                "The Microsoft 365 (Graph) backend is not yet implemented in this build. " +
+                "Choose Standard IMAP/SMTP, or check for a later version.",
+                "Not Yet Available",
+                MessageBoxButton.OK,
+                MessageBoxImage.Information);
+            return;
+        }
+
         DialogResult = true;
         Close();
     }

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -73,6 +73,7 @@ public partial class MainWindow : Window
     private readonly ICredentialService _credentials;
     private readonly IMailService _imap;
     private readonly IOAuthService _oauth;
+    private readonly IFeatureGate _featureGate;
     private readonly ICommandRegistry _registry;
     private bool _webViewReady;
     private string _typeAheadBuffer = string.Empty;
@@ -140,7 +141,8 @@ public partial class MainWindow : Window
         ILocalStoreService localStore,
         IViewService viewService,
         IRuleService ruleService,
-        ITemplateService templateService)
+        ITemplateService templateService,
+        IFeatureGate featureGate)
     {
         _vm = vm;
         _smtp = smtp;
@@ -155,6 +157,7 @@ public partial class MainWindow : Window
         _viewService = viewService;
         _ruleService = ruleService;
         _templateService = templateService;
+        _featureGate = featureGate;
 
         InitializeComponent();
         DataContext = vm;
@@ -3290,7 +3293,7 @@ public partial class MainWindow : Window
 
     private void OpenAccountManager()
     {
-        var accountVm = new AccountManagerViewModel(_accountService, _credentials, _imap, _oauth, _localStore, _configService);
+        var accountVm = new AccountManagerViewModel(_accountService, _credentials, _imap, _oauth, _localStore, _configService, _featureGate);
         var dialog = new AccountManagerDialog(accountVm) { Owner = this };
         if (dialog.ShowDialog() == true)
             _vm.RefreshAccountList();
@@ -3298,7 +3301,7 @@ public partial class MainWindow : Window
 
     private void OpenAccountManagerForAccount(AccountModel account)
     {
-        var accountVm = new AccountManagerViewModel(_accountService, _credentials, _imap, _oauth, _localStore, _configService);
+        var accountVm = new AccountManagerViewModel(_accountService, _credentials, _imap, _oauth, _localStore, _configService, _featureGate);
         var dialog    = new AccountManagerDialog(accountVm) { Owner = this };
         // Pre-select the account in the manager
         accountVm.SelectedAccount = accountVm.Accounts.FirstOrDefault(a => a.Id == account.Id);

--- a/docs/planning/graph-backend-dev-spec.md
+++ b/docs/planning/graph-backend-dev-spec.md
@@ -400,6 +400,7 @@ public class MailServiceRouter : IMailService
 - Router itself implements `IMailService` so `MainViewModel`, `SyncService`, `RuleService` are unchanged — they always saw `IMailService`.
 - Backends are constructed once in `App.xaml.cs` and registered per-account at account load.
 - `RegisterAccount` is idempotent — re-registration replaces the binding.
+- **PR 3 implementation note:** `For()` falls back to the first (default) backend for any unregistered account rather than throwing. In v0.7 the only backend is IMAP, so runtime-added accounts route correctly without plumbing the router through the VM/View layer (QuickMail has no `MainViewModel.AddAccountAsync` hook; accounts are added via the Account Manager dialog and picked up by `RefreshAccountList`). PR 4 (when a second backend exists) must register Graph accounts explicitly at add time, since the fallback assumes IMAP.
 
 ### 6.5 `MailMessageSummary.cs` — string MessageId
 


### PR DESCRIPTION
**PR 3 of the Microsoft Graph backend plan (#24)** — completes the v0.7 refactor trio (after #28 rename and #30 MessageId migration). Adds the per-account **backend router** and the runtime **feature gate** so a Graph backend (PR 4) can ship disabled by default.

**No functional change for existing IMAP accounts.** With the gate off (the default), the Add Account dialog is identical to today. With the gate on, a "Microsoft 365 / Outlook.com" option appears, but selecting and saving it is blocked with a "not yet implemented" message until PR 4.

### What's here
- **`BackendKind` / `FeatureFlag` enums; `IFeatureGate` + `ConfigFeatureGate`** — precedence: CLI `--feature GraphBackend` > `config.ini [features]` > built-in default (`GraphBackend=false`).
- **`MailServiceRouter`** implements `IMailService`, dispatches each call to the per-account backend, and aggregates `InboxNewMailDetected`. v0.7 wraps the single IMAP backend.
- **`AccountModel`** gains `BackendKind` + `TenantId`; **`ConfigModel`** gains `Features`; **`ConfigService`** parses and writes a `[features]` INI section.
- **`App.xaml.cs`** wraps IMAP in the router, registers every account, builds the gate from `--feature` flags, threads both downstream.
- **Add Account UI** — gate-derived backend combo (hidden when only one option); selecting Graph forces OAuth and collapses the IMAP/SMTP fields.

### Three decisions to flag (deviations from the literal spec)
1. **Router fallback vs throw.** The spec's `For()` throws on an unregistered account and assumes a `MainViewModel.AddAccountAsync` hook to register runtime-added accounts. That hook doesn't exist — accounts are added via the Account Manager dialog and picked up by `RefreshAccountList`, which connects them live. Rather than plumb the router through the VM/View layer for what's a no-op until PR 4, `For()` **falls back to the first (default) backend** for unregistered accounts. Correct for v0.7 (everything is IMAP); documented in spec §6.4, and PR 4 must register Graph accounts explicitly at add time. Happy to switch to the throw + explicit VM registration if you'd prefer.
2. **Backend combo hidden when single option** (vs the spec's "render as a static label"). Keeps the default dialog visually unchanged. Easy to switch to a static label.
3. **`TestConnectionAsync` guards on `BackendKind`** rather than being `virtual` (cleaner with `[RelayCommand]`); for Graph it reports the probe lands in PR 4.

### Verification
- `dotnet build -c Release` clean (0 warnings, 0 errors).
- **454 tests pass.** New coverage: `AddAccountViewModel` gate on/off + Graph-selection behavior; `MailServiceRouter` routing / fallback / event aggregation / empty-guard; an `AddAccountDialog` XAML-parse test with the gate **on** (exercises the new combo bindings).

No CHANGELOG entry (gate is off by default / internal, consistent with #28 and #30).
