### PR TITLE
chore: enable Roslyn Recommended analyzers and Roslynator

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -19,3 +19,11 @@ indent_size = 2
 
 [*.md]
 trim_trailing_whitespace = false
+
+[*.cs]
+# Redundant explicit initializers — intentional readability choice in models
+dotnet_diagnostic.CA1805.severity = none
+# FeatureFlag name — intentional; the type represents a feature flag
+dotnet_diagnostic.CA1711.severity = none
+# Locale-sensitive formatting — display strings intentionally use CurrentCulture
+dotnet_diagnostic.CA1305.severity = none

--- a/QuickMail.Tests/QuickMail.Tests.csproj
+++ b/QuickMail.Tests/QuickMail.Tests.csproj
@@ -14,6 +14,7 @@
     <!-- Treat the most dangerous nullable warnings as errors so the CI catches
          null-dereference risks before they become runtime crashes. -->
     <WarningsAsErrors>CS8602;CS8604;CS8618</WarningsAsErrors>
+    <AnalysisMode>Recommended</AnalysisMode>
   </PropertyGroup>
 
   <ItemGroup>

--- a/QuickMail/QuickMail.csproj
+++ b/QuickMail/QuickMail.csproj
@@ -9,6 +9,7 @@
     <Version>0.7.3</Version>
     <AssemblyVersion>0.7.3.0</AssemblyVersion>
     <FileVersion>0.7.3.0</FileVersion>
+    <AnalysisMode>Recommended</AnalysisMode>
     <!-- Single-file publish: native DLLs (WebView2Loader, SQLite) extract to temp on first run -->
     <PublishSingleFile>true</PublishSingleFile>
     <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
@@ -27,6 +28,10 @@
     <PackageReference Include="Microsoft.Identity.Client" Version="4.84.2" />
     <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.84.2" />
     <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.4022.49" />
+    <PackageReference Include="Roslynator.Analyzers" Version="4.12.10">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

- Adds `<AnalysisMode>Recommended</AnalysisMode>` to both projects, enabling the .NET SDK's built-in Roslyn analyzer suite at the Recommended level
- Adds `Roslynator.Analyzers` (analyzer-only NuGet package, no runtime cost) to the main project
- Suppresses three low-signal rules in `.editorconfig`: CA1805 (explicit default init is a readability choice), CA1711 (FeatureFlag name is intentional), CA1305 (display strings correctly use CurrentCulture in a desktop UI)
- Enables Dependabot vulnerability alerts and automated security fixes in GitHub settings (dependabot.yml was already configured)
- All 708 tests pass; build succeeds with genuine findings tracked in #93

## Test plan

- [x] `dotnet build QuickMail/QuickMail.csproj -c Release` — succeeds with expected warnings, no errors
- [x] `dotnet test` — 708 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)