### PR TITLE
fix: reconcile read/flag state of existing messages on virtual-folder refresh

### DIFF
--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -990,17 +990,21 @@ public partial class MainViewModel : ObservableObject
             }
             if (!IsCurrentFolderLoad(loadVersion, expectedFolder)) return;
 
-            var existingKeys = Messages
-                .Select(m => (m.MessageId, m.AccountId, m.FolderName))
-                .ToHashSet();
+            var existingById = Messages
+                .ToDictionary(m => (m.MessageId, m.AccountId, m.FolderName));
 
             foreach (var msg in newMessages.OrderByDescending(m => m.Date))
             {
                 if (!IsCurrentFolderLoad(loadVersion, expectedFolder)) return;
                 var key = (msg.MessageId, msg.AccountId, msg.FolderName);
-                if (!existingKeys.Add(key)) continue;
+                if (existingById.TryGetValue(key, out var prior))
+                {
+                    ReconcileMessageState(prior, msg);
+                    continue;
+                }
                 if (!MatchesFilter(msg) || !MatchesDayLimit(msg)) continue;
                 InsertMessageSorted(msg);
+                existingById[key] = msg;
             }
             if (!IsCurrentFolderLoad(loadVersion, expectedFolder)) return;
 
@@ -1791,6 +1795,21 @@ public partial class MainViewModel : ObservableObject
             else hi = mid;
         }
         Messages.Insert(lo, msg);
+    }
+
+    // Copies server-fresh mutable state onto an existing message already in the list.
+    // Observable properties fire PropertyChanged automatically so the UI updates in place
+    // without removing and re-inserting the row (which would lose selection/focus).
+    private static void ReconcileMessageState(MailMessageSummary existing, MailMessageSummary fresh)
+    {
+        existing.IsRead         = fresh.IsRead;
+        existing.IsReplied      = fresh.IsReplied;
+        existing.IsForwarded    = fresh.IsForwarded;
+        existing.HasAttachments = fresh.HasAttachments;
+        existing.FlagId         = fresh.FlagId;
+        existing.FlagName       = fresh.FlagName;
+        existing.FlagColorHex   = fresh.FlagColorHex;
+        existing.IsServerFlagged = fresh.IsServerFlagged;
     }
 
     // ── Account / folder selection ───────────────────────────────────────────────
@@ -2753,9 +2772,8 @@ public partial class MainViewModel : ObservableObject
                 return;
             }
 
-            var existingKeys = Messages
-                .Select(m => (m.MessageId, m.AccountId, m.FolderName))
-                .ToHashSet();
+            var existingById = Messages
+                .ToDictionary(m => (m.MessageId, m.AccountId, m.FolderName));
 
             foreach (var msg in newMessages.OrderByDescending(m => m.Date))
             {
@@ -2763,13 +2781,17 @@ public partial class MainViewModel : ObservableObject
                     return;
 
                 var key = (msg.MessageId, msg.AccountId, msg.FolderName);
-                if (!existingKeys.Add(key))
+                if (existingById.TryGetValue(key, out var prior))
+                {
+                    ReconcileMessageState(prior, msg);
                     continue;
+                }
 
                 if (!MatchesFilter(msg) || !MatchesDayLimit(msg))
                     continue;
 
                 InsertMessageSorted(msg);
+                existingById[key] = msg;
             }
 
             if (!IsCurrentFolderLoad(loadVersion, AllMailFolder))
@@ -3154,22 +3176,25 @@ public partial class MainViewModel : ObservableObject
                 return;
             }
 
-            var existingKeys = Messages
-                .Select(m => (m.MessageId, m.AccountId, m.FolderName))
-                .ToHashSet();
+            var existingById = Messages
+                .ToDictionary(m => (m.MessageId, m.AccountId, m.FolderName));
 
             foreach (var msg in newMessages.OrderByDescending(m => m.Date))
             {
                 if (!IsCurrentFolderLoad(loadVersion, expectedFolder)) return;
 
                 var key = (msg.MessageId, msg.AccountId, msg.FolderName);
-                if (!existingKeys.Add(key))
+                if (existingById.TryGetValue(key, out var prior))
+                {
+                    ReconcileMessageState(prior, msg);
                     continue;
+                }
 
                 if (!MatchesFilter(msg) || !MatchesDayLimit(msg))
                     continue;
 
                 InsertMessageSorted(msg);
+                existingById[key] = msg;
             }
 
             if (!IsCurrentFolderLoad(loadVersion, expectedFolder)) return;


### PR DESCRIPTION
Fixes #111.

## Summary

- Replaced the add-only `existingKeys` HashSet in all virtual-folder merge paths (All Mail, per-account All Mail, All Inboxes, Drafts, Sent, Trash) with a `Dictionary` keyed on `(MessageId, AccountId, FolderName)`.
- On collision, a new `ReconcileMessageState` helper copies server-fresh mutable fields (`IsRead`, `IsReplied`, `IsForwarded`, `HasAttachments`, flag fields) onto the existing `ObservableObject` in place — triggering `PropertyChanged` so rows update without disturbing selection or screen-reader focus.
- Genuinely new messages are still inserted sorted as before.
- The local-store upsert at the end of each method already covered all fetched messages, so cache correctness was not affected.

## Test plan

- [ ] Open All Mail with at least one unread message; mark it read in another client; press F5 — message should update to read
- [ ] Same test with a flagged/unflagged change
- [ ] Verify in per-account All Mail, All Inboxes, Drafts, Sent, and Trash virtual folders
- [ ] Verify in `--online` mode (already does full replace — should be unaffected)
- [ ] Verify new messages added by F5 still insert sorted correctly
- [ ] Verify selection and screen-reader focus are not disrupted when rows reconcile

🤖 Generated with [Claude Code](https://claude.com/claude-code)