### PR TITLE
Graph send path (PR 5)

### DIFF
--- a/QuickMail.Tests/GraphMailServiceTests.cs
+++ b/QuickMail.Tests/GraphMailServiceTests.cs
@@ -216,8 +216,15 @@ public class GraphMailServiceTests
         // These throw synchronously (expression-bodied `=> throw ...`), so the discard keeps the
         // lambda an Action rather than a Func<Task>.
         Assert.Throws<NotImplementedException>(() => { _ = svc.MoveToTrashAsync(Guid.NewGuid(), "inbox", "m1"); });
-        Assert.Throws<NotImplementedException>(() => { _ = svc.AppendToSentAsync(Guid.NewGuid(), new ComposeModel()); });
         Assert.Throws<NotImplementedException>(() => { _ = svc.CreateFolderAsync(Guid.NewGuid(), null, "New"); });
+    }
+
+    [Fact]
+    public void AppendToSentAsync_IsNoOp_ForGraph()
+    {
+        // Graph /sendMail auto-saves to Sent, so the post-send append is a no-op (not a throw).
+        var (svc, _) = Make(url => (HttpStatusCode.OK, "{}"));
+        Assert.True(svc.AppendToSentAsync(Guid.NewGuid(), new ComposeModel()).IsCompletedSuccessfully);
     }
 
     [Fact]

--- a/QuickMail.Tests/GraphSendMailServiceTests.cs
+++ b/QuickMail.Tests/GraphSendMailServiceTests.cs
@@ -77,8 +77,28 @@ public class GraphSendMailServiceTests
 
         Assert.Equal("https://graph.microsoft.com/v1.0/me/sendMail", handler.Url);
         var mime = DecodeMime(handler.Body!);
-        Assert.Contains("organizer@x.com", mime);
+        Assert.Contains("<me@contoso.com>", mime);                   // From carries the sending account
+        Assert.Contains("organizer@x.com", mime);                    // To is the organizer
         Assert.Contains("method=REPLY", mime.Replace("\"", "")); // calendar method survives the round-trip
+    }
+
+    [Fact]
+    public async Task SendIcsReplyAsync_Throws_ForNullContent()
+    {
+        // A descriptive ArgumentException at the call site beats an NRE from inside MimeKit.
+        var (svc, handler) = Make();
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => svc.SendIcsReplyAsync(null!, GraphAccount(), null, "organizer@x.com"));
+        Assert.Null(handler.Url); // never reached the network
+    }
+
+    [Fact]
+    public async Task SendIcsReplyAsync_Throws_ForMissingOrganizer()
+    {
+        var (svc, handler) = Make();
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => svc.SendIcsReplyAsync("BEGIN:VCALENDAR\nEND:VCALENDAR", GraphAccount(), null, ""));
+        Assert.Null(handler.Url);
     }
 
     [Fact]

--- a/QuickMail.Tests/GraphSendMailServiceTests.cs
+++ b/QuickMail.Tests/GraphSendMailServiceTests.cs
@@ -12,9 +12,12 @@ namespace QuickMail.Tests;
 
 public class GraphSendMailServiceTests
 {
-    /// <summary>Captures the single request it serves and returns 202 Accepted (Graph /sendMail).</summary>
+    /// <summary>Captures the single request it serves and returns the configured status (202 by default).</summary>
     private sealed class CapturingHandler : HttpMessageHandler
     {
+        private readonly HttpStatusCode _status;
+        public CapturingHandler(HttpStatusCode status = HttpStatusCode.Accepted) => _status = status;
+
         public string? Url { get; private set; }
         public string? ContentType { get; private set; }
         public byte[]? Body { get; private set; }
@@ -27,13 +30,15 @@ public class GraphSendMailServiceTests
                 ContentType = request.Content.Headers.ContentType?.MediaType;
                 Body = await request.Content.ReadAsByteArrayAsync(ct);
             }
-            return new HttpResponseMessage(HttpStatusCode.Accepted);
+            // Always attach a body so a non-2xx response is surfaced via EnsureSuccessAsync
+            // (which reads the error body) rather than NRE-ing on null content.
+            return new HttpResponseMessage(_status) { Content = new StringContent("{}", Encoding.UTF8, "application/json") };
         }
     }
 
-    private static (GraphSendMailService Svc, CapturingHandler Handler) Make()
+    private static (GraphSendMailService Svc, CapturingHandler Handler) Make(HttpStatusCode status = HttpStatusCode.Accepted)
     {
-        var handler = new CapturingHandler();
+        var handler = new CapturingHandler(status);
         return (new GraphSendMailService(new StubOAuthService(), new HttpClient(handler)), handler);
     }
 
@@ -74,5 +79,16 @@ public class GraphSendMailServiceTests
         var mime = DecodeMime(handler.Body!);
         Assert.Contains("organizer@x.com", mime);
         Assert.Contains("method=REPLY", mime.Replace("\"", "")); // calendar method survives the round-trip
+    }
+
+    [Fact]
+    public async Task SendAsync_SurfacesNon2xxResponse_AsException()
+    {
+        // A failed /sendMail must propagate — a silently-swallowed send would tell the user the
+        // message was sent when it wasn't. GraphClient.EnsureSuccessAsync throws on non-2xx.
+        var (svc, _) = Make(HttpStatusCode.InternalServerError);
+        var compose = new ComposeModel { To = "alice@x.com", Subject = "Hi", Body = "Hello" };
+
+        await Assert.ThrowsAsync<HttpRequestException>(() => svc.SendAsync(compose, GraphAccount(), null));
     }
 }

--- a/QuickMail.Tests/GraphSendMailServiceTests.cs
+++ b/QuickMail.Tests/GraphSendMailServiceTests.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using QuickMail.Models;
+using QuickMail.Services;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+public class GraphSendMailServiceTests
+{
+    /// <summary>Captures the single request it serves and returns 202 Accepted (Graph /sendMail).</summary>
+    private sealed class CapturingHandler : HttpMessageHandler
+    {
+        public string? Url { get; private set; }
+        public string? ContentType { get; private set; }
+        public byte[]? Body { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            Url = request.RequestUri!.ToString();
+            if (request.Content != null)
+            {
+                ContentType = request.Content.Headers.ContentType?.MediaType;
+                Body = await request.Content.ReadAsByteArrayAsync(ct);
+            }
+            return new HttpResponseMessage(HttpStatusCode.Accepted);
+        }
+    }
+
+    private static (GraphSendMailService Svc, CapturingHandler Handler) Make()
+    {
+        var handler = new CapturingHandler();
+        return (new GraphSendMailService(new StubOAuthService(), new HttpClient(handler)), handler);
+    }
+
+    private static AccountModel GraphAccount() => new()
+    {
+        Id = Guid.NewGuid(),
+        Username = "me@contoso.com",
+        BackendKind = BackendKind.MicrosoftGraph,
+    };
+
+    /// <summary>The body is ASCII base64; decode it back to the raw MIME text.</summary>
+    private static string DecodeMime(byte[] body) =>
+        Encoding.UTF8.GetString(Convert.FromBase64String(Encoding.ASCII.GetString(body)));
+
+    [Fact]
+    public async Task SendAsync_PostsBase64MimeToSendMail()
+    {
+        var (svc, handler) = Make();
+        var compose = new ComposeModel { To = "alice@x.com", Subject = "Hi there", Body = "Hello" };
+
+        await svc.SendAsync(compose, GraphAccount(), null);
+
+        Assert.Equal("https://graph.microsoft.com/v1.0/me/sendMail", handler.Url);
+        Assert.Equal("text/plain", handler.ContentType);
+        var mime = DecodeMime(handler.Body!);
+        Assert.Contains("Subject: Hi there", mime);
+        Assert.Contains("alice@x.com", mime);
+    }
+
+    [Fact]
+    public async Task SendIcsReplyAsync_PostsCalendarReplyToSendMail()
+    {
+        var (svc, handler) = Make();
+
+        await svc.SendIcsReplyAsync("BEGIN:VCALENDAR\nEND:VCALENDAR", GraphAccount(), null, "organizer@x.com");
+
+        Assert.Equal("https://graph.microsoft.com/v1.0/me/sendMail", handler.Url);
+        var mime = DecodeMime(handler.Body!);
+        Assert.Contains("organizer@x.com", mime);
+        Assert.Contains("method=REPLY", mime.Replace("\"", "")); // calendar method survives the round-trip
+    }
+}

--- a/QuickMail.Tests/SmtpServiceDispatchTests.cs
+++ b/QuickMail.Tests/SmtpServiceDispatchTests.cs
@@ -52,4 +52,18 @@ public class SmtpServiceDispatchTests
 
         Assert.True(graph.IcsCalled);
     }
+
+    [Fact]
+    public async Task SendAsync_DoesNotRouteImapAccount_ToGraphBackend()
+    {
+        var graph = new RecordingSmtp();
+        var svc = new SmtpService(new StubOAuthService(), graph);
+        // ImapSmtp account with an empty SMTP host: the MailKit path is taken and fails fast on
+        // connect. The point is the dispatch must NOT hand an IMAP account to the Graph sender.
+        var account = new AccountModel { Id = Guid.NewGuid(), Username = "me@example.com", BackendKind = BackendKind.ImapSmtp, SmtpHost = "" };
+
+        await Assert.ThrowsAnyAsync<Exception>(() => svc.SendAsync(new ComposeModel(), account, "pw"));
+
+        Assert.False(graph.SendCalled); // took the MailKit path, not the Graph dispatch
+    }
 }

--- a/QuickMail.Tests/SmtpServiceDispatchTests.cs
+++ b/QuickMail.Tests/SmtpServiceDispatchTests.cs
@@ -66,4 +66,17 @@ public class SmtpServiceDispatchTests
 
         Assert.False(graph.SendCalled); // took the MailKit path, not the Graph dispatch
     }
+
+    [Fact]
+    public async Task SendIcsReplyAsync_DoesNotRouteImapAccount_ToGraphBackend()
+    {
+        var graph = new RecordingSmtp();
+        var svc = new SmtpService(new StubOAuthService(), graph);
+        var account = new AccountModel { Id = Guid.NewGuid(), Username = "me@example.com", BackendKind = BackendKind.ImapSmtp, SmtpHost = "" };
+
+        await Assert.ThrowsAnyAsync<Exception>(
+            () => svc.SendIcsReplyAsync("BEGIN:VCALENDAR\nEND:VCALENDAR", account, "pw", "organizer@x.com"));
+
+        Assert.False(graph.IcsCalled); // took the MailKit path, not the Graph dispatch
+    }
 }

--- a/QuickMail.Tests/SmtpServiceDispatchTests.cs
+++ b/QuickMail.Tests/SmtpServiceDispatchTests.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using QuickMail.Models;
+using QuickMail.Services;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+public class SmtpServiceDispatchTests
+{
+    /// <summary>Records which method was invoked, so we can assert routing without any network.</summary>
+    private sealed class RecordingSmtp : ISendMailService
+    {
+        public bool SendCalled { get; private set; }
+        public bool IcsCalled { get; private set; }
+
+        public Task SendAsync(ComposeModel compose, AccountModel account, string? password, CancellationToken ct = default)
+        {
+            SendCalled = true;
+            return Task.CompletedTask;
+        }
+
+        public Task SendIcsReplyAsync(string icsReplyContent, AccountModel account, string? password,
+            string organizerEmail, CancellationToken ct = default)
+        {
+            IcsCalled = true;
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public async Task SendAsync_RoutesGraphAccount_ToGraphBackend()
+    {
+        var graph = new RecordingSmtp();
+        var svc = new SmtpService(new StubOAuthService(), graph);
+        var account = new AccountModel { Id = Guid.NewGuid(), Username = "me@contoso.com", BackendKind = BackendKind.MicrosoftGraph };
+
+        await svc.SendAsync(new ComposeModel(), account, null);
+
+        Assert.True(graph.SendCalled); // dispatched, never reached the MailKit SmtpClient
+    }
+
+    [Fact]
+    public async Task SendIcsReplyAsync_RoutesGraphAccount_ToGraphBackend()
+    {
+        var graph = new RecordingSmtp();
+        var svc = new SmtpService(new StubOAuthService(), graph);
+        var account = new AccountModel { Id = Guid.NewGuid(), Username = "me@contoso.com", BackendKind = BackendKind.MicrosoftGraph };
+
+        await svc.SendIcsReplyAsync("BEGIN:VCALENDAR\nEND:VCALENDAR", account, null, "organizer@x.com");
+
+        Assert.True(graph.IcsCalled);
+    }
+}

--- a/QuickMail.Tests/StubServices.cs
+++ b/QuickMail.Tests/StubServices.cs
@@ -53,7 +53,7 @@ sealed class StubImapMailService : IMailService
     public void Dispose() { }
 }
 
-sealed class StubSmtpService : ISmtpService
+sealed class StubSmtpService : ISendMailService
 {
     public Task SendAsync(ComposeModel compose, AccountModel account, string? password, CancellationToken ct = default) => Task.CompletedTask;
     public Task SendIcsReplyAsync(string icsReplyContent, AccountModel account, string? password,

--- a/QuickMail/App.xaml.cs
+++ b/QuickMail/App.xaml.cs
@@ -9,6 +9,9 @@ namespace QuickMail;
 
 public partial class App : Application
 {
+    // Held so OnExit can dispose it — it owns a GraphClient/HttpClient.
+    private GraphSendMailService? _graphSendMail;
+
     protected override void OnStartup(StartupEventArgs e)
     {
         base.OnStartup(e);
@@ -75,8 +78,8 @@ public partial class App : Application
             var configService     = new ConfigService(profile);
             var imapBackend       = new ImapMailService(oauthService, configService);
             var graphBackend      = new GraphMailService(oauthService, configService);
-            var graphSendMail     = new GraphSendMailService(oauthService);
-            var smtpService       = new SmtpService(oauthService, graphSendMail);
+            _graphSendMail        = new GraphSendMailService(oauthService);
+            var smtpService       = new SmtpService(oauthService, _graphSendMail);
 
             // Per-account mail backend router. Each account is registered to the backend its
             // BackendKind selects (IMAP by default, Graph for Microsoft 365 accounts).
@@ -128,6 +131,13 @@ public partial class App : Application
                 LogService.Log("Startup", cur);
             throw;
         }
+    }
+
+    protected override void OnExit(ExitEventArgs e)
+    {
+        // GraphSendMailService owns a GraphClient (and its HttpClient) — release it on exit.
+        _graphSendMail?.Dispose();
+        base.OnExit(e);
     }
 
     /// <summary>

--- a/QuickMail/App.xaml.cs
+++ b/QuickMail/App.xaml.cs
@@ -75,7 +75,8 @@ public partial class App : Application
             var configService     = new ConfigService(profile);
             var imapBackend       = new ImapMailService(oauthService, configService);
             var graphBackend      = new GraphMailService(oauthService, configService);
-            var smtpService       = new SmtpService(oauthService);
+            var graphSendMail     = new GraphSendMailService(oauthService);
+            var smtpService       = new SmtpService(oauthService, graphSendMail);
 
             // Per-account mail backend router. Each account is registered to the backend its
             // BackendKind selects (IMAP by default, Graph for Microsoft 365 accounts).

--- a/QuickMail/Services/Graph/GraphClient.cs
+++ b/QuickMail/Services/Graph/GraphClient.cs
@@ -63,12 +63,28 @@ public sealed class GraphClient : IDisposable
     public async Task PatchAsync(AccountModel account, string path, object body, CancellationToken ct = default)
     {
         var json = JsonSerializer.Serialize(body, JsonOpts);
-        using var resp = await SendAsync(account, HttpMethod.Patch, path, json, ct);
+        using var resp = await SendAsync(account, HttpMethod.Patch, path,
+            () => new StringContent(json, Encoding.UTF8, "application/json"), ct);
+        await EnsureSuccessAsync(resp, ct);
+    }
+
+    /// <summary>
+    /// POSTs an already-encoded raw body with an explicit content type. Used by the Graph send
+    /// path: <c>/me/sendMail</c> takes a base64-encoded MIME message as <c>text/plain</c>.
+    /// </summary>
+    public async Task PostRawAsync(AccountModel account, string path, byte[] body, string contentType, CancellationToken ct = default)
+    {
+        using var resp = await SendAsync(account, HttpMethod.Post, path, () =>
+        {
+            var content = new ByteArrayContent(body);
+            content.Headers.ContentType = new MediaTypeHeaderValue(contentType);
+            return content;
+        }, ct);
         await EnsureSuccessAsync(resp, ct);
     }
 
     private async Task<HttpResponseMessage> SendAsync(
-        AccountModel account, HttpMethod method, string pathOrUrl, string? jsonBody, CancellationToken ct)
+        AccountModel account, HttpMethod method, string pathOrUrl, Func<HttpContent>? contentFactory, CancellationToken ct)
     {
         var url = pathOrUrl.StartsWith("http", StringComparison.OrdinalIgnoreCase) ? pathOrUrl : BaseUrl + pathOrUrl;
 
@@ -78,8 +94,8 @@ public sealed class GraphClient : IDisposable
             var token = await _oauth.GetAccessTokenAsync(account, OAuthService.GraphMailScopes, ct);
             using var req = new HttpRequestMessage(method, url);
             req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            if (jsonBody != null)
-                req.Content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
+            if (contentFactory != null)
+                req.Content = contentFactory(); // fresh per attempt — content can't be resent after a 429
 
             var resp = await _http.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, ct);
             if (resp.StatusCode != (HttpStatusCode)429 || attempt >= 2)

--- a/QuickMail/Services/GraphMailService.cs
+++ b/QuickMail/Services/GraphMailService.cs
@@ -236,8 +236,9 @@ public class GraphMailService : IMailService
         => throw NotYet(nameof(EmptyTrashAsync));
     public Task<string> AppendDraftAsync(Guid accountId, ComposeModel draft, string? replaceMessageId, CancellationToken ct = default)
         => throw NotYet(nameof(AppendDraftAsync));
+    // Graph's /sendMail auto-saves the sent message to the Sent folder, so there is nothing to append.
     public Task AppendToSentAsync(Guid accountId, ComposeModel sent, CancellationToken ct = default)
-        => throw NotYet(nameof(AppendToSentAsync));
+        => Task.CompletedTask;
     public Task<byte[]> DownloadAttachmentAsync(Guid accountId, string folderName, string messageId, string partSpecifier, CancellationToken ct = default)
         => throw NotYet(nameof(DownloadAttachmentAsync));
     public Task CopyMessagesAsync(Guid accountId, string folderName, IList<string> messageIds, string destinationFolder, CancellationToken ct = default)

--- a/QuickMail/Services/GraphSendMailService.cs
+++ b/QuickMail/Services/GraphSendMailService.cs
@@ -1,8 +1,7 @@
 using System;
+using System.Buffers.Text;
 using System.IO;
 using System.Net.Http;
-using System.Reflection;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using MimeKit;
@@ -16,17 +15,15 @@ namespace QuickMail.Services;
 /// (base64-encoded, <c>Content-Type: text/plain</c>); Graph delivers it and auto-saves a copy
 /// to the Sent folder, so <see cref="IMailService.AppendToSentAsync"/> is a no-op for Graph.
 /// </summary>
-public class GraphSendMailService : ISendMailService
+public class GraphSendMailService : ISendMailService, IDisposable
 {
     private readonly GraphClient _client;
-    private static readonly string UserAgent =
-        "QuickMail/" + (Assembly.GetExecutingAssembly().GetName().Version?.ToString(3) ?? "0");
 
     /// <param name="http">Optional injected HttpClient for tests; null uses a real one.</param>
     public GraphSendMailService(IOAuthService oauth, HttpClient? http = null) => _client = new GraphClient(oauth, http);
 
     public Task SendAsync(ComposeModel compose, AccountModel account, string? password, CancellationToken ct = default)
-        => SendMimeAsync(account, MimeMessageBuilder.Build(compose, account, UserAgent), ct);
+        => SendMimeAsync(account, MimeMessageBuilder.Build(compose, account, MimeMessageBuilder.AppUserAgent), ct);
 
     public Task SendIcsReplyAsync(string icsReplyContent, AccountModel account, string? password,
         string organizerEmail, CancellationToken ct = default)
@@ -36,13 +33,17 @@ public class GraphSendMailService : ISendMailService
     {
         using var ms = new MemoryStream();
         await message.WriteToAsync(ms, ct);
-        var mimeBytes = ms.ToArray();
+        int mimeLength = (int)ms.Length;
 
-        // Graph /sendMail takes the MIME message base64-encoded, sent as a text/plain body.
-        var body = Encoding.ASCII.GetBytes(Convert.ToBase64String(mimeBytes));
+        // Graph /sendMail takes the MIME message base64-encoded as a text/plain body. Encode the
+        // MIME bytes straight to base64 ASCII bytes — no intermediate base64 string allocation.
+        var body = new byte[Base64.GetMaxEncodedToUtf8Length(mimeLength)];
+        Base64.EncodeToUtf8(ms.GetBuffer().AsSpan(0, mimeLength), body, out _, out _);
 
-        LogService.Log($"GraphSendMailService: sending {mimeBytes.Length} MIME bytes via /me/sendMail");
+        LogService.Log($"GraphSendMailService: sending {mimeLength} MIME bytes via /me/sendMail");
         await _client.PostRawAsync(account, "/me/sendMail", body, "text/plain", ct);
         LogService.Log("GraphSendMailService: send complete");
     }
+
+    public void Dispose() => _client.Dispose();
 }

--- a/QuickMail/Services/GraphSendMailService.cs
+++ b/QuickMail/Services/GraphSendMailService.cs
@@ -1,0 +1,48 @@
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Reflection;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using MimeKit;
+using QuickMail.Models;
+using QuickMail.Services.Graph;
+
+namespace QuickMail.Services;
+
+/// <summary>
+/// Send path for Microsoft Graph accounts. Posts a MIME message to <c>/me/sendMail</c>
+/// (base64-encoded, <c>Content-Type: text/plain</c>); Graph delivers it and auto-saves a copy
+/// to the Sent folder, so <see cref="IMailService.AppendToSentAsync"/> is a no-op for Graph.
+/// </summary>
+public class GraphSendMailService : ISendMailService
+{
+    private readonly GraphClient _client;
+    private static readonly string UserAgent =
+        "QuickMail/" + (Assembly.GetExecutingAssembly().GetName().Version?.ToString(3) ?? "0");
+
+    /// <param name="http">Optional injected HttpClient for tests; null uses a real one.</param>
+    public GraphSendMailService(IOAuthService oauth, HttpClient? http = null) => _client = new GraphClient(oauth, http);
+
+    public Task SendAsync(ComposeModel compose, AccountModel account, string? password, CancellationToken ct = default)
+        => SendMimeAsync(account, MimeMessageBuilder.Build(compose, account, UserAgent), ct);
+
+    public Task SendIcsReplyAsync(string icsReplyContent, AccountModel account, string? password,
+        string organizerEmail, CancellationToken ct = default)
+        => SendMimeAsync(account, MimeMessageBuilder.BuildIcsReply(account, icsReplyContent, organizerEmail), ct);
+
+    private async Task SendMimeAsync(AccountModel account, MimeMessage message, CancellationToken ct)
+    {
+        using var ms = new MemoryStream();
+        await message.WriteToAsync(ms, ct);
+        var mimeBytes = ms.ToArray();
+
+        // Graph /sendMail takes the MIME message base64-encoded, sent as a text/plain body.
+        var body = Encoding.ASCII.GetBytes(Convert.ToBase64String(mimeBytes));
+
+        LogService.Log($"GraphSendMailService: sending {mimeBytes.Length} MIME bytes via /me/sendMail");
+        await _client.PostRawAsync(account, "/me/sendMail", body, "text/plain", ct);
+        LogService.Log("GraphSendMailService: send complete");
+    }
+}

--- a/QuickMail/Services/ISendMailService.cs
+++ b/QuickMail/Services/ISendMailService.cs
@@ -4,7 +4,7 @@ using QuickMail.Models;
 
 namespace QuickMail.Services;
 
-public interface ISmtpService
+public interface ISendMailService
 {
     Task SendAsync(ComposeModel compose, AccountModel account, string? password, CancellationToken ct = default);
 

--- a/QuickMail/Services/MimeMessageBuilder.cs
+++ b/QuickMail/Services/MimeMessageBuilder.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using MimeKit;
 using QuickMail.Helpers;
@@ -15,6 +16,10 @@ namespace QuickMail.Services;
 /// </summary>
 public static class MimeMessageBuilder
 {
+    /// <summary>The User-Agent string for outgoing mail — one source of truth for every sender.</summary>
+    internal static readonly string AppUserAgent =
+        "QuickMail/" + (Assembly.GetExecutingAssembly().GetName().Version?.ToString(3) ?? "0");
+
     /// <summary>
     /// Builds a complete MIME message from compose fields, including attachments.
     /// </summary>
@@ -100,6 +105,8 @@ public static class MimeMessageBuilder
     /// <param name="organizerEmail">The event organizer's address (the reply recipient).</param>
     public static MimeMessage BuildIcsReply(AccountModel account, string icsReplyContent, string organizerEmail)
     {
+        if (string.IsNullOrWhiteSpace(icsReplyContent))
+            throw new ArgumentException("ICS reply content is required.", nameof(icsReplyContent));
         if (string.IsNullOrWhiteSpace(organizerEmail))
             throw new ArgumentException("Organizer email is required for ICS reply.", nameof(organizerEmail));
 

--- a/QuickMail/Services/MimeMessageBuilder.cs
+++ b/QuickMail/Services/MimeMessageBuilder.cs
@@ -1,5 +1,7 @@
+using System;
 using System.IO;
 using System.Linq;
+using System.Text;
 using MimeKit;
 using QuickMail.Helpers;
 using QuickMail.Models;
@@ -86,6 +88,34 @@ public static class MimeMessageBuilder
             message.Body = bodyEntity;
         }
 
+        return message;
+    }
+
+    /// <summary>
+    /// Builds a calendar REPLY message (accept/decline/tentative) addressed to the event organizer.
+    /// Shared by the SMTP and Graph send paths.
+    /// </summary>
+    /// <param name="account">The sender account (used for the From header).</param>
+    /// <param name="icsReplyContent">A full iCalendar REPLY payload.</param>
+    /// <param name="organizerEmail">The event organizer's address (the reply recipient).</param>
+    public static MimeMessage BuildIcsReply(AccountModel account, string icsReplyContent, string organizerEmail)
+    {
+        if (string.IsNullOrWhiteSpace(organizerEmail))
+            throw new ArgumentException("Organizer email is required for ICS reply.", nameof(organizerEmail));
+
+        var message = new MimeMessage();
+        message.From.Add(new MailboxAddress(account.SenderDisplayName, account.Username));
+        message.To.Add(MailboxAddress.Parse(organizerEmail));
+        message.Subject = "Calendar Response";
+
+        var calendarPart = new TextPart("calendar")
+        {
+            ContentTransferEncoding = ContentEncoding.Base64,
+        };
+        calendarPart.ContentType.Parameters.Add("method", "REPLY");
+        calendarPart.SetText(Encoding.UTF8, icsReplyContent);
+
+        message.Body = calendarPart;
         return message;
     }
 }

--- a/QuickMail/Services/SmtpService.cs
+++ b/QuickMail/Services/SmtpService.cs
@@ -1,4 +1,3 @@
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using MailKit.Net.Smtp;
@@ -11,8 +10,6 @@ public class SmtpService : ISendMailService
 {
     private readonly IOAuthService _oauth;
     private readonly ISendMailService _graphSmtp;
-    private static readonly string UserAgent =
-        "QuickMail/" + (Assembly.GetExecutingAssembly().GetName().Version?.ToString(3) ?? "0");
 
     public SmtpService(IOAuthService oauth, ISendMailService graphSmtp)
     {
@@ -28,7 +25,7 @@ public class SmtpService : ISendMailService
             return;
         }
 
-        var message = MimeMessageBuilder.Build(compose, account, UserAgent);
+        var message = MimeMessageBuilder.Build(compose, account, MimeMessageBuilder.AppUserAgent);
 
         using var client = new SmtpClient();
 

--- a/QuickMail/Services/SmtpService.cs
+++ b/QuickMail/Services/SmtpService.cs
@@ -1,24 +1,33 @@
 using System.Reflection;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using MailKit.Net.Smtp;
 using MailKit.Security;
-using MimeKit;
 using QuickMail.Models;
 
 namespace QuickMail.Services;
 
-public class SmtpService : ISmtpService
+public class SmtpService : ISendMailService
 {
     private readonly IOAuthService _oauth;
+    private readonly ISendMailService _graphSmtp;
     private static readonly string UserAgent =
         "QuickMail/" + (Assembly.GetExecutingAssembly().GetName().Version?.ToString(3) ?? "0");
 
-    public SmtpService(IOAuthService oauth) => _oauth = oauth;
+    public SmtpService(IOAuthService oauth, ISendMailService graphSmtp)
+    {
+        _oauth = oauth;
+        _graphSmtp = graphSmtp;
+    }
 
     public async Task SendAsync(ComposeModel compose, AccountModel account, string? password, CancellationToken ct = default)
     {
+        if (account.BackendKind == BackendKind.MicrosoftGraph)
+        {
+            await _graphSmtp.SendAsync(compose, account, password, ct);
+            return;
+        }
+
         var message = MimeMessageBuilder.Build(compose, account, UserAgent);
 
         using var client = new SmtpClient();
@@ -61,24 +70,13 @@ public class SmtpService : ISmtpService
     public async Task SendIcsReplyAsync(string icsReplyContent, AccountModel account, string? password,
         string organizerEmail, CancellationToken ct = default)
     {
-        var message = new MimeMessage();
-        message.From.Add(new MailboxAddress(account.SenderDisplayName, account.Username));
-
-        if (string.IsNullOrWhiteSpace(organizerEmail))
-            throw new ArgumentException("Organizer email is required for ICS reply.", nameof(organizerEmail));
-
-        message.To.Add(MailboxAddress.Parse(organizerEmail));
-
-        message.Subject = "Calendar Response";
-
-        var calendarPart = new TextPart("calendar")
+        if (account.BackendKind == BackendKind.MicrosoftGraph)
         {
-            ContentTransferEncoding = ContentEncoding.Base64,
-        };
-        calendarPart.ContentType.Parameters.Add("method", "REPLY");
-        calendarPart.SetText(Encoding.UTF8, icsReplyContent);
+            await _graphSmtp.SendIcsReplyAsync(icsReplyContent, account, password, organizerEmail, ct);
+            return;
+        }
 
-        message.Body = calendarPart;
+        var message = MimeMessageBuilder.BuildIcsReply(account, icsReplyContent, organizerEmail);
 
         using var client = new SmtpClient();
 

--- a/QuickMail/ViewModels/ComposeViewModel.cs
+++ b/QuickMail/ViewModels/ComposeViewModel.cs
@@ -16,7 +16,7 @@ namespace QuickMail.ViewModels;
 
 public partial class ComposeViewModel : ObservableObject
 {
-    private readonly ISmtpService _smtp;
+    private readonly ISendMailService _smtp;
     private readonly IAccountService _accountService;
     private readonly ICredentialService _credentials;
     private readonly IMailService _imap;
@@ -118,7 +118,7 @@ public partial class ComposeViewModel : ObservableObject
     /// </summary>
     public Func<string, string, bool>? ConfirmationRequested { get; set; }
 
-    public ComposeViewModel(ISmtpService smtp, IAccountService accountService, ICredentialService credentials, IMailService imap, ITemplateService templateService, IMarkdownService? markdown = null)
+    public ComposeViewModel(ISendMailService smtp, IAccountService accountService, ICredentialService credentials, IMailService imap, ITemplateService templateService, IMarkdownService? markdown = null)
     {
         _smtp = smtp;
         _accountService = accountService;

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -29,7 +29,7 @@ public partial class MainViewModel : ObservableObject
     private readonly IViewService _viewService;
     private readonly ICommandRegistry _commandRegistry;
     private readonly IRuleService _ruleService;
-    private readonly ISmtpService _smtp;
+    private readonly ISendMailService _smtp;
 
     // Separate CTS per operation type so they can't cancel each other accidentally
     private CancellationTokenSource? _connectCts;
@@ -633,7 +633,7 @@ public partial class MainViewModel : ObservableObject
         ICommandRegistry commandRegistry,
         IViewService viewService,
         IRuleService ruleService,
-        ISmtpService smtpService,
+        ISendMailService smtpService,
         bool onlineMode = false)
     {
         _imap            = imap;

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -80,7 +80,7 @@ public partial class MainWindow : Window
     private static readonly TimeSpan TypeAheadResetDelay = TimeSpan.FromSeconds(1);
 
     private readonly MainViewModel _vm;
-    private readonly ISmtpService _smtp;
+    private readonly ISendMailService _smtp;
     private readonly IAccountService _accountService;
     private readonly ICredentialService _credentials;
     private readonly IMailService _imap;
@@ -127,7 +127,7 @@ public partial class MainWindow : Window
 
     public MainWindow(
         MainViewModel vm,
-        ISmtpService smtp,
+        ISendMailService smtp,
         IAccountService accountService,
         ICredentialService credentials,
         IMailService imap,

--- a/docs/planning/graph-backend-dev-spec.md
+++ b/docs/planning/graph-backend-dev-spec.md
@@ -1002,7 +1002,7 @@ foreach (var account in accountService.LoadAccounts())
 
 // SMTP — single service that delegates internally:
 var graphSendMail = new GraphSendMailService(oauthService);
-var smtpService = new SmtpService(oauthService, graphSmtpService);
+var smtpService = new SmtpService(oauthService, graphSendMail);
 
 // Change notifier — composite over both backends:
 var imapNotifier = new ImapChangeNotifier(imapBackend);

--- a/docs/planning/graph-backend-dev-spec.md
+++ b/docs/planning/graph-backend-dev-spec.md
@@ -33,7 +33,7 @@
    - [6.8 `OAuthService.cs` — Per-Call Scopes](#68-oauthservicecs--per-call-scopes)
    - [6.9 `AddAccountViewModel.cs` & Dialog — Account Type Combo](#69-addaccountviewmodelcs--dialog--account-type-combo)
    - [6.10 `GraphMailService.cs` — Read Path](#610-graphmailservicecs--read-path)
-   - [6.11 `GraphSmtpService.cs` — Send Path](#611-graphsmtpservicecs--send-path)
+   - [6.11 `GraphSendMailService.cs` — Send Path](#611-graphsendmailservicecs--send-path)
    - [6.12 `GraphChangeNotifier.cs` — Delta Polling](#612-graphchangenotifiercs--delta-polling)
    - [6.13 `App.xaml.cs` — DI Wiring](#613-appxamlcs--di-wiring)
 7. [Tests](#7-tests)
@@ -78,7 +78,7 @@ This spec implements the [Microsoft Graph Backend PM spec](graph-backend-pm-spec
 | 2 | `uint UniqueId` → `string MessageId`; SQLite schema migration v2 | v0.7 | ~800 |
 | 3 | `BackendKind` + `MailServiceRouter` + **`IFeatureGate` infrastructure** + Add Account UI combo (Microsoft 365 option visible only when `FeatureFlag.GraphBackend` is on) | v0.7 | ~500 |
 | 4 | `GraphMailService` read path + `OAuthService` per-call scopes | v0.8 | ~600 |
-| 5 | `GraphSmtpService` send path | v0.8 | ~150 |
+| 5 | `GraphSendMailService` send path | v0.8 | ~150 |
 | 6 | Graph attachments, folder CRUD, move/copy/delete | v0.8 | ~400 |
 | 7 | `IChangeNotifier`, `ImapChangeNotifier` (extracted), `GraphChangeNotifier` (delta polling) | v0.8 | ~300 |
 | 8 | Tests: `GraphMailServiceTests`, `MailServiceRouterTests`, `FeatureGateTests`, migration round-trip | v0.8 | ~450 |
@@ -100,7 +100,7 @@ Total: ~3100 LOC across ~27 files touched.
 | 6 | `QuickMail/Services/ImapMailService.cs` | 1 | Renamed class (file move from `ImapService.cs`) |
 | 7 | `QuickMail/Services/MailServiceRouter.cs` | 3 | Per-account `IMailService` dispatcher |
 | 8 | `QuickMail/Services/GraphMailService.cs` | 4 | Graph backend |
-| 9 | `QuickMail/Services/GraphSmtpService.cs` | 5 | Graph send via `/me/sendMail` |
+| 9 | `QuickMail/Services/GraphSendMailService.cs` | 5 | Graph send via `/me/sendMail` |
 | 10 | `QuickMail/Services/IChangeNotifier.cs` | 7 | Abstraction over IDLE / delta polling |
 | 11 | `QuickMail/Services/ImapChangeNotifier.cs` | 7 | Extracted from `ImapMailService.StartIdleWatchers` |
 | 12 | `QuickMail/Services/GraphChangeNotifier.cs` | 7 | Delta polling loop |
@@ -222,7 +222,7 @@ Strict ordering. Each PR is mergeable on its own and leaves the app behaviorally
 
 ### PR 5 — Graph send (1-2 evenings)
 
-1. `GraphSmtpService.cs`: implements `ISmtpService`. `SendAsync` posts the MIME from `MimeMessageBuilder` to `POST /me/sendMail` with `Content-Type: text/plain` and base64-encoded MIME body. Graph auto-saves to Sent — `AppendToSentAsync` becomes a no-op for Graph.
+1. `GraphSendMailService.cs`: implements `ISendMailService`. `SendAsync` posts the MIME from `MimeMessageBuilder` to `POST /me/sendMail` with `Content-Type: text/plain` and base64-encoded MIME body. Graph auto-saves to Sent — `AppendToSentAsync` becomes a no-op for Graph.
 2. `App.xaml.cs`: SMTP service is a router too — `SmtpServiceRouter` (simpler than mail; one method). Or: the existing `SmtpService` checks `account.BackendKind` and delegates. Simpler — go with the second.
 3. Modify `SmtpService.SendAsync`: at the top, `if (account.BackendKind == BackendKind.MicrosoftGraph) { await _graphSmtp.SendAsync(...); return; }`.
 4. Smoke: compose and send from an M365 account; verify it appears in Sent.
@@ -809,9 +809,9 @@ public class GraphMailService : IMailService
 - **`--online` mode (#62):** `GraphMailService` has **no `ILocalStoreService` dependency** — every read (connect, folders, summaries, detail, since-date) goes straight to Graph, so `--online` (which leaves the SQLite schema uncreated) is fully supported for Graph accounts with no behavioral difference. `GraphMailService_HasNoLocalStoreDependency_SoOnlineModeWorks` asserts this structurally so the property can't regress. The local-store-first/Graph-fallback pattern lives in `MainViewModel` (router → Graph), unchanged. No `--online`-specific limitations for Graph.
 - **429 retry (#64):** `GraphClient`'s `Retry-After`/default-delay handling is now covered by `GraphClientTests`; the default no-header delay is constructor-injectable (`defaultRetryDelay`, defaults to 2 s) so tests run without real waits.
 
-### 6.11 `GraphSmtpService.cs` — Send Path
+### 6.11 `GraphSendMailService.cs` — Send Path
 
-**Path:** `QuickMail/Services/GraphSmtpService.cs`
+**Path:** `QuickMail/Services/GraphSendMailService.cs`
 
 ```csharp
 using System;
@@ -826,13 +826,13 @@ using QuickMail.Services.Graph;
 
 namespace QuickMail.Services;
 
-public class GraphSmtpService : ISmtpService
+public class GraphSendMailService : ISendMailService
 {
     private readonly GraphClient _client;
     private static readonly string UserAgent =
         "QuickMail/" + (Assembly.GetExecutingAssembly().GetName().Version?.ToString(3) ?? "0");
 
-    public GraphSmtpService(IOAuthService oauth) => _client = new GraphClient(oauth);
+    public GraphSendMailService(IOAuthService oauth) => _client = new GraphClient(oauth);
 
     public async Task SendAsync(ComposeModel compose, AccountModel account, string? password, CancellationToken ct = default)
     {
@@ -845,12 +845,19 @@ public class GraphSmtpService : ISmtpService
         using var content = new ByteArrayContent(mimeBytes);
         content.Headers.ContentType = new MediaTypeHeaderValue("text/plain");
 
-        LogService.Log($"GraphSmtpService: sending {mimeBytes.Length} bytes via /me/sendMail");
+        LogService.Log($"GraphSendMailService: sending {mimeBytes.Length} bytes via /me/sendMail");
         await _client.PostRawAsync(account.Id, "/me/sendMail", content, ct);
-        LogService.Log("GraphSmtpService: send complete");
+        LogService.Log("GraphSendMailService: send complete");
     }
 }
 ```
+
+**PR 5 implementation notes (as built):**
+- **Naming (the class is named for what it does, not a protocol).** Built as **`GraphSendMailService`**, and the send abstraction `ISmtpService` was renamed to **`ISendMailService`** — "SMTP" implied the wire protocol, but the Graph path is pure REST (`/me/sendMail`). The genuinely-SMTP MailKit implementation keeps the accurate name `SmtpService`. `ISendMailService` (not `ISendMessageService`) because the contract is mail-shaped — `ComposeModel`/attachments/`SendIcsReplyAsync`/email account — and would not fit a future SMS/other-channel sender, which would get its own abstraction.
+- **Base64 MIME, not raw.** `/me/sendMail` with `Content-Type: text/plain` requires the body to be the **base64-encoded** MIME message (the raw-bytes snippet above was illustrative). `GraphSendMailService` builds the MIME with `MimeMessageBuilder`, base64-encodes it, and POSTs the ASCII base64 via `GraphClient.PostRawAsync`. Graph auto-saves to Sent.
+- **`GraphClient.PostRawAsync`** was added; `SendAsync` was refactored to take a `Func<HttpContent>?` content factory so the body is rebuilt on each 429 retry (an `HttpContent` can't be resent once consumed). Existing `GetAsync`/`PatchAsync` are unchanged in behavior.
+- **Both send methods dispatch.** `SmtpService` takes the `GraphSendMailService` as `ISendMailService graphSmtp` and routes **both** `SendAsync` and `SendIcsReplyAsync` to it when `BackendKind == MicrosoftGraph` — so calendar accept/decline replies also work for Graph accounts (via `/sendMail`). The ICS-reply MIME building moved to `MimeMessageBuilder.BuildIcsReply`, shared by both backends.
+- **`AppendToSentAsync` is a no-op for Graph** (was `NotImplementedException`) since `/sendMail` auto-saves; the post-send append in `ComposeViewModel` therefore no longer logs a benign failure for Graph accounts.
 
 `SmtpService.SendAsync` dispatches by `BackendKind`:
 
@@ -994,7 +1001,7 @@ foreach (var account in accountService.LoadAccounts())
 }
 
 // SMTP — single service that delegates internally:
-var graphSmtpService = new GraphSmtpService(oauthService);
+var graphSendMail = new GraphSendMailService(oauthService);
 var smtpService = new SmtpService(oauthService, graphSmtpService);
 
 // Change notifier — composite over both backends:

--- a/docs/planning/graph-backend-pm-spec.md
+++ b/docs/planning/graph-backend-pm-spec.md
@@ -137,7 +137,7 @@ The proposal does not chase Outlook on feature breadth (categories, focused inbo
 **v0.8+ — Graph backend (gated, opt-in):**
 - "Microsoft 365" option in Add Account dialog (**only visible when `FeatureFlag.GraphBackend` is enabled**)
 - Full `GraphMailService` implementation: connect, list folders, list messages, get message detail, mark read/unread, move/copy, delete (to Trash), download attachments
-- `GraphSmtpService`: send via `/me/sendMail` (accepts MIME from `MimeMessageBuilder`)
+- `GraphSendMailService`: send via `/me/sendMail` (accepts MIME from `MimeMessageBuilder`)
 - Drafts: append/replace/delete via `/me/messages`
 - Folder CRUD: create/rename/delete/move folders via `/me/mailFolders`
 - New-mail notifications via `delta` polling (replacing IDLE for Graph accounts)
@@ -577,7 +577,7 @@ The single gated surface is the **Add Account combo option**. Everything else is
 | `QuickMail/Services/ImapMailService.cs` | Renamed `ImapService` |
 | `QuickMail/Services/MailServiceRouter.cs` | Per-account dispatcher implementing `IMailService` |
 | `QuickMail/Services/GraphMailService.cs` | New Graph backend |
-| `QuickMail/Services/GraphSmtpService.cs` | New Graph send (via `/me/sendMail`) |
+| `QuickMail/Services/GraphSendMailService.cs` | New Graph send (via `/me/sendMail`) |
 | `QuickMail/Services/IChangeNotifier.cs` | Abstraction over IDLE / delta polling |
 | `QuickMail/Services/ImapChangeNotifier.cs` | Extracted from `ImapService.StartIdleWatchers` |
 | `QuickMail/Services/GraphChangeNotifier.cs` | Delta polling loop |
@@ -617,7 +617,7 @@ Sequenced so that each phase is independently mergeable and reversible until the
 | 2 | `uint UniqueId` → `string MessageId`. SQLite schema migration v2. | None (behavioral parity verified by full test suite + manual smoke) | **3-5** (the painful one) |
 | 3 | `BackendKind` enum + `MailServiceRouter` + `IFeatureGate` infrastructure + Add Account UI combo (Microsoft 365 option present but gated off by default) | New UI element when gate is on; no functional change when gate is off (default) | 2-3 |
 | 4 | `GraphMailService` read path: connect, GetFolders, GetMessageSummaries, GetMessagesSince*, GetMessageDetail, MarkRead | First end-to-end Graph read (only reachable when gate is on) | 4-6 |
-| 5 | `GraphSmtpService`: send via `/me/sendMail`. `AppendToSent` is no-op for Graph. | First Graph send | 1-2 |
+| 5 | `GraphSendMailService`: send via `/me/sendMail`. `AppendToSent` is no-op for Graph. | First Graph send | 1-2 |
 | 6 | Attachments + folder CRUD + move/copy/delete on Graph | Feature parity for daily use | 3-5 |
 | 7 | `GraphChangeNotifier`: delta polling + `IChangeNotifier` abstraction; extract `ImapChangeNotifier` from existing IDLE code | New-mail notifications for Graph accounts | 3-4 |
 | 8 | Tests: `GraphMailServiceTests` with `HttpMessageHandler` stub, `MailServiceRouterTests`, `FeatureGateTests`, migration round-trip test | None (coverage) | 2-3 |

--- a/docs/planning/ics-calendar-pm-spec.md
+++ b/docs/planning/ics-calendar-pm-spec.md
@@ -56,7 +56,7 @@ When someone sends a calendar invite (ICS file attachment), QuickMail currently 
 |------|--------|
 | `QuickMail/Models/MailMessageDetail.cs` | Add `IcsModel? CalendarInvite` property |
 | `QuickMail/Services/ImapService.cs` | Detect `text/calendar` parts, parse with `IcsModel.Parse()` |
-| `QuickMail/Services/ISmtpService.cs` | Add `SendIcsReplyAsync` method |
+| `QuickMail/Services/ISendMailService.cs` | Add `SendIcsReplyAsync` method |
 | `QuickMail/Services/SmtpService.cs` | Implement ICS reply sending |
 | `QuickMail/ViewModels/MainViewModel.cs` | Add invite commands, build event card HTML |
 | `QuickMail/Views/MainWindow.xaml.cs` | Register new commands in CommandRegistry |


### PR DESCRIPTION
PR 5 of the Microsoft Graph backend plan (#24). Lights up the **send path** for Graph accounts, so a Microsoft 365 account can now compose and send. No change for IMAP/SMTP accounts.

## What this does
- **`GraphSendMailService`** — sends by `POST /me/sendMail` with the MIME message base64-encoded as a `text/plain` body. This is **pure Graph REST — no SMTP wire protocol involved**. Graph delivers the message and auto-saves a copy to Sent.
- **`SmtpService` dispatches by backend.** It now takes the Graph sender as `ISendMailService graphSmtp` and routes **both** `SendAsync` and `SendIcsReplyAsync` to it when `account.BackendKind == MicrosoftGraph`; IMAP/SMTP accounts take the existing MailKit path unchanged. So calendar accept/decline replies also work over Graph.
- **`AppendToSentAsync` is a no-op for Graph** (was `NotImplementedException`) — `/sendMail` already saves to Sent, so the post-send append in `ComposeViewModel` no longer logs a benign failure for Graph accounts.

## Naming cleanup (worth a look)
While here, I renamed the send abstraction to remove a protocol-implying misnomer:
- `ISmtpService` → **`ISendMailService`** (it's an abstraction over sending mail, not the SMTP protocol)
- `GraphSmtpService` → **`GraphSendMailService`** (Graph is REST, not SMTP)
- The genuinely-SMTP MailKit implementation **keeps the name `SmtpService`** — that name is accurate.

I chose `ISendMailService` over `ISendMessageService` deliberately: the contract is mail-shaped (`ComposeModel`, attachments, `SendIcsReplyAsync`, an email account), so it wouldn't fit a future SMS/other-channel sender — that would get its own abstraction. Happy to revisit the names if you'd prefer something else.

## Plumbing
- **`GraphClient.PostRawAsync`** added; `SendAsync` refactored to take a `Func<HttpContent>?` content factory so the body is rebuilt on each 429 retry (an `HttpContent` can't be resent once consumed). `GetAsync`/`PatchAsync` behavior unchanged.
- ICS-reply MIME building extracted to **`MimeMessageBuilder.BuildIcsReply`**, shared by both backends.

## Not in this PR
- **Graph mutations** (move/copy/delete/drafts/attachments) still throw `NotImplementedException` — those are PR 6.
- **#63** (gray-out / friendly-error the mutation UI for Graph accounts) — proposed for PR 6, where the disabled-state UI naturally lives alongside the mutation code. Flagging here since #63 was labeled PR 5; happy to pull it forward if you'd rather.

## Tests
- New `GraphSendMailServiceTests` (base64 MIME → `/me/sendMail`, ICS reply) and `SmtpServiceDispatchTests` (both methods route Graph accounts to the Graph sender).
- `dotnet test -c Release`: **628 passed, 0 failed.**
