### PR TITLE
Fix #131: Shift+Tab navigates from message body back to header fields

### DIFF
--- a/QuickMail/Views/ComposeWindow.xaml.cs
+++ b/QuickMail/Views/ComposeWindow.xaml.cs
@@ -946,6 +946,16 @@ public partial class ComposeWindow : Window
             }
         }
 
+        // Shift+Tab when not consumed by list dedent above: move focus back to the
+        // previous header field. AcceptsTab=True blocks WPF's natural tab-navigation
+        // for Shift+Tab just as it does for forward Tab.
+        if (e.Key == Key.Tab && Keyboard.Modifiers == ModifierKeys.Shift)
+        {
+            ((UIElement)sender).MoveFocus(new TraversalRequest(FocusNavigationDirection.Previous));
+            e.Handled = true;
+            return;
+        }
+
         if (e.Key == Key.F7)
         {
             var forward = (Keyboard.Modifiers & ModifierKeys.Shift) == 0;
@@ -1002,7 +1012,18 @@ public partial class ComposeWindow : Window
         if (Keyboard.Modifiers != ModifierKeys.None && Keyboard.Modifiers != ModifierKeys.Shift) return;
 
         var para = RichBodyBox.CaretPosition.Paragraph;
-        if (para?.Parent is not ListItem) return;
+        if (para?.Parent is not ListItem)
+        {
+            // Shift+Tab from a non-list paragraph: move focus back to the previous
+            // header field. AcceptsTab=True blocks the natural WPF focus navigation
+            // for both Tab and Shift+Tab, so we have to do it explicitly.
+            if (Keyboard.Modifiers == ModifierKeys.Shift)
+            {
+                ((UIElement)sender).MoveFocus(new TraversalRequest(FocusNavigationDirection.Previous));
+                e.Handled = true;
+            }
+            return;
+        }
 
         _suppressFormattingAnnouncement = true;
         if (Keyboard.Modifiers == ModifierKeys.Shift)


### PR DESCRIPTION
## Summary

- `AcceptsTab="True"` on the body editors (both `BodyBox` and `RichBodyBox`) blocks WPF's natural Shift+Tab focus navigation in addition to Tab — focus gets stranded in the body with no way out via keyboard
- In `RichBodyBox_PreviewKeyDown` (HTML mode): when Shift+Tab is pressed and the caret is **not** in a list item, calls `MoveFocus(Previous)` and marks the event handled. List items continue to use Shift+Tab for dedentation as before
- In `BodyBox_PreviewKeyDown` (plain-text and Markdown modes): after the Markdown list-dedent block, adds an unconditional Shift+Tab → `MoveFocus(Previous)` case that fires whenever list dedent didn't handle it

## Behaviour preserved

- Tab in the body still inserts a tab character (AcceptsTab=True)
- Shift+Tab in a list item (Markdown or HTML) still dedents
- Shift+Tab outside a list item now moves focus to Subject / Bcc / whichever field precedes the body in tab order

## Test plan

- [ ] HTML mode: Tab into the body from Subject; press Shift+Tab — focus should return to Subject (or Bcc / attachments list if attachments are present)
- [ ] Plain-text mode: same as above
- [ ] Markdown mode outside a list: same
- [ ] Markdown/HTML mode inside a list item: Shift+Tab should still dedent, not navigate away
- [ ] Tab in all modes inside body: should still insert a tab character

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)