### PR TITLE
chore: ignore Tools/MailGenerator credentials and logs directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ MailGenerator/credentials.ini
 /artifacts
 startmail.bat
 startoffline.bat
+Tools/MailGenerator/credentials.ini
+/logs


### PR DESCRIPTION
Adds two .gitignore entries missing after MailGenerator/ moved to Tools/MailGenerator/: Tools/MailGenerator/credentials.ini (test email credentials) and /logs (perf log output). Generated with Claude Code.