### PR TITLE
Fix #130: suppress menu bar activation after Alt+key shortcut

### DIFF
--- a/QuickMail/Views/ComposeWindow.xaml
+++ b/QuickMail/Views/ComposeWindow.xaml
@@ -11,7 +11,8 @@
         Height="540" Width="680"
         MinHeight="360" MinWidth="480"
         WindowStartupLocation="CenterScreen"
-        PreviewKeyDown="Window_PreviewKeyDown">
+        PreviewKeyDown="Window_PreviewKeyDown"
+        PreviewKeyUp="Window_PreviewKeyUp">
 
     <Window.InputBindings>
         <KeyBinding Key="S" Modifiers="Alt"  Command="{Binding SendCommand}"/>

--- a/QuickMail/Views/ComposeWindow.xaml.cs
+++ b/QuickMail/Views/ComposeWindow.xaml.cs
@@ -716,6 +716,20 @@ public partial class ComposeWindow : Window
         }
     }
 
+    // After handling an Alt+key shortcut, suppress the Alt release so DefWindowProc
+    // doesn't generate WM_SYSCOMMAND/SC_KEYMENU and activate the menu bar. Handling
+    // it here (PreviewKeyUp) is more reliable than the WndProc hook alone because it
+    // fires before SC_KEYMENU is generated, even if the compose window is closing.
+    private void Window_PreviewKeyUp(object sender, KeyEventArgs e)
+    {
+        if (!_suppressNextMenuActivation) return;
+        if (e.Key == Key.System && (e.SystemKey == Key.LeftAlt || e.SystemKey == Key.RightAlt))
+        {
+            _suppressNextMenuActivation = false;
+            e.Handled = true;
+        }
+    }
+
     /// <summary>
     /// When the caret moves into a misspelled word during normal cursor navigation,
     /// announce it to screen readers so users hear about spelling errors without


### PR DESCRIPTION
## Summary

- Adds a `PreviewKeyUp` handler on `ComposeWindow` that eats the Alt key release when `_suppressNextMenuActivation` is set
- The existing WndProc hook (intercepting `WM_SYSCOMMAND/SC_KEYMENU`) worked for cases where the compose window stayed open, but not when it closed before the SC_KEYMENU arrived — at that point the message was delivered to the main window's menu bar instead
- Handling the Alt release at the WPF PreviewKeyUp level prevents `DefWindowProc` from generating SC_KEYMENU in the first place, which is reliable regardless of when the window closes

## Root cause

When Alt+S sends a message and the compose window begins closing, the `HwndSource` hook is removed. SC_KEYMENU is generated only when Alt is *released* (on WM_KEYUP for VK_MENU), which can arrive after the hook is gone. The main window then receives SC_KEYMENU and activates its menu bar.

## Test plan

- [ ] Open compose window in HTML mode, write a message, press Alt+S to send — menu bar should NOT receive focus
- [ ] Verify Alt+U (Subject), Alt+M (From), Alt+Y (Body) also still suppress menu activation
- [ ] Verify F10 and bare Alt still open the menu bar normally

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)