### PR TITLE
Message flagging -- full implementation (Phases 1-5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -335,6 +335,9 @@ Every user-facing keyboard shortcut **must** be registered in `CommandRegistry` 
 | F1 | `help.userGuide` | Open User Guide |
 | *(unassigned)* | `settings.toggleCustomAnnouncements` | Toggle Custom Announcements |
 | Ctrl+A | `mail.selectAll` | Select All Messages (message list focus only) |
+| K | `mail.toggleFlag` | Toggle Flag |
+| Ctrl+Shift+K | `mail.pickFlag` | Pick Flag… (Phase 4) |
+| *(unassigned)* | `mail.openFlagManager` | Manage Flags… (Phase 4) |
 | Shift+, | `mail.jumpToFirstInGroup` | First Message in Group |
 | Shift+. | `mail.jumpToLastInGroup` | Last Message in Group |
 | *(unassigned)* | `mail.acceptInvite` | Accept Invitation |

--- a/QuickMail.Tests/ComposeViewModelAutoSaveTests.cs
+++ b/QuickMail.Tests/ComposeViewModelAutoSaveTests.cs
@@ -168,6 +168,7 @@ sealed class RecordingMailService : IMailService
     public Task<MailMessageDetail> PrefetchMessageDetailAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default) => Task.FromResult(new MailMessageDetail());
     public Task MarkReadAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default) => Task.CompletedTask;
     public Task MarkReadBatchAsync(Guid accountId, string folderName, IList<string> messageIds, CancellationToken ct = default) => Task.CompletedTask;
+    public Task SetMessageFlaggedAsync(Guid accountId, string folderName, string messageId, bool flagged, CancellationToken ct = default) => Task.CompletedTask;
     public Task MoveToTrashAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default) => Task.CompletedTask;
     public Task MoveToTrashBatchAsync(Guid accountId, string folderName, IList<string> messageIds, CancellationToken ct = default) => Task.CompletedTask;
     public Task PermanentlyDeleteBatchAsync(Guid accountId, string folderName, IList<string> messageIds, CancellationToken ct = default) => Task.CompletedTask;

--- a/QuickMail.Tests/FlagManagerViewModelTests.cs
+++ b/QuickMail.Tests/FlagManagerViewModelTests.cs
@@ -1,0 +1,314 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using QuickMail.Models;
+using QuickMail.Services;
+using QuickMail.ViewModels;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+public class FlagManagerViewModelTests
+{
+    private sealed class RecordingFlagService : IFlagService
+    {
+        private List<FlagDefinition> _flags;
+        public List<FlagDefinition> Saved { get; private set; } = [];
+        public Guid KDefaultId { get; private set; } = FlagDefinition.BuiltInFlagId;
+
+        public RecordingFlagService(List<FlagDefinition>? initial = null)
+        {
+            _flags = initial ?? [FlagDefinition.CreateBuiltIn()];
+        }
+
+#pragma warning disable CS0067
+        public event EventHandler? FlagDefinitionsChanged;
+#pragma warning restore CS0067
+        public FlagDefinition GetBuiltInFlag() => FlagDefinition.CreateBuiltIn();
+        public Task<List<FlagDefinition>> LoadFlagDefinitionsAsync() => Task.FromResult(new List<FlagDefinition>(_flags));
+        public Task SaveFlagDefinitionsAsync(List<FlagDefinition> flags) { Saved = new List<FlagDefinition>(flags); return Task.CompletedTask; }
+        public Task<FlagDefinition> GetKDefaultFlagAsync() => Task.FromResult(_flags.Find(f => f.Id == KDefaultId) ?? FlagDefinition.CreateBuiltIn());
+        public Task SetKDefaultFlagAsync(Guid flagId) { KDefaultId = flagId; return Task.CompletedTask; }
+        public Task SetMessageFlagAsync(MailMessageSummary message, string? flagId, ILocalStoreService localStore, IMailService mailService, CancellationToken ct = default) => Task.CompletedTask;
+        public Task ToggleDefaultFlagAsync(MailMessageSummary message, ILocalStoreService localStore, IMailService mailService, CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    private static async Task<(FlagManagerViewModel vm, RecordingFlagService svc)> MakeVmAsync(
+        List<FlagDefinition>? flags = null)
+    {
+        var svc = new RecordingFlagService(flags);
+        var vm  = new FlagManagerViewModel(svc);
+        await vm.LoadAsync();
+        return (vm, svc);
+    }
+
+    // ── LoadAsync ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task LoadAsync_PopulatesFlags()
+    {
+        var (vm, _) = await MakeVmAsync();
+        Assert.Single(vm.Flags);
+        Assert.Equal("Flagged", vm.Flags[0].Name);
+    }
+
+    [Fact]
+    public async Task LoadAsync_SelectsFirst()
+    {
+        var (vm, _) = await MakeVmAsync();
+        Assert.NotNull(vm.SelectedFlag);
+        Assert.Equal("Flagged", vm.SelectedFlag!.Name);
+    }
+
+    [Fact]
+    public async Task LoadAsync_OrdersBySortOrder()
+    {
+        var flags = new List<FlagDefinition>
+        {
+            new() { Name = "B", SortOrder = 2 },
+            new() { Id = FlagDefinition.BuiltInFlagId, Name = "Flagged", SortOrder = 0, IsBuiltIn = true },
+            new() { Name = "A", SortOrder = 1 },
+        };
+        var (vm, _) = await MakeVmAsync(flags);
+        Assert.Equal("Flagged", vm.Flags[0].Name);
+        Assert.Equal("A",       vm.Flags[1].Name);
+        Assert.Equal("B",       vm.Flags[2].Name);
+    }
+
+    // ── Add ───────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task AddFlag_AppendsAndSelectsNewFlag()
+    {
+        var (vm, _) = await MakeVmAsync();
+        await vm.AddFlagCommand.ExecuteAsync(null);
+        Assert.Equal(2, vm.Flags.Count);
+        Assert.Equal(vm.Flags[1], vm.SelectedFlag);
+    }
+
+    [Fact]
+    public async Task AddFlag_SavesImmediately()
+    {
+        var (vm, svc) = await MakeVmAsync();
+        await vm.AddFlagCommand.ExecuteAsync(null);
+        Assert.Equal(2, svc.Saved.Count);
+    }
+
+    [Fact]
+    public async Task AddFlag_EntersRenameMode()
+    {
+        var (vm, _) = await MakeVmAsync();
+        await vm.AddFlagCommand.ExecuteAsync(null);
+        Assert.True(vm.IsRenaming);
+    }
+
+    [Fact]
+    public async Task AddFlag_DisabledAt20UserFlags()
+    {
+        var flags = new List<FlagDefinition> { FlagDefinition.CreateBuiltIn() };
+        for (int i = 0; i < 20; i++)
+            flags.Add(new() { Name = $"Flag{i}", SortOrder = i + 1 });
+        var (vm, _) = await MakeVmAsync(flags);
+        Assert.False(vm.AddFlagCommand.CanExecute(null));
+    }
+
+    // ── Delete ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task DeleteFlag_RemovesFlag()
+    {
+        var flags = new List<FlagDefinition>
+        {
+            FlagDefinition.CreateBuiltIn(),
+            new() { Name = "Urgent", SortOrder = 1 },
+        };
+        var (vm, _) = await MakeVmAsync(flags);
+        vm.SelectedFlag = vm.Flags[1];
+        await vm.DeleteFlagCommand.ExecuteAsync(null);
+        Assert.Single(vm.Flags);
+        Assert.Equal("Flagged", vm.Flags[0].Name);
+    }
+
+    [Fact]
+    public async Task DeleteFlag_BuiltIn_NotAllowed()
+    {
+        var (vm, _) = await MakeVmAsync();
+        Assert.False(vm.DeleteFlagCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public async Task DeleteFlag_ConfirmFalse_DoesNotDelete()
+    {
+        var flags = new List<FlagDefinition>
+        {
+            FlagDefinition.CreateBuiltIn(),
+            new() { Name = "ToDelete", SortOrder = 1 },
+        };
+        var (vm, _) = await MakeVmAsync(flags);
+        vm.SelectedFlag = vm.Flags[1];
+        vm.ConfirmDeleteRequested += (_, _) => Task.FromResult(false);
+        await vm.DeleteFlagCommand.ExecuteAsync(null);
+        Assert.Equal(2, vm.Flags.Count);
+    }
+
+    // ── Rename ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task BeginRename_SetsIsRenamingAndEditName()
+    {
+        var (vm, _) = await MakeVmAsync();
+        vm.BeginRenameCommand.Execute(null);
+        Assert.True(vm.IsRenaming);
+        Assert.Equal("Flagged", vm.EditName);
+    }
+
+    [Fact]
+    public async Task SaveRename_UpdatesFlagNameAndSaves()
+    {
+        var (vm, svc) = await MakeVmAsync();
+        vm.BeginRenameCommand.Execute(null);
+        vm.EditName = "Important";
+        await vm.SaveRenameCommand.ExecuteAsync(null);
+        Assert.False(vm.IsRenaming);
+        Assert.Equal("Important", vm.SelectedFlag!.Name);
+        Assert.Equal("Important", svc.Saved[0].Name);
+    }
+
+    [Fact]
+    public async Task SaveRename_EmptyName_SetsError()
+    {
+        var (vm, _) = await MakeVmAsync();
+        vm.BeginRenameCommand.Execute(null);
+        vm.EditName = "   ";
+        await vm.SaveRenameCommand.ExecuteAsync(null);
+        Assert.True(vm.IsRenaming);
+        Assert.NotEmpty(vm.RenameError);
+    }
+
+    [Fact]
+    public async Task SaveRename_TooLongName_SetsError()
+    {
+        var (vm, _) = await MakeVmAsync();
+        vm.BeginRenameCommand.Execute(null);
+        vm.EditName = new string('A', 33);
+        await vm.SaveRenameCommand.ExecuteAsync(null);
+        Assert.True(vm.IsRenaming);
+        Assert.NotEmpty(vm.RenameError);
+    }
+
+    [Fact]
+    public async Task CancelRename_ExitsRenameMode()
+    {
+        var (vm, _) = await MakeVmAsync();
+        vm.BeginRenameCommand.Execute(null);
+        vm.CancelRenameCommand.Execute(null);
+        Assert.False(vm.IsRenaming);
+        Assert.Empty(vm.RenameError);
+    }
+
+    // ── Move ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task MoveDown_ChangesOrder()
+    {
+        var flags = new List<FlagDefinition>
+        {
+            new() { Id = FlagDefinition.BuiltInFlagId, Name = "A", SortOrder = 0, IsBuiltIn = true },
+            new() { Name = "B", SortOrder = 1 },
+        };
+        var (vm, _) = await MakeVmAsync(flags);
+        vm.SelectedFlag = vm.Flags[0];
+        await vm.MoveDownCommand.ExecuteAsync(null);
+        Assert.Equal("B", vm.Flags[0].Name);
+        Assert.Equal("A", vm.Flags[1].Name);
+    }
+
+    [Fact]
+    public async Task MoveUp_ChangesOrder()
+    {
+        var flags = new List<FlagDefinition>
+        {
+            new() { Id = FlagDefinition.BuiltInFlagId, Name = "A", SortOrder = 0, IsBuiltIn = true },
+            new() { Name = "B", SortOrder = 1 },
+        };
+        var (vm, _) = await MakeVmAsync(flags);
+        vm.SelectedFlag = vm.Flags[1];
+        await vm.MoveUpCommand.ExecuteAsync(null);
+        Assert.Equal("B", vm.Flags[0].Name);
+        Assert.Equal("A", vm.Flags[1].Name);
+    }
+
+    [Fact]
+    public async Task CanMoveUp_FalseAtTop()
+    {
+        var (vm, _) = await MakeVmAsync();
+        Assert.False(vm.CanMoveUp);
+    }
+
+    [Fact]
+    public async Task CanMoveDown_FalseAtBottom()
+    {
+        var (vm, _) = await MakeVmAsync();
+        Assert.False(vm.CanMoveDown);
+    }
+
+    // ── SetAsKDefault ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SetAsKDefault_UpdatesKDefaultId()
+    {
+        var customId = Guid.NewGuid();
+        var flags = new List<FlagDefinition>
+        {
+            FlagDefinition.CreateBuiltIn(),
+            new() { Id = customId, Name = "Urgent", SortOrder = 1 },
+        };
+        var (vm, svc) = await MakeVmAsync(flags);
+        vm.SelectedFlag = vm.Flags[1];
+        await vm.SetAsKDefaultCommand.ExecuteAsync(null);
+        Assert.Equal(customId, vm.KDefaultId);
+        Assert.Equal(customId, svc.KDefaultId);
+    }
+
+    // ── ChangeColor ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ChangeColor_UpdatesSelectedFlagAndSaves()
+    {
+        var (vm, svc) = await MakeVmAsync();
+        await vm.ChangeColorCommand.ExecuteAsync("#E53E3E");
+        Assert.Equal("#E53E3E", vm.SelectedFlag!.ColorHex);
+        Assert.Equal("#E53E3E", svc.Saved[0].ColorHex);
+    }
+
+    // ── HasSelection / CanDelete ───────────────────────────────────────────────
+
+    [Fact]
+    public async Task HasSelection_TrueWhenFlagSelected()
+    {
+        var (vm, _) = await MakeVmAsync();
+        Assert.True(vm.HasSelection);
+    }
+
+    [Fact]
+    public async Task CanDelete_FalseForBuiltIn()
+    {
+        var (vm, _) = await MakeVmAsync();
+        Assert.False(vm.CanDelete);
+    }
+
+    [Fact]
+    public async Task CanDelete_TrueForUserFlag()
+    {
+        var flags = new List<FlagDefinition>
+        {
+            FlagDefinition.CreateBuiltIn(),
+            new() { Name = "Custom", SortOrder = 1 },
+        };
+        var (vm, _) = await MakeVmAsync(flags);
+        vm.SelectedFlag = vm.Flags[1];
+        Assert.True(vm.CanDelete);
+    }
+}

--- a/QuickMail.Tests/FlagManagerViewModelTests.cs
+++ b/QuickMail.Tests/FlagManagerViewModelTests.cs
@@ -31,8 +31,8 @@ public class FlagManagerViewModelTests
         public Task SaveFlagDefinitionsAsync(List<FlagDefinition> flags) { Saved = new List<FlagDefinition>(flags); return Task.CompletedTask; }
         public Task<FlagDefinition> GetKDefaultFlagAsync() => Task.FromResult(_flags.Find(f => f.Id == KDefaultId) ?? FlagDefinition.CreateBuiltIn());
         public Task SetKDefaultFlagAsync(Guid flagId) { KDefaultId = flagId; return Task.CompletedTask; }
-        public Task<FlagDefinition?> SetMessageFlagAsync(MailMessageSummary message, string? flagId, CancellationToken ct = default)
-            => Task.FromResult<FlagDefinition?>(flagId != null ? _flags.Find(f => f.Id.ToString() == flagId) : null);
+        public Task<FlagDefinition?> SetMessageFlagAsync(MailMessageSummary message, string? flagId, CancellationToken ct = default, FlagDefinition? resolvedDef = null)
+            => Task.FromResult<FlagDefinition?>(resolvedDef ?? (flagId != null ? _flags.Find(f => f.Id.ToString() == flagId) : null));
         public Task<FlagDefinition?> ToggleDefaultFlagAsync(MailMessageSummary message, CancellationToken ct = default)
             => Task.FromResult<FlagDefinition?>(message.IsFlagged ? null : _flags.Find(f => f.Id == KDefaultId));
     }
@@ -104,6 +104,19 @@ public class FlagManagerViewModelTests
         var (vm, _) = await MakeVmAsync();
         await vm.AddFlagCommand.ExecuteAsync(null);
         Assert.True(vm.IsRenaming);
+    }
+
+    [Fact]
+    public async Task AddFlag_GeneratesUniqueNameWhenNewFlagExists()
+    {
+        var flags = new List<FlagDefinition>
+        {
+            FlagDefinition.CreateBuiltIn(),
+            new() { Name = "New Flag", SortOrder = 1 },
+        };
+        var (vm, _) = await MakeVmAsync(flags);
+        await vm.AddFlagCommand.ExecuteAsync(null);
+        Assert.Equal("New Flag 2", vm.Flags[2].Name);
     }
 
     [Fact]
@@ -188,6 +201,41 @@ public class FlagManagerViewModelTests
         Assert.False(vm.IsRenaming);
         Assert.Equal("Important", vm.SelectedFlag!.Name);
         Assert.Equal("Important", svc.Saved[1].Name);
+    }
+
+    [Fact]
+    public async Task SaveRename_DuplicateName_SetsError()
+    {
+        var flags = new List<FlagDefinition>
+        {
+            FlagDefinition.CreateBuiltIn(),
+            new() { Name = "Urgent",    SortOrder = 1 },
+            new() { Name = "Important", SortOrder = 2 },
+        };
+        var (vm, _) = await MakeVmAsync(flags);
+        vm.SelectedFlag = vm.Flags[1]; // "Urgent"
+        vm.BeginRenameCommand.Execute(null);
+        vm.EditName = "Important";     // already exists on a different flag
+        await vm.SaveRenameCommand.ExecuteAsync(null);
+        Assert.True(vm.IsRenaming);
+        Assert.NotEmpty(vm.RenameError);
+    }
+
+    [Fact]
+    public async Task SaveRename_SameNameAsOwn_Succeeds()
+    {
+        var flags = new List<FlagDefinition>
+        {
+            FlagDefinition.CreateBuiltIn(),
+            new() { Name = "Urgent", SortOrder = 1 },
+        };
+        var (vm, _) = await MakeVmAsync(flags);
+        vm.SelectedFlag = vm.Flags[1];
+        vm.BeginRenameCommand.Execute(null);
+        vm.EditName = "urgent"; // same name, different case — saving own name is fine
+        await vm.SaveRenameCommand.ExecuteAsync(null);
+        Assert.False(vm.IsRenaming);
+        Assert.Empty(vm.RenameError);
     }
 
     [Fact]

--- a/QuickMail.Tests/FlagManagerViewModelTests.cs
+++ b/QuickMail.Tests/FlagManagerViewModelTests.cs
@@ -31,8 +31,10 @@ public class FlagManagerViewModelTests
         public Task SaveFlagDefinitionsAsync(List<FlagDefinition> flags) { Saved = new List<FlagDefinition>(flags); return Task.CompletedTask; }
         public Task<FlagDefinition> GetKDefaultFlagAsync() => Task.FromResult(_flags.Find(f => f.Id == KDefaultId) ?? FlagDefinition.CreateBuiltIn());
         public Task SetKDefaultFlagAsync(Guid flagId) { KDefaultId = flagId; return Task.CompletedTask; }
-        public Task SetMessageFlagAsync(MailMessageSummary message, string? flagId, ILocalStoreService localStore, IMailService mailService, CancellationToken ct = default) => Task.CompletedTask;
-        public Task ToggleDefaultFlagAsync(MailMessageSummary message, ILocalStoreService localStore, IMailService mailService, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<FlagDefinition?> SetMessageFlagAsync(MailMessageSummary message, string? flagId, CancellationToken ct = default)
+            => Task.FromResult<FlagDefinition?>(flagId != null ? _flags.Find(f => f.Id.ToString() == flagId) : null);
+        public Task<FlagDefinition?> ToggleDefaultFlagAsync(MailMessageSummary message, CancellationToken ct = default)
+            => Task.FromResult<FlagDefinition?>(message.IsFlagged ? null : _flags.Find(f => f.Id == KDefaultId));
     }
 
     private static async Task<(FlagManagerViewModel vm, RecordingFlagService svc)> MakeVmAsync(
@@ -158,28 +160,46 @@ public class FlagManagerViewModelTests
     [Fact]
     public async Task BeginRename_SetsIsRenamingAndEditName()
     {
-        var (vm, _) = await MakeVmAsync();
+        var flags = new List<FlagDefinition>
+        {
+            FlagDefinition.CreateBuiltIn(),
+            new() { Name = "Urgent", SortOrder = 1 },
+        };
+        var (vm, _) = await MakeVmAsync(flags);
+        vm.SelectedFlag = vm.Flags[1]; // select non-built-in flag
         vm.BeginRenameCommand.Execute(null);
         Assert.True(vm.IsRenaming);
-        Assert.Equal("Flagged", vm.EditName);
+        Assert.Equal("Urgent", vm.EditName);
     }
 
     [Fact]
     public async Task SaveRename_UpdatesFlagNameAndSaves()
     {
-        var (vm, svc) = await MakeVmAsync();
+        var flags = new List<FlagDefinition>
+        {
+            FlagDefinition.CreateBuiltIn(),
+            new() { Name = "Urgent", SortOrder = 1 },
+        };
+        var (vm, svc) = await MakeVmAsync(flags);
+        vm.SelectedFlag = vm.Flags[1];
         vm.BeginRenameCommand.Execute(null);
         vm.EditName = "Important";
         await vm.SaveRenameCommand.ExecuteAsync(null);
         Assert.False(vm.IsRenaming);
         Assert.Equal("Important", vm.SelectedFlag!.Name);
-        Assert.Equal("Important", svc.Saved[0].Name);
+        Assert.Equal("Important", svc.Saved[1].Name);
     }
 
     [Fact]
     public async Task SaveRename_EmptyName_SetsError()
     {
-        var (vm, _) = await MakeVmAsync();
+        var flags = new List<FlagDefinition>
+        {
+            FlagDefinition.CreateBuiltIn(),
+            new() { Name = "Urgent", SortOrder = 1 },
+        };
+        var (vm, _) = await MakeVmAsync(flags);
+        vm.SelectedFlag = vm.Flags[1];
         vm.BeginRenameCommand.Execute(null);
         vm.EditName = "   ";
         await vm.SaveRenameCommand.ExecuteAsync(null);
@@ -190,7 +210,13 @@ public class FlagManagerViewModelTests
     [Fact]
     public async Task SaveRename_TooLongName_SetsError()
     {
-        var (vm, _) = await MakeVmAsync();
+        var flags = new List<FlagDefinition>
+        {
+            FlagDefinition.CreateBuiltIn(),
+            new() { Name = "Urgent", SortOrder = 1 },
+        };
+        var (vm, _) = await MakeVmAsync(flags);
+        vm.SelectedFlag = vm.Flags[1];
         vm.BeginRenameCommand.Execute(null);
         vm.EditName = new string('A', 33);
         await vm.SaveRenameCommand.ExecuteAsync(null);
@@ -277,10 +303,16 @@ public class FlagManagerViewModelTests
     [Fact]
     public async Task ChangeColor_UpdatesSelectedFlagAndSaves()
     {
-        var (vm, svc) = await MakeVmAsync();
+        var flags = new List<FlagDefinition>
+        {
+            FlagDefinition.CreateBuiltIn(),
+            new() { Name = "Urgent", SortOrder = 1, ColorHex = "#3182CE" },
+        };
+        var (vm, svc) = await MakeVmAsync(flags);
+        vm.SelectedFlag = vm.Flags[1]; // select non-built-in flag
         await vm.ChangeColorCommand.ExecuteAsync("#E53E3E");
         Assert.Equal("#E53E3E", vm.SelectedFlag!.ColorHex);
-        Assert.Equal("#E53E3E", svc.Saved[0].ColorHex);
+        Assert.Equal("#E53E3E", svc.Saved[1].ColorHex);
     }
 
     // ── HasSelection / CanDelete ───────────────────────────────────────────────

--- a/QuickMail.Tests/FlagPickerViewModelTests.cs
+++ b/QuickMail.Tests/FlagPickerViewModelTests.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using QuickMail.Models;
+using QuickMail.Services;
+using QuickMail.ViewModels;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+public class FlagPickerViewModelTests
+{
+    private sealed class TestFlagService : IFlagService
+    {
+        private readonly List<FlagDefinition> _flags;
+
+        public TestFlagService(List<FlagDefinition>? flags = null)
+        {
+            _flags = flags ?? [FlagDefinition.CreateBuiltIn()];
+        }
+
+#pragma warning disable CS0067
+        public event EventHandler? FlagDefinitionsChanged;
+#pragma warning restore CS0067
+        public FlagDefinition GetBuiltInFlag() => FlagDefinition.CreateBuiltIn();
+        public Task<List<FlagDefinition>> LoadFlagDefinitionsAsync() => Task.FromResult(new List<FlagDefinition>(_flags));
+        public Task SaveFlagDefinitionsAsync(List<FlagDefinition> flags) => Task.CompletedTask;
+        public Task<FlagDefinition> GetKDefaultFlagAsync() => Task.FromResult(FlagDefinition.CreateBuiltIn());
+        public Task SetKDefaultFlagAsync(Guid flagId) => Task.CompletedTask;
+        public Task SetMessageFlagAsync(MailMessageSummary message, string? flagId, ILocalStoreService localStore, IMailService mailService, CancellationToken ct = default) => Task.CompletedTask;
+        public Task ToggleDefaultFlagAsync(MailMessageSummary message, ILocalStoreService localStore, IMailService mailService, CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    private static FlagPickerViewModel MakeVm(List<FlagDefinition>? flags = null, bool currentlyFlagged = false)
+    {
+        var svc = new TestFlagService(flags);
+        return new FlagPickerViewModel(svc, currentlyFlagged);
+    }
+
+    [Fact]
+    public void Constructor_InitializesEmpty()
+    {
+        var vm = MakeVm();
+        Assert.Empty(vm.Flags);
+        Assert.Null(vm.SelectedFlag);
+        Assert.False(vm.CurrentlyFlagged);
+    }
+
+    [Fact]
+    public async Task LoadAsync_PopulatesFlags()
+    {
+        var flags = new List<FlagDefinition>
+        {
+            FlagDefinition.CreateBuiltIn(),
+            new() { Name = "Urgent", ColorHex = "#E53E3E" },
+        };
+        var vm = MakeVm(flags);
+        await vm.LoadAsync();
+        Assert.Equal(2, vm.Flags.Count);
+    }
+
+    [Fact]
+    public async Task LoadAsync_SelectsFirstFlag()
+    {
+        var vm = MakeVm();
+        await vm.LoadAsync();
+        Assert.NotNull(vm.SelectedFlag);
+        Assert.Equal("Flagged", vm.SelectedFlag!.Name);
+    }
+
+    [Fact]
+    public async Task LoadAsync_EmptyList_SelectedFlagIsNull()
+    {
+        var vm = MakeVm([]);
+        await vm.LoadAsync();
+        Assert.Null(vm.SelectedFlag);
+    }
+
+    [Fact]
+    public async Task ApplyFlagCommand_RaisesFlagSelectedWithSelectedFlag()
+    {
+        var vm = MakeVm();
+        await vm.LoadAsync();
+
+        FlagDefinition? raised = null;
+        vm.FlagSelected += f => raised = f;
+        vm.ApplyFlagCommand.Execute(null);
+
+        Assert.NotNull(raised);
+        Assert.Equal("Flagged", raised!.Name);
+    }
+
+    [Fact]
+    public async Task ApplyFlagCommand_DisabledWhenNoSelection()
+    {
+        var vm = MakeVm([]);
+        await vm.LoadAsync();
+        Assert.False(vm.ApplyFlagCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public async Task ClearFlagCommand_RaisesFlagSelectedWithNull()
+    {
+        var vm = MakeVm();
+        await vm.LoadAsync();
+
+        bool invoked = false;
+        FlagDefinition? raised = FlagDefinition.CreateBuiltIn();
+        vm.FlagSelected += f => { raised = f; invoked = true; };
+        vm.ClearFlagCommand.Execute(null);
+
+        Assert.True(invoked);
+        Assert.Null(raised);
+    }
+
+    [Fact]
+    public void CurrentlyFlagged_ReflectsConstructorArg()
+    {
+        var vm = MakeVm(currentlyFlagged: true);
+        Assert.True(vm.CurrentlyFlagged);
+    }
+}

--- a/QuickMail.Tests/FlagPickerViewModelTests.cs
+++ b/QuickMail.Tests/FlagPickerViewModelTests.cs
@@ -28,8 +28,8 @@ public class FlagPickerViewModelTests
         public Task SaveFlagDefinitionsAsync(List<FlagDefinition> flags) => Task.CompletedTask;
         public Task<FlagDefinition> GetKDefaultFlagAsync() => Task.FromResult(FlagDefinition.CreateBuiltIn());
         public Task SetKDefaultFlagAsync(Guid flagId) => Task.CompletedTask;
-        public Task<FlagDefinition?> SetMessageFlagAsync(MailMessageSummary message, string? flagId, CancellationToken ct = default)
-            => Task.FromResult<FlagDefinition?>(flagId != null ? _flags.Find(f => f.Id.ToString() == flagId) : null);
+        public Task<FlagDefinition?> SetMessageFlagAsync(MailMessageSummary message, string? flagId, CancellationToken ct = default, FlagDefinition? resolvedDef = null)
+            => Task.FromResult<FlagDefinition?>(resolvedDef ?? (flagId != null ? _flags.Find(f => f.Id.ToString() == flagId) : null));
         public Task<FlagDefinition?> ToggleDefaultFlagAsync(MailMessageSummary message, CancellationToken ct = default)
             => Task.FromResult<FlagDefinition?>(message.IsFlagged ? null : FlagDefinition.CreateBuiltIn());
     }

--- a/QuickMail.Tests/FlagPickerViewModelTests.cs
+++ b/QuickMail.Tests/FlagPickerViewModelTests.cs
@@ -28,8 +28,10 @@ public class FlagPickerViewModelTests
         public Task SaveFlagDefinitionsAsync(List<FlagDefinition> flags) => Task.CompletedTask;
         public Task<FlagDefinition> GetKDefaultFlagAsync() => Task.FromResult(FlagDefinition.CreateBuiltIn());
         public Task SetKDefaultFlagAsync(Guid flagId) => Task.CompletedTask;
-        public Task SetMessageFlagAsync(MailMessageSummary message, string? flagId, ILocalStoreService localStore, IMailService mailService, CancellationToken ct = default) => Task.CompletedTask;
-        public Task ToggleDefaultFlagAsync(MailMessageSummary message, ILocalStoreService localStore, IMailService mailService, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<FlagDefinition?> SetMessageFlagAsync(MailMessageSummary message, string? flagId, CancellationToken ct = default)
+            => Task.FromResult<FlagDefinition?>(flagId != null ? _flags.Find(f => f.Id.ToString() == flagId) : null);
+        public Task<FlagDefinition?> ToggleDefaultFlagAsync(MailMessageSummary message, CancellationToken ct = default)
+            => Task.FromResult<FlagDefinition?>(message.IsFlagged ? null : FlagDefinition.CreateBuiltIn());
     }
 
     private static FlagPickerViewModel MakeVm(List<FlagDefinition>? flags = null, bool currentlyFlagged = false)

--- a/QuickMail.Tests/FlagServiceTests.cs
+++ b/QuickMail.Tests/FlagServiceTests.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Threading.Tasks;
+using QuickMail.Models;
+using QuickMail.Services;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+public class FlagServiceTests
+{
+    private static (FlagService svc, string dir) MakeService()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "FlagServiceTests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var profile = new ProfileContext(dir);
+        var svc = new FlagService(profile, new StubConfigService());
+        return (svc, dir);
+    }
+
+    [Fact]
+    public async Task LoadFlagDefinitions_NoFile_ReturnsBuiltIn()
+    {
+        var (svc, dir) = MakeService();
+        try
+        {
+            var defs = await svc.LoadFlagDefinitionsAsync();
+            Assert.Single(defs);
+            Assert.Equal(FlagDefinition.BuiltInFlagId, defs[0].Id);
+            Assert.True(defs[0].IsBuiltIn);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public async Task ToggleDefault_SetsFlagInLocalStore()
+    {
+        var (svc, dir) = MakeService();
+        try
+        {
+            var store = new RecordingFlagStore();
+            var mail  = new StubImapMailService();
+            var msg   = new MailMessageSummary { MessageId = "1", AccountId = Guid.NewGuid(), FolderName = "INBOX" };
+
+            await svc.ToggleDefaultFlagAsync(msg, store, mail);
+
+            // Local store should have received the built-in flag id.
+            Assert.Equal(1, store.UpdateFlagCalls);
+            Assert.Equal(FlagDefinition.BuiltInFlagId.ToString(), store.LastFlagId);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public async Task ToggleDefault_ClearsFlagInLocalStore()
+    {
+        var (svc, dir) = MakeService();
+        try
+        {
+            var store = new RecordingFlagStore();
+            var mail  = new StubImapMailService();
+            var msg   = new MailMessageSummary
+            {
+                MessageId  = "1",
+                AccountId  = Guid.NewGuid(),
+                FolderName = "INBOX",
+                FlagId     = FlagDefinition.BuiltInFlagId.ToString(),
+            };
+
+            await svc.ToggleDefaultFlagAsync(msg, store, mail);
+
+            // Clear is a null flag id.
+            Assert.Equal(1, store.UpdateFlagCalls);
+            Assert.Null(store.LastFlagId);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public async Task CorruptJson_RecoversWithBuiltInFlag()
+    {
+        var (svc, dir) = MakeService();
+        try
+        {
+            // Write corrupt JSON
+            var flagsFile = Path.Combine(dir, "flags.json");
+            await File.WriteAllTextAsync(flagsFile, "{{NOT_VALID_JSON");
+
+            var defs = await svc.LoadFlagDefinitionsAsync();
+
+            Assert.Single(defs);
+            Assert.Equal(FlagDefinition.BuiltInFlagId, defs[0].Id);
+            // Backup file should exist
+            Assert.True(Directory.GetFiles(dir, "flags.json.bak-*").Length > 0);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public async Task SaveFlagDefinitions_RaisesChanged()
+    {
+        var (svc, dir) = MakeService();
+        try
+        {
+            bool raised = false;
+            svc.FlagDefinitionsChanged += (_, _) => raised = true;
+
+            await svc.SaveFlagDefinitionsAsync(new List<FlagDefinition> { FlagDefinition.CreateBuiltIn() });
+
+            Assert.True(raised);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public async Task GetKDefaultFlag_DefaultsToBuiltIn()
+    {
+        var (svc, dir) = MakeService();
+        try
+        {
+            var kFlag = await svc.GetKDefaultFlagAsync();
+            Assert.Equal(FlagDefinition.BuiltInFlagId, kFlag.Id);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+}
+
+/// <summary>Records UpdateFlagIdAsync calls so tests can assert without a WPF dispatcher.</summary>
+sealed class RecordingFlagStore : ILocalStoreService
+{
+    public int UpdateFlagCalls { get; private set; }
+    public string? LastFlagId  { get; private set; }
+
+    public void Initialize() { }
+    public Task UpsertSummariesAsync(IEnumerable<MailMessageSummary> summaries) => Task.CompletedTask;
+    public Task<List<MailMessageSummary>> LoadAllSummariesAsync() => Task.FromResult(new List<MailMessageSummary>());
+    public Task<List<MailMessageSummary>> LoadAllSummariesAsync(Guid accountId) => Task.FromResult(new List<MailMessageSummary>());
+    public Task<List<MailMessageSummary>> LoadFolderSummariesAsync(Guid accountId, string folderName, int? limit = null) => Task.FromResult(new List<MailMessageSummary>());
+    public Task DeleteSummariesAsync(Guid accountId, string folderName, IEnumerable<string> messageIds) => Task.CompletedTask;
+    public Task DeleteAccountDataAsync(Guid accountId) => Task.CompletedTask;
+    public Task UpdateIsReadAsync(Guid accountId, string folderName, string messageId, bool isRead) => Task.CompletedTask;
+    public Task UpdateIsReadBatchAsync(IEnumerable<(Guid AccountId, string FolderName, string MessageId)> items, bool isRead) => Task.CompletedTask;
+    public Task UpdatePreviewAsync(Guid accountId, string folderName, string messageId, string preview) => Task.CompletedTask;
+    public Task UpdatePreviewsBatchAsync(Guid accountId, string folderName, IEnumerable<(string MessageId, string Preview)> updates) => Task.CompletedTask;
+    public Task<bool> HasSummariesMissingRecipientsAsync() => Task.FromResult(false);
+    public Task UpsertDetailAsync(MailMessageDetail detail) => Task.CompletedTask;
+    public Task<MailMessageDetail?> LoadDetailAsync(Guid accountId, string folderName, string messageId) => Task.FromResult<MailMessageDetail?>(null);
+    public Task<string> GetMaxMessageKeyAsync(Guid accountId, string folderName) => Task.FromResult("0");
+    public Task<HashSet<string>> GetAllMessageIdsAsync(Guid accountId, string folderName) => Task.FromResult(new HashSet<string>());
+    public Task<int> CountSummariesAsync(Guid accountId) => Task.FromResult(0);
+    public Task<DateTimeOffset?> GetOldestMessageDateAsync(Guid accountId) => Task.FromResult<DateTimeOffset?>(null);
+    public Task UpdateFlagIdAsync(Guid accountId, string folderName, string messageId, string? flagId)
+    {
+        UpdateFlagCalls++;
+        LastFlagId = flagId;
+        return Task.CompletedTask;
+    }
+    public Task UpdateFlagIdBatchAsync(IEnumerable<(Guid AccountId, string FolderName, string MessageId)> items, string? flagId) => Task.CompletedTask;
+}

--- a/QuickMail.Tests/FlagServiceTests.cs
+++ b/QuickMail.Tests/FlagServiceTests.cs
@@ -16,7 +16,7 @@ public class FlagServiceTests
         var dir = Path.Combine(Path.GetTempPath(), "FlagServiceTests_" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(dir);
         var profile = new ProfileContext(dir);
-        var svc = new FlagService(profile, new StubConfigService());
+        var svc = new FlagService(profile, new StubConfigService(), new StubLocalStoreService(), new StubImapMailService());
         return (svc, dir);
     }
 
@@ -40,15 +40,13 @@ public class FlagServiceTests
         var (svc, dir) = MakeService();
         try
         {
-            var store = new RecordingFlagStore();
-            var mail  = new StubImapMailService();
-            var msg   = new MailMessageSummary { MessageId = "1", AccountId = Guid.NewGuid(), FolderName = "INBOX" };
+            var msg = new MailMessageSummary { MessageId = "1", AccountId = Guid.NewGuid(), FolderName = "INBOX" };
 
-            await svc.ToggleDefaultFlagAsync(msg, store, mail);
+            var def = await svc.ToggleDefaultFlagAsync(msg);
 
-            // Local store should have received the built-in flag id.
-            Assert.Equal(1, store.UpdateFlagCalls);
-            Assert.Equal(FlagDefinition.BuiltInFlagId.ToString(), store.LastFlagId);
+            // Should return the built-in flag definition when setting.
+            Assert.NotNull(def);
+            Assert.Equal(FlagDefinition.BuiltInFlagId, def!.Id);
         }
         finally { Directory.Delete(dir, true); }
     }
@@ -59,9 +57,7 @@ public class FlagServiceTests
         var (svc, dir) = MakeService();
         try
         {
-            var store = new RecordingFlagStore();
-            var mail  = new StubImapMailService();
-            var msg   = new MailMessageSummary
+            var msg = new MailMessageSummary
             {
                 MessageId  = "1",
                 AccountId  = Guid.NewGuid(),
@@ -69,11 +65,10 @@ public class FlagServiceTests
                 FlagId     = FlagDefinition.BuiltInFlagId.ToString(),
             };
 
-            await svc.ToggleDefaultFlagAsync(msg, store, mail);
+            var def = await svc.ToggleDefaultFlagAsync(msg);
 
-            // Clear is a null flag id.
-            Assert.Equal(1, store.UpdateFlagCalls);
-            Assert.Null(store.LastFlagId);
+            // Should return null when clearing.
+            Assert.Null(def);
         }
         finally { Directory.Delete(dir, true); }
     }

--- a/QuickMail.Tests/GraphBackendGateTests.cs
+++ b/QuickMail.Tests/GraphBackendGateTests.cs
@@ -98,6 +98,7 @@ public class MailServiceRouterTests
         public Task<MailMessageDetail> PrefetchMessageDetailAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default) => Task.FromResult(new MailMessageDetail());
         public Task MarkReadAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default) => Task.CompletedTask;
         public Task MarkReadBatchAsync(Guid accountId, string folderName, IList<string> messageIds, CancellationToken ct = default) => Task.CompletedTask;
+        public Task SetMessageFlaggedAsync(Guid accountId, string folderName, string messageId, bool flagged, CancellationToken ct = default) => Task.CompletedTask;
         public Task MoveToTrashAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default) => Task.CompletedTask;
         public Task MoveToTrashBatchAsync(Guid accountId, string folderName, IList<string> messageIds, CancellationToken ct = default) => Task.CompletedTask;
         public Task PermanentlyDeleteBatchAsync(Guid accountId, string folderName, IList<string> messageIds, CancellationToken ct = default) => Task.CompletedTask;

--- a/QuickMail.Tests/LocalStoreServiceMigrationTests.cs
+++ b/QuickMail.Tests/LocalStoreServiceMigrationTests.cs
@@ -210,4 +210,74 @@ public class LocalStoreServiceMigrationTests
         Assert.Equal("1001", loaded[0].MessageId);
         Assert.Equal("1001", await store.GetMaxMessageKeyAsync(accountId, "Inbox"));
     }
+
+    // ── Phase 5: IMAP ↔ local flag reconciliation (§9.3) ─────────────────────
+
+    private static QuickMail.Models.MailMessageSummary MakeSummary(Guid accountId, string id, bool serverFlagged = false, string? flagId = null) =>
+        new()
+        {
+            MessageId      = id,
+            AccountId      = accountId,
+            FolderName     = "Inbox",
+            Subject        = id,
+            Date           = DateTimeOffset.UtcNow,
+            IsServerFlagged = serverFlagged,
+            FlagId         = flagId,
+        };
+
+    [Fact]
+    public async Task ExternallyFlagged_NewMessage_GetsBuiltInFlagOnUpsert()
+    {
+        var dir       = NewTempDir();
+        var accountId = Guid.NewGuid();
+        var store     = new LocalStoreService(new ProfileContext(dir));
+        store.Initialize();
+
+        // Simulate a message that arrives from IMAP with \Flagged set (flagged in Outlook)
+        // and no local flag_id yet (new message, first sync).
+        var msg = MakeSummary(accountId, "1", serverFlagged: true);
+        await store.UpsertSummariesAsync([msg]);
+
+        var loaded = await store.LoadFolderSummariesAsync(accountId, "Inbox");
+        Assert.Equal(QuickMail.Models.FlagDefinition.BuiltInFlagId.ToString(), loaded[0].FlagId);
+    }
+
+    [Fact]
+    public async Task ExternallyUnflagged_ExistingMessage_ClearsFlagOnUpsert()
+    {
+        var dir       = NewTempDir();
+        var accountId = Guid.NewGuid();
+        var store     = new LocalStoreService(new ProfileContext(dir));
+        store.Initialize();
+
+        // First sync: message arrives server-flagged → gets built-in flag_id.
+        await store.UpsertSummariesAsync([MakeSummary(accountId, "1", serverFlagged: true)]);
+
+        // Second sync: server no longer reports \Flagged (externally unflagged).
+        await store.UpsertSummariesAsync([MakeSummary(accountId, "1", serverFlagged: false)]);
+
+        var loaded = await store.LoadFolderSummariesAsync(accountId, "Inbox");
+        Assert.Null(loaded[0].FlagId);
+    }
+
+    [Fact]
+    public async Task LocalNamedFlag_PreservedWhenServerFlaggedOnUpsert()
+    {
+        var dir       = NewTempDir();
+        var accountId = Guid.NewGuid();
+        var customId  = Guid.NewGuid().ToString();
+        var store     = new LocalStoreService(new ProfileContext(dir));
+        store.Initialize();
+
+        // User sets a named flag ("Urgent") locally — stored via UpdateFlagIdAsync.
+        await store.UpsertSummariesAsync([MakeSummary(accountId, "1", serverFlagged: true)]);
+        await store.UpdateFlagIdAsync(accountId, "Inbox", "1", customId);
+
+        // Next sync: server still reports \Flagged (which it would, since we set it).
+        await store.UpsertSummariesAsync([MakeSummary(accountId, "1", serverFlagged: true)]);
+
+        var loaded = await store.LoadFolderSummariesAsync(accountId, "Inbox");
+        // Local "Urgent" flag must be preserved — not overwritten with the built-in default.
+        Assert.Equal(customId, loaded[0].FlagId);
+    }
 }

--- a/QuickMail.Tests/MainViewModelFlagTests.cs
+++ b/QuickMail.Tests/MainViewModelFlagTests.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using QuickMail.Models;
+using QuickMail.Services;
+using QuickMail.ViewModels;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+public class MainViewModelFlagTests
+{
+    private static MailMessageSummary FlaggedMsg(string id = "1") => new()
+    {
+        MessageId  = id,
+        AccountId  = Guid.NewGuid(),
+        FolderName = "INBOX",
+        FlagId     = FlagDefinition.BuiltInFlagId.ToString(),
+    };
+
+    private static MailMessageSummary UnflaggedMsg(string id = "1") => new()
+    {
+        MessageId  = id,
+        AccountId  = Guid.NewGuid(),
+        FolderName = "INBOX",
+    };
+
+    private static MainViewModel MakeVm(IFlagService flagService, IEnumerable<MailMessageSummary>? messages = null)
+    {
+        ILocalStoreService store = messages != null
+            ? new FilterableStoreForFlags(messages)
+            : new StubLocalStoreService();
+        return new MainViewModel(
+            new StubImapMailService(), new StubAccountService(), new StubCredentialService(),
+            store, new StubOAuthService(), new StubSyncService(), new StubConfigService(),
+            new StubCommandRegistry(), new StubViewService(), new StubRuleService(), new StubSmtpService(),
+            flagService: flagService);
+    }
+
+    [Fact]
+    public async Task FlaggedFilter_ShowsOnlyFlaggedMessages()
+    {
+        var flagged   = FlaggedMsg("1");
+        var unflagged = UnflaggedMsg("2");
+        var vm = MakeVm(new StubFlagService(), new[] { flagged, unflagged });
+        await vm.InitialLoadAsync();
+
+        await vm.SetFilterCommand.ExecuteAsync("flagged");
+
+        Assert.Single(vm.Messages);
+        Assert.Equal("1", vm.Messages[0].MessageId);
+    }
+
+    [Fact]
+    public async Task FlaggedFilter_AllUnflagged_ShowsEmpty()
+    {
+        var msgs = new[] { UnflaggedMsg("1"), UnflaggedMsg("2") };
+        var vm = MakeVm(new StubFlagService(), msgs);
+        await vm.InitialLoadAsync();
+
+        await vm.SetFilterCommand.ExecuteAsync("flagged");
+
+        Assert.Empty(vm.Messages);
+    }
+
+    [Fact]
+    public async Task IsFilterFlagged_TrueWhenFlaggedFilterActive()
+    {
+        var vm = MakeVm(new StubFlagService());
+        await vm.InitialLoadAsync();
+
+        await vm.SetFilterCommand.ExecuteAsync("flagged");
+
+        Assert.True(vm.IsFilterFlagged);
+    }
+
+    [Fact]
+    public async Task IsFilterFlagged_FalseWhenOtherFilterActive()
+    {
+        var vm = MakeVm(new StubFlagService());
+        await vm.InitialLoadAsync();
+
+        await vm.SetFilterCommand.ExecuteAsync("unread");
+
+        Assert.False(vm.IsFilterFlagged);
+    }
+}
+
+/// <summary>Local store stub that serves a fixed set of messages for flag filter tests.</summary>
+sealed class FilterableStoreForFlags : ILocalStoreService
+{
+    private readonly List<MailMessageSummary> _messages;
+
+    public FilterableStoreForFlags(IEnumerable<MailMessageSummary> messages)
+        => _messages = new List<MailMessageSummary>(messages);
+
+    public void Initialize() { }
+    public Task UpsertSummariesAsync(IEnumerable<MailMessageSummary> summaries) => Task.CompletedTask;
+    public Task<List<MailMessageSummary>> LoadAllSummariesAsync() => Task.FromResult(new List<MailMessageSummary>(_messages));
+    public Task<List<MailMessageSummary>> LoadAllSummariesAsync(Guid accountId) => Task.FromResult(new List<MailMessageSummary>(_messages));
+    public Task<List<MailMessageSummary>> LoadFolderSummariesAsync(Guid accountId, string folderName, int? limit = null) => Task.FromResult(new List<MailMessageSummary>(_messages));
+    public Task DeleteSummariesAsync(Guid accountId, string folderName, IEnumerable<string> messageIds) => Task.CompletedTask;
+    public Task DeleteAccountDataAsync(Guid accountId) => Task.CompletedTask;
+    public Task UpdateIsReadAsync(Guid accountId, string folderName, string messageId, bool isRead) => Task.CompletedTask;
+    public Task UpdateIsReadBatchAsync(IEnumerable<(Guid AccountId, string FolderName, string MessageId)> items, bool isRead) => Task.CompletedTask;
+    public Task UpdatePreviewAsync(Guid accountId, string folderName, string messageId, string preview) => Task.CompletedTask;
+    public Task UpdatePreviewsBatchAsync(Guid accountId, string folderName, IEnumerable<(string MessageId, string Preview)> updates) => Task.CompletedTask;
+    public Task<bool> HasSummariesMissingRecipientsAsync() => Task.FromResult(false);
+    public Task UpsertDetailAsync(MailMessageDetail detail) => Task.CompletedTask;
+    public Task<MailMessageDetail?> LoadDetailAsync(Guid accountId, string folderName, string messageId) => Task.FromResult<MailMessageDetail?>(null);
+    public Task<string> GetMaxMessageKeyAsync(Guid accountId, string folderName) => Task.FromResult("0");
+    public Task<HashSet<string>> GetAllMessageIdsAsync(Guid accountId, string folderName) => Task.FromResult(new HashSet<string>());
+    public Task<int> CountSummariesAsync(Guid accountId) => Task.FromResult(0);
+    public Task<DateTimeOffset?> GetOldestMessageDateAsync(Guid accountId) => Task.FromResult<DateTimeOffset?>(null);
+    public Task UpdateFlagIdAsync(Guid accountId, string folderName, string messageId, string? flagId) => Task.CompletedTask;
+    public Task UpdateFlagIdBatchAsync(IEnumerable<(Guid AccountId, string FolderName, string MessageId)> items, string? flagId) => Task.CompletedTask;
+}

--- a/QuickMail.Tests/MainViewModelFlagTests.cs
+++ b/QuickMail.Tests/MainViewModelFlagTests.cs
@@ -84,6 +84,123 @@ public class MainViewModelFlagTests
 
         Assert.False(vm.IsFilterFlagged);
     }
+
+    // ── Phase 5: in-memory flag reconciliation on FolderSynced ───────────────
+
+    private sealed class FireableSyncService : ISyncService
+    {
+        public event Action<IReadOnlyList<MailMessageSummary>>? FolderSynced;
+#pragma warning disable CS0067
+        public event Action<IReadOnlyList<MailMessageSummary>>? MessagesRemoved;
+        public event Action<int>? RulesApplied;
+        public event Action<int, int>? SyncProgressChanged;
+#pragma warning restore CS0067
+        public void Fire(IReadOnlyList<MailMessageSummary> messages) => FolderSynced?.Invoke(messages);
+        public Task SyncAllAccountsAsync(IEnumerable<AccountModel> accounts, IReadOnlyDictionary<Guid, List<MailFolderModel>> cachedFolders, CancellationToken ct) => Task.CompletedTask;
+        public Task SyncOneFolderAsync(AccountModel account, MailFolderModel folder, CancellationToken ct) => Task.CompletedTask;
+        public Task SyncOneFolderOnlineAsync(AccountModel account, MailFolderModel folder, CancellationToken ct) => Task.CompletedTask;
+        public DateTimeOffset? LastSyncedUtc(Guid accountId) => null;
+    }
+
+    [Fact]
+    public async Task OnFolderSynced_ExternallyUnflaggedMessage_ClearsFlagInMemory()
+    {
+        // Arrange: load a flagged message into the VM via the initial FolderSynced fire.
+        var accountId  = Guid.NewGuid();
+        var syncService = new FireableSyncService();
+        var vm = new MainViewModel(
+            new StubImapMailService(), new StubAccountService(), new StubCredentialService(),
+            new StubLocalStoreService(), new StubOAuthService(), syncService,
+            new StubConfigService(), new StubCommandRegistry(), new StubViewService(),
+            new StubRuleService(), new StubSmtpService(), flagService: new StubFlagService());
+
+        await vm.InitialLoadAsync();
+
+        // Point the selected folder at a real folder so FolderSynced processes messages.
+        vm.SelectedFolder = new MailFolderModel
+        {
+            FullName  = "INBOX",
+            AccountId = accountId,
+            IsHeader  = false,
+        };
+
+        // Fire 1: message arrives server-flagged → added to _rawMessages with FlagId set.
+        var flaggedIncoming = new MailMessageSummary
+        {
+            MessageId       = "msg1",
+            AccountId       = accountId,
+            FolderName      = "INBOX",
+            IsServerFlagged = true,
+        };
+        syncService.Fire([flaggedIncoming]);
+
+        var inMemory = vm.LoadedMessages.FirstOrDefault(m => m.MessageId == "msg1");
+        Assert.NotNull(inMemory);
+        Assert.NotNull(inMemory!.FlagId);
+
+        // Fire 2: same message, server now reports not-flagged (externally cleared).
+        var unflaggedSync = new MailMessageSummary
+        {
+            MessageId       = "msg1",
+            AccountId       = accountId,
+            FolderName      = "INBOX",
+            IsServerFlagged = false,
+        };
+        syncService.Fire([unflaggedSync]);
+
+        // The in-memory flag must have been cleared.
+        Assert.Null(inMemory.FlagId);
+    }
+
+    [Fact]
+    public async Task OnFolderSynced_LocalNamedFlag_PreservedWhenServerFlagged()
+    {
+        // Arrange: message in memory with a user-assigned named flag (not the built-in default).
+        var accountId   = Guid.NewGuid();
+        var customFlagId = Guid.NewGuid().ToString();
+        var syncService = new FireableSyncService();
+        var vm = new MainViewModel(
+            new StubImapMailService(), new StubAccountService(), new StubCredentialService(),
+            new StubLocalStoreService(), new StubOAuthService(), syncService,
+            new StubConfigService(), new StubCommandRegistry(), new StubViewService(),
+            new StubRuleService(), new StubSmtpService(), flagService: new StubFlagService());
+
+        await vm.InitialLoadAsync();
+
+        vm.SelectedFolder = new MailFolderModel
+        {
+            FullName  = "INBOX",
+            AccountId = accountId,
+            IsHeader  = false,
+        };
+
+        // Fire 1: message arrives and we simulate a named flag being applied locally.
+        var incoming = new MailMessageSummary
+        {
+            MessageId       = "msg2",
+            AccountId       = accountId,
+            FolderName      = "INBOX",
+            IsServerFlagged = true,
+            FlagId          = customFlagId,
+        };
+        syncService.Fire([incoming]);
+
+        var inMemory = vm.LoadedMessages.FirstOrDefault(m => m.MessageId == "msg2");
+        Assert.NotNull(inMemory);
+        Assert.Equal(customFlagId, inMemory!.FlagId);
+
+        // Fire 2: server still flagged — named flag must NOT be overwritten with built-in default.
+        var syncAgain = new MailMessageSummary
+        {
+            MessageId       = "msg2",
+            AccountId       = accountId,
+            FolderName      = "INBOX",
+            IsServerFlagged = true,
+        };
+        syncService.Fire([syncAgain]);
+
+        Assert.Equal(customFlagId, inMemory.FlagId);
+    }
 }
 
 /// <summary>Local store stub that serves a fixed set of messages for flag filter tests.</summary>

--- a/QuickMail.Tests/MessageFilterTests.cs
+++ b/QuickMail.Tests/MessageFilterTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using QuickMail.Models;
@@ -175,5 +176,30 @@ public class MessageFilterTests
         var vm = await LoadedVm(SampleMessages);
         await vm.SetFilterCommand.ExecuteAsync("unread");
         Assert.True(vm.IsFilterActive);
+    }
+
+    [Fact]
+    public async Task FilterFlagged_ShowsOnlyFlaggedMessages()
+    {
+        var flaggedMsg = new MailMessageSummary
+        {
+            MessageId  = "99",
+            FlagId     = FlagDefinition.BuiltInFlagId.ToString(),
+        };
+        var msgs = SampleMessages.Concat(new[] { flaggedMsg }).ToList();
+        var vm = await LoadedVm(msgs);
+
+        await vm.SetFilterCommand.ExecuteAsync("flagged");
+
+        Assert.Single(vm.Messages);
+        Assert.Equal("99", vm.Messages[0].MessageId);
+    }
+
+    [Fact]
+    public async Task FilterFlagged_NoFlaggedMessages_Empty()
+    {
+        var vm = await LoadedVm(SampleMessages);
+        await vm.SetFilterCommand.ExecuteAsync("flagged");
+        Assert.Empty(vm.Messages);
     }
 }

--- a/QuickMail.Tests/MessageFilterTests.cs
+++ b/QuickMail.Tests/MessageFilterTests.cs
@@ -42,6 +42,8 @@ public class MessageFilterTests
         public Task<HashSet<string>> GetAllMessageIdsAsync(Guid accountId, string folderName) => Task.FromResult(new HashSet<string>());
         public Task<int> CountSummariesAsync(Guid accountId) => Task.FromResult(0);
         public Task<DateTimeOffset?> GetOldestMessageDateAsync(Guid accountId) => Task.FromResult<DateTimeOffset?>(null);
+        public Task UpdateFlagIdAsync(Guid accountId, string folderName, string messageId, string? flagId) => Task.CompletedTask;
+        public Task UpdateFlagIdBatchAsync(IEnumerable<(Guid AccountId, string FolderName, string MessageId)> items, string? flagId) => Task.CompletedTask;
     }
 
     // ── Helpers ─────────────────────────────────────────────────────────────

--- a/QuickMail.Tests/PropertiesBuilderTests.cs
+++ b/QuickMail.Tests/PropertiesBuilderTests.cs
@@ -129,6 +129,28 @@ public class MessagePropertiesBuilderTests
         var storage = sections.First(x => x.Header == "Storage");
         Assert.Contains(storage.Items, i => i.Label == "Status" && i.Value == "Read");
     }
+
+    [Fact]
+    public void Build_FlaggedMessage_IncludesFlagRow()
+    {
+        var s = MakeSummary();
+        s.FlagId   = "00000000-0000-0000-0000-000000000001";
+        s.FlagName = "Urgent";
+        var (_, sections) = MessagePropertiesBuilder.Build(s, null, "Work");
+
+        var storage = sections.First(x => x.Header == "Storage");
+        Assert.Contains(storage.Items, i => i.Label == "Flag" && i.Value == "Urgent");
+    }
+
+    [Fact]
+    public void Build_UnflaggedMessage_ShowsNoneForFlag()
+    {
+        var s = MakeSummary();
+        var (_, sections) = MessagePropertiesBuilder.Build(s, null, "Work");
+
+        var storage = sections.First(x => x.Header == "Storage");
+        Assert.Contains(storage.Items, i => i.Label == "Flag" && i.Value == "None");
+    }
 }
 
 // ── FolderPropertiesBuilder ─────────────────────────────────────────────────

--- a/QuickMail.Tests/SavedViewsTests.cs
+++ b/QuickMail.Tests/SavedViewsTests.cs
@@ -840,6 +840,8 @@ public class SavedViewsMainViewModelTests
         public Task<HashSet<string>> GetAllMessageIdsAsync(Guid accountId, string folderName) => Task.FromResult(new HashSet<string>());
         public Task<int> CountSummariesAsync(Guid accountId) => Task.FromResult(0);
         public Task<DateTimeOffset?> GetOldestMessageDateAsync(Guid accountId) => Task.FromResult<DateTimeOffset?>(null);
+        public Task UpdateFlagIdAsync(Guid accountId, string folderName, string messageId, string? flagId) => Task.CompletedTask;
+        public Task UpdateFlagIdBatchAsync(IEnumerable<(Guid AccountId, string FolderName, string MessageId)> items, string? flagId) => Task.CompletedTask;
     }
 
     private static MainViewModel MakeVmWithStore(IEnumerable<SavedView> views, ILocalStoreService store, IMailService? imap = null)

--- a/QuickMail.Tests/SavedViewsTests.cs
+++ b/QuickMail.Tests/SavedViewsTests.cs
@@ -789,6 +789,7 @@ public class SavedViewsMainViewModelTests
         public Task<MailMessageDetail> PrefetchMessageDetailAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default) => Task.FromResult(new MailMessageDetail());
         public Task MarkReadAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default) => Task.CompletedTask;
         public Task MarkReadBatchAsync(Guid accountId, string folderName, IList<string> messageIds, CancellationToken ct = default) => Task.CompletedTask;
+        public Task SetMessageFlaggedAsync(Guid accountId, string folderName, string messageId, bool flagged, CancellationToken ct = default) => Task.CompletedTask;
         public Task MoveToTrashAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default) => Task.CompletedTask;
         public Task MoveToTrashBatchAsync(Guid accountId, string folderName, IList<string> messageIds, CancellationToken ct = default) => Task.CompletedTask;
         public Task PermanentlyDeleteBatchAsync(Guid accountId, string folderName, IList<string> messageIds, CancellationToken ct = default) => Task.CompletedTask;

--- a/QuickMail.Tests/SessionFeaturesTests.cs
+++ b/QuickMail.Tests/SessionFeaturesTests.cs
@@ -103,6 +103,8 @@ public class PreviewSuppressionTests
         public Task<HashSet<string>> GetAllMessageIdsAsync(Guid accountId, string folderName) => Task.FromResult(new HashSet<string>());
         public Task<int> CountSummariesAsync(Guid accountId) => Task.FromResult(0);
         public Task<DateTimeOffset?> GetOldestMessageDateAsync(Guid accountId) => Task.FromResult<DateTimeOffset?>(null);
+        public Task UpdateFlagIdAsync(Guid accountId, string folderName, string messageId, string? flagId) => Task.CompletedTask;
+        public Task UpdateFlagIdBatchAsync(IEnumerable<(Guid AccountId, string FolderName, string MessageId)> items, string? flagId) => Task.CompletedTask;
     }
 
     private static readonly MailMessageSummary[] MessagesWithPreviews =

--- a/QuickMail.Tests/SessionFeaturesTests.cs
+++ b/QuickMail.Tests/SessionFeaturesTests.cs
@@ -212,6 +212,7 @@ public class IdleNewMailTests
         public Task<MailMessageDetail> PrefetchMessageDetailAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default) => Task.FromResult(new MailMessageDetail());
         public Task MarkReadAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default) => Task.CompletedTask;
         public Task MarkReadBatchAsync(Guid accountId, string folderName, IList<string> messageIds, CancellationToken ct = default) => Task.CompletedTask;
+        public Task SetMessageFlaggedAsync(Guid accountId, string folderName, string messageId, bool flagged, CancellationToken ct = default) => Task.CompletedTask;
         public Task MoveToTrashAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default) => Task.CompletedTask;
         public Task MoveToTrashBatchAsync(Guid accountId, string folderName, IList<string> messageIds, CancellationToken ct = default) => Task.CompletedTask;
         public Task PermanentlyDeleteBatchAsync(Guid accountId, string folderName, IList<string> messageIds, CancellationToken ct = default) => Task.CompletedTask;

--- a/QuickMail.Tests/SettingsViewModelTests.cs
+++ b/QuickMail.Tests/SettingsViewModelTests.cs
@@ -128,4 +128,24 @@ public class SettingsViewModelTests
         Assert.True(row.HasCustomBinding);
         Assert.Equal("Ctrl+G", row.CustomGesture);
     }
+
+    [Fact]
+    public void AnnounceFlagStatus_DefaultsToTrue()
+    {
+        var vm = new SettingsViewModel(new StubConfigService(), new StubCommandRegistry());
+        Assert.True(vm.AnnounceFlagStatus);
+    }
+
+    [Fact]
+    public void AnnounceFlagStatus_LoadAndSave_RoundTrips()
+    {
+        var configService = new StubConfigService();
+
+        var vmSave = new SettingsViewModel(configService, new StubCommandRegistry());
+        vmSave.AnnounceFlagStatus = false;
+        vmSave.SaveCommand.Execute(null);
+
+        var vmLoad = new SettingsViewModel(configService, new StubCommandRegistry());
+        Assert.False(vmLoad.AnnounceFlagStatus);
+    }
 }

--- a/QuickMail.Tests/StubServices.cs
+++ b/QuickMail.Tests/StubServices.cs
@@ -24,6 +24,7 @@ sealed class StubImapMailService : IMailService
     public Task<MailMessageDetail> PrefetchMessageDetailAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default) => Task.FromResult(new MailMessageDetail());
     public Task MarkReadAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default) => Task.CompletedTask;
     public Task MarkReadBatchAsync(Guid accountId, string folderName, IList<string> messageIds, CancellationToken ct = default) => Task.CompletedTask;
+    public Task SetMessageFlaggedAsync(Guid accountId, string folderName, string messageId, bool flagged, CancellationToken ct = default) => Task.CompletedTask;
     public Task MoveToTrashAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default) => Task.CompletedTask;
     public Task MoveToTrashBatchAsync(Guid accountId, string folderName, IList<string> messageIds, CancellationToken ct = default) => Task.CompletedTask;
     public Task PermanentlyDeleteBatchAsync(Guid accountId, string folderName, IList<string> messageIds, CancellationToken ct = default) => Task.CompletedTask;

--- a/QuickMail.Tests/StubServices.cs
+++ b/QuickMail.Tests/StubServices.cs
@@ -102,6 +102,8 @@ sealed class StubLocalStoreService : ILocalStoreService
     public Task<HashSet<string>> GetAllMessageIdsAsync(Guid accountId, string folderName) => Task.FromResult(new HashSet<string>());
     public Task<int> CountSummariesAsync(Guid accountId) => Task.FromResult(0);
     public Task<DateTimeOffset?> GetOldestMessageDateAsync(Guid accountId) => Task.FromResult<DateTimeOffset?>(null);
+    public Task UpdateFlagIdAsync(Guid accountId, string folderName, string messageId, string? flagId) => Task.CompletedTask;
+    public Task UpdateFlagIdBatchAsync(IEnumerable<(Guid AccountId, string FolderName, string MessageId)> items, string? flagId) => Task.CompletedTask;
 }
 
 sealed class StubContactService : IContactService

--- a/QuickMail.Tests/StubServices.cs
+++ b/QuickMail.Tests/StubServices.cs
@@ -235,8 +235,8 @@ sealed class StubFlagService : IFlagService
     public Task SaveFlagDefinitionsAsync(List<FlagDefinition> flags) => Task.CompletedTask;
     public Task<FlagDefinition> GetKDefaultFlagAsync() => Task.FromResult(FlagDefinition.CreateBuiltIn());
     public Task SetKDefaultFlagAsync(Guid flagId) => Task.CompletedTask;
-    public Task<FlagDefinition?> SetMessageFlagAsync(MailMessageSummary message, string? flagId, CancellationToken ct = default)
-        => Task.FromResult<FlagDefinition?>(flagId != null ? FlagDefinition.CreateBuiltIn() : null);
+    public Task<FlagDefinition?> SetMessageFlagAsync(MailMessageSummary message, string? flagId, CancellationToken ct = default, FlagDefinition? resolvedDef = null)
+        => Task.FromResult<FlagDefinition?>(resolvedDef ?? (flagId != null ? FlagDefinition.CreateBuiltIn() : null));
     public Task<FlagDefinition?> ToggleDefaultFlagAsync(MailMessageSummary message, CancellationToken ct = default)
         => Task.FromResult<FlagDefinition?>(message.IsFlagged ? null : FlagDefinition.CreateBuiltIn());
 }

--- a/QuickMail.Tests/StubServices.cs
+++ b/QuickMail.Tests/StubServices.cs
@@ -235,6 +235,8 @@ sealed class StubFlagService : IFlagService
     public Task SaveFlagDefinitionsAsync(List<FlagDefinition> flags) => Task.CompletedTask;
     public Task<FlagDefinition> GetKDefaultFlagAsync() => Task.FromResult(FlagDefinition.CreateBuiltIn());
     public Task SetKDefaultFlagAsync(Guid flagId) => Task.CompletedTask;
-    public Task SetMessageFlagAsync(MailMessageSummary message, string? flagId, ILocalStoreService localStore, IMailService mailService, CancellationToken ct = default) => Task.CompletedTask;
-    public Task ToggleDefaultFlagAsync(MailMessageSummary message, ILocalStoreService localStore, IMailService mailService, CancellationToken ct = default) => Task.CompletedTask;
+    public Task<FlagDefinition?> SetMessageFlagAsync(MailMessageSummary message, string? flagId, CancellationToken ct = default)
+        => Task.FromResult<FlagDefinition?>(flagId != null ? FlagDefinition.CreateBuiltIn() : null);
+    public Task<FlagDefinition?> ToggleDefaultFlagAsync(MailMessageSummary message, CancellationToken ct = default)
+        => Task.FromResult<FlagDefinition?>(message.IsFlagged ? null : FlagDefinition.CreateBuiltIn());
 }

--- a/QuickMail.Tests/StubServices.cs
+++ b/QuickMail.Tests/StubServices.cs
@@ -224,3 +224,17 @@ sealed class StubFeatureGate : IFeatureGate
 
     public bool IsEnabled(FeatureFlag flag) => _flags.TryGetValue(flag, out var v) && v;
 }
+
+sealed class StubFlagService : IFlagService
+{
+#pragma warning disable CS0067
+    public event EventHandler? FlagDefinitionsChanged;
+#pragma warning restore CS0067
+    public FlagDefinition GetBuiltInFlag() => FlagDefinition.CreateBuiltIn();
+    public Task<List<FlagDefinition>> LoadFlagDefinitionsAsync() => Task.FromResult(new List<FlagDefinition> { FlagDefinition.CreateBuiltIn() });
+    public Task SaveFlagDefinitionsAsync(List<FlagDefinition> flags) => Task.CompletedTask;
+    public Task<FlagDefinition> GetKDefaultFlagAsync() => Task.FromResult(FlagDefinition.CreateBuiltIn());
+    public Task SetKDefaultFlagAsync(Guid flagId) => Task.CompletedTask;
+    public Task SetMessageFlagAsync(MailMessageSummary message, string? flagId, ILocalStoreService localStore, IMailService mailService, CancellationToken ct = default) => Task.CompletedTask;
+    public Task ToggleDefaultFlagAsync(MailMessageSummary message, ILocalStoreService localStore, IMailService mailService, CancellationToken ct = default) => Task.CompletedTask;
+}

--- a/QuickMail/App.xaml.cs
+++ b/QuickMail/App.xaml.cs
@@ -121,7 +121,7 @@ public partial class App : Application
             mainVm.RegisterAccountBackend = a => mailRouter.RegisterAccount(a.Id, BackendFor(a));
             mainVm.LoadAccountList(accounts);
 
-            var mainWindow = new MainWindow(mainVm, smtpService, accountService, credentialService, mailRouter, oauthService, commandRegistry, contactService, configService, localStore, viewService, ruleService, templateService, featureGate);
+            var mainWindow = new MainWindow(mainVm, smtpService, accountService, credentialService, mailRouter, oauthService, commandRegistry, contactService, configService, localStore, viewService, ruleService, templateService, featureGate, flagService);
             mainWindow.Show();
         }
         catch (Exception ex)

--- a/QuickMail/App.xaml.cs
+++ b/QuickMail/App.xaml.cs
@@ -113,7 +113,7 @@ public partial class App : Application
             commandRegistry.ApplyUserOverrides(startupCfg.CustomHotkeys);
 
             var viewService = new ViewService(profile);
-            var flagService = new FlagService(profile, configService);
+            var flagService = new FlagService(profile, configService, localStore, mailRouter);
 
             var mainVm = new MainViewModel(
                 mailRouter, accountService, credentialService, localStore, oauthService, syncService, configService, commandRegistry, viewService, ruleService, smtpService,

--- a/QuickMail/App.xaml.cs
+++ b/QuickMail/App.xaml.cs
@@ -113,10 +113,11 @@ public partial class App : Application
             commandRegistry.ApplyUserOverrides(startupCfg.CustomHotkeys);
 
             var viewService = new ViewService(profile);
+            var flagService = new FlagService(profile, configService);
 
             var mainVm = new MainViewModel(
                 mailRouter, accountService, credentialService, localStore, oauthService, syncService, configService, commandRegistry, viewService, ruleService, smtpService,
-                onlineMode: onlineMode);
+                onlineMode: onlineMode, flagService: flagService);
             mainVm.RegisterAccountBackend = a => mailRouter.RegisterAccount(a.Id, BackendFor(a));
             mainVm.LoadAccountList(accounts);
 

--- a/QuickMail/Helpers/MessagePropertiesBuilder.cs
+++ b/QuickMail/Helpers/MessagePropertiesBuilder.cs
@@ -1,6 +1,5 @@
-// Deviation from spec: MailMessageSummary does not carry Cc, ReplyTo, MessageId, Size,
-// IsFlagged, or IsAnswered. Those fields are on MailMessageDetail only. When detail is
-// null the rows show "(not loaded)". IsReplied/IsForwarded replace IsFlagged/IsAnswered.
+// Deviation from spec: MailMessageSummary does not carry Cc, ReplyTo, MessageId, or Size.
+// Those fields are on MailMessageDetail only. When detail is null the rows show "(not loaded)".
 // RawHeaders does not exist on MailMessageDetail so the raw-headers expander is never shown.
 
 using System.Collections.Generic;
@@ -29,6 +28,7 @@ public static class MessagePropertiesBuilder
             new("Account",  accountName),
             new("Folder",   summary.FolderName),
             new("IMAP UID", summary.MessageId),
+            new("Flag",     summary.IsFlagged ? summary.FlagLabel : "None"),
             new("Status",   FormatStatus(summary)),
         };
 

--- a/QuickMail/Models/ConfigModel.cs
+++ b/QuickMail/Models/ConfigModel.cs
@@ -67,6 +67,21 @@ public class ConfigModel
     /// <summary>Announce the block type (heading level, list item, normal text) when the caret moves to a different paragraph in HTML compose mode.</summary>
     public bool AnnounceFormattingWhileNavigating { get; set; } = true;
 
+    /// <summary>
+    /// Include the flag name before read status in each message row's accessible name.
+    /// Default on so screen reader users hear flag state immediately.
+    /// </summary>
+    public bool AnnounceFlagStatus { get; set; } = true;
+
+    // ── Flagging ──────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The Guid string of the named flag that the K key applies.
+    /// Defaults to the built-in "Flagged" flag (FlagDefinition.BuiltInFlagId).
+    /// If the stored Guid does not match any defined flag, FlagService falls back to the built-in.
+    /// </summary>
+    public string DefaultFlagId { get; set; } = "00000000-0000-0000-0000-000000000001";
+
     // ── Compose ───────────────────────────────────────────────────────────────────
 
     /// <summary>Editing mode new compose windows start in. Drafts reopen in the mode they were saved in; templates always reopen in plain text.</summary>

--- a/QuickMail/Models/ConversationGroup.cs
+++ b/QuickMail/Models/ConversationGroup.cs
@@ -36,6 +36,15 @@ public sealed class ConversationGroup : INotifyPropertyChanged
     /// <summary>True when at least one message in the conversation is unread.</summary>
     public bool HasUnread => Messages.Any(m => !m.IsRead);
 
+    /// <summary>True when at least one message in the conversation is flagged.</summary>
+    public bool HasFlagged => Messages.Any(m => m.IsFlagged);
+
+    /// <summary>The flag name of the first flagged message in the group, or null if none are flagged.</summary>
+    public string? FlagLabel => Messages.FirstOrDefault(m => m.IsFlagged)?.FlagLabel;
+
+    /// <summary>The color of the first flagged message's flag, or null if none are flagged.</summary>
+    public string? FlagColorHex => Messages.FirstOrDefault(m => m.IsFlagged)?.FlagColorHex;
+
     /// <summary>
     /// Accessibility label read by screen readers when the tree node receives focus.
     /// Preview is omitted when empty (e.g. when preview is disabled in account settings).
@@ -47,9 +56,10 @@ public sealed class ConversationGroup : INotifyPropertyChanged
             var countWord = Count == 1 ? "message" : "messages";
             var sender    = string.IsNullOrWhiteSpace(LastSenderName) ? string.Empty : $" {LastSenderName}.";
             var unread    = HasUnread ? " Has unread." : string.Empty;
+            var flagged   = HasFlagged ? $" {FlagLabel}." : string.Empty;
             return string.IsNullOrWhiteSpace(Preview)
-                ? $"{Subject}. {Count} {countWord}.{sender}{unread} {DateDisplay}."
-                : $"{Subject}. {Count} {countWord}.{sender}{unread} {Preview}. {DateDisplay}.";
+                ? $"{Subject}. {Count} {countWord}.{sender}{flagged}{unread} {DateDisplay}."
+                : $"{Subject}. {Count} {countWord}.{sender}{flagged}{unread} {Preview}. {DateDisplay}.";
         }
     }
 

--- a/QuickMail/Models/ConversationGroup.cs
+++ b/QuickMail/Models/ConversationGroup.cs
@@ -13,8 +13,37 @@ public sealed class ConversationGroup : INotifyPropertyChanged
     /// <summary>The normalised subject used as the grouping key.</summary>
     public string NormalizedSubject { get; init; } = string.Empty;
 
+    private IReadOnlyList<MailMessageSummary> _messages = [];
+
     /// <summary>Messages in this conversation, newest first.</summary>
-    public IReadOnlyList<MailMessageSummary> Messages { get; init; } = [];
+    public IReadOnlyList<MailMessageSummary> Messages
+    {
+        get => _messages;
+        init
+        {
+            _messages = value;
+            // Subscribe to each message's PropertyChanged so flag-related
+            // computed properties stay in sync when a flag is toggled.
+            foreach (var m in _messages)
+            {
+                if (m is INotifyPropertyChanged npc)
+                    npc.PropertyChanged += OnMessagePropertyChanged;
+            }
+        }
+    }
+
+    private void OnMessagePropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName is nameof(MailMessageSummary.IsFlagged)
+            or nameof(MailMessageSummary.FlagLabel)
+            or nameof(MailMessageSummary.FlagColorHex)
+            or nameof(MailMessageSummary.FlagId))
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(HasFlagged)));
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(FlagLabel)));
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(FlagColorHex)));
+        }
+    }
 
     // ── Computed from the newest message ─────────────────────────────────────
 

--- a/QuickMail/Models/FlagDefinition.cs
+++ b/QuickMail/Models/FlagDefinition.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace QuickMail.Models;
+
+public class FlagDefinition
+{
+    /// <summary>Well-known ID for the built-in "Flagged" flag. Never changes across installs.</summary>
+    public static readonly Guid BuiltInFlagId = new("00000000-0000-0000-0000-000000000001");
+
+    public Guid   Id        { get; set; } = Guid.NewGuid();
+    public string Name      { get; set; } = string.Empty;
+    public string ColorHex  { get; set; } = "#FF8C00";
+    public int    SortOrder { get; set; }
+
+    /// <summary>True for the built-in "Flagged" flag, which cannot be deleted.</summary>
+    public bool   IsBuiltIn { get; set; }
+
+    public static FlagDefinition CreateBuiltIn() => new()
+    {
+        Id        = BuiltInFlagId,
+        Name      = "Flagged",
+        ColorHex  = "#FF8C00",
+        SortOrder = 0,
+        IsBuiltIn = true,
+    };
+}

--- a/QuickMail/Models/FlagDefinition.cs
+++ b/QuickMail/Models/FlagDefinition.cs
@@ -15,7 +15,7 @@ public partial class FlagDefinition : ObservableObject
     private string _name = string.Empty;
 
     [ObservableProperty]
-    private string _colorHex = "#FF8C00";
+    private string _colorHex = "#C05621";
 
     [ObservableProperty]
     private int _sortOrder;
@@ -28,7 +28,7 @@ public partial class FlagDefinition : ObservableObject
     {
         Id        = BuiltInFlagId,
         Name      = "Flagged",
-        ColorHex  = "#FF8C00",
+        ColorHex  = "#C05621",
         SortOrder = 0,
         IsBuiltIn = true,
     };

--- a/QuickMail/Models/FlagDefinition.cs
+++ b/QuickMail/Models/FlagDefinition.cs
@@ -1,19 +1,28 @@
 using System;
+using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace QuickMail.Models;
 
-public class FlagDefinition
+public partial class FlagDefinition : ObservableObject
 {
     /// <summary>Well-known ID for the built-in "Flagged" flag. Never changes across installs.</summary>
     public static readonly Guid BuiltInFlagId = new("00000000-0000-0000-0000-000000000001");
 
-    public Guid   Id        { get; set; } = Guid.NewGuid();
-    public string Name      { get; set; } = string.Empty;
-    public string ColorHex  { get; set; } = "#FF8C00";
-    public int    SortOrder { get; set; }
+    [ObservableProperty]
+    private Guid _id = Guid.NewGuid();
+
+    [ObservableProperty]
+    private string _name = string.Empty;
+
+    [ObservableProperty]
+    private string _colorHex = "#FF8C00";
+
+    [ObservableProperty]
+    private int _sortOrder;
 
     /// <summary>True for the built-in "Flagged" flag, which cannot be deleted.</summary>
-    public bool   IsBuiltIn { get; set; }
+    [ObservableProperty]
+    private bool _isBuiltIn;
 
     public static FlagDefinition CreateBuiltIn() => new()
     {

--- a/QuickMail/Models/MailMessageSummary.cs
+++ b/QuickMail/Models/MailMessageSummary.cs
@@ -36,14 +36,52 @@ public partial class MailMessageSummary : ObservableObject
 
     public bool IsMailingList { get; set; }
 
+    // ── Flag state ────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The Guid string of the named flag applied to this message.
+    /// Null when the message is not flagged.
+    /// </summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsFlagged))]
+    [NotifyPropertyChangedFor(nameof(FlagLabel))]
+    [NotifyPropertyChangedFor(nameof(StatusDisplay))]
+    private string? _flagId;
+
+    /// <summary>Display name of the applied flag, denormalized for rendering. Null when unflagged.</summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(FlagLabel))]
+    private string? _flagName;
+
+    /// <summary>Hex color of the applied flag, denormalized for rendering. Null when unflagged.</summary>
+    [ObservableProperty]
+    private string? _flagColorHex;
+
+    /// <summary>True when this message has a named flag applied.</summary>
+    public bool IsFlagged => FlagId is not null;
+
+    /// <summary>
+    /// Human-readable flag name for accessibility. Empty string when not flagged.
+    /// </summary>
+    public string FlagLabel => FlagName ?? string.Empty;
+
+    /// <summary>
+    /// Whether the IMAP server reported this message as \Flagged.
+    /// Transient — used during sync reconciliation; not persisted directly.
+    /// </summary>
+    public bool IsServerFlagged { get; set; }
+
+    // ── Computed display ──────────────────────────────────────────────────────
+
     /// <summary>
     /// Single-word status shown in the status column.
-    /// Priority: Replied > Fwd > New > (blank for read with no special flag).
+    /// Priority: Flag name > Replied > Fwd > New > (blank for read).
     /// </summary>
     public string StatusDisplay
     {
         get
         {
+            if (IsFlagged)   return FlagLabel;
             if (IsReplied)   return "Replied";
             if (IsForwarded) return "Fwd";
             if (!IsRead)     return "New";
@@ -54,6 +92,7 @@ public partial class MailMessageSummary : ObservableObject
     /// <summary>
     /// Human-readable read/status label for accessibility announcements.
     /// Returns "replied", "forwarded", "unread", or "read".
+    /// Flag status is announced separately via FlagLabel.
     /// </summary>
     public string ReadStatusLabel
     {

--- a/QuickMail/Models/MessageFilter.cs
+++ b/QuickMail/Models/MessageFilter.cs
@@ -23,4 +23,7 @@ public enum MessageFilter
 
     /// <summary>Only messages where the user's own address appears in the To field.</summary>
     ToMe,
+
+    /// <summary>Only messages that have any named flag applied.</summary>
+    Flagged,
 }

--- a/QuickMail/Models/SavedView.cs
+++ b/QuickMail/Models/SavedView.cs
@@ -38,4 +38,11 @@ public class SavedView
     /// Stores the key without the NUL sentinel prefix, e.g. "AllMail". Null for real-folder views.
     /// </summary>
     public string? VirtualFolderKey { get; set; }
+
+    /// <summary>
+    /// When set, the view shows only messages flagged with this specific flag name.
+    /// Null = no named-flag filter (MessageFilter.Flagged shows any flag).
+    /// If the named flag is deleted, MainViewModel treats this as no filter.
+    /// </summary>
+    public string? FlagFilter { get; set; }
 }

--- a/QuickMail/Models/SavedView.cs
+++ b/QuickMail/Models/SavedView.cs
@@ -40,9 +40,10 @@ public class SavedView
     public string? VirtualFolderKey { get; set; }
 
     /// <summary>
-    /// When set, the view shows only messages flagged with this specific flag name.
+    /// When set, the view shows only messages flagged with this specific flag (stored as a Guid string).
     /// Null = no named-flag filter (MessageFilter.Flagged shows any flag).
-    /// If the named flag is deleted, MainViewModel treats this as no filter.
+    /// Using the Guid id rather than the name means a flag rename does not break existing views.
+    /// If the referenced flag is deleted, MainViewModel treats this as no filter.
     /// </summary>
-    public string? FlagFilter { get; set; }
+    public string? FlagFilterId { get; set; }
 }

--- a/QuickMail/Models/SenderGroup.cs
+++ b/QuickMail/Models/SenderGroup.cs
@@ -36,6 +36,15 @@ public sealed class SenderGroup : INotifyPropertyChanged
     /// <summary>True when at least one message in the group is unread.</summary>
     public bool HasUnread => Messages.Any(m => !m.IsRead);
 
+    /// <summary>True when at least one message in the group is flagged.</summary>
+    public bool HasFlagged => Messages.Any(m => m.IsFlagged);
+
+    /// <summary>The flag name of the first flagged message in the group, or null if none are flagged.</summary>
+    public string? FlagLabel => Messages.FirstOrDefault(m => m.IsFlagged)?.FlagLabel;
+
+    /// <summary>The color of the first flagged message's flag, or null if none are flagged.</summary>
+    public string? FlagColorHex => Messages.FirstOrDefault(m => m.IsFlagged)?.FlagColorHex;
+
     /// <summary>Accessibility label read by screen readers when the tree node receives focus.</summary>
     public string AutomationName
     {
@@ -43,9 +52,10 @@ public sealed class SenderGroup : INotifyPropertyChanged
         {
             var countWord = Count == 1 ? "message" : "messages";
             var unread    = HasUnread ? " Has unread." : string.Empty;
+            var flagged   = HasFlagged ? $" {FlagLabel}." : string.Empty;
             return string.IsNullOrWhiteSpace(Preview)
-                ? $"{SenderName}. {Count} {countWord}.{unread} {DateDisplay}."
-                : $"{SenderName}. {Count} {countWord}.{unread} {Preview}. {DateDisplay}.";
+                ? $"{SenderName}. {Count} {countWord}.{flagged}{unread} {DateDisplay}."
+                : $"{SenderName}. {Count} {countWord}.{flagged}{unread} {Preview}. {DateDisplay}.";
         }
     }
 

--- a/QuickMail/Models/SenderGroup.cs
+++ b/QuickMail/Models/SenderGroup.cs
@@ -13,8 +13,35 @@ public sealed class SenderGroup : INotifyPropertyChanged
     /// <summary>The trimmed From string used as the grouping key (case-insensitive).</summary>
     public string SenderKey { get; init; } = string.Empty;
 
+    private IReadOnlyList<MailMessageSummary> _messages = [];
+
     /// <summary>Messages from this sender, newest first.</summary>
-    public IReadOnlyList<MailMessageSummary> Messages { get; init; } = [];
+    public IReadOnlyList<MailMessageSummary> Messages
+    {
+        get => _messages;
+        init
+        {
+            _messages = value;
+            foreach (var m in _messages)
+            {
+                if (m is INotifyPropertyChanged npc)
+                    npc.PropertyChanged += OnMessagePropertyChanged;
+            }
+        }
+    }
+
+    private void OnMessagePropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName is nameof(MailMessageSummary.IsFlagged)
+            or nameof(MailMessageSummary.FlagLabel)
+            or nameof(MailMessageSummary.FlagColorHex)
+            or nameof(MailMessageSummary.FlagId))
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(HasFlagged)));
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(FlagLabel)));
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(FlagColorHex)));
+        }
+    }
 
     // ── Computed from the group / newest message ──────────────────────────────
 

--- a/QuickMail/Services/ConfigService.cs
+++ b/QuickMail/Services/ConfigService.cs
@@ -241,6 +241,10 @@ public class ConfigService : IConfigService
                         if (int.TryParse(value, out var asi))
                             config.AutoSaveIntervalSeconds = Math.Clamp(asi, 30, 600);
                         break;
+                    case "announceflagstatus": config.AnnounceFlagStatus = ParseBool(value); break;
+                    case "defaultflagid":
+                        if (Guid.TryParse(value, out _)) config.DefaultFlagId = value;
+                        break;
                 }
             }
             else if (section == "windowing")
@@ -411,6 +415,15 @@ public class ConfigService : IConfigService
 
         sb.AppendLine($"AutoSaveIntervalSeconds = {Math.Clamp(config.AutoSaveIntervalSeconds, 30, 600)}");
         sb.AppendLine("# Seconds between automatic draft saves. Values: 30-600.");
+        sb.AppendLine();
+
+        sb.AppendLine($"AnnounceFlagStatus = {(config.AnnounceFlagStatus ? "on" : "off")}");
+        sb.AppendLine("# Include flag name when announcing a flagged message during navigation. Values: on, off.");
+        sb.AppendLine();
+
+        sb.AppendLine($"DefaultFlagId = {config.DefaultFlagId}");
+        sb.AppendLine("# The flag applied by K (toggle default flag).");
+        sb.AppendLine("# Default is the built-in flag (00000000-0000-0000-0000-000000000001).");
         sb.AppendLine();
 
         // ── [windowing] ──────────────────────────────────────────────────────────

--- a/QuickMail/Services/FlagService.cs
+++ b/QuickMail/Services/FlagService.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Windows;
 using QuickMail.Models;
 
 namespace QuickMail.Services;
@@ -50,8 +49,12 @@ public class FlagService : IFlagService
             else
             {
                 // Enforce built-in properties so they cannot be mutated on disk.
-                var bi = list.Find(f => f.Id == FlagDefinition.BuiltInFlagId)!;
-                bi.Name      = "Flagged";
+                // ColorHex is also reset here to migrate installs that stored the
+                // pre-WCAG amber (#FF8C00) before the palette was corrected.
+                var bi       = list.Find(f => f.Id == FlagDefinition.BuiltInFlagId)!;
+                var builtIn  = FlagDefinition.CreateBuiltIn();
+                bi.Name      = builtIn.Name;
+                bi.ColorHex  = builtIn.ColorHex;
                 bi.IsBuiltIn = true;
             }
 
@@ -76,13 +79,7 @@ public class FlagService : IFlagService
         var tmp  = _flagsFile + ".tmp";
         await File.WriteAllTextAsync(tmp, json);
         File.Move(tmp, _flagsFile, overwrite: true);
-        // Fire on the UI thread so subscribers (ViewModels) can update
-        // observable collections without needing Dispatcher.Invoke.
-        // Same pattern as SyncService event marshalling.
-        if (Application.Current?.Dispatcher is { } disp)
-            await disp.InvokeAsync(() => FlagDefinitionsChanged?.Invoke(this, EventArgs.Empty));
-        else
-            FlagDefinitionsChanged?.Invoke(this, EventArgs.Empty);
+        FlagDefinitionsChanged?.Invoke(this, EventArgs.Empty);
     }
 
     public async Task<FlagDefinition> GetKDefaultFlagAsync()
@@ -106,7 +103,8 @@ public class FlagService : IFlagService
     public async Task<FlagDefinition?> SetMessageFlagAsync(
         MailMessageSummary message,
         string? flagId,
-        CancellationToken ct = default)
+        CancellationToken ct = default,
+        FlagDefinition? resolvedDef = null)
     {
         // Update local store.
         try
@@ -124,8 +122,11 @@ public class FlagService : IFlagService
             await _mailService.SetMessageFlaggedAsync(
                 message.AccountId, message.FolderName, message.MessageId, isBuiltIn, ct);
 
+        if (flagId == null) return null;
+        if (resolvedDef != null) return resolvedDef;
+
         // Resolve the flag definition so the caller can update the in-memory model.
-        if (flagId != null && Guid.TryParse(flagId, out var defId))
+        if (Guid.TryParse(flagId, out var defId))
         {
             var flags = await LoadFlagDefinitionsAsync();
             return flags.Find(f => f.Id == defId);
@@ -141,6 +142,6 @@ public class FlagService : IFlagService
         if (message.IsFlagged)
             return await SetMessageFlagAsync(message, null, ct);
         else
-            return await SetMessageFlagAsync(message, kFlag.Id.ToString(), ct);
+            return await SetMessageFlagAsync(message, kFlag.Id.ToString(), ct, resolvedDef: kFlag);
     }
 }

--- a/QuickMail/Services/FlagService.cs
+++ b/QuickMail/Services/FlagService.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using QuickMail.Models;
+
+namespace QuickMail.Services;
+
+public class FlagService : IFlagService
+{
+    private readonly string _flagsFile;
+    private readonly string _configFile;
+    private readonly IConfigService _configService;
+
+    private static readonly JsonSerializerOptions JsonOpts = new() { WriteIndented = true };
+
+    public event EventHandler? FlagDefinitionsChanged;
+
+    public FlagService(ProfileContext profile, IConfigService configService)
+    {
+        _flagsFile     = Path.Combine(profile.ProfileDir, "flags.json");
+        _configFile    = Path.Combine(profile.ProfileDir, "config.ini");
+        _configService = configService;
+    }
+
+    public FlagDefinition GetBuiltInFlag() => FlagDefinition.CreateBuiltIn();
+
+    public async Task<List<FlagDefinition>> LoadFlagDefinitionsAsync()
+    {
+        if (!File.Exists(_flagsFile))
+            return new List<FlagDefinition> { FlagDefinition.CreateBuiltIn() };
+
+        try
+        {
+            var json = await File.ReadAllTextAsync(_flagsFile);
+            var list = JsonSerializer.Deserialize<List<FlagDefinition>>(json) ?? new();
+
+            // Ensure the built-in flag is always present and first.
+            if (!list.Exists(f => f.Id == FlagDefinition.BuiltInFlagId))
+                list.Insert(0, FlagDefinition.CreateBuiltIn());
+            else
+            {
+                // Enforce built-in properties so they cannot be mutated on disk.
+                var bi = list.Find(f => f.Id == FlagDefinition.BuiltInFlagId)!;
+                bi.Name     = "Flagged";
+                bi.IsBuiltIn = true;
+            }
+
+            return list;
+        }
+        catch
+        {
+            // Corrupt file — back it up and return defaults.
+            try
+            {
+                File.Move(_flagsFile, _flagsFile + $".bak-{DateTime.UtcNow:yyyyMMddHHmmss}",
+                    overwrite: false);
+            }
+            catch { /* ignore backup failure */ }
+            return new List<FlagDefinition> { FlagDefinition.CreateBuiltIn() };
+        }
+    }
+
+    public async Task SaveFlagDefinitionsAsync(List<FlagDefinition> flags)
+    {
+        var json = JsonSerializer.Serialize(flags, JsonOpts);
+        var tmp  = _flagsFile + ".tmp";
+        await File.WriteAllTextAsync(tmp, json);
+        File.Move(tmp, _flagsFile, overwrite: true);
+        FlagDefinitionsChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    public async Task<FlagDefinition> GetKDefaultFlagAsync()
+    {
+        var cfg   = _configService.Load();
+        if (!Guid.TryParse(cfg.DefaultFlagId, out var id))
+            return FlagDefinition.CreateBuiltIn();
+
+        var flags = await LoadFlagDefinitionsAsync();
+        return flags.Find(f => f.Id == id) ?? FlagDefinition.CreateBuiltIn();
+    }
+
+    public async Task SetKDefaultFlagAsync(Guid flagId)
+    {
+        var cfg = _configService.Load();
+        cfg.DefaultFlagId = flagId.ToString();
+        _configService.Save(cfg);
+        await Task.CompletedTask;
+    }
+
+    public async Task SetMessageFlagAsync(
+        MailMessageSummary message,
+        string? flagId,
+        ILocalStoreService localStore,
+        IMailService mailService,
+        CancellationToken ct = default)
+    {
+        // Update local store.
+        try
+        {
+            await localStore.UpdateFlagIdAsync(
+                message.AccountId, message.FolderName, message.MessageId, flagId);
+        }
+        catch { /* --online mode: local store unavailable */ }
+
+        // Update IMAP \Flagged flag if this is the built-in flag or a clear.
+        bool serverFlagged = flagId != null;
+        await mailService.SetMessageFlaggedAsync(
+            message.AccountId, message.FolderName, message.MessageId, serverFlagged, ct);
+
+        // Update in-memory model.
+        message.FlagId = flagId;
+
+        if (flagId == null)
+        {
+            message.FlagName     = null;
+            message.FlagColorHex = null;
+        }
+        else
+        {
+            var flags = await LoadFlagDefinitionsAsync();
+            var def   = flags.Find(f => f.Id.ToString() == flagId);
+            if (def != null)
+            {
+                message.FlagName     = def.Name;
+                message.FlagColorHex = def.ColorHex;
+            }
+        }
+    }
+
+    public async Task ToggleDefaultFlagAsync(
+        MailMessageSummary message,
+        ILocalStoreService localStore,
+        IMailService mailService,
+        CancellationToken ct = default)
+    {
+        var kFlag = await GetKDefaultFlagAsync();
+
+        // Clear if already flagged with anything; set K-default if unflagged.
+        if (message.IsFlagged)
+            await SetMessageFlagAsync(message, null, localStore, mailService, ct);
+        else
+            await SetMessageFlagAsync(message, kFlag.Id.ToString(), localStore, mailService, ct);
+    }
+}

--- a/QuickMail/Services/FlagService.cs
+++ b/QuickMail/Services/FlagService.cs
@@ -141,12 +141,16 @@ public class FlagService : IFlagService
             resolvedDef = flags.Find(f => f.Id == defId);
         }
 
-        // Update in-memory model on the UI thread.
-        Application.Current.Dispatcher.Invoke(() =>
+        // Update in-memory model on the UI thread (or directly when running outside a WPF app, e.g. in tests).
+        void Apply()
         {
             message.FlagId       = flagId;
             message.FlagName     = resolvedDef?.Name;
             message.FlagColorHex = resolvedDef?.ColorHex;
-        });
+        }
+        if (Application.Current?.Dispatcher is { } disp)
+            disp.Invoke(Apply);
+        else
+            Apply();
     }
 }

--- a/QuickMail/Services/FlagService.cs
+++ b/QuickMail/Services/FlagService.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Windows;
 using QuickMail.Models;
 
 namespace QuickMail.Services;
@@ -11,7 +12,6 @@ namespace QuickMail.Services;
 public class FlagService : IFlagService
 {
     private readonly string _flagsFile;
-    private readonly string _configFile;
     private readonly IConfigService _configService;
 
     private static readonly JsonSerializerOptions JsonOpts = new() { WriteIndented = true };
@@ -21,7 +21,6 @@ public class FlagService : IFlagService
     public FlagService(ProfileContext profile, IConfigService configService)
     {
         _flagsFile     = Path.Combine(profile.ProfileDir, "flags.json");
-        _configFile    = Path.Combine(profile.ProfileDir, "config.ini");
         _configService = configService;
     }
 
@@ -44,7 +43,7 @@ public class FlagService : IFlagService
             {
                 // Enforce built-in properties so they cannot be mutated on disk.
                 var bi = list.Find(f => f.Id == FlagDefinition.BuiltInFlagId)!;
-                bi.Name     = "Flagged";
+                bi.Name      = "Flagged";
                 bi.IsBuiltIn = true;
             }
 
@@ -74,7 +73,7 @@ public class FlagService : IFlagService
 
     public async Task<FlagDefinition> GetKDefaultFlagAsync()
     {
-        var cfg   = _configService.Load();
+        var cfg = _configService.Load();
         if (!Guid.TryParse(cfg.DefaultFlagId, out var id))
             return FlagDefinition.CreateBuiltIn();
 
@@ -82,20 +81,42 @@ public class FlagService : IFlagService
         return flags.Find(f => f.Id == id) ?? FlagDefinition.CreateBuiltIn();
     }
 
-    public async Task SetKDefaultFlagAsync(Guid flagId)
+    public Task SetKDefaultFlagAsync(Guid flagId)
     {
         var cfg = _configService.Load();
         cfg.DefaultFlagId = flagId.ToString();
         _configService.Save(cfg);
-        await Task.CompletedTask;
+        return Task.CompletedTask;
     }
 
-    public async Task SetMessageFlagAsync(
+    public Task SetMessageFlagAsync(
         MailMessageSummary message,
         string? flagId,
         ILocalStoreService localStore,
         IMailService mailService,
         CancellationToken ct = default)
+        => SetMessageFlagCoreAsync(message, flagId, null, localStore, mailService, ct);
+
+    public async Task ToggleDefaultFlagAsync(
+        MailMessageSummary message,
+        ILocalStoreService localStore,
+        IMailService mailService,
+        CancellationToken ct = default)
+    {
+        var kFlag = await GetKDefaultFlagAsync();
+        if (message.IsFlagged)
+            await SetMessageFlagCoreAsync(message, null, null, localStore, mailService, ct);
+        else
+            await SetMessageFlagCoreAsync(message, kFlag.Id.ToString(), kFlag, localStore, mailService, ct);
+    }
+
+    private async Task SetMessageFlagCoreAsync(
+        MailMessageSummary message,
+        string? flagId,
+        FlagDefinition? resolvedDef,
+        ILocalStoreService localStore,
+        IMailService mailService,
+        CancellationToken ct)
     {
         // Update local store.
         try
@@ -105,43 +126,27 @@ public class FlagService : IFlagService
         }
         catch { /* --online mode: local store unavailable */ }
 
-        // Update IMAP \Flagged flag if this is the built-in flag or a clear.
-        bool serverFlagged = flagId != null;
-        await mailService.SetMessageFlaggedAsync(
-            message.AccountId, message.FolderName, message.MessageId, serverFlagged, ct);
+        // Only mirror \Flagged to the server when toggling the built-in flag.
+        // Custom flags are local-only and must not pollute the server's \Flagged state.
+        bool isBuiltIn  = Guid.TryParse(flagId,         out var newFid) && newFid == FlagDefinition.BuiltInFlagId;
+        bool wasBuiltIn = Guid.TryParse(message.FlagId, out var oldFid) && oldFid == FlagDefinition.BuiltInFlagId;
+        if (isBuiltIn || wasBuiltIn)
+            await mailService.SetMessageFlaggedAsync(
+                message.AccountId, message.FolderName, message.MessageId, isBuiltIn, ct);
 
-        // Update in-memory model.
-        message.FlagId = flagId;
-
-        if (flagId == null)
-        {
-            message.FlagName     = null;
-            message.FlagColorHex = null;
-        }
-        else
+        // Resolve flag definition if not already supplied.
+        if (flagId != null && resolvedDef == null && Guid.TryParse(flagId, out var defId))
         {
             var flags = await LoadFlagDefinitionsAsync();
-            var def   = flags.Find(f => f.Id.ToString() == flagId);
-            if (def != null)
-            {
-                message.FlagName     = def.Name;
-                message.FlagColorHex = def.ColorHex;
-            }
+            resolvedDef = flags.Find(f => f.Id == defId);
         }
-    }
 
-    public async Task ToggleDefaultFlagAsync(
-        MailMessageSummary message,
-        ILocalStoreService localStore,
-        IMailService mailService,
-        CancellationToken ct = default)
-    {
-        var kFlag = await GetKDefaultFlagAsync();
-
-        // Clear if already flagged with anything; set K-default if unflagged.
-        if (message.IsFlagged)
-            await SetMessageFlagAsync(message, null, localStore, mailService, ct);
-        else
-            await SetMessageFlagAsync(message, kFlag.Id.ToString(), localStore, mailService, ct);
+        // Update in-memory model on the UI thread.
+        Application.Current.Dispatcher.Invoke(() =>
+        {
+            message.FlagId       = flagId;
+            message.FlagName     = resolvedDef?.Name;
+            message.FlagColorHex = resolvedDef?.ColorHex;
+        });
     }
 }

--- a/QuickMail/Services/FlagService.cs
+++ b/QuickMail/Services/FlagService.cs
@@ -13,15 +13,23 @@ public class FlagService : IFlagService
 {
     private readonly string _flagsFile;
     private readonly IConfigService _configService;
+    private readonly ILocalStoreService _localStore;
+    private readonly IMailService _mailService;
 
     private static readonly JsonSerializerOptions JsonOpts = new() { WriteIndented = true };
 
     public event EventHandler? FlagDefinitionsChanged;
 
-    public FlagService(ProfileContext profile, IConfigService configService)
+    public FlagService(
+        ProfileContext profile,
+        IConfigService configService,
+        ILocalStoreService localStore,
+        IMailService mailService)
     {
         _flagsFile     = Path.Combine(profile.ProfileDir, "flags.json");
         _configService = configService;
+        _localStore    = localStore;
+        _mailService   = mailService;
     }
 
     public FlagDefinition GetBuiltInFlag() => FlagDefinition.CreateBuiltIn();
@@ -68,7 +76,13 @@ public class FlagService : IFlagService
         var tmp  = _flagsFile + ".tmp";
         await File.WriteAllTextAsync(tmp, json);
         File.Move(tmp, _flagsFile, overwrite: true);
-        FlagDefinitionsChanged?.Invoke(this, EventArgs.Empty);
+        // Fire on the UI thread so subscribers (ViewModels) can update
+        // observable collections without needing Dispatcher.Invoke.
+        // Same pattern as SyncService event marshalling.
+        if (Application.Current?.Dispatcher is { } disp)
+            await disp.InvokeAsync(() => FlagDefinitionsChanged?.Invoke(this, EventArgs.Empty));
+        else
+            FlagDefinitionsChanged?.Invoke(this, EventArgs.Empty);
     }
 
     public async Task<FlagDefinition> GetKDefaultFlagAsync()
@@ -89,39 +103,15 @@ public class FlagService : IFlagService
         return Task.CompletedTask;
     }
 
-    public Task SetMessageFlagAsync(
+    public async Task<FlagDefinition?> SetMessageFlagAsync(
         MailMessageSummary message,
         string? flagId,
-        ILocalStoreService localStore,
-        IMailService mailService,
         CancellationToken ct = default)
-        => SetMessageFlagCoreAsync(message, flagId, null, localStore, mailService, ct);
-
-    public async Task ToggleDefaultFlagAsync(
-        MailMessageSummary message,
-        ILocalStoreService localStore,
-        IMailService mailService,
-        CancellationToken ct = default)
-    {
-        var kFlag = await GetKDefaultFlagAsync();
-        if (message.IsFlagged)
-            await SetMessageFlagCoreAsync(message, null, null, localStore, mailService, ct);
-        else
-            await SetMessageFlagCoreAsync(message, kFlag.Id.ToString(), kFlag, localStore, mailService, ct);
-    }
-
-    private async Task SetMessageFlagCoreAsync(
-        MailMessageSummary message,
-        string? flagId,
-        FlagDefinition? resolvedDef,
-        ILocalStoreService localStore,
-        IMailService mailService,
-        CancellationToken ct)
     {
         // Update local store.
         try
         {
-            await localStore.UpdateFlagIdAsync(
+            await _localStore.UpdateFlagIdAsync(
                 message.AccountId, message.FolderName, message.MessageId, flagId);
         }
         catch { /* --online mode: local store unavailable */ }
@@ -131,26 +121,26 @@ public class FlagService : IFlagService
         bool isBuiltIn  = Guid.TryParse(flagId,         out var newFid) && newFid == FlagDefinition.BuiltInFlagId;
         bool wasBuiltIn = Guid.TryParse(message.FlagId, out var oldFid) && oldFid == FlagDefinition.BuiltInFlagId;
         if (isBuiltIn || wasBuiltIn)
-            await mailService.SetMessageFlaggedAsync(
+            await _mailService.SetMessageFlaggedAsync(
                 message.AccountId, message.FolderName, message.MessageId, isBuiltIn, ct);
 
-        // Resolve flag definition if not already supplied.
-        if (flagId != null && resolvedDef == null && Guid.TryParse(flagId, out var defId))
+        // Resolve the flag definition so the caller can update the in-memory model.
+        if (flagId != null && Guid.TryParse(flagId, out var defId))
         {
             var flags = await LoadFlagDefinitionsAsync();
-            resolvedDef = flags.Find(f => f.Id == defId);
+            return flags.Find(f => f.Id == defId);
         }
+        return null;
+    }
 
-        // Update in-memory model on the UI thread (or directly when running outside a WPF app, e.g. in tests).
-        void Apply()
-        {
-            message.FlagId       = flagId;
-            message.FlagName     = resolvedDef?.Name;
-            message.FlagColorHex = resolvedDef?.ColorHex;
-        }
-        if (Application.Current?.Dispatcher is { } disp)
-            disp.Invoke(Apply);
+    public async Task<FlagDefinition?> ToggleDefaultFlagAsync(
+        MailMessageSummary message,
+        CancellationToken ct = default)
+    {
+        var kFlag = await GetKDefaultFlagAsync();
+        if (message.IsFlagged)
+            return await SetMessageFlagAsync(message, null, ct);
         else
-            Apply();
+            return await SetMessageFlagAsync(message, kFlag.Id.ToString(), ct);
     }
 }

--- a/QuickMail/Services/Graph/GraphDtos.cs
+++ b/QuickMail/Services/Graph/GraphDtos.cs
@@ -73,4 +73,11 @@ internal sealed class GraphMessage
     [JsonPropertyName("isRead")] public bool IsRead { get; set; }
     [JsonPropertyName("hasAttachments")] public bool HasAttachments { get; set; }
     [JsonPropertyName("attachments")] public List<GraphAttachment>? Attachments { get; set; }
+    [JsonPropertyName("flag")] public GraphFollowUpFlag? Flag { get; set; }
+}
+
+public class GraphFollowUpFlag
+{
+    /// <summary>Values: "notFlagged" | "flagged" | "complete".</summary>
+    [JsonPropertyName("flagStatus")] public string FlagStatus { get; set; } = "notFlagged";
 }

--- a/QuickMail/Services/Graph/GraphDtos.cs
+++ b/QuickMail/Services/Graph/GraphDtos.cs
@@ -76,7 +76,7 @@ internal sealed class GraphMessage
     [JsonPropertyName("flag")] public GraphFollowUpFlag? Flag { get; set; }
 }
 
-public class GraphFollowUpFlag
+internal sealed class GraphFollowUpFlag
 {
     /// <summary>Values: "notFlagged" | "flagged" | "complete".</summary>
     [JsonPropertyName("flagStatus")] public string FlagStatus { get; set; } = "notFlagged";

--- a/QuickMail/Services/GraphMailService.cs
+++ b/QuickMail/Services/GraphMailService.cs
@@ -159,7 +159,7 @@ public class GraphMailService : IMailService
     {
         var top = limit > 0 ? Math.Min(limit, 999) : 500;
         var path = $"/me/mailFolders/{folderName}/messages?$top={top}&$orderby=receivedDateTime desc" +
-                   "&$select=id,subject,from,toRecipients,receivedDateTime,isRead,bodyPreview,hasAttachments";
+                   "&$select=id,subject,from,toRecipients,receivedDateTime,isRead,bodyPreview,hasAttachments,flag";
         if (since.HasValue)
             path += $"&$filter=receivedDateTime ge {since.Value.ToUniversalTime():yyyy-MM-ddTHH:mm:ssZ}";
 
@@ -266,9 +266,10 @@ public class GraphMailService : IMailService
         To = JoinRecipients(m.ToRecipients),
         Subject = m.Subject ?? "(no subject)",
         Date = m.ReceivedDateTime,
-        IsRead = m.IsRead,
-        Preview = m.BodyPreview ?? string.Empty,
-        HasAttachments = m.HasAttachments,
+        IsRead          = m.IsRead,
+        Preview         = m.BodyPreview ?? string.Empty,
+        HasAttachments  = m.HasAttachments,
+        IsServerFlagged = m.Flag?.FlagStatus == "flagged",
     };
 
     private static MailMessageDetail MapToDetail(GraphMessage m, Guid accountId, string folderName)

--- a/QuickMail/Services/GraphMailService.cs
+++ b/QuickMail/Services/GraphMailService.cs
@@ -189,6 +189,13 @@ public class GraphMailService : IMailService
     public Task MarkReadAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default)
         => _client.PatchAsync(Account(accountId), $"/me/messages/{messageId}", new { isRead = true }, ct);
 
+    public Task SetMessageFlaggedAsync(Guid accountId, string folderName, string messageId, bool flagged, CancellationToken ct = default)
+    {
+        var status = flagged ? "flagged" : "notFlagged";
+        return _client.PatchAsync(Account(accountId), $"/me/messages/{messageId}",
+            new { flag = new { flagStatus = status } }, ct);
+    }
+
     // ── Status / reconciliation ──────────────────────────────────────────────────
     public async Task<(int Total, int Unread)> GetInboxStatusAsync(Guid accountId, CancellationToken ct = default)
     {

--- a/QuickMail/Services/IFlagService.cs
+++ b/QuickMail/Services/IFlagService.cs
@@ -32,7 +32,8 @@ public interface IFlagService
     Task<FlagDefinition?> SetMessageFlagAsync(
         MailMessageSummary message,
         string? flagId,
-        CancellationToken ct = default);
+        CancellationToken ct = default,
+        FlagDefinition? resolvedDef = null);
 
     /// <summary>
     /// Toggles the K-default flag on a message (sets if unflagged, clears if already flagged

--- a/QuickMail/Services/IFlagService.cs
+++ b/QuickMail/Services/IFlagService.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using QuickMail.Models;
+
+namespace QuickMail.Services;
+
+public interface IFlagService
+{
+    /// <summary>Raised on the UI thread when flag definitions are created, renamed, or deleted.</summary>
+    event EventHandler? FlagDefinitionsChanged;
+
+    Task<List<FlagDefinition>> LoadFlagDefinitionsAsync();
+    Task SaveFlagDefinitionsAsync(List<FlagDefinition> flags);
+
+    FlagDefinition GetBuiltInFlag();
+
+    /// <summary>Returns the flag definition the K key applies. Never null — falls back to the built-in flag.</summary>
+    Task<FlagDefinition> GetKDefaultFlagAsync();
+
+    /// <summary>Persists the default flag id used by the K key.</summary>
+    Task SetKDefaultFlagAsync(Guid flagId);
+
+    /// <summary>
+    /// Sets or clears a named flag on a message in the local store and on the server.
+    /// Pass null <paramref name="flagId"/> to clear. If <paramref name="flagId"/> is the
+    /// built-in flag id the IMAP \Flagged flag is also toggled on the server.
+    /// </summary>
+    Task SetMessageFlagAsync(
+        MailMessageSummary message,
+        string? flagId,
+        ILocalStoreService localStore,
+        IMailService mailService,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Toggles the K-default flag on a message (sets if unflagged, clears if already flagged
+    /// with the K-default flag or any flag).
+    /// </summary>
+    Task ToggleDefaultFlagAsync(
+        MailMessageSummary message,
+        ILocalStoreService localStore,
+        IMailService mailService,
+        CancellationToken ct = default);
+}

--- a/QuickMail/Services/IFlagService.cs
+++ b/QuickMail/Services/IFlagService.cs
@@ -26,21 +26,21 @@ public interface IFlagService
     /// Sets or clears a named flag on a message in the local store and on the server.
     /// Pass null <paramref name="flagId"/> to clear. If <paramref name="flagId"/> is the
     /// built-in flag id the IMAP \Flagged flag is also toggled on the server.
+    /// Returns the resolved <see cref="FlagDefinition"/> (or null when clearing) so the
+    /// caller can update the in-memory model on the UI thread.
     /// </summary>
-    Task SetMessageFlagAsync(
+    Task<FlagDefinition?> SetMessageFlagAsync(
         MailMessageSummary message,
         string? flagId,
-        ILocalStoreService localStore,
-        IMailService mailService,
         CancellationToken ct = default);
 
     /// <summary>
     /// Toggles the K-default flag on a message (sets if unflagged, clears if already flagged
     /// with the K-default flag or any flag).
+    /// Returns the resolved <see cref="FlagDefinition"/> (or null when clearing) so the
+    /// caller can update the in-memory model on the UI thread.
     /// </summary>
-    Task ToggleDefaultFlagAsync(
+    Task<FlagDefinition?> ToggleDefaultFlagAsync(
         MailMessageSummary message,
-        ILocalStoreService localStore,
-        IMailService mailService,
         CancellationToken ct = default);
 }

--- a/QuickMail/Services/ILocalStoreService.cs
+++ b/QuickMail/Services/ILocalStoreService.cs
@@ -50,4 +50,18 @@ public interface ILocalStoreService
     /// Used to display the cache window in Account Properties.
     /// </summary>
     Task<DateTimeOffset?> GetOldestMessageDateAsync(Guid accountId);
+
+    /// <summary>
+    /// Sets or clears the named-flag assignment on a single message.
+    /// Pass null for flagId to clear the flag.
+    /// </summary>
+    Task UpdateFlagIdAsync(Guid accountId, string folderName, string messageId, string? flagId);
+
+    /// <summary>
+    /// Batch-sets or clears the named-flag assignment on multiple messages in a single transaction.
+    /// Pass null for flagId to clear all flags in the batch.
+    /// </summary>
+    Task UpdateFlagIdBatchAsync(
+        IEnumerable<(Guid AccountId, string FolderName, string MessageId)> items,
+        string? flagId);
 }

--- a/QuickMail/Services/IMailService.cs
+++ b/QuickMail/Services/IMailService.cs
@@ -42,6 +42,9 @@ public interface IMailService : IDisposable
         Guid accountId, string folderName, string messageId, CancellationToken ct = default);
     Task MarkReadAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default);
     Task MarkReadBatchAsync(Guid accountId, string folderName, IList<string> messageIds, CancellationToken ct = default);
+
+    /// <summary>Sets or clears the server \Flagged flag on a single message.</summary>
+    Task SetMessageFlaggedAsync(Guid accountId, string folderName, string messageId, bool flagged, CancellationToken ct = default);
     Task MoveToTrashAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default);
     Task MoveToTrashBatchAsync(Guid accountId, string folderName, IList<string> messageIds, CancellationToken ct = default);
     /// <summary>Permanently deletes messages already in Trash by setting \Deleted and expunging.</summary>

--- a/QuickMail/Services/ImapMailService.cs
+++ b/QuickMail/Services/ImapMailService.cs
@@ -424,6 +424,23 @@ public class ImapMailService : IMailService
         finally { await folder.CloseAsync(false, ct); }
     }
 
+    public async Task SetMessageFlaggedAsync(Guid accountId, string folderName, string messageId, bool flagged, CancellationToken ct = default)
+    {
+        using var lease = await RentClientAsync(accountId, ct, ImapLeasePriority.Foreground);
+        var client = lease.Client;
+        var folder = await client.GetFolderAsync(folderName, ct);
+        await folder.OpenAsync(FolderAccess.ReadWrite, ct);
+        try
+        {
+            var uid = ToUid(messageId);
+            if (flagged)
+                await folder.AddFlagsAsync(uid, MessageFlags.Flagged, true, ct);
+            else
+                await folder.RemoveFlagsAsync(uid, MessageFlags.Flagged, true, ct);
+        }
+        finally { await folder.CloseAsync(false, ct); }
+    }
+
     public async Task MoveToTrashBatchAsync(Guid accountId, string folderName, IList<string> messageIds, CancellationToken ct = default)
     {
         using var lease = await RentClientAsync(accountId, ct, ImapLeasePriority.Foreground);

--- a/QuickMail/Services/ImapMailService.cs
+++ b/QuickMail/Services/ImapMailService.cs
@@ -1241,13 +1241,14 @@ public class ImapMailService : IMailService
             To          = FormatAddressList(s.Envelope?.To),
             Subject     = s.Envelope?.Subject ?? "(no subject)",
             Date        = s.Envelope?.Date ?? DateTimeOffset.MinValue,
-            IsRead      = (s.Flags & MessageFlags.Seen)     != 0,
-            IsReplied   = (s.Flags & MessageFlags.Answered) != 0,
-            IsForwarded = s.Keywords?.Any(k =>
-                              k.Equals("$Forwarded", StringComparison.OrdinalIgnoreCase) ||
-                              k.Equals("Forwarded",  StringComparison.OrdinalIgnoreCase)) == true,
-            Preview       = s.PreviewText ?? string.Empty,   // populated when server supports IMAP PREVIEW
-            IsMailingList = !string.IsNullOrEmpty(s.Headers?["List-Id"]),
+            IsRead         = (s.Flags & MessageFlags.Seen)     != 0,
+            IsReplied      = (s.Flags & MessageFlags.Answered) != 0,
+            IsForwarded    = s.Keywords?.Any(k =>
+                                 k.Equals("$Forwarded", StringComparison.OrdinalIgnoreCase) ||
+                                 k.Equals("Forwarded",  StringComparison.OrdinalIgnoreCase)) == true,
+            IsServerFlagged = (s.Flags & MessageFlags.Flagged) != 0,
+            Preview         = s.PreviewText ?? string.Empty,   // populated when server supports IMAP PREVIEW
+            IsMailingList   = !string.IsNullOrEmpty(s.Headers?["List-Id"]),
         };
 
     private static async Task<IMailFolder?> FindSpecialFolderAsync(

--- a/QuickMail/Services/LocalStoreService.cs
+++ b/QuickMail/Services/LocalStoreService.cs
@@ -82,6 +82,7 @@ public class LocalStoreService : ILocalStoreService
         RunMigration(conn, "ALTER TABLE MessageSummary ADD COLUMN has_attachments INTEGER NOT NULL DEFAULT 0;");
         RunMigration(conn, "ALTER TABLE MessageSummary ADD COLUMN is_mailing_list INTEGER NOT NULL DEFAULT 0;");
         RunMigration(conn, "ALTER TABLE MessageDetail ADD COLUMN attachments_json TEXT DEFAULT NULL;");
+        RunMigration(conn, "ALTER TABLE MessageSummary ADD COLUMN flag_id TEXT DEFAULT NULL;");
 
         RunDataMigrations(conn);
     }
@@ -94,6 +95,7 @@ public class LocalStoreService : ILocalStoreService
     //   0 → 1   to_addr backfill from MessageDetail
     //   1 → 2   unique_id INTEGER → TEXT (string MessageId); add DeltaToken table
     //   2 → 3   is_mailing_list backfill from to_addr patterns
+    //   (no 3 → 4 data migration needed — flag_id column added via RunMigration; default NULL is correct)
     // Add new migrations as: if (version < 4) { ...; }
     private const int CurrentSchemaVersion = 3;
 
@@ -143,12 +145,13 @@ public class LocalStoreService : ILocalStoreService
                     is_forwarded INTEGER NOT NULL DEFAULT 0,
                     has_attachments INTEGER NOT NULL DEFAULT 0,
                     is_mailing_list INTEGER NOT NULL DEFAULT 0,
+                    flag_id      TEXT    DEFAULT NULL,
                     PRIMARY KEY (unique_id, account_id, folder_name)
                 );
                 INSERT INTO MessageSummary_v2
                 SELECT CAST(unique_id AS TEXT), account_id, folder_name, from_disp, to_addr,
                        subject, date_ticks, is_read, preview_text, is_replied, is_forwarded,
-                       has_attachments, is_mailing_list
+                       has_attachments, is_mailing_list, flag_id
                 FROM MessageSummary;
                 DROP TABLE MessageSummary;
                 ALTER TABLE MessageSummary_v2 RENAME TO MessageSummary;
@@ -245,16 +248,18 @@ public class LocalStoreService : ILocalStoreService
             INSERT INTO MessageSummary(unique_id, account_id, folder_name, from_disp, to_addr, subject, date_ticks, is_read, preview_text, is_replied, is_forwarded, is_mailing_list)
             VALUES($uid, $aid, $fn, $from, $to, $subj, $dt, $read, $preview, $replied, $forwarded, $ml)
             ON CONFLICT(unique_id, account_id, folder_name) DO UPDATE SET
-                from_disp      = excluded.from_disp,
-                to_addr        = excluded.to_addr,
-                subject        = excluded.subject,
-                date_ticks     = excluded.date_ticks,
-                is_read        = excluded.is_read,
-                is_replied     = excluded.is_replied,
-                is_forwarded   = excluded.is_forwarded,
+                from_disp       = excluded.from_disp,
+                to_addr         = excluded.to_addr,
+                subject         = excluded.subject,
+                date_ticks      = excluded.date_ticks,
+                is_read         = excluded.is_read,
+                is_replied      = excluded.is_replied,
+                is_forwarded    = excluded.is_forwarded,
                 is_mailing_list = excluded.is_mailing_list,
-                preview_text   = CASE WHEN excluded.preview_text = '' THEN preview_text ELSE excluded.preview_text END;
+                preview_text    = CASE WHEN excluded.preview_text = '' THEN preview_text ELSE excluded.preview_text END;
             """;
+            // flag_id is intentionally NOT in the upsert DO UPDATE — sync never clears a local
+            // flag assignment. Flag reconciliation runs separately in SyncService.
         var pUid       = cmd.Parameters.Add("$uid",       SqliteType.Text);
         var pAid       = cmd.Parameters.Add("$aid",       SqliteType.Text);
         var pFn        = cmd.Parameters.Add("$fn",        SqliteType.Text);
@@ -292,7 +297,7 @@ public class LocalStoreService : ILocalStoreService
         await using var conn = await OpenAsync();
         await using var cmd = conn.CreateCommand();
         cmd.CommandText =
-            "SELECT unique_id, account_id, folder_name, from_disp, to_addr, subject, date_ticks, is_read, preview_text, is_replied, is_forwarded, has_attachments, is_mailing_list " +
+            "SELECT unique_id, account_id, folder_name, from_disp, to_addr, subject, date_ticks, is_read, preview_text, is_replied, is_forwarded, has_attachments, is_mailing_list, flag_id " +
             "FROM MessageSummary ORDER BY date_ticks DESC;";
         return await ReadSummariesAsync(cmd);
     }
@@ -302,7 +307,7 @@ public class LocalStoreService : ILocalStoreService
         await using var conn = await OpenAsync();
         await using var cmd = conn.CreateCommand();
         cmd.CommandText =
-            "SELECT unique_id, account_id, folder_name, from_disp, to_addr, subject, date_ticks, is_read, preview_text, is_replied, is_forwarded, has_attachments, is_mailing_list " +
+            "SELECT unique_id, account_id, folder_name, from_disp, to_addr, subject, date_ticks, is_read, preview_text, is_replied, is_forwarded, has_attachments, is_mailing_list, flag_id " +
             "FROM MessageSummary WHERE account_id=$aid ORDER BY date_ticks DESC;";
         cmd.Parameters.AddWithValue("$aid", accountId.ToString());
         return await ReadSummariesAsync(cmd);
@@ -313,7 +318,7 @@ public class LocalStoreService : ILocalStoreService
         await using var conn = await OpenAsync();
         await using var cmd = conn.CreateCommand();
         cmd.CommandText =
-            "SELECT unique_id, account_id, folder_name, from_disp, to_addr, subject, date_ticks, is_read, preview_text, is_replied, is_forwarded, has_attachments, is_mailing_list " +
+            "SELECT unique_id, account_id, folder_name, from_disp, to_addr, subject, date_ticks, is_read, preview_text, is_replied, is_forwarded, has_attachments, is_mailing_list, flag_id " +
             "FROM MessageSummary WHERE account_id=$aid AND folder_name=$fn ORDER BY date_ticks DESC" +
             (limit.HasValue ? " LIMIT $limit;" : ";");
         cmd.Parameters.AddWithValue("$aid", accountId.ToString());
@@ -403,6 +408,46 @@ public class LocalStoreService : ILocalStoreService
         var pAid  = cmd.Parameters.Add("$aid",  Microsoft.Data.Sqlite.SqliteType.Text);
         var pFn   = cmd.Parameters.Add("$fn",   Microsoft.Data.Sqlite.SqliteType.Text);
         pRead.Value = isRead ? 1 : 0;
+        foreach (var (accountId, folderName, messageId) in items)
+        {
+            pUid.Value = messageId;
+            pAid.Value = accountId.ToString();
+            pFn.Value  = folderName;
+            await cmd.ExecuteNonQueryAsync();
+        }
+        await tx.CommitAsync();
+    }
+
+    public async Task UpdateFlagIdAsync(Guid accountId, string folderName, string messageId, string? flagId)
+    {
+        await using var conn = await OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText =
+            "UPDATE MessageSummary SET flag_id=$fid " +
+            "WHERE unique_id=$uid AND account_id=$aid AND folder_name=$fn;";
+        cmd.Parameters.AddWithValue("$fid", (object?)flagId ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("$uid", messageId);
+        cmd.Parameters.AddWithValue("$aid", accountId.ToString());
+        cmd.Parameters.AddWithValue("$fn",  folderName);
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    public async Task UpdateFlagIdBatchAsync(
+        IEnumerable<(Guid AccountId, string FolderName, string MessageId)> items,
+        string? flagId)
+    {
+        await using var conn = await OpenAsync();
+        await using var tx = await conn.BeginTransactionAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.Transaction = (Microsoft.Data.Sqlite.SqliteTransaction)tx;
+        cmd.CommandText =
+            "UPDATE MessageSummary SET flag_id=$fid " +
+            "WHERE unique_id=$uid AND account_id=$aid AND folder_name=$fn;";
+        var pFid = cmd.Parameters.Add("$fid", SqliteType.Text);
+        var pUid = cmd.Parameters.Add("$uid", SqliteType.Text);
+        var pAid = cmd.Parameters.Add("$aid", SqliteType.Text);
+        var pFn  = cmd.Parameters.Add("$fn",  SqliteType.Text);
+        pFid.Value = (object?)flagId ?? DBNull.Value;
         foreach (var (accountId, folderName, messageId) in items)
         {
             pUid.Value = messageId;
@@ -609,6 +654,7 @@ public class LocalStoreService : ILocalStoreService
                 IsForwarded    = r.GetInt64(10) != 0,
                 HasAttachments = r.GetInt64(11) != 0,
                 IsMailingList  = r.GetInt64(12) != 0,
+                FlagId         = r.IsDBNull(13) ? null : r.GetString(13),
             });
         }
         return list;

--- a/QuickMail/Services/LocalStoreService.cs
+++ b/QuickMail/Services/LocalStoreService.cs
@@ -257,11 +257,16 @@ public class LocalStoreService : ILocalStoreService
                 is_forwarded    = excluded.is_forwarded,
                 is_mailing_list = excluded.is_mailing_list,
                 preview_text    = CASE WHEN excluded.preview_text = '' THEN preview_text ELSE excluded.preview_text END,
-                flag_id         = CASE WHEN flag_id IS NULL THEN excluded.flag_id ELSE flag_id END;
+                flag_id         = CASE
+                    WHEN excluded.flag_id IS NULL THEN NULL
+                    WHEN flag_id IS NULL           THEN excluded.flag_id
+                    ELSE                                flag_id
+                    END;
             """;
-            // flag_id uses COALESCE semantics on DO UPDATE: a server-flagged message that
-            // has no local flag assignment gets the built-in flag id; an existing user
-            // assignment is never overwritten by sync.
+            // flag_id reconciliation on DO UPDATE (§9.3):
+            //   server unflagged (excluded.flag_id NULL)  → clear any local flag (external unflag)
+            //   server flagged, no local flag             → apply built-in default flag id
+            //   server flagged, local named flag present  → preserve the user's named flag
         var pUid       = cmd.Parameters.Add("$uid",       SqliteType.Text);
         var pAid       = cmd.Parameters.Add("$aid",       SqliteType.Text);
         var pFn        = cmd.Parameters.Add("$fn",        SqliteType.Text);

--- a/QuickMail/Services/LocalStoreService.cs
+++ b/QuickMail/Services/LocalStoreService.cs
@@ -245,8 +245,8 @@ public class LocalStoreService : ILocalStoreService
         await using var tx = await conn.BeginTransactionAsync();
         await using var cmd = conn.CreateCommand();
         cmd.CommandText = """
-            INSERT INTO MessageSummary(unique_id, account_id, folder_name, from_disp, to_addr, subject, date_ticks, is_read, preview_text, is_replied, is_forwarded, is_mailing_list)
-            VALUES($uid, $aid, $fn, $from, $to, $subj, $dt, $read, $preview, $replied, $forwarded, $ml)
+            INSERT INTO MessageSummary(unique_id, account_id, folder_name, from_disp, to_addr, subject, date_ticks, is_read, preview_text, is_replied, is_forwarded, is_mailing_list, flag_id)
+            VALUES($uid, $aid, $fn, $from, $to, $subj, $dt, $read, $preview, $replied, $forwarded, $ml, $flag_id)
             ON CONFLICT(unique_id, account_id, folder_name) DO UPDATE SET
                 from_disp       = excluded.from_disp,
                 to_addr         = excluded.to_addr,
@@ -256,10 +256,12 @@ public class LocalStoreService : ILocalStoreService
                 is_replied      = excluded.is_replied,
                 is_forwarded    = excluded.is_forwarded,
                 is_mailing_list = excluded.is_mailing_list,
-                preview_text    = CASE WHEN excluded.preview_text = '' THEN preview_text ELSE excluded.preview_text END;
+                preview_text    = CASE WHEN excluded.preview_text = '' THEN preview_text ELSE excluded.preview_text END,
+                flag_id         = CASE WHEN flag_id IS NULL THEN excluded.flag_id ELSE flag_id END;
             """;
-            // flag_id is intentionally NOT in the upsert DO UPDATE — sync never clears a local
-            // flag assignment. Flag reconciliation runs separately in SyncService.
+            // flag_id uses COALESCE semantics on DO UPDATE: a server-flagged message that
+            // has no local flag assignment gets the built-in flag id; an existing user
+            // assignment is never overwritten by sync.
         var pUid       = cmd.Parameters.Add("$uid",       SqliteType.Text);
         var pAid       = cmd.Parameters.Add("$aid",       SqliteType.Text);
         var pFn        = cmd.Parameters.Add("$fn",        SqliteType.Text);
@@ -272,6 +274,7 @@ public class LocalStoreService : ILocalStoreService
         var pReplied   = cmd.Parameters.Add("$replied",   SqliteType.Integer);
         var pForwarded = cmd.Parameters.Add("$forwarded", SqliteType.Integer);
         var pMl        = cmd.Parameters.Add("$ml",        SqliteType.Integer);
+        var pFlagId    = cmd.Parameters.Add("$flag_id",   SqliteType.Text);
 
         foreach (var s in summaries)
         {
@@ -287,6 +290,9 @@ public class LocalStoreService : ILocalStoreService
             pReplied.Value   = s.IsReplied        ? 1 : 0;
             pForwarded.Value = s.IsForwarded      ? 1 : 0;
             pMl.Value        = s.IsMailingList    ? 1 : 0;
+            pFlagId.Value    = s.IsServerFlagged
+                ? (object)FlagDefinition.BuiltInFlagId.ToString()
+                : DBNull.Value;
             await cmd.ExecuteNonQueryAsync();
         }
         await tx.CommitAsync();

--- a/QuickMail/Services/MailServiceRouter.cs
+++ b/QuickMail/Services/MailServiceRouter.cs
@@ -90,6 +90,9 @@ public class MailServiceRouter : IMailService
     public Task MarkReadBatchAsync(Guid accountId, string folderName, IList<string> messageIds, CancellationToken ct = default)
         => For(accountId).MarkReadBatchAsync(accountId, folderName, messageIds, ct);
 
+    public Task SetMessageFlaggedAsync(Guid accountId, string folderName, string messageId, bool flagged, CancellationToken ct = default)
+        => For(accountId).SetMessageFlaggedAsync(accountId, folderName, messageId, flagged, ct);
+
     public Task MoveToTrashAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default)
         => For(accountId).MoveToTrashAsync(accountId, folderName, messageId, ct);
 

--- a/QuickMail/ViewModels/FlagManagerViewModel.cs
+++ b/QuickMail/ViewModels/FlagManagerViewModel.cs
@@ -1,0 +1,212 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using QuickMail.Models;
+using QuickMail.Services;
+
+namespace QuickMail.ViewModels;
+
+public partial class FlagManagerViewModel : ObservableObject
+{
+    private const int MaxUserFlags  = 20;
+    private const int MaxNameLength = 32;
+
+    private readonly IFlagService _flagService;
+
+    public ObservableCollection<FlagDefinition> Flags { get; } = [];
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(CanDelete))]
+    [NotifyPropertyChangedFor(nameof(HasSelection))]
+    [NotifyPropertyChangedFor(nameof(CanMoveUp))]
+    [NotifyPropertyChangedFor(nameof(CanMoveDown))]
+    [NotifyCanExecuteChangedFor(nameof(DeleteFlagCommand))]
+    [NotifyCanExecuteChangedFor(nameof(BeginRenameCommand))]
+    [NotifyCanExecuteChangedFor(nameof(MoveUpCommand))]
+    [NotifyCanExecuteChangedFor(nameof(MoveDownCommand))]
+    [NotifyCanExecuteChangedFor(nameof(SetAsKDefaultCommand))]
+    private FlagDefinition? _selectedFlag;
+
+    [ObservableProperty]
+    private bool _isRenaming;
+
+    [ObservableProperty]
+    private string _editName = string.Empty;
+
+    [ObservableProperty]
+    private string _renameError = string.Empty;
+
+    [ObservableProperty]
+    private Guid _kDefaultId;
+
+    public bool HasSelection => SelectedFlag != null;
+    public bool CanDelete    => SelectedFlag?.IsBuiltIn == false;
+    public bool CanMoveUp    => SelectedFlag != null && Flags.IndexOf(SelectedFlag) > 0;
+    public bool CanMoveDown  => SelectedFlag != null && Flags.IndexOf(SelectedFlag) < Flags.Count - 1;
+
+    public static string[] PresetColors { get; } =
+    [
+        "#E53E3E", "#DD6B20", "#FF8C00", "#D69E2E",
+        "#38A169", "#68D391", "#319795", "#00B5D8",
+        "#3182CE", "#5A67D8", "#6B46C1", "#D53F8C",
+    ];
+
+    public event Func<string, string, Task<bool>>? ConfirmDeleteRequested;
+    public event Action<string, AnnouncementCategory>? AnnouncementRequested;
+    public event EventHandler? RenameStarted;
+
+    public FlagManagerViewModel(IFlagService flagService)
+    {
+        _flagService = flagService;
+    }
+
+    public async Task LoadAsync()
+    {
+        var flags = await _flagService.LoadFlagDefinitionsAsync();
+        Flags.Clear();
+        foreach (var f in flags.OrderBy(f => f.SortOrder))
+            Flags.Add(f);
+        var kFlag = await _flagService.GetKDefaultFlagAsync();
+        KDefaultId = kFlag.Id;
+        SelectedFlag = Flags.Count > 0 ? Flags[0] : null;
+    }
+
+    private bool CanAddFlagNow() => Flags.Count(f => !f.IsBuiltIn) < MaxUserFlags;
+    private bool CanDeleteFlagNow() => SelectedFlag?.IsBuiltIn == false;
+    private bool HasSelectionNow() => SelectedFlag != null;
+    private bool CanMoveUpNow()   => SelectedFlag != null && Flags.IndexOf(SelectedFlag) > 0;
+    private bool CanMoveDownNow() => SelectedFlag != null && Flags.IndexOf(SelectedFlag) < Flags.Count - 1;
+
+    [RelayCommand(CanExecute = nameof(CanAddFlagNow))]
+    private async Task AddFlag()
+    {
+        var newFlag = new FlagDefinition
+        {
+            Id        = Guid.NewGuid(),
+            Name      = "New Flag",
+            ColorHex  = "#3182CE",
+            SortOrder = Flags.Count > 0 ? Flags.Max(f => f.SortOrder) + 1 : 1,
+            IsBuiltIn = false,
+        };
+        Flags.Add(newFlag);
+        SelectedFlag = newFlag;
+        await SaveAsync();
+        AddFlagCommand.NotifyCanExecuteChanged();
+        BeginRename();
+    }
+
+    [RelayCommand(CanExecute = nameof(CanDeleteFlagNow))]
+    private async Task DeleteFlag()
+    {
+        if (SelectedFlag == null || SelectedFlag.IsBuiltIn) return;
+        var name = SelectedFlag.Name;
+        bool confirmed = ConfirmDeleteRequested == null
+            || await ConfirmDeleteRequested($"Delete the flag \"{name}\"?", "Delete Flag");
+        if (!confirmed) return;
+
+        int idx = Flags.IndexOf(SelectedFlag);
+        Flags.Remove(SelectedFlag);
+        SelectedFlag = Flags.Count > 0 ? Flags[Math.Min(idx, Flags.Count - 1)] : null;
+        await SaveAsync();
+        AddFlagCommand.NotifyCanExecuteChanged();
+        AnnouncementRequested?.Invoke($"Deleted flag {name}", AnnouncementCategory.Result);
+    }
+
+    [RelayCommand(CanExecute = nameof(HasSelectionNow))]
+    private void BeginRename()
+    {
+        if (SelectedFlag == null) return;
+        EditName = SelectedFlag.Name;
+        RenameError = string.Empty;
+        IsRenaming = true;
+        RenameStarted?.Invoke(this, EventArgs.Empty);
+    }
+
+    [RelayCommand]
+    private async Task SaveRename()
+    {
+        if (SelectedFlag == null) return;
+        var trimmed = EditName.Trim();
+        if (string.IsNullOrEmpty(trimmed))
+        {
+            RenameError = "Name cannot be empty.";
+            return;
+        }
+        if (trimmed.Length > MaxNameLength)
+        {
+            RenameError = $"Name must be {MaxNameLength} characters or fewer.";
+            return;
+        }
+        SelectedFlag.Name = trimmed;
+        IsRenaming = false;
+        RenameError = string.Empty;
+        await SaveAsync();
+        AnnouncementRequested?.Invoke($"Flag renamed to {trimmed}", AnnouncementCategory.Result);
+    }
+
+    [RelayCommand]
+    private void CancelRename()
+    {
+        IsRenaming = false;
+        RenameError = string.Empty;
+    }
+
+    [RelayCommand]
+    private async Task ChangeColor(string hex)
+    {
+        if (SelectedFlag == null || string.IsNullOrEmpty(hex)) return;
+        SelectedFlag.ColorHex = hex;
+        await SaveAsync();
+    }
+
+    [RelayCommand(CanExecute = nameof(CanMoveUpNow))]
+    private async Task MoveUp()
+    {
+        if (SelectedFlag == null) return;
+        int idx = Flags.IndexOf(SelectedFlag);
+        if (idx <= 0) return;
+        var other = Flags[idx - 1];
+        (SelectedFlag.SortOrder, other.SortOrder) = (other.SortOrder, SelectedFlag.SortOrder);
+        Flags.Move(idx, idx - 1);
+        OnPropertyChanged(nameof(CanMoveUp));
+        OnPropertyChanged(nameof(CanMoveDown));
+        MoveUpCommand.NotifyCanExecuteChanged();
+        MoveDownCommand.NotifyCanExecuteChanged();
+        await SaveAsync();
+    }
+
+    [RelayCommand(CanExecute = nameof(CanMoveDownNow))]
+    private async Task MoveDown()
+    {
+        if (SelectedFlag == null) return;
+        int idx = Flags.IndexOf(SelectedFlag);
+        if (idx >= Flags.Count - 1) return;
+        var other = Flags[idx + 1];
+        (SelectedFlag.SortOrder, other.SortOrder) = (other.SortOrder, SelectedFlag.SortOrder);
+        Flags.Move(idx, idx + 1);
+        OnPropertyChanged(nameof(CanMoveUp));
+        OnPropertyChanged(nameof(CanMoveDown));
+        MoveUpCommand.NotifyCanExecuteChanged();
+        MoveDownCommand.NotifyCanExecuteChanged();
+        await SaveAsync();
+    }
+
+    [RelayCommand(CanExecute = nameof(HasSelectionNow))]
+    private async Task SetAsKDefault()
+    {
+        if (SelectedFlag == null) return;
+        await _flagService.SetKDefaultFlagAsync(SelectedFlag.Id);
+        KDefaultId = SelectedFlag.Id;
+        AnnouncementRequested?.Invoke(
+            $"{SelectedFlag.Name} is now the default flag for K",
+            AnnouncementCategory.Result);
+    }
+
+    private async Task SaveAsync()
+    {
+        await _flagService.SaveFlagDefinitionsAsync([.. Flags]);
+    }
+}

--- a/QuickMail/ViewModels/FlagManagerViewModel.cs
+++ b/QuickMail/ViewModels/FlagManagerViewModel.cs
@@ -52,8 +52,8 @@ public partial class FlagManagerViewModel : ObservableObject
 
     public static string[] PresetColors { get; } =
     [
-        "#E53E3E", "#DD6B20", "#FF8C00", "#D69E2E",
-        "#38A169", "#68D391", "#319795", "#00B5D8",
+        "#E53E3E", "#DD6B20", "#C05621", "#B7791F",
+        "#38A169", "#276749", "#319795", "#0987A0",
         "#3182CE", "#5A67D8", "#6B46C1", "#D53F8C",
     ];
 
@@ -67,9 +67,10 @@ public partial class FlagManagerViewModel : ObservableObject
         Flags.CollectionChanged += (_, _) => RecomputeUserFlagCount();
     }
 
-    public async Task LoadAsync()
+    public async Task LoadAsync(CancellationToken ct = default)
     {
         var flags = await _flagService.LoadFlagDefinitionsAsync();
+        ct.ThrowIfCancellationRequested();
         Flags.Clear();
         foreach (var f in flags.OrderBy(f => f.SortOrder))
             Flags.Add(f);
@@ -95,10 +96,16 @@ public partial class FlagManagerViewModel : ObservableObject
     [RelayCommand(CanExecute = nameof(CanAddFlagNow))]
     private async Task AddFlag()
     {
+        const string baseName = "New Flag";
+        var name = baseName;
+        int n = 2;
+        while (Flags.Any(f => f.Name.Equals(name, StringComparison.OrdinalIgnoreCase)))
+            name = $"{baseName} {n++}";
+
         var newFlag = new FlagDefinition
         {
             Id        = Guid.NewGuid(),
-            Name      = "New Flag",
+            Name      = name,
             ColorHex  = "#3182CE",
             SortOrder = Flags.Count > 0 ? Flags.Max(f => f.SortOrder) + 1 : 1,
             IsBuiltIn = false,
@@ -148,6 +155,11 @@ public partial class FlagManagerViewModel : ObservableObject
         if (trimmed.Length > MaxNameLength)
         {
             RenameError = $"Name must be {MaxNameLength} characters or fewer.";
+            return;
+        }
+        if (Flags.Any(f => f != SelectedFlag && f.Name.Equals(trimmed, StringComparison.OrdinalIgnoreCase)))
+        {
+            RenameError = $"\"{trimmed}\" is already in use.";
             return;
         }
         SelectedFlag.Name = trimmed;

--- a/QuickMail/ViewModels/FlagManagerViewModel.cs
+++ b/QuickMail/ViewModels/FlagManagerViewModel.cs
@@ -42,10 +42,13 @@ public partial class FlagManagerViewModel : ObservableObject
     [ObservableProperty]
     private Guid _kDefaultId;
 
-    public bool HasSelection => SelectedFlag != null;
-    public bool CanDelete    => SelectedFlag?.IsBuiltIn == false;
-    public bool CanMoveUp    => SelectedFlag != null && Flags.IndexOf(SelectedFlag) > 0;
-    public bool CanMoveDown  => SelectedFlag != null && Flags.IndexOf(SelectedFlag) < Flags.Count - 1;
+    public bool HasSelection => HasSelectionNow();
+    public bool CanDelete    => CanDeleteFlagNow();
+    public bool CanMoveUp    => CanMoveUpNow();
+    public bool CanMoveDown  => CanMoveDownNow();
+
+    // Track user-flag count so CanAddFlagNow doesn't need a LINQ scan on every check.
+    private int _userFlagCount;
 
     public static string[] PresetColors { get; } =
     [
@@ -61,6 +64,7 @@ public partial class FlagManagerViewModel : ObservableObject
     public FlagManagerViewModel(IFlagService flagService)
     {
         _flagService = flagService;
+        Flags.CollectionChanged += (_, _) => RecomputeUserFlagCount();
     }
 
     public async Task LoadAsync()
@@ -69,16 +73,24 @@ public partial class FlagManagerViewModel : ObservableObject
         Flags.Clear();
         foreach (var f in flags.OrderBy(f => f.SortOrder))
             Flags.Add(f);
+        RecomputeUserFlagCount();
         var kFlag = await _flagService.GetKDefaultFlagAsync();
         KDefaultId = kFlag.Id;
         SelectedFlag = Flags.Count > 0 ? Flags[0] : null;
     }
 
-    private bool CanAddFlagNow() => Flags.Count(f => !f.IsBuiltIn) < MaxUserFlags;
+    private bool CanAddFlagNow() => _userFlagCount < MaxUserFlags;
     private bool CanDeleteFlagNow() => SelectedFlag?.IsBuiltIn == false;
     private bool HasSelectionNow() => SelectedFlag != null;
+    private bool CanRenameNow() => SelectedFlag?.IsBuiltIn == false;
     private bool CanMoveUpNow()   => SelectedFlag != null && Flags.IndexOf(SelectedFlag) > 0;
     private bool CanMoveDownNow() => SelectedFlag != null && Flags.IndexOf(SelectedFlag) < Flags.Count - 1;
+
+    private void RecomputeUserFlagCount()
+    {
+        _userFlagCount = Flags.Count(f => !f.IsBuiltIn);
+        AddFlagCommand.NotifyCanExecuteChanged();
+    }
 
     [RelayCommand(CanExecute = nameof(CanAddFlagNow))]
     private async Task AddFlag()
@@ -94,7 +106,6 @@ public partial class FlagManagerViewModel : ObservableObject
         Flags.Add(newFlag);
         SelectedFlag = newFlag;
         await SaveAsync();
-        AddFlagCommand.NotifyCanExecuteChanged();
         BeginRename();
     }
 
@@ -111,14 +122,13 @@ public partial class FlagManagerViewModel : ObservableObject
         Flags.Remove(SelectedFlag);
         SelectedFlag = Flags.Count > 0 ? Flags[Math.Min(idx, Flags.Count - 1)] : null;
         await SaveAsync();
-        AddFlagCommand.NotifyCanExecuteChanged();
         AnnouncementRequested?.Invoke($"Deleted flag {name}", AnnouncementCategory.Result);
     }
 
-    [RelayCommand(CanExecute = nameof(HasSelectionNow))]
+    [RelayCommand(CanExecute = nameof(CanRenameNow))]
     private void BeginRename()
     {
-        if (SelectedFlag == null) return;
+        if (SelectedFlag == null || SelectedFlag.IsBuiltIn) return;
         EditName = SelectedFlag.Name;
         RenameError = string.Empty;
         IsRenaming = true;
@@ -158,6 +168,7 @@ public partial class FlagManagerViewModel : ObservableObject
     private async Task ChangeColor(string hex)
     {
         if (SelectedFlag == null || string.IsNullOrEmpty(hex)) return;
+        if (SelectedFlag.IsBuiltIn) return;
         SelectedFlag.ColorHex = hex;
         await SaveAsync();
     }

--- a/QuickMail/ViewModels/FlagPickerViewModel.cs
+++ b/QuickMail/ViewModels/FlagPickerViewModel.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using QuickMail.Models;
+using QuickMail.Services;
+
+namespace QuickMail.ViewModels;
+
+public partial class FlagPickerViewModel : ObservableObject
+{
+    private readonly IFlagService _flagService;
+
+    public ObservableCollection<FlagDefinition> Flags { get; } = [];
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(ApplyFlagCommand))]
+    private FlagDefinition? _selectedFlag;
+
+    public bool CurrentlyFlagged { get; }
+
+    public event Action<FlagDefinition?>? FlagSelected;
+
+    public FlagPickerViewModel(IFlagService flagService, bool currentlyFlagged)
+    {
+        _flagService = flagService;
+        CurrentlyFlagged = currentlyFlagged;
+    }
+
+    public async Task LoadAsync()
+    {
+        var flags = await _flagService.LoadFlagDefinitionsAsync();
+        Flags.Clear();
+        foreach (var f in flags)
+            Flags.Add(f);
+        SelectedFlag = Flags.Count > 0 ? Flags[0] : null;
+    }
+
+    private bool HasSelection() => SelectedFlag != null;
+
+    [RelayCommand(CanExecute = nameof(HasSelection))]
+    private void ApplyFlag()
+    {
+        FlagSelected?.Invoke(SelectedFlag);
+    }
+
+    [RelayCommand]
+    private void ClearFlag()
+    {
+        FlagSelected?.Invoke(null);
+    }
+}

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -76,6 +76,9 @@ public partial class MainViewModel : ObservableObject
     // Version stamp for message body loads; latest selection wins.
     private int _messageLoadVersion;
 
+    private bool _announceFlagStatus;
+    private string? _activeFlagFilterId;
+
     // Retains folder lists for every account that has been connected this session
     private readonly Dictionary<Guid, List<MailFolderModel>> _cachedFolders = new();
     public IReadOnlyDictionary<Guid, List<MailFolderModel>> CachedFolders => _cachedFolders;
@@ -112,6 +115,11 @@ public partial class MainViewModel : ObservableObject
     {
         FullName    = "\u0000AllTrash",
         DisplayName = "All Trash"
+    };
+    public static readonly MailFolderModel AllFlaggedFolder = new()
+    {
+        FullName    = "\u0000AllFlagged",
+        DisplayName = "All Flagged Mail"
     };
 
     // Sentinel prefix for per-account "All Mail" virtual folders, e.g. "\u0000AccountMail:{guid}".
@@ -184,7 +192,8 @@ public partial class MainViewModel : ObservableObject
                string.Equals(folder.FullName, AllInboxesFolder.FullName, StringComparison.Ordinal) ||
                string.Equals(folder.FullName, AllDraftsFolder.FullName, StringComparison.Ordinal) ||
                string.Equals(folder.FullName, AllSentFolder.FullName, StringComparison.Ordinal) ||
-               string.Equals(folder.FullName, AllTrashFolder.FullName, StringComparison.Ordinal);
+               string.Equals(folder.FullName, AllTrashFolder.FullName, StringComparison.Ordinal) ||
+               string.Equals(folder.FullName, AllFlaggedFolder.FullName, StringComparison.Ordinal);
     }
 
     // ── Saved views ───────────────────────────────────────────────────────────────
@@ -310,7 +319,9 @@ public partial class MainViewModel : ObservableObject
     public bool IsFilterReplied         => ActiveFilter == MessageFilter.Replied;
     public bool IsFilterForwarded       => ActiveFilter == MessageFilter.Forwarded;
     public bool IsFilterToMe            => ActiveFilter == MessageFilter.ToMe;
+    public bool IsFilterFlagged         => ActiveFilter == MessageFilter.Flagged;
     public bool IsFilterActive          => ActiveFilter != MessageFilter.All;
+    public bool AnnounceFlagStatus      => _announceFlagStatus;
     public string FilterLabel => ActiveFilter switch
     {
         MessageFilter.Unread          => "Unread",
@@ -662,11 +673,14 @@ public partial class MainViewModel : ObservableObject
         MessageOpenMode = cfg.Windowing.MessageOpenMode;
         EnsureMessageListTab();
         _activeSort = ConfigModel.ParseSort(cfg.Sort);
+        _announceFlagStatus = cfg.AnnounceFlagStatus;
 
         _syncService.FolderSynced    += OnFolderSynced;
         _syncService.MessagesRemoved += OnMessagesRemoved;
         _syncService.RulesApplied    += OnRulesApplied;
         _imap.InboxNewMailDetected += OnInboxNewMailDetected;
+        if (_flagService != null)
+            _flagService.FlagDefinitionsChanged += OnFlagDefinitionsChanged;
 
         // Load saved views and register their commands before the UI is shown.
         LoadSavedViews();
@@ -819,6 +833,7 @@ public partial class MainViewModel : ObservableObject
             _             => MessageFilter.All,
         };
         ActiveSort = ConfigModel.ParseSort(view.Sort);
+        _activeFlagFilterId = string.IsNullOrEmpty(view.FlagFilterId) ? null : view.FlagFilterId;
 
         ActiveDayLimit = view.DaysOfMail;
         SearchText     = string.Empty;
@@ -1408,6 +1423,11 @@ public partial class MainViewModel : ObservableObject
             // Per-account "All Mail" - only messages belonging to that account.
             relevant = incoming.Where(m => m.AccountId == watchedAccountId);
         }
+        else if (selected.FullName == AllFlaggedFolder.FullName)
+        {
+            // All Flagged Mail — only accept flagged incoming messages.
+            relevant = incoming.Where(m => m.IsFlagged);
+        }
         else if (selected.FullName == AllInboxesFolder.FullName ||
                  selected.FullName == AllDraftsFolder.FullName  ||
                  selected.FullName == AllSentFolder.FullName    ||
@@ -1634,6 +1654,8 @@ public partial class MainViewModel : ObservableObject
         IEnumerable<MailMessageSummary> result = _rawMessages;
         if (ActiveFilter != MessageFilter.All)
             result = result.Where(MatchesFilter);
+        if (ActiveFilter == MessageFilter.Flagged && _activeFlagFilterId != null)
+            result = result.Where(m => m.FlagId == _activeFlagFilterId);
         if (ActiveDayLimit.HasValue)
             result = result.Where(MatchesDayLimit);
         if (!string.IsNullOrWhiteSpace(SearchText))
@@ -1979,6 +2001,7 @@ public partial class MainViewModel : ObservableObject
         allMailGroup.Children.Add(new FolderTreeNode { Folder = AllDraftsFolder,  Label = AllDraftsFolder.DisplayName });
         allMailGroup.Children.Add(new FolderTreeNode { Folder = AllSentFolder,    Label = AllSentFolder.DisplayName });
         allMailGroup.Children.Add(new FolderTreeNode { Folder = AllTrashFolder,   Label = AllTrashFolder.DisplayName });
+        allMailGroup.Children.Add(new FolderTreeNode { Folder = AllFlaggedFolder, Label = AllFlaggedFolder.DisplayName });
         roots.Add(allMailGroup);
 
         foreach (var account in Accounts)
@@ -2028,6 +2051,7 @@ public partial class MainViewModel : ObservableObject
         OnPropertyChanged(nameof(IsFilterForwarded));
         OnPropertyChanged(nameof(IsFilterToMe));
         OnPropertyChanged(nameof(IsFilterActive));
+        OnPropertyChanged(nameof(IsFilterFlagged));
         OnPropertyChanged(nameof(FilterLabel));
         OnPropertyChanged(nameof(WindowTitle));
 
@@ -2276,14 +2300,15 @@ public partial class MainViewModel : ObservableObject
         }
 
         _suppressFilterRebuild = true;
-        ActiveFilter   = MessageFilter.All;
-        ActiveDayLimit = null;
-        SearchText     = string.Empty;
-        IsSearchActive = false;
-        ActiveView     = null;
-        SelectedFolder = folder;
-        MessageDetail  = null;
-        IsMessageOpen  = false;
+        ActiveFilter        = MessageFilter.All;
+        ActiveDayLimit      = null;
+        _activeFlagFilterId = null;
+        SearchText          = string.Empty;
+        IsSearchActive      = false;
+        ActiveView          = null;
+        SelectedFolder      = folder;
+        MessageDetail       = null;
+        IsMessageOpen       = false;
         _suppressFilterRebuild = false;
 
         if (IsVirtualFolder(folder))
@@ -2803,6 +2828,7 @@ public partial class MainViewModel : ObservableObject
         if (folder.FullName == AllDraftsFolder.FullName)  return FetchVirtualFolderAsync(SpecialFolderKind.Drafts, "All Drafts");
         if (folder.FullName == AllSentFolder.FullName)    return FetchVirtualFolderAsync(SpecialFolderKind.Sent,   "All Sent");
         if (folder.FullName == AllTrashFolder.FullName)   return FetchVirtualFolderAsync(SpecialFolderKind.Trash,  "All Trash");
+        if (folder.FullName == AllFlaggedFolder.FullName) return FetchAllFlaggedAsync();
         if (TryGetAccountIdFromSentinel(folder.FullName, out var accountId)) return FetchAccountAllMailAsync(accountId);
 
         // Saved-view sentinels — re-fetch without resetting mode/filter/sort
@@ -2813,6 +2839,104 @@ public partial class MainViewModel : ObservableObject
             if (view != null) return FetchViewFoldersAsync(view);
         }
         return Task.CompletedTask;
+    }
+
+    private async Task FetchAllFlaggedAsync()
+    {
+        var loadVersion = Interlocked.Increment(ref _folderLoadVersion);
+        var expectedFolder = SelectedFolder;
+        Messages.Clear();
+        StatusText = "Loading flagged messages…";
+        IsBusy = true;
+
+        try
+        {
+            List<MailMessageSummary> all;
+            if (OnlineMode)
+            {
+                all = new List<MailMessageSummary>();
+            }
+            else
+            {
+                all = await _localStore.LoadAllSummariesAsync();
+            }
+            if (!IsCurrentFolderLoad(loadVersion, expectedFolder)) return;
+
+            await ResolveFlagNamesAsync(all);
+            var flagged = all.Where(m => m.IsFlagged).ToList();
+            SetMessages(flagged.OrderByDescending(m => m.Date).ToList());
+            var n = Messages.Count;
+            StatusText = n == 0 ? "No flagged messages." : $"{n} flagged {(n == 1 ? "message" : "messages")}.";
+        }
+        catch (Exception ex)
+        {
+            LogService.Log("FetchAllFlagged failed", ex);
+            StatusText = "Could not load flagged messages.";
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    public async Task ToggleSingleFlagAsync(MailMessageSummary message)
+    {
+        if (_flagService == null) return;
+        try
+        {
+            ReplaceCts(ref _messageActionCts, out var ct);
+            bool wasFlagged = message.IsFlagged;
+            await _flagService.ToggleDefaultFlagAsync(message, _localStore, _imap, ct);
+            if (_announceFlagStatus)
+            {
+                var text = wasFlagged ? "Unflagged" : $"{message.FlagName ?? "Flagged"}";
+                Announce(text, AnnouncementCategory.Result);
+            }
+        }
+        catch (OperationCanceledException) { }
+        catch (Exception ex) { LogService.Log("ToggleSingleFlag failed", ex); }
+    }
+
+    public async Task ToggleGroupFlagAsync(IReadOnlyList<MailMessageSummary> messages)
+    {
+        if (_flagService == null || messages.Count == 0) return;
+        try
+        {
+            ReplaceCts(ref _messageActionCts, out var ct);
+            bool anyFlagged = messages.Any(m => m.IsFlagged);
+            var kFlag = await _flagService.GetKDefaultFlagAsync();
+            string? targetFlagId = anyFlagged ? null : kFlag.Id.ToString();
+            foreach (var msg in messages)
+                await _flagService.SetMessageFlagAsync(msg, targetFlagId, _localStore, _imap, ct);
+            if (_announceFlagStatus)
+            {
+                var text = anyFlagged
+                    ? $"Unflagged {messages.Count} {(messages.Count == 1 ? "message" : "messages")}"
+                    : $"Flagged {messages.Count} {(messages.Count == 1 ? "message" : "messages")}";
+                Announce(text, AnnouncementCategory.Result);
+            }
+        }
+        catch (OperationCanceledException) { }
+        catch (Exception ex) { LogService.Log("ToggleGroupFlag failed", ex); }
+    }
+
+    private async void OnFlagDefinitionsChanged(object? sender, EventArgs e)
+    {
+        if (_flagService == null) return;
+        var defs = await _flagService.LoadFlagDefinitionsAsync();
+        var lookup = new Dictionary<Guid, FlagDefinition>(defs.Count);
+        foreach (var d in defs) lookup[d.Id] = d;
+        Application.Current.Dispatcher.Invoke(() =>
+        {
+            foreach (var msg in _rawMessages)
+            {
+                if (msg.FlagId != null && Guid.TryParse(msg.FlagId, out var fid) && lookup.TryGetValue(fid, out var def))
+                {
+                    msg.FlagName     = def.Name;
+                    msg.FlagColorHex = def.ColorHex;
+                }
+            }
+        });
     }
 
     /// <summary>

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -2920,6 +2920,23 @@ public partial class MainViewModel : ObservableObject
         catch (Exception ex) { LogService.Log("ToggleGroupFlag failed", ex); }
     }
 
+    public async Task SetMessageFlagAsync(MailMessageSummary message, string? flagId)
+    {
+        if (_flagService == null) return;
+        try
+        {
+            ReplaceCts(ref _messageActionCts, out var ct);
+            await _flagService.SetMessageFlagAsync(message, flagId, _localStore, _imap, ct);
+            if (_announceFlagStatus)
+            {
+                var text = flagId == null ? "Unflagged" : (message.FlagName ?? "Flagged");
+                Announce(text, AnnouncementCategory.Result);
+            }
+        }
+        catch (OperationCanceledException) { }
+        catch (Exception ex) { LogService.Log("SetMessageFlag failed", ex); }
+    }
+
     private async void OnFlagDefinitionsChanged(object? sender, EventArgs e)
     {
         if (_flagService == null) return;

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -79,6 +79,7 @@ public partial class MainViewModel : ObservableObject
 
     private bool _announceFlagStatus;
     private string? _activeFlagFilterId;
+    private EventHandler? _onFlagDefinitionsChanged;
 
     // Retains folder lists for every account that has been connected this session
     private readonly Dictionary<Guid, List<MailFolderModel>> _cachedFolders = new();
@@ -313,6 +314,8 @@ public partial class MainViewModel : ObservableObject
     public bool IsFromView          => ViewMode == ViewMode.From;
     public bool IsToView            => ViewMode == ViewMode.To;
 
+    public ObservableCollection<FlagDefinition> FlagDefinitions { get; } = [];
+
     public bool IsFilterAll             => ActiveFilter == MessageFilter.All;
     public bool IsFilterUnread          => ActiveFilter == MessageFilter.Unread;
     public bool IsFilterRead            => ActiveFilter == MessageFilter.Read;
@@ -321,6 +324,7 @@ public partial class MainViewModel : ObservableObject
     public bool IsFilterForwarded       => ActiveFilter == MessageFilter.Forwarded;
     public bool IsFilterToMe            => ActiveFilter == MessageFilter.ToMe;
     public bool IsFilterFlagged         => ActiveFilter == MessageFilter.Flagged;
+    public bool IsFilterAllFlagged      => ActiveFilter == MessageFilter.Flagged && _activeFlagFilterId == null;
     public bool IsFilterActive          => ActiveFilter != MessageFilter.All;
     public bool AnnounceFlagStatus      => _announceFlagStatus;
     /// <summary>Named-flag sub-filter id, set by saved views. Null = show all flagged messages.</summary>
@@ -683,7 +687,10 @@ public partial class MainViewModel : ObservableObject
         _syncService.RulesApplied    += OnRulesApplied;
         _imap.InboxNewMailDetected += OnInboxNewMailDetected;
         if (_flagService != null)
-            _flagService.FlagDefinitionsChanged += async (_, _) => await OnFlagDefinitionsChangedAsync();
+        {
+            _onFlagDefinitionsChanged = (_, _) => _ = OnFlagDefinitionsChangedAsync();
+            _flagService.FlagDefinitionsChanged += _onFlagDefinitionsChanged;
+        }
 
         // Load saved views and register their commands before the UI is shown.
         LoadSavedViews();
@@ -836,7 +843,7 @@ public partial class MainViewModel : ObservableObject
             _             => MessageFilter.All,
         };
         ActiveSort = ConfigModel.ParseSort(view.Sort);
-        _activeFlagFilterId = string.IsNullOrEmpty(view.FlagFilterId) ? null : view.FlagFilterId;
+        SetActiveFlagFilterId(string.IsNullOrEmpty(view.FlagFilterId) ? null : view.FlagFilterId);
 
         // Validate the flag filter id against current flag definitions.
         // If the referenced flag has been deleted, treat it as no filter
@@ -846,7 +853,7 @@ public partial class MainViewModel : ObservableObject
         {
             var defs = await _flagService.LoadFlagDefinitionsAsync();
             if (!defs.Exists(d => d.Id == flagGuid))
-                _activeFlagFilterId = null;
+                SetActiveFlagFilterId(null);
         }
 
         ActiveDayLimit = view.DaysOfMail;
@@ -1235,6 +1242,13 @@ public partial class MainViewModel : ObservableObject
     {
         SelectedFolder = AllMailFolder;
         LastSyncText = "Never synced";  // Ensure sync time is visible in status bar
+        if (_flagService != null)
+        {
+            var defs = await _flagService.LoadFlagDefinitionsAsync();
+            FlagDefinitions.Clear();
+            foreach (var d in defs.OrderBy(d => d.SortOrder))
+                FlagDefinitions.Add(d);
+        }
         if (OnlineMode)
         {
             StatusText = "Online mode — connecting…";
@@ -2078,6 +2092,7 @@ public partial class MainViewModel : ObservableObject
         OnPropertyChanged(nameof(IsFilterToMe));
         OnPropertyChanged(nameof(IsFilterActive));
         OnPropertyChanged(nameof(IsFilterFlagged));
+        OnPropertyChanged(nameof(IsFilterAllFlagged));
         OnPropertyChanged(nameof(FilterLabel));
         OnPropertyChanged(nameof(WindowTitle));
 
@@ -2328,7 +2343,7 @@ public partial class MainViewModel : ObservableObject
         _suppressFilterRebuild = true;
         ActiveFilter        = MessageFilter.All;
         ActiveDayLimit      = null;
-        _activeFlagFilterId = null;
+        SetActiveFlagFilterId(null);
         SearchText          = string.Empty;
         IsSearchActive      = false;
         ActiveView          = null;
@@ -3010,30 +3025,40 @@ public partial class MainViewModel : ObservableObject
 
     private async Task OnFlagDefinitionsChangedAsync()
     {
-        if (_flagService == null) return;
-        var defs = await _flagService.LoadFlagDefinitionsAsync();
-        var lookup = new Dictionary<Guid, FlagDefinition>(defs.Count);
-        foreach (var d in defs) lookup[d.Id] = d;
-        // Event is now marshalled to the UI thread by FlagService, so no
-        // Dispatcher.Invoke needed here.
-        foreach (var msg in _rawMessages)
+        try
         {
-            if (msg.FlagId != null && Guid.TryParse(msg.FlagId, out var fid))
+            if (_flagService == null) return;
+            var defs = await _flagService.LoadFlagDefinitionsAsync();
+
+            FlagDefinitions.Clear();
+            foreach (var d in defs.OrderBy(d => d.SortOrder))
+                FlagDefinitions.Add(d);
+
+            var lookup = new Dictionary<Guid, FlagDefinition>(defs.Count);
+            foreach (var d in defs) lookup[d.Id] = d;
+            foreach (var msg in _rawMessages)
             {
-                if (lookup.TryGetValue(fid, out var def))
+                if (msg.FlagId != null && Guid.TryParse(msg.FlagId, out var fid))
                 {
-                    msg.FlagName     = def.Name;
-                    msg.FlagColorHex = def.ColorHex;
-                }
-                else
-                {
-                    // Flag was deleted — clear all flag state so the message
-                    // no longer appears flagged or stuck in the Flagged filter.
-                    msg.FlagId       = null;
-                    msg.FlagName     = null;
-                    msg.FlagColorHex = null;
+                    if (lookup.TryGetValue(fid, out var def))
+                    {
+                        msg.FlagName     = def.Name;
+                        msg.FlagColorHex = def.ColorHex;
+                    }
+                    else
+                    {
+                        // Flag was deleted — clear all flag state so the message
+                        // no longer appears flagged or stuck in the Flagged filter.
+                        msg.FlagId       = null;
+                        msg.FlagName     = null;
+                        msg.FlagColorHex = null;
+                    }
                 }
             }
+        }
+        catch (Exception ex)
+        {
+            LogService.Log("OnFlagDefinitionsChanged", ex);
         }
     }
 
@@ -4312,6 +4337,13 @@ public partial class MainViewModel : ObservableObject
 
     // ── Filter command ────────────────────────────────────────────────────────
 
+    private void SetActiveFlagFilterId(string? id)
+    {
+        _activeFlagFilterId = id;
+        OnPropertyChanged(nameof(ActiveFlagFilterId));
+        OnPropertyChanged(nameof(IsFilterAllFlagged));
+    }
+
     [RelayCommand]
     private Task SetFilterAsync(string? filter)
     {
@@ -4328,7 +4360,16 @@ public partial class MainViewModel : ObservableObject
         };
         // Clear any named-flag sub-filter from a previously applied saved view
         // so the user sees all flagged messages, not just one specific flag.
-        _activeFlagFilterId = null;
+        SetActiveFlagFilterId(null);
+        return Task.CompletedTask;
+    }
+
+    [RelayCommand]
+    private Task SetFlagFilterAsync(string flagId)
+    {
+        ActiveFilter = MessageFilter.Flagged;
+        SetActiveFlagFilterId(flagId);
+        ApplyFiltersAndSearch();
         return Task.CompletedTask;
     }
 

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -30,6 +30,7 @@ public partial class MainViewModel : ObservableObject
     private readonly ICommandRegistry _commandRegistry;
     private readonly IRuleService _ruleService;
     private readonly ISendMailService _smtp;
+    private readonly IFlagService? _flagService;
 
     // Separate CTS per operation type so they can't cancel each other accidentally
     private CancellationTokenSource? _connectCts;

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -37,6 +37,7 @@ public partial class MainViewModel : ObservableObject
     private CancellationTokenSource? _folderCts;
     private CancellationTokenSource? _messageLoadCts;
     private CancellationTokenSource? _messageActionCts;
+    private CancellationTokenSource? _flagActionCts;
     private CancellationTokenSource? _prefetchCts;
 
     private const int PrefetchRadiusAroundOpen = 5;
@@ -322,6 +323,8 @@ public partial class MainViewModel : ObservableObject
     public bool IsFilterFlagged         => ActiveFilter == MessageFilter.Flagged;
     public bool IsFilterActive          => ActiveFilter != MessageFilter.All;
     public bool AnnounceFlagStatus      => _announceFlagStatus;
+    /// <summary>Named-flag sub-filter id, set by saved views. Null = show all flagged messages.</summary>
+    public string? ActiveFlagFilterId   => _activeFlagFilterId;
     public string FilterLabel => ActiveFilter switch
     {
         MessageFilter.Unread          => "Unread",
@@ -680,7 +683,7 @@ public partial class MainViewModel : ObservableObject
         _syncService.RulesApplied    += OnRulesApplied;
         _imap.InboxNewMailDetected += OnInboxNewMailDetected;
         if (_flagService != null)
-            _flagService.FlagDefinitionsChanged += OnFlagDefinitionsChanged;
+            _flagService.FlagDefinitionsChanged += async (_, _) => await OnFlagDefinitionsChangedAsync();
 
         // Load saved views and register their commands before the UI is shown.
         LoadSavedViews();
@@ -834,6 +837,17 @@ public partial class MainViewModel : ObservableObject
         };
         ActiveSort = ConfigModel.ParseSort(view.Sort);
         _activeFlagFilterId = string.IsNullOrEmpty(view.FlagFilterId) ? null : view.FlagFilterId;
+
+        // Validate the flag filter id against current flag definitions.
+        // If the referenced flag has been deleted, treat it as no filter
+        // rather than showing an empty list with no explanation.
+        if (_activeFlagFilterId != null && _flagService != null &&
+            Guid.TryParse(_activeFlagFilterId, out var flagGuid))
+        {
+            var defs = await _flagService.LoadFlagDefinitionsAsync();
+            if (!defs.Exists(d => d.Id == flagGuid))
+                _activeFlagFilterId = null;
+        }
 
         ActiveDayLimit = view.DaysOfMail;
         SearchText     = string.Empty;
@@ -1014,6 +1028,8 @@ public partial class MainViewModel : ObservableObject
     internal void ApplySettings(ConfigModel cfg)
     {
         ShowMessageStatus = cfg.ShowMessageStatus;
+        _announceFlagStatus = cfg.AnnounceFlagStatus;
+        OnPropertyChanged(nameof(AnnounceFlagStatus));
 
         var newPreviewLines = cfg.PreviewLines;
         var newShowPreview  = newPreviewLines > 0;
@@ -2859,12 +2875,39 @@ public partial class MainViewModel : ObservableObject
         StatusText = "Loading flagged messages…";
         IsBusy = true;
 
+        _folderCts?.Cancel();
+        ReplaceCts(ref _folderCts, out var ct);
+
         try
         {
             List<MailMessageSummary> all;
             if (OnlineMode)
             {
+                // In --online mode, fetch from every non-excluded folder across all accounts
+                // and filter to flagged messages client-side.
                 all = new List<MailMessageSummary>();
+                foreach (var account in Accounts)
+                {
+                    if (!_cachedFolders.TryGetValue(account.Id, out var folders)) continue;
+                    foreach (var folder in folders)
+                    {
+                        if (folder.ExcludeFromAllMail) continue;
+                        ct.ThrowIfCancellationRequested();
+                        try
+                        {
+                            var msgs = _syncDays > 0
+                                ? await _imap.GetMessagesSinceDateAsync(
+                                    account.Id, folder.FullName, DateTime.UtcNow.AddDays(-_syncDays), ct)
+                                : await _imap.GetMessageSummariesAsync(account.Id, folder.FullName, 50000, ct);
+                            all.AddRange(msgs.Where(m => m.IsFlagged));
+                        }
+                        catch (OperationCanceledException) { throw; }
+                        catch (Exception ex)
+                        {
+                            LogService.Log($"FetchAllFlagged online {account.DisplayName}/{folder.DisplayName}", ex);
+                        }
+                    }
+                }
             }
             else
             {
@@ -2878,6 +2921,11 @@ public partial class MainViewModel : ObservableObject
             var n = Messages.Count;
             StatusText = n == 0 ? "No flagged messages." : $"{n} flagged {(n == 1 ? "message" : "messages")}.";
         }
+        catch (OperationCanceledException)
+        {
+            if (loadVersion == _folderLoadVersion)
+                StatusText = "Flagged messages load cancelled.";
+        }
         catch (Exception ex)
         {
             LogService.Log("FetchAllFlagged failed", ex);
@@ -2885,7 +2933,8 @@ public partial class MainViewModel : ObservableObject
         }
         finally
         {
-            IsBusy = false;
+            if (loadVersion == _folderLoadVersion)
+                IsBusy = false;
         }
     }
 
@@ -2894,9 +2943,13 @@ public partial class MainViewModel : ObservableObject
         if (_flagService == null) return;
         try
         {
-            ReplaceCts(ref _messageActionCts, out var ct);
+            ReplaceCts(ref _flagActionCts, out var ct);
             bool wasFlagged = message.IsFlagged;
-            await _flagService.ToggleDefaultFlagAsync(message, _localStore, _imap, ct);
+            var def = await _flagService.ToggleDefaultFlagAsync(message, ct);
+            // Update in-memory model (we're on the UI thread from the command handler).
+            message.FlagId       = wasFlagged ? null : def?.Id.ToString();
+            message.FlagName     = def?.Name;
+            message.FlagColorHex = def?.ColorHex;
             if (_announceFlagStatus)
             {
                 var text = wasFlagged ? "Unflagged" : $"{message.FlagName ?? "Flagged"}";
@@ -2912,12 +2965,17 @@ public partial class MainViewModel : ObservableObject
         if (_flagService == null || messages.Count == 0) return;
         try
         {
-            ReplaceCts(ref _messageActionCts, out var ct);
+            ReplaceCts(ref _flagActionCts, out var ct);
             bool anyFlagged = messages.Any(m => m.IsFlagged);
             var kFlag = await _flagService.GetKDefaultFlagAsync();
             string? targetFlagId = anyFlagged ? null : kFlag.Id.ToString();
             foreach (var msg in messages)
-                await _flagService.SetMessageFlagAsync(msg, targetFlagId, _localStore, _imap, ct);
+            {
+                var def = await _flagService.SetMessageFlagAsync(msg, targetFlagId, ct);
+                msg.FlagId       = targetFlagId;
+                msg.FlagName     = def?.Name;
+                msg.FlagColorHex = def?.ColorHex;
+            }
             if (_announceFlagStatus)
             {
                 var text = anyFlagged
@@ -2935,8 +2993,11 @@ public partial class MainViewModel : ObservableObject
         if (_flagService == null) return;
         try
         {
-            ReplaceCts(ref _messageActionCts, out var ct);
-            await _flagService.SetMessageFlagAsync(message, flagId, _localStore, _imap, ct);
+            ReplaceCts(ref _flagActionCts, out var ct);
+            var def = await _flagService.SetMessageFlagAsync(message, flagId, ct);
+            message.FlagId       = flagId;
+            message.FlagName     = def?.Name;
+            message.FlagColorHex = def?.ColorHex;
             if (_announceFlagStatus)
             {
                 var text = flagId == null ? "Unflagged" : (message.FlagName ?? "Flagged");
@@ -2947,23 +3008,33 @@ public partial class MainViewModel : ObservableObject
         catch (Exception ex) { LogService.Log("SetMessageFlag failed", ex); }
     }
 
-    private async void OnFlagDefinitionsChanged(object? sender, EventArgs e)
+    private async Task OnFlagDefinitionsChangedAsync()
     {
         if (_flagService == null) return;
         var defs = await _flagService.LoadFlagDefinitionsAsync();
         var lookup = new Dictionary<Guid, FlagDefinition>(defs.Count);
         foreach (var d in defs) lookup[d.Id] = d;
-        Application.Current.Dispatcher.Invoke(() =>
+        // Event is now marshalled to the UI thread by FlagService, so no
+        // Dispatcher.Invoke needed here.
+        foreach (var msg in _rawMessages)
         {
-            foreach (var msg in _rawMessages)
+            if (msg.FlagId != null && Guid.TryParse(msg.FlagId, out var fid))
             {
-                if (msg.FlagId != null && Guid.TryParse(msg.FlagId, out var fid) && lookup.TryGetValue(fid, out var def))
+                if (lookup.TryGetValue(fid, out var def))
                 {
                     msg.FlagName     = def.Name;
                     msg.FlagColorHex = def.ColorHex;
                 }
+                else
+                {
+                    // Flag was deleted — clear all flag state so the message
+                    // no longer appears flagged or stuck in the Flagged filter.
+                    msg.FlagId       = null;
+                    msg.FlagName     = null;
+                    msg.FlagColorHex = null;
+                }
             }
-        });
+        }
     }
 
     /// <summary>
@@ -3095,6 +3166,7 @@ public partial class MainViewModel : ObservableObject
             if (!IsCurrentFolderLoad(loadVersion, expectedFolder))
                 return;
 
+            await ResolveFlagNamesAsync(all);
             var sorted = all.OrderByDescending(m => m.Date).ToList();
             SetMessages(sorted);
             StatusText = sorted.Count == 0
@@ -4254,6 +4326,9 @@ public partial class MainViewModel : ObservableObject
             "flagged"     => MessageFilter.Flagged,
             _             => MessageFilter.All,
         };
+        // Clear any named-flag sub-filter from a previously applied saved view
+        // so the user sees all flagged messages, not just one specific flag.
+        _activeFlagFilterId = null;
         return Task.CompletedTask;
     }
 

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -1459,28 +1459,38 @@ public partial class MainViewModel : ObservableObject
             return;
         }
 
-        // Hash existing keys once so the dedupe check is O(1) per incoming item
-        // instead of an O(n) scan per item — that would dominate a multi-thousand-message
-        // All Mail view and freeze the UI thread. Use _rawMessages (not Messages) as the
-        // canonical set so filtered-out messages still prevent duplicates.
-        var seen = new HashSet<(string, Guid, string)>(_rawMessages.Count);
+        // Build a lookup map once so dedupe and flag-reconciliation are both O(1) per incoming
+        // item instead of O(n) scans — critical in All Mail views with thousands of messages.
+        var rawByKey = new Dictionary<(string, Guid, string), MailMessageSummary>(_rawMessages.Count);
         foreach (var e in _rawMessages)
-            seen.Add((e.MessageId, e.AccountId, e.FolderName));
+            rawByKey.TryAdd((e.MessageId, e.AccountId, e.FolderName), e);
+        var seen = new HashSet<(string, Guid, string)>(rawByKey.Keys);
 
         // Collect truly new messages; add them to _rawMessages immediately so the
         // search pool stays in sync with what the list will eventually show.
         var toInsert = new List<MailMessageSummary>();
         foreach (var msg in relevant.OrderByDescending(m => m.Date))
         {
-            // Reconcile server-flagged state: a message with \Flagged set on the server
-            // but no local flag assignment gets the built-in flag id so it displays correctly.
-            // (FlagName/FlagColorHex stay null until the next ResolveFlagNamesAsync call, but
-            // FlagId being set ensures IsFlagged, StatusDisplay, and MatchesFilter work.)
+            // Reconcile server-flagged state for new incoming messages: a message with
+            // \Flagged set on the server but no local flag assignment gets the built-in flag
+            // id so it displays correctly.  FlagName/FlagColorHex stay null until the next
+            // ResolveFlagNamesAsync call, but FlagId ensures IsFlagged and MatchesFilter work.
             if (msg.IsServerFlagged && msg.FlagId == null)
                 msg.FlagId = Models.FlagDefinition.BuiltInFlagId.ToString();
 
             if (!seen.Add((msg.MessageId, msg.AccountId, msg.FolderName)))
+            {
+                // Existing message: reconcile external flag change (§9.3).
+                // If the server now reports not-flagged but the in-memory message still has
+                // a flag set, another client cleared it — clear our local flag to match.
+                if (!msg.IsServerFlagged &&
+                    rawByKey.TryGetValue((msg.MessageId, msg.AccountId, msg.FolderName), out var existing) &&
+                    existing.FlagId != null)
+                {
+                    existing.FlagId = null;
+                }
                 continue;
+            }
             _rawMessages.Add(msg);
             if (!MatchesFilter(msg)) continue;
             if (!MatchesDayLimit(msg)) continue;

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -319,6 +319,7 @@ public partial class MainViewModel : ObservableObject
         MessageFilter.Replied         => "Replied",
         MessageFilter.Forwarded       => "Forwarded",
         MessageFilter.ToMe            => "To Me",
+        MessageFilter.Flagged         => "Flagged",
         _                             => string.Empty,
     };
 
@@ -635,7 +636,8 @@ public partial class MainViewModel : ObservableObject
         IViewService viewService,
         IRuleService ruleService,
         ISendMailService smtpService,
-        bool onlineMode = false)
+        bool onlineMode = false,
+        IFlagService? flagService = null)
     {
         _imap            = imap;
         _accountService  = accountService;
@@ -648,6 +650,7 @@ public partial class MainViewModel : ObservableObject
         _viewService     = viewService;
         _ruleService     = ruleService;
         _smtp            = smtpService;
+        _flagService     = flagService;
         OnlineMode       = onlineMode;
 
         var cfg = _configService.Load();
@@ -812,6 +815,7 @@ public partial class MainViewModel : ObservableObject
             "replied"     => MessageFilter.Replied,
             "forwarded"   => MessageFilter.Forwarded,
             "tome"        => MessageFilter.ToMe,
+            "flagged"     => MessageFilter.Flagged,
             _             => MessageFilter.All,
         };
         ActiveSort = ConfigModel.ParseSort(view.Sort);
@@ -899,6 +903,7 @@ public partial class MainViewModel : ObservableObject
                 }
                 if (!IsCurrentFolderLoad(loadVersion, expectedFolder)) return;
 
+                await ResolveFlagNamesAsync(cached);
                 SetMessages(cached.OrderByDescending(m => m.Date));
                 StatusText = cached.Count > 0
                     ? $"{cached.Count} cached messages (checking for new…)"
@@ -1206,6 +1211,7 @@ public partial class MainViewModel : ObservableObject
             return;
         }
         var cached = await _localStore.LoadAllSummariesAsync();
+        await ResolveFlagNamesAsync(cached);
         SetMessages(cached);
         StatusText = cached.Count > 0
             ? $"{cached.Count} messages (cached — syncing…)"
@@ -1446,6 +1452,13 @@ public partial class MainViewModel : ObservableObject
         var toInsert = new List<MailMessageSummary>();
         foreach (var msg in relevant.OrderByDescending(m => m.Date))
         {
+            // Reconcile server-flagged state: a message with \Flagged set on the server
+            // but no local flag assignment gets the built-in flag id so it displays correctly.
+            // (FlagName/FlagColorHex stay null until the next ResolveFlagNamesAsync call, but
+            // FlagId being set ensures IsFlagged, StatusDisplay, and MatchesFilter work.)
+            if (msg.IsServerFlagged && msg.FlagId == null)
+                msg.FlagId = Models.FlagDefinition.BuiltInFlagId.ToString();
+
             if (!seen.Add((msg.MessageId, msg.AccountId, msg.FolderName)))
                 continue;
             _rawMessages.Add(msg);
@@ -1666,6 +1679,7 @@ public partial class MainViewModel : ObservableObject
         MessageFilter.Replied         => msg.IsReplied,
         MessageFilter.Forwarded       => msg.IsForwarded,
         MessageFilter.ToMe            => !msg.IsMailingList && Accounts.Any(a => msg.To.Contains(a.Username, StringComparison.OrdinalIgnoreCase)),
+        MessageFilter.Flagged         => msg.IsFlagged,
         _                             => true,
     };
 
@@ -1673,6 +1687,27 @@ public partial class MainViewModel : ObservableObject
     // MatchesFilter without an explicit ActiveDayLimit.HasValue guard at every site.
     private bool MatchesDayLimit(MailMessageSummary msg)
         => !ActiveDayLimit.HasValue || msg.Date >= DateTimeOffset.Now.AddDays(-ActiveDayLimit.Value);
+
+    // Populates FlagName and FlagColorHex on messages that have a FlagId set but no
+    // display name — which is the case for every cache load, since ReadSummariesAsync
+    // only reads flag_id. Skips gracefully when _flagService is not wired up.
+    private async Task ResolveFlagNamesAsync(IList<MailMessageSummary> messages)
+    {
+        if (_flagService == null) return;
+        var flagged = messages.Where(m => m.FlagId != null).ToList();
+        if (flagged.Count == 0) return;
+        var defs = await _flagService.LoadFlagDefinitionsAsync();
+        var lookup = new Dictionary<Guid, FlagDefinition>(defs.Count);
+        foreach (var d in defs) lookup[d.Id] = d;
+        foreach (var m in flagged)
+        {
+            if (m.FlagId != null && Guid.TryParse(m.FlagId, out var fid) && lookup.TryGetValue(fid, out var def))
+            {
+                m.FlagName     = def.Name;
+                m.FlagColorHex = def.ColorHex;
+            }
+        }
+    }
 
     // Binary-insert into the descending-by-date Messages collection.
     private void InsertMessageSorted(MailMessageSummary msg)
@@ -2302,6 +2337,7 @@ public partial class MainViewModel : ObservableObject
                 if (!IsCurrentFolderLoad(loadVersion, folder))
                     return;
 
+                await ResolveFlagNamesAsync(cached);
                 SetMessages(cached);
                 StatusText = cached.Count > 0
                     ? $"{cached.Count} cached {(cached.Count == 1 ? "message" : "messages")} (checking for new…)"
@@ -2573,6 +2609,7 @@ public partial class MainViewModel : ObservableObject
                 if (!IsCurrentFolderLoad(loadVersion, AllMailFolder))
                     return;
 
+                await ResolveFlagNamesAsync(cached);
                 SetMessages(cached);
                 StatusText = cached.Count > 0
                     ? $"{cached.Count} messages (checking for new…)"
@@ -2805,6 +2842,7 @@ public partial class MainViewModel : ObservableObject
                 var cached = await _localStore.LoadAllSummariesAsync(accountId);
                 if (!IsCurrentFolderLoad(loadVersion, expectedFolder)) return;
 
+                await ResolveFlagNamesAsync(cached);
                 SetMessages(cached);
                 StatusText = cached.Count > 0
                     ? $"{cached.Count} messages (checking for new…)"
@@ -4062,6 +4100,7 @@ public partial class MainViewModel : ObservableObject
             "replied"     => MessageFilter.Replied,
             "forwarded"   => MessageFilter.Forwarded,
             "tome"        => MessageFilter.ToMe,
+            "flagged"     => MessageFilter.Flagged,
             _             => MessageFilter.All,
         };
         return Task.CompletedTask;

--- a/QuickMail/ViewModels/SettingsViewModel.cs
+++ b/QuickMail/ViewModels/SettingsViewModel.cs
@@ -53,6 +53,9 @@ public partial class SettingsViewModel : ObservableObject
     private bool _announceFormattingWhileNavigating;
 
     [ObservableProperty]
+    private bool _announceFlagStatus;
+
+    [ObservableProperty]
     private bool _confirmEmptyTrash;
 
     // ── Composing ──────────────────────────────────────────────────────────────────
@@ -135,6 +138,7 @@ public partial class SettingsViewModel : ObservableObject
         AnnounceSpellingWhileNavigating  = cfg.AnnounceSpellingWhileNavigating;
         AnnounceSpellingSuggestions      = cfg.AnnounceSpellingSuggestions;
         AnnounceFormattingWhileNavigating = cfg.AnnounceFormattingWhileNavigating;
+        AnnounceFlagStatus               = cfg.AnnounceFlagStatus;
         ConfirmEmptyTrash                = cfg.ConfirmEmptyTrash;
         AutoSaveDrafts                   = cfg.AutoSaveDrafts;
         AutoSaveIntervalSeconds          = cfg.AutoSaveIntervalSeconds;
@@ -184,6 +188,7 @@ public partial class SettingsViewModel : ObservableObject
         cfg.AnnounceSpellingWhileNavigating  = AnnounceSpellingWhileNavigating;
         cfg.AnnounceSpellingSuggestions      = AnnounceSpellingSuggestions;
         cfg.AnnounceFormattingWhileNavigating = AnnounceFormattingWhileNavigating;
+        cfg.AnnounceFlagStatus               = AnnounceFlagStatus;
         cfg.ConfirmEmptyTrash                = ConfirmEmptyTrash;
         cfg.AutoSaveDrafts                   = AutoSaveDrafts;
         cfg.AutoSaveIntervalSeconds          = AutoSaveIntervalSeconds;

--- a/QuickMail/ViewModels/ViewManagerViewModel.cs
+++ b/QuickMail/ViewModels/ViewManagerViewModel.cs
@@ -674,6 +674,7 @@ public partial class ViewManagerViewModel : ObservableObject
         "attachments" => "With Attachments",
         "replied"     => "Replied",
         "forwarded"   => "Forwarded",
+        "flagged"     => "Flagged",
         _             => "All",
     };
 

--- a/QuickMail/ViewModels/ViewManagerViewModel.cs
+++ b/QuickMail/ViewModels/ViewManagerViewModel.cs
@@ -253,6 +253,9 @@ public partial class ViewManagerViewModel : ObservableObject
 
     public int? CurrentDayLimit { get; }
 
+    /// <summary>Named-flag sub-filter id from the main VM, captured into saved views.</summary>
+    private readonly string? _activeFlagFilterId;
+
     public ViewManagerViewModel(
         IViewService     viewService,
         IConfigService   configService,
@@ -264,7 +267,8 @@ public partial class ViewManagerViewModel : ObservableObject
         MessageFilter    currentFilter,
         MessageSort      currentSort,
         int?             currentDayLimit = null,
-        bool             isCreateMode    = false)
+        bool             isCreateMode    = false,
+        string?          activeFlagFilterId = null)
     {
         _viewService   = viewService;
         _configService = configService;
@@ -277,6 +281,7 @@ public partial class ViewManagerViewModel : ObservableObject
         CurrentFilter    = currentFilter;
         CurrentSort      = currentSort;
         CurrentDayLimit  = currentDayLimit;
+        _activeFlagFilterId = activeFlagFilterId;
 
         SavedViews = new ObservableCollection<SavedView>(savedViews);
     }
@@ -298,11 +303,12 @@ public partial class ViewManagerViewModel : ObservableObject
     {
         var view = new SavedView
         {
-            Name       = GenerateName(),
-            ViewMode   = CurrentViewMode.ToString().ToLowerInvariant(),
-            Filter     = FilterKey(CurrentFilter),
-            Sort       = SortKey(CurrentSort),
-            DaysOfMail = CurrentDayLimit,
+            Name         = GenerateName(),
+            ViewMode     = CurrentViewMode.ToString().ToLowerInvariant(),
+            Filter       = FilterKey(CurrentFilter),
+            Sort         = SortKey(CurrentSort),
+            DaysOfMail   = CurrentDayLimit,
+            FlagFilterId = _activeFlagFilterId,
         };
 
         if (IsRealImapFolder(CurrentFolder) && CurrentAccount != null)
@@ -696,6 +702,7 @@ public partial class ViewManagerViewModel : ObservableObject
         MessageFilter.Replied         => "replied",
         MessageFilter.Forwarded       => "forwarded",
         MessageFilter.ToMe            => "tome",
+        MessageFilter.Flagged         => "flagged",
         _                             => "all",
     };
 

--- a/QuickMail/Views/FlagManagerWindow.xaml
+++ b/QuickMail/Views/FlagManagerWindow.xaml
@@ -1,0 +1,265 @@
+<Window x:Class="QuickMail.Views.FlagManagerWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:views="clr-namespace:QuickMail.Views"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        mc:Ignorable="d"
+        Title="Flag Manager"
+        Width="520" Height="440"
+        MinWidth="420" MinHeight="340"
+        WindowStartupLocation="CenterOwner"
+        ShowInTaskbar="False">
+
+    <Window.Resources>
+        <views:StringToBrushConverter x:Key="StringToBrushConverter"/>
+    </Window.Resources>
+
+    <DockPanel>
+        <!-- Toolbar -->
+        <ToolBar x:Name="FlagToolbar"
+                 DockPanel.Dock="Top"
+                 AutomationProperties.Name="Flag manager toolbar">
+            <Button x:Name="AddButton"
+                    Content="Add Flag"
+                    Command="{Binding AddFlagCommand}"
+                    AutomationProperties.Name="Add Flag"/>
+            <Button x:Name="DeleteButton"
+                    Content="Delete"
+                    Command="{Binding DeleteFlagCommand}"
+                    AutomationProperties.Name="Delete selected flag"/>
+            <Separator/>
+            <Button x:Name="MoveUpButton"
+                    Content="Move Up"
+                    Command="{Binding MoveUpCommand}"
+                    AutomationProperties.Name="Move flag up"/>
+            <Button x:Name="MoveDownButton"
+                    Content="Move Down"
+                    Command="{Binding MoveDownCommand}"
+                    AutomationProperties.Name="Move flag down"/>
+            <Separator/>
+            <Button x:Name="SetDefaultButton"
+                    Content="Set K Default"
+                    Command="{Binding SetAsKDefaultCommand}"
+                    AutomationProperties.Name="Set as K key default flag"/>
+        </ToolBar>
+
+        <!-- Close button row -->
+        <Border DockPanel.Dock="Bottom" Padding="8,4">
+            <Button x:Name="CloseButton"
+                    Content="Close"
+                    IsCancel="True"
+                    HorizontalAlignment="Right"
+                    Width="72"/>
+        </Border>
+
+        <!-- Main content: flag list + edit panel -->
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="180" MinWidth="120"/>
+                <ColumnDefinition Width="4"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+
+            <!-- Flag list -->
+            <ListBox x:Name="FlagList"
+                     Grid.Column="0"
+                     ItemsSource="{Binding Flags}"
+                     SelectedItem="{Binding SelectedFlag}"
+                     Margin="8,4,0,4"
+                     AutomationProperties.Name="Flags">
+                <ListBox.ItemContainerStyle>
+                    <Style TargetType="ListBoxItem">
+                        <Setter Property="AutomationProperties.Name" Value="{Binding Name}"/>
+                        <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+                    </Style>
+                </ListBox.ItemContainerStyle>
+                <ListBox.ItemTemplate>
+                    <DataTemplate>
+                        <DockPanel>
+                            <Border Width="12" Height="12"
+                                    CornerRadius="2"
+                                    Margin="0,0,6,0"
+                                    VerticalAlignment="Center"
+                                    Background="{Binding ColorHex, Converter={StaticResource StringToBrushConverter}}"/>
+                            <TextBlock Text="{Binding Name}"
+                                       VerticalAlignment="Center"
+                                       TextTrimming="CharacterEllipsis"/>
+                        </DockPanel>
+                    </DataTemplate>
+                </ListBox.ItemTemplate>
+            </ListBox>
+
+            <GridSplitter Grid.Column="1" Width="4" HorizontalAlignment="Stretch"/>
+
+            <!-- Edit panel -->
+            <ScrollViewer x:Name="EditPanel"
+                          Grid.Column="2"
+                          Margin="8,4,8,4"
+                          VerticalScrollBarVisibility="Auto">
+                <StackPanel>
+                    <TextBlock Text="No flag selected."
+                               Margin="0,8,0,0"
+                               Foreground="Gray">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Visibility" Value="Collapsed"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding HasSelection}" Value="False">
+                                        <Setter Property="Visibility" Value="Visible"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+
+                    <StackPanel>
+                        <StackPanel.Style>
+                            <Style TargetType="StackPanel">
+                                <Setter Property="Visibility" Value="Visible"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding HasSelection}" Value="False">
+                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </StackPanel.Style>
+
+                        <!-- Name section -->
+                        <TextBlock Text="Name" FontWeight="SemiBold" Margin="0,8,0,2"/>
+
+                        <!-- Read-only name + Rename button (shown when not renaming) -->
+                        <DockPanel>
+                            <DockPanel.Style>
+                                <Style TargetType="DockPanel">
+                                    <Setter Property="Visibility" Value="Visible"/>
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding IsRenaming}" Value="True">
+                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </DockPanel.Style>
+                            <Button DockPanel.Dock="Right"
+                                    Content="Rename"
+                                    Command="{Binding BeginRenameCommand}"
+                                    Width="68" Margin="4,0,0,0"
+                                    AutomationProperties.Name="Rename selected flag"/>
+                            <TextBlock Text="{Binding SelectedFlag.Name}"
+                                       VerticalAlignment="Center"
+                                       TextTrimming="CharacterEllipsis"/>
+                        </DockPanel>
+
+                        <!-- Edit name TextBox (shown when renaming) -->
+                        <StackPanel>
+                            <StackPanel.Style>
+                                <Style TargetType="StackPanel">
+                                    <Setter Property="Visibility" Value="Collapsed"/>
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding IsRenaming}" Value="True">
+                                            <Setter Property="Visibility" Value="Visible"/>
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </StackPanel.Style>
+                            <TextBox x:Name="EditNameBox"
+                                     Text="{Binding EditName, UpdateSourceTrigger=PropertyChanged}"
+                                     MaxLength="32"
+                                     AutomationProperties.Name="Flag name"
+                                     Margin="0,0,0,2"/>
+                            <TextBlock Text="{Binding RenameError}"
+                                       Foreground="Red"
+                                       FontSize="11"
+                                       Margin="0,0,0,4">
+                                <TextBlock.Style>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="Visibility" Value="Visible"/>
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding RenameError}" Value="">
+                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </TextBlock.Style>
+                            </TextBlock>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Content="Save"
+                                        Command="{Binding SaveRenameCommand}"
+                                        Width="60" Margin="0,0,4,0"
+                                        IsDefault="True"/>
+                                <Button Content="Cancel"
+                                        Command="{Binding CancelRenameCommand}"
+                                        Width="60"/>
+                            </StackPanel>
+                        </StackPanel>
+
+                        <!-- Color section -->
+                        <TextBlock Text="Color" FontWeight="SemiBold" Margin="0,12,0,4"/>
+
+                        <!-- Color swatch for selected flag -->
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,6">
+                            <Border Width="24" Height="24"
+                                    CornerRadius="3"
+                                    Margin="0,0,8,0"
+                                    Background="{Binding SelectedFlag.ColorHex, Converter={StaticResource StringToBrushConverter}}"/>
+                            <TextBlock Text="{Binding SelectedFlag.ColorHex}"
+                                       VerticalAlignment="Center"
+                                       Foreground="Gray"
+                                       FontSize="11"/>
+                        </StackPanel>
+
+                        <!-- 12 preset color buttons (radio group) -->
+                        <WrapPanel x:Name="ColorPanel"
+                                   AutomationProperties.Name="Preset colors"
+                                   KeyboardNavigation.TabNavigation="Once"
+                                   KeyboardNavigation.DirectionalNavigation="Cycle">
+                            <WrapPanel.Resources>
+                                <Style TargetType="RadioButton">
+                                    <Setter Property="Width" Value="28"/>
+                                    <Setter Property="Height" Value="28"/>
+                                    <Setter Property="Margin" Value="2"/>
+                                    <Setter Property="GroupName" Value="ColorGroup"/>
+                                    <Setter Property="Template">
+                                        <Setter.Value>
+                                            <ControlTemplate TargetType="RadioButton">
+                                                <Border Background="{TemplateBinding Tag, Converter={StaticResource StringToBrushConverter}}"
+                                                        CornerRadius="3"
+                                                        BorderThickness="2">
+                                                    <Border.Style>
+                                                        <Style TargetType="Border">
+                                                            <Setter Property="BorderBrush" Value="Transparent"/>
+                                                            <Style.Triggers>
+                                                                <DataTrigger Binding="{Binding IsChecked, RelativeSource={RelativeSource TemplatedParent}}" Value="True">
+                                                                    <Setter Property="BorderBrush" Value="White"/>
+                                                                </DataTrigger>
+                                                                <Trigger Property="IsMouseOver" Value="True">
+                                                                    <Setter Property="BorderBrush" Value="#80FFFFFF"/>
+                                                                </Trigger>
+                                                            </Style.Triggers>
+                                                        </Style>
+                                                    </Border.Style>
+                                                </Border>
+                                            </ControlTemplate>
+                                        </Setter.Value>
+                                    </Setter>
+                                </Style>
+                            </WrapPanel.Resources>
+                            <RadioButton Tag="#E53E3E" AutomationProperties.Name="Red"     Command="{Binding DataContext.ChangeColorCommand, RelativeSource={RelativeSource AncestorType=Window}}" CommandParameter="#E53E3E"/>
+                            <RadioButton Tag="#DD6B20" AutomationProperties.Name="Orange"  Command="{Binding DataContext.ChangeColorCommand, RelativeSource={RelativeSource AncestorType=Window}}" CommandParameter="#DD6B20"/>
+                            <RadioButton Tag="#FF8C00" AutomationProperties.Name="Amber"   Command="{Binding DataContext.ChangeColorCommand, RelativeSource={RelativeSource AncestorType=Window}}" CommandParameter="#FF8C00"/>
+                            <RadioButton Tag="#D69E2E" AutomationProperties.Name="Yellow"  Command="{Binding DataContext.ChangeColorCommand, RelativeSource={RelativeSource AncestorType=Window}}" CommandParameter="#D69E2E"/>
+                            <RadioButton Tag="#38A169" AutomationProperties.Name="Green"   Command="{Binding DataContext.ChangeColorCommand, RelativeSource={RelativeSource AncestorType=Window}}" CommandParameter="#38A169"/>
+                            <RadioButton Tag="#68D391" AutomationProperties.Name="Lime"    Command="{Binding DataContext.ChangeColorCommand, RelativeSource={RelativeSource AncestorType=Window}}" CommandParameter="#68D391"/>
+                            <RadioButton Tag="#319795" AutomationProperties.Name="Teal"    Command="{Binding DataContext.ChangeColorCommand, RelativeSource={RelativeSource AncestorType=Window}}" CommandParameter="#319795"/>
+                            <RadioButton Tag="#00B5D8" AutomationProperties.Name="Cyan"    Command="{Binding DataContext.ChangeColorCommand, RelativeSource={RelativeSource AncestorType=Window}}" CommandParameter="#00B5D8"/>
+                            <RadioButton Tag="#3182CE" AutomationProperties.Name="Blue"    Command="{Binding DataContext.ChangeColorCommand, RelativeSource={RelativeSource AncestorType=Window}}" CommandParameter="#3182CE"/>
+                            <RadioButton Tag="#5A67D8" AutomationProperties.Name="Indigo"  Command="{Binding DataContext.ChangeColorCommand, RelativeSource={RelativeSource AncestorType=Window}}" CommandParameter="#5A67D8"/>
+                            <RadioButton Tag="#6B46C1" AutomationProperties.Name="Violet"  Command="{Binding DataContext.ChangeColorCommand, RelativeSource={RelativeSource AncestorType=Window}}" CommandParameter="#6B46C1"/>
+                            <RadioButton Tag="#D53F8C" AutomationProperties.Name="Pink"    Command="{Binding DataContext.ChangeColorCommand, RelativeSource={RelativeSource AncestorType=Window}}" CommandParameter="#D53F8C"/>
+                        </WrapPanel>
+                    </StackPanel>
+                </StackPanel>
+            </ScrollViewer>
+        </Grid>
+    </DockPanel>
+</Window>

--- a/QuickMail/Views/FlagManagerWindow.xaml
+++ b/QuickMail/Views/FlagManagerWindow.xaml
@@ -19,6 +19,7 @@
         <!-- Toolbar -->
         <ToolBar x:Name="FlagToolbar"
                  DockPanel.Dock="Top"
+                 KeyboardNavigation.TabNavigation="Continue"
                  AutomationProperties.Name="Flag manager">
             <Button x:Name="AddButton"
                     Content="Add Flag"
@@ -90,7 +91,7 @@
                 </ListBox.ItemTemplate>
             </ListBox>
 
-            <GridSplitter Grid.Column="1" Width="4" HorizontalAlignment="Stretch"/>
+            <GridSplitter Grid.Column="1" Width="4" HorizontalAlignment="Stretch" IsTabStop="False"/>
 
             <!-- Edit panel -->
             <ScrollViewer x:Name="EditPanel"
@@ -262,12 +263,12 @@
                             </WrapPanel.Resources>
                             <RadioButton Tag="#E53E3E" AutomationProperties.Name="Red"     Command="{Binding DataContext.ChangeColorCommand, RelativeSource={RelativeSource AncestorType=Window}}" CommandParameter="#E53E3E"/>
                             <RadioButton Tag="#DD6B20" AutomationProperties.Name="Orange"  Command="{Binding DataContext.ChangeColorCommand, RelativeSource={RelativeSource AncestorType=Window}}" CommandParameter="#DD6B20"/>
-                            <RadioButton Tag="#FF8C00" AutomationProperties.Name="Amber"   Command="{Binding DataContext.ChangeColorCommand, RelativeSource={RelativeSource AncestorType=Window}}" CommandParameter="#FF8C00"/>
-                            <RadioButton Tag="#D69E2E" AutomationProperties.Name="Yellow"  Command="{Binding DataContext.ChangeColorCommand, RelativeSource={RelativeSource AncestorType=Window}}" CommandParameter="#D69E2E"/>
+                            <RadioButton Tag="#C05621" AutomationProperties.Name="Amber"   Command="{Binding DataContext.ChangeColorCommand, RelativeSource={RelativeSource AncestorType=Window}}" CommandParameter="#C05621"/>
+                            <RadioButton Tag="#B7791F" AutomationProperties.Name="Yellow"  Command="{Binding DataContext.ChangeColorCommand, RelativeSource={RelativeSource AncestorType=Window}}" CommandParameter="#B7791F"/>
                             <RadioButton Tag="#38A169" AutomationProperties.Name="Green"   Command="{Binding DataContext.ChangeColorCommand, RelativeSource={RelativeSource AncestorType=Window}}" CommandParameter="#38A169"/>
-                            <RadioButton Tag="#68D391" AutomationProperties.Name="Lime"    Command="{Binding DataContext.ChangeColorCommand, RelativeSource={RelativeSource AncestorType=Window}}" CommandParameter="#68D391"/>
+                            <RadioButton Tag="#276749" AutomationProperties.Name="Lime"    Command="{Binding DataContext.ChangeColorCommand, RelativeSource={RelativeSource AncestorType=Window}}" CommandParameter="#276749"/>
                             <RadioButton Tag="#319795" AutomationProperties.Name="Teal"    Command="{Binding DataContext.ChangeColorCommand, RelativeSource={RelativeSource AncestorType=Window}}" CommandParameter="#319795"/>
-                            <RadioButton Tag="#00B5D8" AutomationProperties.Name="Cyan"    Command="{Binding DataContext.ChangeColorCommand, RelativeSource={RelativeSource AncestorType=Window}}" CommandParameter="#00B5D8"/>
+                            <RadioButton Tag="#0987A0" AutomationProperties.Name="Cyan"    Command="{Binding DataContext.ChangeColorCommand, RelativeSource={RelativeSource AncestorType=Window}}" CommandParameter="#0987A0"/>
                             <RadioButton Tag="#3182CE" AutomationProperties.Name="Blue"    Command="{Binding DataContext.ChangeColorCommand, RelativeSource={RelativeSource AncestorType=Window}}" CommandParameter="#3182CE"/>
                             <RadioButton Tag="#5A67D8" AutomationProperties.Name="Indigo"  Command="{Binding DataContext.ChangeColorCommand, RelativeSource={RelativeSource AncestorType=Window}}" CommandParameter="#5A67D8"/>
                             <RadioButton Tag="#6B46C1" AutomationProperties.Name="Violet"  Command="{Binding DataContext.ChangeColorCommand, RelativeSource={RelativeSource AncestorType=Window}}" CommandParameter="#6B46C1"/>

--- a/QuickMail/Views/FlagManagerWindow.xaml
+++ b/QuickMail/Views/FlagManagerWindow.xaml
@@ -19,7 +19,7 @@
         <!-- Toolbar -->
         <ToolBar x:Name="FlagToolbar"
                  DockPanel.Dock="Top"
-                 AutomationProperties.Name="Flag manager toolbar">
+                 AutomationProperties.Name="Flag manager">
             <Button x:Name="AddButton"
                     Content="Add Flag"
                     Command="{Binding AddFlagCommand}"
@@ -27,21 +27,21 @@
             <Button x:Name="DeleteButton"
                     Content="Delete"
                     Command="{Binding DeleteFlagCommand}"
-                    AutomationProperties.Name="Delete selected flag"/>
+                    AutomationProperties.Name="Delete"/>
             <Separator/>
             <Button x:Name="MoveUpButton"
                     Content="Move Up"
                     Command="{Binding MoveUpCommand}"
-                    AutomationProperties.Name="Move flag up"/>
+                    AutomationProperties.Name="Move up"/>
             <Button x:Name="MoveDownButton"
                     Content="Move Down"
                     Command="{Binding MoveDownCommand}"
-                    AutomationProperties.Name="Move flag down"/>
+                    AutomationProperties.Name="Move down"/>
             <Separator/>
             <Button x:Name="SetDefaultButton"
                     Content="Set K Default"
                     Command="{Binding SetAsKDefaultCommand}"
-                    AutomationProperties.Name="Set as K key default flag"/>
+                    AutomationProperties.Name="Set K default"/>
         </ToolBar>
 
         <!-- Close button row -->
@@ -144,7 +144,7 @@
                                     Content="Rename"
                                     Command="{Binding BeginRenameCommand}"
                                     Width="68" Margin="4,0,0,0"
-                                    AutomationProperties.Name="Rename selected flag"/>
+                                    AutomationProperties.Name="Rename"/>
                             <TextBlock Text="{Binding SelectedFlag.Name}"
                                        VerticalAlignment="Center"
                                        TextTrimming="CharacterEllipsis"/>
@@ -219,6 +219,22 @@
                                     <Setter Property="Height" Value="28"/>
                                     <Setter Property="Margin" Value="2"/>
                                     <Setter Property="GroupName" Value="ColorGroup"/>
+                                    <Setter Property="FocusVisualStyle">
+                                        <Setter.Value>
+                                            <Style TargetType="Control">
+                                                <Setter Property="Template">
+                                                    <Setter.Value>
+                                                        <ControlTemplate>
+                                                            <Rectangle Stroke="White" StrokeThickness="2"
+                                                                       StrokeDashArray="2,1"
+                                                                       RadiusX="3" RadiusY="3"
+                                                                       Margin="-2"/>
+                                                        </ControlTemplate>
+                                                    </Setter.Value>
+                                                </Setter>
+                                            </Style>
+                                        </Setter.Value>
+                                    </Setter>
                                     <Setter Property="Template">
                                         <Setter.Value>
                                             <ControlTemplate TargetType="RadioButton">

--- a/QuickMail/Views/FlagManagerWindow.xaml.cs
+++ b/QuickMail/Views/FlagManagerWindow.xaml.cs
@@ -12,6 +12,7 @@ public partial class FlagManagerWindow : Window
 {
     private readonly FlagManagerViewModel _vm;
     private readonly CommandRegistry _localRegistry = new();
+    private CancellationTokenSource? _loadCts;
 
     public FlagManagerWindow(FlagManagerViewModel vm)
     {
@@ -27,8 +28,10 @@ public partial class FlagManagerWindow : Window
 
         Loaded += async (_, _) =>
         {
-            await _vm.LoadAsync();
-            FlagList.Focus();
+            _loadCts = new CancellationTokenSource();
+            try { await _vm.LoadAsync(_loadCts.Token); }
+            catch (OperationCanceledException) { return; }
+            FocusPane(FlagList);
         };
     }
 
@@ -157,6 +160,8 @@ public partial class FlagManagerWindow : Window
 
     protected override void OnClosed(EventArgs e)
     {
+        _loadCts?.Cancel();
+        _loadCts?.Dispose();
         _vm.ConfirmDeleteRequested -= OnConfirmDelete;
         _vm.AnnouncementRequested  -= OnAnnouncement;
         _vm.RenameStarted          -= OnRenameStarted;

--- a/QuickMail/Views/FlagManagerWindow.xaml.cs
+++ b/QuickMail/Views/FlagManagerWindow.xaml.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Input;
+using QuickMail.Models;
+using QuickMail.Services;
+using QuickMail.ViewModels;
+
+namespace QuickMail.Views;
+
+public partial class FlagManagerWindow : Window
+{
+    private readonly FlagManagerViewModel _vm;
+    private readonly CommandRegistry _localRegistry = new();
+
+    public FlagManagerWindow(FlagManagerViewModel vm)
+    {
+        _vm = vm;
+        InitializeComponent();
+        DataContext = vm;
+
+        RegisterLocalCommands();
+
+        vm.ConfirmDeleteRequested += OnConfirmDelete;
+        vm.AnnouncementRequested  += OnAnnouncement;
+        vm.RenameStarted          += OnRenameStarted;
+
+        Loaded += async (_, _) =>
+        {
+            await _vm.LoadAsync();
+            FlagList.Focus();
+        };
+    }
+
+    private async Task<bool> OnConfirmDelete(string msg, string title) =>
+        await Application.Current.Dispatcher.InvokeAsync(() =>
+            MessageBox.Show(this, msg, title, MessageBoxButton.YesNo, MessageBoxImage.Warning)
+            == MessageBoxResult.Yes);
+
+    private void OnAnnouncement(string text, AnnouncementCategory cat) =>
+        AccessibilityHelper.Announce(this, text, interrupt: true, category: cat);
+
+    private void OnRenameStarted(object? sender, EventArgs e) =>
+        Dispatcher.InvokeAsync(() => EditNameBox.Focus(), System.Windows.Threading.DispatcherPriority.Input);
+
+    private void RegisterLocalCommands()
+    {
+        _localRegistry.Register(new CommandDefinition(
+            "flagmgr.add", "Flag", "Add Flag",
+            () => _vm.AddFlagCommand.Execute(null)));
+        _localRegistry.Register(new CommandDefinition(
+            "flagmgr.delete", "Flag", "Delete Selected Flag",
+            () => _vm.DeleteFlagCommand.Execute(null),
+            isAvailable: () => _vm.CanDelete));
+        _localRegistry.Register(new CommandDefinition(
+            "flagmgr.rename", "Flag", "Rename Selected Flag",
+            () => _vm.BeginRenameCommand.Execute(null),
+            isAvailable: () => _vm.HasSelection));
+        _localRegistry.Register(new CommandDefinition(
+            "flagmgr.moveup", "Flag", "Move Flag Up",
+            () => _vm.MoveUpCommand.Execute(null),
+            isAvailable: () => _vm.CanMoveUp));
+        _localRegistry.Register(new CommandDefinition(
+            "flagmgr.movedown", "Flag", "Move Flag Down",
+            () => _vm.MoveDownCommand.Execute(null),
+            isAvailable: () => _vm.CanMoveDown));
+        _localRegistry.Register(new CommandDefinition(
+            "flagmgr.setdefault", "Flag", "Set as K Key Default",
+            () => _vm.SetAsKDefaultCommand.Execute(null),
+            isAvailable: () => _vm.HasSelection));
+        _localRegistry.Register(new CommandDefinition(
+            "flagmgr.close", "Flag", "Close",
+            () => Close()));
+    }
+
+    protected override void OnPreviewKeyDown(KeyEventArgs e)
+    {
+        base.OnPreviewKeyDown(e);
+
+        if (e.Key == Key.F6)
+        {
+            CycleFocus(Keyboard.Modifiers.HasFlag(ModifierKeys.Shift));
+            e.Handled = true;
+            return;
+        }
+
+        if (e.Key == Key.P &&
+            Keyboard.Modifiers == (ModifierKeys.Control | ModifierKeys.Shift))
+        {
+            OpenCommandPalette();
+            e.Handled = true;
+            return;
+        }
+
+        if (e.Key == Key.Enter && FlagList.IsKeyboardFocusWithin && !_vm.IsRenaming)
+        {
+            _vm.BeginRenameCommand.Execute(null);
+            e.Handled = true;
+            return;
+        }
+
+        if (e.Key == Key.Enter && EditNameBox.IsKeyboardFocusWithin)
+        {
+            _vm.SaveRenameCommand.Execute(null);
+            e.Handled = true;
+            return;
+        }
+
+        if (e.Key == Key.Escape && _vm.IsRenaming)
+        {
+            _vm.CancelRenameCommand.Execute(null);
+            FlagList.Focus();
+            e.Handled = true;
+        }
+    }
+
+    private void CycleFocus(bool reverse)
+    {
+        UIElement[] panes = [FlagToolbar, FlagList, EditPanel];
+        int current = -1;
+        for (int i = 0; i < panes.Length; i++)
+        {
+            if (panes[i].IsKeyboardFocusWithin) { current = i; break; }
+        }
+        int next = reverse
+            ? (current <= 0 ? panes.Length - 1 : current - 1)
+            : (current >= panes.Length - 1 ? 0 : current + 1);
+        FocusPane(panes[next]);
+    }
+
+    private static void FocusPane(UIElement pane)
+    {
+        pane.Focus();
+        if (pane is System.Windows.Controls.ToolBar tb)
+        {
+            tb.MoveFocus(new TraversalRequest(FocusNavigationDirection.First));
+            return;
+        }
+        if (pane is System.Windows.Controls.Primitives.Selector sel &&
+            sel.Items.Count > 0 &&
+            sel.ItemContainerGenerator.ContainerFromIndex(
+                sel.SelectedIndex >= 0 ? sel.SelectedIndex : 0) is IInputElement item)
+        {
+            item.Focus();
+            return;
+        }
+        pane.MoveFocus(new TraversalRequest(FocusNavigationDirection.First));
+    }
+
+    private void OpenCommandPalette()
+    {
+        var prev = Keyboard.FocusedElement as IInputElement;
+        var palette = new CommandPaletteWindow(_localRegistry) { Owner = this };
+        palette.ShowDialog();
+        (prev ?? FlagList).Focus();
+    }
+
+    protected override void OnClosed(EventArgs e)
+    {
+        _vm.ConfirmDeleteRequested -= OnConfirmDelete;
+        _vm.AnnouncementRequested  -= OnAnnouncement;
+        _vm.RenameStarted          -= OnRenameStarted;
+        base.OnClosed(e);
+    }
+}

--- a/QuickMail/Views/FlagPickerWindow.xaml
+++ b/QuickMail/Views/FlagPickerWindow.xaml
@@ -1,0 +1,62 @@
+<Window x:Class="QuickMail.Views.FlagPickerWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:views="clr-namespace:QuickMail.Views"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        mc:Ignorable="d"
+        Title="Select Flag"
+        Width="280" Height="340"
+        ResizeMode="NoResize"
+        WindowStartupLocation="CenterOwner"
+        ShowInTaskbar="False">
+
+    <Window.Resources>
+        <views:StringToBrushConverter x:Key="StringToBrushConverter"/>
+    </Window.Resources>
+
+    <DockPanel Margin="8">
+        <TextBlock DockPanel.Dock="Top"
+                   Text="Select flag:"
+                   Margin="0,0,0,6"
+                   FontWeight="SemiBold"/>
+
+        <StackPanel DockPanel.Dock="Bottom"
+                    Orientation="Horizontal"
+                    HorizontalAlignment="Right"
+                    Margin="0,8,0,0">
+            <Button x:Name="ClearButton"
+                    Content="_Clear Flag"
+                    Command="{Binding ClearFlagCommand}"
+                    Width="80" Margin="0,0,4,0"/>
+            <Button x:Name="CancelButton"
+                    Content="Cancel"
+                    IsCancel="True"
+                    Width="64"/>
+        </StackPanel>
+
+        <ListBox x:Name="FlagList"
+                 ItemsSource="{Binding Flags}"
+                 SelectedItem="{Binding SelectedFlag}"
+                 AutomationProperties.Name="Flags"
+                 ScrollViewer.HorizontalScrollBarVisibility="Disabled">
+            <ListBox.ItemContainerStyle>
+                <Style TargetType="ListBoxItem">
+                    <Setter Property="AutomationProperties.Name" Value="{Binding Name}"/>
+                </Style>
+            </ListBox.ItemContainerStyle>
+            <ListBox.ItemTemplate>
+                <DataTemplate>
+                    <StackPanel Orientation="Horizontal" Margin="2">
+                        <Border Width="14" Height="14"
+                                CornerRadius="2"
+                                Margin="0,0,8,0"
+                                VerticalAlignment="Center"
+                                Background="{Binding ColorHex, Converter={StaticResource StringToBrushConverter}}"/>
+                        <TextBlock Text="{Binding Name}" VerticalAlignment="Center"/>
+                    </StackPanel>
+                </DataTemplate>
+            </ListBox.ItemTemplate>
+        </ListBox>
+    </DockPanel>
+</Window>

--- a/QuickMail/Views/FlagPickerWindow.xaml.cs
+++ b/QuickMail/Views/FlagPickerWindow.xaml.cs
@@ -1,0 +1,52 @@
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Input;
+using QuickMail.Models;
+using QuickMail.Services;
+using QuickMail.ViewModels;
+
+namespace QuickMail.Views;
+
+public partial class FlagPickerWindow : Window
+{
+    private readonly FlagPickerViewModel _vm;
+
+    public string? ResultFlagId { get; private set; }
+
+    public FlagPickerWindow(IFlagService flagService, bool currentlyFlagged)
+    {
+        _vm = new FlagPickerViewModel(flagService, currentlyFlagged);
+        InitializeComponent();
+        DataContext = _vm;
+
+        _vm.FlagSelected += OnFlagSelected;
+
+        Loaded += async (_, _) =>
+        {
+            await _vm.LoadAsync();
+            FlagList.Focus();
+        };
+    }
+
+    private void OnFlagSelected(FlagDefinition? flag)
+    {
+        ResultFlagId = flag?.Id.ToString();
+        DialogResult = true;
+    }
+
+    protected override void OnPreviewKeyDown(KeyEventArgs e)
+    {
+        base.OnPreviewKeyDown(e);
+        if (e.Key == Key.Enter && FlagList.IsKeyboardFocusWithin)
+        {
+            _vm.ApplyFlagCommand.Execute(null);
+            e.Handled = true;
+        }
+    }
+
+    protected override void OnClosed(System.EventArgs e)
+    {
+        _vm.FlagSelected -= OnFlagSelected;
+        base.OnClosed(e);
+    }
+}

--- a/QuickMail/Views/FlagPickerWindow.xaml.cs
+++ b/QuickMail/Views/FlagPickerWindow.xaml.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
@@ -10,6 +12,8 @@ namespace QuickMail.Views;
 public partial class FlagPickerWindow : Window
 {
     private readonly FlagPickerViewModel _vm;
+    private readonly CommandRegistry _localRegistry = new();
+    private CancellationTokenSource? _loadCts;
 
     public string? ResultFlagId { get; private set; }
 
@@ -19,13 +23,35 @@ public partial class FlagPickerWindow : Window
         InitializeComponent();
         DataContext = _vm;
 
+        RegisterLocalCommands();
+
         _vm.FlagSelected += OnFlagSelected;
 
         Loaded += async (_, _) =>
         {
-            await _vm.LoadAsync();
-            FlagList.Focus();
+            _loadCts = new CancellationTokenSource();
+            try
+            {
+                await _vm.LoadAsync();
+                if (!_loadCts.IsCancellationRequested)
+                    FlagList.Focus();
+            }
+            catch (OperationCanceledException) { }
         };
+    }
+
+    private void RegisterLocalCommands()
+    {
+        _localRegistry.Register(new CommandDefinition(
+            "flagpicker.apply", "Flag", "Apply Selected Flag",
+            () => _vm.ApplyFlagCommand.Execute(null),
+            isAvailable: () => _vm.SelectedFlag != null));
+        _localRegistry.Register(new CommandDefinition(
+            "flagpicker.clear", "Flag", "Clear Flag",
+            () => _vm.ClearFlagCommand.Execute(null)));
+        _localRegistry.Register(new CommandDefinition(
+            "flagpicker.cancel", "Flag", "Cancel",
+            () => { DialogResult = false; }));
     }
 
     private void OnFlagSelected(FlagDefinition? flag)
@@ -37,6 +63,22 @@ public partial class FlagPickerWindow : Window
     protected override void OnPreviewKeyDown(KeyEventArgs e)
     {
         base.OnPreviewKeyDown(e);
+
+        if (e.Key == Key.F6)
+        {
+            CycleFocus(Keyboard.Modifiers.HasFlag(ModifierKeys.Shift));
+            e.Handled = true;
+            return;
+        }
+
+        if (e.Key == Key.P &&
+            Keyboard.Modifiers == (ModifierKeys.Control | ModifierKeys.Shift))
+        {
+            OpenCommandPalette();
+            e.Handled = true;
+            return;
+        }
+
         if (e.Key == Key.Enter && FlagList.IsKeyboardFocusWithin)
         {
             _vm.ApplyFlagCommand.Execute(null);
@@ -44,8 +86,32 @@ public partial class FlagPickerWindow : Window
         }
     }
 
-    protected override void OnClosed(System.EventArgs e)
+    private void CycleFocus(bool reverse)
     {
+        UIElement[] panes = [FlagList, ClearButton, CancelButton];
+        int current = -1;
+        for (int i = 0; i < panes.Length; i++)
+        {
+            if (panes[i].IsKeyboardFocusWithin) { current = i; break; }
+        }
+        int next = reverse
+            ? (current <= 0 ? panes.Length - 1 : current - 1)
+            : (current >= panes.Length - 1 ? 0 : current + 1);
+        panes[next].Focus();
+    }
+
+    private void OpenCommandPalette()
+    {
+        var prev = Keyboard.FocusedElement as IInputElement;
+        var palette = new CommandPaletteWindow(_localRegistry) { Owner = this };
+        palette.ShowDialog();
+        (prev ?? FlagList).Focus();
+    }
+
+    protected override void OnClosed(EventArgs e)
+    {
+        _loadCts?.Cancel();
+        _loadCts?.Dispose();
         _vm.FlagSelected -= OnFlagSelected;
         base.OnClosed(e);
     }

--- a/QuickMail/Views/MainWindow.xaml
+++ b/QuickMail/Views/MainWindow.xaml
@@ -389,11 +389,16 @@
                               Command="{Binding SetFilterCommand}"
                               CommandParameter="tome"/>
                     <Separator/>
-                    <MenuItem Header="Fla_gged"
-                              IsCheckable="True"
-                              IsChecked="{Binding IsFilterFlagged, Mode=OneWay}"
-                              Command="{Binding SetFilterCommand}"
-                              CommandParameter="flagged"/>
+                    <MenuItem x:Name="FilterFlaggedItem"
+                              Header="Fla_gged"
+                              IsChecked="{Binding IsFilterFlagged, Mode=OneWay}">
+                        <MenuItem Header="All Fla_gged"
+                                  IsCheckable="True"
+                                  IsChecked="{Binding IsFilterAllFlagged, Mode=OneWay}"
+                                  Command="{Binding SetFilterCommand}"
+                                  CommandParameter="flagged"/>
+                        <Separator x:Name="FilterFlaggedSeparator"/>
+                    </MenuItem>
                 </MenuItem>
                 <MenuItem Header="S_ort">
                     <MenuItem Header="Newest _First"

--- a/QuickMail/Views/MainWindow.xaml
+++ b/QuickMail/Views/MainWindow.xaml
@@ -386,6 +386,12 @@
                               IsChecked="{Binding IsFilterToMe, Mode=OneWay}"
                               Command="{Binding SetFilterCommand}"
                               CommandParameter="tome"/>
+                    <Separator/>
+                    <MenuItem Header="Fla_gged"
+                              IsCheckable="True"
+                              IsChecked="{Binding IsFilterFlagged, Mode=OneWay}"
+                              Command="{Binding SetFilterCommand}"
+                              CommandParameter="flagged"/>
                 </MenuItem>
                 <MenuItem Header="S_ort">
                     <MenuItem Header="Newest _First"

--- a/QuickMail/Views/MainWindow.xaml
+++ b/QuickMail/Views/MainWindow.xaml
@@ -1191,6 +1191,7 @@
                                         <Border Width="4" HorizontalAlignment="Left" IsHitTestVisible="False"
                                                 Background="{Binding FlagColorHex, Converter={StaticResource StringToBrushConverter}}"/>
                                         <Border Background="Transparent"
+                                                Focusable="False"
                                                 Tag="{Binding}"
                                                 MouseLeftButtonUp="FlagHitArea_MouseLeftButtonUp"/>
                                     </Grid>
@@ -1238,6 +1239,7 @@
                                         <Border Width="4" HorizontalAlignment="Left" IsHitTestVisible="False"
                                                 Background="{Binding FlagColorHex, Converter={StaticResource StringToBrushConverter}}"/>
                                         <Border Background="Transparent"
+                                                Focusable="False"
                                                 Tag="{Binding}"
                                                 MouseLeftButtonUp="FlagHitArea_MouseLeftButtonUp"/>
                                     </Grid>
@@ -1318,6 +1320,7 @@
                                         <Border Width="4" HorizontalAlignment="Left" IsHitTestVisible="False"
                                                 Background="{Binding FlagColorHex, Converter={StaticResource StringToBrushConverter}}"/>
                                         <Border Background="Transparent"
+                                                Focusable="False"
                                                 Tag="{Binding}"
                                                 MouseLeftButtonUp="FlagHitArea_MouseLeftButtonUp"/>
                                     </Grid>
@@ -1365,6 +1368,7 @@
                                         <Border Width="4" HorizontalAlignment="Left" IsHitTestVisible="False"
                                                 Background="{Binding FlagColorHex, Converter={StaticResource StringToBrushConverter}}"/>
                                         <Border Background="Transparent"
+                                                Focusable="False"
                                                 Tag="{Binding}"
                                                 MouseLeftButtonUp="FlagHitArea_MouseLeftButtonUp"/>
                                     </Grid>
@@ -1442,6 +1446,7 @@
                                         <Border Width="4" HorizontalAlignment="Left" IsHitTestVisible="False"
                                                 Background="{Binding FlagColorHex, Converter={StaticResource StringToBrushConverter}}"/>
                                         <Border Background="Transparent"
+                                                Focusable="False"
                                                 Tag="{Binding}"
                                                 MouseLeftButtonUp="FlagHitArea_MouseLeftButtonUp"/>
                                     </Grid>
@@ -1489,6 +1494,7 @@
                                         <Border Width="4" HorizontalAlignment="Left" IsHitTestVisible="False"
                                                 Background="{Binding FlagColorHex, Converter={StaticResource StringToBrushConverter}}"/>
                                         <Border Background="Transparent"
+                                                Focusable="False"
                                                 Tag="{Binding}"
                                                 MouseLeftButtonUp="FlagHitArea_MouseLeftButtonUp"/>
                                     </Grid>

--- a/QuickMail/Views/MainWindow.xaml
+++ b/QuickMail/Views/MainWindow.xaml
@@ -17,6 +17,8 @@
         <local:InverseBoolToVisibilityConverter x:Key="InverseBoolToVisibilityConverter"/>
         <local:BoolToColumnWidthConverter       x:Key="BoolToColumnWidthConverter"/>
         <local:StringToVisibilityConverter      x:Key="StringToVisibilityConverter"/>
+        <local:StringToBrushConverter           x:Key="StringToBrushConverter"/>
+        <local:MessageAccessibleNameConverter   x:Key="MessageAccessibleNameConverter"/>
 
         <!-- ── Shared context menus ── -->
 
@@ -1117,14 +1119,23 @@
                         </ListView.View>
                         <ListView.ItemContainerStyle>
                             <Style TargetType="ListViewItem" BasedOn="{StaticResource {x:Type ListViewItem}}">
+                                <Setter Property="BorderThickness" Value="4,0,0,0"/>
+                                <Setter Property="BorderBrush">
+                                    <Setter.Value>
+                                        <Binding Path="FlagColorHex" Converter="{StaticResource StringToBrushConverter}"/>
+                                    </Setter.Value>
+                                </Setter>
                                 <Setter Property="AutomationProperties.Name">
                                     <Setter.Value>
-                                        <MultiBinding StringFormat="{}{0}. {1}. {2}. {3}. {4}.">
+                                        <MultiBinding Converter="{StaticResource MessageAccessibleNameConverter}">
+                                            <Binding Path="FlagLabel"/>
                                             <Binding Path="ReadStatusLabel"/>
                                             <Binding Path="From"/>
                                             <Binding Path="Subject"/>
                                             <Binding Path="Preview"/>
                                             <Binding Path="DateDisplay"/>
+                                            <Binding Path="DataContext.AnnounceFlagStatus"
+                                                     RelativeSource="{RelativeSource AncestorType=Window}"/>
                                         </MultiBinding>
                                     </Setter.Value>
                                 </Setter>
@@ -1156,12 +1167,15 @@
                                    BasedOn="{StaticResource {x:Type TreeViewItem}}">
                                 <Setter Property="AutomationProperties.Name">
                                     <Setter.Value>
-                                        <MultiBinding StringFormat="{}{0}. {1}. {2}. {3}. {4}.">
+                                        <MultiBinding Converter="{StaticResource MessageAccessibleNameConverter}">
+                                            <Binding Path="FlagLabel"/>
                                             <Binding Path="ReadStatusLabel"/>
                                             <Binding Path="From"/>
                                             <Binding Path="Subject"/>
                                             <Binding Path="Preview"/>
                                             <Binding Path="DateDisplay"/>
+                                            <Binding Path="DataContext.AnnounceFlagStatus"
+                                                     RelativeSource="{RelativeSource AncestorType=Window}"/>
                                         </MultiBinding>
                                     </Setter.Value>
                                 </Setter>
@@ -1172,59 +1186,77 @@
                             <HierarchicalDataTemplate DataType="{x:Type models:ConversationGroup}"
                                                       ItemsSource="{Binding Messages}"
                                                       ItemContainerStyle="{StaticResource MessageTreeItemStyle}">
-                                <StackPanel>
-                                    <TextBlock TextTrimming="CharacterEllipsis"
-                                               FontWeight="{Binding HasUnread, Converter={StaticResource BoolToWeightConverter}}">
-                                        <Run Text="{Binding Subject, Mode=OneWay}"/>
-                                        <Run Text=" "/>
-                                        <Run Text="{Binding Count, StringFormat=({0}), Mode=OneWay}"/>
-                                    </TextBlock>
-                                    <TextBlock Text="{Binding LastSenderName}"
-                                               FontSize="11" Opacity="0.85"
-                                               TextTrimming="CharacterEllipsis">
-                                        <TextBlock.Style>
-                                            <Style TargetType="TextBlock">
-                                                <Style.Triggers>
-                                                    <DataTrigger Binding="{Binding LastSenderName}" Value="">
-                                                        <Setter Property="Visibility" Value="Collapsed"/>
-                                                    </DataTrigger>
-                                                </Style.Triggers>
-                                            </Style>
-                                        </TextBlock.Style>
-                                    </TextBlock>
-                                    <TextBlock Text="{Binding Preview}"
-                                               FontSize="11" Opacity="0.7"
-                                               TextTrimming="CharacterEllipsis">
-                                        <TextBlock.Style>
-                                            <Style TargetType="TextBlock">
-                                                <Style.Triggers>
-                                                    <DataTrigger Binding="{Binding Preview}" Value="">
-                                                        <Setter Property="Visibility" Value="Collapsed"/>
-                                                    </DataTrigger>
-                                                </Style.Triggers>
-                                            </Style>
-                                        </TextBlock.Style>
-                                    </TextBlock>
-                                </StackPanel>
+                                <DockPanel LastChildFill="True">
+                                    <Grid DockPanel.Dock="Left" Width="16">
+                                        <Border Width="4" HorizontalAlignment="Left" IsHitTestVisible="False"
+                                                Background="{Binding FlagColorHex, Converter={StaticResource StringToBrushConverter}}"/>
+                                        <Border Background="Transparent"
+                                                Tag="{Binding}"
+                                                MouseLeftButtonUp="FlagHitArea_MouseLeftButtonUp"/>
+                                    </Grid>
+                                    <StackPanel>
+                                        <TextBlock TextTrimming="CharacterEllipsis"
+                                                   FontWeight="{Binding HasUnread, Converter={StaticResource BoolToWeightConverter}}">
+                                            <Run Text="{Binding Subject, Mode=OneWay}"/>
+                                            <Run Text=" "/>
+                                            <Run Text="{Binding Count, StringFormat=({0}), Mode=OneWay}"/>
+                                        </TextBlock>
+                                        <TextBlock Text="{Binding LastSenderName}"
+                                                   FontSize="11" Opacity="0.85"
+                                                   TextTrimming="CharacterEllipsis">
+                                            <TextBlock.Style>
+                                                <Style TargetType="TextBlock">
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding LastSenderName}" Value="">
+                                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </TextBlock.Style>
+                                        </TextBlock>
+                                        <TextBlock Text="{Binding Preview}"
+                                                   FontSize="11" Opacity="0.7"
+                                                   TextTrimming="CharacterEllipsis">
+                                            <TextBlock.Style>
+                                                <Style TargetType="TextBlock">
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding Preview}" Value="">
+                                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </TextBlock.Style>
+                                        </TextBlock>
+                                    </StackPanel>
+                                </DockPanel>
                             </HierarchicalDataTemplate>
 
                             <!-- Level 2: individual message row matching the ListView column layout -->
                             <DataTemplate DataType="{x:Type models:MailMessageSummary}">
-                                <Grid>
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="180"/>
-                                        <ColumnDefinition Width="*"/>
-                                        <ColumnDefinition Width="80"/>
-                                    </Grid.ColumnDefinitions>
-                                    <TextBlock Grid.Column="0" Text="{Binding From}"
-                                               FontWeight="{Binding IsRead, Converter={StaticResource BoolToWeightConverter}}"
-                                               TextTrimming="CharacterEllipsis"/>
-                                    <TextBlock Grid.Column="1" Text="{Binding Subject}"
-                                               FontWeight="{Binding IsRead, Converter={StaticResource BoolToWeightConverter}}"
-                                               TextTrimming="CharacterEllipsis"/>
-                                    <TextBlock Grid.Column="2" Text="{Binding DateDisplay}"
-                                               TextAlignment="Right"/>
-                                </Grid>
+                                <DockPanel LastChildFill="True">
+                                    <Grid DockPanel.Dock="Left" Width="16">
+                                        <Border Width="4" HorizontalAlignment="Left" IsHitTestVisible="False"
+                                                Background="{Binding FlagColorHex, Converter={StaticResource StringToBrushConverter}}"/>
+                                        <Border Background="Transparent"
+                                                Tag="{Binding}"
+                                                MouseLeftButtonUp="FlagHitArea_MouseLeftButtonUp"/>
+                                    </Grid>
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="180"/>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="80"/>
+                                        </Grid.ColumnDefinitions>
+                                        <TextBlock Grid.Column="0" Text="{Binding From}"
+                                                   FontWeight="{Binding IsRead, Converter={StaticResource BoolToWeightConverter}}"
+                                                   TextTrimming="CharacterEllipsis"/>
+                                        <TextBlock Grid.Column="1" Text="{Binding Subject}"
+                                                   FontWeight="{Binding IsRead, Converter={StaticResource BoolToWeightConverter}}"
+                                                   TextTrimming="CharacterEllipsis"/>
+                                        <TextBlock Grid.Column="2" Text="{Binding DateDisplay}"
+                                                   TextAlignment="Right"/>
+                                    </Grid>
+                                </DockPanel>
                             </DataTemplate>
                         </TreeView.Resources>
                         <TreeView.ItemContainerStyle>
@@ -1260,12 +1292,15 @@
                                    BasedOn="{StaticResource {x:Type TreeViewItem}}">
                                 <Setter Property="AutomationProperties.Name">
                                     <Setter.Value>
-                                        <MultiBinding StringFormat="{}{0}. {1}. {2}. {3}. {4}.">
+                                        <MultiBinding Converter="{StaticResource MessageAccessibleNameConverter}">
+                                            <Binding Path="FlagLabel"/>
                                             <Binding Path="ReadStatusLabel"/>
                                             <Binding Path="From"/>
                                             <Binding Path="Subject"/>
                                             <Binding Path="Preview"/>
                                             <Binding Path="DateDisplay"/>
+                                            <Binding Path="DataContext.AnnounceFlagStatus"
+                                                     RelativeSource="{RelativeSource AncestorType=Window}"/>
                                         </MultiBinding>
                                     </Setter.Value>
                                 </Setter>
@@ -1278,59 +1313,77 @@
                             <HierarchicalDataTemplate DataType="{x:Type models:SenderGroup}"
                                                       ItemsSource="{Binding Messages}"
                                                       ItemContainerStyle="{StaticResource SenderMessageTreeItemStyle}">
-                                <StackPanel>
-                                    <TextBlock TextTrimming="CharacterEllipsis"
-                                               FontWeight="{Binding HasUnread, Converter={StaticResource BoolToWeightConverter}}">
-                                        <Run Text="{Binding SenderName, Mode=OneWay}"/>
-                                        <Run Text=" "/>
-                                        <Run Text="{Binding Count, StringFormat=({0}), Mode=OneWay}"/>
-                                    </TextBlock>
-                                    <TextBlock Text="{Binding NewestSubject}"
-                                               FontSize="11" Opacity="0.85"
-                                               TextTrimming="CharacterEllipsis">
-                                        <TextBlock.Style>
-                                            <Style TargetType="TextBlock">
-                                                <Style.Triggers>
-                                                    <DataTrigger Binding="{Binding NewestSubject}" Value="">
-                                                        <Setter Property="Visibility" Value="Collapsed"/>
-                                                    </DataTrigger>
-                                                </Style.Triggers>
-                                            </Style>
-                                        </TextBlock.Style>
-                                    </TextBlock>
-                                    <TextBlock Text="{Binding Preview}"
-                                               FontSize="11" Opacity="0.7"
-                                               TextTrimming="CharacterEllipsis">
-                                        <TextBlock.Style>
-                                            <Style TargetType="TextBlock">
-                                                <Style.Triggers>
-                                                    <DataTrigger Binding="{Binding Preview}" Value="">
-                                                        <Setter Property="Visibility" Value="Collapsed"/>
-                                                    </DataTrigger>
-                                                </Style.Triggers>
-                                            </Style>
-                                        </TextBlock.Style>
-                                    </TextBlock>
-                                </StackPanel>
+                                <DockPanel LastChildFill="True">
+                                    <Grid DockPanel.Dock="Left" Width="16">
+                                        <Border Width="4" HorizontalAlignment="Left" IsHitTestVisible="False"
+                                                Background="{Binding FlagColorHex, Converter={StaticResource StringToBrushConverter}}"/>
+                                        <Border Background="Transparent"
+                                                Tag="{Binding}"
+                                                MouseLeftButtonUp="FlagHitArea_MouseLeftButtonUp"/>
+                                    </Grid>
+                                    <StackPanel>
+                                        <TextBlock TextTrimming="CharacterEllipsis"
+                                                   FontWeight="{Binding HasUnread, Converter={StaticResource BoolToWeightConverter}}">
+                                            <Run Text="{Binding SenderName, Mode=OneWay}"/>
+                                            <Run Text=" "/>
+                                            <Run Text="{Binding Count, StringFormat=({0}), Mode=OneWay}"/>
+                                        </TextBlock>
+                                        <TextBlock Text="{Binding NewestSubject}"
+                                                   FontSize="11" Opacity="0.85"
+                                                   TextTrimming="CharacterEllipsis">
+                                            <TextBlock.Style>
+                                                <Style TargetType="TextBlock">
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding NewestSubject}" Value="">
+                                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </TextBlock.Style>
+                                        </TextBlock>
+                                        <TextBlock Text="{Binding Preview}"
+                                                   FontSize="11" Opacity="0.7"
+                                                   TextTrimming="CharacterEllipsis">
+                                            <TextBlock.Style>
+                                                <Style TargetType="TextBlock">
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding Preview}" Value="">
+                                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </TextBlock.Style>
+                                        </TextBlock>
+                                    </StackPanel>
+                                </DockPanel>
                             </HierarchicalDataTemplate>
 
                             <!-- Level 2: individual message row matching the ListView column layout -->
                             <DataTemplate DataType="{x:Type models:MailMessageSummary}">
-                                <Grid>
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="180"/>
-                                        <ColumnDefinition Width="*"/>
-                                        <ColumnDefinition Width="80"/>
-                                    </Grid.ColumnDefinitions>
-                                    <TextBlock Grid.Column="0" Text="{Binding From}"
-                                               FontWeight="{Binding IsRead, Converter={StaticResource BoolToWeightConverter}}"
-                                               TextTrimming="CharacterEllipsis"/>
-                                    <TextBlock Grid.Column="1" Text="{Binding Subject}"
-                                               FontWeight="{Binding IsRead, Converter={StaticResource BoolToWeightConverter}}"
-                                               TextTrimming="CharacterEllipsis"/>
-                                    <TextBlock Grid.Column="2" Text="{Binding DateDisplay}"
-                                               TextAlignment="Right"/>
-                                </Grid>
+                                <DockPanel LastChildFill="True">
+                                    <Grid DockPanel.Dock="Left" Width="16">
+                                        <Border Width="4" HorizontalAlignment="Left" IsHitTestVisible="False"
+                                                Background="{Binding FlagColorHex, Converter={StaticResource StringToBrushConverter}}"/>
+                                        <Border Background="Transparent"
+                                                Tag="{Binding}"
+                                                MouseLeftButtonUp="FlagHitArea_MouseLeftButtonUp"/>
+                                    </Grid>
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="180"/>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="80"/>
+                                        </Grid.ColumnDefinitions>
+                                        <TextBlock Grid.Column="0" Text="{Binding From}"
+                                                   FontWeight="{Binding IsRead, Converter={StaticResource BoolToWeightConverter}}"
+                                                   TextTrimming="CharacterEllipsis"/>
+                                        <TextBlock Grid.Column="1" Text="{Binding Subject}"
+                                                   FontWeight="{Binding IsRead, Converter={StaticResource BoolToWeightConverter}}"
+                                                   TextTrimming="CharacterEllipsis"/>
+                                        <TextBlock Grid.Column="2" Text="{Binding DateDisplay}"
+                                                   TextAlignment="Right"/>
+                                    </Grid>
+                                </DockPanel>
                             </DataTemplate>
                         </TreeView.Resources>
                         <TreeView.ItemContainerStyle>
@@ -1366,12 +1419,15 @@
                                    BasedOn="{StaticResource {x:Type TreeViewItem}}">
                                 <Setter Property="AutomationProperties.Name">
                                     <Setter.Value>
-                                        <MultiBinding StringFormat="{}{0}. {1}. {2}. {3}. {4}.">
+                                        <MultiBinding Converter="{StaticResource MessageAccessibleNameConverter}">
+                                            <Binding Path="FlagLabel"/>
                                             <Binding Path="ReadStatusLabel"/>
                                             <Binding Path="From"/>
                                             <Binding Path="Subject"/>
                                             <Binding Path="Preview"/>
                                             <Binding Path="DateDisplay"/>
+                                            <Binding Path="DataContext.AnnounceFlagStatus"
+                                                     RelativeSource="{RelativeSource AncestorType=Window}"/>
                                         </MultiBinding>
                                     </Setter.Value>
                                 </Setter>
@@ -1381,59 +1437,77 @@
                             <HierarchicalDataTemplate DataType="{x:Type models:SenderGroup}"
                                                       ItemsSource="{Binding Messages}"
                                                       ItemContainerStyle="{StaticResource ToMessageTreeItemStyle}">
-                                <StackPanel>
-                                    <TextBlock TextTrimming="CharacterEllipsis"
-                                               FontWeight="{Binding HasUnread, Converter={StaticResource BoolToWeightConverter}}">
-                                        <Run Text="{Binding SenderName, Mode=OneWay}"/>
-                                        <Run Text=" "/>
-                                        <Run Text="{Binding Count, StringFormat=({0}), Mode=OneWay}"/>
-                                    </TextBlock>
-                                    <TextBlock Text="{Binding NewestSubject}"
-                                               FontSize="11" Opacity="0.85"
-                                               TextTrimming="CharacterEllipsis">
-                                        <TextBlock.Style>
-                                            <Style TargetType="TextBlock">
-                                                <Style.Triggers>
-                                                    <DataTrigger Binding="{Binding NewestSubject}" Value="">
-                                                        <Setter Property="Visibility" Value="Collapsed"/>
-                                                    </DataTrigger>
-                                                </Style.Triggers>
-                                            </Style>
-                                        </TextBlock.Style>
-                                    </TextBlock>
-                                    <TextBlock Text="{Binding Preview}"
-                                               FontSize="11" Opacity="0.7"
-                                               TextTrimming="CharacterEllipsis">
-                                        <TextBlock.Style>
-                                            <Style TargetType="TextBlock">
-                                                <Style.Triggers>
-                                                    <DataTrigger Binding="{Binding Preview}" Value="">
-                                                        <Setter Property="Visibility" Value="Collapsed"/>
-                                                    </DataTrigger>
-                                                </Style.Triggers>
-                                            </Style>
-                                        </TextBlock.Style>
-                                    </TextBlock>
-                                </StackPanel>
+                                <DockPanel LastChildFill="True">
+                                    <Grid DockPanel.Dock="Left" Width="16">
+                                        <Border Width="4" HorizontalAlignment="Left" IsHitTestVisible="False"
+                                                Background="{Binding FlagColorHex, Converter={StaticResource StringToBrushConverter}}"/>
+                                        <Border Background="Transparent"
+                                                Tag="{Binding}"
+                                                MouseLeftButtonUp="FlagHitArea_MouseLeftButtonUp"/>
+                                    </Grid>
+                                    <StackPanel>
+                                        <TextBlock TextTrimming="CharacterEllipsis"
+                                                   FontWeight="{Binding HasUnread, Converter={StaticResource BoolToWeightConverter}}">
+                                            <Run Text="{Binding SenderName, Mode=OneWay}"/>
+                                            <Run Text=" "/>
+                                            <Run Text="{Binding Count, StringFormat=({0}), Mode=OneWay}"/>
+                                        </TextBlock>
+                                        <TextBlock Text="{Binding NewestSubject}"
+                                                   FontSize="11" Opacity="0.85"
+                                                   TextTrimming="CharacterEllipsis">
+                                            <TextBlock.Style>
+                                                <Style TargetType="TextBlock">
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding NewestSubject}" Value="">
+                                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </TextBlock.Style>
+                                        </TextBlock>
+                                        <TextBlock Text="{Binding Preview}"
+                                                   FontSize="11" Opacity="0.7"
+                                                   TextTrimming="CharacterEllipsis">
+                                            <TextBlock.Style>
+                                                <Style TargetType="TextBlock">
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding Preview}" Value="">
+                                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </TextBlock.Style>
+                                        </TextBlock>
+                                    </StackPanel>
+                                </DockPanel>
                             </HierarchicalDataTemplate>
 
                             <!-- Level 2: individual message row matching the ListView column layout -->
                             <DataTemplate DataType="{x:Type models:MailMessageSummary}">
-                                <Grid>
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="180"/>
-                                        <ColumnDefinition Width="*"/>
-                                        <ColumnDefinition Width="80"/>
-                                    </Grid.ColumnDefinitions>
-                                    <TextBlock Grid.Column="0" Text="{Binding From}"
-                                               FontWeight="{Binding IsRead, Converter={StaticResource BoolToWeightConverter}}"
-                                               TextTrimming="CharacterEllipsis"/>
-                                    <TextBlock Grid.Column="1" Text="{Binding Subject}"
-                                               FontWeight="{Binding IsRead, Converter={StaticResource BoolToWeightConverter}}"
-                                               TextTrimming="CharacterEllipsis"/>
-                                    <TextBlock Grid.Column="2" Text="{Binding DateDisplay}"
-                                               TextAlignment="Right"/>
-                                </Grid>
+                                <DockPanel LastChildFill="True">
+                                    <Grid DockPanel.Dock="Left" Width="16">
+                                        <Border Width="4" HorizontalAlignment="Left" IsHitTestVisible="False"
+                                                Background="{Binding FlagColorHex, Converter={StaticResource StringToBrushConverter}}"/>
+                                        <Border Background="Transparent"
+                                                Tag="{Binding}"
+                                                MouseLeftButtonUp="FlagHitArea_MouseLeftButtonUp"/>
+                                    </Grid>
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="180"/>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="80"/>
+                                        </Grid.ColumnDefinitions>
+                                        <TextBlock Grid.Column="0" Text="{Binding From}"
+                                                   FontWeight="{Binding IsRead, Converter={StaticResource BoolToWeightConverter}}"
+                                                   TextTrimming="CharacterEllipsis"/>
+                                        <TextBlock Grid.Column="1" Text="{Binding Subject}"
+                                                   FontWeight="{Binding IsRead, Converter={StaticResource BoolToWeightConverter}}"
+                                                   TextTrimming="CharacterEllipsis"/>
+                                        <TextBlock Grid.Column="2" Text="{Binding DateDisplay}"
+                                                   TextAlignment="Right"/>
+                                    </Grid>
+                                </DockPanel>
                             </DataTemplate>
                         </TreeView.Resources>
                         <TreeView.ItemContainerStyle>

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -168,6 +168,7 @@ public partial class MainWindow : Window
     private readonly IViewService _viewService;
     private readonly IRuleService _ruleService;
     private readonly ITemplateService _templateService;
+    private readonly IFlagService? _flagService;
 
     private TutorialViewModel? _tutorialVm;
 
@@ -190,7 +191,8 @@ public partial class MainWindow : Window
         IViewService viewService,
         IRuleService ruleService,
         ITemplateService templateService,
-        IFeatureGate featureGate)
+        IFeatureGate featureGate,
+        IFlagService? flagService = null)
     {
         _vm = vm;
         _smtp = smtp;
@@ -206,6 +208,7 @@ public partial class MainWindow : Window
         _ruleService = ruleService;
         _templateService = templateService;
         _featureGate = featureGate;
+        _flagService = flagService;
 
         InitializeComponent();
         DataContext = vm;
@@ -1621,15 +1624,29 @@ public partial class MainWindow : Window
             await _vm.ToggleSingleFlagAsync(_vm.SelectedMessage);
     }
 
-    private Task PickFlagCommandAsync()
+    private async Task PickFlagCommandAsync()
     {
-        // Phase 4: flag picker window not yet implemented.
-        return Task.CompletedTask;
+        if (_flagService == null) return;
+        var msg = _vm.SelectedMessage;
+        if (msg == null) return;
+
+        var prev = Keyboard.FocusedElement as IInputElement;
+        var picker = new FlagPickerWindow(_flagService, msg.IsFlagged) { Owner = this };
+        picker.ShowDialog();
+        (prev ?? MessageList).Focus();
+
+        if (picker.DialogResult == true)
+            await _vm.SetMessageFlagAsync(msg, picker.ResultFlagId);
     }
 
     private void OpenFlagManager()
     {
-        // Phase 4: flag manager window not yet implemented.
+        if (_flagService == null) return;
+        var prev = Keyboard.FocusedElement as IInputElement;
+        var vmFm = new FlagManagerViewModel(_flagService);
+        var win  = new FlagManagerWindow(vmFm) { Owner = this };
+        win.ShowDialog();
+        (prev ?? MessageList).Focus();
     }
 
     private void ExtendSelectionToTop()

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -618,6 +618,22 @@ public partial class MainWindow : Window
             defaultKey: Key.A, defaultModifiers: ModifierKeys.Control,
             isAvailable: IsMessageListFocused));
 
+        _registry.Register(new CommandDefinition(
+            id: "mail.toggleFlag", category: "Mail", title: "Toggle Flag",
+            execute: async () => await ToggleFlagCommandAsync(),
+            defaultKey: Key.K, defaultModifiers: ModifierKeys.None,
+            isAvailable: () => _vm.HasSelectedMessage || IsGroupRowSelected()));
+
+        _registry.Register(new CommandDefinition(
+            id: "mail.pickFlag", category: "Mail", title: "Pick Flag…",
+            execute: async () => await PickFlagCommandAsync(),
+            defaultKey: Key.K, defaultModifiers: ModifierKeys.Control | ModifierKeys.Shift,
+            isAvailable: () => _vm.HasSelectedMessage));
+
+        _registry.Register(new CommandDefinition(
+            id: "mail.openFlagManager", category: "Mail", title: "Manage Flags…",
+            execute: OpenFlagManager));
+
         // Override the VM's mail.delete with one that deletes ALL selected messages.
         // The VM registration uses DeleteMessageCommand, which deletes only SelectedMessage
         // (one item). When the message list has focus with multiple items selected, bypass
@@ -1534,6 +1550,37 @@ public partial class MainWindow : Window
         return false;
     }
 
+    private bool IsGroupRowSelected()
+    {
+        if (_vm.IsConversationsView) return ConversationTree.SelectedItem is ConversationGroup;
+        if (_vm.IsFromView)          return SenderGroupTree.SelectedItem is SenderGroup;
+        if (_vm.IsToView)            return ToGroupTree.SelectedItem is SenderGroup;
+        return false;
+    }
+
+    private async Task ToggleFlagCommandAsync()
+    {
+        if (_vm.IsConversationsView && ConversationTree.SelectedItem is ConversationGroup cg)
+            await _vm.ToggleGroupFlagAsync(cg.Messages);
+        else if (_vm.IsFromView && SenderGroupTree.SelectedItem is SenderGroup sg)
+            await _vm.ToggleGroupFlagAsync(sg.Messages);
+        else if (_vm.IsToView && ToGroupTree.SelectedItem is SenderGroup tg)
+            await _vm.ToggleGroupFlagAsync(tg.Messages);
+        else if (_vm.SelectedMessage != null)
+            await _vm.ToggleSingleFlagAsync(_vm.SelectedMessage);
+    }
+
+    private Task PickFlagCommandAsync()
+    {
+        // Phase 4: flag picker window not yet implemented.
+        return Task.CompletedTask;
+    }
+
+    private void OpenFlagManager()
+    {
+        // Phase 4: flag manager window not yet implemented.
+    }
+
     private void ExtendSelectionToTop()
     {
         if (MessageList.Items.Count == 0) return;
@@ -2443,8 +2490,13 @@ public partial class MainWindow : Window
     }
 
     // Builds the screen-reader announcement string for a single message row.
-    private static string MessageSummaryAnnouncement(MailMessageSummary msg) =>
-        $"{msg.ReadStatusLabel}. {msg.From}. {msg.Subject}. {msg.Preview}. {msg.DateDisplay}.";
+    private string MessageSummaryAnnouncement(MailMessageSummary msg)
+    {
+        var flag = _vm.AnnounceFlagStatus && !string.IsNullOrEmpty(msg.FlagLabel)
+            ? msg.FlagLabel + ". "
+            : string.Empty;
+        return $"{flag}{msg.ReadStatusLabel}. {msg.From}. {msg.Subject}. {msg.Preview}. {msg.DateDisplay}.";
+    }
 
     // After an async conversation rebuild, selects and focuses the conversation
     // at the given index (clamped to the new list size).

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -228,6 +228,8 @@ public partial class MainWindow : Window
             if (e.PropertyName == nameof(MainViewModel.ActiveView))
                 UpdateViewMenuCheckmarks();
         };
+        vm.FlagDefinitions.CollectionChanged += (_, _) => RebuildFlagSubmenuItems();
+        FilterFlaggedItem.SubmenuOpened += (_, _) => UpdateFlagSubmenuChecks();
         vm.ConfirmationRequested = (message, title) =>
             MessageBox.Show(message, title, MessageBoxButton.YesNo, MessageBoxImage.Warning)
             == MessageBoxResult.Yes;
@@ -4144,6 +4146,32 @@ public partial class MainWindow : Window
         {
             if (obj is MenuItem { Tag: Guid id } item)
                 item.IsChecked = id == _vm.ActiveView?.Id;
+        }
+    }
+
+    private void RebuildFlagSubmenuItems()
+    {
+        // Items 0 = "All Flagged", 1 = Separator — keep those, remove the rest.
+        while (FilterFlaggedItem.Items.Count > 2)
+            FilterFlaggedItem.Items.RemoveAt(2);
+
+        foreach (var flag in _vm.FlagDefinitions)
+        {
+            var flagId = flag.Id.ToString();
+            var item = new MenuItem { Header = flag.Name, IsCheckable = true, Tag = flagId };
+            item.Click += (_, _) => _vm.SetFlagFilterCommand.Execute(flagId);
+            FilterFlaggedItem.Items.Add(item);
+        }
+        UpdateFlagSubmenuChecks();
+    }
+
+    private void UpdateFlagSubmenuChecks()
+    {
+        for (int i = 2; i < FilterFlaggedItem.Items.Count; i++)
+        {
+            if (FilterFlaggedItem.Items[i] is MenuItem { Tag: string flagId } item)
+                item.IsChecked = _vm.ActiveFilter == MessageFilter.Flagged
+                    && _vm.ActiveFlagFilterId == flagId;
         }
     }
 

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -4017,7 +4017,8 @@ public partial class MainWindow : Window
             currentFilter:    _vm.ActiveFilter,
             currentSort:      _vm.ActiveSort,
             currentDayLimit:  _vm.ActiveDayLimit,
-            isCreateMode:     createMode);
+            isCreateMode:     createMode,
+            activeFlagFilterId: _vm.ActiveFlagFilterId);
 
         var dialog = new ViewManagerWindow(vmVm, createMode) { Owner = this };
         dialog.ShowDialog();

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -75,6 +75,57 @@ public class StringToVisibilityConverter : IValueConverter
         throw new NotSupportedException();
 }
 
+/// <summary>
+/// Converts a hex color string (e.g. "#FF8C00") to a SolidColorBrush.
+/// Returns Transparent when the string is null or empty (message is unflagged).
+/// </summary>
+public class StringToBrushConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value is string hex && !string.IsNullOrEmpty(hex))
+        {
+            try
+            {
+                var color = (System.Windows.Media.Color)
+                    System.Windows.Media.ColorConverter.ConvertFromString(hex);
+                return new System.Windows.Media.SolidColorBrush(color);
+            }
+            catch { }
+        }
+        return System.Windows.Media.Brushes.Transparent;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) =>
+        throw new NotSupportedException();
+}
+
+/// <summary>
+/// Builds the accessible name string for a message row, optionally prepending the flag label.
+/// Values: [FlagLabel, ReadStatusLabel, From, Subject, Preview, DateDisplay, AnnounceFlagStatus].
+/// </summary>
+public class MessageAccessibleNameConverter : IMultiValueConverter
+{
+    public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (values.Length < 7) return string.Empty;
+        var flagLabel       = values[0] as string ?? string.Empty;
+        var readStatusLabel = values[1] as string ?? string.Empty;
+        var from            = values[2] as string ?? string.Empty;
+        var subject         = values[3] as string ?? string.Empty;
+        var preview         = values[4] as string ?? string.Empty;
+        var dateDisplay     = values[5] as string ?? string.Empty;
+        var announceFlag    = values[6] is bool b && b;
+        var flagPrefix      = announceFlag && !string.IsNullOrEmpty(flagLabel)
+                                ? flagLabel + ". "
+                                : string.Empty;
+        return $"{flagPrefix}{readStatusLabel}. {from}. {subject}. {preview}. {dateDisplay}.";
+    }
+
+    public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture) =>
+        throw new NotSupportedException();
+}
+
 public partial class MainWindow : Window
 {
     private static readonly TimeSpan TypeAheadResetDelay = TimeSpan.FromSeconds(1);
@@ -2487,6 +2538,20 @@ public partial class MainWindow : Window
         {
             e.Handled = true;
         }
+    }
+
+    // Click handler for the 16px transparent flag hit area in all message row DataTemplates.
+    // Tag is set to the MailMessageSummary, ConversationGroup, or SenderGroup in the template.
+    private async void FlagHitArea_MouseLeftButtonUp(object sender, MouseButtonEventArgs e)
+    {
+        if (sender is not FrameworkElement fe) return;
+        e.Handled = true;
+        if (fe.Tag is MailMessageSummary msg)
+            await _vm.ToggleSingleFlagAsync(msg);
+        else if (fe.Tag is ConversationGroup cg)
+            await _vm.ToggleGroupFlagAsync(cg.Messages);
+        else if (fe.Tag is SenderGroup sg)
+            await _vm.ToggleGroupFlagAsync(sg.Messages);
     }
 
     // Builds the screen-reader announcement string for a single message row.

--- a/QuickMail/Views/SettingsDialog.xaml
+++ b/QuickMail/Views/SettingsDialog.xaml
@@ -225,6 +225,11 @@
                                           IsChecked="{Binding AnnounceFormattingWhileNavigating, Mode=TwoWay}"
                                           Margin="16,4,0,0"
                                           AutomationProperties.Name="Announce block type such as heading level when the caret moves to a different paragraph in HTML compose mode"/>
+
+                                <CheckBox Content="Announce fla_g status"
+                                          IsChecked="{Binding AnnounceFlagStatus, Mode=TwoWay}"
+                                          Margin="16,4,0,0"
+                                          AutomationProperties.Name="Announce flag status when navigating to a flagged message"/>
                             </StackPanel>
                         </GroupBox>
                     </StackPanel>

--- a/QuickMail/Views/SettingsDialog.xaml
+++ b/QuickMail/Views/SettingsDialog.xaml
@@ -229,7 +229,7 @@
                                 <CheckBox Content="Announce fla_g status"
                                           IsChecked="{Binding AnnounceFlagStatus, Mode=TwoWay}"
                                           Margin="16,4,0,0"
-                                          AutomationProperties.Name="Announce flag status when navigating to a flagged message"/>
+                                          AutomationProperties.Name="Announce flag status"/>
                             </StackPanel>
                         </GroupBox>
                     </StackPanel>

--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -20,6 +20,7 @@ QuickMail is a desktop email client for Windows. It supports multiple IMAP/SMTP 
 - [From view (by sender)](#from-view-by-sender)
 - [To view (by recipient)](#to-view-by-recipient)
 - [Filtering messages](#filtering-messages)
+- [Flagging messages](#flagging-messages)
 - [Sorting messages](#sorting-messages)
 - [Mail rules](#mail-rules)
 - [Saved views](#saved-views)
@@ -397,6 +398,7 @@ The top of the folder list contains a group of **virtual folders** that aggregat
 | **All Drafts** | Draft messages from every account |
 | **All Sent** | Sent messages from every account |
 | **All Trash** | Deleted messages from every account |
+| **All Flagged Mail** | All flagged messages across every account, sorted newest-first — see [Flagging messages](#flagging-messages) |
 
 Each account also has its own **All Mail — {Account Name}** entry directly under that account in the folder tree. Selecting it shows all mail for that account only, without mixing in messages from other accounts. These per-account folders also appear in the **Go to Folder** picker.
 
@@ -452,6 +454,7 @@ The **View → Filter** submenu (and the command palette) let you narrow the mes
 | **Show All** | All messages (no filter active) |
 | **Unread** | Messages that have not been read, replied to, or forwarded |
 | **Read** | Messages that have been marked as read |
+| **Flagged** | Messages that have any flag set — see [Flagging messages](#flagging-messages) |
 | **With Attachments** | Messages that have at least one attachment |
 | **Replied** | Messages you have replied to |
 | **Forwarded** | Messages you have forwarded |
@@ -467,6 +470,91 @@ The **View → Filter** submenu (and the command palette) let you narrow the mes
 The active filter is shown in the window title bar. Navigating to a different folder automatically clears the filter.
 
 Filter commands can be assigned custom keyboard shortcuts in **File → Settings → Keyboard Shortcuts**.
+
+---
+
+## Flagging messages
+
+A **flag** marks a message as requiring action or follow-up. One press of `K` flags a message; another press unflags it. Flags you set in QuickMail are synced to your mail server, so they appear in other mail apps (Outlook, Thunderbird, mobile apps) that share the same account.
+
+### The built-in flag
+
+QuickMail includes one built-in flag named **Flagged**, shown in amber. This is the flag the `K` key applies by default, and it maps directly to the standard IMAP `\Flagged` flag — called "starred" in some apps. Any messages you have already flagged in another mail app appear as flagged in QuickMail after the next sync.
+
+### Toggling a flag
+
+With a message selected in the message list:
+
+- Press `K` to flag the message. The flag indicator appears on the row and the screen reader announces `"Flagged: Flagged."`
+- Press `K` again to unflag. The indicator disappears and the screen reader announces `"Unflagged."`
+
+If the message already has a named flag applied, pressing `K` removes that flag (it does not replace it with the default flag).
+
+### Picking a specific named flag
+
+If you have created named flags (see [Named flags and the Flag Manager](#named-flags-and-the-flag-manager) below), press `Ctrl+Shift+K` to open the flag picker. The picker lists all your defined flags plus a **Clear flag** option. Use **Up/Down** arrows to choose, then press **Enter** to apply and close. Press **Escape** to close without making a change.
+
+Only one flag can be set on a message at a time. Applying a different flag replaces the current one.
+
+### Flagging a conversation or group
+
+In Conversations, From, or To view, you can flag all messages in a group at once. Select the group row (not an individual message inside it) and press `K`. The screen reader announces how many messages were flagged — for example, `"Flagged 4 messages: Flagged."`
+
+### Named flags and the Flag Manager
+
+Beyond the built-in flag, you can create up to 20 **named flags** with custom colors — for example, "Urgent" (red), "Waiting" (yellow), or "Done" (green).
+
+**Opening the Flag Manager:**
+
+Open the command palette (`Ctrl+Shift+P`) and type "Manage Flags," then press **Enter**.
+
+The Flag Manager shows your flag list on the left and an edit panel on the right. From here you can:
+
+| Action | How |
+|--------|-----|
+| Add a new flag | Activate **Add Flag** |
+| Rename a flag | Select a flag, edit the **Flag Name** field |
+| Change the color | Select a flag, then choose from the color buttons in the edit panel |
+| Reorder flags | Activate **Move Up** or **Move Down** |
+| Delete a flag | Select a flag, then activate **Delete Flag** — the built-in flag cannot be deleted |
+| Set the K default | Select a flag and activate **Set as K default** to make `K` apply that flag |
+
+Press **Escape** or use the command palette (`Ctrl+Shift+P` → "Close") to close the Flag Manager.
+
+Named flag definitions are stored in `flags.json` in your data folder and are local to your QuickMail profile.
+
+**Changing which flag K applies:**
+
+By default `K` applies the built-in "Flagged" flag. To change this, open the Flag Manager, select a named flag, and activate **Set as K default**. `K` now applies that flag. This setting persists across restarts.
+
+### Filtering to flagged messages
+
+Open **View → Filter → Flagged** (or use the command palette and search for "flagged") to show only messages that have any flag set. The active filter is shown in the window title bar.
+
+To return to the full message list, open **View → Filter → Show All** or run **Show All Messages** from the command palette.
+
+Pressing `K` to unflag a message while the Flagged filter is active removes the message from the list immediately, since it no longer matches the filter.
+
+### All Flagged Mail
+
+The folder tree includes an **All Flagged Mail** virtual folder that shows every flagged message from all your accounts in one place, sorted newest-first. This is useful for a daily review of everything you have marked for follow-up.
+
+Select **All Flagged Mail** in the folder tree to open it. Like other virtual folders it is a read-only view — no messages are moved or copied.
+
+### Saved views with the Flagged filter
+
+When you save a view with the **Flagged** filter active, that filter is captured as part of the view. Applying the view later restores the Flagged filter automatically. Assign a keyboard shortcut to the view in the View Manager to jump to your flagged messages instantly.
+
+### Server sync
+
+- **IMAP accounts:** Flagging a message sets the standard `\Flagged` flag on the server immediately. Other mail apps using the same account see the flag on their next sync. Flags set by those other apps appear in QuickMail on your next refresh (`F5`).
+- **Microsoft 365 (Graph) accounts:** Flagging sets the `followUpFlag` on the message via the Graph API — the same flag Outlook shows as "Flag for follow-up."
+
+### Screen reader experience
+
+When you navigate to a flagged message, the screen reader announces the flag name before the read status — for example: *"Urgent. Unread. Kelly Ford. Budget review. …"*
+
+To turn off this announcement, open **File → Settings → General** and uncheck **Announce flag status** in the Screen Reader Announcements section. The visual flag indicator remains; only the spoken announcement is suppressed.
 
 ---
 
@@ -1227,6 +1315,8 @@ To skip the confirmation, open **File → Settings**, select the **General** tab
 | Ctrl+F | Forward |
 | Ctrl+Enter | Open selected message in a new window |
 | Delete | Delete selected message(s) |
+| K | Toggle flag on selected message or group |
+| Ctrl+Shift+K | Open flag picker |
 | Ctrl+Shift+L | Manage Rules |
 | Ctrl+Shift+T | Create Rule from Message |
 | Ctrl+Shift+V | Cycle view mode (Messages / From / To / Conversations) |
@@ -1311,6 +1401,7 @@ QuickMail keeps all its files under `%AppData%\QuickMail\` (typically `C:\Users\
 |---------------|----------|
 | `accounts.json` | Account configuration — server addresses, ports, display names. No passwords. |
 | `contacts.json` | Address book contacts — display names and email addresses (human-readable JSON) |
+| `flags.json` | Named flag definitions — colors and names (human-readable JSON) |
 | `rules.json` | Mail rules — conditions and actions for automatic message processing |
 | `config.ini` | Optional settings file — see [Configuration file](#configuration-file) below. |
 | `mail.db` | Local message cache (SQLite database) |
@@ -1338,6 +1429,7 @@ Lines starting with `#` are comments and are ignored. The file uses a simple `ke
 | `DefaultComposeMode` | `plain` / `markdown` / `html` | `plain` | The editing mode new compose windows start in. Drafts and templates always reopen in plain text. Also available in Settings → General → Composing. |
 | `AutoSaveDrafts` | `on` / `off` | `on` | Automatically save the message as a server draft while composing. Also available in Settings → General → Composing. |
 | `AutoSaveIntervalSeconds` | `30`–`600` | `120` | Seconds between automatic draft saves. Also available in Settings → General → Composing. |
+| `AnnounceFlagStatus` | `true` / `false` | `true` | When on, the flag name is announced before the read status when navigating flagged messages. Also available in Settings → General → Screen Reader Announcements. |
 
 ### `[account:<guid>]` overrides
 

--- a/docs/planning/SPEC-TEMPLATE.md
+++ b/docs/planning/SPEC-TEMPLATE.md
@@ -156,6 +156,21 @@ Call out code you might duplicate and plan extractions:
 
 This is where you catch the "bugs that hide in duplication" ahead of time.
 
+### 5.4 Shared component audit (mandatory)
+
+**List every existing class, UserControl, ViewModel, or service the feature will modify or call, together with its other consumers.**
+
+This is the single most common source of regressions in AI-assisted development. An AI given a spec that says "add a retry button to the review dialog" will add it — without knowing the same dialog is also used for a different flow where the retry button makes no sense. The audit forces that question before code is written.
+
+| Component | File | Other consumers | Change needed | Risk |
+|---|---|---|---|---|
+| `ExistingDialog.xaml` | `Views/ExistingDialog.xaml` | Called from FlowA, FlowB | Add `AllowRetry` property | Verify FlowB still works with `AllowRetry=false` |
+| `MessageBodyHelper` | `Helpers/MessageBodyHelper.cs` | ComposeWindow, MessageWindow | Add overload | Existing callers use default overload — no change |
+
+**Expected output:** "This feature modifies [X, Y, Z]. Their other consumers are [A, B, C]. Changes to X are backward-compatible because [reason]. Changes to Y require [FlowB to be verified in the acceptance walkthrough]."
+
+If a component has no other consumers, say so explicitly — it confirms you checked.
+
 ---
 
 ## Section 6: Keyboard Walkthrough (Mandatory)
@@ -207,7 +222,52 @@ Before implementation, answer these explicitly:
 
 ---
 
-## Section 8: Success Metrics
+## Section 8: Acceptance Walkthrough (Mandatory)
+
+**This is different from the keyboard walkthrough.** The keyboard walkthrough (§6) is a design document — it proves the feature is fully *specified*. The acceptance walkthrough is a runtime testing script — it proves the feature actually *works* after implementation. You run this yourself in the app at Session 3, before handing to code review.
+
+Each step is a concrete action you physically perform and a concrete thing you physically observe. No vague outcomes ("it works correctly") — every verify clause must be something you can see, hear from a screen reader, or confirm is absent.
+
+**Format:**
+
+### Scenario: [Name]
+
+**Setup:** [App state before starting — e.g., "app running, message list open, no compose window"]
+
+1. Do [action]. **Verify:** [Exact observable outcome — text displayed, focus landed, announcement heard, element absent.]
+2. Do [action]. **Verify:** …
+3. **Edge case:** Do [unusual action]. **Verify:** [No crash / correct degradation.]
+
+**Mark each step pass/fail as you test. Any fail = document before handing to Session 4.**
+
+**Scenarios to always include:**
+- **Primary happy path** — the main use case end-to-end
+- **Primary error case** — what happens when the operation fails (network error, validation failure, empty state)
+- **One scenario per shared component caller** — for every consumer listed in §5.4, verify it still works correctly after your changes
+- **Every new setting** — toggle on, verify UI response; toggle off, verify UI response; no app restart required
+- **`--online` mode** — if the feature calls `LocalStore`, run with `--online` flag and confirm graceful fallback
+- **Screen reader** — tab through every new control, confirm `AutomationProperties.Name` is read correctly, confirm announcements fire at the right moments
+- **Focus restoration** — if any dialog opens, confirm focus returns to the correct element when it closes
+
+**Example — adding a "Retry" option to an existing review dialog:**
+
+### Scenario: Retry from review dialog
+
+**Setup:** App running, a message is open. Trigger the feature that opens the review dialog.
+
+1. Perform the primary action. **Verify:** Review dialog opens, focus lands on the result text, screen reader announces the dialog title.
+2. Activate the Retry button. **Verify:** Dialog closes, operation re-runs, review dialog reopens with new result.
+3. Press Escape. **Verify:** Dialog closes without saving. Focus returns to the message body.
+
+### Scenario: Original flow — verify no regression
+
+**Setup:** Trigger the *other* flow that uses the same dialog (the one that should NOT have a retry button).
+
+1. Perform the original action. **Verify:** Review dialog opens. **No Retry button is present.** Result text control is named correctly for this context (not the name from the new flow).
+
+---
+
+## Section 9: Success Metrics
 
 How will you measure that this feature works, post-implementation and post-review?
 
@@ -219,7 +279,7 @@ How will you measure that this feature works, post-implementation and post-revie
 
 ---
 
-## Section 9: Implementation Phases
+## Section 10: Implementation Phases
 
 Break the work into **3–5 testable phases**, each of which can be code-reviewed and committed independently. Each phase should have:
 
@@ -287,7 +347,7 @@ Break the work into **3–5 testable phases**, each of which can be code-reviewe
 
 ---
 
-## Section 10: Files to Create / Modify
+## Section 11: Files to Create / Modify
 
 Explicit list. This is your implementation checklist and the code reviewer's map.
 
@@ -309,7 +369,7 @@ Explicit list. This is your implementation checklist and the code reviewer's map
 
 ---
 
-## Section 11: Tests to Add
+## Section 12: Tests to Add
 
 For each new class, list the tests you'll need:
 
@@ -323,9 +383,9 @@ For each new class, list the tests you'll need:
 
 ---
 
-## Section 12: Known Risks & Open Questions
+## Section 13: Known Risks & Open Questions
 
-### 12.1 Risks identified in the spec
+### 13.1 Risks identified in the spec
 
 For each risk, state:
 - **Risk:** What could go wrong?
@@ -341,7 +401,7 @@ For each risk, state:
 | Modal dialog fires ViewsChanged while tab dialog is open → crash | Medium | Blocker | Rule enforcement: tab dialog must not subscribe to ViewsChanged before ShowDialog(). Code review gate. |
 | Screen reader user can't tell which tab is active | Medium | Major | Accessibility test in keyboard walkthrough; automated test in v2. |
 
-### 12.2 Open questions
+### 13.2 Open questions
 
 Issues that need resolution before implementation starts:
 
@@ -352,7 +412,7 @@ Every open question gets a decision before the spec is approved. Document the de
 
 ---
 
-## Section 13: Appendix — Keyboard Reference
+## Section 14: Appendix — Keyboard Reference
 
 If the feature adds multiple shortcuts, a cheat sheet is helpful:
 
@@ -366,11 +426,11 @@ If the feature adds multiple shortcuts, a cheat sheet is helpful:
 
 ---
 
-## Section 14: Implementation Guidance for AI
+## Section 15: Implementation Guidance for AI
 
 This section is **written to the AI assistant** who will read the spec during Session 2. It's in the approved spec, not a separate memo.
 
-### 14.1 Adjustments you're expected to make
+### 15.1 Adjustments you're expected to make
 
 State what you've intentionally left vague, expecting the AI to figure out:
 
@@ -378,14 +438,21 @@ State what you've intentionally left vague, expecting the AI to figure out:
 - "The keyboard walkthrough assumes focus restoration works the same as the existing reading pane. If you find that's not true, adjust the implementation and document the deviation."
 - "The accessibility checklist says tabs will announce their title and position. You'll decide whether 'Tab 2 of 5: subject' or 'Second tab: subject' is better, and make that announcement consistent throughout."
 
-### 14.2 When to ask for clarification
+### 15.2 When to ask for clarification
 
 Signal what's unclear or what needs a design decision before you start:
 
 - "If [architectural risk] becomes a problem during implementation, the approved mitigation is [X]. If that doesn't work, ping the user before proceeding further."
 - "The keyboard walkthrough is normative — if you find a shortcut conflicts with an existing one, stop and ask before working around it."
 
-### 14.3 After implementation: what will be tested
+### 15.3 After implementation: acceptance walkthrough preview
+
+"After you build this, the user will run the Acceptance Walkthrough in §8. Reference that section for the full script. The steps most likely to catch bugs in this feature are:
+- [List the 2–3 steps from §8 that are highest risk for this specific implementation]
+
+If any of these fail, document the failure and it will be addressed in Session 4 (code review)."
+
+### 15.4 After implementation: what will be tested (legacy)
 
 "After you build this, the user will test in the app by:
 1. Opening 5 messages in tabs.
@@ -397,7 +464,7 @@ If any of these fail, you'll address them in Session 4 (code review)."
 
 ---
 
-## Section 15: Session Boundaries (Template Guidance)
+## Section 16: Session Boundaries (Template Guidance)
 
 Insert this section **after the spec is approved**, to guide the AI on when to start each session.
 
@@ -429,7 +496,9 @@ Before you approve a spec and move to Session 2 (implementation), verify:
 
 - [ ] **Scope is bounded.** The feature doesn't try to do too much in one session.
 - [ ] **Architecture is decided.** No major "we'll figure this out during coding" decisions.
+- [ ] **Shared component audit complete (§5.4).** Every existing class/dialog/service modified is named, with all its other consumers listed.
 - [ ] **Keyboard walkthrough is complete.** No "TBD" paths.
+- [ ] **Acceptance walkthrough written (§8).** Covers happy path, primary error case, one scenario per shared component caller, every new setting.
 - [ ] **Accessibility is explicit.** Not "we'll make it accessible during review."
 - [ ] **Implementation phases are testable.** Each phase is code-reviewable on its own.
 - [ ] **Risk assessment is documented.** Known risks have mitigations.
@@ -443,8 +512,8 @@ Before you approve a spec and move to Session 2 (implementation), verify:
 
 Some features don't need all sections:
 
-- **Bug fix or small enhancement** — Use sections 1, 2, 3, 4, 8, 11 only. (1 page, not 20.)
-- **Refactoring with no user-facing change** — Use section 5 (architecture), skip UI/keyboard/accessibility.
+- **Bug fix or small enhancement** — Use sections 1, 2, 3, 4, 9, 12 only. Add a short §8 acceptance walkthrough. (1 page, not 20.)
+- **Refactoring with no user-facing change** — Use section 5 (architecture, including §5.4 shared component audit), skip UI/keyboard/accessibility.
 - **Configuration tweak** — Use sections 1, 4, and a simple table of settings.
 
 Adjust the depth to the scope. The template is a maximum, not a minimum.
@@ -454,8 +523,10 @@ Adjust the depth to the scope. The template is a maximum, not a minimum.
 ## Why This Template Works with AI
 
 1. **Explicit decision points** — AI knows what's decided and what needs judgment. It won't second-guess architecture decisions during implementation.
-2. **Keyboard walkthrough** — AI reads the walkthrough and builds UX that matches. No surprises at test time.
-3. **Accessibility is upfront** — Not bolted on post-hoc. AI implements with access in mind.
-4. **Phases are independent** — AI can tackle each phase in a session, commit it, and you can review.
-5. **Risk mitigation is named** — When AI encounters the risk during coding, it knows the mitigation to apply.
-6. **Session boundaries are clear** — AI knows when to say "this is working, time for human review" vs. "I found a bug, let me fix it."
+2. **Shared component audit** — AI is told explicitly which existing code it's modifying and who else uses it. Regressions in other call sites are caught in the spec, not post-merge.
+3. **Keyboard walkthrough** — AI reads the walkthrough and builds UX that matches. No surprises at test time.
+4. **Acceptance walkthrough** — You run a concrete test script after implementation. Bugs that survive code review (especially shared-component regressions) surface here, before merge.
+5. **Accessibility is upfront** — Not bolted on post-hoc. AI implements with access in mind.
+6. **Phases are independent** — AI can tackle each phase in a session, commit it, and you can review.
+7. **Risk mitigation is named** — When AI encounters the risk during coding, it knows the mitigation to apply.
+8. **Session boundaries are clear** — AI knows when to say "this is working, time for human review" vs. "I found a bug, let me fix it."


### PR DESCRIPTION
## Summary

Implements all five phases of the [email flagging spec](https://github.com/kellylford/QuickMail/blob/main/docs/planning/flag-mail-pm-dev-spec.md).

**Phase 1 — Data model, SQLite, IMAP/Graph read+write, FlagService**
- `FlagDefinition` model (built-in flag + user-defined named flags) and `flags.json` persistence
- `flag_id` column in SQLite with reconciliation-aware upsert
- IMAP read (`\Flagged` to built-in flag id) and write (`SetMessageFlaggedAsync`)
- Graph API read (`flag.flagStatus == flagged`) and write (PATCH endpoint)
- `IFlagService` / `FlagService`: load/save definitions, K-default flag, `SetMessageFlagAsync`, `ToggleDefaultFlagAsync`

**Phase 2 — Toggle (K key), All Flagged virtual folder, filter menu, settings**
- `K` key toggles the K-default flag on selected messages; multi-select supported
- `\x00AllFlagged` virtual folder shows flagged messages across all accounts
- Filter menu entry for flagged messages; `SavedView.FlagFilterId` for per-flag filtering
- `AnnounceFlagStatus` config setting; `ResolveFlagNamesAsync` populates display names after sync

**Phase 3 — Flag indicator UI and accessibility**
- Flag color swatch in the message list item template
- `IsFlagged` / `FlagLabel` / `StatusDisplay` on `MailMessageSummary`
- Accessible name on flagged items reflects the flag name

**Phase 4 — Flag Manager window + flag picker popup**
- `FlagManagerWindow` (CRUD for user flags: add, rename, delete, reorder, color picker, K-default)
- `FlagPickerWindow` popup for `Ctrl+Shift+K` — pick any flag or clear the flag on a message
- Both windows follow the new-window checklist: F6 ring, command palette, cancellation, focus restoration
- `FlagManagerViewModel` and `FlagPickerViewModel` with full test coverage (32 new tests)

**Phase 5 — IMAP to local flag reconciliation on sync**
- `UpsertSummariesAsync` SQL CASE fixed: server-unflagged messages now clear `flag_id` in the DB
- `OnFolderSynced` clears `FlagId` in memory when the server reports `\Flagged` was removed externally
- Named flags set locally are preserved when the server still reports `\Flagged`
- 5 new tests covering all three reconciliation cases

## Test plan

- [x] Build succeeds with no warnings
- [x] `dotnet test` passes all 676 tests (up from 623 before this branch)
- [x] K key toggles flag; multi-select toggles all selected messages
- [x] All Flagged virtual folder shows and updates correctly
- [x] Flag Manager opens, add/rename/delete/reorder/color/K-default all work keyboard-only
- [x] Flag picker popup (Ctrl+Shift+K) selects a flag or clears it
- [x] Externally flagged message (flagged in another client) appears flagged on next sync
- [x] Externally unflagged message loses its flag on next sync; locally named flag is preserved

Part of #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)