### PR TITLE
Google OAuth 2.0 (Gmail) account support

### DIFF
--- a/.github/workflows/quickmail.yml
+++ b/.github/workflows/quickmail.yml
@@ -19,6 +19,21 @@ jobs:
         with:
           dotnet-version: '8.0.x'
 
+      - name: Write Google OAuth credentials
+        shell: pwsh
+        env:
+          GOOGLE_CLIENT_ID:     ${{ secrets.GOOGLE_CLIENT_ID }}
+          GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+        run: |
+          @"
+          namespace QuickMail.Services;
+          public partial class GoogleOAuthService
+          {
+              private const string ClientId     = "$env:GOOGLE_CLIENT_ID";
+              private const string ClientSecret = "$env:GOOGLE_CLIENT_SECRET";
+          }
+          "@ | Set-Content -Path "QuickMail/Services/GoogleOAuthService.Credentials.cs" -Encoding UTF8
+
       - name: Test
         run: dotnet test QuickMail.Tests/QuickMail.Tests.csproj -c Release --logger "trx;LogFileName=results.trx"
 

--- a/.github/workflows/quickmail.yml
+++ b/.github/workflows/quickmail.yml
@@ -43,6 +43,7 @@ jobs:
         with:
           name: test-results
           path: QuickMail.Tests/TestResults/results.trx
+          retention-days: 7
 
       - name: Publish
         run: dotnet publish QuickMail/QuickMail.csproj -c Release -o publish/
@@ -54,6 +55,7 @@ jobs:
           name: QuickMail-win-x64
           path: publish/QuickMail.exe
           if-no-files-found: error
+          retention-days: 7
 
       - name: Install Inno Setup
         if: startsWith(github.ref, 'refs/tags/v')

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ Thumbs.db
 # MailGenerator credentials (contains passwords)
 MailGenerator/credentials.ini
 
+# Google OAuth client credentials (real values — copy from docs/GoogleOAuthService.Credentials.example)
+**/GoogleOAuthService.Credentials.cs
+
 # Claude Code worktrees and local session data
 .claude/worktrees/
 .claude/settings.local.json

--- a/QuickMail.Tests/StubServices.cs
+++ b/QuickMail.Tests/StubServices.cs
@@ -73,6 +73,16 @@ sealed class StubCredentialService : ICredentialService
     public void SavePassword(Guid accountId, string password) { }
     public string? GetPassword(Guid accountId) => null;
     public void DeletePassword(Guid accountId) { }
+    public void SaveSecret(string key, string value) { }
+    public string? GetSecret(string key) => null;
+    public void DeleteSecret(string key) { }
+}
+
+sealed class StubGoogleOAuthService : IGoogleOAuthService
+{
+    public Task<string> GetAccessTokenAsync(string username, CancellationToken ct = default) => Task.FromResult(string.Empty);
+    public Task<OAuthResult> SignInInteractiveAsync(string loginHint, CancellationToken ct = default) => Task.FromResult(new OAuthResult(string.Empty, loginHint));
+    public Task SignOutAsync(string username) => Task.CompletedTask;
 }
 
 sealed class StubOAuthService : IOAuthService

--- a/QuickMail/App.xaml.cs
+++ b/QuickMail/App.xaml.cs
@@ -78,11 +78,13 @@ public partial class App : Application
         {
             var accountService    = new AccountService(profile);
             var credentialService = new CredentialService();
-            var oauthService      = new OAuthService(profile);
             var configService     = new ConfigService(profile);
+            var msOAuthService    = new OAuthService(profile);
+            var googleOAuth       = new GoogleOAuthService(configService, credentialService);
+            var oauthService      = new OAuthRouter(msOAuthService, googleOAuth);
             var imapBackend       = new ImapMailService(oauthService, configService);
-            var graphBackend      = new GraphMailService(oauthService, configService);
-            _graphSendMail        = new GraphSendMailService(oauthService);
+            var graphBackend      = new GraphMailService(msOAuthService, configService);
+            _graphSendMail        = new GraphSendMailService(msOAuthService);
             var smtpService       = new SmtpService(oauthService, _graphSendMail);
 
             // Per-account mail backend router. Each account is registered to the backend its

--- a/QuickMail/App.xaml.cs
+++ b/QuickMail/App.xaml.cs
@@ -80,7 +80,7 @@ public partial class App : Application
             var credentialService = new CredentialService();
             var configService     = new ConfigService(profile);
             var msOAuthService    = new OAuthService(profile);
-            var googleOAuth       = new GoogleOAuthService(configService, credentialService);
+            var googleOAuth       = new GoogleOAuthService(credentialService);
             var oauthService      = new OAuthRouter(msOAuthService, googleOAuth);
             var imapBackend       = new ImapMailService(oauthService, configService);
             var graphBackend      = new GraphMailService(msOAuthService, configService);

--- a/QuickMail/Helpers/AccountPropertiesBuilder.cs
+++ b/QuickMail/Helpers/AccountPropertiesBuilder.cs
@@ -38,9 +38,12 @@ public static class AccountPropertiesBuilder
         var auth = new List<PropertyItem>
         {
             new("Authentication",
-                account.AuthType == AuthType.OAuth2Microsoft
-                    ? "OAuth2 (Microsoft 365)"
-                    : "Password (Windows Credential Manager)"),
+                account.AuthType switch
+                {
+                    AuthType.OAuth2Microsoft => "OAuth2 (Microsoft 365)",
+                    AuthType.OAuth2Google    => "OAuth2 (Google / Gmail)",
+                    _                        => "Password (Windows Credential Manager)",
+                }),
             new("Last synced",
                 lastSyncedUtc.HasValue
                     ? lastSyncedUtc.Value.ToLocalTime().ToString("f")

--- a/QuickMail/Models/AuthType.cs
+++ b/QuickMail/Models/AuthType.cs
@@ -3,5 +3,6 @@ namespace QuickMail.Models;
 public enum AuthType
 {
     Password,
-    OAuth2Microsoft
+    OAuth2Microsoft,
+    OAuth2Google,
 }

--- a/QuickMail/Models/ConfigModel.cs
+++ b/QuickMail/Models/ConfigModel.cs
@@ -120,6 +120,20 @@ public class ConfigModel
     /// <summary>User-defined keyboard shortcut overrides, stored in hotkeys.json.</summary>
     public List<HotkeyBinding> CustomHotkeys { get; set; } = [];
 
+    // ── Google OAuth client credentials ──────────────────────────────────────────
+
+    /// <summary>
+    /// Google OAuth client ID from the Google Cloud Console app registration.
+    /// Set in the [google] section of config.ini. Never committed to source control.
+    /// </summary>
+    public string GoogleClientId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Google OAuth client secret from the Google Cloud Console app registration.
+    /// Set in the [google] section of config.ini. Never committed to source control.
+    /// </summary>
+    public string GoogleClientSecret { get; set; } = string.Empty;
+
     // ── Feature flags ─────────────────────────────────────────────────────────────
 
     /// <summary>

--- a/QuickMail/Models/FeatureFlag.cs
+++ b/QuickMail/Models/FeatureFlag.cs
@@ -11,4 +11,11 @@ public enum FeatureFlag
     /// Default: false. Flip the default to true via a future joint-decision PR.
     /// </summary>
     GraphBackend,
+
+    /// <summary>
+    /// Shows the Google OAuth (Gmail) option in Add Account and Account Manager dialogs.
+    /// Default: false. Enable in config.ini as GoogleAuth=true under [features].
+    /// Requires GoogleClientId and GoogleClientSecret in the [google] section of config.ini.
+    /// </summary>
+    GoogleAuth,
 }

--- a/QuickMail/Models/FeatureFlag.cs
+++ b/QuickMail/Models/FeatureFlag.cs
@@ -14,8 +14,7 @@ public enum FeatureFlag
 
     /// <summary>
     /// Shows the Google OAuth (Gmail) option in Add Account and Account Manager dialogs.
-    /// Default: false. Enable in config.ini as GoogleAuth=true under [features].
-    /// Requires GoogleClientId and GoogleClientSecret in the [google] section of config.ini.
+    /// Default: true. Disable in config.ini with GoogleAuth=false under [features].
     /// </summary>
     GoogleAuth,
 }

--- a/QuickMail/QuickMail.csproj
+++ b/QuickMail/QuickMail.csproj
@@ -21,6 +21,7 @@
 
   <ItemGroup>
     <PackageReference Include="AdysTech.CredentialManager" Version="3.1.0" />
+    <PackageReference Include="Google.Apis.Auth" Version="1.75.0" />
     <PackageReference Include="Markdig" Version="1.3.0" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.9" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />

--- a/QuickMail/Services/ConfigFeatureGate.cs
+++ b/QuickMail/Services/ConfigFeatureGate.cs
@@ -13,7 +13,7 @@ namespace QuickMail.Services;
 public class ConfigFeatureGate : IFeatureGate
 {
     /// <summary>Built-in defaults. Every flag MUST appear here.</summary>
-    private static readonly IReadOnlyDictionary<FeatureFlag, bool> Defaults = new Dictionary<FeatureFlag, bool>
+    private static readonly Dictionary<FeatureFlag, bool> Defaults = new Dictionary<FeatureFlag, bool>
     {
         [FeatureFlag.GraphBackend] = false,
     };

--- a/QuickMail/Services/ConfigFeatureGate.cs
+++ b/QuickMail/Services/ConfigFeatureGate.cs
@@ -16,6 +16,7 @@ public class ConfigFeatureGate : IFeatureGate
     private static readonly Dictionary<FeatureFlag, bool> Defaults = new Dictionary<FeatureFlag, bool>
     {
         [FeatureFlag.GraphBackend] = false,
+        [FeatureFlag.GoogleAuth]   = true,
     };
 
     private readonly Dictionary<string, string> _configFlags;

--- a/QuickMail/Services/ConfigService.cs
+++ b/QuickMail/Services/ConfigService.cs
@@ -169,6 +169,11 @@ public class ConfigService : IConfigService
                     section  = "features";
                     acctGuid = Guid.Empty;
                 }
+                else if (header == "google")
+                {
+                    section  = "google";
+                    acctGuid = Guid.Empty;
+                }
                 else
                 {
                     section = null;
@@ -281,6 +286,14 @@ public class ConfigService : IConfigService
             {
                 // Preserve the original key case so IFeatureGate matches FeatureFlag.ToString().
                 config.Features[rawKey] = value;
+            }
+            else if (section == "google")
+            {
+                switch (key)
+                {
+                    case "googleclientid":     config.GoogleClientId     = value; break;
+                    case "googleclientsecret": config.GoogleClientSecret = value; break;
+                }
             }
         }
 
@@ -461,6 +474,22 @@ public class ConfigService : IConfigService
                 sb.AppendLine("# Override preview lines for this account. Remove to use global setting.");
                 sb.AppendLine();
             }
+        }
+
+        // ── [google] ───────────────────────────────────────────────────────────────
+        // Only written when credentials are present, so the default config stays clean.
+        if (!string.IsNullOrEmpty(config.GoogleClientId) || !string.IsNullOrEmpty(config.GoogleClientSecret))
+        {
+            sb.AppendLine("[google]");
+            sb.AppendLine("# Google OAuth credentials from Google Cloud Console.");
+            sb.AppendLine("# Required to use Google OAuth (Gmail) accounts.");
+            sb.AppendLine("# Never commit this file to source control.");
+            sb.AppendLine();
+            if (!string.IsNullOrEmpty(config.GoogleClientId))
+                sb.AppendLine($"GoogleClientId = {config.GoogleClientId}");
+            if (!string.IsNullOrEmpty(config.GoogleClientSecret))
+                sb.AppendLine($"GoogleClientSecret = {config.GoogleClientSecret}");
+            sb.AppendLine();
         }
 
         // ── [features] ─────────────────────────────────────────────────────────────

--- a/QuickMail/Services/CredentialService.cs
+++ b/QuickMail/Services/CredentialService.cs
@@ -27,4 +27,24 @@ public class CredentialService : ICredentialService
         try { CredentialManager.RemoveCredentials(Key(accountId)); }
         catch { /* already gone */ }
     }
+
+    public void SaveSecret(string key, string value)
+    {
+        var credential = new NetworkCredential(key, value);
+        CredentialManager.SaveCredentials(key, credential);
+    }
+
+    public string? GetSecret(string key)
+    {
+        var credential = CredentialManager.GetCredentials(key);
+        return credential?.SecurePassword is { } sp && sp.Length > 0
+            ? new NetworkCredential(string.Empty, sp).Password
+            : credential?.Password;
+    }
+
+    public void DeleteSecret(string key)
+    {
+        try { CredentialManager.RemoveCredentials(key); }
+        catch { /* already gone */ }
+    }
 }

--- a/QuickMail/Services/GoogleOAuthService.cs
+++ b/QuickMail/Services/GoogleOAuthService.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Google.Apis.Auth.OAuth2;
+using Google.Apis.Auth.OAuth2.Flows;
+using Google.Apis.Auth.OAuth2.Responses;
+using Google.Apis.Util.Store;
+using QuickMail.Models;
+
+namespace QuickMail.Services;
+
+public class GoogleOAuthService : IGoogleOAuthService
+{
+    // Gmail IMAP/SMTP access + openid/email so we can confirm the signed-in address from the id_token.
+    private static readonly string[] Scopes = ["https://mail.google.com/", "openid", "email"];
+
+    private static string TokenKey(string username)
+        => $"QuickMail:GoogleToken:{username.ToLowerInvariant()}";
+
+    private readonly IConfigService _configService;
+    private readonly ICredentialService _credentialService;
+
+    // In-memory cache: lowercase username → live UserCredential (holds access token + auto-refresh)
+    private readonly Dictionary<string, UserCredential> _cache = [];
+
+    public GoogleOAuthService(IConfigService configService, ICredentialService credentialService)
+    {
+        _configService     = configService;
+        _credentialService = credentialService;
+    }
+
+    private GoogleAuthorizationCodeFlow CreateFlow(IDataStore? dataStore = null)
+    {
+        var cfg = _configService.Load();
+        return new GoogleAuthorizationCodeFlow(new GoogleAuthorizationCodeFlow.Initializer
+        {
+            ClientSecrets = new ClientSecrets
+            {
+                ClientId     = cfg.GoogleClientId,
+                ClientSecret = cfg.GoogleClientSecret,
+            },
+            Scopes    = Scopes,
+            DataStore = dataStore ?? new NoOpDataStore(),
+        });
+    }
+
+    public async Task<string> GetAccessTokenAsync(string username, CancellationToken ct = default)
+    {
+        var key = username.ToLowerInvariant();
+
+        if (!_cache.TryGetValue(key, out var credential))
+        {
+            var refreshToken = _credentialService.GetSecret(TokenKey(username));
+            if (string.IsNullOrEmpty(refreshToken))
+                throw new InvalidOperationException($"No Google credentials stored for {username}. Sign in first.");
+
+            credential = new UserCredential(CreateFlow(new NoOpDataStore()), username, new TokenResponse
+            {
+                RefreshToken = refreshToken,
+            });
+            _cache[key] = credential;
+        }
+
+        // GetAccessTokenForRequestAsync refreshes automatically when the access token is expired.
+        return await credential.GetAccessTokenForRequestAsync(cancellationToken: ct);
+    }
+
+    public async Task<OAuthResult> SignInInteractiveAsync(string loginHint, CancellationToken ct = default)
+    {
+        // NoOpDataStore: we handle persistence ourselves via CredentialService / WCM.
+        var flow     = CreateFlow(new NoOpDataStore());
+        var receiver = new LocalServerCodeReceiver();
+        var app      = new AuthorizationCodeInstalledApp(flow, receiver);
+
+        var userId     = string.IsNullOrEmpty(loginHint) ? "user" : loginHint;
+        var credential = await app.AuthorizeAsync(userId, ct);
+
+        var email = ExtractEmailFromIdToken(credential.Token.IdToken) ?? loginHint;
+        if (string.IsNullOrEmpty(email))
+            throw new InvalidOperationException("Google sign-in completed but the signed-in address could not be determined.");
+
+        var refreshToken = credential.Token.RefreshToken;
+        if (!string.IsNullOrEmpty(refreshToken))
+            _credentialService.SaveSecret(TokenKey(email), refreshToken);
+        else
+            LogService.Log("GoogleOAuthService: no refresh token returned — consent may already have been granted.");
+
+        _cache[email.ToLowerInvariant()] = credential;
+
+        LogService.Log($"GoogleOAuthService: interactive sign-in complete for {email}");
+        var accessToken = await credential.GetAccessTokenForRequestAsync(cancellationToken: ct);
+        return new OAuthResult(accessToken, email);
+    }
+
+    public Task SignOutAsync(string username)
+    {
+        _cache.Remove(username.ToLowerInvariant());
+        _credentialService.DeleteSecret(TokenKey(username));
+        LogService.Log($"GoogleOAuthService: signed out {username}");
+        return Task.CompletedTask;
+    }
+
+    // Decodes the JWT payload to extract the email claim without making a network call.
+    // Safe here because the token came directly from Google's token endpoint over TLS.
+    private static string? ExtractEmailFromIdToken(string? idToken)
+    {
+        if (string.IsNullOrEmpty(idToken)) return null;
+
+        var parts = idToken.Split('.');
+        if (parts.Length < 2) return null;
+
+        var payload = parts[1];
+        // Pad base64url to standard base64
+        var padded = (payload.Length % 4) switch
+        {
+            2 => payload + "==",
+            3 => payload + "=",
+            _ => payload,
+        };
+        padded = padded.Replace('-', '+').Replace('_', '/');
+
+        try
+        {
+            var bytes = Convert.FromBase64String(padded);
+            var json  = Encoding.UTF8.GetString(bytes);
+            using var doc = JsonDocument.Parse(json);
+            if (doc.RootElement.TryGetProperty("email", out var emailProp))
+                return emailProp.GetString();
+        }
+        catch (Exception ex)
+        {
+            LogService.Log($"GoogleOAuthService: failed to decode id_token payload: {ex.Message}");
+        }
+
+        return null;
+    }
+
+    // Discards all token-store calls from AuthorizationCodeInstalledApp.
+    // We handle persistence ourselves via CredentialService.
+    private sealed class NoOpDataStore : IDataStore
+    {
+        public Task StoreAsync<T>(string key, T value)  => Task.CompletedTask;
+        public Task DeleteAsync<T>(string key)           => Task.CompletedTask;
+        public Task<T> GetAsync<T>(string key)           => Task.FromResult(default(T)!);
+        public Task ClearAsync()                         => Task.CompletedTask;
+    }
+}

--- a/QuickMail/Services/GoogleOAuthService.cs
+++ b/QuickMail/Services/GoogleOAuthService.cs
@@ -32,7 +32,7 @@ public partial class GoogleOAuthService : IGoogleOAuthService
         _credentialService = credentialService;
     }
 
-    private GoogleAuthorizationCodeFlow CreateFlow(IDataStore? dataStore = null)
+    private static GoogleAuthorizationCodeFlow CreateFlow(IDataStore? dataStore = null)
     {
         return new GoogleAuthorizationCodeFlow(new GoogleAuthorizationCodeFlow.Initializer
         {

--- a/QuickMail/Services/GoogleOAuthService.cs
+++ b/QuickMail/Services/GoogleOAuthService.cs
@@ -8,11 +8,13 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Auth.OAuth2.Flows;
 using Google.Apis.Auth.OAuth2.Responses;
 using Google.Apis.Util.Store;
-using QuickMail.Models;
 
 namespace QuickMail.Services;
 
-public class GoogleOAuthService : IGoogleOAuthService
+// ClientId and ClientSecret are defined in GoogleOAuthService.Credentials.cs (gitignored).
+// Copy docs/GoogleOAuthService.Credentials.example to
+// QuickMail/Services/GoogleOAuthService.Credentials.cs and fill in your values.
+public partial class GoogleOAuthService : IGoogleOAuthService
 {
     // Gmail IMAP/SMTP access + openid/email so we can confirm the signed-in address from the id_token.
     private static readonly string[] Scopes = ["https://mail.google.com/", "openid", "email"];
@@ -20,27 +22,24 @@ public class GoogleOAuthService : IGoogleOAuthService
     private static string TokenKey(string username)
         => $"QuickMail:GoogleToken:{username.ToLowerInvariant()}";
 
-    private readonly IConfigService _configService;
     private readonly ICredentialService _credentialService;
 
     // In-memory cache: lowercase username → live UserCredential (holds access token + auto-refresh)
     private readonly Dictionary<string, UserCredential> _cache = [];
 
-    public GoogleOAuthService(IConfigService configService, ICredentialService credentialService)
+    public GoogleOAuthService(ICredentialService credentialService)
     {
-        _configService     = configService;
         _credentialService = credentialService;
     }
 
     private GoogleAuthorizationCodeFlow CreateFlow(IDataStore? dataStore = null)
     {
-        var cfg = _configService.Load();
         return new GoogleAuthorizationCodeFlow(new GoogleAuthorizationCodeFlow.Initializer
         {
             ClientSecrets = new ClientSecrets
             {
-                ClientId     = cfg.GoogleClientId,
-                ClientSecret = cfg.GoogleClientSecret,
+                ClientId     = ClientId,
+                ClientSecret = ClientSecret,
             },
             Scopes    = Scopes,
             DataStore = dataStore ?? new NoOpDataStore(),

--- a/QuickMail/Services/ICredentialService.cs
+++ b/QuickMail/Services/ICredentialService.cs
@@ -7,4 +7,9 @@ public interface ICredentialService
     void SavePassword(Guid accountId, string password);
     string? GetPassword(Guid accountId);
     void DeletePassword(Guid accountId);
+
+    /// <summary>Stores an arbitrary secret under the given key in Windows Credential Manager.</summary>
+    void SaveSecret(string key, string value);
+    string? GetSecret(string key);
+    void DeleteSecret(string key);
 }

--- a/QuickMail/Services/IGoogleOAuthService.cs
+++ b/QuickMail/Services/IGoogleOAuthService.cs
@@ -1,0 +1,22 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace QuickMail.Services;
+
+public interface IGoogleOAuthService
+{
+    /// <summary>
+    /// Returns a valid access token for the given username, refreshing silently if expired.
+    /// Throws <see cref="System.InvalidOperationException"/> if no stored credential exists — call
+    /// <see cref="SignInInteractiveAsync"/> first.
+    /// </summary>
+    Task<string> GetAccessTokenAsync(string username, CancellationToken ct = default);
+
+    /// <summary>
+    /// Opens the system browser for Google sign-in. Stores the refresh token and returns the
+    /// access token plus the confirmed Gmail address.
+    /// </summary>
+    Task<OAuthResult> SignInInteractiveAsync(string loginHint, CancellationToken ct = default);
+
+    Task SignOutAsync(string username);
+}

--- a/QuickMail/Services/ImapMailService.cs
+++ b/QuickMail/Services/ImapMailService.cs
@@ -956,7 +956,7 @@ public class ImapMailService : IMailService
             LogService.Debug($"  user={account.Username}");
             await client.ConnectAsync(account.ImapHost, account.ImapPort, ssl, ct);
 
-            if (account.AuthType == AuthType.OAuth2Microsoft)
+            if (account.AuthType is AuthType.OAuth2Microsoft or AuthType.OAuth2Google)
             {
                 var token = await _oauth.GetAccessTokenAsync(account, ct);
                 await client.AuthenticateAsync(new SaslMechanismOAuth2(account.Username, token), ct);

--- a/QuickMail/Services/ImapMailService.cs
+++ b/QuickMail/Services/ImapMailService.cs
@@ -19,6 +19,8 @@ namespace QuickMail.Services;
 
 public class ImapMailService : IMailService
 {
+    private static readonly string[] ComposeModeHeaders = ["X-QuickMail-Compose-Mode"];
+
     private const int DefaultMaxConnectionsPerAccount = 6;
     private const int AbsoluteMaxConnectionsPerAccount = 15;
     private const int ForegroundReservedConnectionCount = 2;
@@ -112,7 +114,7 @@ public class ImapMailService : IMailService
 
     public async Task<List<MailFolderModel>> GetFoldersAsync(Guid accountId, CancellationToken ct = default)
     {
-        using var lease = await RentClientAsync(accountId, ct, ImapLeasePriority.Foreground);
+        using var lease = await RentClientAsync(accountId, ImapLeasePriority.Foreground, ct);
         var client = lease.Client;
         var result = new List<MailFolderModel>();
 
@@ -182,7 +184,7 @@ public class ImapMailService : IMailService
 
     public async Task<(int Total, int Unread)> GetInboxStatusAsync(Guid accountId, CancellationToken ct = default)
     {
-        using var lease = await RentClientAsync(accountId, ct, ImapLeasePriority.Background);
+        using var lease = await RentClientAsync(accountId, ImapLeasePriority.Background, ct);
         var inbox = lease.Client.Inbox!;
         await inbox.StatusAsync(StatusItems.Count | StatusItems.Unread, ct);
         LogService.Debug($"GetInboxStatus: account={accountId} Total={inbox.Count} Unread={inbox.Unread}");
@@ -195,7 +197,7 @@ public class ImapMailService : IMailService
         Guid accountId, string folderName, int maxMessages, CancellationToken ct = default)
     {
         LogService.Log($"GetMessageSummaries: folder={folderName} maxMessages={maxMessages}");
-        using var lease = await RentClientAsync(accountId, ct, ImapLeasePriority.Foreground);
+        using var lease = await RentClientAsync(accountId, ImapLeasePriority.Foreground, ct);
         var client = lease.Client;
         var folder = await client.GetFolderAsync(folderName, ct);
         await folder.OpenAsync(FolderAccess.ReadOnly, ct);
@@ -229,7 +231,7 @@ public class ImapMailService : IMailService
         Guid accountId, string folderName, DateTime since, CancellationToken ct = default)
     {
         LogService.Log($"GetMessagesSinceDate: folder={folderName} since={since:yyyy-MM-dd}");
-        using var lease = await RentClientAsync(accountId, ct, ImapLeasePriority.Background);
+        using var lease = await RentClientAsync(accountId, ImapLeasePriority.Background, ct);
         var client = lease.Client;
         var folder = await client.GetFolderAsync(folderName, ct);
         await folder.OpenAsync(FolderAccess.ReadOnly, ct);
@@ -259,7 +261,7 @@ public class ImapMailService : IMailService
     public async Task<List<MailMessageSummary>> GetMessagesSinceAsync(
         Guid accountId, string folderName, string sinceMessageId, int initialCount, CancellationToken ct = default)
     {
-        using var lease = await RentClientAsync(accountId, ct, ImapLeasePriority.Background);
+        using var lease = await RentClientAsync(accountId, ImapLeasePriority.Background, ct);
         var client = lease.Client;
         var folder = await client.GetFolderAsync(folderName, ct);
         await folder.OpenAsync(FolderAccess.ReadOnly, ct);
@@ -304,7 +306,7 @@ public class ImapMailService : IMailService
         Guid accountId, string folderName, string messageId,
         bool markRead, ImapLeasePriority priority, CancellationToken ct)
     {
-        using var lease = await RentClientAsync(accountId, ct, priority);
+        using var lease = await RentClientAsync(accountId, priority, ct);
         var client = lease.Client;
         var folder = await client.GetFolderAsync(folderName, ct);
         var access = markRead ? FolderAccess.ReadWrite : FolderAccess.ReadOnly;
@@ -319,7 +321,7 @@ public class ImapMailService : IMailService
                 | MessageSummaryItems.Envelope
                 | MessageSummaryItems.Flags
                 | MessageSummaryItems.BodyStructure,
-                new[] { "X-QuickMail-Compose-Mode" },
+                ComposeModeHeaders,
                 ct);
 
             var s = summaries.FirstOrDefault()
@@ -405,7 +407,7 @@ public class ImapMailService : IMailService
 
     public async Task MarkReadAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default)
     {
-        using var lease = await RentClientAsync(accountId, ct, ImapLeasePriority.Foreground);
+        using var lease = await RentClientAsync(accountId, ImapLeasePriority.Foreground, ct);
         var client = lease.Client;
         var folder = await client.GetFolderAsync(folderName, ct);
         await folder.OpenAsync(FolderAccess.ReadWrite, ct);
@@ -416,7 +418,7 @@ public class ImapMailService : IMailService
     public async Task MarkReadBatchAsync(Guid accountId, string folderName, IList<string> messageIds, CancellationToken ct = default)
     {
         if (messageIds.Count == 0) return;
-        using var lease = await RentClientAsync(accountId, ct, ImapLeasePriority.Foreground);
+        using var lease = await RentClientAsync(accountId, ImapLeasePriority.Foreground, ct);
         var client = lease.Client;
         var folder = await client.GetFolderAsync(folderName, ct);
         await folder.OpenAsync(FolderAccess.ReadWrite, ct);
@@ -426,7 +428,7 @@ public class ImapMailService : IMailService
 
     public async Task SetMessageFlaggedAsync(Guid accountId, string folderName, string messageId, bool flagged, CancellationToken ct = default)
     {
-        using var lease = await RentClientAsync(accountId, ct, ImapLeasePriority.Foreground);
+        using var lease = await RentClientAsync(accountId, ImapLeasePriority.Foreground, ct);
         var client = lease.Client;
         var folder = await client.GetFolderAsync(folderName, ct);
         await folder.OpenAsync(FolderAccess.ReadWrite, ct);
@@ -443,7 +445,7 @@ public class ImapMailService : IMailService
 
     public async Task MoveToTrashBatchAsync(Guid accountId, string folderName, IList<string> messageIds, CancellationToken ct = default)
     {
-        using var lease = await RentClientAsync(accountId, ct, ImapLeasePriority.Foreground);
+        using var lease = await RentClientAsync(accountId, ImapLeasePriority.Foreground, ct);
         var client = lease.Client;
         var folder = await client.GetFolderAsync(folderName, ct);
         await folder.OpenAsync(FolderAccess.ReadWrite, ct);
@@ -459,7 +461,7 @@ public class ImapMailService : IMailService
 
     public async Task MoveToTrashAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default)
     {
-        using var lease = await RentClientAsync(accountId, ct, ImapLeasePriority.Foreground);
+        using var lease = await RentClientAsync(accountId, ImapLeasePriority.Foreground, ct);
         var client = lease.Client;
         var folder = await client.GetFolderAsync(folderName, ct);
         await folder.OpenAsync(FolderAccess.ReadWrite, ct);
@@ -477,7 +479,7 @@ public class ImapMailService : IMailService
 
     public async Task<string?> FindDraftsFolderNameAsync(Guid accountId, CancellationToken ct = default)
     {
-        using var lease = await RentClientAsync(accountId, ct, ImapLeasePriority.Foreground);
+        using var lease = await RentClientAsync(accountId, ImapLeasePriority.Foreground, ct);
         var client = lease.Client;
         var drafts = await FindSpecialFolderAsync(client, ct, SpecialFolder.Drafts);
         return drafts?.FullName;
@@ -486,7 +488,7 @@ public class ImapMailService : IMailService
     public async Task<string> AppendDraftAsync(
         Guid accountId, ComposeModel draft, string? replaceMessageId, CancellationToken ct = default)
     {
-        using var lease = await RentClientAsync(accountId, ct, ImapLeasePriority.Foreground);
+        using var lease = await RentClientAsync(accountId, ImapLeasePriority.Foreground, ct);
         var client  = lease.Client;
         var account = _accounts[accountId];
 
@@ -521,7 +523,7 @@ public class ImapMailService : IMailService
     public async Task AppendToSentAsync(
         Guid accountId, ComposeModel sent, CancellationToken ct = default)
     {
-        using var lease = await RentClientAsync(accountId, ct, ImapLeasePriority.Foreground);
+        using var lease = await RentClientAsync(accountId, ImapLeasePriority.Foreground, ct);
         var client  = lease.Client;
         var account = _accounts[accountId];
 
@@ -547,7 +549,7 @@ public class ImapMailService : IMailService
 
     public async Task CopyMessagesAsync(Guid accountId, string folderName, IList<string> messageIds, string destinationFolder, CancellationToken ct = default)
     {
-        using var lease = await RentClientAsync(accountId, ct, ImapLeasePriority.Foreground);
+        using var lease = await RentClientAsync(accountId, ImapLeasePriority.Foreground, ct);
         var client = lease.Client;
         var folder = await client.GetFolderAsync(folderName, ct);
         var dest   = await client.GetFolderAsync(destinationFolder, ct);
@@ -558,7 +560,7 @@ public class ImapMailService : IMailService
 
     public async Task MoveMessagesAsync(Guid accountId, string folderName, IList<string> messageIds, string destinationFolder, CancellationToken ct = default)
     {
-        using var lease = await RentClientAsync(accountId, ct, ImapLeasePriority.Foreground);
+        using var lease = await RentClientAsync(accountId, ImapLeasePriority.Foreground, ct);
         var client = lease.Client;
         var folder = await client.GetFolderAsync(folderName, ct);
         var dest   = await client.GetFolderAsync(destinationFolder, ct);
@@ -571,7 +573,7 @@ public class ImapMailService : IMailService
 
     public async Task CreateFolderAsync(Guid accountId, string? parentFolderName, string name, CancellationToken ct = default)
     {
-        using var lease = await RentClientAsync(accountId, ct, ImapLeasePriority.Foreground);
+        using var lease = await RentClientAsync(accountId, ImapLeasePriority.Foreground, ct);
         var client = lease.Client;
         IMailFolder parent = string.IsNullOrEmpty(parentFolderName)
             ? client.GetFolder(client.PersonalNamespaces[0])
@@ -581,7 +583,7 @@ public class ImapMailService : IMailService
 
     public async Task DeleteFolderAsync(Guid accountId, string folderName, CancellationToken ct = default)
     {
-        using var lease = await RentClientAsync(accountId, ct, ImapLeasePriority.Foreground);
+        using var lease = await RentClientAsync(accountId, ImapLeasePriority.Foreground, ct);
         var client = lease.Client;
         var folder = await client.GetFolderAsync(folderName, ct);
 
@@ -604,7 +606,7 @@ public class ImapMailService : IMailService
 
     public async Task RenameFolderAsync(Guid accountId, string folderName, string newName, string? newParentFolderName, CancellationToken ct = default)
     {
-        using var lease = await RentClientAsync(accountId, ct, ImapLeasePriority.Foreground);
+        using var lease = await RentClientAsync(accountId, ImapLeasePriority.Foreground, ct);
         var client = lease.Client;
         var folder = await client.GetFolderAsync(folderName, ct);
         IMailFolder parent = string.IsNullOrEmpty(newParentFolderName)
@@ -615,7 +617,7 @@ public class ImapMailService : IMailService
 
     public async Task CopyFolderAsync(Guid accountId, string folderName, string? destinationParentName, CancellationToken ct = default)
     {
-        using var lease = await RentClientAsync(accountId, ct, ImapLeasePriority.Foreground);
+        using var lease = await RentClientAsync(accountId, ImapLeasePriority.Foreground, ct);
         await CopyFolderCoreAsync(lease.Client, folderName, destinationParentName, ct);
     }
 
@@ -649,7 +651,7 @@ public class ImapMailService : IMailService
 
     public async Task<int> EmptyTrashAsync(Guid accountId, CancellationToken ct = default)
     {
-        using var lease = await RentClientAsync(accountId, ct, ImapLeasePriority.Foreground);
+        using var lease = await RentClientAsync(accountId, ImapLeasePriority.Foreground, ct);
         var client = lease.Client;
         var trash  = await FindSpecialFolderAsync(client, ct, SpecialFolder.Trash, SpecialFolder.Junk);
 
@@ -676,7 +678,7 @@ public class ImapMailService : IMailService
 
     public async Task<IList<string>> GetFolderMessageIdsAsync(Guid accountId, string folderName, CancellationToken ct = default)
     {
-        using var lease = await RentClientAsync(accountId, ct, ImapLeasePriority.Background);
+        using var lease = await RentClientAsync(accountId, ImapLeasePriority.Background, ct);
         var client = lease.Client;
         var folder = await client.GetFolderAsync(folderName, ct);
         await folder.OpenAsync(FolderAccess.ReadOnly, ct);
@@ -698,7 +700,7 @@ public class ImapMailService : IMailService
         if (messageIds.Count == 0 || maxLines <= 0)
             return new Dictionary<string, string>();
 
-        using var lease = await RentClientAsync(accountId, ct, ImapLeasePriority.Background);
+        using var lease = await RentClientAsync(accountId, ImapLeasePriority.Background, ct);
         var client = lease.Client;
         var folder = await client.GetFolderAsync(folderName, ct);
         await folder.OpenAsync(FolderAccess.ReadOnly, ct);
@@ -869,7 +871,7 @@ public class ImapMailService : IMailService
 
     public async Task<int> PollAsync(Guid accountId, string folderName, CancellationToken ct = default)
     {
-        using var lease = await RentClientAsync(accountId, ct, ImapLeasePriority.Background);
+        using var lease = await RentClientAsync(accountId, ImapLeasePriority.Background, ct);
         var client = lease.Client;
         var folder = await client.GetFolderAsync(folderName, ct);
         await folder.OpenAsync(FolderAccess.ReadOnly, ct);
@@ -882,7 +884,7 @@ public class ImapMailService : IMailService
     public async Task<byte[]> DownloadAttachmentAsync(
         Guid accountId, string folderName, string messageId, string partSpecifier, CancellationToken ct = default)
     {
-        using var lease = await RentClientAsync(accountId, ct, ImapLeasePriority.Foreground);
+        using var lease = await RentClientAsync(accountId, ImapLeasePriority.Foreground, ct);
         var client = lease.Client;
         var folder = await client.GetFolderAsync(folderName, ct);
         await folder.OpenAsync(FolderAccess.ReadOnly, ct);
@@ -902,7 +904,7 @@ public class ImapMailService : IMailService
             var decoded = await folder.GetBodyPartAsync(mailKitUid, bodyPart, ct);
             using var stream = new MemoryStream();
             if (decoded is MimePart mp)
-                mp.Content!.DecodeTo(stream);
+                mp.Content!.DecodeTo(stream, CancellationToken.None);
             else if (decoded is MessagePart msgPart)
                 await msgPart.Message!.WriteToAsync(stream, ct);
             return stream.ToArray();
@@ -917,7 +919,7 @@ public class ImapMailService : IMailService
     /// are single-command objects, so every concurrent operation gets its own client.
     /// </summary>
     private async Task<ImapClientLease> RentClientAsync(
-        Guid accountId, CancellationToken ct, ImapLeasePriority priority)
+        Guid accountId, ImapLeasePriority priority, CancellationToken ct)
     {
         ThrowIfDisposed();
 
@@ -1450,7 +1452,7 @@ public class ImapMailService : IMailService
 
     public async Task PermanentlyDeleteBatchAsync(Guid accountId, string folderName, IList<string> messageIds, CancellationToken ct = default)
     {
-        using var lease = await RentClientAsync(accountId, ct, ImapLeasePriority.Foreground);
+        using var lease = await RentClientAsync(accountId, ImapLeasePriority.Foreground, ct);
         var client = lease.Client;
         var folder = await client.GetFolderAsync(folderName, ct);
         await folder.OpenAsync(FolderAccess.ReadWrite, ct);
@@ -1468,7 +1470,7 @@ public class ImapMailService : IMailService
         if (!_pools.ContainsKey(accountId)) return;
         try
         {
-            using var lease = await RentClientAsync(accountId, ct, ImapLeasePriority.Background);
+            using var lease = await RentClientAsync(accountId, ImapLeasePriority.Background, ct);
             await lease.Client.NoOpAsync(ct);
         }
         catch (OperationCanceledException) { throw; }
@@ -1484,7 +1486,7 @@ public class ImapMailService : IMailService
         if (!_pools.ContainsKey(accountId)) return 0;
         try
         {
-            using var lease = await RentClientAsync(accountId, ct, ImapLeasePriority.Background);
+            using var lease = await RentClientAsync(accountId, ImapLeasePriority.Background, ct);
             var client = lease.Client;
             var trashFolder = await FindSpecialFolderAsync(client, ct, SpecialFolder.Trash, SpecialFolder.Junk);
             if (trashFolder == null) return 0;

--- a/QuickMail/Services/MailServiceRouter.cs
+++ b/QuickMail/Services/MailServiceRouter.cs
@@ -19,7 +19,7 @@ namespace QuickMail.Services;
 public class MailServiceRouter : IMailService
 {
     private readonly ConcurrentDictionary<Guid, IMailService> _byAccount = new();
-    private readonly IReadOnlyList<IMailService> _allBackends; // ordered, for event aggregation + fan-out
+    private readonly List<IMailService> _allBackends; // ordered, for event aggregation + fan-out
     private readonly IMailService _defaultBackend;             // fallback for unregistered accounts
 
     public MailServiceRouter(IEnumerable<IMailService> backends)

--- a/QuickMail/Services/OAuthRouter.cs
+++ b/QuickMail/Services/OAuthRouter.cs
@@ -1,0 +1,51 @@
+using System.Threading;
+using System.Threading.Tasks;
+using QuickMail.Models;
+
+namespace QuickMail.Services;
+
+/// <summary>
+/// Routes OAuth calls to <see cref="IOAuthService"/> (Microsoft MSAL) or
+/// <see cref="IGoogleOAuthService"/> based on the account's <see cref="AuthType"/>.
+/// Implements <see cref="IOAuthService"/> so all existing callers need no changes.
+/// </summary>
+public class OAuthRouter : IOAuthService
+{
+    private readonly IOAuthService _microsoft;
+    private readonly IGoogleOAuthService _google;
+
+    public OAuthRouter(IOAuthService microsoft, IGoogleOAuthService google)
+    {
+        _microsoft = microsoft;
+        _google    = google;
+    }
+
+    public Task<string> GetAccessTokenAsync(AccountModel account, CancellationToken ct = default)
+    {
+        return account.AuthType == AuthType.OAuth2Google
+            ? _google.GetAccessTokenAsync(account.Username, ct)
+            : _microsoft.GetAccessTokenAsync(account, ct);
+    }
+
+    public Task<string> GetAccessTokenAsync(AccountModel account, string[] scopes, CancellationToken ct = default)
+    {
+        // Google scopes are fixed at consent time; the scopes parameter applies only to Microsoft.
+        return account.AuthType == AuthType.OAuth2Google
+            ? _google.GetAccessTokenAsync(account.Username, ct)
+            : _microsoft.GetAccessTokenAsync(account, scopes, ct);
+    }
+
+    public Task<OAuthResult> SignInInteractiveAsync(AccountModel account, CancellationToken ct = default)
+    {
+        return account.AuthType == AuthType.OAuth2Google
+            ? _google.SignInInteractiveAsync(account.Username, ct)
+            : _microsoft.SignInInteractiveAsync(account, ct);
+    }
+
+    public Task SignOutAsync(AccountModel account)
+    {
+        return account.AuthType == AuthType.OAuth2Google
+            ? _google.SignOutAsync(account.Username)
+            : _microsoft.SignOutAsync(account);
+    }
+}

--- a/QuickMail/Services/SmtpService.cs
+++ b/QuickMail/Services/SmtpService.cs
@@ -46,7 +46,7 @@ public class SmtpService : ISendMailService
             await client.ConnectAsync(account.SmtpHost, account.SmtpPort, ssl, ct);
             LogService.Log($"SmtpService: connected to {account.SmtpHost}:{account.SmtpPort}");
 
-            if (account.AuthType == AuthType.OAuth2Microsoft)
+            if (account.AuthType is AuthType.OAuth2Microsoft or AuthType.OAuth2Google)
             {
                 LogService.Debug($"SmtpService: authenticating via XOAUTH2");
                 var token = await _oauth.GetAccessTokenAsync(account, ct);
@@ -97,7 +97,7 @@ public class SmtpService : ISendMailService
             LogService.Log($"SmtpService: sending ICS reply to {account.SmtpHost}:{account.SmtpPort}");
             await client.ConnectAsync(account.SmtpHost, account.SmtpPort, ssl, ct);
 
-            if (account.AuthType == AuthType.OAuth2Microsoft)
+            if (account.AuthType is AuthType.OAuth2Microsoft or AuthType.OAuth2Google)
             {
                 var token = await _oauth.GetAccessTokenAsync(account, ct);
                 await client.AuthenticateAsync(new SaslMechanismOAuth2(account.Username, token), ct);

--- a/QuickMail/ViewModels/AccountEditorViewModel.cs
+++ b/QuickMail/ViewModels/AccountEditorViewModel.cs
@@ -34,6 +34,7 @@ public abstract partial class AccountEditorViewModel : ObservableObject
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(IsPasswordAuth))]
     [NotifyPropertyChangedFor(nameof(IsOAuth2))]
+    [NotifyPropertyChangedFor(nameof(IsGoogleOAuth))]
     [NotifyPropertyChangedFor(nameof(AuthTypeIndex))]
     private AuthType _authType = AuthType.Password;
 
@@ -53,11 +54,28 @@ public abstract partial class AccountEditorViewModel : ObservableObject
 
     public bool IsPasswordAuth => AuthType == AuthType.Password;
     public bool IsOAuth2       => AuthType == AuthType.OAuth2Microsoft;
+    public bool IsGoogleOAuth  => AuthType == AuthType.OAuth2Google;
+
+    /// <summary>
+    /// Whether the Google OAuth option is available in this editor context.
+    /// Derived classes override to reflect their feature-gate state.
+    /// </summary>
+    public virtual bool ShowGoogleAuthOption => false;
 
     public int AuthTypeIndex
     {
-        get => AuthType == AuthType.Password ? 0 : 1;
-        set => AuthType = value == 0 ? AuthType.Password : AuthType.OAuth2Microsoft;
+        get => AuthType switch
+        {
+            AuthType.OAuth2Microsoft => 1,
+            AuthType.OAuth2Google    => 2,
+            _                        => 0,
+        };
+        set => AuthType = value switch
+        {
+            1 => AuthType.OAuth2Microsoft,
+            2 => AuthType.OAuth2Google,
+            _ => AuthType.Password,
+        };
     }
 
     protected AccountEditorViewModel(IMailService mailService, IOAuthService oauth)
@@ -98,6 +116,29 @@ public abstract partial class AccountEditorViewModel : ObservableObject
     }
 
     [RelayCommand]
+    private async Task SignInGoogleAsync()
+    {
+        IsBusy = true;
+        StatusText = "Opening browser for Google sign-in…";
+        try
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
+            var tempAccount = new AccountModel { Username = Username, AuthType = AuthType.OAuth2Google, BackendKind = BackendKind.ImapSmtp };
+            var result = await OAuthService.SignInInteractiveAsync(tempAccount, cts.Token);
+            Username = result.Username;
+            StatusText = $"Signed in as {result.Username}";
+        }
+        catch (Exception ex)
+        {
+            StatusText = $"Sign-in failed: {ex.Message}";
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    [RelayCommand]
     private async Task TestConnectionAsync()
     {
         // Branch on backend before the IMAP-specific validation. Graph accounts have no IMAP
@@ -107,6 +148,12 @@ public abstract partial class AccountEditorViewModel : ObservableObject
             // A Graph account is verified by the OAuth sign-in itself (it acquires a Graph token and
             // populates the username from /me). There is no separate host/port to probe.
             StatusText = "For Microsoft 365, use Sign in with Microsoft to verify access.";
+            return;
+        }
+
+        if (IsGoogleOAuth)
+        {
+            StatusText = "For Gmail, use Sign in with Google to verify access.";
             return;
         }
 

--- a/QuickMail/ViewModels/AccountManagerViewModel.cs
+++ b/QuickMail/ViewModels/AccountManagerViewModel.cs
@@ -27,6 +27,8 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
 
     public bool IsEditing => SelectedAccount != null;
 
+    public override bool ShowGoogleAuthOption => _featureGate.IsEnabled(FeatureFlag.GoogleAuth);
+
     public AccountManagerViewModel(
         IAccountService accountService,
         ICredentialService credentials,
@@ -136,10 +138,10 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
         try   { await _localStore.DeleteAccountDataAsync(account.Id); }
         catch (Exception ex) { LogService.Log($"AccountManager.DeleteAccount: failed to purge mail.db — {ex.Message}"); }
 
-        if (account.AuthType == AuthType.OAuth2Microsoft)
+        if (account.AuthType is AuthType.OAuth2Microsoft or AuthType.OAuth2Google)
         {
             try   { await _oauth.SignOutAsync(account); }
-            catch (Exception ex) { LogService.Log($"AccountManager.DeleteAccount: failed MSAL sign-out — {ex.Message}"); }
+            catch (Exception ex) { LogService.Log($"AccountManager.DeleteAccount: failed OAuth sign-out — {ex.Message}"); }
         }
 
         StatusText = "Account deleted.";

--- a/QuickMail/ViewModels/AddAccountViewModel.cs
+++ b/QuickMail/ViewModels/AddAccountViewModel.cs
@@ -7,9 +7,13 @@ namespace QuickMail.ViewModels;
 
 public partial class AddAccountViewModel : AccountEditorViewModel
 {
+    private readonly IFeatureGate _gate;
+
     public AddAccountViewModel(IFeatureGate gate, IMailService mailService, IOAuthService oauth)
         : base(mailService, oauth)
     {
+        _gate = gate;
+
         var backends = new List<BackendKindOption>
         {
             new(BackendKind.ImapSmtp, "Standard IMAP/SMTP"),
@@ -29,6 +33,8 @@ public partial class AddAccountViewModel : AccountEditorViewModel
     /// one option exists (the default), it renders a static label to reduce clutter.
     /// </summary>
     public bool ShowBackendPicker => AvailableBackends.Count > 1;
+
+    public override bool ShowGoogleAuthOption => _gate.IsEnabled(FeatureFlag.GoogleAuth);
 
     [ObservableProperty]
     private BackendKindOption _selectedBackend;
@@ -52,8 +58,7 @@ public partial class AddAccountViewModel : AccountEditorViewModel
 
     protected override void OnAuthTypeChangedInternal(AuthType value)
     {
-        // Auto-fill personal Outlook.com IMAP/SMTP settings only for the IMAP backend — a Graph
-        // account also uses OAuth but must NOT get IMAP host defaults.
+        // Auto-fill server settings for OAuth providers.
         if (value == AuthType.OAuth2Microsoft && BackendKind == BackendKind.ImapSmtp)
         {
             ImapHost              = "outlook.office365.com";
@@ -61,6 +66,18 @@ public partial class AddAccountViewModel : AccountEditorViewModel
             ImapUseSsl            = true;
             ImapAcceptInvalidCert = false;
             SmtpHost              = "smtp-mail.outlook.com";
+            SmtpPort              = 587;
+            SmtpUseSsl            = false;
+            SmtpAcceptInvalidCert = false;
+            Password              = string.Empty;
+        }
+        else if (value == AuthType.OAuth2Google)
+        {
+            ImapHost              = "imap.gmail.com";
+            ImapPort              = 993;
+            ImapUseSsl            = true;
+            ImapAcceptInvalidCert = false;
+            SmtpHost              = "smtp.gmail.com";
             SmtpPort              = 587;
             SmtpUseSsl            = false;
             SmtpAcceptInvalidCert = false;

--- a/QuickMail/ViewModels/AddAccountViewModel.cs
+++ b/QuickMail/ViewModels/AddAccountViewModel.cs
@@ -23,6 +23,16 @@ public partial class AddAccountViewModel : AccountEditorViewModel
 
         AvailableBackends = backends;
         _selectedBackend = backends[0];
+
+        PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName != nameof(Username)) return;
+            if (!ShowGoogleAuthOption) return;
+            if (AuthType == AuthType.OAuth2Google) return;
+            var lower = Username.ToLowerInvariant();
+            if (lower.EndsWith("@gmail.com") || lower.EndsWith("@googlemail.com"))
+                AuthType = AuthType.OAuth2Google;
+        };
     }
 
     /// <summary>Backend options offered in the dialog, derived from the feature gate.</summary>
@@ -54,16 +64,6 @@ public partial class AddAccountViewModel : AccountEditorViewModel
             SmtpHost = string.Empty;
             Password = string.Empty;
         }
-    }
-
-    partial void OnUsernameChanged(string value)
-    {
-        if (!ShowGoogleAuthOption) return;
-        if (AuthType == AuthType.OAuth2Google) return;
-
-        var lower = value.ToLowerInvariant();
-        if (lower.EndsWith("@gmail.com") || lower.EndsWith("@googlemail.com"))
-            AuthType = AuthType.OAuth2Google;
     }
 
     protected override void OnAuthTypeChangedInternal(AuthType value)

--- a/QuickMail/ViewModels/AddAccountViewModel.cs
+++ b/QuickMail/ViewModels/AddAccountViewModel.cs
@@ -56,6 +56,16 @@ public partial class AddAccountViewModel : AccountEditorViewModel
         }
     }
 
+    partial void OnUsernameChanged(string value)
+    {
+        if (!ShowGoogleAuthOption) return;
+        if (AuthType == AuthType.OAuth2Google) return;
+
+        var lower = value.ToLowerInvariant();
+        if (lower.EndsWith("@gmail.com") || lower.EndsWith("@googlemail.com"))
+            AuthType = AuthType.OAuth2Google;
+    }
+
     protected override void OnAuthTypeChangedInternal(AuthType value)
     {
         // Auto-fill server settings for OAuth providers.

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -4000,10 +4000,10 @@ public partial class MainViewModel : ObservableObject
         try   { await _localStore.DeleteAccountDataAsync(account.Id); }
         catch (Exception ex) { LogService.Log($"DeleteAccount: failed to purge mail.db — {ex.Message}"); }
 
-        if (account.AuthType == AuthType.OAuth2Microsoft)
+        if (account.AuthType is AuthType.OAuth2Microsoft or AuthType.OAuth2Google)
         {
             try   { await _oauthService.SignOutAsync(account); }
-            catch (Exception ex) { LogService.Log($"DeleteAccount: failed MSAL sign-out — {ex.Message}"); }
+            catch (Exception ex) { LogService.Log($"DeleteAccount: failed OAuth sign-out — {ex.Message}"); }
         }
 
         StatusText = $"Account '{account.AccountLabel}' removed.";

--- a/QuickMail/Views/AccountManagerDialog.xaml
+++ b/QuickMail/Views/AccountManagerDialog.xaml
@@ -100,6 +100,7 @@
                               TabIndex="3">
                         <ComboBoxItem>Password</ComboBoxItem>
                         <ComboBoxItem>Microsoft OAuth2 (Outlook.com)</ComboBoxItem>
+                        <ComboBoxItem Visibility="{Binding ShowGoogleAuthOption, Converter={StaticResource BoolToVisibility}}">Google OAuth (Gmail)</ComboBoxItem>
                     </ComboBox>
                 </StackPanel>
 
@@ -113,12 +114,21 @@
                                  PasswordChanged="PasswordBox_PasswordChanged"/>
                 </StackPanel>
 
-                <!-- OAuth2 sign-in panel -->
+                <!-- Microsoft OAuth2 sign-in panel -->
                 <StackPanel Visibility="{Binding IsOAuth2, Converter={StaticResource BoolToVisibility}}"
                             Margin="0,4,0,0">
                     <Button Content="Sign in with _Microsoft…"
                             Command="{Binding SignInMicrosoftCommand}"
                             AutomationProperties.Name="Sign in with Microsoft account in browser"
+                            HorizontalAlignment="Left" MinWidth="200" TabIndex="5"/>
+                </StackPanel>
+
+                <!-- Google OAuth sign-in panel -->
+                <StackPanel Visibility="{Binding IsGoogleOAuth, Converter={StaticResource BoolToVisibility}}"
+                            Margin="0,4,0,0">
+                    <Button Content="Sign in with _Google…"
+                            Command="{Binding SignInGoogleCommand}"
+                            AutomationProperties.Name="Sign in with Google account in browser"
                             HorizontalAlignment="Left" MinWidth="200" TabIndex="5"/>
                 </StackPanel>
 

--- a/QuickMail/Views/AddAccountDialog.xaml
+++ b/QuickMail/Views/AddAccountDialog.xaml
@@ -65,6 +65,7 @@
                               TabIndex="3">
                         <ComboBoxItem>Password</ComboBoxItem>
                         <ComboBoxItem>Microsoft OAuth2 (Outlook.com)</ComboBoxItem>
+                        <ComboBoxItem Visibility="{Binding ShowGoogleAuthOption, Converter={StaticResource BoolToVisibility}}">Google OAuth (Gmail)</ComboBoxItem>
                     </ComboBox>
                 </StackPanel>
 
@@ -78,12 +79,21 @@
                                  PasswordChanged="PasswordBox_PasswordChanged"/>
                 </StackPanel>
 
-                <!-- OAuth2 sign-in panel (hidden for password auth) -->
+                <!-- Microsoft OAuth2 sign-in panel -->
                 <StackPanel Visibility="{Binding IsOAuth2, Converter={StaticResource BoolToVisibility}}"
                             Margin="0,4,0,0">
                     <Button Content="Sign in with _Microsoft…"
                             Command="{Binding SignInMicrosoftCommand}"
                             AutomationProperties.Name="Sign in with Microsoft account in browser"
+                            HorizontalAlignment="Left" MinWidth="200" TabIndex="5"/>
+                </StackPanel>
+
+                <!-- Google OAuth sign-in panel -->
+                <StackPanel Visibility="{Binding IsGoogleOAuth, Converter={StaticResource BoolToVisibility}}"
+                            Margin="0,4,0,0">
+                    <Button Content="Sign in with _Google…"
+                            Command="{Binding SignInGoogleCommand}"
+                            AutomationProperties.Name="Sign in with Google account in browser"
                             HorizontalAlignment="Left" MinWidth="200" TabIndex="5"/>
                 </StackPanel>
 

--- a/docs/GOOGLE-AUTH-SPEC.md
+++ b/docs/GOOGLE-AUTH-SPEC.md
@@ -1,0 +1,342 @@
+# Google OAuth 2.0 Authentication — Implementation Spec
+
+## Context
+
+QuickMail already has working Microsoft OAuth via MSAL (`OAuthService`, `AuthType.OAuth2Microsoft`).
+This spec adds Google OAuth so users can add Gmail accounts using IMAP/SMTP with the XOAUTH2
+mechanism — the same wire protocol already used for Microsoft accounts.
+
+The user has already registered QuickMail as a Desktop app in Google Cloud Console and added
+their Gmail address as a test user. Client ID and Client Secret are available.
+
+---
+
+## Scope
+
+- Add Gmail as an account type in the Add Account dialog
+- OAuth 2.0 installed-app flow (browser → localhost redirect → token exchange)
+- Refresh token stored in Windows Credential Manager via `CredentialService`
+- Access token fetched/refreshed in memory; passed to MailKit's existing `SaslMechanismOAuth2`
+- No Google REST API usage — IMAP (`imap.gmail.com:993`) and SMTP (`smtp.gmail.com:587`) only
+
+---
+
+## Prerequisites
+
+The following are assumed complete before implementation begins:
+
+- Google Cloud Console app registered as type **Desktop app**
+- Gmail API enabled on the project
+- Test user (kelly@theideaplace.net or equivalent) added to the OAuth consent screen
+- Client ID and Client Secret recorded and ready to add to `config.ini`
+
+---
+
+## Client credential storage
+
+The Google Client ID and Secret are stored in the user's `config.ini` (in `%APPDATA%\QuickMail`),
+**not** in the source repo. This keeps them out of version control and means the same binary can
+work for any user who configures their own Google app.
+
+Add two new fields to `ConfigModel`:
+
+```csharp
+public string GoogleClientId     { get; set; } = string.Empty;
+public string GoogleClientSecret { get; set; } = string.Empty;
+```
+
+`ConfigService` reads/writes these automatically via its existing INI serialization. The user sets
+them once and they persist across app restarts. No UI is needed for this — config.ini is a
+power-user file.
+
+---
+
+## New AuthType value
+
+```csharp
+public enum AuthType
+{
+    Password,
+    OAuth2Microsoft,
+    OAuth2Google,       // ← new
+}
+```
+
+---
+
+## New NuGet package
+
+`Google.Apis.Auth` (latest stable, currently ~1.68). This provides:
+
+- `GoogleAuthorizationCodeFlow` — manages the OAuth 2.0 code flow
+- `LocalServerCodeReceiver` — opens a loopback HTTP listener for the redirect URI
+- `UserCredential` — wraps the access + refresh token and handles automatic refresh
+
+No `Google.Apis.Gmail.v1` package is needed — we use IMAP/SMTP, not the Gmail REST API.
+
+---
+
+## Token storage
+
+Google issues a **refresh token** once (at first consent) and short-lived **access tokens**
+(valid ~1 hour). The refresh token must survive app restarts.
+
+- **Refresh token**: stored in Windows Credential Manager via the existing `CredentialService`,
+  keyed as `QuickMail/Google/<username>` (same pattern as passwords). The `CredentialService`
+  already handles secure storage; no new storage mechanism is needed.
+- **Access token**: held in memory inside `GoogleOAuthService`. Refreshed automatically when
+  expired using `UserCredential.GetAccessTokenForRequestAsync()`.
+
+---
+
+## New service: `GoogleOAuthService`
+
+New file: `QuickMail/Services/GoogleOAuthService.cs`
+
+```csharp
+public interface IGoogleOAuthService
+{
+    /// <summary>
+    /// Returns a valid access token, refreshing silently if needed.
+    /// Throws if no stored credential exists — call SignInInteractiveAsync first.
+    /// </summary>
+    Task<string> GetAccessTokenAsync(string username, CancellationToken ct = default);
+
+    /// <summary>
+    /// Opens the system browser for Google sign-in. Stores the resulting credential
+    /// (including refresh token) and returns the access token + confirmed email address.
+    /// </summary>
+    Task<OAuthResult> SignInInteractiveAsync(string loginHint, CancellationToken ct = default);
+
+    Task SignOutAsync(string username);
+}
+```
+
+Implementation notes:
+- Constructor receives `IConfigService` (for Client ID/Secret) and `ICredentialService` (for
+  refresh token storage).
+- On startup, loads any stored refresh token from `CredentialService` and reconstructs a
+  `UserCredential` so silent refresh works without a new browser flow.
+- `SignInInteractiveAsync` uses `LocalServerCodeReceiver` so the browser redirects to
+  `http://127.0.0.1:<dynamic-port>/` — this matches Google's "Desktop app" redirect URI rules.
+- After sign-in, stores the refresh token via `CredentialService.SaveCredential(key, refreshToken)`.
+- `GetAccessTokenAsync` calls `credential.GetAccessTokenForRequestAsync()` which handles refresh
+  transparently.
+
+---
+
+## OAuthRouter
+
+Rather than modifying `OAuthService` (Microsoft-only) or making `ImapMailService` aware of two
+different OAuth services, introduce a thin router.
+
+New file: `QuickMail/Services/OAuthRouter.cs`
+
+```csharp
+public class OAuthRouter : IOAuthService
+{
+    private readonly IOAuthService _microsoft;
+    private readonly IGoogleOAuthService _google;
+
+    public OAuthRouter(IOAuthService microsoft, IGoogleOAuthService google) { ... }
+
+    public Task<string> GetAccessTokenAsync(AccountModel account, CancellationToken ct = default)
+    {
+        return account.AuthType == AuthType.OAuth2Google
+            ? _google.GetAccessTokenAsync(account.Username, ct)
+            : _microsoft.GetAccessTokenAsync(account, ct);
+    }
+
+    // SignInInteractiveAsync and SignOutAsync route the same way.
+}
+```
+
+`App.xaml.cs` wires this up:
+```csharp
+var msOAuth     = new OAuthService(profile);
+var googleOAuth = new GoogleOAuthService(configService, credentialService);
+var oauthRouter = new OAuthRouter(msOAuth, googleOAuth);
+// pass oauthRouter wherever IOAuthService is needed
+```
+
+`ImapMailService` and `SmtpService` already call `_oauth.GetAccessTokenAsync(account, ct)` and
+pass the result to `SaslMechanismOAuth2(account.Username, token)`. No changes needed there beyond
+adding `AuthType.OAuth2Google` to the existing `if (account.AuthType == AuthType.OAuth2Microsoft)`
+guard — change it to `if (account.AuthType is AuthType.OAuth2Microsoft or AuthType.OAuth2Google)`.
+
+---
+
+## AccountEditorViewModel changes
+
+Add `SignInGoogleCommand` alongside the existing `SignInMicrosoftCommand`:
+
+```csharp
+[RelayCommand]
+private async Task SignInGoogleAsync()
+{
+    IsBusy = true;
+    StatusText = "Opening browser for Google sign-in…";
+    try
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
+        var result = await GoogleOAuthService.SignInInteractiveAsync(Username, cts.Token);
+        Username   = result.Username;
+        StatusText = $"Signed in as {result.Username}";
+    }
+    catch (Exception ex)
+    {
+        StatusText = $"Sign-in failed: {ex.Message}";
+    }
+    finally { IsBusy = false; }
+}
+```
+
+`AccountEditorViewModel` needs `IGoogleOAuthService` injected (or a combined wrapper). The
+constructor signature changes to accept it.
+
+New computed property to drive XAML visibility:
+```csharp
+public bool IsGoogleOAuth => AuthType == AuthType.OAuth2Google;
+```
+
+---
+
+## AddAccountViewModel changes
+
+Add `AuthType.OAuth2Google` as a selectable option. When selected:
+- Auto-fill: `imap.gmail.com:993 SSL`, `smtp.gmail.com:587 STARTTLS`
+- Clear password field
+- `IsPasswordAuth = false`, `IsOAuth2 = false`, `IsGoogleOAuth = true`
+
+The `AuthType` combo in `AddAccountDialog.xaml` gains a third item:
+```xml
+<ComboBoxItem>Google OAuth (Gmail)</ComboBoxItem>
+```
+
+`AuthTypeIndex` mapping expands to handle 0/1/2.
+
+---
+
+## AddAccountDialog.xaml changes
+
+Add a "Sign in with Google" button, visible only when `IsGoogleOAuth` is true:
+
+```xml
+<StackPanel Visibility="{Binding IsGoogleOAuth, Converter={StaticResource BoolToVisibility}}"
+            Margin="0,4,0,0">
+    <Button Content="Sign in with _Google…"
+            Command="{Binding SignInGoogleCommand}"
+            AutomationProperties.Name="Sign in with Google account in browser"
+            HorizontalAlignment="Left" MinWidth="200" TabIndex="5"/>
+</StackPanel>
+```
+
+The existing Microsoft sign-in panel already uses the same pattern.
+
+---
+
+## FeatureFlag
+
+Add a `GoogleAuth` flag to `FeatureFlag.cs` (default `false`):
+
+```csharp
+/// <summary>
+/// Shows the Google OAuth option in Add Account.
+/// Default: false. Enable in config.ini as FeatureFlag_GoogleAuth=true once tested.
+/// </summary>
+GoogleAuth,
+```
+
+`AddAccountViewModel` gates the Google option behind `gate.IsEnabled(FeatureFlag.GoogleAuth)`,
+same as `GraphBackend` gates the Microsoft Graph option.
+
+---
+
+## Keyboard walkthrough
+
+### Adding a Gmail account
+
+1. User opens Account Manager (menu or keyboard shortcut).
+2. User activates "Add Account" button.
+3. Add Account dialog opens. Focus lands on "Account Name" field.
+4. User fills in Account Name, Display Name, Email / Username.
+5. User Tabs to the "Authentication" combo box. Currently reads "Password".
+6. User presses Alt+Down, arrows to "Google OAuth (Gmail)", presses Enter (or Tab).
+   Screen reader announces: "Google OAuth (Gmail)".
+   IMAP host auto-fills to `imap.gmail.com`, port 993. SMTP fills to `smtp.gmail.com`, port 587.
+   Password field collapses. "Sign in with Google" button appears.
+7. User Tabs to "Sign in with Google" and presses Enter (or Space).
+   Screen reader announces: "Opening browser for Google sign-in…" (Status announce, Result category).
+   Default browser opens to Google's OAuth consent screen.
+8. User signs in to Google and grants permission in the browser.
+   Browser shows a plain "Authentication successful" page and can be closed.
+9. Focus returns to the dialog. Status field reads: "Signed in as user@gmail.com".
+   Screen reader announces the status text (it is a live region or re-read on focus).
+   Username field is now populated with the confirmed Gmail address.
+10. User Tabs to "Add Account" button and presses Enter.
+    Account is saved. Dialog closes. Account appears in the account list.
+    Screen reader announces: "Account added." (Result category).
+
+### Token refresh (background, transparent to user)
+
+At IMAP connect time (startup or after idle), `ImapMailService` calls
+`_oauth.GetAccessTokenAsync(account)`. The router calls `GoogleOAuthService.GetAccessTokenAsync`
+which calls `UserCredential.GetAccessTokenForRequestAsync()`. If the access token is still valid
+it is returned immediately. If expired, `UserCredential` silently uses the stored refresh token to
+obtain a new access token — no browser, no user interaction. If the refresh token itself is
+revoked (user removed app access in Google settings), the connect attempt throws
+`OperationCanceledException` or a custom auth exception; `ImapMailService` surfaces this as a
+connection failure and the account shows as disconnected.
+
+---
+
+## Infrastructure changes
+
+| What | Change |
+|------|--------|
+| `AuthType` enum | Add `OAuth2Google` |
+| `FeatureFlag` enum | Add `GoogleAuth` |
+| `ConfigModel` | Add `GoogleClientId`, `GoogleClientSecret` |
+| `GoogleOAuthService.cs` | New service, new interface `IGoogleOAuthService` |
+| `OAuthRouter.cs` | New class implementing `IOAuthService`, routes by `AuthType` |
+| `App.xaml.cs` | Wire `GoogleOAuthService` and `OAuthRouter`; pass router as `IOAuthService` |
+| `AccountEditorViewModel` | Add `SignInGoogleCommand`, `IsGoogleOAuth` property |
+| `AddAccountViewModel` | Add Google option, `OnAuthTypeChanged` case for Google host auto-fill |
+| `AddAccountDialog.xaml` | New "Google OAuth" combo item, "Sign in with Google" button panel |
+| `ImapMailService.cs` | Extend OAuth guard: `OAuth2Microsoft or OAuth2Google` |
+| `SmtpService.cs` | Same extend |
+| `StubServices.cs` (tests) | Extend `StubOAuthService` to handle `OAuth2Google` without crashing |
+| NuGet | Add `Google.Apis.Auth` |
+
+No changes to:
+- `OAuthService` (Microsoft MSAL — untouched)
+- `CredentialService` (already stores arbitrary secrets by key)
+- `BackendKind` (Google uses `ImapSmtp` backend, no new backend type)
+- F6 ring (no new primary pane)
+- `CommandRegistry` (no new commands)
+
+---
+
+## Announcements
+
+| Trigger | Text | Category |
+|---------|------|----------|
+| Sign-in button activated | "Opening browser for Google sign-in…" | `Status` |
+| Sign-in completes | "Signed in as {email}" (via StatusText binding, not programmatic announce) | n/a |
+| Sign-in fails | "Sign-in failed: {reason}" (via StatusText binding) | n/a |
+| Account added | "Account added." | `Result` |
+
+Status and error text are surfaced via the existing `StatusText` binding on the Add Account
+dialog, which is already a visible text block. No new `AccessibilityHelper.Announce` calls are
+needed for the happy path. The failure path inherits the existing pattern.
+
+---
+
+## Out of scope
+
+- **Gmail REST API**: not used; all access is IMAP/SMTP with OAuth tokens.
+- **Google Workspace / organisational accounts**: the consent screen and scope (`https://mail.google.com/`) work for personal Gmail. Workspace accounts may need additional admin consent — defer.
+- **Multiple Google accounts**: the existing multi-account architecture handles this; each account stores its own refresh token keyed by username.
+- **Editing an existing account's auth method**: changing from password to Google OAuth on an existing account is not supported — delete and re-add (same restriction as Microsoft OAuth today).
+- **Token revocation detection in UI**: if a refresh token is revoked, the account shows as disconnected with a generic connection error. A specific "re-authenticate" prompt is not in scope.
+- **Linux / macOS**: `CredentialService` uses Windows Credential Manager. Not in scope.

--- a/docs/GoogleOAuthService.Credentials.example
+++ b/docs/GoogleOAuthService.Credentials.example
@@ -1,0 +1,18 @@
+// To build QuickMail with Google OAuth support:
+//
+// 1. Register a Desktop app in Google Cloud Console and enable the Gmail API.
+// 2. Copy this file to:
+//        QuickMail/Services/GoogleOAuthService.Credentials.cs
+// 3. Fill in your Client ID and Client Secret below.
+// 4. That file is gitignored and will never be committed.
+//
+// The distributed binary includes the baked-in credentials; end users do not
+// need to configure anything. Only builders/contributors need this file.
+
+namespace QuickMail.Services;
+
+public partial class GoogleOAuthService
+{
+    private const string ClientId     = "YOUR_CLIENT_ID.apps.googleusercontent.com";
+    private const string ClientSecret = "YOUR_CLIENT_SECRET";
+}

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>QuickMail Privacy Policy</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      font-size: 16px;
+      line-height: 1.6;
+      color: #24292e;
+      max-width: 760px;
+      margin: 0 auto;
+      padding: 2rem 1.5rem 4rem;
+    }
+    h1 { font-size: 2rem; border-bottom: 1px solid #e1e4e8; padding-bottom: 0.5rem; }
+    h2 { font-size: 1.25rem; margin-top: 2rem; }
+    p, li { margin-top: 0.5rem; }
+    ul { padding-left: 1.5rem; }
+    code {
+      font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+      font-size: 0.9em;
+      background: #f6f8fa;
+      padding: 0.1em 0.4em;
+      border-radius: 3px;
+    }
+    .effective { color: #586069; font-size: 0.9rem; margin-top: -0.5rem; }
+    .callout {
+      border-left: 4px solid #0366d6;
+      background: #f1f8ff;
+      padding: 0.75rem 1rem;
+      margin: 1.5rem 0;
+      border-radius: 0 4px 4px 0;
+    }
+  </style>
+</head>
+<body>
+
+<h1>QuickMail Privacy Policy</h1>
+<p class="effective">Effective date: June 17, 2026</p>
+
+<div class="callout">
+  <strong>Short version:</strong> QuickMail is a local desktop application with no servers. Your email stays on your device. Nothing you read, write, or receive through QuickMail is transmitted to the developer or any third party by the application.
+</div>
+
+<h2>What QuickMail is</h2>
+<p>
+  QuickMail is a free, open-source Windows desktop email client. It runs entirely on your computer.
+  There are no QuickMail servers, no accounts to create with the developer, and no cloud sync.
+</p>
+
+<h2>Information QuickMail accesses</h2>
+
+<h3>Email account credentials</h3>
+<p>
+  QuickMail connects to your email provider on your behalf. For standard IMAP/SMTP accounts,
+  your password is stored in <strong>Windows Credential Manager</strong> — a secure, encrypted
+  store built into Windows — and is never written to disk in plain text.
+</p>
+<p>
+  For Gmail accounts, QuickMail uses Google OAuth 2.0. You sign in through Google's own
+  sign-in page; QuickMail never sees your Google password. Google issues QuickMail a refresh
+  token, which is stored in Windows Credential Manager on your device. QuickMail uses this
+  token to request short-lived access tokens from Google in order to read and send your email.
+</p>
+
+<h3>Email content</h3>
+<p>
+  QuickMail reads your email so you can read it. Message content is processed locally and
+  cached in a SQLite database on your device at
+  <code>%APPDATA%\QuickMail</code>. This content is never transmitted to the developer
+  or any third party.
+</p>
+
+<h3>Log file</h3>
+<p>
+  When the <code>/debug</code> startup flag is used, QuickMail writes a log file
+  (<code>quickmail.log</code>) to your profile directory to help with troubleshooting.
+  This file records connection events and errors. It does not record email content,
+  passwords, or OAuth tokens.
+</p>
+
+<h2>Google user data — specific disclosures</h2>
+<p>QuickMail requests the following Google OAuth scope when you add a Gmail account:</p>
+<ul>
+  <li>
+    <code>https://mail.google.com/</code> — full Gmail access (read, compose, send, delete),
+    required to function as an email client
+  </li>
+</ul>
+<p>QuickMail uses this access <strong>only</strong> to:</p>
+<ul>
+  <li>Display your email messages</li>
+  <li>Send messages on your behalf when you choose to send them</li>
+  <li>Manage message state (read/unread, move, delete) as you direct</li>
+</ul>
+<p>QuickMail does <strong>not</strong>:</p>
+<ul>
+  <li>Share your Gmail data with any person or service</li>
+  <li>Use your Gmail data for advertising, profiling, or any purpose other than operating the email client</li>
+  <li>Allow any human to read your email content</li>
+  <li>Store your Gmail data anywhere other than your local device</li>
+  <li>Transfer your Gmail data to AI tools or train machine learning models with it</li>
+</ul>
+<p>
+  QuickMail's use and transfer of information received from Google APIs adheres to the
+  <a href="https://developers.google.com/terms/api-services-user-data-policy">Google API Services User Data Policy</a>,
+  including the Limited Use requirements.
+</p>
+
+<h3>Revoking access</h3>
+<p>
+  To revoke QuickMail's access to your Gmail account at any time, visit
+  <a href="https://myaccount.google.com/permissions">Google Account Permissions</a>
+  and remove QuickMail. You can also sign out from within the application, which
+  immediately deletes the stored refresh token from Windows Credential Manager.
+</p>
+
+<h2>Analytics and telemetry</h2>
+<p>QuickMail collects no analytics, usage statistics, or telemetry of any kind.</p>
+
+<h2>Data retention and deletion</h2>
+<p>
+  All data QuickMail stores — the local email cache, settings, and credential tokens —
+  is stored on your device under <code>%APPDATA%\QuickMail</code>. You can delete this
+  folder at any time to remove all locally stored data. Uninstalling QuickMail does not
+  automatically delete this folder.
+</p>
+
+<h2>Children's privacy</h2>
+<p>
+  QuickMail is not directed at children under 13 and does not knowingly collect
+  information from children.
+</p>
+
+<h2>Changes to this policy</h2>
+<p>
+  If this policy changes materially, the updated policy will be published at this URL
+  with a new effective date. The history of changes is visible in the
+  <a href="https://github.com/kellylford/QuickMail">QuickMail GitHub repository</a>.
+</p>
+
+<h2>Contact</h2>
+<p>
+  For privacy questions or concerns, contact:
+  <a href="mailto:kelly@theideaplace.net">kelly@theideaplace.net</a>
+</p>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Full Google OAuth 2.0 / Gmail support via `Google.Apis.Auth` and XOAUTH2/IMAP
- Sign in with Google browser flow using `LocalServerCodeReceiver`; refresh token stored in Windows Credential Manager
- Google Auth enabled by default; users can disable with `GoogleAuth=false` in `[features]` section of config.ini
- Auto-selects Google OAuth when a `@gmail.com` or `@googlemail.com` address is typed in Add Account
- Auto-fills Gmail server settings (imap.gmail.com:993, smtp.gmail.com:587) when Google OAuth is selected
- OAuth credentials kept out of source via gitignored partial class; GitHub Actions generates the file from repo secrets
- Privacy policy added at `docs/privacy.html` (served via GitHub Pages once merged); required for Google OAuth verification
- Artifact retention set to 7 days in CI workflow

## New issue filed

- [#103](https://github.com/kellylford/QuickMail/issues/103) — Gmail virtual folder deduplication (`[Gmail]/All Mail` causes duplicate messages in unified views); deferred to a follow-up PR

## Test plan

- [ ] Add a Gmail account using Sign in with Google; verify browser opens, consent completes, account appears
- [ ] Verify typing a @gmail.com address in Add Account auto-selects Google OAuth and fills server fields
- [ ] Verify typing a non-Gmail address leaves auth type unchanged
- [ ] Verify signing out of a Gmail account removes the token from Windows Credential Manager
- [ ] Verify CI passes on this branch with Google credentials injected from secrets
- [ ] Confirm privacy policy renders at https://kellylford.github.io/QuickMail/privacy.html after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)