### PR TITLE
fix: Shift+Tab navigation wrap and screen reader labels in shortcuts list

### DIFF
--- a/QuickMail.Tests/SettingsViewModelTests.cs
+++ b/QuickMail.Tests/SettingsViewModelTests.cs
@@ -108,6 +108,36 @@ public class SettingsViewModelTests
     }
 
     [Fact]
+    public void HotkeyRow_AccessibleName_ReflectsCurrentGesture()
+    {
+        var registry = new StubCommandRegistry();
+        registry.Register(new CommandDefinition("mail.reply", "Mail", "Reply", () => { }, Key.R, ModifierKeys.Control));
+
+        var vm = new SettingsViewModel(new StubConfigService(), registry);
+        var row = vm.HotkeyRows[0];
+
+        Assert.Equal("Reply, Mail, Ctrl+R", row.AccessibleName);
+
+        row.SetCustomBinding(Key.K, ModifierKeys.Control);
+        Assert.Equal("Reply, Mail, Ctrl+K", row.AccessibleName);
+
+        row.ClearCustomBinding();
+        Assert.Equal("Reply, Mail, Ctrl+R", row.AccessibleName);
+    }
+
+    [Fact]
+    public void HotkeyRow_AccessibleName_NoShortcut_WhenNoneAssigned()
+    {
+        var registry = new StubCommandRegistry();
+        registry.RegisterTestCommand("test.cmd", "Test", "Command");
+
+        var vm = new SettingsViewModel(new StubConfigService(), registry);
+        var row = vm.HotkeyRows[0];
+
+        Assert.Equal("Command, Test, no shortcut", row.AccessibleName);
+    }
+
+    [Fact]
     public void LoadExistingHotkeys_PopulatesCustomBindings()
     {
         var configService = new StubConfigService();

--- a/QuickMail/ViewModels/SettingsViewModel.cs
+++ b/QuickMail/ViewModels/SettingsViewModel.cs
@@ -243,10 +243,21 @@ public partial class SettingsViewModel : ObservableObject
 
         [ObservableProperty]
         [NotifyPropertyChangedFor(nameof(ActiveGesture))]
+        [NotifyPropertyChangedFor(nameof(AccessibleName))]
         private string _customGesture = string.Empty;
 
         /// <summary>The binding currently in effect — custom if set, otherwise the default.</summary>
         public string ActiveGesture => HasCustomBinding ? CustomGesture : DefaultGesture;
+
+        /// <summary>Screen-reader label: "Title, Category, shortcut" (or "no shortcut").</summary>
+        public string AccessibleName
+        {
+            get
+            {
+                var gesture = string.IsNullOrEmpty(ActiveGesture) ? "no shortcut" : ActiveGesture;
+                return $"{Title}, {Category}, {gesture}";
+            }
+        }
 
         public bool HasCustomBinding => _customKey != Key.None;
 

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -1109,6 +1109,13 @@ public partial class MainWindow : Window
     // Enter on an account: connect and load folders; focus stays here
     private async void AccountList_PreviewKeyDown(object sender, KeyEventArgs e)
     {
+        if (e.Key == Key.Tab && Keyboard.Modifiers == ModifierKeys.Shift)
+        {
+            e.Handled = true;
+            FocusActiveMessagePanel();
+            return;
+        }
+
         if (e.Key == Key.Enter && AccountList.SelectedItem is AccountModel account)
         {
             e.Handled = true;

--- a/QuickMail/Views/SettingsDialog.xaml
+++ b/QuickMail/Views/SettingsDialog.xaml
@@ -296,6 +296,11 @@
                               KeyDown="HotkeyListView_KeyDown"
                               SelectionChanged="HotkeyListView_SelectionChanged"
                               AutomationProperties.Name="Keyboard shortcuts list">
+                        <ListView.ItemContainerStyle>
+                            <Style TargetType="ListViewItem">
+                                <Setter Property="AutomationProperties.Name" Value="{Binding AccessibleName}"/>
+                            </Style>
+                        </ListView.ItemContainerStyle>
                         <ListView.View>
                             <GridView>
                                 <GridViewColumn Header="Category" DisplayMemberBinding="{Binding Category}" Width="90"/>

--- a/docs/release-notes-v0.7.5.md
+++ b/docs/release-notes-v0.7.5.md
@@ -29,6 +29,10 @@ Once added, iCloud accounts sync and send mail the same way as any other IMAP/SM
 
 ## Bug Fixes
 
+- **Shift+Tab navigation now wraps from the account list back to the message panel.** Pressing Shift+Tab moved focus backward through the message panel, folder tree, and account list, but pressing Shift+Tab again from the account list produced no response — focus was stuck. The backward cycle now completes correctly: Shift+Tab from the account list moves focus to the active message panel, consistent with how the forward Tab cycle works. (#106)
+
+- **Keyboard shortcuts list now announces correctly with screen readers.** When arrowing through the keyboard shortcuts list in Settings, NVDA and Narrator were reading the internal class name (`SettingsViewModel+HotkeyRowViewModel`) instead of the command name. Each row now has a proper accessible label — command name, category, and current shortcut — that screen readers announce when focus moves to a row. This bug did not affect JAWS, which has a long-standing workaround for this specific WPF pattern. (#107)
+
 - **Deleted iCloud messages going to Junk instead of Trash.** When deleting a message from an iCloud account, QuickMail was moving it to the Junk folder rather than Trash. The delete logic was falling back to Junk when it could not identify the Trash folder by name — iCloud names its trash folder "Deleted Messages" rather than "Trash". The name-based fallback now recognises "Deleted Messages", and the fallback to Junk has been removed from the delete path entirely (Junk is never an acceptable destination for deleted messages).
 
 ---


### PR DESCRIPTION
## Summary

- **#106 — Shift+Tab navigation stuck at account list**: Pressing Shift+Tab cycled backward through message panel → folder tree → account list, then stopped. Added a Shift+Tab handler to `AccountList_PreviewKeyDown` that calls `FocusActiveMessagePanel()`, completing the reverse cycle. Mirrors the same explicit-handler pattern already used in all four message-panel variants for their own Shift+Tab.

- **#107 — Screen reader reads class name in shortcuts list**: Arrowing through the keyboard shortcuts list in Settings caused NVDA and Narrator to announce `SettingsViewModel+HotkeyRowViewModel` — the CLR type name — instead of the command being focused. Added `AccessibleName` to `HotkeyRowViewModel` (`"{Title}, {Category}, {gesture}"`) and bound it via `ListView.ItemContainerStyle`. JAWS was unaffected because it has a long-standing heuristic that walks the visual subtree when the UIA name is unhelpful; NVDA and Narrator do not.

## Test plan

- [x] All 720 tests pass
- [ ] Shift+Tab from account list moves focus to message panel (manual, keyboard)
- [ ] Arrow through keyboard shortcuts list with NVDA/Narrator — confirms command name is announced correctly
- [ ] Arrow through same list with JAWS — confirms no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)