### PR TITLE
Folder tree UX: delete in place, Delete key, correct context menu

### DIFF
--- a/QuickMail/Services/CommandRegistry.cs
+++ b/QuickMail/Services/CommandRegistry.cs
@@ -53,14 +53,22 @@ public sealed class CommandRegistry : ICommandRegistry
         if (overrideHit != null) return overrideHit;
 
         // Fall back to default gestures (skipping any command that has a live override).
+        // When several commands share a default gesture (e.g. Delete → mail.delete and
+        // folder.delete), prefer whichever is currently available for the focus; fall back to the
+        // first match so the dispatcher's own availability check still applies.
+        CommandDefinition? firstMatch = null;
         foreach (var cmd in _byId.Values)
         {
             if (suppressed.Contains(cmd.Id)) continue;
             if (cmd.DefaultKey == key && cmd.DefaultModifiers == modifiers)
-                return cmd;
+            {
+                firstMatch ??= cmd;
+                if (cmd.IsAvailable?.Invoke() ?? true)
+                    return cmd;
+            }
         }
 
-        return null;
+        return firstMatch;
     }
 
     /// <summary>

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -4089,10 +4089,22 @@ public partial class MainViewModel : ObservableObject
         }
 
         // IMAP: children live under "Parent/Child" or "Parent.Child", so also drop by path prefix.
-        _cachedFolders[accountId] = folders.Where(f =>
-            !removeIds.Contains(f.FullName) &&
-            !f.FullName.StartsWith(deleted.FullName + "/", StringComparison.OrdinalIgnoreCase) &&
-            !f.FullName.StartsWith(deleted.FullName + ".", StringComparison.OrdinalIgnoreCase)).ToList();
+        bool ShouldRemove(MailFolderModel f) =>
+            removeIds.Contains(f.FullName) ||
+            f.FullName.StartsWith(deleted.FullName + "/", StringComparison.OrdinalIgnoreCase) ||
+            f.FullName.StartsWith(deleted.FullName + ".", StringComparison.OrdinalIgnoreCase);
+
+        _cachedFolders[accountId] = folders.Where(f => !ShouldRemove(f)).ToList();
+
+        // Keep the flat Folders collection in sync — it backs saved-view resolution, the folder
+        // picker, and the next tree rebuild, so a stale entry there would resolve a deleted folder.
+        for (int i = Folders.Count - 1; i >= 0; i--)
+            if (Folders[i].AccountId == accountId && !Folders[i].IsHeader && ShouldRemove(Folders[i]))
+                Folders.RemoveAt(i);
+
+        // Re-sum the account's unread badge from the pruned folder list.
+        var account = Accounts.FirstOrDefault(a => a.Id == accountId);
+        if (account != null) ApplyAccountStatus(account, _cachedFolders[accountId]);
     }
 
     /// <summary>
@@ -4186,13 +4198,15 @@ public partial class MainViewModel : ObservableObject
     /// Moves all messages in the folder to Trash, deletes the folder, and refreshes the tree.
     /// Shows a confirmation dialog first.
     /// </summary>
-    public async Task DeleteFolderAsync(FolderTreeNode node)
+    /// <summary>Deletes the folder. Returns true if the deletion happened, false if it was
+    /// cancelled at the confirmation prompt, pre-condition-failed, or errored.</summary>
+    public async Task<bool> DeleteFolderAsync(FolderTreeNode node)
     {
-        if (node.Folder == null || node.IsHeader) return;
+        if (node.Folder == null || node.IsHeader) return false;
 
         if (ConfirmationRequested?.Invoke(
             $"Delete the folder '{node.Label}' and move all its messages to Trash?",
-            "Delete Folder") != true) return;
+            "Delete Folder") != true) return false;
 
         StatusText = $"Deleting folder '{node.Label}'…";
         IsBusy     = true;
@@ -4216,11 +4230,13 @@ public partial class MainViewModel : ObservableObject
             RemoveFolderFromCacheOptimistically(node.Folder.AccountId, node.Folder);
             RemoveNodeFromTree(node);
             StatusText = $"Folder '{node.Label}' deleted.";
+            return true;
         }
         catch (Exception ex)
         {
             StatusText = $"Failed to delete folder: {ex.Message}";
             LogService.Log("DeleteFolder", ex);
+            return false;
         }
         finally { IsBusy = false; }
     }

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -4068,6 +4068,49 @@ public partial class MainViewModel : ObservableObject
         }
     }
 
+    /// <summary>
+    /// Removes a folder and its descendants from the cached folder list so the tree reflects a
+    /// delete immediately, without waiting on an eventually-consistent server re-fetch. Graph models
+    /// children by <see cref="MailFolderModel.ParentId"/>; IMAP encodes them in the separator path.
+    /// </summary>
+    private void RemoveFolderFromCacheOptimistically(Guid accountId, MailFolderModel deleted)
+    {
+        if (!_cachedFolders.TryGetValue(accountId, out var folders)) return;
+
+        // Graph: collect the whole subtree transitively by ParentId.
+        var removeIds = new HashSet<string>(StringComparer.Ordinal) { deleted.FullName };
+        bool grew = true;
+        while (grew)
+        {
+            grew = false;
+            foreach (var f in folders)
+                if (f.ParentId != null && removeIds.Contains(f.ParentId) && removeIds.Add(f.FullName))
+                    grew = true;
+        }
+
+        // IMAP: children live under "Parent/Child" or "Parent.Child", so also drop by path prefix.
+        _cachedFolders[accountId] = folders.Where(f =>
+            !removeIds.Contains(f.FullName) &&
+            !f.FullName.StartsWith(deleted.FullName + "/", StringComparison.OrdinalIgnoreCase) &&
+            !f.FullName.StartsWith(deleted.FullName + ".", StringComparison.OrdinalIgnoreCase)).ToList();
+    }
+
+    /// <summary>
+    /// Removes a node from the live <see cref="FolderTree"/> in place (without a full rebuild), so the
+    /// rest of the tree keeps its expansion state. Returns true if the node was found and removed.
+    /// </summary>
+    private bool RemoveNodeFromTree(FolderTreeNode target) => RemoveNodeFromChildren(FolderTree, target);
+
+    private static bool RemoveNodeFromChildren(ObservableCollection<FolderTreeNode> siblings, FolderTreeNode target)
+    {
+        for (int i = 0; i < siblings.Count; i++)
+        {
+            if (ReferenceEquals(siblings[i], target)) { siblings.RemoveAt(i); return true; }
+            if (RemoveNodeFromChildren(siblings[i].Children, target)) return true;
+        }
+        return false;
+    }
+
     /// <summary>Creates a new folder under the given parent and refreshes the tree.</summary>
     public async Task CreateFolderAndRefreshAsync(Guid accountId, string? parentFolderName, string name)
     {
@@ -4165,7 +4208,13 @@ public partial class MainViewModel : ObservableObject
                 await FetchAllMailAsync();
             }
 
-            await RefreshFolderListAsync(node.Folder.AccountId);
+            // Remove the folder immediately rather than via a server re-fetch — Graph is eventually
+            // consistent and can still return the just-deleted folder for a brief window. Drop it
+            // from the flat cache (so a later full rebuild stays correct) and splice the node out of
+            // the live tree in place, which preserves every other folder's expansion state and lets
+            // the View land focus on the neighbour (a full rebuild would collapse and reset focus).
+            RemoveFolderFromCacheOptimistically(node.Folder.AccountId, node.Folder);
+            RemoveNodeFromTree(node);
             StatusText = $"Folder '{node.Label}' deleted.";
         }
         catch (Exception ex)

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -855,6 +855,13 @@ public partial class MainWindow : Window
     private void OnWindowContextMenuOpening(object sender, ContextMenuEventArgs e)
     {
         if (e.Handled) return;
+
+        // Only act as the message-list fallback. The folder tree owns its own FolderContextMenu;
+        // if the request came from there, bail so that menu opens instead of stealing it with the
+        // message menu (which would wrongly show Reply/Reply All on a folder).
+        if (e.OriginalSource is DependencyObject src && IsWithin(src, FolderList))
+            return;
+
         if (_vm.IsMessagesView && MessageList.Visibility == Visibility.Visible
             && MessageList.Items.Count > 0)
         {
@@ -863,6 +870,20 @@ public partial class MainWindow : Window
             cm.IsOpen = true;
             e.Handled = true;
         }
+    }
+
+    // Walks visual then logical ancestors to test whether <paramref name="node"/> sits inside
+    // <paramref name="container"/>. Used to route a bubbled ContextMenuOpening to the right pane.
+    private static bool IsWithin(DependencyObject? node, DependencyObject container)
+    {
+        while (node != null)
+        {
+            if (ReferenceEquals(node, container)) return true;
+            node = node is System.Windows.Media.Visual or System.Windows.Media.Media3D.Visual3D
+                ? System.Windows.Media.VisualTreeHelper.GetParent(node)
+                : LogicalTreeHelper.GetParent(node);
+        }
+        return false;
     }
 
     // Global key handler (PreviewKeyDown so it fires before any child can swallow the event).
@@ -894,6 +915,18 @@ public partial class MainWindow : Window
                     interrupt: true, category: AnnouncementCategory.Result);
             }
             e.Handled = true;
+            return;
+        }
+
+        // Delete on a real folder in the folder tree deletes that folder. The global mail.delete
+        // (also bound to Delete) would otherwise grab the key and act on the message list.
+        if (key == Key.Delete && modifiers == ModifierKeys.None &&
+            FolderList.IsKeyboardFocusWithin &&
+            FolderList.SelectedItem is FolderTreeNode folderNode &&
+            IsDeletableFolderNode(folderNode))
+        {
+            e.Handled = true;
+            await DeleteFolderWithFocusAsync(folderNode);
             return;
         }
 
@@ -3850,8 +3883,49 @@ public partial class MainWindow : Window
     private async void FolderContextMenu_DeleteFolder_Click(object sender, RoutedEventArgs e)
     {
         var node = GetContextMenuFolderNode(sender);
-        if (node == null) return;
+        if (node != null)
+            await DeleteFolderWithFocusAsync(node);
+    }
+
+    // Deletes the folder and lands focus on the folder above. The VM splices the node out of the
+    // tree in place (no rebuild), so the captured neighbour reference stays valid for FocusTreeItem.
+    private async Task DeleteFolderWithFocusAsync(FolderTreeNode node)
+    {
+        var above = FindVisibleFolderNodeAbove(node);
         await _vm.DeleteFolderAsync(node);
+        if (above != null)
+            FocusTreeItem(FolderList, above);
+    }
+
+    // A real, deletable account folder (not a header, a virtual/aggregate folder, or a sentinel node).
+    private static bool IsDeletableFolderNode(FolderTreeNode node) =>
+        node.Folder is { } f && !node.IsHeader &&
+        f.AccountId != Guid.Empty &&
+        f.FullName.Length > 0 && f.FullName[0] != '\0';
+
+    // The folder node visually above the given one, honoring expansion: its previous sibling, or its
+    // parent when it is the first child. Null when it is the first node in the tree.
+    private FolderTreeNode? FindVisibleFolderNodeAbove(FolderTreeNode node)
+    {
+        FolderTreeNode? prev = null;
+        foreach (var n in FlattenVisibleFolderNodes(_vm.FolderTree))
+        {
+            if (ReferenceEquals(n, node)) return prev;
+            prev = n;
+        }
+        return null;
+    }
+
+    private static System.Collections.Generic.IEnumerable<FolderTreeNode> FlattenVisibleFolderNodes(
+        System.Collections.Generic.IEnumerable<FolderTreeNode> nodes)
+    {
+        foreach (var n in nodes)
+        {
+            yield return n;
+            if (n.IsExpanded)
+                foreach (var c in FlattenVisibleFolderNodes(n.Children))
+                    yield return c;
+        }
     }
 
     // ── Message context menu handlers ────────────────────────────────────────

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -726,7 +726,17 @@ public partial class MainWindow : Window
             defaultKey: Key.Delete, defaultModifiers: ModifierKeys.None,
             isAvailable: () => _vm.HasSelectedMessage
                 && !(IsMessageListFocused() && MessageList.SelectedItems.Count > 1)
-                && !IsGroupTreeFocused()));
+                && !IsGroupTreeFocused()
+                && !FolderList.IsKeyboardFocusWithin)); // folder.delete owns Delete in the folder tree
+
+        // Delete on a real folder in the folder tree deletes that folder (shares the Delete gesture
+        // with mail.delete; the registry prefers whichever command is available for the focus).
+        _registry.Register(new CommandDefinition(
+            id: "folder.delete", category: "Mail", title: "Delete Folder",
+            execute: () => _ = DeleteSelectedFolderAsync(),
+            defaultKey: Key.Delete, defaultModifiers: ModifierKeys.None,
+            isAvailable: () => FolderList.IsKeyboardFocusWithin
+                && FolderList.SelectedItem is FolderTreeNode n && IsDeletableFolderNode(n)));
 
         // ── Pane navigation (Ctrl+Alt+1/2/3 — always work regardless of tab mode) ──
         _registry.Register(new CommandDefinition(
@@ -859,7 +869,7 @@ public partial class MainWindow : Window
         // Only act as the message-list fallback. The folder tree owns its own FolderContextMenu;
         // if the request came from there, bail so that menu opens instead of stealing it with the
         // message menu (which would wrongly show Reply/Reply All on a folder).
-        if (e.OriginalSource is DependencyObject src && IsWithin(src, FolderList))
+        if (e.OriginalSource is DependencyObject src && IsDescendantOf(FolderList, src))
             return;
 
         if (_vm.IsMessagesView && MessageList.Visibility == Visibility.Visible
@@ -872,19 +882,6 @@ public partial class MainWindow : Window
         }
     }
 
-    // Walks visual then logical ancestors to test whether <paramref name="node"/> sits inside
-    // <paramref name="container"/>. Used to route a bubbled ContextMenuOpening to the right pane.
-    private static bool IsWithin(DependencyObject? node, DependencyObject container)
-    {
-        while (node != null)
-        {
-            if (ReferenceEquals(node, container)) return true;
-            node = node is System.Windows.Media.Visual or System.Windows.Media.Media3D.Visual3D
-                ? System.Windows.Media.VisualTreeHelper.GetParent(node)
-                : LogicalTreeHelper.GetParent(node);
-        }
-        return false;
-    }
 
     // Global key handler (PreviewKeyDown so it fires before any child can swallow the event).
     private async void OnWindowKeyDown(object sender, KeyEventArgs e)
@@ -915,18 +912,6 @@ public partial class MainWindow : Window
                     interrupt: true, category: AnnouncementCategory.Result);
             }
             e.Handled = true;
-            return;
-        }
-
-        // Delete on a real folder in the folder tree deletes that folder. The global mail.delete
-        // (also bound to Delete) would otherwise grab the key and act on the message list.
-        if (key == Key.Delete && modifiers == ModifierKeys.None &&
-            FolderList.IsKeyboardFocusWithin &&
-            FolderList.SelectedItem is FolderTreeNode folderNode &&
-            IsDeletableFolderNode(folderNode))
-        {
-            e.Handled = true;
-            await DeleteFolderWithFocusAsync(folderNode);
             return;
         }
 
@@ -3892,9 +3877,17 @@ public partial class MainWindow : Window
     private async Task DeleteFolderWithFocusAsync(FolderTreeNode node)
     {
         var above = FindVisibleFolderNodeAbove(node);
-        await _vm.DeleteFolderAsync(node);
-        if (above != null)
+        // Only move focus if the delete actually happened — a cancelled confirmation must leave the
+        // user where they were.
+        if (await _vm.DeleteFolderAsync(node) && above != null)
             FocusTreeItem(FolderList, above);
+    }
+
+    // Invoked by the folder.delete command (Delete key on the folder tree).
+    private async Task DeleteSelectedFolderAsync()
+    {
+        if (FolderList.SelectedItem is FolderTreeNode node && IsDeletableFolderNode(node))
+            await DeleteFolderWithFocusAsync(node);
     }
 
     // A real, deletable account folder (not a header, a virtual/aggregate folder, or a sentinel node).


### PR DESCRIPTION
Three related folder-tree interaction fixes, surfaced while testing Graph folder mutations.

## Delete a folder updates the tree in place
Deleting a folder rebuilt the whole tree, which collapsed every folder and dumped focus at the top. Now the node is spliced out of its parent's `Children` in place (and the folder + descendants are dropped from the cache), so the rest of the tree keeps its expansion and **focus lands on the folder above** the deleted one. This also avoids Graph's eventually-consistent re-fetch briefly re-surfacing the just-deleted folder (Graph soft-deletes folders to Deleted Items).

## Delete key on a folder deletes the folder
The global `mail.delete` command is bound to <kbd>Delete</kbd> and dispatched by the window-level `PreviewKeyDown` (which tunnels before the folder tree), so <kbd>Delete</kbd> on a folder was acting on the message list. Now, when the folder tree has focus and a **real** (non-header, non-virtual) folder is selected, <kbd>Delete</kbd> deletes that folder — same confirmation + focus-to-folder-above — and is marked handled so `mail.delete` doesn't fire.

## Fixes #112 — folder context menu showed message commands
With focus on a folder, the context menu showed Reply / Reply All instead of New/Move/Copy/Delete folder. Folder items *do* have the right menu (`FolderContextMenu` via the `TreeView.ItemContainerStyle`), but `OnWindowContextMenuOpening` — a Window-level fallback added so a message-list rebuild doesn't drop to the Win32 system menu — fired during the event bubble and opened `MessageContextMenu` whenever the message view was visible, stealing the folder's own menu. It now bails when the request originated inside `FolderList`, so the folder menu opens. The message-list rebuild fallback is preserved.

Fixes #112.
