### PR TITLE
Graph: fetch and nest child folders; readable folder-picker paths

### DIFF
--- a/QuickMail.Tests/FolderPickerPathTests.cs
+++ b/QuickMail.Tests/FolderPickerPathTests.cs
@@ -19,7 +19,8 @@ public class FolderPickerPathTests
     public void BuildFolderPath_Imap_UsesSeparatorFullName()
     {
         var folder = F("INBOX/Projects/2026", "2026"); // ParentId null → IMAP
-        var byId = new Dictionary<string, MailFolderModel> { [folder.FullName] = folder };
+        // IMAP exits before consulting byId, so an empty map makes that independence explicit.
+        var byId = new Dictionary<string, MailFolderModel>();
 
         Assert.Equal("INBOX/Projects/2026", FolderPickerWindow.BuildFolderPath(folder, byId));
     }

--- a/QuickMail.Tests/FolderPickerPathTests.cs
+++ b/QuickMail.Tests/FolderPickerPathTests.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+using QuickMail.Models;
+using QuickMail.Views;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// Verifies the folder picker shows readable paths for both backends — and never the raw Graph
+/// folder id, which is what <see cref="MailFolderModel.FullName"/> holds for Graph accounts.
+/// </summary>
+public class FolderPickerPathTests
+{
+    private static MailFolderModel F(
+        string fullName, string display, string? parentId = null)
+        => new() { FullName = fullName, DisplayName = display, ParentId = parentId };
+
+    [Fact]
+    public void BuildFolderPath_Imap_UsesSeparatorFullName()
+    {
+        var folder = F("INBOX/Projects/2026", "2026"); // ParentId null → IMAP
+        var byId = new Dictionary<string, MailFolderModel> { [folder.FullName] = folder };
+
+        Assert.Equal("INBOX/Projects/2026", FolderPickerWindow.BuildFolderPath(folder, byId));
+    }
+
+    [Fact]
+    public void BuildFolderPath_Graph_BuildsDisplayNamePathFromParentChain()
+    {
+        // Opaque Graph ids; the path must be reconstructed from DisplayNames, not the ids.
+        var inbox    = F("AAA", "Inbox",    parentId: "root");
+        var projects = F("BBB", "Projects", parentId: "AAA");
+        var year     = F("CCC", "2026",     parentId: "BBB");
+        var byId = new Dictionary<string, MailFolderModel>
+        {
+            [inbox.FullName] = inbox, [projects.FullName] = projects, [year.FullName] = year,
+        };
+
+        Assert.Equal("Inbox/Projects/2026", FolderPickerWindow.BuildFolderPath(year, byId));
+        Assert.Equal("Inbox/Projects", FolderPickerWindow.BuildFolderPath(projects, byId));
+        // A top-level Graph folder whose parent ("root") isn't in the set is just its own name.
+        Assert.Equal("Inbox", FolderPickerWindow.BuildFolderPath(inbox, byId));
+        // The raw id never appears.
+        Assert.DoesNotContain("CCC", FolderPickerWindow.BuildFolderPath(year, byId));
+    }
+}

--- a/QuickMail.Tests/FolderTreeBuilderTests.cs
+++ b/QuickMail.Tests/FolderTreeBuilderTests.cs
@@ -62,6 +62,28 @@ public class FolderTreeBuilderTests
     }
 
     [Fact]
+    public void Build_OrdersWellKnownFoldersConventionally()
+    {
+        // Deliberately scrambled input; expect Inbox, Drafts, Sent, Deleted, Junk, then custom A→Z.
+        var flat = new List<MailFolderModel>
+        {
+            F("zzz", "Zeta",    parentId: "root"),
+            F("j",   "Junk",    parentId: "root", kind: SpecialFolderKind.Junk),
+            F("d",   "Drafts",  parentId: "root", kind: SpecialFolderKind.Drafts),
+            F("aaa", "Alpha",   parentId: "root"),
+            F("t",   "Deleted", parentId: "root", kind: SpecialFolderKind.Trash),
+            F("i",   "Inbox",   parentId: "root", kind: SpecialFolderKind.Inbox),
+            F("s",   "Sent",    parentId: "root", kind: SpecialFolderKind.Sent),
+        };
+
+        var roots = FolderTreeBuilder.Build(flat);
+
+        Assert.Equal(
+            new[] { "Inbox", "Drafts", "Sent", "Deleted", "Junk", "Alpha", "Zeta" },
+            roots.Select(r => r.Folder!.DisplayName).ToArray());
+    }
+
+    [Fact]
     public void Build_Graph_WrapsRootsUnderAccountHeader_WithoutFlattening()
     {
         var account = new AccountModel { AccountName = "Work", Username = "w@x.com" };

--- a/QuickMail.Tests/FolderTreeBuilderTests.cs
+++ b/QuickMail.Tests/FolderTreeBuilderTests.cs
@@ -1,0 +1,86 @@
+using System.Collections.Generic;
+using System.Linq;
+using QuickMail.Models;
+using QuickMail.Services;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+public class FolderTreeBuilderTests
+{
+    private static MailFolderModel F(
+        string fullName, string display, string? parentId = null,
+        SpecialFolderKind kind = SpecialFolderKind.None)
+        => new() { FullName = fullName, DisplayName = display, ParentId = parentId, Kind = kind };
+
+    [Fact]
+    public void Build_Imap_NestsBySeparator()
+    {
+        // IMAP encodes hierarchy in the separator-delimited FullName; ParentId is null throughout.
+        var flat = new List<MailFolderModel>
+        {
+            F("INBOX", "INBOX"),
+            F("INBOX/Projects", "Projects"),
+            F("INBOX/Projects/2026", "2026"),
+        };
+
+        var roots = FolderTreeBuilder.Build(flat);
+
+        var inbox = Assert.Single(roots);
+        Assert.Equal("INBOX", inbox.Label);
+        var projects = Assert.Single(inbox.Children);
+        Assert.Equal("Projects", projects.Label);
+        var year = Assert.Single(projects.Children);
+        Assert.Equal("2026", year.Label);
+    }
+
+    [Fact]
+    public void Build_Graph_NestsByParentId()
+    {
+        // Graph: opaque ids, hierarchy via ParentId; top-level folders point at a parent ("root")
+        // that is not part of the fetched set, so they surface as tree roots.
+        var flat = new List<MailFolderModel>
+        {
+            F("f1", "Inbox",    parentId: "root", kind: SpecialFolderKind.Inbox),
+            F("c1", "Projects", parentId: "f1"),
+            F("g1", "2026",     parentId: "c1"),
+            F("f2", "Archive",  parentId: "root"),
+        };
+
+        var roots = FolderTreeBuilder.Build(flat);
+
+        // Two roots, Inbox first (by kind), then Archive (alphabetical).
+        Assert.Equal(2, roots.Count);
+        Assert.Equal("Inbox", roots[0].Folder!.DisplayName);
+        Assert.Equal("Archive", roots[1].Folder!.DisplayName);
+
+        // Inbox > Projects > 2026 nests three deep.
+        var projects = Assert.Single(roots[0].Children);
+        Assert.Equal("Projects", projects.Folder!.DisplayName);
+        var year = Assert.Single(projects.Children);
+        Assert.Equal("2026", year.Folder!.DisplayName);
+    }
+
+    [Fact]
+    public void Build_Graph_WrapsRootsUnderAccountHeader_WithoutFlattening()
+    {
+        var account = new AccountModel { AccountName = "Work", Username = "w@x.com" };
+        var flat = new List<MailFolderModel>
+        {
+            F("f1", "Inbox", parentId: "root", kind: SpecialFolderKind.Inbox),
+            F("c1", "Sub",   parentId: "f1"),
+        };
+
+        var roots = FolderTreeBuilder.Build(flat, account);
+
+        var header = Assert.Single(roots);
+        Assert.True(header.IsHeader);
+        Assert.Equal("Work", header.Label);
+
+        var inbox = Assert.Single(header.Children);
+        Assert.Equal("Inbox", inbox.Folder!.DisplayName);
+        // The sub-folder nests under Inbox rather than being flattened to a sibling.
+        var sub = Assert.Single(inbox.Children);
+        Assert.Equal("Sub", sub.Folder!.DisplayName);
+    }
+}

--- a/QuickMail.Tests/GrabAddressesDialogTests.cs
+++ b/QuickMail.Tests/GrabAddressesDialogTests.cs
@@ -354,7 +354,14 @@ public class GrabAddressesDialogTests
     private static void PumpUntil(Func<bool> condition, int maxIterations = 50)
     {
         for (int i = 0; i < maxIterations && !condition(); i++)
+        {
             DoEvents();
+            // If I/O is still in flight, the async continuation hasn't been posted to the
+            // dispatcher yet — DoEvents() returns without processing it. A short sleep gives
+            // the thread pool time to complete the write and post the continuation.
+            if (!condition())
+                System.Threading.Thread.Sleep(10);
+        }
     }
 
     private static void EnsureApplication()

--- a/QuickMail.Tests/GraphMailServiceTests.cs
+++ b/QuickMail.Tests/GraphMailServiceTests.cs
@@ -139,6 +139,43 @@ public class GraphMailServiceTests
     }
 
     [Fact]
+    public async Task GetFoldersAsync_DescendsIntoChildFolders_AndSetsParentId()
+    {
+        // /me/mailFolders returns only top-level folders; nested folders must be fetched by
+        // walking each folder's /childFolders endpoint for as long as childFolderCount > 0.
+        const string top = """
+            {"value":[
+              {"id":"f1","displayName":"Inbox","parentFolderId":"root","childFolderCount":1,"totalItemCount":10,"unreadItemCount":0},
+              {"id":"f2","displayName":"Archive","parentFolderId":"root","childFolderCount":0,"totalItemCount":0,"unreadItemCount":0}
+            ]}
+            """;
+        const string f1Children = """
+            {"value":[{"id":"c1","displayName":"Projects","parentFolderId":"f1","childFolderCount":1,"totalItemCount":4,"unreadItemCount":1}]}
+            """;
+        const string c1Children = """
+            {"value":[{"id":"g1","displayName":"2026","parentFolderId":"c1","childFolderCount":0,"totalItemCount":2,"unreadItemCount":0}]}
+            """;
+
+        var (svc, handler) = Make(url =>
+              url.Contains("/me?")                         ? (HttpStatusCode.OK, MeJson)
+            : url.Contains("/mailFolders/f1/childFolders") ? (HttpStatusCode.OK, f1Children)
+            : url.Contains("/mailFolders/c1/childFolders") ? (HttpStatusCode.OK, c1Children)
+            : url.Contains("/me/mailFolders?")             ? (HttpStatusCode.OK, top)
+            : (HttpStatusCode.OK, """{"value":[]}"""));    // well-known lookups resolve to nothing
+
+        var account = GraphAccount();
+        await svc.ConnectAsync(account);
+        var folders = await svc.GetFoldersAsync(account.Id);
+
+        // Top-level f1, f2 plus nested c1 (under f1) and g1 (under c1).
+        Assert.Equal(4, folders.Count);
+        Assert.Equal("f1", folders.Single(f => f.FullName == "c1").ParentId);
+        Assert.Equal("c1", folders.Single(f => f.FullName == "g1").ParentId);
+        // f2 had no children, so no descent request was made for it.
+        Assert.DoesNotContain(handler.Requests, r => r.Contains("/mailFolders/f2/childFolders"));
+    }
+
+    [Fact]
     public async Task GetMessageSummariesAsync_MapsFields()
     {
         const string msgs = """

--- a/QuickMail/Models/MailFolderModel.cs
+++ b/QuickMail/Models/MailFolderModel.cs
@@ -9,6 +9,13 @@ public class MailFolderModel
     public Guid AccountId { get; set; }
     public bool IsHeader { get; set; }
     public string FullName { get; set; } = string.Empty;
+    /// <summary>
+    /// Parent folder identifier for backends that model hierarchy by parent reference rather than
+    /// by a path-separated name (Microsoft Graph). Null for IMAP, where nesting is encoded in
+    /// <see cref="FullName"/> via the namespace separator. When non-null on any folder in a set,
+    /// <c>FolderTreeBuilder</c> builds the hierarchy from parent IDs instead of the separator.
+    /// </summary>
+    public string? ParentId { get; set; }
     public string DisplayName { get; set; } = string.Empty;
     public int UnreadCount { get; set; }
     /// <summary>Total number of messages in the folder as reported by the server at connection time.</summary>

--- a/QuickMail/Services/FolderTreeBuilder.cs
+++ b/QuickMail/Services/FolderTreeBuilder.cs
@@ -47,13 +47,13 @@ public static class FolderTreeBuilder
         // MailKit uses '.' or '/' depending on the server's namespace separator.
         char sep = DetectSeparator(list);
 
-        // Sort: INBOX first, then alphabetically
+        // Order well-known folders conventionally (Inbox, Drafts, Sent, Deleted, Junk), then the
+        // rest alphabetically. `list` is the local copy from Build()'s flat.ToList(), so sorting it
+        // in place is safe.
         list.Sort((a, b) =>
         {
-            bool aInbox = a.FullName.Equals("INBOX", StringComparison.OrdinalIgnoreCase);
-            bool bInbox = b.FullName.Equals("INBOX", StringComparison.OrdinalIgnoreCase);
-            if (aInbox && !bInbox) return -1;
-            if (!aInbox && bInbox) return 1;
+            int ra = WellKnownRank(a), rb = WellKnownRank(b);
+            if (ra != rb) return ra.CompareTo(rb);
             return string.Compare(a.FullName, b.FullName, StringComparison.OrdinalIgnoreCase);
         });
 
@@ -74,13 +74,12 @@ public static class FolderTreeBuilder
     private static List<FolderTreeNode> BuildByParentId(List<MailFolderModel> list)
     {
         // Sort up front so both the roots and each parent's children come out in display order
-        // (Inbox first, then alphabetical); the insertion order below is preserved into the tree.
+        // (well-known folders first in conventional order, then alphabetical); the insertion order
+        // below is preserved into the tree. `list` is Build()'s flat.ToList() copy — safe to sort.
         list.Sort((a, b) =>
         {
-            bool aInbox = a.Kind == SpecialFolderKind.Inbox;
-            bool bInbox = b.Kind == SpecialFolderKind.Inbox;
-            if (aInbox && !bInbox) return -1;
-            if (!aInbox && bInbox) return 1;
+            int ra = WellKnownRank(a), rb = WellKnownRank(b);
+            if (ra != rb) return ra.CompareTo(rb);
             return string.Compare(a.DisplayName, b.DisplayName, StringComparison.OrdinalIgnoreCase);
         });
 
@@ -142,6 +141,24 @@ public static class FolderTreeBuilder
 
     private static string BuildLabel(MailFolderModel f) =>
         f.UnreadCount > 0 ? $"{f.DisplayName} ({f.UnreadCount} unread)" : f.DisplayName;
+
+    // Conventional mailbox order: Inbox, Drafts, Sent, Deleted, Junk, then everything else
+    // alphabetically. INBOX is matched by name too — the IMAP inbox is the canonical "INBOX" and a
+    // server might not flag its Kind.
+    private static int WellKnownRank(MailFolderModel f)
+    {
+        if (f.Kind == SpecialFolderKind.Inbox ||
+            f.FullName.Equals("INBOX", StringComparison.OrdinalIgnoreCase))
+            return 0;
+        return f.Kind switch
+        {
+            SpecialFolderKind.Drafts => 1,
+            SpecialFolderKind.Sent   => 2,
+            SpecialFolderKind.Trash  => 3,
+            SpecialFolderKind.Junk   => 4,
+            _ => 5,
+        };
+    }
 
     private static char DetectSeparator(List<MailFolderModel> folders)
     {

--- a/QuickMail/Services/FolderTreeBuilder.cs
+++ b/QuickMail/Services/FolderTreeBuilder.cs
@@ -15,6 +15,34 @@ public static class FolderTreeBuilder
         var list = flat.ToList();
         if (list.Count == 0) return [];
 
+        // Two hierarchy models: Microsoft Graph references the parent by id (ParentId), while IMAP
+        // encodes nesting in the separator-delimited FullName. Pick the strategy from the data so a
+        // Graph account's sub-folders nest correctly without disturbing the IMAP path logic.
+        var folderRoots = list.Any(f => f.ParentId != null)
+            ? BuildByParentId(list)
+            : BuildBySeparator(list);
+
+        // Wrap folder roots under the account as the top-level tree node
+        if (account != null)
+        {
+            var accountNode = new FolderTreeNode
+            {
+                Label      = account.AccountLabel,
+                Folder     = null,
+                IsHeader   = true,
+                IsExpanded = true,
+            };
+            foreach (var root in folderRoots)
+                accountNode.Children.Add(root);
+            return [accountNode];
+        }
+
+        return folderRoots;
+    }
+
+    // ── IMAP: hierarchy encoded in the separator-delimited FullName ───────────────────
+    private static List<FolderTreeNode> BuildBySeparator(List<MailFolderModel> list)
+    {
         // Detect separator: use the character between the first two path segments.
         // MailKit uses '.' or '/' depending on the server's namespace separator.
         char sep = DetectSeparator(list);
@@ -39,22 +67,41 @@ public static class FolderTreeBuilder
             EnsurePath(parts, folder, sep, folderRoots, byPath);
         }
 
-        // Wrap folder roots under the account as the top-level tree node
-        if (account != null)
+        return folderRoots;
+    }
+
+    // ── Graph: hierarchy referenced by parent id (ParentId → parent's FullName) ───────
+    private static List<FolderTreeNode> BuildByParentId(List<MailFolderModel> list)
+    {
+        // Sort up front so both the roots and each parent's children come out in display order
+        // (Inbox first, then alphabetical); the insertion order below is preserved into the tree.
+        list.Sort((a, b) =>
         {
-            var accountNode = new FolderTreeNode
-            {
-                Label      = account.AccountLabel,
-                Folder     = null,
-                IsHeader   = true,
-                IsExpanded = true,
-            };
-            foreach (var root in folderRoots)
-                accountNode.Children.Add(root);
-            return [accountNode];
+            bool aInbox = a.Kind == SpecialFolderKind.Inbox;
+            bool bInbox = b.Kind == SpecialFolderKind.Inbox;
+            if (aInbox && !bInbox) return -1;
+            if (!aInbox && bInbox) return 1;
+            return string.Compare(a.DisplayName, b.DisplayName, StringComparison.OrdinalIgnoreCase);
+        });
+
+        // One node per folder, keyed by its own id (FullName). Graph ids are case-sensitive.
+        var byId = new Dictionary<string, FolderTreeNode>(StringComparer.Ordinal);
+        foreach (var f in list)
+            byId[f.FullName] = new FolderTreeNode { Folder = f, Label = BuildLabel(f) };
+
+        var roots = new List<FolderTreeNode>();
+        foreach (var f in list)
+        {
+            var node = byId[f.FullName];
+            // A folder roots out when it has no parent, or its parent isn't part of this set —
+            // top-level Graph folders point at the hidden msgfolderroot, which we never fetch.
+            if (f.ParentId != null && byId.TryGetValue(f.ParentId, out var parent))
+                parent.Children.Add(node);
+            else
+                roots.Add(node);
         }
 
-        return folderRoots;
+        return roots;
     }
 
     private static void EnsurePath(

--- a/QuickMail/Services/Graph/GraphDtos.cs
+++ b/QuickMail/Services/Graph/GraphDtos.cs
@@ -22,6 +22,7 @@ internal sealed class GraphMailFolder
     [JsonPropertyName("id")] public string Id { get; set; } = string.Empty;
     [JsonPropertyName("displayName")] public string DisplayName { get; set; } = string.Empty;
     [JsonPropertyName("parentFolderId")] public string? ParentFolderId { get; set; }
+    [JsonPropertyName("childFolderCount")] public int ChildFolderCount { get; set; }
     [JsonPropertyName("totalItemCount")] public int TotalItemCount { get; set; }
     [JsonPropertyName("unreadItemCount")] public int UnreadItemCount { get; set; }
 }

--- a/QuickMail/Services/GraphMailService.cs
+++ b/QuickMail/Services/GraphMailService.cs
@@ -115,13 +115,32 @@ public class GraphMailService : IMailService
     // ── Folders ──────────────────────────────────────────────────────────────────
     public async Task<List<MailFolderModel>> GetFoldersAsync(Guid accountId, CancellationToken ct = default)
     {
-        var folders = await _client.GetAllPagesAsync<GraphMailFolder>(
-            Account(accountId),
-            "/me/mailFolders?$top=100&$select=id,displayName,parentFolderId,totalItemCount,unreadItemCount", ct);
+        var account = Account(accountId);
+
+        // Graph's /me/mailFolders returns ONLY top-level folders. Nested folders live under each
+        // folder's /childFolders endpoint, so walk down into any folder that reports children —
+        // otherwise sub-folders (e.g. Inbox/Projects/2026) never appear in the tree at all.
+        const string select =
+            "$select=id,displayName,parentFolderId,childFolderCount,totalItemCount,unreadItemCount";
+
+        var all = await _client.GetAllPagesAsync<GraphMailFolder>(
+            account, $"/me/mailFolders?$top=100&{select}", ct);
+
+        // Breadth-first descent: each iteration fetches the children of folders known to have them.
+        var pending = new Queue<GraphMailFolder>(all.Where(f => f.ChildFolderCount > 0));
+        while (pending.Count > 0)
+        {
+            var parent = pending.Dequeue();
+            var children = await _client.GetAllPagesAsync<GraphMailFolder>(
+                account, $"/me/mailFolders/{parent.Id}/childFolders?$top=100&{select}", ct);
+            all.AddRange(children);
+            foreach (var c in children.Where(c => c.ChildFolderCount > 0))
+                pending.Enqueue(c);
+        }
 
         var wellKnown = _wellKnownFolders.TryGetValue(accountId, out var map) ? map : EmptyWellKnown;
 
-        return folders.Select(f =>
+        return all.Select(f =>
         {
             // Prefer the well-known folder ID resolved at connect (locale- and rename-proof);
             // fall back to display-name matching for anything not resolved.
@@ -130,6 +149,7 @@ public class GraphMailService : IMailService
             {
                 AccountId = accountId,
                 FullName = f.Id,             // Graph uses opaque folder IDs as the "folder name"
+                ParentId = f.ParentFolderId, // hierarchy is by parent reference, not a path separator
                 DisplayName = f.DisplayName,
                 UnreadCount = f.UnreadItemCount,
                 MessageCount = f.TotalItemCount,

--- a/QuickMail/Views/FolderPickerWindow.xaml.cs
+++ b/QuickMail/Views/FolderPickerWindow.xaml.cs
@@ -9,6 +9,7 @@ using System.Windows.Data;
 using System.Windows.Input;
 using System.Windows.Threading;
 using QuickMail.Models;
+using QuickMail.Services;
 
 namespace QuickMail.Views;
 
@@ -17,6 +18,9 @@ namespace QuickMail.Views;
 /// </summary>
 public partial class FolderPickerWindow : Window
 {
+    // Shared empty map for IMAP accounts, whose folders never consult byId in BuildFolderPath.
+    private static readonly Dictionary<string, MailFolderModel> EmptyFolderById = new();
+
     private readonly ObservableCollection<FolderPickerItem> _items = [];
     private readonly ICollectionView _view;
     private readonly MailFolderModel? _initialFolder;
@@ -59,8 +63,11 @@ public partial class FolderPickerWindow : Window
             }
 
             // Graph references parents by id, so a folder's FullName is an opaque id — build a
-            // readable path from DisplayNames. IMAP already carries a separator path in FullName.
-            var byId = folders.ToDictionary(f => f.FullName, StringComparer.Ordinal);
+            // readable path from DisplayNames. IMAP carries a separator path in FullName already and
+            // never consults byId, so don't build it for an all-IMAP account.
+            var byId = folders.Any(f => f.ParentId != null)
+                ? folders.ToDictionary(f => f.FullName, StringComparer.Ordinal)
+                : EmptyFolderById;
 
             foreach (var (folder, folderPath) in folders
                          .Where(f => !f.IsHeader)
@@ -119,13 +126,17 @@ public partial class FolderPickerWindow : Window
 
         var segments = new List<string> { folder.DisplayName };
         var current = folder;
-        for (int guard = 0;
-             current.ParentId != null && byId.TryGetValue(current.ParentId, out var parent) && guard < 64;
-             guard++)
+        int guard = 0;
+        while (current.ParentId != null && byId.TryGetValue(current.ParentId, out var parent) && guard < 64)
         {
             segments.Add(parent.DisplayName);
             current = parent;
+            guard++;
         }
+        // The guard only trips on a ParentId cycle (which Graph shouldn't produce). Surface it in
+        // /debug so a subtly-truncated path is discoverable rather than silent.
+        if (guard >= 64)
+            LogService.Debug($"FolderPickerWindow: path for '{folder.DisplayName}' hit the 64-deep guard — possible ParentId cycle.");
         segments.Reverse();
         return string.Join('/', segments);
     }

--- a/QuickMail/Views/FolderPickerWindow.xaml.cs
+++ b/QuickMail/Views/FolderPickerWindow.xaml.cs
@@ -58,14 +58,16 @@ public partial class FolderPickerWindow : Window
                     $"{account.AccountLabel} - {accountMailFolder.DisplayName}"));
             }
 
-            foreach (var folder in folders
+            // Graph references parents by id, so a folder's FullName is an opaque id — build a
+            // readable path from DisplayNames. IMAP already carries a separator path in FullName.
+            var byId = folders.ToDictionary(f => f.FullName, StringComparer.Ordinal);
+
+            foreach (var (folder, folderPath) in folders
                          .Where(f => !f.IsHeader)
-                         .OrderBy(f => IsInbox(f) ? 0 : 1)
-                         .ThenBy(f => f.FullName, StringComparer.OrdinalIgnoreCase))
+                         .Select(f => (Folder: f, Path: BuildFolderPath(f, byId)))
+                         .OrderBy(x => IsInbox(x.Folder) ? 0 : 1)
+                         .ThenBy(x => x.Path, StringComparer.OrdinalIgnoreCase))
             {
-                var folderPath = string.IsNullOrWhiteSpace(folder.FullName)
-                    ? folder.DisplayName
-                    : folder.FullName;
                 _items.Add(new FolderPickerItem(
                     folder,
                     account,
@@ -101,7 +103,32 @@ public partial class FolderPickerWindow : Window
     }
 
     private static bool IsInbox(MailFolderModel folder) =>
+        folder.Kind == SpecialFolderKind.Inbox ||
         folder.FullName.Equals("INBOX", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Human-readable folder path for display. IMAP keeps its separator-delimited FullName; Graph
+    /// (whose FullName is an opaque id) is reconstructed from DisplayNames up the ParentId chain,
+    /// e.g. "Inbox/Projects/2026", so the picker never shows a raw folder id.
+    /// </summary>
+    internal static string BuildFolderPath(
+        MailFolderModel folder, IReadOnlyDictionary<string, MailFolderModel> byId)
+    {
+        if (folder.ParentId == null)
+            return string.IsNullOrWhiteSpace(folder.FullName) ? folder.DisplayName : folder.FullName;
+
+        var segments = new List<string> { folder.DisplayName };
+        var current = folder;
+        for (int guard = 0;
+             current.ParentId != null && byId.TryGetValue(current.ParentId, out var parent) && guard < 64;
+             guard++)
+        {
+            segments.Add(parent.DisplayName);
+            current = parent;
+        }
+        segments.Reverse();
+        return string.Join('/', segments);
+    }
 
     private bool FilterItem(object item)
     {


### PR DESCRIPTION
Fixes #109.

## Problem

On Microsoft Graph accounts, **nested folders never appeared in the tree** and the **move/copy folder picker showed the raw opaque folder ID** instead of the folder name (the screen reader announced e.g. `QM Test - AAMkADRmODc0...`). Both stem from one root cause: Graph identifies folders by an opaque id (stored in `MailFolderModel.FullName`) and models hierarchy by *parent reference*, while the existing folder code assumed the IMAP model where `FullName` is a separator-delimited path (`INBOX/Projects/2026`).

Found during live smoke testing on a Graph (Office 365) account with nested folders.

## Changes

- **Fetch nested folders.** `GraphMailService.GetFoldersAsync` now does a breadth-first descent into `/me/mailFolders/{id}/childFolders` for any folder reporting children (added `childFolderCount` to the folder DTO), and carries each folder's `parentFolderId`. `/me/mailFolders` alone only returns top-level folders.
- **Carry the parent.** New `MailFolderModel.ParentId` (null for IMAP).
- **Build the tree by parent id for Graph.** `FolderTreeBuilder` builds the hierarchy from parent ids when any folder carries `ParentId`; the IMAP separator path is untouched and only used when no folder has a `ParentId`.
- **Readable picker labels.** The folder picker reconstructs a `DisplayName` path from the parent chain (e.g. `Inbox/Projects/2026`) instead of showing `FullName`, so a raw Graph id is never displayed.

## Tests

- `GraphMailServiceTests.GetFoldersAsync_DescendsIntoChildFolders_AndSetsParentId` — nested fetch + `ParentId` wiring, and that childless folders trigger no descent request.
- `FolderTreeBuilderTests` — IMAP separator nesting still works; Graph parent-id nesting (3 deep); roots wrap under the account header without flattening.
- `FolderPickerPathTests` — IMAP keeps its `FullName` path; Graph builds a display-name path and never surfaces the id.

Full suite green (726 tests) on latest `main`. IMAP behaviour is unchanged.

## Notes

- The picker path format (`Inbox/Projects/2026`) is open to refinement; this PR focuses on never showing the raw id.
- Graph folder **CRUD and message copy/move are still stubbed** (PR 6 work) — this PR is read/display only.
