### PR TITLE
PR 4: Graph read path

### DIFF
--- a/QuickMail.Tests/GraphBackendGateTests.cs
+++ b/QuickMail.Tests/GraphBackendGateTests.cs
@@ -78,7 +78,9 @@ public class MailServiceRouterTests
         public void RaiseNewMail(Guid accountId) => InboxNewMailDetected?.Invoke(accountId);
 
         public event Action<Guid>? InboxNewMailDetected;
+#pragma warning disable CS0067 // not raised by this fake
         public event Action<Guid, bool>? AccountReachabilityChanged;
+#pragma warning restore CS0067
 
         public Task<List<MailFolderModel>> GetFoldersAsync(Guid accountId, CancellationToken ct = default)
         {

--- a/QuickMail.Tests/GraphMailServiceTests.cs
+++ b/QuickMail.Tests/GraphMailServiceTests.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using QuickMail.Models;
+using QuickMail.Services;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+public class GraphMailServiceTests
+{
+    /// <summary>Routes each request to a canned JSON response by URL, recording the requested URLs.</summary>
+    private sealed class StubHttpHandler : HttpMessageHandler
+    {
+        private readonly Func<string, (HttpStatusCode Status, string Json)> _respond;
+        public List<string> Requests { get; } = new();
+
+        public StubHttpHandler(Func<string, (HttpStatusCode, string)> respond) => _respond = respond;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            var url = request.RequestUri!.ToString();
+            Requests.Add(url);
+            var (status, json) = _respond(url);
+            return Task.FromResult(new HttpResponseMessage(status)
+            {
+                Content = new StringContent(json, Encoding.UTF8, "application/json"),
+            });
+        }
+    }
+
+    private const string MeJson = """{"id":"u1","userPrincipalName":"user@contoso.com"}""";
+
+    private static (GraphMailService Svc, StubHttpHandler Handler) Make(Func<string, (HttpStatusCode, string)> respond)
+    {
+        var handler = new StubHttpHandler(respond);
+        var svc = new GraphMailService(new StubOAuthService(), null, new HttpClient(handler));
+        return (svc, handler);
+    }
+
+    private static AccountModel GraphAccount() => new()
+    {
+        Id = Guid.NewGuid(),
+        Username = "old@contoso.com",
+        BackendKind = BackendKind.MicrosoftGraph,
+    };
+
+    [Fact]
+    public async Task ConnectAsync_UpdatesUsernameFromMe()
+    {
+        var (svc, _) = Make(url => (HttpStatusCode.OK, MeJson));
+        var account = GraphAccount();
+
+        await svc.ConnectAsync(account);
+
+        Assert.Equal("user@contoso.com", account.Username);
+    }
+
+    [Fact]
+    public async Task GetFoldersAsync_MapsFolders_FollowsNextLink_AndFlagsSpecial()
+    {
+        const string page1 = """
+            {"value":[
+              {"id":"f1","displayName":"Inbox","totalItemCount":10,"unreadItemCount":3},
+              {"id":"f2","displayName":"Sent Items","totalItemCount":5,"unreadItemCount":0}
+            ],"@odata.nextLink":"https://graph.microsoft.com/v1.0/me/mailFolders?$skiptoken=P2"}
+            """;
+        const string page2 = """{"value":[{"id":"f3","displayName":"Archive","totalItemCount":2,"unreadItemCount":1}]}""";
+
+        var (svc, _) = Make(url =>
+            url.Contains("/me?") ? (HttpStatusCode.OK, MeJson)
+            : url.Contains("skiptoken=P2") ? (HttpStatusCode.OK, page2)
+            : (HttpStatusCode.OK, page1));
+
+        var account = GraphAccount();
+        await svc.ConnectAsync(account);
+        var folders = await svc.GetFoldersAsync(account.Id);
+
+        Assert.Equal(3, folders.Count); // nextLink page followed
+        var inbox = folders.Single(f => f.FullName == "f1");
+        Assert.Equal(SpecialFolderKind.Inbox, inbox.Kind);
+        Assert.False(inbox.ExcludeFromAllMail);
+        Assert.Equal(3, inbox.UnreadCount);
+
+        var sent = folders.Single(f => f.FullName == "f2");
+        Assert.Equal(SpecialFolderKind.Sent, sent.Kind);
+        Assert.True(sent.ExcludeFromAllMail);
+
+        var archive = folders.Single(f => f.FullName == "f3");
+        Assert.Equal(SpecialFolderKind.None, archive.Kind);
+        Assert.False(archive.ExcludeFromAllMail);
+    }
+
+    [Fact]
+    public async Task GetMessageSummariesAsync_MapsFields()
+    {
+        const string msgs = """
+            {"value":[{
+              "id":"m1","subject":"Hello",
+              "from":{"emailAddress":{"name":"Alice","address":"alice@x.com"}},
+              "toRecipients":[{"emailAddress":{"address":"me@x.com"}}],
+              "receivedDateTime":"2024-01-02T03:04:05Z","isRead":false,
+              "bodyPreview":"hi there","hasAttachments":true
+            }]}
+            """;
+        var (svc, _) = Make(url => url.Contains("/me?") ? (HttpStatusCode.OK, MeJson) : (HttpStatusCode.OK, msgs));
+
+        var account = GraphAccount();
+        await svc.ConnectAsync(account);
+        var list = await svc.GetMessageSummariesAsync(account.Id, "inbox", 50);
+
+        var m = Assert.Single(list);
+        Assert.Equal("m1", m.MessageId);
+        Assert.Equal("Alice <alice@x.com>", m.From);
+        Assert.Equal("me@x.com", m.To);
+        Assert.Equal("Hello", m.Subject);
+        Assert.False(m.IsRead);
+        Assert.Equal("hi there", m.Preview);
+        Assert.True(m.HasAttachments);
+    }
+
+    [Fact]
+    public async Task GetMessageDetailAsync_MapsBodyAndExcludesInlineAttachments()
+    {
+        const string detail = """
+            {"id":"m1","subject":"Hello",
+             "body":{"contentType":"html","content":"<p>Hi</p>"},
+             "from":{"emailAddress":{"address":"alice@x.com"}},
+             "toRecipients":[{"emailAddress":{"address":"me@x.com"}}],
+             "ccRecipients":[],"internetMessageId":"<abc@x>",
+             "receivedDateTime":"2024-01-02T03:04:05Z","isRead":true,"hasAttachments":true,
+             "attachments":[
+               {"id":"a1","name":"doc.pdf","contentType":"application/pdf","size":1234,"isInline":false},
+               {"id":"a2","name":"inline.png","contentType":"image/png","size":50,"isInline":true}
+             ]}
+            """;
+        var (svc, _) = Make(url => url.Contains("/me?") ? (HttpStatusCode.OK, MeJson) : (HttpStatusCode.OK, detail));
+
+        var account = GraphAccount();
+        await svc.ConnectAsync(account);
+        var d = await svc.GetMessageDetailAsync(account.Id, "inbox", "m1");
+
+        Assert.Equal("m1", d.MessageId);
+        Assert.Equal("<p>Hi</p>", d.HtmlBody);
+        Assert.Equal(string.Empty, d.PlainTextBody);
+        Assert.Equal("<abc@x>", d.InternetMessageId);
+        var att = Assert.Single(d.Attachments); // inline excluded
+        Assert.Equal("doc.pdf", att.FileName);
+        Assert.Equal("a1", att.PartSpecifier);  // Graph attachment id
+        Assert.Equal(1234, att.FileSize);
+    }
+
+    [Fact]
+    public async Task GetMessagesSinceDateAsync_AddsReceivedDateTimeFilter()
+    {
+        var (svc, handler) = Make(url => url.Contains("/me?") ? (HttpStatusCode.OK, MeJson) : (HttpStatusCode.OK, """{"value":[]}"""));
+
+        var account = GraphAccount();
+        await svc.ConnectAsync(account);
+        await svc.GetMessagesSinceDateAsync(account.Id, "inbox", DateTime.UtcNow.AddDays(-7));
+
+        Assert.Contains(handler.Requests, u => Uri.UnescapeDataString(u).Contains("filter=receivedDateTime ge"));
+    }
+
+    [Fact]
+    public void Mutation_Throws_NotImplemented_InPR4()
+    {
+        var (svc, _) = Make(url => (HttpStatusCode.OK, "{}"));
+        // These throw synchronously (expression-bodied `=> throw ...`), so the discard keeps the
+        // lambda an Action rather than a Func<Task>.
+        Assert.Throws<NotImplementedException>(() => { _ = svc.MoveToTrashAsync(Guid.NewGuid(), "inbox", "m1"); });
+        Assert.Throws<NotImplementedException>(() => { _ = svc.AppendToSentAsync(Guid.NewGuid(), new ComposeModel()); });
+        Assert.Throws<NotImplementedException>(() => { _ = svc.CreateFolderAsync(Guid.NewGuid(), null, "New"); });
+    }
+
+    [Fact]
+    public async Task PerAccountCall_BeforeConnect_Throws()
+    {
+        var (svc, _) = Make(url => (HttpStatusCode.OK, "{}"));
+        // No ConnectAsync first → the account isn't registered, so token resolution can't proceed.
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => svc.GetFoldersAsync(Guid.NewGuid()));
+    }
+}

--- a/QuickMail.Tests/SessionFeaturesTests.cs
+++ b/QuickMail.Tests/SessionFeaturesTests.cs
@@ -189,7 +189,9 @@ public class IdleNewMailTests
         public FireableMailService(Guid accountId) => _accountId = accountId;
 
         public event Action<Guid>? InboxNewMailDetected;
+#pragma warning disable CS0067 // not raised by this fake
         public event Action<Guid, bool>? AccountReachabilityChanged;
+#pragma warning restore CS0067
         public void FireNewMail() => InboxNewMailDetected?.Invoke(_accountId);
 
         // Return one INBOX folder so ConnectAllAccountsAsync populates _cachedFolders.

--- a/QuickMail.Tests/StubServices.cs
+++ b/QuickMail.Tests/StubServices.cs
@@ -77,6 +77,7 @@ sealed class StubCredentialService : ICredentialService
 sealed class StubOAuthService : IOAuthService
 {
     public Task<string> GetAccessTokenAsync(AccountModel account, CancellationToken ct = default) => Task.FromResult(string.Empty);
+    public Task<string> GetAccessTokenAsync(AccountModel account, string[] scopes, CancellationToken ct = default) => Task.FromResult(string.Empty);
     public Task<OAuthResult> SignInInteractiveAsync(AccountModel account, CancellationToken ct = default) => Task.FromResult(new OAuthResult(string.Empty, string.Empty));
     public Task SignOutAsync(AccountModel account) => Task.CompletedTask;
 }

--- a/QuickMail/App.xaml.cs
+++ b/QuickMail/App.xaml.cs
@@ -1,5 +1,6 @@
 using System.Threading.Tasks;
 using System.Windows;
+using QuickMail.Models;
 using QuickMail.Services;
 using QuickMail.ViewModels;
 using QuickMail.Views;
@@ -73,21 +74,23 @@ public partial class App : Application
             var oauthService      = new OAuthService(profile);
             var configService     = new ConfigService(profile);
             var imapBackend       = new ImapMailService(oauthService, configService);
+            var graphBackend      = new GraphMailService(oauthService, configService);
             var smtpService       = new SmtpService(oauthService);
 
-            // Per-account mail backend router. v0.7 ships a single backend (IMAP); PR 4 adds Graph
-            // and routes Microsoft 365 accounts to it.
-            var mailRouter = new MailServiceRouter(new IMailService[] { imapBackend });
+            // Per-account mail backend router. Each account is registered to the backend its
+            // BackendKind selects (IMAP by default, Graph for Microsoft 365 accounts).
+            var mailRouter = new MailServiceRouter(new IMailService[] { imapBackend, graphBackend });
+            IMailService BackendFor(AccountModel a)
+                => a.BackendKind == BackendKind.MicrosoftGraph ? graphBackend : imapBackend;
 
             var localStore = new LocalStoreService(profile);
             if (!onlineMode)
                 localStore.Initialize();
 
-            // Load accounts once — after the store is initialized — and reuse the list for both
-            // router registration and the view model, avoiding a second synchronous accounts.json read.
+            // Load accounts once — after the store is initialized — and reuse the list for the VM.
+            // Router registration runs via mainVm.RegisterAccountBackend (set below), which also
+            // covers accounts added at runtime through RefreshAccountList.
             var accounts = accountService.LoadAccounts();
-            foreach (var account in accounts)
-                mailRouter.RegisterAccount(account.Id, imapBackend);
 
             var contactService = new ContactService(profile);
             var templateService = new TemplateService(profile);
@@ -110,6 +113,7 @@ public partial class App : Application
             var mainVm = new MainViewModel(
                 mailRouter, accountService, credentialService, localStore, oauthService, syncService, configService, commandRegistry, viewService, ruleService, smtpService,
                 onlineMode: onlineMode);
+            mainVm.RegisterAccountBackend = a => mailRouter.RegisterAccount(a.Id, BackendFor(a));
             mainVm.LoadAccountList(accounts);
 
             var mainWindow = new MainWindow(mainVm, smtpService, accountService, credentialService, mailRouter, oauthService, commandRegistry, contactService, configService, localStore, viewService, ruleService, templateService, featureGate);

--- a/QuickMail/Services/Graph/GraphClient.cs
+++ b/QuickMail/Services/Graph/GraphClient.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using QuickMail.Models;
+
+namespace QuickMail.Services.Graph;
+
+/// <summary>
+/// Thin <see cref="HttpClient"/> wrapper over the Microsoft Graph v1.0 endpoint. Adds the bearer
+/// token (Graph scopes) per request, follows <c>@odata.nextLink</c> for collections, and retries
+/// on HTTP 429 honoring <c>Retry-After</c>. A raw HttpClient (not the Graph SDK) keeps the
+/// published binary small, per the dev spec.
+/// </summary>
+public sealed class GraphClient : IDisposable
+{
+    private const string BaseUrl = "https://graph.microsoft.com/v1.0";
+    private static readonly JsonSerializerOptions JsonOpts = new() { PropertyNameCaseInsensitive = true };
+
+    private readonly IOAuthService _oauth;
+    private readonly HttpClient _http;
+    private readonly bool _ownsHttp;
+
+    public GraphClient(IOAuthService oauth, HttpClient? http = null)
+    {
+        _oauth = oauth;
+        _http = http ?? new HttpClient();
+        _ownsHttp = http is null;
+    }
+
+    public async Task<T?> GetAsync<T>(AccountModel account, string path, CancellationToken ct = default)
+    {
+        using var resp = await SendAsync(account, HttpMethod.Get, path, null, ct);
+        await EnsureSuccessAsync(resp, ct);
+        return await resp.Content.ReadFromJsonAsync<T>(JsonOpts, ct);
+    }
+
+    /// <summary>GET a collection, following <c>@odata.nextLink</c> until exhausted.</summary>
+    public async Task<List<T>> GetAllPagesAsync<T>(AccountModel account, string path, CancellationToken ct = default)
+    {
+        var all = new List<T>();
+        string? next = path;
+        while (!string.IsNullOrEmpty(next))
+        {
+            using var resp = await SendAsync(account, HttpMethod.Get, next, null, ct);
+            await EnsureSuccessAsync(resp, ct);
+            var page = await resp.Content.ReadFromJsonAsync<GraphCollection<T>>(JsonOpts, ct);
+            if (page?.Value != null) all.AddRange(page.Value);
+            next = page?.NextLink; // absolute URL; SendAsync passes it through unchanged
+        }
+        return all;
+    }
+
+    public async Task PatchAsync(AccountModel account, string path, object body, CancellationToken ct = default)
+    {
+        var json = JsonSerializer.Serialize(body, JsonOpts);
+        using var resp = await SendAsync(account, HttpMethod.Patch, path, json, ct);
+        await EnsureSuccessAsync(resp, ct);
+    }
+
+    private async Task<HttpResponseMessage> SendAsync(
+        AccountModel account, HttpMethod method, string pathOrUrl, string? jsonBody, CancellationToken ct)
+    {
+        var url = pathOrUrl.StartsWith("http", StringComparison.OrdinalIgnoreCase) ? pathOrUrl : BaseUrl + pathOrUrl;
+
+        // Up to 3 attempts to ride out HTTP 429 throttling.
+        for (int attempt = 0; ; attempt++)
+        {
+            var token = await _oauth.GetAccessTokenAsync(account, OAuthService.GraphMailScopes, ct);
+            using var req = new HttpRequestMessage(method, url);
+            req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            if (jsonBody != null)
+                req.Content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
+
+            var resp = await _http.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, ct);
+            if (resp.StatusCode != (HttpStatusCode)429 || attempt >= 2)
+                return resp;
+
+            var delay = resp.Headers.RetryAfter?.Delta ?? TimeSpan.FromSeconds(2);
+            resp.Dispose();
+            await Task.Delay(delay, ct);
+        }
+    }
+
+    private static async Task EnsureSuccessAsync(HttpResponseMessage resp, CancellationToken ct)
+    {
+        if (resp.IsSuccessStatusCode) return;
+        var body = await resp.Content.ReadAsStringAsync(ct);
+        throw new HttpRequestException(
+            $"Graph request failed ({(int)resp.StatusCode} {resp.StatusCode}): {Truncate(body, 500)}");
+    }
+
+    private static string Truncate(string s, int max) => s.Length <= max ? s : s[..max];
+
+    public void Dispose()
+    {
+        if (_ownsHttp) _http.Dispose();
+    }
+}

--- a/QuickMail/Services/Graph/GraphDtos.cs
+++ b/QuickMail/Services/Graph/GraphDtos.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace QuickMail.Services.Graph;
+
+/// <summary>Paging envelope for a Microsoft Graph collection response.</summary>
+internal sealed class GraphCollection<T>
+{
+    [JsonPropertyName("value")] public List<T> Value { get; set; } = new();
+    [JsonPropertyName("@odata.nextLink")] public string? NextLink { get; set; }
+}
+
+internal sealed class GraphMe
+{
+    [JsonPropertyName("id")] public string? Id { get; set; }
+    [JsonPropertyName("userPrincipalName")] public string? UserPrincipalName { get; set; }
+}
+
+internal sealed class GraphMailFolder
+{
+    [JsonPropertyName("id")] public string Id { get; set; } = string.Empty;
+    [JsonPropertyName("displayName")] public string DisplayName { get; set; } = string.Empty;
+    [JsonPropertyName("parentFolderId")] public string? ParentFolderId { get; set; }
+    [JsonPropertyName("totalItemCount")] public int TotalItemCount { get; set; }
+    [JsonPropertyName("unreadItemCount")] public int UnreadItemCount { get; set; }
+}
+
+internal sealed class GraphEmailAddress
+{
+    [JsonPropertyName("name")] public string? Name { get; set; }
+    [JsonPropertyName("address")] public string? Address { get; set; }
+
+    /// <summary>Render as an RFC822-style header value: "Name &lt;addr&gt;", or just the address.</summary>
+    public string AsHeaderString()
+        => string.IsNullOrEmpty(Name) || string.Equals(Name, Address, StringComparison.OrdinalIgnoreCase)
+            ? Address ?? string.Empty
+            : $"{Name} <{Address}>";
+}
+
+internal sealed class GraphRecipient
+{
+    [JsonPropertyName("emailAddress")] public GraphEmailAddress? EmailAddress { get; set; }
+}
+
+internal sealed class GraphItemBody
+{
+    [JsonPropertyName("contentType")] public string? ContentType { get; set; } // "html" | "text"
+    [JsonPropertyName("content")] public string? Content { get; set; }
+}
+
+internal sealed class GraphAttachment
+{
+    [JsonPropertyName("id")] public string Id { get; set; } = string.Empty;
+    [JsonPropertyName("name")] public string? Name { get; set; }
+    [JsonPropertyName("contentType")] public string? ContentType { get; set; }
+    [JsonPropertyName("size")] public long Size { get; set; }
+    [JsonPropertyName("isInline")] public bool IsInline { get; set; }
+}
+
+internal sealed class GraphMessage
+{
+    [JsonPropertyName("id")] public string Id { get; set; } = string.Empty;
+    [JsonPropertyName("subject")] public string? Subject { get; set; }
+    [JsonPropertyName("bodyPreview")] public string? BodyPreview { get; set; }
+    [JsonPropertyName("body")] public GraphItemBody? Body { get; set; }
+    [JsonPropertyName("from")] public GraphRecipient? From { get; set; }
+    [JsonPropertyName("toRecipients")] public List<GraphRecipient>? ToRecipients { get; set; }
+    [JsonPropertyName("ccRecipients")] public List<GraphRecipient>? CcRecipients { get; set; }
+    [JsonPropertyName("replyTo")] public List<GraphRecipient>? ReplyTo { get; set; }
+    [JsonPropertyName("internetMessageId")] public string? InternetMessageId { get; set; }
+    [JsonPropertyName("receivedDateTime")] public DateTimeOffset ReceivedDateTime { get; set; }
+    [JsonPropertyName("isRead")] public bool IsRead { get; set; }
+    [JsonPropertyName("hasAttachments")] public bool HasAttachments { get; set; }
+    [JsonPropertyName("attachments")] public List<GraphAttachment>? Attachments { get; set; }
+}

--- a/QuickMail/Services/GraphMailService.cs
+++ b/QuickMail/Services/GraphMailService.cs
@@ -1,0 +1,259 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using QuickMail.Models;
+using QuickMail.Services.Graph;
+
+namespace QuickMail.Services;
+
+/// <summary>
+/// <see cref="IMailService"/> implementation backed by Microsoft Graph (v1.0). PR 4 implements the
+/// read path (connect, folders, summaries, detail, mark-read, status); mutations, attachment
+/// download, folder CRUD, and change notifications throw and are lit up in PRs 5–7.
+/// </summary>
+public class GraphMailService : IMailService
+{
+    private readonly GraphClient _client;
+    private readonly IConfigService? _config;
+
+    // accountId -> the connected AccountModel, so per-accountId calls can acquire the right token.
+    private readonly ConcurrentDictionary<Guid, AccountModel> _accounts = new();
+
+    public GraphMailService(IOAuthService oauth, IConfigService? config = null, HttpClient? http = null)
+    {
+        _client = new GraphClient(oauth, http);
+        _config = config;
+    }
+
+#pragma warning disable CS0067 // events are part of IMailService; Graph raises them in PR 7
+    public event Action<Guid, bool>? AccountReachabilityChanged;
+    public event Action<Guid>? InboxNewMailDetected;
+#pragma warning restore CS0067
+
+    // ── Connect ────────────────────────────────────────────────────────────────────
+    public async Task ConnectAsync(AccountModel account, string? password = null, CancellationToken ct = default)
+    {
+        _accounts[account.Id] = account;
+        var me = await _client.GetAsync<GraphMe>(account, "/me?$select=id,userPrincipalName", ct);
+        if (string.IsNullOrEmpty(me?.UserPrincipalName))
+            throw new InvalidOperationException("Graph /me returned no userPrincipalName.");
+        if (!string.Equals(account.Username, me.UserPrincipalName, StringComparison.OrdinalIgnoreCase))
+        {
+            LogService.Log($"GraphMailService: token UPN {me.UserPrincipalName} differs from account.Username {account.Username}; updating.");
+            account.Username = me.UserPrincipalName;
+        }
+        LogService.Log($"GraphMailService: connected for {account.AccountLabel} ({account.Username}).");
+    }
+
+    public Task DisconnectAsync(Guid accountId, CancellationToken ct = default) => Task.CompletedTask;
+
+    private AccountModel Account(Guid accountId)
+        => _accounts.TryGetValue(accountId, out var a)
+            ? a
+            : throw new InvalidOperationException($"Graph account {accountId} is not connected.");
+
+    // ── Folders ──────────────────────────────────────────────────────────────────
+    public async Task<List<MailFolderModel>> GetFoldersAsync(Guid accountId, CancellationToken ct = default)
+    {
+        var folders = await _client.GetAllPagesAsync<GraphMailFolder>(
+            Account(accountId),
+            "/me/mailFolders?$top=100&$select=id,displayName,parentFolderId,totalItemCount,unreadItemCount", ct);
+
+        return folders.Select(f => new MailFolderModel
+        {
+            AccountId = accountId,
+            FullName = f.Id,                 // Graph uses opaque folder IDs as the "folder name"
+            DisplayName = f.DisplayName,
+            UnreadCount = f.UnreadItemCount,
+            MessageCount = f.TotalItemCount,
+            Kind = MapWellKnownFolder(f.DisplayName),
+            ExcludeFromAllMail = ShouldExcludeFromAll(f.DisplayName),
+        }).ToList();
+    }
+
+    // ── Message summaries ────────────────────────────────────────────────────────
+    public Task<List<MailMessageSummary>> GetMessageSummariesAsync(
+        Guid accountId, string folderName, int maxMessages, CancellationToken ct = default)
+        => FetchSummariesAsync(Account(accountId), folderName, maxMessages, since: null, ct);
+
+    public Task<List<MailMessageSummary>> GetMessagesSinceDateAsync(
+        Guid accountId, string folderName, DateTime since, CancellationToken ct = default)
+        => FetchSummariesAsync(Account(accountId), folderName, 999, since, ct);
+
+    // Graph ignores sinceMessageId (its message IDs are non-numeric). Until delta polling lands in
+    // PR 7, an incremental sync just re-fetches the recent N; the store/VM dedupe by MessageId.
+    public Task<List<MailMessageSummary>> GetMessagesSinceAsync(
+        Guid accountId, string folderName, string sinceMessageId, int initialCount, CancellationToken ct = default)
+        => FetchSummariesAsync(Account(accountId), folderName, initialCount, since: null, ct);
+
+    private async Task<List<MailMessageSummary>> FetchSummariesAsync(
+        AccountModel account, string folderName, int limit, DateTime? since, CancellationToken ct)
+    {
+        var top = limit > 0 ? Math.Min(limit, 999) : 500;
+        var path = $"/me/mailFolders/{folderName}/messages?$top={top}&$orderby=receivedDateTime desc" +
+                   "&$select=id,subject,from,toRecipients,receivedDateTime,isRead,bodyPreview,hasAttachments";
+        if (since.HasValue)
+            path += $"&$filter=receivedDateTime ge {since.Value.ToUniversalTime():yyyy-MM-ddTHH:mm:ssZ}";
+
+        // Single page only — $top bounds the result like IMAP's initialCount (no nextLink following).
+        var page = await _client.GetAsync<GraphCollection<GraphMessage>>(account, path, ct);
+        return (page?.Value ?? new List<GraphMessage>())
+            .Select(m => MapToSummary(m, account.Id, folderName)).ToList();
+    }
+
+    // ── Message detail ───────────────────────────────────────────────────────────
+    public async Task<MailMessageDetail> GetMessageDetailAsync(
+        Guid accountId, string folderName, string messageId, CancellationToken ct = default)
+    {
+        var path = $"/me/messages/{messageId}" +
+                   "?$select=id,subject,body,from,toRecipients,ccRecipients,replyTo,internetMessageId,receivedDateTime,isRead,hasAttachments" +
+                   "&$expand=attachments($select=id,name,contentType,size,isInline)";
+        var m = await _client.GetAsync<GraphMessage>(Account(accountId), path, ct)
+            ?? throw new InvalidOperationException($"Graph message {messageId} not found.");
+        return MapToDetail(m, accountId, folderName);
+    }
+
+    // Graph GET does not set the Seen flag, so prefetch is identical to a normal detail fetch.
+    public Task<MailMessageDetail> PrefetchMessageDetailAsync(
+        Guid accountId, string folderName, string messageId, CancellationToken ct = default)
+        => GetMessageDetailAsync(accountId, folderName, messageId, ct);
+
+    public Task MarkReadAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default)
+        => _client.PatchAsync(Account(accountId), $"/me/messages/{messageId}", new { isRead = true }, ct);
+
+    // ── Status / reconciliation ──────────────────────────────────────────────────
+    public async Task<(int Total, int Unread)> GetInboxStatusAsync(Guid accountId, CancellationToken ct = default)
+    {
+        var f = await _client.GetAsync<GraphMailFolder>(
+            Account(accountId), "/me/mailFolders/Inbox?$select=totalItemCount,unreadItemCount", ct);
+        return (f?.TotalItemCount ?? 0, f?.UnreadItemCount ?? 0);
+    }
+
+    public async Task<IList<string>> GetFolderMessageIdsAsync(Guid accountId, string folderName, CancellationToken ct = default)
+    {
+        var msgs = await _client.GetAllPagesAsync<GraphMessage>(
+            Account(accountId), $"/me/mailFolders/{folderName}/messages?$select=id&$top=999", ct);
+        return msgs.Select(m => m.Id).ToList();
+    }
+
+    public Task<string?> FindDraftsFolderNameAsync(Guid accountId, CancellationToken ct = default)
+        => Task.FromResult<string?>("Drafts"); // Graph well-known folder name; valid as a folder ID
+
+    // ── Safe no-ops (Graph has no persistent connection / IDLE; previews are native) ──
+    public Task NoOpAsync(Guid accountId, CancellationToken ct = default) => Task.CompletedTask;
+    public Task<int> PollAsync(Guid accountId, string folderName, CancellationToken ct = default) => Task.FromResult(0);
+    public Task<int> CountTrashMessagesAsync(Guid accountId, CancellationToken ct = default) => Task.FromResult(0); // real count in PR 5/6
+    public Task<IReadOnlyDictionary<string, string>> FetchPreviewsAsync(
+        Guid accountId, string folderName, IList<string> messageIds, int maxLines, CancellationToken ct = default)
+        => Task.FromResult<IReadOnlyDictionary<string, string>>(new Dictionary<string, string>()); // bodyPreview is fetched inline
+
+    // Graph delivers new-mail notifications via delta polling (PR 7), not IMAP IDLE. No-op here so a
+    // mixed account list doesn't throw at startup.
+    public void StartIdleWatchers(IReadOnlyList<AccountModel> accounts, CancellationToken ct = default) { }
+    public void StopIdleWatchers() { }
+
+    // ── Mutations / attachments / folder CRUD — PR 5/6 ───────────────────────────
+    private static NotImplementedException NotYet(string member)
+        => new($"GraphMailService.{member} lands in PR 5/6.");
+
+    public Task MarkReadBatchAsync(Guid accountId, string folderName, IList<string> messageIds, CancellationToken ct = default)
+        => throw NotYet(nameof(MarkReadBatchAsync));
+    public Task MoveToTrashAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default)
+        => throw NotYet(nameof(MoveToTrashAsync));
+    public Task MoveToTrashBatchAsync(Guid accountId, string folderName, IList<string> messageIds, CancellationToken ct = default)
+        => throw NotYet(nameof(MoveToTrashBatchAsync));
+    public Task PermanentlyDeleteBatchAsync(Guid accountId, string folderName, IList<string> messageIds, CancellationToken ct = default)
+        => throw NotYet(nameof(PermanentlyDeleteBatchAsync));
+    public Task<int> EmptyTrashAsync(Guid accountId, CancellationToken ct = default)
+        => throw NotYet(nameof(EmptyTrashAsync));
+    public Task<string> AppendDraftAsync(Guid accountId, ComposeModel draft, string? replaceMessageId, CancellationToken ct = default)
+        => throw NotYet(nameof(AppendDraftAsync));
+    public Task AppendToSentAsync(Guid accountId, ComposeModel sent, CancellationToken ct = default)
+        => throw NotYet(nameof(AppendToSentAsync));
+    public Task<byte[]> DownloadAttachmentAsync(Guid accountId, string folderName, string messageId, string partSpecifier, CancellationToken ct = default)
+        => throw NotYet(nameof(DownloadAttachmentAsync));
+    public Task CopyMessagesAsync(Guid accountId, string folderName, IList<string> messageIds, string destinationFolder, CancellationToken ct = default)
+        => throw NotYet(nameof(CopyMessagesAsync));
+    public Task MoveMessagesAsync(Guid accountId, string folderName, IList<string> messageIds, string destinationFolder, CancellationToken ct = default)
+        => throw NotYet(nameof(MoveMessagesAsync));
+    public Task CreateFolderAsync(Guid accountId, string? parentFolderName, string name, CancellationToken ct = default)
+        => throw NotYet(nameof(CreateFolderAsync));
+    public Task DeleteFolderAsync(Guid accountId, string folderName, CancellationToken ct = default)
+        => throw NotYet(nameof(DeleteFolderAsync));
+    public Task RenameFolderAsync(Guid accountId, string folderName, string newName, string? newParentFolderName, CancellationToken ct = default)
+        => throw NotYet(nameof(RenameFolderAsync));
+    public Task CopyFolderAsync(Guid accountId, string folderName, string? destinationParentName, CancellationToken ct = default)
+        => throw NotYet(nameof(CopyFolderAsync));
+
+    public void Dispose() => _client.Dispose();
+
+    // ── Mapping helpers ──────────────────────────────────────────────────────────
+    private static MailMessageSummary MapToSummary(GraphMessage m, Guid accountId, string folderName) => new()
+    {
+        MessageId = m.Id,
+        AccountId = accountId,
+        FolderName = folderName,
+        From = m.From?.EmailAddress?.AsHeaderString() ?? string.Empty,
+        To = JoinRecipients(m.ToRecipients),
+        Subject = m.Subject ?? "(no subject)",
+        Date = m.ReceivedDateTime,
+        IsRead = m.IsRead,
+        Preview = m.BodyPreview ?? string.Empty,
+        HasAttachments = m.HasAttachments,
+    };
+
+    private static MailMessageDetail MapToDetail(GraphMessage m, Guid accountId, string folderName)
+    {
+        var isHtml = string.Equals(m.Body?.ContentType, "html", StringComparison.OrdinalIgnoreCase);
+        var attachments = (m.Attachments ?? new List<GraphAttachment>())
+            .Where(a => !a.IsInline)
+            .Select(a => new AttachmentModel
+            {
+                FileName = a.Name ?? "(attachment)",
+                ContentType = a.ContentType ?? "application/octet-stream",
+                FileSize = a.Size,
+                PartSpecifier = a.Id, // Graph attachment id; used by DownloadAttachment in PR 5/6
+            }).ToList();
+
+        return new MailMessageDetail
+        {
+            MessageId = m.Id,
+            AccountId = accountId,
+            FolderName = folderName,
+            From = m.From?.EmailAddress?.AsHeaderString() ?? string.Empty,
+            To = JoinRecipients(m.ToRecipients),
+            Cc = JoinRecipients(m.CcRecipients),
+            ReplyTo = JoinRecipients(m.ReplyTo),
+            Subject = m.Subject ?? "(no subject)",
+            Date = m.ReceivedDateTime,
+            IsRead = m.IsRead,
+            InternetMessageId = m.InternetMessageId ?? string.Empty,
+            PlainTextBody = isHtml ? string.Empty : (m.Body?.Content ?? string.Empty),
+            HtmlBody = isHtml ? (m.Body?.Content ?? string.Empty) : string.Empty,
+            Attachments = attachments,
+        };
+    }
+
+    private static string JoinRecipients(List<GraphRecipient>? recipients)
+        => string.Join(", ", (recipients ?? new List<GraphRecipient>())
+            .Select(r => r.EmailAddress?.AsHeaderString() ?? string.Empty)
+            .Where(s => s.Length > 0));
+
+    private static SpecialFolderKind MapWellKnownFolder(string displayName) => displayName.Trim().ToLowerInvariant() switch
+    {
+        "inbox" => SpecialFolderKind.Inbox,
+        "sent items" or "sent" => SpecialFolderKind.Sent,
+        "drafts" => SpecialFolderKind.Drafts,
+        "deleted items" or "trash" => SpecialFolderKind.Trash,
+        "junk email" or "junk" => SpecialFolderKind.Junk,
+        _ => SpecialFolderKind.None,
+    };
+
+    private static bool ShouldExcludeFromAll(string displayName)
+        => MapWellKnownFolder(displayName) is SpecialFolderKind.Sent or SpecialFolderKind.Drafts
+            or SpecialFolderKind.Trash or SpecialFolderKind.Junk;
+}

--- a/QuickMail/Services/IOAuthService.cs
+++ b/QuickMail/Services/IOAuthService.cs
@@ -15,6 +15,12 @@ public interface IOAuthService
     Task<string> GetAccessTokenAsync(AccountModel account, CancellationToken ct = default);
 
     /// <summary>
+    /// Returns an access token for the given explicit scope set (used by the Graph backend to
+    /// request Graph scopes rather than the account's default IMAP scopes). Silent-then-interactive.
+    /// </summary>
+    Task<string> GetAccessTokenAsync(AccountModel account, string[] scopes, CancellationToken ct = default);
+
+    /// <summary>
     /// Forces a browser-based interactive sign-in and returns the token + the
     /// signed-in username (UPN) so the caller can populate the Username field.
     /// </summary>

--- a/QuickMail/Services/OAuthService.cs
+++ b/QuickMail/Services/OAuthService.cs
@@ -14,13 +14,26 @@ public class OAuthService : IOAuthService
     private const string ClientId  = "bcdc84f1-d37c-4581-b14a-a01f7b3a1312";
     private const string Authority = "https://login.microsoftonline.com/common";
 
-    // Scopes required for IMAP + SMTP access
-    private static readonly string[] Scopes =
+    // Delegated scopes per backend. An account's BackendKind selects which set is requested.
+    public static readonly string[] ImapSmtpScopes =
     [
         "https://outlook.office.com/IMAP.AccessAsUser.All",
         "https://outlook.office.com/SMTP.Send",
-        "offline_access"
+        "offline_access",
     ];
+
+    public static readonly string[] GraphMailScopes =
+    [
+        "https://graph.microsoft.com/Mail.ReadWrite",
+        "https://graph.microsoft.com/Mail.Send",
+        "https://graph.microsoft.com/MailboxSettings.Read",
+        "https://graph.microsoft.com/User.Read",
+        "https://graph.microsoft.com/User.ReadBasic.All",
+        "offline_access",
+    ];
+
+    private static string[] DefaultScopesFor(AccountModel account)
+        => account.BackendKind == BackendKind.MicrosoftGraph ? GraphMailScopes : ImapSmtpScopes;
 
     private readonly string _cacheDir;
     private const string CacheFileName = "msal.cache";
@@ -55,7 +68,10 @@ public class OAuthService : IOAuthService
         LogService.Log("OAuthService: token cache registered.");
     }
 
-    public async Task<string> GetAccessTokenAsync(AccountModel account, CancellationToken ct = default)
+    public Task<string> GetAccessTokenAsync(AccountModel account, CancellationToken ct = default)
+        => GetAccessTokenAsync(account, DefaultScopesFor(account), ct);
+
+    public async Task<string> GetAccessTokenAsync(AccountModel account, string[] scopes, CancellationToken ct = default)
     {
         var msalAccounts = await _msal.GetAccountsAsync();
         var msalAccount  = msalAccounts.FirstOrDefault(a =>
@@ -65,7 +81,7 @@ public class OAuthService : IOAuthService
         {
             try
             {
-                var silent = await _msal.AcquireTokenSilent(Scopes, msalAccount).ExecuteAsync(ct);
+                var silent = await _msal.AcquireTokenSilent(scopes, msalAccount).ExecuteAsync(ct);
                 LogService.Log($"OAuthService: silent token acquired for {account.Username}");
                 return silent.AccessToken;
             }
@@ -75,15 +91,18 @@ public class OAuthService : IOAuthService
             }
         }
 
-        var result = await SignInInteractiveAsync(account, ct);
+        var result = await SignInInteractiveAsync(account, scopes, ct);
         return result.AccessToken;
     }
 
-    public async Task<OAuthResult> SignInInteractiveAsync(AccountModel account, CancellationToken ct = default)
+    public Task<OAuthResult> SignInInteractiveAsync(AccountModel account, CancellationToken ct = default)
+        => SignInInteractiveAsync(account, DefaultScopesFor(account), ct);
+
+    public async Task<OAuthResult> SignInInteractiveAsync(AccountModel account, string[] scopes, CancellationToken ct = default)
     {
         LogService.Log($"OAuthService: starting interactive sign-in for {account.Username}");
 
-        var builder = _msal.AcquireTokenInteractive(Scopes)
+        var builder = _msal.AcquireTokenInteractive(scopes)
             // Opens the system default browser; no embedded WebView dependency
             .WithUseEmbeddedWebView(false)
             // Force credential entry when a specific account is expected,

--- a/QuickMail/ViewModels/AccountEditorViewModel.cs
+++ b/QuickMail/ViewModels/AccountEditorViewModel.cs
@@ -82,7 +82,7 @@ public abstract partial class AccountEditorViewModel : ObservableObject
         try
         {
             using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(3));
-            var tempAccount = new AccountModel { Username = Username, AuthType = AuthType.OAuth2Microsoft };
+            var tempAccount = new AccountModel { Username = Username, AuthType = AuthType.OAuth2Microsoft, BackendKind = BackendKind };
             var result = await OAuthService.SignInInteractiveAsync(tempAccount, cts.Token);
             Username = result.Username;
             StatusText = $"Signed in as {result.Username}";
@@ -104,7 +104,9 @@ public abstract partial class AccountEditorViewModel : ObservableObject
         // host/port; their connectivity probe (GET /me) lands with the Graph backend in PR 4.
         if (IsGraphBackend)
         {
-            StatusText = "Connection testing for Microsoft 365 accounts is available once the Graph backend ships.";
+            // A Graph account is verified by the OAuth sign-in itself (it acquires a Graph token and
+            // populates the username from /me). There is no separate host/port to probe.
+            StatusText = "For Microsoft 365, use Sign in with Microsoft to verify access.";
             return;
         }
 

--- a/QuickMail/ViewModels/AccountManagerViewModel.cs
+++ b/QuickMail/ViewModels/AccountManagerViewModel.cs
@@ -49,6 +49,7 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
     partial void OnSelectedAccountChanged(AccountModel? value)
     {
         if (value == null) return;
+        BackendKind = value.BackendKind; // drives IsGraphBackend/IsImapBackend → hides auth + IMAP/SMTP for Graph
         AccountName = value.AccountName;
         DisplayName = value.DisplayName;
         Username = value.Username;

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -670,9 +670,19 @@ public partial class MainViewModel : ObservableObject
         UpdateRulesStatusText();
     }
 
+    /// <summary>
+    /// Set by the composition root to bind each account to its mail backend (IMAP or Graph) in the
+    /// router before the account is connected. Invoked for every account on load/refresh, so accounts
+    /// added at runtime via <see cref="RefreshAccountList"/> are registered to the correct backend.
+    /// </summary>
+    public Action<AccountModel>? RegisterAccountBackend { get; set; }
+
     public void LoadAccountList(List<AccountModel>? preloaded = null)
     {
-        Accounts = new ObservableCollection<AccountModel>(preloaded ?? _accountService.LoadAccounts());
+        var accounts = preloaded ?? _accountService.LoadAccounts();
+        foreach (var account in accounts)
+            RegisterAccountBackend?.Invoke(account);
+        Accounts = new ObservableCollection<AccountModel>(accounts);
     }
 
     // ── Saved-views lifecycle ─────────────────────────────────────────────────────

--- a/QuickMail/Views/AccountManagerDialog.xaml
+++ b/QuickMail/Views/AccountManagerDialog.xaml
@@ -8,7 +8,8 @@
         Height="660" Width="720"
         MinHeight="500" MinWidth="580"
         WindowStartupLocation="CenterOwner"
-        ResizeMode="CanResize">
+        ResizeMode="CanResize"
+        Loaded="Window_Loaded">
 
     <Window.Resources>
         <BooleanToVisibilityConverter x:Key="BoolToVisibility"/>
@@ -42,7 +43,8 @@
                         AutomationProperties.Name="Set selected account as default for new messages"
                         MinWidth="75"/>
             </StackPanel>
-            <ListBox ItemsSource="{Binding Accounts}"
+            <ListBox x:Name="AccountListBox"
+                     ItemsSource="{Binding Accounts}"
                      SelectedItem="{Binding SelectedAccount, Mode=TwoWay}"
                      AutomationProperties.Name="Account list"
                      TextSearch.TextPath="AccountLabelWithDefault"
@@ -89,15 +91,17 @@
                          AutomationProperties.LabeledBy="{Binding ElementName=LblUsername}"
                          TabIndex="2"/>
 
-                <!-- Authentication type -->
-                <TextBlock x:Name="LblAuthType" Text="_Authentication:" Margin="0,8,0,2"/>
-                <ComboBox SelectedIndex="{Binding AuthTypeIndex, Mode=TwoWay}"
-                          AutomationProperties.LabeledBy="{Binding ElementName=LblAuthType}"
-                          AutomationProperties.Name="Authentication method"
-                          TabIndex="3">
-                    <ComboBoxItem>Password</ComboBoxItem>
-                    <ComboBoxItem>Microsoft OAuth2 (Outlook.com)</ComboBoxItem>
-                </ComboBox>
+                <!-- Authentication type — hidden for Microsoft 365 (Graph), which is always OAuth. -->
+                <StackPanel Visibility="{Binding IsImapBackend, Converter={StaticResource BoolToVisibility}}">
+                    <TextBlock x:Name="LblAuthType" Text="_Authentication:" Margin="0,8,0,2"/>
+                    <ComboBox SelectedIndex="{Binding AuthTypeIndex, Mode=TwoWay}"
+                              AutomationProperties.LabeledBy="{Binding ElementName=LblAuthType}"
+                              AutomationProperties.Name="Authentication method"
+                              TabIndex="3">
+                        <ComboBoxItem>Password</ComboBoxItem>
+                        <ComboBoxItem>Microsoft OAuth2 (Outlook.com)</ComboBoxItem>
+                    </ComboBox>
+                </StackPanel>
 
                 <!-- Password panel -->
                 <StackPanel Visibility="{Binding IsPasswordAuth, Converter={StaticResource BoolToVisibility}}">
@@ -118,6 +122,8 @@
                             HorizontalAlignment="Left" MinWidth="200" TabIndex="5"/>
                 </StackPanel>
 
+                <!-- IMAP + SMTP server settings — hidden for Microsoft 365 (Graph) accounts. -->
+                <StackPanel Visibility="{Binding IsImapBackend, Converter={StaticResource BoolToVisibility}}">
                 <Separator Margin="0,12"/>
 
                 <!-- IMAP Settings -->
@@ -167,6 +173,7 @@
                           IsChecked="{Binding SmtpAcceptInvalidCert}"
                           AutomationProperties.Name="SMTP accept invalid SSL certificates"
                           Margin="0,0,0,6" TabIndex="10"/>
+                </StackPanel>
 
                 <Separator Margin="0,6"/>
 

--- a/QuickMail/Views/AccountManagerDialog.xaml.cs
+++ b/QuickMail/Views/AccountManagerDialog.xaml.cs
@@ -1,5 +1,6 @@
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
 using QuickMail.Models;
 using QuickMail.ViewModels;
 
@@ -19,6 +20,26 @@ public partial class AccountManagerDialog : Window
             if (e.PropertyName == nameof(vm.StatusText) && !string.IsNullOrEmpty(vm.StatusText))
                 AccessibilityHelper.Announce(this, vm.StatusText, category: AnnouncementCategory.Status);
         };
+    }
+
+    private void Window_Loaded(object sender, RoutedEventArgs e)
+    {
+        if (_vm.Accounts.Count == 0) return;
+
+        // Land keyboard focus on the FIRST account item (not the list container, which a screen
+        // reader announces as "0 items"). Focusing the item container gives it keyboard focus
+        // WITHOUT selecting it — selection happens only on arrow/Space/click — so the user hears
+        // the first account and can then choose one. Realize the container first.
+        AccountListBox.UpdateLayout();
+        if (AccountListBox.ItemContainerGenerator.ContainerFromIndex(0) is ListBoxItem first)
+        {
+            first.Focus();
+            Keyboard.Focus(first);
+        }
+        else
+        {
+            AccountListBox.Focus();
+        }
     }
 
     private void PasswordBox_PasswordChanged(object sender, RoutedEventArgs e)

--- a/QuickMail/Views/AddAccountDialog.xaml
+++ b/QuickMail/Views/AddAccountDialog.xaml
@@ -33,7 +33,8 @@
                               ItemsSource="{Binding AvailableBackends}"
                               SelectedItem="{Binding SelectedBackend, Mode=TwoWay}"
                               SelectionChanged="BackendComboBox_SelectionChanged"
-                              AutomationProperties.LabeledBy="{Binding ElementName=LblBackend}"/>
+                              AutomationProperties.LabeledBy="{Binding ElementName=LblBackend}"
+                              TabIndex="0"/>
                     <Separator Margin="0,12"/>
                 </StackPanel>
 
@@ -55,15 +56,17 @@
                          AutomationProperties.LabeledBy="{Binding ElementName=LblUsername}"
                          TabIndex="2"/>
 
-                <!-- Authentication type -->
-                <TextBlock x:Name="LblAuthType" Text="_Authentication:" Margin="0,8,0,2"/>
-                <ComboBox SelectedIndex="{Binding AuthTypeIndex, Mode=TwoWay}"
-                          AutomationProperties.LabeledBy="{Binding ElementName=LblAuthType}"
-                          AutomationProperties.Name="Authentication method"
-                          TabIndex="3">
-                    <ComboBoxItem>Password</ComboBoxItem>
-                    <ComboBoxItem>Microsoft OAuth2 (Outlook.com)</ComboBoxItem>
-                </ComboBox>
+                <!-- Authentication type — hidden for Microsoft 365 (Graph), which is always OAuth. -->
+                <StackPanel Visibility="{Binding IsImapBackend, Converter={StaticResource BoolToVisibility}}">
+                    <TextBlock x:Name="LblAuthType" Text="_Authentication:" Margin="0,8,0,2"/>
+                    <ComboBox SelectedIndex="{Binding AuthTypeIndex, Mode=TwoWay}"
+                              AutomationProperties.LabeledBy="{Binding ElementName=LblAuthType}"
+                              AutomationProperties.Name="Authentication method"
+                              TabIndex="3">
+                        <ComboBoxItem>Password</ComboBoxItem>
+                        <ComboBoxItem>Microsoft OAuth2 (Outlook.com)</ComboBoxItem>
+                    </ComboBox>
+                </StackPanel>
 
                 <!-- Password panel (hidden for OAuth2) -->
                 <StackPanel Visibility="{Binding IsPasswordAuth, Converter={StaticResource BoolToVisibility}}">

--- a/QuickMail/Views/AddAccountDialog.xaml.cs
+++ b/QuickMail/Views/AddAccountDialog.xaml.cs
@@ -72,20 +72,6 @@ public partial class AddAccountDialog : Window
 
     private void AddButton_Click(object sender, RoutedEventArgs e)
     {
-        // PR 3 ships the Graph option behind the feature gate but not the backend itself.
-        // Selecting it and saving is blocked with a clear message until PR 4 lands.
-        if (_vm.SelectedBackend?.Kind == BackendKind.MicrosoftGraph)
-        {
-            MessageBox.Show(
-                this,
-                "The Microsoft 365 (Graph) backend is not yet implemented in this build. " +
-                "Choose Standard IMAP/SMTP, or check for a later version.",
-                "Not Yet Available",
-                MessageBoxButton.OK,
-                MessageBoxImage.Information);
-            return;
-        }
-
         DialogResult = true;
         Close();
     }

--- a/QuickMail/Views/AddAccountDialog.xaml.cs
+++ b/QuickMail/Views/AddAccountDialog.xaml.cs
@@ -27,8 +27,12 @@ public partial class AddAccountDialog : Window
 
     private void Window_Loaded(object sender, RoutedEventArgs e)
     {
-        AccountNameBox.Focus();
-        Keyboard.Focus(AccountNameBox);
+        // Land on the Account Type picker first when it's shown (more than one backend available),
+        // so the choice that changes which fields matter comes before those fields. When there's
+        // only one backend the picker is hidden, so start on Account Name as before.
+        var first = _vm.ShowBackendPicker ? (Control)BackendComboBox : AccountNameBox;
+        first.Focus();
+        Keyboard.Focus(first);
     }
 
     private void OnIsBusyChanged()

--- a/docs/planning/graph-backend-dev-spec.md
+++ b/docs/planning/graph-backend-dev-spec.md
@@ -796,6 +796,14 @@ public class GraphMailService : IMailService
 }
 ```
 
+**PR 4 implementation notes (as built):**
+- `GraphMailService.StartIdleWatchers`/`StopIdleWatchers` are **no-ops**, not throwing — Graph has no IMAP IDLE (notifications arrive via delta polling in PR 7), and throwing would break a mixed IMAP+Graph account list at startup. `NoOpAsync`, `PollAsync` (→0), `FetchPreviewsAsync` (→empty; Graph fills `bodyPreview` natively), and `CountTrashMessagesAsync` (→0; real count in PR 5/6) are likewise safe no-ops so the read/sync path never throws. All true mutations + `DownloadAttachmentAsync` + folder CRUD throw `NotImplementedException` (PR 5/6).
+- **Runtime registration (the PR 3 follow-up):** `MainViewModel.RegisterAccountBackend` — set by `App.xaml.cs` to `a => router.RegisterAccount(a.Id, BackendFor(a))` — runs for every account in `LoadAccountList`, so accounts added at runtime via `RefreshAccountList` bind to the correct backend by `BackendKind` instead of falling back to IMAP.
+- **Scopes:** `GraphMailScopes` requests `Mail.ReadWrite`, `Mail.Send`, `MailboxSettings.Read`, `User.Read`, `User.ReadBasic.All`, `offline_access` (one consent covers PRs 4–6 + directory search). The Add Account "Sign in with Microsoft" button sets the temp account's `BackendKind` so sign-in requests Graph scopes via the per-call overload.
+- **Bounded vs full fetch:** message-summary fetches use a single page bounded by `$top` (mirroring IMAP's `initialCount`); folder lists and `GetFolderMessageIdsAsync` follow `@odata.nextLink` to completion.
+- **Test Connection for Graph:** a not-yet-saved account isn't registered in the router (which would route it to the IMAP fallback), so the Graph "Test Connection" directs the user to "Sign in with Microsoft" — the sign-in itself (token + `/me`) is the verification. A dedicated probe can be added once in-progress-account registration is supported.
+- `GetMaxMessageKeyAsync` is always `"0"` for Graph (non-numeric ids `CAST` to 0), so a Graph folder always takes the "recent N / since-date" sync branch — correct; delta makes it efficient in PR 7.
+
 ### 6.11 `GraphSmtpService.cs` — Send Path
 
 **Path:** `QuickMail/Services/GraphSmtpService.cs`


### PR DESCRIPTION
**PR 4 of the Microsoft Graph backend plan (#24)** — the first PR that actually talks to Graph. Adds a working **read path** so a Microsoft 365 account can be added and its mail browsed. Gated behind `GraphBackend`; **no change for IMAP accounts**.

The Azure app registration's Graph delegated scopes are now configured, so this is testable end-to-end on a real M365 mailbox.

### What's implemented
- **`GraphClient`** — thin `HttpClient` wrapper over Graph v1.0: per-request bearer token (Graph scopes), `@odata.nextLink` paging, 429 `Retry-After` retry. Raw `HttpClient` (no Graph SDK) per the dev spec, with an injectable `HttpClient` for tests.
- **`GraphMailService : IMailService`** — read path live: `ConnectAsync` (`/me`), folders, message summaries, message detail (body + attachments, inline excluded), `MarkReadAsync` (`PATCH isRead`), inbox status, drafts-name, folder ids.
- **`OAuthService`** — `GraphMailScopes` + scope selection by `BackendKind`; per-call `GetAccessTokenAsync(scopes)` overload.
- **DI + runtime registration** — `App.xaml.cs` builds the Graph backend and registers each account by `BackendKind`; `MainViewModel.RegisterAccountBackend` binds runtime-added accounts (this is the PR 3 follow-up you flagged).
- **Add Account** — the "Microsoft 365" option is now selectable and saveable; "Sign in with Microsoft" requests Graph scopes.

### Decisions / deviations from the skeleton (dev §6.10 "as built")
1. **`StartIdleWatchers` is a no-op, not a throw.** The spec skeleton threw, but Graph has no IMAP IDLE and a *throw* would break a mixed IMAP+Graph account list at startup. Same for `NoOpAsync`/`PollAsync`/`FetchPreviewsAsync`/`CountTrashMessagesAsync` — safe no-ops so the read/sync path never throws. Real mutations + attachment download + folder CRUD throw `NotImplementedException` (PR 5/6).
2. **Runtime registration** via a `RegisterAccountBackend` delegate (set in `App.xaml.cs`, invoked in `LoadAccountList`) — so a Graph account added at runtime routes to Graph, not the router's IMAP fallback.
3. **Bounded summary fetch** — message-summary calls fetch a single `$top`-bounded page (mirroring IMAP `initialCount`); only folder lists and `GetFolderMessageIdsAsync` follow `nextLink` to completion.
4. **Test Connection for Graph** directs to "Sign in with Microsoft" — a not-yet-saved account isn't registered in the router (would route to IMAP), and the sign-in (`/me` + token) is itself the verification.
5. **Incremental sync:** `GetMaxMessageKeyAsync` is always `"0"` for Graph (non-numeric ids), so a Graph folder always takes the "recent N / since-date" branch — correct; delta polling makes it efficient in PR 7.

### Verification
- `dotnet build -c Release` clean (0 warnings, 0 errors).
- **472 tests pass.** New `GraphMailServiceTests` use an `HttpMessageHandler` stub to verify folder/summary/detail mapping, special-folder flags, `@odata.nextLink` paging, the `$filter` on `GetMessagesSinceDateAsync`, and that mutations throw.

Read-only by design: send is PR 5, mutations PR 6, notifications PR 7. No CHANGELOG entry (gated/internal).
