### PR TITLE
chore: migrate test project from xunit v2 to xunit.v3

### DIFF
--- a/QuickMail.Tests/QuickMail.Tests.csproj
+++ b/QuickMail.Tests/QuickMail.Tests.csproj
@@ -20,10 +20,10 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="10.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
     <!-- STA-thread fact attribute for WPF tests -->
-    <PackageReference Include="Xunit.StaFact" Version="1.1.11" />
+    <PackageReference Include="Xunit.StaFact" Version="3.0.13" />
   </ItemGroup>
 
   <ItemGroup>

--- a/QuickMail.Tests/QuickMail.Tests.csproj
+++ b/QuickMail.Tests/QuickMail.Tests.csproj
@@ -9,8 +9,11 @@
     <IsTestProject>true</IsTestProject>
     <!-- STA is required for WPF object instantiation -->
     <ApartmentState>STA</ApartmentState>
-    <!-- Match the main project's RID so the ProjectReference output path resolves correctly -->
+    <!-- Match the main project's RID and self-contained mode so the ProjectReference output
+         path resolves correctly and NETSDK1151 is satisfied (xunit.v3 sets UseAppHost=true
+         via its build targets, which triggers the self-contained compatibility check) -->
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <SelfContained>true</SelfContained>
     <!-- Treat the most dangerous nullable warnings as errors so the CI catches
          null-dereference risks before they become runtime crashes. -->
     <WarningsAsErrors>CS8602;CS8604;CS8618</WarningsAsErrors>


### PR DESCRIPTION
## Summary

- Replaces `xunit 2.9.3` with `xunit.v3 3.2.2`
- Bumps `Xunit.StaFact` from `1.1.11` to `3.0.13`
- No test code changes needed — all attributes and assertions are source-compatible between v2 and v3

## Why

`Xunit.StaFact` 2.x+ targets xunit v3. Running both `xunit` (v2) and the v3 core pulled in by StaFact in the same project causes `CS0433` type-ambiguity errors on `[Fact]`, `[Collection]`, and related attributes. This failure first appeared on Dependabot PR #84 after yesterday's merges added new test files.

Rather than pin StaFact to the last xunit-v2-compatible release (1.2.69), this migrates the full test project to xunit.v3, which is the current/maintained path.

## Test plan

- [ ] All existing tests pass on CI (.NET 8, Windows runner)
- [ ] No CS0433 ambiguity errors
- [ ] `[StaFact]` and `[StaTheory]` STA-thread WPF tests run correctly

Closes Dependabot PR #84.

Generated with Claude Code