### PR TITLE
Graph PR 7a: extract IChangeNotifier (decouple new-mail/reachability from IMailService)

### DIFF
--- a/QuickMail.Tests/ComposeViewModelAutoSaveTests.cs
+++ b/QuickMail.Tests/ComposeViewModelAutoSaveTests.cs
@@ -187,11 +187,5 @@ sealed class RecordingMailService : IMailService
     public Task DeleteFolderAsync(Guid accountId, string folderName, CancellationToken ct = default) => Task.CompletedTask;
     public Task RenameFolderAsync(Guid accountId, string folderName, string newName, string? newParentFolderName, CancellationToken ct = default) => Task.CompletedTask;
     public Task CopyFolderAsync(Guid accountId, string folderName, string? destinationParentName, CancellationToken ct = default) => Task.CompletedTask;
-#pragma warning disable CS0067
-    public event Action<Guid, bool>? AccountReachabilityChanged;
-    public event Action<Guid>? InboxNewMailDetected;
-#pragma warning restore CS0067
-    public void StartIdleWatchers(IReadOnlyList<AccountModel> accounts, CancellationToken ct = default) { }
-    public void StopIdleWatchers() { }
     public void Dispose() { }
 }

--- a/QuickMail.Tests/GraphBackendGateTests.cs
+++ b/QuickMail.Tests/GraphBackendGateTests.cs
@@ -158,8 +158,9 @@ public class ChangeNotifierRouterTests
     private sealed class RecordingChangeNotifier : IChangeNotifier
     {
         public IReadOnlyList<AccountModel>? LastWatchedAccounts { get; private set; }
+        public bool StopWatchersCalled { get; private set; }
         public void StartWatchers(IReadOnlyList<AccountModel> accounts, CancellationToken ct = default) => LastWatchedAccounts = accounts;
-        public void StopWatchers() { }
+        public void StopWatchers() => StopWatchersCalled = true;
 
         public event Action<Guid>? InboxNewMailDetected;
         public event Action<Guid, bool>? AccountReachabilityChanged;
@@ -181,6 +182,7 @@ public class ChangeNotifierRouterTests
         // Graph accounts have no notifier until PR 7b, so only the IMAP account is watched.
         Assert.NotNull(imap.LastWatchedAccounts);
         Assert.Equal(new[] { imapAcct.Id }, imap.LastWatchedAccounts!.Select(a => a.Id));
+        Assert.DoesNotContain(graphAcct.Id, imap.LastWatchedAccounts!.Select(a => a.Id));
     }
 
     [Fact]
@@ -226,6 +228,18 @@ public class ChangeNotifierRouterTests
         imap.RaiseNewMail(Guid.NewGuid());
 
         Assert.Empty(seen);
+    }
+
+    [Fact]
+    public void Dispose_CallsStopWatchersOnInnerNotifier()
+    {
+        var imap = new RecordingChangeNotifier();
+        var router = new ChangeNotifierRouter(imap);
+
+        router.Dispose();
+
+        // Disposing the router must tear down the watcher tasks, not just unsubscribe events.
+        Assert.True(imap.StopWatchersCalled);
     }
 }
 

--- a/QuickMail.Tests/GraphBackendGateTests.cs
+++ b/QuickMail.Tests/GraphBackendGateTests.cs
@@ -75,12 +75,6 @@ public class MailServiceRouterTests
     private sealed class RecordingMailService : IMailService
     {
         public Guid? LastAccountId { get; private set; }
-        public void RaiseNewMail(Guid accountId) => InboxNewMailDetected?.Invoke(accountId);
-
-        public event Action<Guid>? InboxNewMailDetected;
-#pragma warning disable CS0067 // not raised by this fake
-        public event Action<Guid, bool>? AccountReachabilityChanged;
-#pragma warning restore CS0067
 
         public Task<List<MailFolderModel>> GetFoldersAsync(Guid accountId, CancellationToken ct = default)
         {
@@ -119,9 +113,6 @@ public class MailServiceRouterTests
         public Task DeleteFolderAsync(Guid accountId, string folderName, CancellationToken ct = default) => Task.CompletedTask;
         public Task RenameFolderAsync(Guid accountId, string folderName, string newName, string? newParentFolderName, CancellationToken ct = default) => Task.CompletedTask;
         public Task CopyFolderAsync(Guid accountId, string folderName, string? destinationParentName, CancellationToken ct = default) => Task.CompletedTask;
-        public IReadOnlyList<AccountModel>? LastIdleAccounts { get; private set; }
-        public void StartIdleWatchers(IReadOnlyList<AccountModel> accounts, CancellationToken ct = default) => LastIdleAccounts = accounts;
-        public void StopIdleWatchers() { }
         public void Dispose() { }
     }
 
@@ -156,45 +147,85 @@ public class MailServiceRouterTests
     }
 
     [Fact]
-    public void AggregatesInboxNewMailFromAllBackends()
+    public void EmptyBackends_Throws()
+        => Assert.Throws<ArgumentException>(() => new MailServiceRouter(Array.Empty<IMailService>()));
+
+}
+
+/// <summary>Covers <see cref="ChangeNotifierRouter"/>: per-backend account partitioning and event forwarding.</summary>
+public class ChangeNotifierRouterTests
+{
+    private sealed class RecordingChangeNotifier : IChangeNotifier
     {
-        var imap = new RecordingMailService();
-        var graph = new RecordingMailService();
-        var router = new MailServiceRouter(new IMailService[] { imap, graph });
+        public IReadOnlyList<AccountModel>? LastWatchedAccounts { get; private set; }
+        public void StartWatchers(IReadOnlyList<AccountModel> accounts, CancellationToken ct = default) => LastWatchedAccounts = accounts;
+        public void StopWatchers() { }
+
+        public event Action<Guid>? InboxNewMailDetected;
+        public event Action<Guid, bool>? AccountReachabilityChanged;
+        public void RaiseNewMail(Guid accountId) => InboxNewMailDetected?.Invoke(accountId);
+        public void RaiseReachability(Guid accountId, bool reachable) => AccountReachabilityChanged?.Invoke(accountId, reachable);
+    }
+
+    [Fact]
+    public void StartWatchers_PassesOnlyImapAccountsToNotifier()
+    {
+        var imap = new RecordingChangeNotifier();
+        var router = new ChangeNotifierRouter(imap);
+
+        var imapAcct  = new AccountModel { Id = Guid.NewGuid(), BackendKind = BackendKind.ImapSmtp };
+        var graphAcct = new AccountModel { Id = Guid.NewGuid(), BackendKind = BackendKind.MicrosoftGraph };
+
+        router.StartWatchers(new[] { imapAcct, graphAcct }, TestContext.Current.CancellationToken);
+
+        // Graph accounts have no notifier until PR 7b, so only the IMAP account is watched.
+        Assert.NotNull(imap.LastWatchedAccounts);
+        Assert.Equal(new[] { imapAcct.Id }, imap.LastWatchedAccounts!.Select(a => a.Id));
+    }
+
+    [Fact]
+    public void ForwardsInboxNewMailFromInnerNotifier()
+    {
+        var imap = new RecordingChangeNotifier();
+        var router = new ChangeNotifierRouter(imap);
 
         var seen = new List<Guid>();
         router.InboxNewMailDetected += seen.Add;
 
-        var a1 = Guid.NewGuid();
-        var a2 = Guid.NewGuid();
-        imap.RaiseNewMail(a1);
-        graph.RaiseNewMail(a2);
+        var id = Guid.NewGuid();
+        imap.RaiseNewMail(id);
 
-        Assert.Equal(new[] { a1, a2 }, seen);
+        Assert.Equal(new[] { id }, seen);
     }
 
     [Fact]
-    public void EmptyBackends_Throws()
-        => Assert.Throws<ArgumentException>(() => new MailServiceRouter(Array.Empty<IMailService>()));
+    public void ForwardsReachabilityFromInnerNotifier()
+    {
+        var imap = new RecordingChangeNotifier();
+        var router = new ChangeNotifierRouter(imap);
+
+        var seen = new List<(Guid Id, bool Reachable)>();
+        router.AccountReachabilityChanged += (id, r) => seen.Add((id, r));
+
+        var acct = Guid.NewGuid();
+        imap.RaiseReachability(acct, false);
+
+        Assert.Equal(new[] { (acct, false) }, seen);
+    }
 
     [Fact]
-    public void StartIdleWatchers_PassesEachBackendOnlyItsAccounts()
+    public void Dispose_StopsForwarding()
     {
-        var imap = new RecordingMailService();
-        var graph = new RecordingMailService();
-        var router = new MailServiceRouter(new IMailService[] { imap, graph });
+        var imap = new RecordingChangeNotifier();
+        var router = new ChangeNotifierRouter(imap);
 
-        var imapAcct = new AccountModel { Id = Guid.NewGuid() };
-        var graphAcct = new AccountModel { Id = Guid.NewGuid() };
-        router.RegisterAccount(imapAcct.Id, imap);
-        router.RegisterAccount(graphAcct.Id, graph);
+        var seen = new List<Guid>();
+        router.InboxNewMailDetected += seen.Add;
+        router.Dispose();
 
-        router.StartIdleWatchers(new[] { imapAcct, graphAcct }, TestContext.Current.CancellationToken);
+        imap.RaiseNewMail(Guid.NewGuid());
 
-        Assert.NotNull(imap.LastIdleAccounts);
-        Assert.NotNull(graph.LastIdleAccounts);
-        Assert.Equal(new[] { imapAcct.Id }, imap.LastIdleAccounts!.Select(a => a.Id));
-        Assert.Equal(new[] { graphAcct.Id }, graph.LastIdleAccounts!.Select(a => a.Id));
+        Assert.Empty(seen);
     }
 }
 

--- a/QuickMail.Tests/SavedViewsTests.cs
+++ b/QuickMail.Tests/SavedViewsTests.cs
@@ -810,12 +810,6 @@ public class SavedViewsMainViewModelTests
         public Task DeleteFolderAsync(Guid accountId, string folderName, CancellationToken ct = default) => Task.CompletedTask;
         public Task RenameFolderAsync(Guid accountId, string folderName, string newName, string? newParentFolderName, CancellationToken ct = default) => Task.CompletedTask;
         public Task CopyFolderAsync(Guid accountId, string folderName, string? destinationParentName, CancellationToken ct = default) => Task.CompletedTask;
-#pragma warning disable CS0067
-        public event Action<Guid>? InboxNewMailDetected;
-        public event Action<Guid, bool>? AccountReachabilityChanged;
-#pragma warning restore CS0067
-        public void StartIdleWatchers(IReadOnlyList<AccountModel> accounts, CancellationToken ct = default) { }
-        public void StopIdleWatchers() { }
         public void Dispose() { }
     }
 

--- a/QuickMail.Tests/SessionFeaturesTests.cs
+++ b/QuickMail.Tests/SessionFeaturesTests.cs
@@ -185,7 +185,7 @@ public class OnlineModeTests
 
 public class IdleNewMailTests
 {
-    sealed class FireableMailService : IMailService
+    sealed class FireableMailService : IMailService, IChangeNotifier
     {
         private readonly Guid _accountId;
         public FireableMailService(Guid accountId) => _accountId = accountId;
@@ -233,8 +233,8 @@ public class IdleNewMailTests
         public Task DeleteFolderAsync(Guid accountId, string folderName, CancellationToken ct = default) => Task.CompletedTask;
         public Task RenameFolderAsync(Guid accountId, string folderName, string newName, string? newParentFolderName, CancellationToken ct = default) => Task.CompletedTask;
         public Task CopyFolderAsync(Guid accountId, string folderName, string? destinationParentName, CancellationToken ct = default) => Task.CompletedTask;
-        public void StartIdleWatchers(IReadOnlyList<AccountModel> accounts, CancellationToken ct = default) { }
-        public void StopIdleWatchers() { }
+        public void StartWatchers(IReadOnlyList<AccountModel> accounts, CancellationToken ct = default) { }
+        public void StopWatchers() { }
         public void Dispose() { }
     }
 
@@ -288,7 +288,7 @@ public class IdleNewMailTests
             imap, new StubAccountService(), new StubCredentialService(),
             new StubLocalStoreService(), new StubOAuthService(), sync,
             new StubConfigService(), new StubCommandRegistry(), new StubViewService(),
-            new StubRuleService(), new StubSmtpService());
+            new StubRuleService(), new StubSmtpService(), changeNotifier: imap);
 
         // Seed the account and connect so _cachedFolders gets the INBOX entry.
         vm.Accounts.Add(account);
@@ -319,7 +319,7 @@ public class IdleNewMailTests
             imap, new StubAccountService(), new StubCredentialService(),
             new StubLocalStoreService(), new StubOAuthService(), sync,
             new StubConfigService(), new StubCommandRegistry(), new StubViewService(),
-            new StubRuleService(), new StubSmtpService(), onlineMode: true);
+            new StubRuleService(), new StubSmtpService(), onlineMode: true, changeNotifier: imap);
 
         vm.Accounts.Add(account);
         await vm.ConnectAllAccountsAsync();

--- a/QuickMail.Tests/StubServices.cs
+++ b/QuickMail.Tests/StubServices.cs
@@ -45,12 +45,6 @@ sealed class StubImapMailService : IMailService
     public Task DeleteFolderAsync(Guid accountId, string folderName, CancellationToken ct = default) => Task.CompletedTask;
     public Task RenameFolderAsync(Guid accountId, string folderName, string newName, string? newParentFolderName, CancellationToken ct = default) => Task.CompletedTask;
     public Task CopyFolderAsync(Guid accountId, string folderName, string? destinationParentName, CancellationToken ct = default) => Task.CompletedTask;
-#pragma warning disable CS0067
-    public event Action<Guid, bool>? AccountReachabilityChanged;
-    public event Action<Guid>? InboxNewMailDetected;
-#pragma warning restore CS0067
-    public void StartIdleWatchers(IReadOnlyList<AccountModel> accounts, CancellationToken ct = default) { }
-    public void StopIdleWatchers() { }
     public void Dispose() { }
 }
 

--- a/QuickMail/App.xaml.cs
+++ b/QuickMail/App.xaml.cs
@@ -15,6 +15,7 @@ public partial class App : Application
     private GraphSendMailService? _graphSendMail;
     private ContactService? _contactService;
     private TemplateService? _templateService;
+    private ChangeNotifierRouter? _changeNotifier;
 
     protected override void OnStartup(StartupEventArgs e)
     {
@@ -93,6 +94,11 @@ public partial class App : Application
             IMailService BackendFor(AccountModel a)
                 => a.BackendKind == BackendKind.MicrosoftGraph ? graphBackend : imapBackend;
 
+            // Change-notification router (new-mail + reachability). IMAP's strategy is a held IDLE
+            // connection, implemented by ImapMailService itself because it is bound to the IMAP
+            // connection lifecycle. Graph delta-poll notification arrives in PR 7b.
+            _changeNotifier = new ChangeNotifierRouter(imapBackend);
+
             var localStore = new LocalStoreService(profile);
             if (!onlineMode)
                 localStore.Initialize();
@@ -125,7 +131,7 @@ public partial class App : Application
 
             var mainVm = new MainViewModel(
                 mailRouter, accountService, credentialService, localStore, oauthService, syncService, configService, commandRegistry, viewService, ruleService, smtpService,
-                onlineMode: onlineMode, flagService: flagService);
+                onlineMode: onlineMode, flagService: flagService, changeNotifier: _changeNotifier);
             mainVm.RegisterAccountBackend = a => mailRouter.RegisterAccount(a.Id, BackendFor(a));
             mainVm.LoadAccountList(accounts);
 
@@ -144,6 +150,7 @@ public partial class App : Application
 
     protected override void OnExit(ExitEventArgs e)
     {
+        _changeNotifier?.Dispose();
         _graphSendMail?.Dispose();
         _contactService?.Dispose();
         _templateService?.Dispose();

--- a/QuickMail/App.xaml.cs
+++ b/QuickMail/App.xaml.cs
@@ -16,6 +16,7 @@ public partial class App : Application
     private ContactService? _contactService;
     private TemplateService? _templateService;
     private ChangeNotifierRouter? _changeNotifier;
+    private ImapMailService? _imapBackend;
 
     protected override void OnStartup(StartupEventArgs e)
     {
@@ -83,7 +84,8 @@ public partial class App : Application
             var msOAuthService    = new OAuthService(profile);
             var googleOAuth       = new GoogleOAuthService(credentialService);
             var oauthService      = new OAuthRouter(msOAuthService, googleOAuth);
-            var imapBackend       = new ImapMailService(oauthService, configService);
+            _imapBackend          = new ImapMailService(oauthService, configService);
+            var imapBackend       = _imapBackend;
             var graphBackend      = new GraphMailService(msOAuthService, configService);
             _graphSendMail        = new GraphSendMailService(msOAuthService);
             var smtpService       = new SmtpService(oauthService, _graphSendMail);
@@ -150,7 +152,8 @@ public partial class App : Application
 
     protected override void OnExit(ExitEventArgs e)
     {
-        _changeNotifier?.Dispose();
+        _changeNotifier?.Dispose(); // stops IDLE watchers + severs the event chain
+        _imapBackend?.Dispose();    // closes connection pools (StopWatchers already ran, and is idempotent)
         _graphSendMail?.Dispose();
         _contactService?.Dispose();
         _templateService?.Dispose();

--- a/QuickMail/Services/ChangeNotifierRouter.cs
+++ b/QuickMail/Services/ChangeNotifierRouter.cs
@@ -46,6 +46,7 @@ public sealed class ChangeNotifierRouter : IChangeNotifier, IDisposable
 
     public void Dispose()
     {
+        _imap.StopWatchers(); // tear down watcher tasks before severing the event chain
         _imap.InboxNewMailDetected -= OnInboxNewMail;
         _imap.AccountReachabilityChanged -= OnReachabilityChanged;
     }

--- a/QuickMail/Services/ChangeNotifierRouter.cs
+++ b/QuickMail/Services/ChangeNotifierRouter.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using QuickMail.Models;
+
+namespace QuickMail.Services;
+
+/// <summary>
+/// Aggregates per-backend <see cref="IChangeNotifier"/> implementations behind one surface, the way
+/// <see cref="MailServiceRouter"/> does for <see cref="IMailService"/>. <see cref="StartWatchers"/>
+/// partitions accounts by backend so each notifier only watches the accounts it owns; events from
+/// every backend are forwarded to a single set of subscribers.
+///
+/// PR 7a wires only the IMAP notifier (a held IDLE connection per account, implemented by
+/// <see cref="ImapMailService"/> itself — IMAP's IDLE watcher is bound to the IMAP connection
+/// lifecycle, so it is not a separate object). PR 7b adds a Graph delta-poll notifier and routes
+/// Microsoft Graph accounts to it; IMAP accounts continue to go to the IMAP notifier.
+/// </summary>
+public sealed class ChangeNotifierRouter : IChangeNotifier, IDisposable
+{
+    private readonly IChangeNotifier _imap;
+
+    public ChangeNotifierRouter(IChangeNotifier imapNotifier)
+    {
+        _imap = imapNotifier;
+        _imap.InboxNewMailDetected += OnInboxNewMail;
+        _imap.AccountReachabilityChanged += OnReachabilityChanged;
+    }
+
+    public event Action<Guid>? InboxNewMailDetected;
+    public event Action<Guid, bool>? AccountReachabilityChanged;
+
+    private void OnInboxNewMail(Guid accountId) => InboxNewMailDetected?.Invoke(accountId);
+    private void OnReachabilityChanged(Guid accountId, bool isReachable) => AccountReachabilityChanged?.Invoke(accountId, isReachable);
+
+    public void StartWatchers(IReadOnlyList<AccountModel> accounts, CancellationToken ct = default)
+    {
+        // IMAP IDLE watches only IMAP accounts. Graph accounts get no watcher until PR 7b adds the
+        // delta-poll notifier; routing them here would attempt a doomed IMAP connection.
+        var imapAccounts = accounts.Where(a => a.BackendKind == BackendKind.ImapSmtp).ToList();
+        _imap.StartWatchers(imapAccounts, ct);
+    }
+
+    public void StopWatchers() => _imap.StopWatchers();
+
+    public void Dispose()
+    {
+        _imap.InboxNewMailDetected -= OnInboxNewMail;
+        _imap.AccountReachabilityChanged -= OnReachabilityChanged;
+    }
+}

--- a/QuickMail/Services/GraphMailService.cs
+++ b/QuickMail/Services/GraphMailService.cs
@@ -48,11 +48,6 @@ public class GraphMailService : IMailService
         _config = config;
     }
 
-#pragma warning disable CS0067 // events are part of IMailService; Graph raises them in PR 7
-    public event Action<Guid, bool>? AccountReachabilityChanged;
-    public event Action<Guid>? InboxNewMailDetected;
-#pragma warning restore CS0067
-
     // ── Connect ────────────────────────────────────────────────────────────────────
     public async Task ConnectAsync(AccountModel account, string? password = null, CancellationToken ct = default)
     {
@@ -256,11 +251,6 @@ public class GraphMailService : IMailService
     public Task<IReadOnlyDictionary<string, string>> FetchPreviewsAsync(
         Guid accountId, string folderName, IList<string> messageIds, int maxLines, CancellationToken ct = default)
         => Task.FromResult<IReadOnlyDictionary<string, string>>(new Dictionary<string, string>()); // bodyPreview is fetched inline
-
-    // Graph delivers new-mail notifications via delta polling (PR 7), not IMAP IDLE. No-op here so a
-    // mixed account list doesn't throw at startup.
-    public void StartIdleWatchers(IReadOnlyList<AccountModel> accounts, CancellationToken ct = default) { }
-    public void StopIdleWatchers() { }
 
     // ── Mutations / attachments / folder CRUD ────────────────────────────────────
     // Graph well-known folder names double as folder ids in URLs.

--- a/QuickMail/Services/IChangeNotifier.cs
+++ b/QuickMail/Services/IChangeNotifier.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using QuickMail.Models;
+
+namespace QuickMail.Services;
+
+/// <summary>
+/// Watches connected accounts for new mail and connectivity changes, raising events the UI
+/// subscribes to. Extracted from <see cref="IMailService"/> (PR 7) so each backend can supply its
+/// own notification strategy: IMAP holds an IDLE connection per account
+/// (<see cref="ImapMailService"/>), and Microsoft Graph polls a delta query (added in PR 7b). The
+/// per-backend notifiers are aggregated behind one surface by <see cref="ChangeNotifierRouter"/>.
+/// </summary>
+public interface IChangeNotifier
+{
+    /// <summary>
+    /// Raised on the ThreadPool when new mail is detected in the given account's INBOX. Handlers
+    /// should marshal to the UI thread if needed.
+    /// </summary>
+    event Action<Guid>? InboxNewMailDetected;
+
+    /// <summary>
+    /// Raised when an account's watcher loses (false) or regains (true) connectivity. Fired on the
+    /// ThreadPool; handlers should marshal to the UI thread if needed.
+    /// </summary>
+    event Action<Guid, bool>? AccountReachabilityChanged;
+
+    /// <summary>
+    /// Starts (or restarts) one watcher per account. Call after all accounts are connected. Safe to
+    /// call repeatedly — an existing watcher for the same account is stopped and replaced.
+    /// </summary>
+    void StartWatchers(IReadOnlyList<AccountModel> accounts, CancellationToken ct = default);
+
+    /// <summary>Stops all watchers.</summary>
+    void StopWatchers();
+}

--- a/QuickMail/Services/IMailService.cs
+++ b/QuickMail/Services/IMailService.cs
@@ -53,34 +53,11 @@ public interface IMailService : IDisposable
     Task NoOpAsync(Guid accountId, CancellationToken ct = default);
 
     /// <summary>
-    /// Raised when an account's reachability changes (connection lost due to IDLE watcher failure,
-    /// or connection restored after successful IDLE reconnect). The bool indicates current reachability.
-    /// Fired on the ThreadPool; handlers should marshal to UI thread if needed.
-    /// </summary>
-    event Action<Guid, bool>? AccountReachabilityChanged;
-
-    /// <summary>
     /// Counts messages in the Trash folder (if it exists) without opening other folders.
     /// Returns 0 if Trash does not exist or is empty.
     /// </summary>
     Task<int> CountTrashMessagesAsync(Guid accountId, CancellationToken ct = default);
 
-    /// <summary>
-    /// Raised on the ThreadPool when IMAP IDLE detects new mail in the INBOX of the given account.
-    /// The handler should marshal to the UI thread if needed.
-    /// </summary>
-    event Action<Guid>? InboxNewMailDetected;
-
-    /// <summary>
-    /// Starts one IDLE watcher connection per account in <paramref name="accounts"/>.
-    /// Each watcher watches INBOX and fires <see cref="InboxNewMailDetected"/> when new mail arrives.
-    /// Call after all accounts are connected. Safe to call multiple times — existing watchers for
-    /// the same account are stopped and replaced.
-    /// </summary>
-    void StartIdleWatchers(IReadOnlyList<AccountModel> accounts, CancellationToken ct = default);
-
-    /// <summary>Stops all IDLE watcher connections.</summary>
-    void StopIdleWatchers();
     Task<int> EmptyTrashAsync(Guid accountId, CancellationToken ct = default);
     Task<IList<string>> GetFolderMessageIdsAsync(Guid accountId, string folderName, CancellationToken ct = default);
 

--- a/QuickMail/Services/ImapMailService.cs
+++ b/QuickMail/Services/ImapMailService.cs
@@ -17,7 +17,7 @@ using QuickMail.Models;
 
 namespace QuickMail.Services;
 
-public class ImapMailService : IMailService
+public class ImapMailService : IMailService, IChangeNotifier
 {
     private static readonly string[] ComposeModeHeaders = ["X-QuickMail-Compose-Mode"];
 
@@ -741,9 +741,12 @@ public class ImapMailService : IMailService
         finally { await folder.CloseAsync(false, ct); }
     }
 
-    // ── IDLE watchers ────────────────────────────────────────────────────────────
+    // ── IDLE watchers (IChangeNotifier) ──────────────────────────────────────────
+    // IMAP's change-notification strategy is a held IDLE connection per account. It lives here
+    // rather than in a separate notifier class because it is bound to the IMAP connection lifecycle:
+    // DisconnectAsync cancels an account's watcher and Dispose stops them all. See IChangeNotifier.
 
-    public void StartIdleWatchers(IReadOnlyList<AccountModel> accounts, CancellationToken ct = default)
+    public void StartWatchers(IReadOnlyList<AccountModel> accounts, CancellationToken ct = default)
     {
         foreach (var account in accounts)
         {
@@ -762,7 +765,7 @@ public class ImapMailService : IMailService
         }
     }
 
-    public void StopIdleWatchers()
+    public void StopWatchers()
     {
         foreach (var kvp in _idleCts)
         {
@@ -1511,7 +1514,7 @@ public class ImapMailService : IMailService
     {
         if (_disposed) return;
         _disposed = true;
-        StopIdleWatchers();
+        StopWatchers();
         foreach (var pool in _pools.Values)
             pool.Dispose();
         _pools.Clear();

--- a/QuickMail/Services/MailServiceRouter.cs
+++ b/QuickMail/Services/MailServiceRouter.cs
@@ -28,11 +28,6 @@ public class MailServiceRouter : IMailService
         if (_allBackends.Count == 0)
             throw new ArgumentException("MailServiceRouter requires at least one backend.", nameof(backends));
         _defaultBackend = _allBackends[0];
-        foreach (var b in _allBackends)
-        {
-            b.InboxNewMailDetected += OnInnerInboxNewMail;
-            b.AccountReachabilityChanged += OnInnerAccountReachabilityChanged;
-        }
     }
 
     /// <summary>Bind an account to a specific backend. Called once at account-load time and once per Add Account. Idempotent.</summary>
@@ -51,13 +46,6 @@ public class MailServiceRouter : IMailService
         => _byAccount.TryGetValue(accountId, out var b) ? b : _defaultBackend;
 
     private IMailService For(AccountModel account) => For(account.Id);
-
-    // ── Event aggregation ────────────────────────────────────────────────────────
-    public event Action<Guid>? InboxNewMailDetected;
-    public event Action<Guid, bool>? AccountReachabilityChanged;
-
-    private void OnInnerInboxNewMail(Guid accountId) => InboxNewMailDetected?.Invoke(accountId);
-    private void OnInnerAccountReachabilityChanged(Guid accountId, bool isReachable) => AccountReachabilityChanged?.Invoke(accountId, isReachable);
 
     // ── Per-account delegation ─────────────────────────────────────────────────────
     public Task ConnectAsync(AccountModel account, string? password = null, CancellationToken ct = default)
@@ -153,40 +141,10 @@ public class MailServiceRouter : IMailService
     public Task CopyFolderAsync(Guid accountId, string folderName, string? destinationParentName, CancellationToken ct = default)
         => For(accountId).CopyFolderAsync(accountId, folderName, destinationParentName, ct);
 
-    // ── Account-list-level operations: fan out to every backend ────────────────────
-    // Each backend starts watchers only for the accounts it can actually connect; passing the full
-    // list to all backends is correct because an account is only ever registered to one backend.
-    public void StartIdleWatchers(IReadOnlyList<AccountModel> accounts, CancellationToken ct = default)
-    {
-        // Give each backend only the accounts registered to it (unregistered accounts fall back to
-        // the default backend), so a backend never spins up watcher tasks for accounts it doesn't own.
-        var byBackend = new Dictionary<IMailService, List<AccountModel>>();
-        foreach (var account in accounts)
-        {
-            var backend = _byAccount.TryGetValue(account.Id, out var b) ? b : _defaultBackend;
-            if (!byBackend.TryGetValue(backend, out var list))
-                byBackend[backend] = list = new List<AccountModel>();
-            list.Add(account);
-        }
-
-        foreach (var b in _allBackends)
-            b.StartIdleWatchers(byBackend.TryGetValue(b, out var list) ? list : new List<AccountModel>(), ct);
-    }
-
-    public void StopIdleWatchers()
-    {
-        foreach (var b in _allBackends)
-            b.StopIdleWatchers();
-    }
-
     public void Dispose()
     {
         foreach (var b in _allBackends)
-        {
-            b.InboxNewMailDetected -= OnInnerInboxNewMail;
-            b.AccountReachabilityChanged -= OnInnerAccountReachabilityChanged;
             b.Dispose();
-        }
         GC.SuppressFinalize(this);
     }
 }

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -81,6 +81,7 @@ public partial class MainViewModel : ObservableObject
     private bool _announceFlagStatus;
     private string? _activeFlagFilterId;
     private EventHandler? _onFlagDefinitionsChanged;
+    private Action<Guid, bool>? _onReachabilityChanged;
 
     // Retains folder lists for every account that has been connected this session
     private readonly Dictionary<Guid, List<MailFolderModel>> _cachedFolders = new();
@@ -1300,9 +1301,15 @@ public partial class MainViewModel : ObservableObject
         _changeNotifier?.StartWatchers(accountList, ct);
 
         // Subscribe to account reachability changes (watcher connection lost/restored).
-        // No announcement — this is internal bookkeeping.
+        // No announcement — this is internal bookkeeping. Stored in a field and unsubscribed first so
+        // repeated StartBackgroundSyncAsync calls don't stack handlers (each capturing a stale list).
+        // The event fires on the ThreadPool, so marshal the UI-touching work onto the UI thread.
         if (_changeNotifier != null)
-            _changeNotifier.AccountReachabilityChanged += (accountId, isReachable) =>
+        {
+            if (_onReachabilityChanged != null)
+                _changeNotifier.AccountReachabilityChanged -= _onReachabilityChanged;
+
+            _onReachabilityChanged = (accountId, isReachable) => InvokeOnUi(() =>
             {
                 var account = accountList.FirstOrDefault(a => a.Id == accountId);
                 if (account != null)
@@ -1310,7 +1317,9 @@ public partial class MainViewModel : ObservableObject
                     var folders = isReachable && _cachedFolders.TryGetValue(accountId, out var f) ? f : null;
                     ApplyAccountStatus(account, folders);
                 }
-            };
+            });
+            _changeNotifier.AccountReachabilityChanged += _onReachabilityChanged;
+        }
 
         // Subscribe to sync progress updates.
         // Announce every 10 folders to avoid excessive screen reader chatter.
@@ -1579,9 +1588,10 @@ public partial class MainViewModel : ObservableObject
 
         RebuildActiveGroupView();
     }
-    // Called on a ThreadPool thread by the IDLE watcher when new mail lands in an inbox.
-    // Runs a targeted sync for that account's INBOX so the message appears in the list.
-    private void OnInboxNewMailDetected(Guid accountId)
+    // Called on a ThreadPool thread by the change notifier when new mail lands in an inbox.
+    // Runs a targeted sync for that account's INBOX so the message appears in the list. Accounts and
+    // _cachedFolders are UI-thread-owned, so resolve them on the UI thread before the background sync.
+    private void OnInboxNewMailDetected(Guid accountId) => InvokeOnUi(() =>
     {
         var account = Accounts.FirstOrDefault(a => a.Id == accountId);
         if (account is null) return;
@@ -1608,6 +1618,17 @@ public partial class MainViewModel : ObservableObject
                 LogService.Log("IDLE targeted sync", ex);
             }
         });
+    });
+
+    // Marshals a ThreadPool callback onto the UI thread. Runs inline when already on the UI thread or
+    // when there is no Application (unit tests), keeping ThreadPool-fired handlers testable.
+    private static void InvokeOnUi(Action action)
+    {
+        var dispatcher = App.Current?.Dispatcher;
+        if (dispatcher is null || dispatcher.CheckAccess())
+            action();
+        else
+            dispatcher.InvokeAsync(action);
     }
 
     private void OnMessagesRemoved(IReadOnlyList<MailMessageSummary> removed)

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -20,6 +20,7 @@ namespace QuickMail.ViewModels;
 public partial class MainViewModel : ObservableObject
 {
     private readonly IMailService _imap;
+    private readonly IChangeNotifier? _changeNotifier;
     private readonly IAccountService _accountService;
     private readonly ICredentialService _credentials;
     private readonly ILocalStoreService _localStore;
@@ -657,9 +658,11 @@ public partial class MainViewModel : ObservableObject
         IRuleService ruleService,
         ISendMailService smtpService,
         bool onlineMode = false,
-        IFlagService? flagService = null)
+        IFlagService? flagService = null,
+        IChangeNotifier? changeNotifier = null)
     {
         _imap            = imap;
+        _changeNotifier  = changeNotifier;
         _accountService  = accountService;
         _credentials     = credentials;
         _localStore      = localStore;
@@ -687,7 +690,8 @@ public partial class MainViewModel : ObservableObject
         _syncService.FolderSynced    += OnFolderSynced;
         _syncService.MessagesRemoved += OnMessagesRemoved;
         _syncService.RulesApplied    += OnRulesApplied;
-        _imap.InboxNewMailDetected += OnInboxNewMailDetected;
+        if (_changeNotifier != null)
+            _changeNotifier.InboxNewMailDetected += OnInboxNewMailDetected;
         if (_flagService != null)
         {
             _onFlagDefinitionsChanged = (_, _) => _ = OnFlagDefinitionsChangedAsync();
@@ -1293,19 +1297,20 @@ public partial class MainViewModel : ObservableObject
         if (_cachedFolders.Count == 0) return;
 
         var accountList = Accounts.ToList();
-        _imap.StartIdleWatchers(accountList, ct);
+        _changeNotifier?.StartWatchers(accountList, ct);
 
-        // Subscribe to account reachability changes (IDLE watcher connection lost/restored).
+        // Subscribe to account reachability changes (watcher connection lost/restored).
         // No announcement — this is internal bookkeeping.
-        _imap.AccountReachabilityChanged += (accountId, isReachable) =>
-        {
-            var account = accountList.FirstOrDefault(a => a.Id == accountId);
-            if (account != null)
+        if (_changeNotifier != null)
+            _changeNotifier.AccountReachabilityChanged += (accountId, isReachable) =>
             {
-                var folders = isReachable && _cachedFolders.TryGetValue(accountId, out var f) ? f : null;
-                ApplyAccountStatus(account, folders);
-            }
-        };
+                var account = accountList.FirstOrDefault(a => a.Id == accountId);
+                if (account != null)
+                {
+                    var folders = isReachable && _cachedFolders.TryGetValue(accountId, out var f) ? f : null;
+                    ApplyAccountStatus(account, folders);
+                }
+            };
 
         // Subscribe to sync progress updates.
         // Announce every 10 folders to avoid excessive screen reader chatter.


### PR DESCRIPTION
## What this is

First half of PR 7 (change notifications). A **behavior-preserving refactor** that pulls new-mail and account-reachability notification out of `IMailService` into a dedicated `IChangeNotifier` abstraction, so each backend can supply its own strategy. IMAP keeps its held-IDLE-connection watcher; the Graph delta-poll notifier lands in **PR 7b**.

No functional change for existing IMAP users — this is plumbing that unblocks Graph new-mail detection.

## Changes

- **New `IChangeNotifier`** — `InboxNewMailDetected`, `AccountReachabilityChanged`, `StartWatchers`, `StopWatchers`.
- **New `ChangeNotifierRouter`** — aggregates per-backend notifiers behind one surface (the way `MailServiceRouter` does for `IMailService`) and partitions accounts by `BackendKind`. For 7a it wires only the IMAP notifier; Graph accounts get no watcher until 7b.
- **`ImapMailService` implements `IChangeNotifier` directly** (see design note below). `StartIdleWatchers`/`StopIdleWatchers` → `StartWatchers`/`StopWatchers`. The IDLE watcher loop, fields, and event-raising are otherwise untouched.
- **`IMailService`, `MailServiceRouter`, `GraphMailService`, and the test stubs** drop the four IDLE members.
- **`MainViewModel`** takes an optional `IChangeNotifier` (App passes the router; tests pass null) and subscribes to it instead of to the mail service.
- **Tests** — new `ChangeNotifierRouterTests` (account partitioning + event forwarding + dispose); the existing `IdleNewMailTests` are migrated to drive the change notifier.

## Design note (worth your eye)

The spec called for a separate `ImapChangeNotifier` class. While implementing, I found the IDLE watcher is bound to the **IMAP connection lifecycle**, not just to connection *creation*: `DisconnectAsync` cancels an account's watcher CTS directly and `Dispose` stops them all. Extracting it to a standalone class would need event plumbing in *both* directions (mail service ↔ notifier) — more moving parts and more risk in exactly the "safe half."

So `ImapMailService` implements `IChangeNotifier` itself: the IDLE code doesn't move, so there's zero behavior change, and `IMailService` still gets cleaned up. The asymmetry is justified — IMAP IDLE is intrinsically tied to the IMAP connection; Graph delta-polling owns its own `GraphClient` and will be a clean separate `GraphChangeNotifier` in 7b. Happy to revisit if you'd rather a standalone class.

## Testing

- Build clean; full suite green apart from one **known pre-existing flake** (`PreviewSuppressionTests.InitialLoad_PreviewLinesNonZero_PreservesPreview` — async preview timing, passes 3/3 in isolation; untouched by this PR).
- New/migrated notifier tests: 6/6 pass.

**Please run your own client off this branch for a bit before merging.** This moves live IMAP IDLE code and I don't have an IMAP mailbox to exercise the held-connection path — unit tests can't cover a real IDLE session. Worth confirming: new-mail notifications still fire, no reconnect spam, and account-reachability (connection lost/restored) still toggles.
