### PR TITLE
docs: reduce CLAUDE.md by 49%, extract reference material to docs/

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ build.bat clean
 
 Or directly: `dotnet run --project QuickMail`.
 
-The `installer` target requires [Inno Setup 6](https://jrsoftware.org/isdl.php) (`ISCC.exe`). The installer is defined in `installer/quickmail.iss`; see [Installer](#installer) below.
+The `installer` target requires [Inno Setup 6](https://jrsoftware.org/isdl.php) (`ISCC.exe`). See `docs/INSTALLER.md` for installer details.
 
 Startup flags: `/debug` enables verbose file logging. `--profileDir <path>` overrides the data directory (default `%APPDATA%\QuickMail`); useful for isolated testing.
 
@@ -50,106 +50,10 @@ All tests use `StubServices.cs` stub implementations to avoid real network and c
 
 ## Architecture
 
-### Service Layer
-
-**App.xaml.cs** is the manual DI composition root — no container. Services are wired in `OnStartup` in dependency order:
+Manual DI root in `App.xaml.cs` — no container. Services wired in `OnStartup`:
 `ProfileContext` → `AccountService` → `CredentialService` → `OAuthService` → `ImapService` → `SmtpService` → `ConfigService` → `LocalStoreService` → `ContactService` → `TemplateService` → `RuleService` → `SyncService` → `ViewService` → `CommandRegistry` → `MainViewModel` → `MainWindow`.
 
-Every service has a matching interface in `Services/I*.cs`, making them fully substitutable in tests.
-
-**ImapService** uses MailKit and leases `ImapClient` instances from a bounded per-account pool. Foreground operations (message open, attachment download, mutating user actions) use foreground leases. Background work (sync, UID checks, polling, preview fetches, prefetch) uses background leases capped below the full pool so sync cannot starve interactive work. `MaxImapConnectionsPerAccount` defaults to 6 and is clamped to 1-15.
-
-**LocalStoreService** (SQLite via `Microsoft.Data.Sqlite`) caches messages in `mail.db` with WAL journaling. It stores `MessageSummary` rows for list panes and `MessageDetail` rows for body/attachment metadata, and handles column-addition migrations at startup. Schema version is tracked via `PRAGMA user_version` so data migrations run exactly once.
-
-**SyncService** runs background IMAP sync. It raises `FolderSynced`, `MessagesRemoved`, and `RulesApplied` events; `MainViewModel` subscribes and merges new data into observable collections. UI is populated from the SQLite cache immediately, then background sync fills gaps.
-
-**OAuthService** wraps MSAL (`Microsoft.Identity.Client`) for Microsoft 365 / Outlook OAuth2. Token refresh is handled automatically; passwords for OAuth accounts are not stored in Credential Manager.
-
-**ConfigService** reads/writes `config.ini` (INI format, human-editable) and `hotkeys.json` (JSON). Settings include `PreviewLines`, `ShowMessageStatus`, `ViewMode`, `SyncDays`, `InitialSyncCount`, with optional per-account `[account:{guid}]` overrides. Results are cached after first load.
-
-**ContactService** stores the address book in `contacts.json` and contact groups in `groups.json`. Both files share a single `SemaphoreSlim` load lock so concurrent group and contact writes cannot tear. Upserts by email address (case-insensitive); `SearchContactsAsync` returns up to 10 results ordered by `LastUsedTicks`. Contacts are auto-upserted when mail is sent.
-
-Groups (`GroupModel`) are flat, local-only, and keyed by an incrementing integer `Id` with a list of `MemberContactIds`. `LoadAllGroupsAsync` returns groups sorted by `LastUsedTicks` descending; `TouchGroupAsync` bumps the timestamp so a freshly-inserted group sorts to the top. The model exposes computed `ResolvedMemberCount` and `MissingContactCount` (both `[JsonIgnore]`) and a human-readable `Display` ("Name, N members" / "(M missing)" / "Empty group") so the UI does not have to recompute them. The full group surface is on `IContactService`: `LoadAllGroupsAsync`, `CreateGroupAsync`, `RenameGroupAsync`, `DeleteGroupAsync`, `AddMemberAsync`, `RemoveMemberAsync`, `ListGroupsForContactAsync`, `TouchGroupAsync`. A corrupt `groups.json` is renamed to `groups.json.bak-{timestamp}` and treated as empty, matching the recovery behaviour used for views, rules, and templates.
-
-**RuleService** loads/saves mail rules from `rules.json`. Each `MailRule` has AND-combined conditions (FromContains, ToContains, SubjectContains, BodyContains, MustHaveAttachments) and one action (MarkAsRead, MarkAsUnread, MoveToFolder, Delete). `ApplyRulesAsync` is called by `SyncService` on incoming messages; `ApplyRulesToExistingAsync` runs on demand against the full cache. Rules can be scoped to one account via `AccountId` (null = all accounts). File writes use an atomic temp-then-rename pattern.
-
-**ViewService** persists `SavedView` objects to `views.json`. A `SavedView` bundles one or more folders with a view mode, filter, sort order, optional `Hotkey` gesture string, `IsDefault` flag, and optional `DaysOfMail` limit. File is written atomically.
-
-**TemplateService** persists `MessageTemplate` objects to `templates.json`. Thread-safe via `SemaphoreSlim`; writes use atomic temp-then-rename. Templates are ordered alphabetically by title on load.
-
-**CommandRegistry** holds all `CommandDefinition` instances (id, category, title, default gesture, execute action). Commands are registered in `MainWindow`'s constructor. `FindByGesture()` checks user overrides from `hotkeys.json` first, then falls back to defaults. The command palette (`Ctrl+P`) uses `CommandPaletteViewModel` to display and invoke them.
-
-**ProfileContext** resolves the data directory for the process. All services that write files derive their paths from it. Supports `--profileDir <path>` CLI override for alternate profiles (e.g. during testing). All file-writing services take `ProfileContext` in their constructor — do not accept raw `string` paths.
-
-**Static utilities** (no DI required):
-- `ConversationBuilder` — groups messages by normalized subject (strips all leading Re:/Fwd: chains); used for Conversations view mode
-- `SenderGroupBuilder` — groups messages by From or To; used for From/To view modes
-- `MimeMessageBuilder` — builds a `MimeMessage` from `ComposeModel` + `AccountModel`; shared by `SmtpService` and `ImapService` (draft saving)
-- `AddressParser` — splits comma/semicolon-delimited address strings into `MailboxAddress` objects
-- `MessagePropertiesBuilder`, `FolderPropertiesBuilder`, `AccountPropertiesBuilder`, `ContactPropertiesBuilder`, `GroupPropertiesBuilder`, `AttachmentPropertiesBuilder` — transform model objects into `(title, sections[])` for `PropertiesViewModel`. Pure static functions, no DI, testable without UI. Each takes the relevant model(s) and returns a list of `PropertySection` records containing `PropertyItem` (label/value) rows.
-- `FolderTreeBuilder` — builds `FolderTreeNode` hierarchy from a flat `MailFolderModel` list; auto-detects IMAP path separator (`.` or `/`)
-
-### Helpers
-
-**`BatchObservableCollection<T>`** (`Helpers/BatchObservableCollection.cs`) — subclass of `ObservableCollection<T>` that suppresses individual `CollectionChanged` notifications during bulk mutations and fires a single `Reset` when the batch closes. This prevents screen readers from re-announcing the focused item after every insert during background sync. Always use `BeginBatchScope()` in a `using` block (auto-closes on exception); the manual `BeginBatch()` / `EndBatch()` pair is available for explicit `try/finally` sites. Nesting is safe — the outermost scope fires the reset.
-
-### ViewModel State
-
-**MainViewModel** owns application state. Key patterns:
-
-- Cancellation token sources are scoped by activity: connect, folder load, message load, background sync, and prefetch.
-- Version stamps discard stale async results after folder/message/view changes.
-- View modes: Messages, Conversations, From, and To.
-- `OnFolderSynced` and `OnMessagesRemoved` must use key-based lookups, not repeated `Messages.Any()` / `FirstOrDefault()` scans over large All Mail views.
-- `_suppressFolderSyncUpdates` silences sync events during startup; `_suppressFilterRebuild` prevents stale filter application during folder transitions.
-
-**AddressBookViewModel** owns the Address Book window's two-tab state (Contacts and Groups). It exposes `Groups: ObservableCollection<GroupModel>` sorted by `LastUsedTicks` descending and a derived `SelectedGroupMembers: ObservableCollection<ContactModel>` rebuilt whenever `SelectedGroup` changes. Confirmation dialogs and screen reader announcements are surfaced via `event Func<string, string, Task<bool>>? ConfirmRequested` and `event Action<string, AnnouncementCategory>? AnnouncementRequested`; the View subscribes and shows the dialog or calls `AccessibilityHelper.Announce` directly. The `InsertGroup(Action<ContactModel>)` private helper iterates `SelectedGroupMembers` in recency order and calls the inserter for each — the Compose window sets those inserters via `SetInsertActions(to, cc, bcc)` so a group can be dropped into any address field with one command. **GroupManagerViewModel** is a sibling VM that powers the standalone `GroupManagerWindow` (`Ctrl+Shift+M`); it shares the same `IContactService` instance and raises `GroupsChanged` for the parent to refresh.
-
-### Runtime Modes
-
-QuickMail has startup flags that alter which services are available. New code that calls any service must account for the mode it may be running in.
-
-| Flag | Effect on services |
-|---|---|
-| *(normal)* | All services available. SQLite schema fully created. `LocalStoreService` returns cached data. |
-| `--online` | SQLite schema is **not created**. `LocalStoreService` methods will throw `SqliteException` on any call. All data must come from the backend (IMAP or Graph). |
-| `--profileDir <path>` | All file-based services use the alternate path. No effect on availability. |
-
-**Graph accounts in `--online` mode:** fully supported, no behavioral difference. `GraphMailService` has **no `ILocalStoreService` dependency** — every read goes straight to the Graph REST API, so the uncreated SQLite schema never matters. (`GraphMailServiceTests.GraphMailService_HasNoLocalStoreDependency_SoOnlineModeWorks` guards this structurally.) The local-store-first / backend-fallback pattern below lives in `MainViewModel`, which dispatches the fallback through the `MailServiceRouter` to whichever backend owns the account.
-
-**The standard fetch pattern for message bodies** — used wherever a message detail is needed:
-
-```csharp
-MailMessageDetail? detail = null;
-try
-{
-    detail = await _localStore.LoadDetailAsync(accountId, folder, uid);
-}
-catch { /* local store unavailable (e.g. online mode) — fall through to IMAP */ }
-
-if (detail == null)
-    detail = await _imap.GetMessageDetailAsync(accountId, folder, uid, ct);
-```
-
-This pattern must use **two separate try/catch scopes** — one for the local store call and one (outer) for the whole method. A single outer catch that covers both the local store and the IMAP call will swallow the local store exception and silently skip the IMAP fallback, leaving the UI blank with no visible error.
-
-- ✅ Inner catch around `LoadDetailAsync` only — falls through to IMAP on any failure.
-- ❌ Single outer catch around both calls — IMAP is never reached when local store throws.
-
-When adding any new code that calls `LocalStoreService`, ask: does this work in `--online` mode? If the answer is "it will throw," wrap that call in its own catch with an explicit fallback.
-
-### Virtual Folders
-
-Virtual folders use `FullName` sentinel strings starting with `\x00` to distinguish them from real IMAP folders.
-
-| FullName | Scope |
-|---|---|
-| `\x00AllMail` | Union of all non-excluded folders across all accounts |
-| `\x00AllInboxes` | Inbox only from each account |
-| `\x00AllDrafts` / `\x00AllSent` / `\x00AllTrash` | Global drafts/sent/trash |
-| `\x00AccountMail:{guid}` | All folders for one account |
-
-Trash, Junk, Sent, and Drafts are excluded from `\x00AllMail` via `folder.ExcludeFromAllMail`. When a virtual folder is selected, `MainViewModel` queries multiple real folders and merges results sorted newest-first.
+Every service has a matching interface in `Services/I*.cs`. See `docs/ARCHITECTURE.md` for full service descriptions, runtime modes, and virtual folder sentinels.
 
 ## Key Conventions
 
@@ -303,70 +207,7 @@ Every user-facing keyboard shortcut **must** be registered in `CommandRegistry` 
 2. Add a menu item with matching `InputGestureText` if applicable.
 3. Do **not** add a duplicate hardcoded branch in `PreviewKeyDown`.
 
-### Registered shortcut table (MainWindow)
-
-| Key | Command ID | Title |
-|---|---|---|
-| Ctrl+0 | *(hardcoded)* | Focus toolbar |
-| Ctrl+1 | *(hardcoded)* | Focus account list (or tab 1 when tabs are open) |
-| Ctrl+2 / Ctrl+Y | `view.focusFolders` | Focus Folder Tree (or tab 2 when tabs are open) |
-| Ctrl+3 | *(hardcoded)* | Focus message list (or tab 3 when tabs are open) |
-| Ctrl+4–8 | *(hardcoded)* | Jump to tab 4–8 (when tabs are open) |
-| Ctrl+9 | *(hardcoded/registry)* | Jump to last tab (tabs open) or `view.focusStatusBar` (no tabs) |
-| Ctrl+Alt+1 | `view.focusAccounts` | Focus Account List (always) |
-| Ctrl+Alt+2 | *(hardcoded)* | Focus Folder Tree (always) |
-| Ctrl+Alt+3 | `view.focusMessages` | Focus Message List (always) |
-| F6 / Shift+F6 | *(hardcoded)* | Cycle panes |
-| Escape | *(hardcoded)* | Close reading pane |
-| Ctrl+Shift+P | *(hardcoded)* | Command Palette |
-| Ctrl+N | `mail.new` | New Message |
-| Ctrl+R | `mail.reply` | Reply |
-| Ctrl+Shift+R | `mail.replyAll` | Reply All |
-| Ctrl+F | `mail.forward` | Forward |
-| Delete | `mail.delete` | Delete |
-| Ctrl+Q | `mail.markRead` | Mark as Read |
-| F5 | `mail.refresh` | Refresh |
-| Ctrl+Shift+E | `mail.emptyTrash` | Empty Trash |
-| Ctrl+Shift+V | `view.openViewMenu` | Open View Menu |
-| Ctrl+Shift+F | `view.searchFolders` | Search Folders… |
-| Ctrl+Shift+S | `view.search` | Search Messages… |
-| Ctrl+Shift+G | `contacts.grabAddresses` | Grab Addresses from Message |
-| Ctrl+Shift+B | `contacts.openAddressBook` | Address Book |
-| F1 | `help.userGuide` | Open User Guide |
-| *(unassigned)* | `settings.toggleCustomAnnouncements` | Toggle Custom Announcements |
-| Ctrl+A | `mail.selectAll` | Select All Messages (message list focus only) |
-| Shift+, | `mail.jumpToFirstInGroup` | First Message in Group |
-| Shift+. | `mail.jumpToLastInGroup` | Last Message in Group |
-| *(unassigned)* | `mail.acceptInvite` | Accept Invitation |
-| *(unassigned)* | `mail.declineInvite` | Decline Invitation |
-| *(unassigned)* | `mail.tentativeInvite` | Tentatively Accept Invitation |
-| *(unassigned)* | `help.keyboardTutorial` | Keyboard Tutorial |
-| Ctrl+Shift+T | `view.focusTabs` | Focus Tab Strip |
-| Alt+Enter | `view.showProperties` | View Properties |
-| Ctrl+Tab | `tabs.next` | Next Tab |
-| Ctrl+Shift+Tab | `tabs.previous` | Previous Tab |
-| Ctrl+W | `tabs.close` | Close Tab |
-| Ctrl+Shift+` | `tabs.list` | Tab List… |
-| *(unassigned)* | `tabs.closeOthers` | Close Other Tabs |
-| *(unassigned)* | `tabs.moveLeft` | Move Tab Left |
-| *(unassigned)* | `tabs.moveRight` | Move Tab Right |
-| *(unassigned)* | `tabs.promote` | Move Tab to New Window |
-| *(unassigned)* | `mail.openInNewTab` | Open in New Tab |
-| *(unassigned)* | `mail.openInWindow` | Open in New Window |
-
-**Compose window shortcuts** (Alt+S, Ctrl+Enter, Ctrl+S, Ctrl+Shift+A, F7, Shift+F7, Alt+Y, Alt+U, Alt+M, Escape) are registered or hardcoded in `ComposeWindow.xaml.cs`. Registry-based ones appear in the compose window's command palette (`Ctrl+Shift+P`) but are **not** user-customisable via the Settings dialog. The main window's `CommandRegistry` and `hotkeys.json` do not include compose commands. `Ctrl+Enter` is hardcoded (like `Ctrl+Shift+P`) as a second send gesture so it does not create a duplicate "Send Message" entry in the palette.
-
-**Compose menu bar**: `ComposeWindow` has a standard menu bar (File / Edit / View / Format / Tools). It is not a tab stop (reached with Alt or F10, per platform convention). Every item dispatches to the same handler or command as its keyboard shortcut, and `InputGestureText` must match the registered default gesture. **Top-level menus are never disabled** (Windows standard — a disabled top-level menu is skipped by arrow navigation, stranding its items); availability is expressed per item. Format items gray out in Plain Text mode only, and because WPF skips disabled items during arrow navigation, opening the Format menu in Plain Text announces a Hint explaining why. The View menu's mode items get radio-style check marks synced in `SyncModeSelector`. The window's `PreviewKeyDown` steps aside on Escape when a menu, combo dropdown, or the autocomplete popup is open so transient UI can close itself.
-
-**Formatting works in both rich modes.** HTML mode applies real formatting to the RichTextBox; Markdown mode inserts the equivalent syntax through `MarkdownEditing` (`Helpers/MarkdownEditing.cs` — pure, unit-tested text operations applied via `TextBox.SelectedText` so each toggle is one undo unit). Exception: underline has no Markdown form and the Markdig pipeline uses `DisableHtml()`, so underline in Markdown announces that it requires HTML mode. Formatting result announcements go through `ComposeWindow.AnnounceFormatting`, which defers to `DispatcherPriority.ApplicationIdle` and interrupts — menu invocations restore focus to the editor on close, and an immediate announcement would be silenced by the screen reader's focus speech.
-
-**Compose window title** is `"{subject or kind} - {mode} - QuickMail"` (e.g. "Lunch Friday - HTML - QuickMail") so the taskbar and Alt+Tab identify the message and editing format. `WindowTitle` is notified on both Subject and CurrentMode changes.
-
-**Draft autosave**: compose windows auto-save dirty composes as drafts on a `DispatcherTimer` (config keys `AutoSaveDrafts`, default on, and `AutoSaveIntervalSeconds`, default 120, clamped 30–600; both editable in Settings → General → Composing). `ComposeViewModel.AutoSaveAsync` is quiet by design: success only updates the visual `AutoSaveText` status ("Auto-saved 3:42 PM") with **no announcement**; a failure raises `AutoSaveFailed` once (announced with `AnnouncementCategory.Status`) and re-arms after the next success. Autosave skips template edits, untouched composes, and composes with no recipient/subject/body/attachment. The palette command `compose.announceAutoSave` ("Announce Last Auto-Save") speaks the last autosave time on demand.
-
-**Compose modes** (`ComposeMode`: PlainText / Markdown / Html) are switched with `Ctrl+Shift+1/2/3`, the View menu, or the mode ComboBox in the status row. Plain Text and Markdown edit in `BodyBox` (TextBox); HTML mode edits in `RichBodyBox` — a native WPF `RichTextBox`, deliberately **not** WebView2 `contenteditable`, so screen readers stay in their normal edit cursor with no virtual cursor.
-
-**Never replace `RichTextBox.Document` — enforced.** WPF's `RichTextBoxAutomationPeer` binds its UIA TextPattern to the text container of the document present at peer creation and never rebinds, even for freshly created peers. After a `Document` assignment, screen readers permanently read the stale (empty) original document instead of what is on screen — the editor goes completely silent. All content loads must mutate the existing document via `RichTextDocumentConverter.LoadInto(doc, html)`. Regression-tested in `ComposeUiaTextPatternTests`, which asserts the UIA TextPattern text through real mode switches. Formatting commands (Ctrl+B/I/U, Ctrl+Shift+X strikethrough, Ctrl+Alt+1/2/3 headings, Ctrl+Shift+L/N lists, Ctrl+L insert link, Ctrl+Space clear formatting, Ctrl+T announce formatting state, Ctrl+Shift+T show formatting in a browsable list — `FormattingListWindow`) are HTML-mode-only via `IsAvailable`; `F8` opens the preview window (`MarkdownPreviewWindow`) in both Markdown and HTML modes — a fully focusable WebView2 in a separate window so screen readers can browse the rendered output as a web page. Conversions run through `IMarkdownService` (Markdig with an explicit bounded pipeline: pipe tables, strikethrough, auto-links, raw HTML disabled, task lists excluded for WCAG) and `RichTextDocumentConverter` (FlowDocument ↔ HTML/Markdown; headings 1–6, pre with fence language, hr, and blockquote tracked via `Paragraph.Tag`; table header cells and alignment via `TableCell.Tag`; image src via `Run.Tag` with alt text as run text; verbatim hrefs via `Hyperlink.Tag`). The Markdown → HTML → FlowDocument → Markdown round trip must stay lossless — `MarkdownRoundTripTests` holds an exact-equality corpus plus well-formedness/WCAG-structure checks on the wrapped document (`WrapDocument` emits a full HTML5 document: doctype, `lang`, charset, subject as title). Rich-mode messages are sent as `multipart/alternative` by `MimeMessageBuilder` whenever `ComposeModel.HtmlBody` is non-empty. Every formatting action announces its result ("Bold on", "Heading 2") via `AccessibilityHelper.Announce` with `AnnouncementCategory.Result`. The default mode for new composes is `DefaultComposeMode` in `config.ini` (plain/markdown/html); drafts reopen in the mode they were saved in (stored as `X-QuickMail-Compose-Mode` MIME header); templates always reopen in plain text. `RichTextDocumentConverter.LoadInto` accepts both HTML fragments and full HTML documents (the `<html>` and `<body>` wrappers are treated as transparent block containers), so the full wrapped document from `detail.HtmlBody` can be loaded directly into the rich editor when restoring an HTML draft.
+See `docs/KEYBOARD-SHORTCUTS.md` for the full registered shortcut table and compose window details.
 
 ## Accessibility Checklist — Apply to Every XAML Change
 
@@ -394,7 +235,7 @@ Before a feature branch is committed:
 1. **Exercise every entry point.** A message-opening feature must be tested from the flat message list, the conversations tree, and the from/to group trees. A feature that only works from one view is incomplete.
 2. **Exercise every configured mode.** If a feature has a mode setting (e.g. ReadingPane / Tab / Window), verify it works correctly in every mode before committing.
 3. **Keyboard-only walkthrough.** Perform the full user journey using only the keyboard — Tab, arrow keys, Enter, Escape, F6. If focus is lost or stranded at any point, it is a bug, not a follow-up.
-4. **No silent empty state from caught exceptions.** A `catch` block that swallows an exception and leaves the UI blank is never acceptable. If a primary data source fails (e.g. SQLite unavailable in `--online` mode), the catch must fall through to a visible fallback (e.g. IMAP fetch) or surface an error. Catch blocks that silently return convert failures into debugging marathons. See the **standard fetch pattern** in the Runtime Modes section — the local store and IMAP calls must be in separate catch scopes so a local store failure does not prevent the IMAP fallback from running.
+4. **No silent empty state from caught exceptions.** A `catch` block that swallows an exception and leaves the UI blank is never acceptable. If a primary data source fails (e.g. SQLite unavailable in `--online` mode), the catch must fall through to a visible fallback (e.g. IMAP fetch) or surface an error. Catch blocks that silently return convert failures into debugging marathons. See the **standard fetch pattern** in `docs/ARCHITECTURE.md` — the local store and IMAP calls must be in separate catch scopes so a local store failure does not prevent the IMAP fallback from running.
 5. **Test in `--online` mode** for any feature that calls `LocalStoreService`. Run with `--online` and verify the feature works correctly from IMAP alone. Features that only pass in normal mode are incomplete.
 6. **If the feature affects startup state, verify it activates before the user sees content.** Any feature that influences what the user sees or hears at launch (default view, folder selection, announcement text, connection status, etc.) must be applied in `InitialLoadAsync`, not deferred to the end of `StartBackgroundSyncAsync`. Deferring to post-sync means the user sees a different state for 20–40 seconds before the feature takes effect.
 
@@ -425,89 +266,3 @@ Explicitly list every change to shared infrastructure:
 ### Out of scope
 
 Explicitly state what the feature does not do. This surfaces assumptions that need a design decision and prevents scope creep. If something is deferred, say so — do not leave it implicit.
-
-
-## Accessibility Checklist — Apply to Every XAML Change
-
-Before committing any XAML, verify each of these:
-
-- **`AutomationProperties.Name` is a short label only.** No descriptions, no role names (not "tab", "button", "checkbox"), no keyboard shortcuts, no sentences. The screen reader already announces the role; repeating it doubles the speech. Wrong: `"General settings tab"`. Right: `"General settings"`.
-- **Hints and usage instructions go through `AccessibilityHelper.Announce`**, not into `AutomationProperties.Name`. If a keyboard shortcut or usage tip is worth surfacing, deliver it as `AnnouncementCategory.Hint` when the control is first focused — where the user's hint preference applies.
-- **Radio button groups have one tab stop.** The container must have `KeyboardNavigation.TabNavigation="Once"` and `KeyboardNavigation.DirectionalNavigation="Cycle"`. All buttons in the group share the same `GroupName`. Individual radio buttons must not each be reachable via Tab.
-- **New primary pane controls are in the F6 ring.** Any list, tree, or panel that is a major navigation destination must be added to `CycleFocusAsync` and `GetFocusedPaneIndex` in `MainWindow.xaml.cs`. A control that can receive focus but is not in F6 is stranded.
-
-## New Window Checklist — Apply When Creating Any Window Subclass
-
-Every `Window` subclass requires all of the following before it is committed:
-
-- **F6 / Shift+F6 focus cycle.** Define the logical pane stops (e.g. toolbar, header fields, body). Implement a cycle method and handle `F6` / `Shift+F6` in `PreviewKeyDown`.
-- **WebView2 F6 relay.** If the window contains a WebView2, the injected JS keydown script must relay `F6` and `Shift+F6` as postMessages back to WPF, exactly as `MainWindow` does. Without this, F6 pressed inside the body is swallowed and the cycle breaks.
-- **Command palette.** Wire `Ctrl+Shift+P` to open a local command palette containing all window-scoped actions (close, navigate, move, etc.). Follow the pattern in `ComposeWindow.xaml.cs`. Actions that have no default hotkey still belong in the palette so users can discover them.
-- **Cancellation token.** Any async load must use a `CancellationTokenSource` field. Cancel and dispose it in `OnClosing`. Re-create it at the start of each new load so navigating away cancels in-flight fetches.
-- **Focus restoration on close.** Capture the originating focused element (or its index) before the window opens. When the window closes, explicitly return focus to that position. WPF's default return-to-owner behaviour is not reliable for virtualised list items.
-
-## Feature Checklist — Apply Before Committing Any New Feature
-
-Before a feature branch is committed:
-
-1. **Exercise every entry point.** A message-opening feature must be tested from the flat message list, the conversations tree, and the from/to group trees. A feature that only works from one view is incomplete.
-2. **Exercise every configured mode.** If a feature has a mode setting (e.g. ReadingPane / Tab / Window), verify it works correctly in every mode before committing.
-3. **Keyboard-only walkthrough.** Perform the full user journey using only the keyboard — Tab, arrow keys, Enter, Escape, F6. If focus is lost or stranded at any point, it is a bug, not a follow-up.
-4. **No silent empty state from caught exceptions.** A `catch` block that swallows an exception and leaves the UI blank is never acceptable. If a primary data source fails (e.g. SQLite unavailable in `--online` mode), the catch must fall through to a visible fallback (e.g. IMAP fetch) or surface an error. Catch blocks that silently return convert failures into debugging marathons. See the **standard fetch pattern** in the Runtime Modes section — the local store and IMAP calls must be in separate catch scopes so a local store failure does not prevent the IMAP fallback from running.
-5. **Test in `--online` mode** for any feature that calls `LocalStoreService`. Run with `--online` and verify the feature works correctly from IMAP alone. Features that only pass in normal mode are incomplete.
-6. **If the feature affects startup state, verify it activates before the user sees content.** Any feature that influences what the user sees or hears at launch (default view, folder selection, announcement text, connection status, etc.) must be applied in `InitialLoadAsync`, not deferred to the end of `StartBackgroundSyncAsync`. Deferring to post-sync means the user sees a different state for 20–40 seconds before the feature takes effect.
-
-## Spec Writing Requirements
-
-When AI generates a spec from a conceptual directive, the spec is not ready for implementation until it includes all three of these sections.
-
-### Keyboard walkthrough
-
-A numbered step-by-step sequence showing exactly what the user does and what they hear or see, for each distinct mode or path. Example:
-
-1. User presses Enter on a message. Screen reader announces: "Opening message."
-2. A window appears with focus on the message body. Screen reader announces: "Message body. [Subject]."
-3. User presses F6. Focus moves to the toolbar. Screen reader announces: "Toolbar."
-4. User presses Escape. Window closes. Focus returns to the originating message in the list.
-
-This forces every interaction to be explicitly designed before any code is written. A gap in the walkthrough means a missing design decision — not something to be resolved during coding.
-
-### Infrastructure changes
-
-Explicitly list every change to shared infrastructure:
-- Which panes are added to or removed from the F6 ring
-- Which commands are added to `CommandRegistry`, with category and whether a default key is assigned
-- Which `AutomationProperties.Name` values are introduced or changed
-- Which `AccessibilityHelper.Announce` calls are added, with category (Hint/Status/Result). **Reminder**: announcements in each category are gated by user configuration (`AnnounceHints`, `AnnounceStatus`, `AnnounceResults`) — specs must explicitly choose the category so implementation respects user preferences.
-- Whether VM state properties (e.g. `IsMessageOpen`) need updating to reflect the new feature
-
-### Out of scope
-
-Explicitly state what the feature does not do. This surfaces assumptions that need a design decision and prevents scope creep. If something is deferred, say so — do not leave it implicit.
-
-## Installer
-
-`installer/quickmail.iss` is an Inno Setup 6 script that packages the **self-contained single-file** `publish/QuickMail.exe` into a Windows installer. `build.bat installer` runs `dotnet publish` then `ISCC.exe`, emitting `installer/Output/quickmail-v<version>-setup.exe` (gitignored).
-
-Key facts:
-
-- **Only `QuickMail.exe` is shipped.** Because the build is self-contained (the .NET 8 runtime is bundled in the exe), there is **no .NET runtime dependency**. The `.pdb` and `Microsoft.Web.WebView2.*.xml` files that also appear in `publish/` are intentionally excluded.
-- **The single external prerequisite is the WebView2 Runtime**, installed on demand via `Dependency_AddWebView2` from the bundled `installer/CodeDependencies.iss` (the standard DomGries dependency helper, vendored verbatim — leave it unmodified).
-- **Version is read from the exe** at compile time via `GetVersionNumbersString`, so it always matches `FileVersion` in the csproj — never hardcode it in the `.iss`.
-- **Per-user install by default** (`PrivilegesRequired=lowest` + `PrivilegesRequiredOverridesAllowed=dialog`); the user may opt into an all-users install, which elevates.
-- **No app mutex exists**, so `CloseApplications=yes` uses the Restart Manager to detect a running copy during an upgrade.
-- Uninstall offers to delete user data under `%APPDATA%\QuickMail`; Credential Manager entries are left untouched.
-- English-only UI strings live in `installer/Languages/Custom.en.isl` (define only messages not already in Inno's `Default.isl`).
-- The installer is a downstream packaging artifact — it does **not** alter the GitHub Actions release, which still ships the bare self-contained `QuickMail.exe`.
-
-## Dependencies
-
-| Package | Version | Purpose |
-|---|---|---|
-| MailKit | 4.16.0 | IMAP + SMTP protocol |
-| Markdig | 1.2.0 | Markdown ↔ HTML for compose modes |
-| CommunityToolkit.Mvvm | 8.4.2 | ObservableProperty, RelayCommand |
-| Microsoft.Data.Sqlite | 10.0.7 | Local message cache |
-| Microsoft.Web.WebView2 | 1.0.3912.50 | HTML email rendering |
-| Microsoft.Identity.Client | 4.84.0 | OAuth2 (Microsoft 365) |
-| AdysTech.CredentialManager | 3.1.0 | Windows Credential Manager |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,102 @@
+# Architecture
+
+## Service Layer
+
+**App.xaml.cs** is the manual DI composition root — no container. Services are wired in `OnStartup` in dependency order:
+`ProfileContext` → `AccountService` → `CredentialService` → `OAuthService` → `ImapService` → `SmtpService` → `ConfigService` → `LocalStoreService` → `ContactService` → `TemplateService` → `RuleService` → `SyncService` → `ViewService` → `CommandRegistry` → `MainViewModel` → `MainWindow`.
+
+Every service has a matching interface in `Services/I*.cs`, making them fully substitutable in tests.
+
+**ImapService** uses MailKit and leases `ImapClient` instances from a bounded per-account pool. Foreground operations (message open, attachment download, mutating user actions) use foreground leases. Background work (sync, UID checks, polling, preview fetches, prefetch) uses background leases capped below the full pool so sync cannot starve interactive work. `MaxImapConnectionsPerAccount` defaults to 6 and is clamped to 1-15.
+
+**LocalStoreService** (SQLite via `Microsoft.Data.Sqlite`) caches messages in `mail.db` with WAL journaling. It stores `MessageSummary` rows for list panes and `MessageDetail` rows for body/attachment metadata, and handles column-addition migrations at startup. Schema version is tracked via `PRAGMA user_version` so data migrations run exactly once.
+
+**SyncService** runs background IMAP sync. It raises `FolderSynced`, `MessagesRemoved`, and `RulesApplied` events; `MainViewModel` subscribes and merges new data into observable collections. UI is populated from the SQLite cache immediately, then background sync fills gaps.
+
+**OAuthService** wraps MSAL (`Microsoft.Identity.Client`) for Microsoft 365 / Outlook OAuth2. Token refresh is handled automatically; passwords for OAuth accounts are not stored in Credential Manager.
+
+**ConfigService** reads/writes `config.ini` (INI format, human-editable) and `hotkeys.json` (JSON). Settings include `PreviewLines`, `ShowMessageStatus`, `ViewMode`, `SyncDays`, `InitialSyncCount`, with optional per-account `[account:{guid}]` overrides. Results are cached after first load.
+
+**ContactService** stores the address book in `contacts.json` and contact groups in `groups.json`. Both files share a single `SemaphoreSlim` load lock so concurrent group and contact writes cannot tear. Upserts by email address (case-insensitive); `SearchContactsAsync` returns up to 10 results ordered by `LastUsedTicks`. Contacts are auto-upserted when mail is sent.
+
+Groups (`GroupModel`) are flat, local-only, and keyed by an incrementing integer `Id` with a list of `MemberContactIds`. `LoadAllGroupsAsync` returns groups sorted by `LastUsedTicks` descending; `TouchGroupAsync` bumps the timestamp so a freshly-inserted group sorts to the top. The model exposes computed `ResolvedMemberCount` and `MissingContactCount` (both `[JsonIgnore]`) and a human-readable `Display` ("Name, N members" / "(M missing)" / "Empty group") so the UI does not have to recompute them. The full group surface is on `IContactService`: `LoadAllGroupsAsync`, `CreateGroupAsync`, `RenameGroupAsync`, `DeleteGroupAsync`, `AddMemberAsync`, `RemoveMemberAsync`, `ListGroupsForContactAsync`, `TouchGroupAsync`. A corrupt `groups.json` is renamed to `groups.json.bak-{timestamp}` and treated as empty, matching the recovery behaviour used for views, rules, and templates.
+
+**RuleService** loads/saves mail rules from `rules.json`. Each `MailRule` has AND-combined conditions (FromContains, ToContains, SubjectContains, BodyContains, MustHaveAttachments) and one action (MarkAsRead, MarkAsUnread, MoveToFolder, Delete). `ApplyRulesAsync` is called by `SyncService` on incoming messages; `ApplyRulesToExistingAsync` runs on demand against the full cache. Rules can be scoped to one account via `AccountId` (null = all accounts). File writes use an atomic temp-then-rename pattern.
+
+**ViewService** persists `SavedView` objects to `views.json`. A `SavedView` bundles one or more folders with a view mode, filter, sort order, optional `Hotkey` gesture string, `IsDefault` flag, and optional `DaysOfMail` limit. File is written atomically.
+
+**TemplateService** persists `MessageTemplate` objects to `templates.json`. Thread-safe via `SemaphoreSlim`; writes use atomic temp-then-rename. Templates are ordered alphabetically by title on load.
+
+**CommandRegistry** holds all `CommandDefinition` instances (id, category, title, default gesture, execute action). Commands are registered in `MainWindow`'s constructor. `FindByGesture()` checks user overrides from `hotkeys.json` first, then falls back to defaults. The command palette (`Ctrl+P`) uses `CommandPaletteViewModel` to display and invoke them.
+
+**ProfileContext** resolves the data directory for the process. All services that write files derive their paths from it. Supports `--profileDir <path>` CLI override for alternate profiles (e.g. during testing). All file-writing services take `ProfileContext` in their constructor — do not accept raw `string` paths.
+
+**Static utilities** (no DI required):
+- `ConversationBuilder` — groups messages by normalized subject (strips all leading Re:/Fwd: chains); used for Conversations view mode
+- `SenderGroupBuilder` — groups messages by From or To; used for From/To view modes
+- `MimeMessageBuilder` — builds a `MimeMessage` from `ComposeModel` + `AccountModel`; shared by `SmtpService` and `ImapService` (draft saving)
+- `AddressParser` — splits comma/semicolon-delimited address strings into `MailboxAddress` objects
+- `MessagePropertiesBuilder`, `FolderPropertiesBuilder`, `AccountPropertiesBuilder`, `ContactPropertiesBuilder`, `GroupPropertiesBuilder`, `AttachmentPropertiesBuilder` — transform model objects into `(title, sections[])` for `PropertiesViewModel`. Pure static functions, no DI, testable without UI. Each takes the relevant model(s) and returns a list of `PropertySection` records containing `PropertyItem` (label/value) rows.
+- `FolderTreeBuilder` — builds `FolderTreeNode` hierarchy from a flat `MailFolderModel` list; auto-detects IMAP path separator (`.` or `/`)
+
+## Helpers
+
+**`BatchObservableCollection<T>`** (`Helpers/BatchObservableCollection.cs`) — subclass of `ObservableCollection<T>` that suppresses individual `CollectionChanged` notifications during bulk mutations and fires a single `Reset` when the batch closes. This prevents screen readers from re-announcing the focused item after every insert during background sync. Always use `BeginBatchScope()` in a `using` block (auto-closes on exception); the manual `BeginBatch()` / `EndBatch()` pair is available for explicit `try/finally` sites. Nesting is safe — the outermost scope fires the reset.
+
+## ViewModel State
+
+**MainViewModel** owns application state. Key patterns:
+
+- Cancellation token sources are scoped by activity: connect, folder load, message load, background sync, and prefetch.
+- Version stamps discard stale async results after folder/message/view changes.
+- View modes: Messages, Conversations, From, and To.
+- `OnFolderSynced` and `OnMessagesRemoved` must use key-based lookups, not repeated `Messages.Any()` / `FirstOrDefault()` scans over large All Mail views.
+- `_suppressFolderSyncUpdates` silences sync events during startup; `_suppressFilterRebuild` prevents stale filter application during folder transitions.
+
+**AddressBookViewModel** owns the Address Book window's two-tab state (Contacts and Groups). It exposes `Groups: ObservableCollection<GroupModel>` sorted by `LastUsedTicks` descending and a derived `SelectedGroupMembers: ObservableCollection<ContactModel>` rebuilt whenever `SelectedGroup` changes. Confirmation dialogs and screen reader announcements are surfaced via `event Func<string, string, Task<bool>>? ConfirmRequested` and `event Action<string, AnnouncementCategory>? AnnouncementRequested`; the View subscribes and shows the dialog or calls `AccessibilityHelper.Announce` directly. The `InsertGroup(Action<ContactModel>)` private helper iterates `SelectedGroupMembers` in recency order and calls the inserter for each — the Compose window sets those inserters via `SetInsertActions(to, cc, bcc)` so a group can be dropped into any address field with one command. **GroupManagerViewModel** is a sibling VM that powers the standalone `GroupManagerWindow` (`Ctrl+Shift+M`); it shares the same `IContactService` instance and raises `GroupsChanged` for the parent to refresh.
+
+## Runtime Modes
+
+QuickMail has startup flags that alter which services are available. New code that calls any service must account for the mode it may be running in.
+
+| Flag | Effect on services |
+|---|---|
+| *(normal)* | All services available. SQLite schema fully created. `LocalStoreService` returns cached data. |
+| `--online` | SQLite schema is **not created**. `LocalStoreService` methods will throw `SqliteException` on any call. All data must come from the backend (IMAP or Graph). |
+| `--profileDir <path>` | All file-based services use the alternate path. No effect on availability. |
+
+**Graph accounts in `--online` mode:** fully supported, no behavioral difference. `GraphMailService` has **no `ILocalStoreService` dependency** — every read goes straight to the Graph REST API, so the uncreated SQLite schema never matters. (`GraphMailServiceTests.GraphMailService_HasNoLocalStoreDependency_SoOnlineModeWorks` guards this structurally.) The local-store-first / backend-fallback pattern below lives in `MainViewModel`, which dispatches the fallback through the `MailServiceRouter` to whichever backend owns the account.
+
+**The standard fetch pattern for message bodies** — used wherever a message detail is needed:
+
+```csharp
+MailMessageDetail? detail = null;
+try
+{
+    detail = await _localStore.LoadDetailAsync(accountId, folder, uid);
+}
+catch { /* local store unavailable (e.g. online mode) — fall through to IMAP */ }
+
+if (detail == null)
+    detail = await _imap.GetMessageDetailAsync(accountId, folder, uid, ct);
+```
+
+This pattern must use **two separate try/catch scopes** — one for the local store call and one (outer) for the whole method. A single outer catch that covers both the local store and the IMAP call will swallow the local store exception and silently skip the IMAP fallback, leaving the UI blank with no visible error.
+
+- ✅ Inner catch around `LoadDetailAsync` only — falls through to IMAP on any failure.
+- ❌ Single outer catch around both calls — IMAP is never reached when local store throws.
+
+When adding any new code that calls `LocalStoreService`, ask: does this work in `--online` mode? If the answer is "it will throw," wrap that call in its own catch with an explicit fallback.
+
+## Virtual Folders
+
+Virtual folders use `FullName` sentinel strings starting with `\x00` to distinguish them from real IMAP folders.
+
+| FullName | Scope |
+|---|---|
+| `\x00AllMail` | Union of all non-excluded folders across all accounts |
+| `\x00AllInboxes` | Inbox only from each account |
+| `\x00AllDrafts` / `\x00AllSent` / `\x00AllTrash` | Global drafts/sent/trash |
+| `\x00AccountMail:{guid}` | All folders for one account |
+
+Trash, Junk, Sent, and Drafts are excluded from `\x00AllMail` via `folder.ExcludeFromAllMail`. When a virtual folder is selected, `MainViewModel` queries multiple real folders and merges results sorted newest-first.

--- a/docs/INSTALLER.md
+++ b/docs/INSTALLER.md
@@ -1,0 +1,14 @@
+# Installer
+
+`installer/quickmail.iss` is an Inno Setup 6 script that packages the **self-contained single-file** `publish/QuickMail.exe` into a Windows installer. `build.bat installer` runs `dotnet publish` then `ISCC.exe`, emitting `installer/Output/quickmail-v<version>-setup.exe` (gitignored).
+
+Key facts:
+
+- **Only `QuickMail.exe` is shipped.** Because the build is self-contained (the .NET 8 runtime is bundled in the exe), there is **no .NET runtime dependency**. The `.pdb` and `Microsoft.Web.WebView2.*.xml` files that also appear in `publish/` are intentionally excluded.
+- **The single external prerequisite is the WebView2 Runtime**, installed on demand via `Dependency_AddWebView2` from the bundled `installer/CodeDependencies.iss` (the standard DomGries dependency helper, vendored verbatim — leave it unmodified).
+- **Version is read from the exe** at compile time via `GetVersionNumbersString`, so it always matches `FileVersion` in the csproj — never hardcode it in the `.iss`.
+- **Per-user install by default** (`PrivilegesRequired=lowest` + `PrivilegesRequiredOverridesAllowed=dialog`); the user may opt into an all-users install, which elevates.
+- **No app mutex exists**, so `CloseApplications=yes` uses the Restart Manager to detect a running copy during an upgrade.
+- Uninstall offers to delete user data under `%APPDATA%\QuickMail`; Credential Manager entries are left untouched.
+- English-only UI strings live in `installer/Languages/Custom.en.isl` (define only messages not already in Inno's `Default.isl`).
+- The installer is a downstream packaging artifact — it does **not** alter the GitHub Actions release, which still ships the bare self-contained `QuickMail.exe`.

--- a/docs/KEYBOARD-SHORTCUTS.md
+++ b/docs/KEYBOARD-SHORTCUTS.md
@@ -1,0 +1,68 @@
+# Keyboard Shortcuts Reference
+
+## Registered shortcut table (MainWindow)
+
+| Key | Command ID | Title |
+|---|---|---|
+| Ctrl+0 | *(hardcoded)* | Focus toolbar |
+| Ctrl+1 | *(hardcoded)* | Focus account list (or tab 1 when tabs are open) |
+| Ctrl+2 / Ctrl+Y | `view.focusFolders` | Focus Folder Tree (or tab 2 when tabs are open) |
+| Ctrl+3 | *(hardcoded)* | Focus message list (or tab 3 when tabs are open) |
+| Ctrl+4–8 | *(hardcoded)* | Jump to tab 4–8 (when tabs are open) |
+| Ctrl+9 | *(hardcoded/registry)* | Jump to last tab (tabs open) or `view.focusStatusBar` (no tabs) |
+| Ctrl+Alt+1 | `view.focusAccounts` | Focus Account List (always) |
+| Ctrl+Alt+2 | *(hardcoded)* | Focus Folder Tree (always) |
+| Ctrl+Alt+3 | `view.focusMessages` | Focus Message List (always) |
+| F6 / Shift+F6 | *(hardcoded)* | Cycle panes |
+| Escape | *(hardcoded)* | Close reading pane |
+| Ctrl+Shift+P | *(hardcoded)* | Command Palette |
+| Ctrl+N | `mail.new` | New Message |
+| Ctrl+R | `mail.reply` | Reply |
+| Ctrl+Shift+R | `mail.replyAll` | Reply All |
+| Ctrl+F | `mail.forward` | Forward |
+| Delete | `mail.delete` | Delete |
+| Ctrl+Q | `mail.markRead` | Mark as Read |
+| F5 | `mail.refresh` | Refresh |
+| Ctrl+Shift+E | `mail.emptyTrash` | Empty Trash |
+| Ctrl+Shift+V | `view.openViewMenu` | Open View Menu |
+| Ctrl+Shift+F | `view.searchFolders` | Search Folders… |
+| Ctrl+Shift+S | `view.search` | Search Messages… |
+| Ctrl+Shift+G | `contacts.grabAddresses` | Grab Addresses from Message |
+| Ctrl+Shift+B | `contacts.openAddressBook` | Address Book |
+| F1 | `help.userGuide` | Open User Guide |
+| *(unassigned)* | `settings.toggleCustomAnnouncements` | Toggle Custom Announcements |
+| Ctrl+A | `mail.selectAll` | Select All Messages (message list focus only) |
+| Shift+, | `mail.jumpToFirstInGroup` | First Message in Group |
+| Shift+. | `mail.jumpToLastInGroup` | Last Message in Group |
+| *(unassigned)* | `mail.acceptInvite` | Accept Invitation |
+| *(unassigned)* | `mail.declineInvite` | Decline Invitation |
+| *(unassigned)* | `mail.tentativeInvite` | Tentatively Accept Invitation |
+| *(unassigned)* | `help.keyboardTutorial` | Keyboard Tutorial |
+| Ctrl+Shift+T | `view.focusTabs` | Focus Tab Strip |
+| Alt+Enter | `view.showProperties` | View Properties |
+| Ctrl+Tab | `tabs.next` | Next Tab |
+| Ctrl+Shift+Tab | `tabs.previous` | Previous Tab |
+| Ctrl+W | `tabs.close` | Close Tab |
+| Ctrl+Shift+` | `tabs.list` | Tab List… |
+| *(unassigned)* | `tabs.closeOthers` | Close Other Tabs |
+| *(unassigned)* | `tabs.moveLeft` | Move Tab Left |
+| *(unassigned)* | `tabs.moveRight` | Move Tab Right |
+| *(unassigned)* | `tabs.promote` | Move Tab to New Window |
+| *(unassigned)* | `mail.openInNewTab` | Open in New Tab |
+| *(unassigned)* | `mail.openInWindow` | Open in New Window |
+
+## Compose Window
+
+**Shortcuts** (Alt+S, Ctrl+Enter, Ctrl+S, Ctrl+Shift+A, F7, Shift+F7, Alt+Y, Alt+U, Alt+M, Escape) are registered or hardcoded in `ComposeWindow.xaml.cs`. Registry-based ones appear in the compose window's command palette (`Ctrl+Shift+P`) but are **not** user-customisable via the Settings dialog. The main window's `CommandRegistry` and `hotkeys.json` do not include compose commands. `Ctrl+Enter` is hardcoded (like `Ctrl+Shift+P`) as a second send gesture so it does not create a duplicate "Send Message" entry in the palette.
+
+**Menu bar**: `ComposeWindow` has a standard menu bar (File / Edit / View / Format / Tools). It is not a tab stop (reached with Alt or F10, per platform convention). Every item dispatches to the same handler or command as its keyboard shortcut, and `InputGestureText` must match the registered default gesture. **Top-level menus are never disabled** (Windows standard — a disabled top-level menu is skipped by arrow navigation, stranding its items); availability is expressed per item. Format items gray out in Plain Text mode only, and because WPF skips disabled items during arrow navigation, opening the Format menu in Plain Text announces a Hint explaining why. The View menu's mode items get radio-style check marks synced in `SyncModeSelector`. The window's `PreviewKeyDown` steps aside on Escape when a menu, combo dropdown, or the autocomplete popup is open so transient UI can close itself.
+
+**Formatting** works in both rich modes. HTML mode applies real formatting to the RichTextBox; Markdown mode inserts the equivalent syntax through `MarkdownEditing` (`Helpers/MarkdownEditing.cs` — pure, unit-tested text operations applied via `TextBox.SelectedText` so each toggle is one undo unit). Exception: underline has no Markdown form and the Markdig pipeline uses `DisableHtml()`, so underline in Markdown announces that it requires HTML mode. Formatting result announcements go through `ComposeWindow.AnnounceFormatting`, which defers to `DispatcherPriority.ApplicationIdle` and interrupts — menu invocations restore focus to the editor on close, and an immediate announcement would be silenced by the screen reader's focus speech.
+
+**Window title** is `"{subject or kind} - {mode} - QuickMail"` (e.g. "Lunch Friday - HTML - QuickMail") so the taskbar and Alt+Tab identify the message and editing format. `WindowTitle` is notified on both Subject and CurrentMode changes.
+
+**Draft autosave**: compose windows auto-save dirty composes as drafts on a `DispatcherTimer` (config keys `AutoSaveDrafts`, default on, and `AutoSaveIntervalSeconds`, default 120, clamped 30–600; both editable in Settings → General → Composing). `ComposeViewModel.AutoSaveAsync` is quiet by design: success only updates the visual `AutoSaveText` status ("Auto-saved 3:42 PM") with **no announcement**; a failure raises `AutoSaveFailed` once (announced with `AnnouncementCategory.Status`) and re-arms after the next success. Autosave skips template edits, untouched composes, and composes with no recipient/subject/body/attachment. The palette command `compose.announceAutoSave` ("Announce Last Auto-Save") speaks the last autosave time on demand.
+
+**Compose modes** (`ComposeMode`: PlainText / Markdown / Html) are switched with `Ctrl+Shift+1/2/3`, the View menu, or the mode ComboBox in the status row. Plain Text and Markdown edit in `BodyBox` (TextBox); HTML mode edits in `RichBodyBox` — a native WPF `RichTextBox`, deliberately **not** WebView2 `contenteditable`, so screen readers stay in their normal edit cursor with no virtual cursor.
+
+**Never replace `RichTextBox.Document` — enforced.** WPF's `RichTextBoxAutomationPeer` binds its UIA TextPattern to the text container of the document present at peer creation and never rebinds, even for freshly created peers. After a `Document` assignment, screen readers permanently read the stale (empty) original document instead of what is on screen — the editor goes completely silent. All content loads must mutate the existing document via `RichTextDocumentConverter.LoadInto(doc, html)`. Regression-tested in `ComposeUiaTextPatternTests`, which asserts the UIA TextPattern text through real mode switches. Formatting commands (Ctrl+B/I/U, Ctrl+Shift+X strikethrough, Ctrl+Alt+1/2/3 headings, Ctrl+Shift+L/N lists, Ctrl+L insert link, Ctrl+Space clear formatting, Ctrl+T announce formatting state, Ctrl+Shift+T show formatting in a browsable list — `FormattingListWindow`) are HTML-mode-only via `IsAvailable`; `F8` opens the preview window (`MarkdownPreviewWindow`) in both Markdown and HTML modes — a fully focusable WebView2 in a separate window so screen readers can browse the rendered output as a web page. Conversions run through `IMarkdownService` (Markdig with an explicit bounded pipeline: pipe tables, strikethrough, auto-links, raw HTML disabled, task lists excluded for WCAG) and `RichTextDocumentConverter` (FlowDocument ↔ HTML/Markdown; headings 1–6, pre with fence language, hr, and blockquote tracked via `Paragraph.Tag`; table header cells and alignment via `TableCell.Tag`; image src via `Run.Tag` with alt text as run text; verbatim hrefs via `Hyperlink.Tag`). The Markdown → HTML → FlowDocument → Markdown round trip must stay lossless — `MarkdownRoundTripTests` holds an exact-equality corpus plus well-formedness/WCAG-structure checks on the wrapped document (`WrapDocument` emits a full HTML5 document: doctype, `lang`, charset, subject as title). Rich-mode messages are sent as `multipart/alternative` by `MimeMessageBuilder` whenever `ComposeModel.HtmlBody` is non-empty. Every formatting action announces its result ("Bold on", "Heading 2") via `AccessibilityHelper.Announce` with `AnnouncementCategory.Result`. The default mode for new composes is `DefaultComposeMode` in `config.ini` (plain/markdown/html); drafts reopen in the mode they were saved in (stored as `X-QuickMail-Compose-Mode` MIME header); templates always reopen in plain text. `RichTextDocumentConverter.LoadInto` accepts both HTML fragments and full HTML documents (the `<html>` and `<body>` wrappers are treated as transparent block containers), so the full wrapped document from `detail.HtmlBody` can be loaded directly into the rich editor when restoring an HTML draft.


### PR DESCRIPTION
## Summary

- Removed four sections that each appeared twice verbatim (Accessibility Checklist, New Window Checklist, Feature Checklist, Spec Writing Requirements)
- Extracted service-layer descriptions, runtime modes, and virtual folder table to `docs/ARCHITECTURE.md`
- Extracted registered shortcut table and compose window details to `docs/KEYBOARD-SHORTCUTS.md`
- Extracted installer details to `docs/INSTALLER.md`
- Removed the dependencies table (redundant with the .csproj)
- CLAUDE.md now points to each extracted doc at the relevant section

Result: 514 to 265 lines in CLAUDE.md. All content is preserved, just moved to on-demand reference files.

## Test plan

- Verify docs/ARCHITECTURE.md, docs/KEYBOARD-SHORTCUTS.md, and docs/INSTALLER.md contain the expected extracted content
- Verify CLAUDE.md has correct pointers and no duplicated sections

Generated with Claude Code