### PR TITLE
Virtual-folder refresh: surface folder changes and remove deleted messages

### DIFF
--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -1836,8 +1836,28 @@ public partial class MainViewModel : ObservableObject
             minDateByFolder.TryGetValue((m.AccountId, m.FolderName), out var min) &&
             m.Date >= min &&
             !fetchedKeys.Contains((m.MessageId, m.AccountId, m.FolderName))).ToList();
+        if (vanished.Count == 0) return;
+
+        // Mirror RemoveFromActiveViewAsync: remove from the backing _rawMessages too (else they
+        // reappear when ApplyFiltersAndSearch rebuilds Messages), decrement account unread counts,
+        // and clear the reading pane if the open message was one of the removed ones. Messages in the
+        // visible list are always present in _rawMessages, so they are safe to count for removal.
+        var vanishedKeys = new HashSet<(string, Guid, string)>(
+            vanished.Select(m => (m.MessageId, m.AccountId, m.FolderName)));
+        _rawMessages.RemoveAll(m => vanishedKeys.Contains((m.MessageId, m.AccountId, m.FolderName)));
+
+        bool removedOpen = vanished.Any(m => m == SelectedMessage);
         foreach (var m in vanished)
             Messages.Remove(m);
+
+        UpdateAccountCountsAfterRemoval(vanished);
+
+        if (removedOpen)
+        {
+            SelectedMessage = Messages.Count > 0 ? Messages[0] : null;
+            MessageDetail   = null;
+            IsMessageOpen   = false;
+        }
     }
 
     // ── Account / folder selection ───────────────────────────────────────────────
@@ -2736,22 +2756,32 @@ public partial class MainViewModel : ObservableObject
     /// </summary>
     private async Task RefreshAllFolderListsAsync()
     {
-        var changed = false;
-        foreach (var account in Accounts.ToList())
+        // Fetch every account's folder list concurrently — they're independent, and a single slow or
+        // timed-out account shouldn't serialise the whole refresh (mirrors FetchAllMailAsync).
+        var fetches = Accounts.ToList().Select(async account =>
         {
             try
             {
                 using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
-                var folderList = await _imap.GetFoldersAsync(account.Id, cts.Token);
-                if (!_cachedFolders.TryGetValue(account.Id, out var prev) || FolderSetChanged(prev, folderList))
-                {
-                    _cachedFolders[account.Id] = folderList;
-                    ApplyAccountStatus(account, folderList);
-                    changed = true;
-                }
+                return (account, folders: (List<MailFolderModel>?)await _imap.GetFoldersAsync(account.Id, cts.Token));
             }
-            catch (OperationCanceledException) { }
-            catch (Exception ex) { LogService.Log($"RefreshFolderList {account.AccountLabel}", ex); }
+            catch (OperationCanceledException) { return (account, folders: (List<MailFolderModel>?)null); }
+            catch (Exception ex) { LogService.Log($"RefreshFolderList {account.AccountLabel}", ex); return (account, folders: (List<MailFolderModel>?)null); }
+        });
+        var results = await Task.WhenAll(fetches);
+
+        // Apply results on the continuation (UI thread): mutate the cache and rebuild only if a
+        // folder was actually added or removed, so an ordinary refresh doesn't disturb focus.
+        var changed = false;
+        foreach (var (account, folders) in results)
+        {
+            if (folders == null) continue;
+            if (!_cachedFolders.TryGetValue(account.Id, out var prev) || FolderSetChanged(prev, folders))
+            {
+                _cachedFolders[account.Id] = folders;
+                ApplyAccountStatus(account, folders);
+                changed = true;
+            }
         }
         if (changed) RebuildFolderListFromCache();
     }

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -1006,6 +1006,9 @@ public partial class MainViewModel : ObservableObject
                 InsertMessageSorted(msg);
                 existingById[key] = msg;
             }
+
+            RemoveVanishedMessages(newMessages);
+
             if (!IsCurrentFolderLoad(loadVersion, expectedFolder)) return;
 
             if (!OnlineMode && newMessages.Count > 0)
@@ -1812,6 +1815,31 @@ public partial class MainViewModel : ObservableObject
         existing.IsServerFlagged = fresh.IsServerFlagged;
     }
 
+    /// <summary>
+    /// Removes messages that vanished from the server within the fetched range (deleted in another
+    /// client). Scoped per folder to the returned date range so messages older than the fetch window
+    /// — simply not returned — are not wrongly dropped. Call after an aggregate/virtual merge.
+    /// </summary>
+    private void RemoveVanishedMessages(IReadOnlyList<MailMessageSummary> newMessages)
+    {
+        var fetchedKeys = new HashSet<(string, Guid, string)>();
+        var minDateByFolder = new Dictionary<(Guid, string), DateTimeOffset>();
+        foreach (var m in newMessages)
+        {
+            fetchedKeys.Add((m.MessageId, m.AccountId, m.FolderName));
+            var fk = (m.AccountId, m.FolderName);
+            if (!minDateByFolder.TryGetValue(fk, out var min) || m.Date < min)
+                minDateByFolder[fk] = m.Date;
+        }
+
+        var vanished = Messages.Where(m =>
+            minDateByFolder.TryGetValue((m.AccountId, m.FolderName), out var min) &&
+            m.Date >= min &&
+            !fetchedKeys.Contains((m.MessageId, m.AccountId, m.FolderName))).ToList();
+        foreach (var m in vanished)
+            Messages.Remove(m);
+    }
+
     // ── Account / folder selection ───────────────────────────────────────────────
 
     /// <summary>
@@ -2007,6 +2035,13 @@ public partial class MainViewModel : ObservableObject
 
     private void BuildFolderTree()
     {
+        // Capture which folders the user has expanded so the rebuild (which creates fresh, collapsed
+        // node objects) doesn't collapse the whole tree on a refresh.
+        var expandedKeys = new HashSet<string>(StringComparer.Ordinal);
+        if (FolderTree != null)
+            foreach (var n in FlattenAllNodes(FolderTree))
+                if (n.IsExpanded) expandedKeys.Add(NodeKey(n));
+
         var roots = new List<FolderTreeNode>();
 
         // "Views" group — shown only when the user has saved at least one view.
@@ -2102,7 +2137,26 @@ public partial class MainViewModel : ObservableObject
             }
         }
 
+        // Restore expansion captured above (additive: header groups keep their built-in expanded
+        // default; previously-expanded folders are re-expanded).
+        foreach (var n in FlattenAllNodes(roots))
+            if (expandedKeys.Contains(NodeKey(n)))
+                n.IsExpanded = true;
+
         FolderTree = new ObservableCollection<FolderTreeNode>(roots);
+    }
+
+    private static string NodeKey(FolderTreeNode n) =>
+        n.Folder != null ? $"F:{n.Folder.AccountId}:{n.Folder.FullName}" : $"H:{n.Label}";
+
+    private static IEnumerable<FolderTreeNode> FlattenAllNodes(IEnumerable<FolderTreeNode> nodes)
+    {
+        foreach (var n in nodes)
+        {
+            yield return n;
+            foreach (var c in FlattenAllNodes(n.Children))
+                yield return c;
+        }
     }
 
     // ── View-mode grouping ────────────────────────────────────────────────────────
@@ -2661,6 +2715,10 @@ public partial class MainViewModel : ObservableObject
     [RelayCommand]
     private async Task RefreshAsync()
     {
+        // Pick up folders created/removed on the server since the last full sync. Only rebuilds the
+        // tree when the folder set actually changed, so an ordinary refresh doesn't disturb focus.
+        await RefreshAllFolderListsAsync();
+
         if (ActiveView != null)
         {
             await ApplyViewAsync(ActiveView);
@@ -2670,6 +2728,39 @@ public partial class MainViewModel : ObservableObject
             await FetchVirtualAsync(SelectedFolder!);
         else if (SelectedFolder != null && SelectedFolder.AccountId != Guid.Empty)
             await FetchFolderAsync();
+    }
+
+    /// <summary>
+    /// Re-fetches every connected account's folder list and rebuilds the tree only if a folder was
+    /// added or removed on the server, so a manual refresh surfaces server-side folder changes.
+    /// </summary>
+    private async Task RefreshAllFolderListsAsync()
+    {
+        var changed = false;
+        foreach (var account in Accounts.ToList())
+        {
+            try
+            {
+                using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+                var folderList = await _imap.GetFoldersAsync(account.Id, cts.Token);
+                if (!_cachedFolders.TryGetValue(account.Id, out var prev) || FolderSetChanged(prev, folderList))
+                {
+                    _cachedFolders[account.Id] = folderList;
+                    ApplyAccountStatus(account, folderList);
+                    changed = true;
+                }
+            }
+            catch (OperationCanceledException) { }
+            catch (Exception ex) { LogService.Log($"RefreshFolderList {account.AccountLabel}", ex); }
+        }
+        if (changed) RebuildFolderListFromCache();
+    }
+
+    private static bool FolderSetChanged(List<MailFolderModel> previous, List<MailFolderModel> current)
+    {
+        if (previous.Count != current.Count) return true;
+        var prevNames = previous.Select(f => f.FullName).ToHashSet(StringComparer.Ordinal);
+        return current.Any(f => !prevNames.Contains(f.FullName));
     }
 
     [RelayCommand]
@@ -2793,6 +2884,8 @@ public partial class MainViewModel : ObservableObject
                 InsertMessageSorted(msg);
                 existingById[key] = msg;
             }
+
+            RemoveVanishedMessages(newMessages);
 
             if (!IsCurrentFolderLoad(loadVersion, AllMailFolder))
                 return;
@@ -3196,6 +3289,8 @@ public partial class MainViewModel : ObservableObject
                 InsertMessageSorted(msg);
                 existingById[key] = msg;
             }
+
+            RemoveVanishedMessages(newMessages);
 
             if (!IsCurrentFolderLoad(loadVersion, expectedFolder)) return;
 


### PR DESCRIPTION
Builds on #113 (read/flag reconcile) to make a manual refresh a *complete* refresh. Two additions, both in `MainViewModel`:

## F5 surfaces server-side folder changes
F5 re-fetched the current folder's *messages* but never the *folder list*, so a folder created or deleted in another client never showed up. `RefreshAsync` now re-fetches every connected account's folder list and rebuilds the tree — but **only when the folder set actually changed** (`FolderSetChanged`), so an ordinary refresh with no folder changes doesn't disturb focus. `BuildFolderTree` now **preserves expansion** across the rebuild (captures expanded nodes by key, re-applies after), so the tree no longer collapses on a refresh.

## Deleted messages disappear on refresh
#113 reconciles the state of messages that are *still* on the server, but a message **deleted** in another client lingered in aggregate views. Each virtual/aggregate merge path now calls `RemoveVanishedMessages`, which drops messages that are absent from the fetched set — **scoped per folder to the returned date range**, so messages older than the fetch window (simply not returned) are never wrongly removed.

Together with #113, an All-Mail refresh now reflects reads, flags, new mail, deleted mail, and folder add/remove.
