### PR TITLE
chore: fix xUnit1051 — pass TestContext.Current.CancellationToken in async tests

### DIFF
--- a/QuickMail.Tests/ContactServiceGroupTests.cs
+++ b/QuickMail.Tests/ContactServiceGroupTests.cs
@@ -70,7 +70,7 @@ public class ContactServiceGroupTestsV2
         {
             var a = await service.CreateGroupAsync("Zebra");
             var b = await service.CreateGroupAsync("Alpha");
-            await Task.Delay(20);
+            await Task.Delay(20, TestContext.Current.CancellationToken);
             await service.TouchGroupAsync(b);
             var groups = await service.LoadAllGroupsAsync();
             Assert.Equal(2, groups.Count);
@@ -328,7 +328,7 @@ public class ContactServiceGroupTestsV2
         try
         {
             await service.CreateGroupAsync("Atomic");
-            var json = await File.ReadAllTextAsync(Path.Combine(dir, "groups.json"));
+            var json = await File.ReadAllTextAsync(Path.Combine(dir, "groups.json"), TestContext.Current.CancellationToken);
             using var doc = JsonDocument.Parse(json);
             Assert.Equal(1, doc.RootElement.GetArrayLength());
             Assert.Empty(Directory.GetFiles(dir, "groups.json.tmp"));
@@ -352,7 +352,7 @@ public class ContactServiceGroupTestsV2
                 tasks.Add(service.UpsertContactAsync(MakeContact($"User{i}")));
             }
             var all = Task.WhenAll(tasks);
-            var completed = await Task.WhenAny(all, Task.Delay(TimeSpan.FromSeconds(10)));
+            var completed = await Task.WhenAny(all, Task.Delay(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken));
             Assert.Same(all, completed);
         }
         finally { Cleanup(dir); }

--- a/QuickMail.Tests/FlagServiceTests.cs
+++ b/QuickMail.Tests/FlagServiceTests.cs
@@ -42,7 +42,7 @@ public class FlagServiceTests
         {
             var msg = new MailMessageSummary { MessageId = "1", AccountId = Guid.NewGuid(), FolderName = "INBOX" };
 
-            var def = await svc.ToggleDefaultFlagAsync(msg);
+            var def = await svc.ToggleDefaultFlagAsync(msg, TestContext.Current.CancellationToken);
 
             // Should return the built-in flag definition when setting.
             Assert.NotNull(def);
@@ -65,7 +65,7 @@ public class FlagServiceTests
                 FlagId     = FlagDefinition.BuiltInFlagId.ToString(),
             };
 
-            var def = await svc.ToggleDefaultFlagAsync(msg);
+            var def = await svc.ToggleDefaultFlagAsync(msg, TestContext.Current.CancellationToken);
 
             // Should return null when clearing.
             Assert.Null(def);
@@ -81,7 +81,7 @@ public class FlagServiceTests
         {
             // Write corrupt JSON
             var flagsFile = Path.Combine(dir, "flags.json");
-            await File.WriteAllTextAsync(flagsFile, "{{NOT_VALID_JSON");
+            await File.WriteAllTextAsync(flagsFile, "{{NOT_VALID_JSON", TestContext.Current.CancellationToken);
 
             var defs = await svc.LoadFlagDefinitionsAsync();
 

--- a/QuickMail.Tests/GraphBackendGateTests.cs
+++ b/QuickMail.Tests/GraphBackendGateTests.cs
@@ -135,7 +135,7 @@ public class MailServiceRouterTests
         var graphAcct = Guid.NewGuid();
         router.RegisterAccount(graphAcct, graph);
 
-        await router.GetFoldersAsync(graphAcct);
+        await router.GetFoldersAsync(graphAcct, TestContext.Current.CancellationToken);
 
         Assert.Equal(graphAcct, graph.LastAccountId);
         Assert.Null(imap.LastAccountId);
@@ -149,7 +149,7 @@ public class MailServiceRouterTests
         var router = new MailServiceRouter(new IMailService[] { imap, graph }); // imap is the default
 
         var unknown = Guid.NewGuid();
-        await router.GetFoldersAsync(unknown);
+        await router.GetFoldersAsync(unknown, TestContext.Current.CancellationToken);
 
         Assert.Equal(unknown, imap.LastAccountId);
         Assert.Null(graph.LastAccountId);
@@ -189,7 +189,7 @@ public class MailServiceRouterTests
         router.RegisterAccount(imapAcct.Id, imap);
         router.RegisterAccount(graphAcct.Id, graph);
 
-        router.StartIdleWatchers(new[] { imapAcct, graphAcct });
+        router.StartIdleWatchers(new[] { imapAcct, graphAcct }, TestContext.Current.CancellationToken);
 
         Assert.NotNull(imap.LastIdleAccounts);
         Assert.NotNull(graph.LastIdleAccounts);

--- a/QuickMail.Tests/GraphClientTests.cs
+++ b/QuickMail.Tests/GraphClientTests.cs
@@ -60,7 +60,7 @@ public class GraphClientTests
         var handler = new SequenceHandler(Resp((HttpStatusCode)429), Resp(HttpStatusCode.OK));
         var client = Client(handler);
 
-        var result = await client.GetAsync<JsonElement>(Account(), "/me");
+        var result = await client.GetAsync<JsonElement>(Account(), "/me", TestContext.Current.CancellationToken);
 
         Assert.Equal(2, handler.Calls); // one 429 retry, then success
     }
@@ -71,7 +71,7 @@ public class GraphClientTests
         var handler = new SequenceHandler(Resp((HttpStatusCode)429, retryAfter: TimeSpan.Zero), Resp(HttpStatusCode.OK));
         var client = Client(handler);
 
-        await client.GetAsync<JsonElement>(Account(), "/me");
+        await client.GetAsync<JsonElement>(Account(), "/me", TestContext.Current.CancellationToken);
 
         Assert.Equal(2, handler.Calls);
     }
@@ -83,7 +83,7 @@ public class GraphClientTests
         var handler = new SequenceHandler(Resp((HttpStatusCode)429), Resp(HttpStatusCode.OK));
         var client = Client(handler);
 
-        await client.GetAsync<JsonElement>(Account(), "/me");
+        await client.GetAsync<JsonElement>(Account(), "/me", TestContext.Current.CancellationToken);
 
         Assert.Equal(2, handler.Calls);
     }
@@ -95,7 +95,7 @@ public class GraphClientTests
         var handler = new SequenceHandler(Resp((HttpStatusCode)429), Resp((HttpStatusCode)429), Resp((HttpStatusCode)429));
         var client = Client(handler);
 
-        await Assert.ThrowsAsync<HttpRequestException>(() => client.GetAsync<JsonElement>(Account(), "/me"));
+        await Assert.ThrowsAsync<HttpRequestException>(() => client.GetAsync<JsonElement>(Account(), "/me", TestContext.Current.CancellationToken));
         Assert.Equal(3, handler.Calls); // attempts 0, 1, 2 — no fourth
     }
 
@@ -106,7 +106,7 @@ public class GraphClientTests
         var handler = new SequenceHandler(throttled, Resp(HttpStatusCode.OK));
         var client = Client(handler);
 
-        await client.GetAsync<JsonElement>(Account(), "/me");
+        await client.GetAsync<JsonElement>(Account(), "/me", TestContext.Current.CancellationToken);
 
         Assert.True(throttled.Disposed, "the retried 429 response should be disposed before the next attempt");
     }

--- a/QuickMail.Tests/GraphMailServiceTests.cs
+++ b/QuickMail.Tests/GraphMailServiceTests.cs
@@ -56,7 +56,7 @@ public class GraphMailServiceTests
         var (svc, _) = Make(url => (HttpStatusCode.OK, MeJson));
         var account = GraphAccount();
 
-        await svc.ConnectAsync(account);
+        await svc.ConnectAsync(account, ct: TestContext.Current.CancellationToken);
 
         Assert.Equal("user@contoso.com", account.Username);
     }
@@ -85,8 +85,8 @@ public class GraphMailServiceTests
             : (HttpStatusCode.OK, page1));
 
         var account = GraphAccount();
-        await svc.ConnectAsync(account);
-        var folders = await svc.GetFoldersAsync(account.Id);
+        await svc.ConnectAsync(account, ct: TestContext.Current.CancellationToken);
+        var folders = await svc.GetFoldersAsync(account.Id, TestContext.Current.CancellationToken);
 
         Assert.Equal(3, folders.Count); // nextLink page followed
         var inbox = folders.Single(f => f.FullName == "f1");
@@ -124,8 +124,8 @@ public class GraphMailServiceTests
             : (HttpStatusCode.OK, MeJson));
 
         var account = GraphAccount();
-        await svc.ConnectAsync(account);
-        var folders = await svc.GetFoldersAsync(account.Id);
+        await svc.ConnectAsync(account, ct: TestContext.Current.CancellationToken);
+        var folders = await svc.GetFoldersAsync(account.Id, TestContext.Current.CancellationToken);
 
         var inbox = folders.Single(f => f.FullName == "F-INBOX");
         Assert.Equal(SpecialFolderKind.Inbox, inbox.Kind);  // by ID, despite "Posteingang"
@@ -164,8 +164,8 @@ public class GraphMailServiceTests
             : (HttpStatusCode.OK, """{"value":[]}"""));    // well-known lookups resolve to nothing
 
         var account = GraphAccount();
-        await svc.ConnectAsync(account);
-        var folders = await svc.GetFoldersAsync(account.Id);
+        await svc.ConnectAsync(account, ct: TestContext.Current.CancellationToken);
+        var folders = await svc.GetFoldersAsync(account.Id, TestContext.Current.CancellationToken);
 
         // Top-level f1, f2 plus nested c1 (under f1) and g1 (under c1).
         Assert.Equal(4, folders.Count);
@@ -190,8 +190,8 @@ public class GraphMailServiceTests
         var (svc, _) = Make(url => url.Contains("/me?") ? (HttpStatusCode.OK, MeJson) : (HttpStatusCode.OK, msgs));
 
         var account = GraphAccount();
-        await svc.ConnectAsync(account);
-        var list = await svc.GetMessageSummariesAsync(account.Id, "inbox", 50);
+        await svc.ConnectAsync(account, ct: TestContext.Current.CancellationToken);
+        var list = await svc.GetMessageSummariesAsync(account.Id, "inbox", 50, TestContext.Current.CancellationToken);
 
         var m = Assert.Single(list);
         Assert.Equal("m1", m.MessageId);
@@ -221,8 +221,8 @@ public class GraphMailServiceTests
         var (svc, _) = Make(url => url.Contains("/me?") ? (HttpStatusCode.OK, MeJson) : (HttpStatusCode.OK, detail));
 
         var account = GraphAccount();
-        await svc.ConnectAsync(account);
-        var d = await svc.GetMessageDetailAsync(account.Id, "inbox", "m1");
+        await svc.ConnectAsync(account, ct: TestContext.Current.CancellationToken);
+        var d = await svc.GetMessageDetailAsync(account.Id, "inbox", "m1", TestContext.Current.CancellationToken);
 
         Assert.Equal("m1", d.MessageId);
         Assert.Equal("<p>Hi</p>", d.HtmlBody);
@@ -240,8 +240,8 @@ public class GraphMailServiceTests
         var (svc, handler) = Make(url => url.Contains("/me?") ? (HttpStatusCode.OK, MeJson) : (HttpStatusCode.OK, """{"value":[]}"""));
 
         var account = GraphAccount();
-        await svc.ConnectAsync(account);
-        await svc.GetMessagesSinceDateAsync(account.Id, "inbox", DateTime.UtcNow.AddDays(-7));
+        await svc.ConnectAsync(account, ct: TestContext.Current.CancellationToken);
+        await svc.GetMessagesSinceDateAsync(account.Id, "inbox", DateTime.UtcNow.AddDays(-7), TestContext.Current.CancellationToken);
 
         Assert.Contains(handler.Requests, u => Uri.UnescapeDataString(u).Contains("filter=receivedDateTime ge"));
     }
@@ -252,8 +252,8 @@ public class GraphMailServiceTests
         var (svc, _) = Make(url => (HttpStatusCode.OK, "{}"));
         // These throw synchronously (expression-bodied `=> throw ...`), so the discard keeps the
         // lambda an Action rather than a Func<Task>.
-        Assert.Throws<NotImplementedException>(() => { _ = svc.MoveToTrashAsync(Guid.NewGuid(), "inbox", "m1"); });
-        Assert.Throws<NotImplementedException>(() => { _ = svc.CreateFolderAsync(Guid.NewGuid(), null, "New"); });
+        Assert.Throws<NotImplementedException>(() => { _ = svc.MoveToTrashAsync(Guid.NewGuid(), "inbox", "m1", TestContext.Current.CancellationToken); });
+        Assert.Throws<NotImplementedException>(() => { _ = svc.CreateFolderAsync(Guid.NewGuid(), null, "New", TestContext.Current.CancellationToken); });
     }
 
     [Fact]
@@ -261,7 +261,7 @@ public class GraphMailServiceTests
     {
         // Graph /sendMail auto-saves to Sent, so the post-send append is a no-op (not a throw).
         var (svc, _) = Make(url => (HttpStatusCode.OK, "{}"));
-        Assert.True(svc.AppendToSentAsync(Guid.NewGuid(), new ComposeModel()).IsCompletedSuccessfully);
+        Assert.True(svc.AppendToSentAsync(Guid.NewGuid(), new ComposeModel(), TestContext.Current.CancellationToken).IsCompletedSuccessfully);
     }
 
     [Fact]
@@ -281,6 +281,6 @@ public class GraphMailServiceTests
         var (svc, _) = Make(url => (HttpStatusCode.OK, "{}"));
         // No ConnectAsync first → the account isn't registered, so token resolution can't proceed.
         await Assert.ThrowsAsync<InvalidOperationException>(
-            () => svc.GetFoldersAsync(Guid.NewGuid()));
+            () => svc.GetFoldersAsync(Guid.NewGuid(), TestContext.Current.CancellationToken));
     }
 }

--- a/QuickMail.Tests/GraphSendMailServiceTests.cs
+++ b/QuickMail.Tests/GraphSendMailServiceTests.cs
@@ -59,7 +59,7 @@ public class GraphSendMailServiceTests
         var (svc, handler) = Make();
         var compose = new ComposeModel { To = "alice@x.com", Subject = "Hi there", Body = "Hello" };
 
-        await svc.SendAsync(compose, GraphAccount(), null);
+        await svc.SendAsync(compose, GraphAccount(), null, TestContext.Current.CancellationToken);
 
         Assert.Equal("https://graph.microsoft.com/v1.0/me/sendMail", handler.Url);
         Assert.Equal("text/plain", handler.ContentType);
@@ -73,7 +73,7 @@ public class GraphSendMailServiceTests
     {
         var (svc, handler) = Make();
 
-        await svc.SendIcsReplyAsync("BEGIN:VCALENDAR\nEND:VCALENDAR", GraphAccount(), null, "organizer@x.com");
+        await svc.SendIcsReplyAsync("BEGIN:VCALENDAR\nEND:VCALENDAR", GraphAccount(), null, "organizer@x.com", TestContext.Current.CancellationToken);
 
         Assert.Equal("https://graph.microsoft.com/v1.0/me/sendMail", handler.Url);
         var mime = DecodeMime(handler.Body!);
@@ -88,7 +88,7 @@ public class GraphSendMailServiceTests
         // A descriptive ArgumentException at the call site beats an NRE from inside MimeKit.
         var (svc, handler) = Make();
         await Assert.ThrowsAsync<ArgumentException>(
-            () => svc.SendIcsReplyAsync(null!, GraphAccount(), null, "organizer@x.com"));
+            () => svc.SendIcsReplyAsync(null!, GraphAccount(), null, "organizer@x.com", TestContext.Current.CancellationToken));
         Assert.Null(handler.Url); // never reached the network
     }
 
@@ -97,7 +97,7 @@ public class GraphSendMailServiceTests
     {
         var (svc, handler) = Make();
         await Assert.ThrowsAsync<ArgumentException>(
-            () => svc.SendIcsReplyAsync("BEGIN:VCALENDAR\nEND:VCALENDAR", GraphAccount(), null, ""));
+            () => svc.SendIcsReplyAsync("BEGIN:VCALENDAR\nEND:VCALENDAR", GraphAccount(), null, "", TestContext.Current.CancellationToken));
         Assert.Null(handler.Url);
     }
 
@@ -109,6 +109,6 @@ public class GraphSendMailServiceTests
         var (svc, _) = Make(HttpStatusCode.InternalServerError);
         var compose = new ComposeModel { To = "alice@x.com", Subject = "Hi", Body = "Hello" };
 
-        await Assert.ThrowsAsync<HttpRequestException>(() => svc.SendAsync(compose, GraphAccount(), null));
+        await Assert.ThrowsAsync<HttpRequestException>(() => svc.SendAsync(compose, GraphAccount(), null, TestContext.Current.CancellationToken));
     }
 }

--- a/QuickMail.Tests/RuleServiceTests.cs
+++ b/QuickMail.Tests/RuleServiceTests.cs
@@ -287,7 +287,7 @@ public class RuleServiceTests
             var accountId = Guid.NewGuid();
             var msgs = new List<MailMessageSummary> { MakeMsg(from: "alice@example.com", accountId: accountId) };
 
-            var (count, _) = await svc.ApplyRulesAsync(msgs, accountId, CancellationToken.None);
+            var (count, _) = await svc.ApplyRulesAsync(msgs, accountId, TestContext.Current.CancellationToken);
             Assert.Equal(0, count);
             Assert.False(msgs[0].IsRead); // not changed
         }
@@ -310,7 +310,7 @@ public class RuleServiceTests
             var otherAccountId = Guid.NewGuid();
             var msgs = new List<MailMessageSummary> { MakeMsg(from: "alice@example.com", accountId: otherAccountId) };
 
-            var (count, _) = await svc.ApplyRulesAsync(msgs, otherAccountId, CancellationToken.None);
+            var (count, _) = await svc.ApplyRulesAsync(msgs, otherAccountId, TestContext.Current.CancellationToken);
             Assert.Equal(0, count);
         }
         finally { if (Directory.Exists(dir)) Directory.Delete(dir, true); }
@@ -331,7 +331,7 @@ public class RuleServiceTests
             var accountId = Guid.NewGuid();
             var msgs = new List<MailMessageSummary> { MakeMsg(from: "alice@example.com", accountId: accountId, isRead: false) };
 
-            var (count, _) = await svc.ApplyRulesAsync(msgs, accountId, CancellationToken.None);
+            var (count, _) = await svc.ApplyRulesAsync(msgs, accountId, TestContext.Current.CancellationToken);
             Assert.Equal(1, count);
             Assert.True(msgs[0].IsRead);
         }
@@ -353,7 +353,7 @@ public class RuleServiceTests
             var accountId = Guid.NewGuid();
             var msgs = new List<MailMessageSummary> { MakeMsg(from: "alice@example.com", accountId: accountId, isRead: true) };
 
-            var (count, _) = await svc.ApplyRulesAsync(msgs, accountId, CancellationToken.None);
+            var (count, _) = await svc.ApplyRulesAsync(msgs, accountId, TestContext.Current.CancellationToken);
             Assert.Equal(1, count);
             Assert.False(msgs[0].IsRead);
         }
@@ -381,7 +381,7 @@ public class RuleServiceTests
                 MakeMsg(from: "charlie@example.com", uid: 3, accountId: accountId),
             };
 
-            var (count, _) = await svc.ApplyRulesAsync(msgs, accountId, CancellationToken.None);
+            var (count, _) = await svc.ApplyRulesAsync(msgs, accountId, TestContext.Current.CancellationToken);
             Assert.Equal(2, count); // msg 1 matches rule 1, msg 2 matches rule 2
         }
         finally { if (Directory.Exists(dir)) Directory.Delete(dir, true); }
@@ -399,7 +399,7 @@ public class RuleServiceTests
             var accountId = Guid.NewGuid();
             var msgs = new List<MailMessageSummary> { MakeMsg(accountId: accountId) };
 
-            var (count, _) = await svc.ApplyRulesAsync(msgs, accountId, CancellationToken.None);
+            var (count, _) = await svc.ApplyRulesAsync(msgs, accountId, TestContext.Current.CancellationToken);
             Assert.Equal(0, count);
         }
         finally { if (Directory.Exists(dir)) Directory.Delete(dir, true); }
@@ -444,7 +444,7 @@ public class RuleServiceTests
             var accountId = Guid.NewGuid();
             var msgs = new List<MailMessageSummary> { MakeMsg(from: "alice@example.com", accountId: accountId) };
 
-            var (count, _) = await svc.ApplyRulesAsync(msgs, accountId, CancellationToken.None);
+            var (count, _) = await svc.ApplyRulesAsync(msgs, accountId, TestContext.Current.CancellationToken);
             Assert.Equal(1, count);
         }
         finally { if (Directory.Exists(dir)) Directory.Delete(dir, true); }

--- a/QuickMail.Tests/SavedViewsTests.cs
+++ b/QuickMail.Tests/SavedViewsTests.cs
@@ -900,7 +900,7 @@ public class SavedViewsMainViewModelTests
         AddVirtualFolders(vm);
 
         await SelectView(vm, view);
-        await Task.Delay(50);  // let Phase 2 (no-op for AllMail with empty Accounts) complete
+        await Task.Delay(50, TestContext.Current.CancellationToken);  // let Phase 2 (no-op for AllMail with empty Accounts) complete
 
         Assert.Equal(7, vm.ActiveDayLimit);
         // With no accounts in vm.Accounts, FetchAllMailAsync's Phase 2 won't fetch.
@@ -932,7 +932,7 @@ public class SavedViewsMainViewModelTests
 
         await SelectView(vm, view);
         // Give the fire-and-forget RefreshFolderFromServerAsync a chance to complete.
-        await Task.Delay(50);
+        await Task.Delay(50, TestContext.Current.CancellationToken);
 
         Assert.Equal(7, vm.ActiveDayLimit);
         Assert.Single(vm.Messages);

--- a/QuickMail.Tests/SessionFeaturesTests.cs
+++ b/QuickMail.Tests/SessionFeaturesTests.cs
@@ -297,7 +297,7 @@ public class IdleNewMailTests
         // Fire the IDLE event — OnInboxNewMailDetected runs SyncOneFolderAsync via Task.Run.
         imap.FireNewMail();
 
-        var result = await sync.SyncOneFolderCalled.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        var result = await sync.SyncOneFolderCalled.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         Assert.Equal(accountId, result.Account.Id);
         Assert.Equal(SpecialFolderKind.Inbox, result.Folder.Kind);
     }
@@ -327,7 +327,7 @@ public class IdleNewMailTests
         imap.FireNewMail();
 
         // In online mode the handler must call SyncOneFolderOnlineAsync (not SyncOneFolderAsync).
-        var result = await sync.SyncOneFolderOnlineCalled.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        var result = await sync.SyncOneFolderOnlineCalled.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         Assert.Equal(accountId, result.Account.Id);
         Assert.Equal(SpecialFolderKind.Inbox, result.Folder.Kind);
         Assert.False(sync.SyncOneFolderCalled.Task.IsCompleted);

--- a/QuickMail.Tests/SmtpServiceDispatchTests.cs
+++ b/QuickMail.Tests/SmtpServiceDispatchTests.cs
@@ -36,7 +36,7 @@ public class SmtpServiceDispatchTests
         var svc = new SmtpService(new StubOAuthService(), graph);
         var account = new AccountModel { Id = Guid.NewGuid(), Username = "me@contoso.com", BackendKind = BackendKind.MicrosoftGraph };
 
-        await svc.SendAsync(new ComposeModel(), account, null);
+        await svc.SendAsync(new ComposeModel(), account, null, TestContext.Current.CancellationToken);
 
         Assert.True(graph.SendCalled); // dispatched, never reached the MailKit SmtpClient
     }
@@ -48,7 +48,7 @@ public class SmtpServiceDispatchTests
         var svc = new SmtpService(new StubOAuthService(), graph);
         var account = new AccountModel { Id = Guid.NewGuid(), Username = "me@contoso.com", BackendKind = BackendKind.MicrosoftGraph };
 
-        await svc.SendIcsReplyAsync("BEGIN:VCALENDAR\nEND:VCALENDAR", account, null, "organizer@x.com");
+        await svc.SendIcsReplyAsync("BEGIN:VCALENDAR\nEND:VCALENDAR", account, null, "organizer@x.com", TestContext.Current.CancellationToken);
 
         Assert.True(graph.IcsCalled);
     }
@@ -62,7 +62,7 @@ public class SmtpServiceDispatchTests
         // connect. The point is the dispatch must NOT hand an IMAP account to the Graph sender.
         var account = new AccountModel { Id = Guid.NewGuid(), Username = "me@example.com", BackendKind = BackendKind.ImapSmtp, SmtpHost = "" };
 
-        await Assert.ThrowsAnyAsync<Exception>(() => svc.SendAsync(new ComposeModel(), account, "pw"));
+        await Assert.ThrowsAnyAsync<Exception>(() => svc.SendAsync(new ComposeModel(), account, "pw", TestContext.Current.CancellationToken));
 
         Assert.False(graph.SendCalled); // took the MailKit path, not the Graph dispatch
     }
@@ -75,7 +75,7 @@ public class SmtpServiceDispatchTests
         var account = new AccountModel { Id = Guid.NewGuid(), Username = "me@example.com", BackendKind = BackendKind.ImapSmtp, SmtpHost = "" };
 
         await Assert.ThrowsAnyAsync<Exception>(
-            () => svc.SendIcsReplyAsync("BEGIN:VCALENDAR\nEND:VCALENDAR", account, "pw", "organizer@x.com"));
+            () => svc.SendIcsReplyAsync("BEGIN:VCALENDAR\nEND:VCALENDAR", account, "pw", "organizer@x.com", TestContext.Current.CancellationToken));
 
         Assert.False(graph.IcsCalled); // took the MailKit path, not the Graph dispatch
     }

--- a/QuickMail.Tests/TemplateServiceTests.cs
+++ b/QuickMail.Tests/TemplateServiceTests.cs
@@ -75,7 +75,7 @@ public class TemplateServiceTests
         {
             // Write garbage to the templates file
             var filePath = Path.Combine(dir, "templates.json");
-            await File.WriteAllTextAsync(filePath, "this is not valid json {{{");
+            await File.WriteAllTextAsync(filePath, "this is not valid json {{{", TestContext.Current.CancellationToken);
 
             var templates = await service.LoadAllAsync();
 
@@ -93,7 +93,7 @@ public class TemplateServiceTests
         try
         {
             var filePath = Path.Combine(dir, "templates.json");
-            await File.WriteAllTextAsync(filePath, "");
+            await File.WriteAllTextAsync(filePath, "", TestContext.Current.CancellationToken);
 
             var templates = await service.LoadAllAsync();
 


### PR DESCRIPTION
## Summary

- Fixes all 53 xUnit1051 analyzer warnings introduced by the xunit v3 migration
- No logic changes — only how CancellationToken is passed to async methods

## Why

xunit.v3 ships with the xUnit1051 rule: async methods that have a `CancellationToken` overload should receive `TestContext.Current.CancellationToken` so the test runner can cancel in-flight tests responsively.

Two fix patterns:
1. `CancellationToken.None` → `TestContext.Current.CancellationToken`
2. No-token overloads (`Task.Delay`, `File.ReadAllTextAsync`, service methods) → add `TestContext.Current.CancellationToken`

`ConnectAsync` calls use the named arg `ct:` because its second positional parameter is `string? password`, not `CancellationToken`.

## Test plan

- [ ] Build produces 0 xUnit1051 warnings
- [ ] All 727 tests pass on CI

Generated with Claude Code