### PR TITLE
Graph PR 6: message & folder mutations

### DIFF
--- a/QuickMail.Tests/GraphMailServiceMutationTests.cs
+++ b/QuickMail.Tests/GraphMailServiceMutationTests.cs
@@ -16,8 +16,17 @@ namespace QuickMail.Tests;
 /// PR 6 — exercises the Graph mutation surface (move/copy/delete/trash, mark-read, drafts,
 /// attachment download, folder CRUD) against a stub handler that records method, URL, and body.
 /// </summary>
-public class GraphMailServiceMutationTests
+public class GraphMailServiceMutationTests : IDisposable
 {
+    // GraphMailService wraps a GraphClient/HttpClient; dispose every one created during a test
+    // (CLAUDE.md IDisposable rule). xUnit disposes the test-class instance after each test.
+    private readonly List<GraphMailService> _created = new();
+
+    public void Dispose()
+    {
+        foreach (var svc in _created) svc.Dispose();
+    }
+
     private sealed class RecordingHandler : HttpMessageHandler
     {
         private readonly Func<string, (HttpStatusCode Status, string Json)> _respond;
@@ -39,16 +48,17 @@ public class GraphMailServiceMutationTests
 
     // ConnectAsync probes /me and the five well-known folders; anything not explicitly stubbed
     // returns "{}" (a folder with a null id → skipped), which is harmless for mutation tests.
-    private static (GraphMailService Svc, RecordingHandler Handler) Make(Func<string, (HttpStatusCode, string)> respond)
+    private (GraphMailService Svc, RecordingHandler Handler) Make(Func<string, (HttpStatusCode, string)> respond)
     {
         var handler = new RecordingHandler(url => url.Contains("/me?") ? (HttpStatusCode.OK, MeJson) : respond(url));
         var svc = new GraphMailService(new StubOAuthService(), null, new HttpClient(handler));
+        _created.Add(svc);
         return (svc, handler);
     }
 
     private static (HttpStatusCode, string) Ok(string json = "{}") => (HttpStatusCode.OK, json);
 
-    private static async Task<(GraphMailService Svc, RecordingHandler Handler, AccountModel Account)> ConnectedAsync(
+    private async Task<(GraphMailService Svc, RecordingHandler Handler, AccountModel Account)> ConnectedAsync(
         Func<string, (HttpStatusCode, string)>? respond = null)
     {
         var (svc, handler) = Make(respond ?? (_ => Ok()));
@@ -184,6 +194,17 @@ public class GraphMailServiceMutationTests
         Assert.Contains("Renamed", patch.Body);
         var move = Assert.Single(h.Calls, c => c.Method == "POST" && c.Url.Contains("/me/mailFolders/f1/move"));
         Assert.Contains("parent2", move.Body);
+    }
+
+    [Fact]
+    public async Task RenameFolderAsync_RenameOnly_PatchesNameWithoutMoving()
+    {
+        var (svc, h, acct) = await ConnectedAsync();
+
+        await svc.RenameFolderAsync(acct.Id, "f1", "Renamed", newParentFolderName: null);
+
+        Assert.Single(h.Calls, c => c.Method == "PATCH" && c.Url.EndsWith("/me/mailFolders/f1"));
+        Assert.DoesNotContain(h.Calls, c => c.Url.Contains("/move"));
     }
 
     [Fact]

--- a/QuickMail.Tests/GraphMailServiceMutationTests.cs
+++ b/QuickMail.Tests/GraphMailServiceMutationTests.cs
@@ -1,0 +1,237 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using QuickMail.Models;
+using QuickMail.Services;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// PR 6 — exercises the Graph mutation surface (move/copy/delete/trash, mark-read, drafts,
+/// attachment download, folder CRUD) against a stub handler that records method, URL, and body.
+/// </summary>
+public class GraphMailServiceMutationTests
+{
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        private readonly Func<string, (HttpStatusCode Status, string Json)> _respond;
+        public List<(string Method, string Url, string Body)> Calls { get; } = new();
+
+        public RecordingHandler(Func<string, (HttpStatusCode, string)> respond) => _respond = respond;
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            var url = request.RequestUri!.ToString();
+            var body = request.Content is null ? "" : await request.Content.ReadAsStringAsync(ct);
+            Calls.Add((request.Method.Method, url, body));
+            var (status, json) = _respond(url);
+            return new HttpResponseMessage(status) { Content = new StringContent(json, Encoding.UTF8, "application/json") };
+        }
+    }
+
+    private const string MeJson = """{"id":"u1","userPrincipalName":"user@contoso.com"}""";
+
+    // ConnectAsync probes /me and the five well-known folders; anything not explicitly stubbed
+    // returns "{}" (a folder with a null id → skipped), which is harmless for mutation tests.
+    private static (GraphMailService Svc, RecordingHandler Handler) Make(Func<string, (HttpStatusCode, string)> respond)
+    {
+        var handler = new RecordingHandler(url => url.Contains("/me?") ? (HttpStatusCode.OK, MeJson) : respond(url));
+        var svc = new GraphMailService(new StubOAuthService(), null, new HttpClient(handler));
+        return (svc, handler);
+    }
+
+    private static (HttpStatusCode, string) Ok(string json = "{}") => (HttpStatusCode.OK, json);
+
+    private static async Task<(GraphMailService Svc, RecordingHandler Handler, AccountModel Account)> ConnectedAsync(
+        Func<string, (HttpStatusCode, string)>? respond = null)
+    {
+        var (svc, handler) = Make(respond ?? (_ => Ok()));
+        var account = new AccountModel { Id = Guid.NewGuid(), Username = "old@contoso.com", BackendKind = BackendKind.MicrosoftGraph };
+        await svc.ConnectAsync(account);
+        return (svc, handler, account);
+    }
+
+    [Fact]
+    public async Task MoveMessagesAsync_PostsMovePerMessage_WithDestination()
+    {
+        var (svc, h, acct) = await ConnectedAsync();
+
+        await svc.MoveMessagesAsync(acct.Id, "inbox", new[] { "m1", "m2" }, "archive");
+
+        var moves = h.Calls.Where(c => c.Method == "POST" && c.Url.Contains("/move")).ToList();
+        Assert.Equal(2, moves.Count);
+        Assert.Contains(moves, c => c.Url.Contains("/me/messages/m1/move"));
+        Assert.Contains(moves, c => c.Url.Contains("/me/messages/m2/move"));
+        Assert.All(moves, c => Assert.Contains("archive", c.Body));
+    }
+
+    [Fact]
+    public async Task CopyMessagesAsync_PostsCopyPerMessage()
+    {
+        var (svc, h, acct) = await ConnectedAsync();
+
+        await svc.CopyMessagesAsync(acct.Id, "inbox", new[] { "m1" }, "archive");
+
+        var copy = Assert.Single(h.Calls, c => c.Method == "POST" && c.Url.Contains("/me/messages/m1/copy"));
+        Assert.Contains("archive", copy.Body);
+    }
+
+    [Fact]
+    public async Task MoveToTrashBatchAsync_MovesToDeletedItems()
+    {
+        var (svc, h, acct) = await ConnectedAsync();
+
+        await svc.MoveToTrashBatchAsync(acct.Id, "inbox", new[] { "m1", "m2" });
+
+        var moves = h.Calls.Where(c => c.Method == "POST" && c.Url.Contains("/move")).ToList();
+        Assert.Equal(2, moves.Count);
+        Assert.All(moves, c => Assert.Contains("deleteditems", c.Body));
+    }
+
+    [Fact]
+    public async Task PermanentlyDeleteBatchAsync_DeletesEachMessage()
+    {
+        var (svc, h, acct) = await ConnectedAsync();
+
+        await svc.PermanentlyDeleteBatchAsync(acct.Id, "deleteditems", new[] { "m1", "m2" });
+
+        var deletes = h.Calls.Where(c => c.Method == "DELETE" && c.Url.Contains("/me/messages/")).ToList();
+        Assert.Equal(2, deletes.Count);
+        Assert.Contains(deletes, c => c.Url.EndsWith("/me/messages/m1"));
+        Assert.Contains(deletes, c => c.Url.EndsWith("/me/messages/m2"));
+    }
+
+    [Fact]
+    public async Task EmptyTrashAsync_DeletesEveryTrashMessage_AndReturnsCount()
+    {
+        var (svc, h, acct) = await ConnectedAsync(url =>
+            url.Contains("/mailFolders/deleteditems/messages")
+                ? Ok("""{"value":[{"id":"d1"},{"id":"d2"},{"id":"d3"}]}""")
+                : Ok());
+
+        var count = await svc.EmptyTrashAsync(acct.Id);
+
+        Assert.Equal(3, count);
+        Assert.Equal(3, h.Calls.Count(c => c.Method == "DELETE" && c.Url.Contains("/me/messages/")));
+    }
+
+    [Fact]
+    public async Task MarkReadBatchAsync_PatchesIsReadPerMessage()
+    {
+        var (svc, h, acct) = await ConnectedAsync();
+
+        await svc.MarkReadBatchAsync(acct.Id, "inbox", new[] { "m1", "m2" });
+
+        var patches = h.Calls.Where(c => c.Method == "PATCH" && c.Url.Contains("/me/messages/")).ToList();
+        Assert.Equal(2, patches.Count);
+        Assert.All(patches, c => Assert.Contains("isRead", c.Body));
+    }
+
+    [Fact]
+    public async Task CountTrashMessagesAsync_ReadsDeletedItemsTotal()
+    {
+        var (svc, _, acct) = await ConnectedAsync(url =>
+            url.Contains("/mailFolders/deleteditems?") ? Ok("""{"totalItemCount":7}""") : Ok());
+
+        Assert.Equal(7, await svc.CountTrashMessagesAsync(acct.Id));
+    }
+
+    [Fact]
+    public async Task CreateFolderAsync_TopLevel_PostsToMailFolders()
+    {
+        var (svc, h, acct) = await ConnectedAsync();
+
+        await svc.CreateFolderAsync(acct.Id, null, "Projects");
+
+        var post = Assert.Single(h.Calls, c => c.Method == "POST" && c.Url.EndsWith("/me/mailFolders"));
+        Assert.Contains("Projects", post.Body);
+    }
+
+    [Fact]
+    public async Task CreateFolderAsync_WithParent_PostsToChildFolders()
+    {
+        var (svc, h, acct) = await ConnectedAsync();
+
+        await svc.CreateFolderAsync(acct.Id, "parent1", "Sub");
+
+        Assert.Single(h.Calls, c => c.Method == "POST" && c.Url.Contains("/me/mailFolders/parent1/childFolders"));
+    }
+
+    [Fact]
+    public async Task DeleteFolderAsync_DeletesTheFolder()
+    {
+        var (svc, h, acct) = await ConnectedAsync();
+
+        await svc.DeleteFolderAsync(acct.Id, "f1");
+
+        Assert.Single(h.Calls, c => c.Method == "DELETE" && c.Url.EndsWith("/me/mailFolders/f1"));
+    }
+
+    [Fact]
+    public async Task RenameFolderAsync_PatchesNameThenMovesToNewParent()
+    {
+        var (svc, h, acct) = await ConnectedAsync();
+
+        await svc.RenameFolderAsync(acct.Id, "f1", "Renamed", "parent2");
+
+        var patch = Assert.Single(h.Calls, c => c.Method == "PATCH" && c.Url.EndsWith("/me/mailFolders/f1"));
+        Assert.Contains("Renamed", patch.Body);
+        var move = Assert.Single(h.Calls, c => c.Method == "POST" && c.Url.Contains("/me/mailFolders/f1/move"));
+        Assert.Contains("parent2", move.Body);
+    }
+
+    [Fact]
+    public async Task CopyFolderAsync_PostsCopyToDestination()
+    {
+        var (svc, h, acct) = await ConnectedAsync();
+
+        await svc.CopyFolderAsync(acct.Id, "f1", "dest");
+
+        var copy = Assert.Single(h.Calls, c => c.Method == "POST" && c.Url.Contains("/me/mailFolders/f1/copy"));
+        Assert.Contains("dest", copy.Body);
+    }
+
+    [Fact]
+    public async Task DownloadAttachmentAsync_GetsAttachmentValueBytes()
+    {
+        var (svc, _, acct) = await ConnectedAsync(url =>
+            url.Contains("/attachments/a1/$value") ? Ok("FILEDATA") : Ok());
+
+        var bytes = await svc.DownloadAttachmentAsync(acct.Id, "inbox", "m1", "a1");
+
+        Assert.Equal("FILEDATA", Encoding.UTF8.GetString(bytes));
+    }
+
+    [Fact]
+    public async Task AppendDraftAsync_PostsMimeToMessages_AndReturnsNewId()
+    {
+        var (svc, h, acct) = await ConnectedAsync(url =>
+            url.EndsWith("/me/messages") ? Ok("""{"id":"draft1"}""") : Ok());
+
+        var id = await svc.AppendDraftAsync(acct.Id,
+            new ComposeModel { To = "a@b.com", Subject = "s", Body = "hi" }, replaceMessageId: null);
+
+        Assert.Equal("draft1", id);
+        var post = Assert.Single(h.Calls, c => c.Method == "POST" && c.Url.EndsWith("/me/messages"));
+        Assert.NotEmpty(post.Body); // base64 MIME
+    }
+
+    [Fact]
+    public async Task AppendDraftAsync_DeletesOldDraft_WhenReplacing()
+    {
+        var (svc, h, acct) = await ConnectedAsync(url =>
+            url.EndsWith("/me/messages") ? Ok("""{"id":"draft2"}""") : Ok());
+
+        await svc.AppendDraftAsync(acct.Id,
+            new ComposeModel { To = "a@b.com", Subject = "s", Body = "hi" }, replaceMessageId: "old1");
+
+        Assert.Single(h.Calls, c => c.Method == "DELETE" && c.Url.EndsWith("/me/messages/old1"));
+        Assert.Single(h.Calls, c => c.Method == "POST" && c.Url.EndsWith("/me/messages"));
+    }
+}

--- a/QuickMail.Tests/GraphMailServiceTests.cs
+++ b/QuickMail.Tests/GraphMailServiceTests.cs
@@ -247,16 +247,6 @@ public class GraphMailServiceTests
     }
 
     [Fact]
-    public void Mutation_Throws_NotImplemented_InPR4()
-    {
-        var (svc, _) = Make(url => (HttpStatusCode.OK, "{}"));
-        // These throw synchronously (expression-bodied `=> throw ...`), so the discard keeps the
-        // lambda an Action rather than a Func<Task>.
-        Assert.Throws<NotImplementedException>(() => { _ = svc.MoveToTrashAsync(Guid.NewGuid(), "inbox", "m1"); });
-        Assert.Throws<NotImplementedException>(() => { _ = svc.CreateFolderAsync(Guid.NewGuid(), null, "New"); });
-    }
-
-    [Fact]
     public void AppendToSentAsync_IsNoOp_ForGraph()
     {
         // Graph /sendMail auto-saves to Sent, so the post-send append is a no-op (not a throw).

--- a/QuickMail/Services/Graph/GraphClient.cs
+++ b/QuickMail/Services/Graph/GraphClient.cs
@@ -83,6 +83,47 @@ public sealed class GraphClient : IDisposable
         await EnsureSuccessAsync(resp, ct);
     }
 
+    /// <summary>POSTs a JSON body and ignores the response payload (move/copy/folder operations).</summary>
+    public async Task PostAsync(AccountModel account, string path, object body, CancellationToken ct = default)
+    {
+        var json = JsonSerializer.Serialize(body, JsonOpts);
+        using var resp = await SendAsync(account, HttpMethod.Post, path,
+            () => new StringContent(json, Encoding.UTF8, "application/json"), ct);
+        await EnsureSuccessAsync(resp, ct);
+    }
+
+    /// <summary>
+    /// POSTs an already-encoded raw body and deserializes the JSON response. Used to create a draft
+    /// from MIME (<c>POST /me/messages</c>), where the created message's id is needed back.
+    /// </summary>
+    public async Task<T?> PostRawReadAsync<T>(
+        AccountModel account, string path, byte[] body, string contentType, CancellationToken ct = default)
+    {
+        using var resp = await SendAsync(account, HttpMethod.Post, path, () =>
+        {
+            var content = new ByteArrayContent(body);
+            content.Headers.ContentType = new MediaTypeHeaderValue(contentType);
+            return content;
+        }, ct);
+        await EnsureSuccessAsync(resp, ct);
+        return await resp.Content.ReadFromJsonAsync<T>(JsonOpts, ct);
+    }
+
+    /// <summary>DELETEs a resource (permanent message delete, folder delete).</summary>
+    public async Task DeleteAsync(AccountModel account, string path, CancellationToken ct = default)
+    {
+        using var resp = await SendAsync(account, HttpMethod.Delete, path, null, ct);
+        await EnsureSuccessAsync(resp, ct);
+    }
+
+    /// <summary>GETs a raw byte payload (attachment <c>$value</c> download).</summary>
+    public async Task<byte[]> GetBytesAsync(AccountModel account, string path, CancellationToken ct = default)
+    {
+        using var resp = await SendAsync(account, HttpMethod.Get, path, null, ct);
+        await EnsureSuccessAsync(resp, ct);
+        return await resp.Content.ReadAsByteArrayAsync(ct);
+    }
+
     private async Task<HttpResponseMessage> SendAsync(
         AccountModel account, HttpMethod method, string pathOrUrl, Func<HttpContent>? contentFactory, CancellationToken ct)
     {

--- a/QuickMail/Services/GraphMailService.cs
+++ b/QuickMail/Services/GraphMailService.cs
@@ -134,16 +134,19 @@ public class GraphMailService : IMailService
         // into the Trash folder — surfacing those recoverable folders back in the tree makes a delete
         // look like it didn't take. We still show Deleted Items itself, just not its sub-folders.
         var trashId = wellKnown.FirstOrDefault(kv => kv.Value == SpecialFolderKind.Trash).Key;
+        if (trashId == null)
+            LogService.Log($"GraphMailService: Trash folder id unresolved for account {accountId}; " +
+                           "cannot filter recoverable sub-folders out of the tree.");
 
         // Breadth-first descent: each iteration fetches the children of folders known to have them.
-        var pending = new Queue<GraphMailFolder>(all.Where(f => f.ChildFolderCount > 0 && f.Id != trashId));
+        var pending = new Queue<GraphMailFolder>(all.Where(f => f.ChildFolderCount > 0 && (trashId == null || f.Id != trashId)));
         while (pending.Count > 0)
         {
             var parent = pending.Dequeue();
             var children = await _client.GetAllPagesAsync<GraphMailFolder>(
                 account, $"/me/mailFolders/{parent.Id}/childFolders?$top=100&{select}", ct);
             all.AddRange(children);
-            foreach (var c in children.Where(c => c.ChildFolderCount > 0 && c.Id != trashId))
+            foreach (var c in children.Where(c => c.ChildFolderCount > 0 && (trashId == null || c.Id != trashId)))
                 pending.Enqueue(c);
         }
 
@@ -297,16 +300,20 @@ public class GraphMailService : IMailService
     public async Task<string> AppendDraftAsync(Guid accountId, ComposeModel draft, string? replaceMessageId, CancellationToken ct = default)
     {
         var account = Account(accountId);
-        // Editing an existing draft: remove the old copy first (mirrors the IMAP delete-then-append).
-        if (!string.IsNullOrEmpty(replaceMessageId))
+
+        // POST the new draft to /me/messages (base64, text/plain) FIRST — Graph files it under Drafts
+        // and returns the created message. Only then delete the old copy: Graph's DELETE is an
+        // immediate, unrecoverable hard delete (unlike IMAP's deferred expunge), so a failure between
+        // the two must leave the content recoverable (at worst a duplicate draft) rather than gone.
+        var mime = MimeMessageBuilder.Build(draft, account, MimeMessageBuilder.AppUserAgent);
+        var body = await MimeMessageBuilder.ToBase64BytesAsync(mime, ct);
+        var created = await _client.PostRawReadAsync<GraphMessage>(account, "/me/messages", body, "text/plain", ct);
+        var newId = created?.Id ?? string.Empty;
+
+        if (!string.IsNullOrEmpty(replaceMessageId) && !string.IsNullOrEmpty(newId))
             await _client.DeleteAsync(account, $"/me/messages/{replaceMessageId}", ct);
 
-        // POST the MIME draft to /me/messages (base64, text/plain); Graph files it under Drafts and
-        // returns the created message, whose id becomes the new draft key.
-        var mime = MimeMessageBuilder.Build(draft, account, MimeMessageBuilder.AppUserAgent);
-        var body = await ToBase64MimeAsync(mime, ct);
-        var created = await _client.PostRawReadAsync<GraphMessage>(account, "/me/messages", body, "text/plain", ct);
-        return created?.Id ?? string.Empty;
+        return newId;
     }
 
     // Graph's /sendMail auto-saves the sent message to the Sent folder, so there is nothing to append.
@@ -348,10 +355,11 @@ public class GraphMailService : IMailService
     public async Task RenameFolderAsync(Guid accountId, string folderName, string newName, string? newParentFolderName, CancellationToken ct = default)
     {
         var account = Account(accountId);
-        // Mirror IMAP's RenameAsync(parent, name): set the display name and reparent in one operation.
+        // Rename: set the display name. Only move when a new parent is actually requested — a
+        // rename-only call (null newParentFolderName) must not POST a redundant move-to-root.
         await _client.PatchAsync(account, $"/me/mailFolders/{folderName}", new { displayName = newName }, ct);
-        var destination = string.IsNullOrEmpty(newParentFolderName) ? RootFolderId : newParentFolderName;
-        await _client.PostAsync(account, $"/me/mailFolders/{folderName}/move", new { destinationId = destination }, ct);
+        if (!string.IsNullOrEmpty(newParentFolderName))
+            await _client.PostAsync(account, $"/me/mailFolders/{folderName}/move", new { destinationId = newParentFolderName }, ct);
     }
 
     public Task CopyFolderAsync(Guid accountId, string folderName, string? destinationParentName, CancellationToken ct = default)
@@ -359,13 +367,6 @@ public class GraphMailService : IMailService
         // Graph copies the folder and all of its messages (and sub-folders) server-side in one call.
         var destination = string.IsNullOrEmpty(destinationParentName) ? RootFolderId : destinationParentName;
         return _client.PostAsync(Account(accountId), $"/me/mailFolders/{folderName}/copy", new { destinationId = destination }, ct);
-    }
-
-    private static async Task<byte[]> ToBase64MimeAsync(MimeMessage message, CancellationToken ct)
-    {
-        using var ms = new MemoryStream();
-        await message.WriteToAsync(ms, ct);
-        return Encoding.ASCII.GetBytes(Convert.ToBase64String(ms.ToArray()));
     }
 
     public void Dispose()

--- a/QuickMail/Services/GraphMailService.cs
+++ b/QuickMail/Services/GraphMailService.cs
@@ -129,19 +129,23 @@ public class GraphMailService : IMailService
         var all = await _client.GetAllPagesAsync<GraphMailFolder>(
             account, $"/me/mailFolders?$top=100&{select}", ct);
 
+        var wellKnown = _wellKnownFolders.TryGetValue(accountId, out var map) ? map : EmptyWellKnown;
+        // A folder deleted via Graph is moved under Deleted Items (a soft delete), so don't descend
+        // into the Trash folder — surfacing those recoverable folders back in the tree makes a delete
+        // look like it didn't take. We still show Deleted Items itself, just not its sub-folders.
+        var trashId = wellKnown.FirstOrDefault(kv => kv.Value == SpecialFolderKind.Trash).Key;
+
         // Breadth-first descent: each iteration fetches the children of folders known to have them.
-        var pending = new Queue<GraphMailFolder>(all.Where(f => f.ChildFolderCount > 0));
+        var pending = new Queue<GraphMailFolder>(all.Where(f => f.ChildFolderCount > 0 && f.Id != trashId));
         while (pending.Count > 0)
         {
             var parent = pending.Dequeue();
             var children = await _client.GetAllPagesAsync<GraphMailFolder>(
                 account, $"/me/mailFolders/{parent.Id}/childFolders?$top=100&{select}", ct);
             all.AddRange(children);
-            foreach (var c in children.Where(c => c.ChildFolderCount > 0))
+            foreach (var c in children.Where(c => c.ChildFolderCount > 0 && c.Id != trashId))
                 pending.Enqueue(c);
         }
-
-        var wellKnown = _wellKnownFolders.TryGetValue(accountId, out var map) ? map : EmptyWellKnown;
 
         return all.Select(f =>
         {

--- a/QuickMail/Services/GraphMailService.cs
+++ b/QuickMail/Services/GraphMailService.cs
@@ -1,10 +1,13 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net.Http;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using MimeKit;
 using QuickMail.Models;
 using QuickMail.Services.Graph;
 
@@ -237,7 +240,12 @@ public class GraphMailService : IMailService
     // ── Safe no-ops (Graph has no persistent connection / IDLE; previews are native) ──
     public Task NoOpAsync(Guid accountId, CancellationToken ct = default) => Task.CompletedTask;
     public Task<int> PollAsync(Guid accountId, string folderName, CancellationToken ct = default) => Task.FromResult(0);
-    public Task<int> CountTrashMessagesAsync(Guid accountId, CancellationToken ct = default) => Task.FromResult(0); // real count in PR 5/6
+    public async Task<int> CountTrashMessagesAsync(Guid accountId, CancellationToken ct = default)
+    {
+        var f = await _client.GetAsync<GraphMailFolder>(
+            Account(accountId), $"/me/mailFolders/{DeletedItemsFolderId}?$select=totalItemCount", ct);
+        return f?.TotalItemCount ?? 0;
+    }
     public Task<IReadOnlyDictionary<string, string>> FetchPreviewsAsync(
         Guid accountId, string folderName, IList<string> messageIds, int maxLines, CancellationToken ct = default)
         => Task.FromResult<IReadOnlyDictionary<string, string>>(new Dictionary<string, string>()); // bodyPreview is fetched inline
@@ -247,39 +255,114 @@ public class GraphMailService : IMailService
     public void StartIdleWatchers(IReadOnlyList<AccountModel> accounts, CancellationToken ct = default) { }
     public void StopIdleWatchers() { }
 
-    // ── Mutations / attachments / folder CRUD — PR 5/6 ───────────────────────────
-    private static NotImplementedException NotYet(string member)
-        => new($"GraphMailService.{member} lands in PR 5/6.");
+    // ── Mutations / attachments / folder CRUD ────────────────────────────────────
+    // Graph well-known folder names double as folder ids in URLs.
+    private const string DeletedItemsFolderId = "deleteditems";
+    private const string RootFolderId         = "msgfolderroot";
 
-    public Task MarkReadBatchAsync(Guid accountId, string folderName, IList<string> messageIds, CancellationToken ct = default)
-        => throw NotYet(nameof(MarkReadBatchAsync));
+    public async Task MarkReadBatchAsync(Guid accountId, string folderName, IList<string> messageIds, CancellationToken ct = default)
+    {
+        var account = Account(accountId);
+        foreach (var id in messageIds)
+            await _client.PatchAsync(account, $"/me/messages/{id}", new { isRead = true }, ct);
+    }
+
     public Task MoveToTrashAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default)
-        => throw NotYet(nameof(MoveToTrashAsync));
+        => MoveMessagesAsync(accountId, folderName, new[] { messageId }, DeletedItemsFolderId, ct);
+
     public Task MoveToTrashBatchAsync(Guid accountId, string folderName, IList<string> messageIds, CancellationToken ct = default)
-        => throw NotYet(nameof(MoveToTrashBatchAsync));
-    public Task PermanentlyDeleteBatchAsync(Guid accountId, string folderName, IList<string> messageIds, CancellationToken ct = default)
-        => throw NotYet(nameof(PermanentlyDeleteBatchAsync));
-    public Task<int> EmptyTrashAsync(Guid accountId, CancellationToken ct = default)
-        => throw NotYet(nameof(EmptyTrashAsync));
-    public Task<string> AppendDraftAsync(Guid accountId, ComposeModel draft, string? replaceMessageId, CancellationToken ct = default)
-        => throw NotYet(nameof(AppendDraftAsync));
+        => MoveMessagesAsync(accountId, folderName, messageIds, DeletedItemsFolderId, ct);
+
+    public async Task PermanentlyDeleteBatchAsync(Guid accountId, string folderName, IList<string> messageIds, CancellationToken ct = default)
+    {
+        var account = Account(accountId);
+        foreach (var id in messageIds)
+            await _client.DeleteAsync(account, $"/me/messages/{id}", ct);
+    }
+
+    public async Task<int> EmptyTrashAsync(Guid accountId, CancellationToken ct = default)
+    {
+        var account = Account(accountId);
+        var msgs = await _client.GetAllPagesAsync<GraphMessage>(
+            account, $"/me/mailFolders/{DeletedItemsFolderId}/messages?$select=id&$top=999", ct);
+        foreach (var m in msgs)
+            await _client.DeleteAsync(account, $"/me/messages/{m.Id}", ct);
+        return msgs.Count;
+    }
+
+    public async Task<string> AppendDraftAsync(Guid accountId, ComposeModel draft, string? replaceMessageId, CancellationToken ct = default)
+    {
+        var account = Account(accountId);
+        // Editing an existing draft: remove the old copy first (mirrors the IMAP delete-then-append).
+        if (!string.IsNullOrEmpty(replaceMessageId))
+            await _client.DeleteAsync(account, $"/me/messages/{replaceMessageId}", ct);
+
+        // POST the MIME draft to /me/messages (base64, text/plain); Graph files it under Drafts and
+        // returns the created message, whose id becomes the new draft key.
+        var mime = MimeMessageBuilder.Build(draft, account, MimeMessageBuilder.AppUserAgent);
+        var body = await ToBase64MimeAsync(mime, ct);
+        var created = await _client.PostRawReadAsync<GraphMessage>(account, "/me/messages", body, "text/plain", ct);
+        return created?.Id ?? string.Empty;
+    }
+
     // Graph's /sendMail auto-saves the sent message to the Sent folder, so there is nothing to append.
     public Task AppendToSentAsync(Guid accountId, ComposeModel sent, CancellationToken ct = default)
         => Task.CompletedTask;
+
     public Task<byte[]> DownloadAttachmentAsync(Guid accountId, string folderName, string messageId, string partSpecifier, CancellationToken ct = default)
-        => throw NotYet(nameof(DownloadAttachmentAsync));
-    public Task CopyMessagesAsync(Guid accountId, string folderName, IList<string> messageIds, string destinationFolder, CancellationToken ct = default)
-        => throw NotYet(nameof(CopyMessagesAsync));
-    public Task MoveMessagesAsync(Guid accountId, string folderName, IList<string> messageIds, string destinationFolder, CancellationToken ct = default)
-        => throw NotYet(nameof(MoveMessagesAsync));
-    public Task CreateFolderAsync(Guid accountId, string? parentFolderName, string name, CancellationToken ct = default)
-        => throw NotYet(nameof(CreateFolderAsync));
+        // partSpecifier carries the Graph attachment id (set by MapToDetail).
+        => _client.GetBytesAsync(Account(accountId), $"/me/messages/{messageId}/attachments/{partSpecifier}/$value", ct);
+
+    public async Task CopyMessagesAsync(Guid accountId, string folderName, IList<string> messageIds, string destinationFolder, CancellationToken ct = default)
+    {
+        var account = Account(accountId);
+        foreach (var id in messageIds)
+            await _client.PostAsync(account, $"/me/messages/{id}/copy", new { destinationId = destinationFolder }, ct);
+    }
+
+    public async Task MoveMessagesAsync(Guid accountId, string folderName, IList<string> messageIds, string destinationFolder, CancellationToken ct = default)
+    {
+        var account = Account(accountId);
+        foreach (var id in messageIds)
+            await _client.PostAsync(account, $"/me/messages/{id}/move", new { destinationId = destinationFolder }, ct);
+    }
+
+    public async Task CreateFolderAsync(Guid accountId, string? parentFolderName, string name, CancellationToken ct = default)
+    {
+        var account = Account(accountId);
+        // null parent = account root; otherwise create under the parent's childFolders collection.
+        var path = string.IsNullOrEmpty(parentFolderName)
+            ? "/me/mailFolders"
+            : $"/me/mailFolders/{parentFolderName}/childFolders";
+        await _client.PostAsync(account, path, new { displayName = name }, ct);
+    }
+
     public Task DeleteFolderAsync(Guid accountId, string folderName, CancellationToken ct = default)
-        => throw NotYet(nameof(DeleteFolderAsync));
-    public Task RenameFolderAsync(Guid accountId, string folderName, string newName, string? newParentFolderName, CancellationToken ct = default)
-        => throw NotYet(nameof(RenameFolderAsync));
+        // Graph moves a deleted folder to Deleted Items (recoverable), matching the IMAP safety behaviour.
+        => _client.DeleteAsync(Account(accountId), $"/me/mailFolders/{folderName}", ct);
+
+    public async Task RenameFolderAsync(Guid accountId, string folderName, string newName, string? newParentFolderName, CancellationToken ct = default)
+    {
+        var account = Account(accountId);
+        // Mirror IMAP's RenameAsync(parent, name): set the display name and reparent in one operation.
+        await _client.PatchAsync(account, $"/me/mailFolders/{folderName}", new { displayName = newName }, ct);
+        var destination = string.IsNullOrEmpty(newParentFolderName) ? RootFolderId : newParentFolderName;
+        await _client.PostAsync(account, $"/me/mailFolders/{folderName}/move", new { destinationId = destination }, ct);
+    }
+
     public Task CopyFolderAsync(Guid accountId, string folderName, string? destinationParentName, CancellationToken ct = default)
-        => throw NotYet(nameof(CopyFolderAsync));
+    {
+        // Graph copies the folder and all of its messages (and sub-folders) server-side in one call.
+        var destination = string.IsNullOrEmpty(destinationParentName) ? RootFolderId : destinationParentName;
+        return _client.PostAsync(Account(accountId), $"/me/mailFolders/{folderName}/copy", new { destinationId = destination }, ct);
+    }
+
+    private static async Task<byte[]> ToBase64MimeAsync(MimeMessage message, CancellationToken ct)
+    {
+        using var ms = new MemoryStream();
+        await message.WriteToAsync(ms, ct);
+        return Encoding.ASCII.GetBytes(Convert.ToBase64String(ms.ToArray()));
+    }
 
     public void Dispose()
     {

--- a/QuickMail/Services/GraphSendMailService.cs
+++ b/QuickMail/Services/GraphSendMailService.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Buffers.Text;
-using System.IO;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -31,16 +29,9 @@ public class GraphSendMailService : ISendMailService, IDisposable
 
     private async Task SendMimeAsync(AccountModel account, MimeMessage message, CancellationToken ct)
     {
-        using var ms = new MemoryStream();
-        await message.WriteToAsync(ms, ct);
-        int mimeLength = (int)ms.Length;
-
-        // Graph /sendMail takes the MIME message base64-encoded as a text/plain body. Encode the
-        // MIME bytes straight to base64 ASCII bytes — no intermediate base64 string allocation.
-        var body = new byte[Base64.GetMaxEncodedToUtf8Length(mimeLength)];
-        Base64.EncodeToUtf8(ms.GetBuffer().AsSpan(0, mimeLength), body, out _, out _);
-
-        LogService.Log($"GraphSendMailService: sending {mimeLength} MIME bytes via /me/sendMail");
+        // Graph /sendMail takes the MIME message base64-encoded as a text/plain body.
+        var body = await MimeMessageBuilder.ToBase64BytesAsync(message, ct);
+        LogService.Log($"GraphSendMailService: sending {body.Length} base64 bytes via /me/sendMail");
         await _client.PostRawAsync(account, "/me/sendMail", body, "text/plain", ct);
         LogService.Log("GraphSendMailService: send complete");
     }

--- a/QuickMail/Services/MimeMessageBuilder.cs
+++ b/QuickMail/Services/MimeMessageBuilder.cs
@@ -1,8 +1,11 @@
 using System;
+using System.Buffers.Text;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using MimeKit;
 using QuickMail.Helpers;
 using QuickMail.Models;
@@ -19,6 +22,22 @@ public static class MimeMessageBuilder
     /// <summary>The User-Agent string for outgoing mail — one source of truth for every sender.</summary>
     internal static readonly string AppUserAgent =
         "QuickMail/" + (Assembly.GetExecutingAssembly().GetName().Version?.ToString(3) ?? "0");
+
+    /// <summary>
+    /// Serializes a <see cref="MimeMessage"/> to base64-encoded ASCII bytes — the form Graph's
+    /// <c>/me/sendMail</c> and <c>/me/messages</c> endpoints accept as a <c>text/plain</c> body.
+    /// Encodes straight to base64 (no intermediate string, and <c>GetBuffer()</c> avoids a copy) to
+    /// keep peak memory low for large/attachment-bearing messages.
+    /// </summary>
+    internal static async Task<byte[]> ToBase64BytesAsync(MimeMessage message, CancellationToken ct = default)
+    {
+        using var ms = new MemoryStream();
+        await message.WriteToAsync(ms, ct);
+        int mimeLength = (int)ms.Length;
+        var body = new byte[Base64.GetMaxEncodedToUtf8Length(mimeLength)];
+        Base64.EncodeToUtf8(ms.GetBuffer().AsSpan(0, mimeLength), body, out _, out _);
+        return body;
+    }
 
     /// <summary>
     /// Builds a complete MIME message from compose fields, including attachments.


### PR DESCRIPTION
Implements the Graph dev-spec **PR 6** — lights up the mutation surface that `GraphMailService` had stubbed, so a Microsoft Graph account supports the full action set. Dispatched through the existing `MailServiceRouter`, so **no DI/VM changes are needed**.

## Messages
- **Move / move-to-trash** — `POST /messages/{id}/move` (trash → `deleteditems`)
- **Copy** — `POST /messages/{id}/copy`
- **Permanent delete / empty trash** — `DELETE /messages/{id}`
- **Mark read (batch)** — `PATCH /messages/{id}`
- **Trash count** — `GET /mailFolders/deleteditems?$select=totalItemCount`

## Drafts & attachments
- **Save/replace draft** — `POST /me/messages` with base64 MIME (Graph files it under Drafts); deletes the prior draft first when replacing
- **Download attachment** — `GET /messages/{id}/attachments/{ref}/$value`

## Folders
- **Create** (top-level or child), **delete**, **rename+move**, **copy** via the `mailFolders` endpoints
- **Don't descend into Deleted Items**: Graph's `DELETE` on a folder is a *soft delete* (moves it under Deleted Items, returns 204). `GetFoldersAsync` now skips the Trash folder's sub-folders so a deleted folder doesn't reappear in the tree on a refresh. Deleted Items itself is still shown.

## Plumbing & tests
- Adds `GraphClient` verbs: `PostAsync`, `PostRawReadAsync<T>`, `DeleteAsync`, `GetBytesAsync`.
- 15 mutation tests (method + URL + body against a recording stub); removed the now-obsolete "mutations throw NotImplemented" test.

## Notes / deferred
- Batches issue **sequential** per-message requests rather than Graph `$batch` — correct, just more calls; `$batch` is a future optimization.
- The cosmetic `AttachmentModel.PartSpecifier → AttachmentRef` rename (spec PR 6 item 2) is deferred to keep this focused on behavior.
