### PR TITLE
Graph PR 7b: GraphChangeNotifier delta polling (new-mail detection for Graph accounts)

### DIFF
--- a/QuickMail.Tests/FlagServiceTests.cs
+++ b/QuickMail.Tests/FlagServiceTests.cs
@@ -160,4 +160,6 @@ sealed class RecordingFlagStore : ILocalStoreService
     public Task<List<(Guid AccountId, string FolderName, string MessageId, string IcsText)>> LoadAllCalendarIcsAsync()
         => Task.FromResult(new List<(Guid, string, string, string)>());
     public Task ClearOrphanedCalendarSourceLinksAsync() => Task.CompletedTask;
+    public Task<string?> GetDeltaTokenAsync(Guid accountId, string folderId) => Task.FromResult<string?>(null);
+    public Task SetDeltaTokenAsync(Guid accountId, string folderId, string deltaToken) => Task.CompletedTask;
 }

--- a/QuickMail.Tests/GraphBackendGateTests.cs
+++ b/QuickMail.Tests/GraphBackendGateTests.cs
@@ -169,42 +169,46 @@ public class ChangeNotifierRouterTests
     }
 
     [Fact]
-    public void StartWatchers_PassesOnlyImapAccountsToNotifier()
+    public void StartWatchers_FansFullListToEveryNotifier()
     {
         var imap = new RecordingChangeNotifier();
-        var router = new ChangeNotifierRouter(imap);
+        var graph = new RecordingChangeNotifier();
+        var router = new ChangeNotifierRouter(new IChangeNotifier[] { imap, graph });
 
         var imapAcct  = new AccountModel { Id = Guid.NewGuid(), BackendKind = BackendKind.ImapSmtp };
         var graphAcct = new AccountModel { Id = Guid.NewGuid(), BackendKind = BackendKind.MicrosoftGraph };
 
         router.StartWatchers(new[] { imapAcct, graphAcct }, TestContext.Current.CancellationToken);
 
-        // Graph accounts have no notifier until PR 7b, so only the IMAP account is watched.
-        Assert.NotNull(imap.LastWatchedAccounts);
-        Assert.Equal(new[] { imapAcct.Id }, imap.LastWatchedAccounts!.Select(a => a.Id));
-        Assert.DoesNotContain(graphAcct.Id, imap.LastWatchedAccounts!.Select(a => a.Id));
+        // The router fans the full list to every notifier; each notifier filters to its own accounts.
+        Assert.Equal(new[] { imapAcct.Id, graphAcct.Id }, imap.LastWatchedAccounts!.Select(a => a.Id));
+        Assert.Equal(new[] { imapAcct.Id, graphAcct.Id }, graph.LastWatchedAccounts!.Select(a => a.Id));
     }
 
     [Fact]
-    public void ForwardsInboxNewMailFromInnerNotifier()
+    public void ForwardsInboxNewMailFromAnyNotifier()
     {
         var imap = new RecordingChangeNotifier();
-        var router = new ChangeNotifierRouter(imap);
+        var graph = new RecordingChangeNotifier();
+        var router = new ChangeNotifierRouter(new IChangeNotifier[] { imap, graph });
 
         var seen = new List<Guid>();
         router.InboxNewMailDetected += seen.Add;
 
-        var id = Guid.NewGuid();
-        imap.RaiseNewMail(id);
+        var fromImap = Guid.NewGuid();
+        var fromGraph = Guid.NewGuid();
+        imap.RaiseNewMail(fromImap);
+        graph.RaiseNewMail(fromGraph);
 
-        Assert.Equal(new[] { id }, seen);
+        Assert.Equal(new[] { fromImap, fromGraph }, seen);
     }
 
     [Fact]
-    public void ForwardsReachabilityFromInnerNotifier()
+    public void ForwardsReachabilityFromAnyNotifier()
     {
         var imap = new RecordingChangeNotifier();
-        var router = new ChangeNotifierRouter(imap);
+        var graph = new RecordingChangeNotifier();
+        var router = new ChangeNotifierRouter(new IChangeNotifier[] { imap, graph });
 
         var seen = new List<(Guid Id, bool Reachable)>();
         router.AccountReachabilityChanged += (id, r) => seen.Add((id, r));
@@ -219,7 +223,7 @@ public class ChangeNotifierRouterTests
     public void Dispose_StopsForwarding()
     {
         var imap = new RecordingChangeNotifier();
-        var router = new ChangeNotifierRouter(imap);
+        var router = new ChangeNotifierRouter(new IChangeNotifier[] { imap });
 
         var seen = new List<Guid>();
         router.InboxNewMailDetected += seen.Add;
@@ -231,15 +235,17 @@ public class ChangeNotifierRouterTests
     }
 
     [Fact]
-    public void Dispose_CallsStopWatchersOnInnerNotifier()
+    public void Dispose_CallsStopWatchersOnEveryNotifier()
     {
         var imap = new RecordingChangeNotifier();
-        var router = new ChangeNotifierRouter(imap);
+        var graph = new RecordingChangeNotifier();
+        var router = new ChangeNotifierRouter(new IChangeNotifier[] { imap, graph });
 
         router.Dispose();
 
-        // Disposing the router must tear down the watcher tasks, not just unsubscribe events.
+        // Disposing the router must tear down every notifier's watcher tasks, not just unsubscribe.
         Assert.True(imap.StopWatchersCalled);
+        Assert.True(graph.StopWatchersCalled);
     }
 }
 

--- a/QuickMail.Tests/GraphChangeNotifierTests.cs
+++ b/QuickMail.Tests/GraphChangeNotifierTests.cs
@@ -1,0 +1,213 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using QuickMail.Models;
+using QuickMail.Services;
+using QuickMail.Services.Graph;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// Tests for <see cref="GraphChangeNotifier"/> delta polling and the delta-cursor store methods.
+/// Each test uses a fresh temp-directory profile so the real SQLite DeltaToken table is exercised.
+/// </summary>
+public class GraphChangeNotifierTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly LocalStoreService _store;
+
+    public GraphChangeNotifierTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"qm-graphnotif-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        _store = new LocalStoreService(new ProfileContext(_tempDir));
+        _store.Initialize();
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); } catch { }
+    }
+
+    /// <summary>Routes each request to a canned JSON response by URL, recording the requested URLs in order.</summary>
+    private sealed class StubHttpHandler : HttpMessageHandler
+    {
+        private readonly Func<string, (HttpStatusCode Status, string Json)> _respond;
+        public ConcurrentQueue<string> Requests { get; } = new();
+
+        public StubHttpHandler(Func<string, (HttpStatusCode, string)> respond) => _respond = respond;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            var url = request.RequestUri!.ToString();
+            Requests.Enqueue(url);
+            var (status, json) = _respond(url);
+            return Task.FromResult(new HttpResponseMessage(status)
+            {
+                Content = new StringContent(json, Encoding.UTF8, "application/json"),
+            });
+        }
+    }
+
+    private static AccountModel GraphAccount() => new()
+    {
+        Id = Guid.NewGuid(),
+        AccountName = "M365",
+        Username = "user@contoso.com",
+        BackendKind = BackendKind.MicrosoftGraph,
+    };
+
+    private GraphChangeNotifier MakeNotifier(StubHttpHandler handler) =>
+        new(new GraphClient(new StubOAuthService(), new HttpClient(handler)), _store);
+
+    private static async Task WaitForAsync(Func<Task<bool>> condition, int timeoutMs = 5000)
+    {
+        var deadline = Environment.TickCount64 + timeoutMs;
+        while (Environment.TickCount64 < deadline)
+        {
+            if (await condition()) return;
+            await Task.Delay(15);
+        }
+        throw new TimeoutException("Condition not met within timeout.");
+    }
+
+    [Fact]
+    public async Task FirstPoll_WithMessages_RaisesInboxNewMail_AndPersistsDeltaLink()
+    {
+        const string deltaLink = "https://graph.microsoft.com/v1.0/me/mailFolders/Inbox/messages/delta?$deltatoken=NEW";
+        var handler = new StubHttpHandler(_ =>
+            (HttpStatusCode.OK, $$"""{"value":[{"id":"m1"}],"@odata.deltaLink":"{{deltaLink}}"}"""));
+
+        var account = GraphAccount();
+        using var notifier = MakeNotifier(handler);
+        var raised = new TaskCompletionSource<Guid>();
+        notifier.InboxNewMailDetected += id => raised.TrySetResult(id);
+
+        notifier.StartWatchers(new[] { account }, TestContext.Current.CancellationToken);
+
+        var raisedId = await raised.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        Assert.Equal(account.Id, raisedId);
+
+        // First request used the fresh delta enumeration URL (no stored cursor yet).
+        Assert.Contains("/messages/delta?$select=id", handler.Requests.First());
+
+        // The final page's deltaLink is persisted for the next tick.
+        await WaitForAsync(async () => await _store.GetDeltaTokenAsync(account.Id, "Inbox") == deltaLink);
+        notifier.StopWatchers();
+    }
+
+    [Fact]
+    public async Task Poll_WithStoredCursor_RequestsStoredDeltaLinkVerbatim()
+    {
+        var account = GraphAccount();
+        const string storedCursor = "https://graph.microsoft.com/v1.0/me/mailFolders/Inbox/messages/delta?$deltatoken=SEEDED";
+        await _store.SetDeltaTokenAsync(account.Id, "Inbox", storedCursor);
+
+        var firstRequest = new TaskCompletionSource<string>();
+        var handler = new StubHttpHandler(url =>
+        {
+            firstRequest.TrySetResult(url);
+            return (HttpStatusCode.OK, """{"value":[],"@odata.deltaLink":"https://graph.microsoft.com/v1.0/x?$deltatoken=NEXT"}""");
+        });
+
+        using var notifier = MakeNotifier(handler);
+        notifier.StartWatchers(new[] { account }, TestContext.Current.CancellationToken);
+
+        var requested = await firstRequest.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        Assert.Equal(storedCursor, requested); // requested verbatim, not the fresh delta URL
+        notifier.StopWatchers();
+    }
+
+    [Fact]
+    public async Task Poll_FollowsNextLinkAcrossPages_PersistsFinalDeltaLink()
+    {
+        const string page2 = "https://graph.microsoft.com/v1.0/me/mailFolders/Inbox/messages/delta?$skiptoken=PAGE2";
+        const string finalDelta = "https://graph.microsoft.com/v1.0/me/mailFolders/Inbox/messages/delta?$deltatoken=FINAL";
+        var handler = new StubHttpHandler(url =>
+            url.Contains("$skiptoken=PAGE2")
+                ? (HttpStatusCode.OK, $$"""{"value":[{"id":"m2"}],"@odata.deltaLink":"{{finalDelta}}"}""")
+                : (HttpStatusCode.OK, $$"""{"value":[{"id":"m1"}],"@odata.nextLink":"{{page2}}"}"""));
+
+        var account = GraphAccount();
+        using var notifier = MakeNotifier(handler);
+        notifier.StartWatchers(new[] { account }, TestContext.Current.CancellationToken);
+
+        // The final page's deltaLink (not the within-tick nextLink) is what gets persisted.
+        await WaitForAsync(async () => await _store.GetDeltaTokenAsync(account.Id, "Inbox") == finalDelta);
+        Assert.Contains(handler.Requests, u => u.Contains("$skiptoken=PAGE2")); // second page was followed
+        notifier.StopWatchers();
+    }
+
+    [Fact]
+    public void StartWatchers_IgnoresNonGraphAccounts()
+    {
+        var handler = new StubHttpHandler(_ => (HttpStatusCode.OK, "{}"));
+        var imapAccount = new AccountModel { Id = Guid.NewGuid(), BackendKind = BackendKind.ImapSmtp };
+        using var notifier = MakeNotifier(handler);
+
+        notifier.StartWatchers(new[] { imapAccount }, TestContext.Current.CancellationToken);
+        notifier.StopWatchers();
+
+        // No Graph account → no poll task → no HTTP request ever issued.
+        Assert.Empty(handler.Requests);
+    }
+}
+
+/// <summary>Round-trip tests for the DeltaToken store methods on the real SQLite store.</summary>
+public class DeltaTokenStoreTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly LocalStoreService _store;
+
+    public DeltaTokenStoreTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"qm-delta-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        _store = new LocalStoreService(new ProfileContext(_tempDir));
+        _store.Initialize();
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); } catch { }
+    }
+
+    [Fact]
+    public async Task GetDeltaToken_ReturnsNull_WhenNoneStored()
+        => Assert.Null(await _store.GetDeltaTokenAsync(Guid.NewGuid(), "Inbox"));
+
+    [Fact]
+    public async Task SetThenGet_RoundTrips()
+    {
+        var account = Guid.NewGuid();
+        await _store.SetDeltaTokenAsync(account, "Inbox", "https://graph/delta?$deltatoken=ABC");
+        Assert.Equal("https://graph/delta?$deltatoken=ABC", await _store.GetDeltaTokenAsync(account, "Inbox"));
+    }
+
+    [Fact]
+    public async Task Set_OverwritesExistingCursor()
+    {
+        var account = Guid.NewGuid();
+        await _store.SetDeltaTokenAsync(account, "Inbox", "first");
+        await _store.SetDeltaTokenAsync(account, "Inbox", "second");
+        Assert.Equal("second", await _store.GetDeltaTokenAsync(account, "Inbox"));
+    }
+
+    [Fact]
+    public async Task DeltaToken_IsScopedPerAccount()
+    {
+        var a = Guid.NewGuid();
+        var b = Guid.NewGuid();
+        await _store.SetDeltaTokenAsync(a, "Inbox", "token-a");
+        Assert.Equal("token-a", await _store.GetDeltaTokenAsync(a, "Inbox"));
+        Assert.Null(await _store.GetDeltaTokenAsync(b, "Inbox"));
+    }
+}

--- a/QuickMail.Tests/MainViewModelFlagTests.cs
+++ b/QuickMail.Tests/MainViewModelFlagTests.cs
@@ -238,4 +238,6 @@ sealed class FilterableStoreForFlags : ILocalStoreService
     public Task<List<(Guid AccountId, string FolderName, string MessageId, string IcsText)>> LoadAllCalendarIcsAsync()
         => Task.FromResult(new List<(Guid, string, string, string)>());
     public Task ClearOrphanedCalendarSourceLinksAsync() => Task.CompletedTask;
+    public Task<string?> GetDeltaTokenAsync(Guid accountId, string folderId) => Task.FromResult<string?>(null);
+    public Task SetDeltaTokenAsync(Guid accountId, string folderId, string deltaToken) => Task.CompletedTask;
 }

--- a/QuickMail.Tests/MessageFilterTests.cs
+++ b/QuickMail.Tests/MessageFilterTests.cs
@@ -52,6 +52,8 @@ public class MessageFilterTests
         public Task<List<(Guid AccountId, string FolderName, string MessageId, string IcsText)>> LoadAllCalendarIcsAsync()
             => Task.FromResult(new List<(Guid, string, string, string)>());
         public Task ClearOrphanedCalendarSourceLinksAsync() => Task.CompletedTask;
+        public Task<string?> GetDeltaTokenAsync(Guid accountId, string folderId) => Task.FromResult<string?>(null);
+        public Task SetDeltaTokenAsync(Guid accountId, string folderId, string deltaToken) => Task.CompletedTask;
     }
 
     // ── Helpers ─────────────────────────────────────────────────────────────

--- a/QuickMail.Tests/SavedViewsTests.cs
+++ b/QuickMail.Tests/SavedViewsTests.cs
@@ -844,6 +844,8 @@ public class SavedViewsMainViewModelTests
         public Task<List<(Guid AccountId, string FolderName, string MessageId, string IcsText)>> LoadAllCalendarIcsAsync()
             => Task.FromResult(new List<(Guid, string, string, string)>());
         public Task ClearOrphanedCalendarSourceLinksAsync() => Task.CompletedTask;
+        public Task<string?> GetDeltaTokenAsync(Guid accountId, string folderId) => Task.FromResult<string?>(null);
+        public Task SetDeltaTokenAsync(Guid accountId, string folderId, string deltaToken) => Task.CompletedTask;
     }
 
     private static MainViewModel MakeVmWithStore(IEnumerable<SavedView> views, ILocalStoreService store, IMailService? imap = null)

--- a/QuickMail.Tests/SessionFeaturesTests.cs
+++ b/QuickMail.Tests/SessionFeaturesTests.cs
@@ -112,6 +112,8 @@ public class PreviewSuppressionTests
         public Task<List<(Guid AccountId, string FolderName, string MessageId, string IcsText)>> LoadAllCalendarIcsAsync()
             => Task.FromResult(new List<(Guid, string, string, string)>());
         public Task ClearOrphanedCalendarSourceLinksAsync() => Task.CompletedTask;
+        public Task<string?> GetDeltaTokenAsync(Guid accountId, string folderId) => Task.FromResult<string?>(null);
+        public Task SetDeltaTokenAsync(Guid accountId, string folderId, string deltaToken) => Task.CompletedTask;
     }
 
     private static readonly MailMessageSummary[] MessagesWithPreviews =

--- a/QuickMail.Tests/StubServices.cs
+++ b/QuickMail.Tests/StubServices.cs
@@ -116,6 +116,8 @@ sealed class StubLocalStoreService : ILocalStoreService
     public Task<List<(Guid AccountId, string FolderName, string MessageId, string IcsText)>> LoadAllCalendarIcsAsync()
         => Task.FromResult(new List<(Guid, string, string, string)>());
     public Task ClearOrphanedCalendarSourceLinksAsync() => Task.CompletedTask;
+    public Task<string?> GetDeltaTokenAsync(Guid accountId, string folderId) => Task.FromResult<string?>(null);
+    public Task SetDeltaTokenAsync(Guid accountId, string folderId, string deltaToken) => Task.CompletedTask;
 }
 
 sealed class StubContactService : IContactService

--- a/QuickMail/App.xaml.cs
+++ b/QuickMail/App.xaml.cs
@@ -16,6 +16,7 @@ public partial class App : Application
     private ContactService? _contactService;
     private TemplateService? _templateService;
     private ChangeNotifierRouter? _changeNotifier;
+    private GraphChangeNotifier? _graphNotifier;
     private ImapMailService? _imapBackend;
 
     protected override void OnStartup(StartupEventArgs e)
@@ -96,14 +97,16 @@ public partial class App : Application
             IMailService BackendFor(AccountModel a)
                 => a.BackendKind == BackendKind.MicrosoftGraph ? graphBackend : imapBackend;
 
-            // Change-notification router (new-mail + reachability). IMAP's strategy is a held IDLE
-            // connection, implemented by ImapMailService itself because it is bound to the IMAP
-            // connection lifecycle. Graph delta-poll notification arrives in PR 7b.
-            _changeNotifier = new ChangeNotifierRouter(imapBackend);
-
             var localStore = new LocalStoreService(profile);
             if (!onlineMode)
                 localStore.Initialize();
+
+            // Change-notification router (new-mail + reachability). IMAP's strategy is a held IDLE
+            // connection, implemented by ImapMailService itself because it is bound to the IMAP
+            // connection lifecycle. Graph uses delta polling, which needs the local store for its
+            // delta cursor — hence wired after localStore. Each notifier filters to its own accounts.
+            _graphNotifier  = new GraphChangeNotifier(graphBackend.Client, localStore, configService);
+            _changeNotifier = new ChangeNotifierRouter(new IChangeNotifier[] { imapBackend, _graphNotifier });
 
             // Load accounts once — after the store is initialized — and reuse the list for the VM.
             // Router registration runs via mainVm.RegisterAccountBackend (set below), which also
@@ -157,7 +160,8 @@ public partial class App : Application
 
     protected override void OnExit(ExitEventArgs e)
     {
-        _changeNotifier?.Dispose(); // stops IDLE watchers + severs the event chain
+        _changeNotifier?.Dispose(); // stops all watchers (IDLE + Graph poll) + severs the event chain
+        _graphNotifier?.Dispose();  // disposes the Graph poll CTS (StopWatchers already ran; idempotent)
         _imapBackend?.Dispose();    // closes connection pools (StopWatchers already ran, and is idempotent)
         _graphSendMail?.Dispose();
         _contactService?.Dispose();

--- a/QuickMail/Models/ConfigModel.cs
+++ b/QuickMail/Models/ConfigModel.cs
@@ -41,6 +41,12 @@ public class ConfigModel
     /// </summary>
     public int InitialSyncCount { get; set; } = 500;
 
+    /// <summary>
+    /// Poll interval (seconds) for the Microsoft Graph new-mail delta watcher. Default 60, clamped
+    /// to 30–600. IMAP accounts use a held IDLE connection instead and ignore this setting.
+    /// </summary>
+    public int GraphPollSeconds { get; set; } = 60;
+
     // ── Screen reader announcement settings ──────────────────────────────────────
 
     /// <summary>Master switch for all custom screen reader announcements from QuickMail code.</summary>

--- a/QuickMail/Services/ChangeNotifierRouter.cs
+++ b/QuickMail/Services/ChangeNotifierRouter.cs
@@ -9,23 +9,29 @@ namespace QuickMail.Services;
 /// <summary>
 /// Aggregates per-backend <see cref="IChangeNotifier"/> implementations behind one surface, the way
 /// <see cref="MailServiceRouter"/> does for <see cref="IMailService"/>. <see cref="StartWatchers"/>
-/// partitions accounts by backend so each notifier only watches the accounts it owns; events from
-/// every backend are forwarded to a single set of subscribers.
+/// fans the account list out to every notifier; each notifier watches only the accounts it owns
+/// (IMAP IDLE filters to <see cref="BackendKind.ImapSmtp"/>, Graph delta-poll to
+/// <see cref="BackendKind.MicrosoftGraph"/>). Events from every backend are forwarded to a single
+/// set of subscribers.
 ///
-/// PR 7a wires only the IMAP notifier (a held IDLE connection per account, implemented by
-/// <see cref="ImapMailService"/> itself — IMAP's IDLE watcher is bound to the IMAP connection
-/// lifecycle, so it is not a separate object). PR 7b adds a Graph delta-poll notifier and routes
-/// Microsoft Graph accounts to it; IMAP accounts continue to go to the IMAP notifier.
+/// The IMAP notifier is <see cref="ImapMailService"/> itself — IMAP's IDLE watcher is bound to the
+/// IMAP connection lifecycle, so it is not a separate object — while the Graph notifier is a
+/// standalone <see cref="GraphChangeNotifier"/> (it owns its own polling loop and HTTP client).
+/// Each notifier is owned and disposed by the composition root; this router only stops watchers and
+/// unsubscribes on <see cref="Dispose"/>.
 /// </summary>
 public sealed class ChangeNotifierRouter : IChangeNotifier, IDisposable
 {
-    private readonly IChangeNotifier _imap;
+    private readonly IReadOnlyList<IChangeNotifier> _notifiers;
 
-    public ChangeNotifierRouter(IChangeNotifier imapNotifier)
+    public ChangeNotifierRouter(IEnumerable<IChangeNotifier> notifiers)
     {
-        _imap = imapNotifier;
-        _imap.InboxNewMailDetected += OnInboxNewMail;
-        _imap.AccountReachabilityChanged += OnReachabilityChanged;
+        _notifiers = notifiers.ToList();
+        foreach (var n in _notifiers)
+        {
+            n.InboxNewMailDetected += OnInboxNewMail;
+            n.AccountReachabilityChanged += OnReachabilityChanged;
+        }
     }
 
     public event Action<Guid>? InboxNewMailDetected;
@@ -36,18 +42,24 @@ public sealed class ChangeNotifierRouter : IChangeNotifier, IDisposable
 
     public void StartWatchers(IReadOnlyList<AccountModel> accounts, CancellationToken ct = default)
     {
-        // IMAP IDLE watches only IMAP accounts. Graph accounts get no watcher until PR 7b adds the
-        // delta-poll notifier; routing them here would attempt a doomed IMAP connection.
-        var imapAccounts = accounts.Where(a => a.BackendKind == BackendKind.ImapSmtp).ToList();
-        _imap.StartWatchers(imapAccounts, ct);
+        // Fan the full list out to each notifier; every notifier filters to the accounts it owns.
+        foreach (var n in _notifiers)
+            n.StartWatchers(accounts, ct);
     }
 
-    public void StopWatchers() => _imap.StopWatchers();
+    public void StopWatchers()
+    {
+        foreach (var n in _notifiers)
+            n.StopWatchers();
+    }
 
     public void Dispose()
     {
-        _imap.StopWatchers(); // tear down watcher tasks before severing the event chain
-        _imap.InboxNewMailDetected -= OnInboxNewMail;
-        _imap.AccountReachabilityChanged -= OnReachabilityChanged;
+        foreach (var n in _notifiers)
+        {
+            n.StopWatchers(); // tear down watcher tasks before severing the event chain
+            n.InboxNewMailDetected -= OnInboxNewMail;
+            n.AccountReachabilityChanged -= OnReachabilityChanged;
+        }
     }
 }

--- a/QuickMail/Services/ConfigService.cs
+++ b/QuickMail/Services/ConfigService.cs
@@ -218,6 +218,9 @@ public class ConfigService : IConfigService
                     case "initialsynccount":
                         if (int.TryParse(value, out var isc)) config.InitialSyncCount = Math.Max(0, isc);
                         break;
+                    case "graphpollseconds":
+                        if (int.TryParse(value, out var gps)) config.GraphPollSeconds = Math.Clamp(gps, 30, 600);
+                        break;
                     case "customannouncements":  config.CustomAnnouncements = ParseBool(value); break;
                     case "announcehints":        config.AnnounceHints        = ParseBool(value); break;
                     case "announcestatus":       config.AnnounceStatus       = ParseBool(value); break;
@@ -354,6 +357,11 @@ public class ConfigService : IConfigService
         sb.AppendLine($"InitialSyncCount = {config.InitialSyncCount}");
         sb.AppendLine("# Number of messages to fetch on the initial sync of a folder.");
         sb.AppendLine("# Default is 500. Set to 0 to fetch all messages in the folder.");
+        sb.AppendLine();
+
+        sb.AppendLine($"GraphPollSeconds = {Math.Clamp(config.GraphPollSeconds, 30, 600)}");
+        sb.AppendLine("# Poll interval (seconds) for the Microsoft Graph new-mail watcher.");
+        sb.AppendLine("# Default is 60. Values: 30-600. IMAP accounts use IDLE and ignore this.");
         sb.AppendLine();
 
         sb.AppendLine($"CustomAnnouncements = {(config.CustomAnnouncements ? "on" : "off")}");

--- a/QuickMail/Services/Graph/GraphDtos.cs
+++ b/QuickMail/Services/Graph/GraphDtos.cs
@@ -11,6 +11,18 @@ internal sealed class GraphCollection<T>
     [JsonPropertyName("@odata.nextLink")] public string? NextLink { get; set; }
 }
 
+/// <summary>
+/// Response shape for a <c>/messages/delta</c> query. Exposes both cursors so the poll loop can
+/// tell them apart: <see cref="NextLink"/> pages WITHIN a tick (transient, never persisted), while
+/// <see cref="DeltaLink"/> is the cursor for the NEXT tick (persisted). See dev spec §6.12.
+/// </summary>
+internal sealed class GraphDeltaResponse
+{
+    [JsonPropertyName("value")]            public GraphMessage[]? Value { get; set; }
+    [JsonPropertyName("@odata.nextLink")]  public string? NextLink { get; set; }
+    [JsonPropertyName("@odata.deltaLink")] public string? DeltaLink { get; set; }
+}
+
 internal sealed class GraphMe
 {
     [JsonPropertyName("id")] public string? Id { get; set; }

--- a/QuickMail/Services/GraphChangeNotifier.cs
+++ b/QuickMail/Services/GraphChangeNotifier.cs
@@ -50,6 +50,12 @@ public sealed class GraphChangeNotifier : IChangeNotifier, IDisposable
 
     public void StopWatchers()
     {
+        // Single-lifecycle assumption: StartWatchers once at startup, StopWatchers once on exit.
+        // Clearing _watchers and cancelling the CTS signals the poll tasks to exit, but does NOT
+        // await them — they unwind when they next observe the cancelled token. That's fine for the
+        // start-once/stop-once lifecycle; a caller that restarts watchers dynamically would see the
+        // old tasks briefly race the new ones (harmless — they hold the old CTS and independent
+        // accounts) but has no fence guaranteeing the old tasks have exited.
         var cts = _cts;
         _cts = null;
         _watchers.Clear();
@@ -61,8 +67,6 @@ public sealed class GraphChangeNotifier : IChangeNotifier, IDisposable
 
     private async Task PollLoopAsync(AccountModel account, CancellationToken ct)
     {
-        var intervalSec = Math.Clamp(_config?.Load().GraphPollSeconds ?? 60, 30, 600);
-
         while (!ct.IsCancellationRequested)
         {
             try
@@ -91,6 +95,11 @@ public sealed class GraphChangeNotifier : IChangeNotifier, IDisposable
                     url = resp?.NextLink;                             // null on the final page
                 }
 
+                // At-least-once semantics, by design: the event fires BEFORE the cursor is persisted.
+                // If the app exits in this window, the next startup re-polls from the old/absent cursor
+                // and may re-notify for the same messages — but the resulting sync is idempotent (same
+                // message ids are not re-inserted), so nothing is lost or duplicated. Persisting first
+                // would risk the opposite (a missed notification), which is worse.
                 if (sawMessages)
                     InboxNewMailDetected?.Invoke(account.Id);
 
@@ -100,6 +109,9 @@ public sealed class GraphChangeNotifier : IChangeNotifier, IDisposable
             catch (OperationCanceledException) { return; }
             catch (Exception ex) { LogService.Log($"GraphChangeNotifier {account.AccountLabel}", ex); }
 
+            // Re-read each tick so an edit to GraphPollSeconds in config.ini takes effect without an
+            // app restart. _config.Load() is a file read, but once per interval (>=30 s) is negligible.
+            var intervalSec = Math.Clamp(_config?.Load().GraphPollSeconds ?? 60, 30, 600);
             try { await Task.Delay(TimeSpan.FromSeconds(intervalSec), ct); }
             catch (OperationCanceledException) { return; }
         }

--- a/QuickMail/Services/GraphChangeNotifier.cs
+++ b/QuickMail/Services/GraphChangeNotifier.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using QuickMail.Models;
+using QuickMail.Services.Graph;
+
+namespace QuickMail.Services;
+
+/// <summary>
+/// Microsoft Graph implementation of <see cref="IChangeNotifier"/>. Graph has no held-connection
+/// push for desktop clients (subscriptions need a public callback URL), so new mail is detected by
+/// polling each account's INBOX <c>/messages/delta</c> query on an interval. The stored
+/// <c>@odata.deltaLink</c> cursor makes each poll incremental: it returns only what changed since the
+/// previous tick. IMAP accounts use a held IDLE connection (<see cref="ImapMailService"/>) instead.
+/// See dev spec §6.12.
+/// </summary>
+public sealed class GraphChangeNotifier : IChangeNotifier, IDisposable
+{
+    private readonly GraphClient _client;
+    private readonly ILocalStoreService _store; // delta-cursor persistence
+    private readonly IConfigService? _config;
+    private readonly Dictionary<Guid, Task> _watchers = new();
+    private CancellationTokenSource? _cts;
+
+    public event Action<Guid>? InboxNewMailDetected;
+#pragma warning disable CS0067 // Graph polling has no reachability signal; declared to satisfy IChangeNotifier.
+    public event Action<Guid, bool>? AccountReachabilityChanged;
+#pragma warning restore CS0067
+
+    public GraphChangeNotifier(GraphClient client, ILocalStoreService store, IConfigService? config = null)
+    {
+        _client = client;
+        _store  = store;
+        _config = config;
+    }
+
+    public void StartWatchers(IReadOnlyList<AccountModel> accounts, CancellationToken ct = default)
+    {
+        StopWatchers();
+        _cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+
+        foreach (var account in accounts.Where(a => a.BackendKind == BackendKind.MicrosoftGraph))
+        {
+            var captured = account;
+            _watchers[captured.Id] = Task.Run(() => PollLoopAsync(captured, _cts.Token), _cts.Token);
+        }
+    }
+
+    public void StopWatchers()
+    {
+        var cts = _cts;
+        _cts = null;
+        _watchers.Clear();
+        if (cts != null)
+        {
+            try { cts.Cancel(); cts.Dispose(); } catch { /* best effort */ }
+        }
+    }
+
+    private async Task PollLoopAsync(AccountModel account, CancellationToken ct)
+    {
+        var intervalSec = Math.Clamp(_config?.Load().GraphPollSeconds ?? 60, 30, 600);
+
+        while (!ct.IsCancellationRequested)
+        {
+            try
+            {
+                // The stored cursor is a full @odata.deltaLink URL captured at the end of the previous
+                // tick (null on the very first poll → start a fresh delta enumeration). IMPORTANT:
+                // @odata.deltaLink (persisted; drives the NEXT tick) and @odata.nextLink/$skipToken
+                // (paging WITHIN this tick) are two different cursors. Only the deltaLink is persisted.
+                var deltaLink = await _store.GetDeltaTokenAsync(account.Id, "Inbox");
+                var url = string.IsNullOrEmpty(deltaLink)
+                    ? "/me/mailFolders/Inbox/messages/delta?$select=id"
+                    : deltaLink; // request the stored deltaLink URL verbatim
+
+                var sawMessages = false;
+                string? nextDeltaLink = null;
+
+                // Drain this tick's pages: follow @odata.nextLink to exhaustion, then keep the final
+                // page's @odata.deltaLink as the cursor for the next tick.
+                while (!string.IsNullOrEmpty(url))
+                {
+                    var resp = await _client.GetAsync<GraphDeltaResponse>(account, url, ct);
+                    if (resp?.Value?.Length > 0)
+                        sawMessages = true;
+
+                    nextDeltaLink = resp?.DeltaLink ?? nextDeltaLink; // set only on the final page
+                    url = resp?.NextLink;                             // null on the final page
+                }
+
+                if (sawMessages)
+                    InboxNewMailDetected?.Invoke(account.Id);
+
+                if (!string.IsNullOrEmpty(nextDeltaLink))
+                    await _store.SetDeltaTokenAsync(account.Id, "Inbox", nextDeltaLink);
+            }
+            catch (OperationCanceledException) { return; }
+            catch (Exception ex) { LogService.Log($"GraphChangeNotifier {account.AccountLabel}", ex); }
+
+            try { await Task.Delay(TimeSpan.FromSeconds(intervalSec), ct); }
+            catch (OperationCanceledException) { return; }
+        }
+    }
+
+    public void Dispose()
+    {
+        StopWatchers();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/QuickMail/Services/GraphMailService.cs
+++ b/QuickMail/Services/GraphMailService.cs
@@ -23,6 +23,9 @@ public class GraphMailService : IMailService
     private readonly GraphClient _client;
     private readonly IConfigService? _config;
 
+    /// <summary>The shared Graph HTTP client, reused by <see cref="GraphChangeNotifier"/> for delta polling.</summary>
+    internal GraphClient Client => _client;
+
     // accountId -> the connected AccountModel, so per-accountId calls can acquire the right token.
     private readonly ConcurrentDictionary<Guid, AccountModel> _accounts = new();
 

--- a/QuickMail/Services/ILocalStoreService.cs
+++ b/QuickMail/Services/ILocalStoreService.cs
@@ -92,4 +92,13 @@ public interface ILocalStoreService
     /// "message not found" errors when the user tries to open the invitation.
     /// </summary>
     Task ClearOrphanedCalendarSourceLinksAsync();
+
+    /// <summary>
+    /// Returns the stored Microsoft Graph delta cursor (a full <c>@odata.deltaLink</c> URL) for an
+    /// account+folder, or null if none has been persisted yet (first poll). See dev spec §6.12.
+    /// </summary>
+    Task<string?> GetDeltaTokenAsync(Guid accountId, string folderId);
+
+    /// <summary>Persists the Graph delta cursor for an account+folder, replacing any existing value.</summary>
+    Task SetDeltaTokenAsync(Guid accountId, string folderId, string deltaToken);
 }

--- a/QuickMail/Services/ImapMailService.cs
+++ b/QuickMail/Services/ImapMailService.cs
@@ -750,7 +750,9 @@ public class ImapMailService : IMailService, IChangeNotifier
 
     public void StartWatchers(IReadOnlyList<AccountModel> accounts, CancellationToken ct = default)
     {
-        foreach (var account in accounts)
+        // The change-notifier router fans the full account list out to every notifier; IMAP IDLE only
+        // handles IMAP accounts (a Graph account here would spin up a doomed IMAP connection).
+        foreach (var account in accounts.Where(a => a.BackendKind == BackendKind.ImapSmtp))
         {
             // Cancel any existing watcher for this account.
             if (_idleCts.TryRemove(account.Id, out var old))

--- a/QuickMail/Services/LocalStoreService.cs
+++ b/QuickMail/Services/LocalStoreService.cs
@@ -906,4 +906,35 @@ public class LocalStoreService : ILocalStoreService
             """;
         await cmd.ExecuteNonQueryAsync();
     }
+
+    // ── Graph delta cursors (PR 7b) ──────────────────────────────────────────────
+
+    public async Task<string?> GetDeltaTokenAsync(Guid accountId, string folderId)
+    {
+        await using var conn = await OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT delta_token FROM DeltaToken WHERE account_id=$aid AND folder_id=$fid;";
+        cmd.Parameters.AddWithValue("$aid", accountId.ToString());
+        cmd.Parameters.AddWithValue("$fid", folderId);
+        var result = await cmd.ExecuteScalarAsync();
+        return result as string;
+    }
+
+    public async Task SetDeltaTokenAsync(Guid accountId, string folderId, string deltaToken)
+    {
+        await using var conn = await OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            INSERT INTO DeltaToken(account_id, folder_id, delta_token, updated_utc)
+            VALUES($aid, $fid, $token, $now)
+            ON CONFLICT(account_id, folder_id) DO UPDATE SET
+                delta_token = excluded.delta_token,
+                updated_utc = excluded.updated_utc;
+            """;
+        cmd.Parameters.AddWithValue("$aid",   accountId.ToString());
+        cmd.Parameters.AddWithValue("$fid",   folderId);
+        cmd.Parameters.AddWithValue("$token", deltaToken);
+        cmd.Parameters.AddWithValue("$now",   DateTime.UtcNow.Ticks);
+        await cmd.ExecuteNonQueryAsync();
+    }
 }


### PR DESCRIPTION
## What this is

The second half of PR 7, building on the `IChangeNotifier` abstraction from #127. Microsoft Graph accounts now detect new mail on their own — the same capability IMAP accounts get from a held IDLE connection. With this, a Graph account no longer needs a manual refresh to notice new mail.

Graph has no usable push for a desktop client (subscriptions require a public HTTPS callback URL), so detection is **delta polling**: each account's INBOX `/messages/delta` query is polled on an interval, and the stored `@odata.deltaLink` cursor makes every poll incremental.

## Changes

- **`GraphChangeNotifier`** (`IChangeNotifier`) — one poll task per Graph account. Each tick: request the stored `@odata.deltaLink` (or a fresh `/me/mailFolders/Inbox/messages/delta?$select=id` on the first poll), follow `@odata.nextLink` to the end of the page set, raise `InboxNewMailDetected` if any page had ≥1 message, and persist the final page's `@odata.deltaLink` as the next-tick cursor.
- **Delta-cursor store** — `LocalStoreService.GetDeltaTokenAsync` / `SetDeltaTokenAsync`, backed by the `DeltaToken` table that's been in the schema since PR 2's migration.
- **`ConfigModel.GraphPollSeconds`** (default 60, clamped 30–600), parsed and written by `ConfigService`. IMAP accounts ignore it (they use IDLE).
- **`ChangeNotifierRouter` generalized** — now fans the account list out to multiple notifiers; each notifier filters to the accounts it owns. `GraphChangeNotifier` filters to Graph; `ImapMailService.StartWatchers` now filters to `ImapSmtp` (a Graph account reaching the IMAP IDLE watcher would spin up a doomed connection). `App` wires both notifiers and disposes both on exit.
- **`GraphMailService.Client`** (internal) lets the notifier reuse the same authenticated `GraphClient`. New `GraphDeltaResponse` DTO exposes both cursors.

## The deltaLink vs nextLink footgun

The thing most likely to be subtly wrong here, handled explicitly: `@odata.deltaLink` (persisted, drives the *next* tick) and `@odata.nextLink`/`$skipToken` (within-tick paging, transient) are **different cursors**. The poll loop follows `nextLink` to drain the current tick's pages, but only ever persists the final page's `deltaLink`. There's a test that drives a two-page response and asserts the persisted cursor is the `deltaLink`, not the `nextLink`.

## Testing

- **`GraphChangeNotifierTests`** (stub HTTP handler + real temp-DB store): first poll with messages raises + persists the deltaLink and uses the fresh delta URL; a pre-seeded cursor is requested verbatim; `nextLink` paging is followed and the final `deltaLink` persisted; non-Graph accounts are ignored (no request issued).
- **`DeltaTokenStoreTests`**: round-trip, overwrite, null-when-absent, per-account scoping against the real SQLite store.
- Router fan-out tests updated; full suite green apart from the known `PreviewSuppressionTests.InitialLoad_PreviewLinesNonZero_PreservesPreview` flake (async preview timing, untouched here).

**Needs a reviewer with a real M365 account.** I have no Graph mailbox to exercise the live delta loop. Worth confirming: send mail to the M365 account from elsewhere and verify QuickMail notices within the poll interval (~60s); that it doesn't re-notify on every tick once caught up (the cursor advances); and that the interval is honored.
