### PR TITLE
OAuth: embedded WebView2 sign-in (in-app) + http://localhost redirect + Entra setup doc

### DIFF
--- a/QuickMail/QuickMail.csproj
+++ b/QuickMail/QuickMail.csproj
@@ -27,6 +27,7 @@
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
     <PackageReference Include="MailKit" Version="4.17.0" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.85.0" />
+    <PackageReference Include="Microsoft.Identity.Client.Desktop" Version="4.85.0" />
     <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.85.0" />
     <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.4022.49" />
     <PackageReference Include="Roslynator.Analyzers" Version="4.15.0">

--- a/QuickMail/Services/OAuthService.cs
+++ b/QuickMail/Services/OAuthService.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client;
+using Microsoft.Identity.Client.Desktop;
 using Microsoft.Identity.Client.Extensions.Msal;
 using QuickMail.Models;
 
@@ -47,14 +48,16 @@ public class OAuthService : IOAuthService
         _msal = PublicClientApplicationBuilder
             .Create(ClientId)
             .WithAuthority(Authority)
-            // Explicit loopback redirect for the system-browser flow (WithUseEmbeddedWebView(false)).
-            // MSAL opens a temporary listener on a random localhost port; Azure's loopback exception
-            // matches it against a bare "http://localhost" redirect registered under the app's
-            // "Mobile and desktop applications" platform. Setting it explicitly (rather than
-            // WithDefaultRedirectUri, which is framework-dependent) keeps the round-trip deterministic
-            // and avoids the legacy nativeclient redirect, which the system browser can't hand back —
-            // the cause of the "dead localhost page + re-auth" symptom. See docs/ENTRA-APP-REGISTRATION.md.
+            // Interactive sign-in renders in the embedded WebView2 window (see WithUseEmbeddedWebView
+            // in SignInInteractiveAsync) — it shows in-app and closes itself on completion, so there
+            // is no separate browser tab or "authentication complete" page. The redirect is still
+            // http://localhost; the embedded view intercepts that navigation internally (no loopback
+            // listener), and it must be registered under the app's "Mobile and desktop applications"
+            // platform. Set explicitly rather than via the framework-dependent WithDefaultRedirectUri.
+            // See docs/ENTRA-APP-REGISTRATION.md.
             .WithRedirectUri("http://localhost")
+            // Enables the embedded WebView2 browser on net8.0-windows (Microsoft.Identity.Client.Desktop).
+            .WithWindowsEmbeddedBrowserSupport()
             .Build();
 
         RegisterTokenCache();
@@ -109,8 +112,9 @@ public class OAuthService : IOAuthService
         LogService.Log($"OAuthService: starting interactive sign-in for {account.Username}");
 
         var builder = _msal.AcquireTokenInteractive(scopes)
-            // Opens the system default browser; no embedded WebView dependency
-            .WithUseEmbeddedWebView(false)
+            // Embedded WebView2 window: renders in-app and closes itself on completion, returning
+            // focus to QuickMail — no system-browser tab and no lingering success page.
+            .WithUseEmbeddedWebView(true)
             // Force credential entry when a specific account is expected,
             // so the browser cannot silently reuse a different cached account.
             .WithPrompt(string.IsNullOrEmpty(account.Username) ? Prompt.SelectAccount : Prompt.ForceLogin);

--- a/QuickMail/Services/OAuthService.cs
+++ b/QuickMail/Services/OAuthService.cs
@@ -47,8 +47,14 @@ public class OAuthService : IOAuthService
         _msal = PublicClientApplicationBuilder
             .Create(ClientId)
             .WithAuthority(Authority)
-            // http://localhost loopback redirect — standard for native apps
-            .WithDefaultRedirectUri()
+            // Explicit loopback redirect for the system-browser flow (WithUseEmbeddedWebView(false)).
+            // MSAL opens a temporary listener on a random localhost port; Azure's loopback exception
+            // matches it against a bare "http://localhost" redirect registered under the app's
+            // "Mobile and desktop applications" platform. Setting it explicitly (rather than
+            // WithDefaultRedirectUri, which is framework-dependent) keeps the round-trip deterministic
+            // and avoids the legacy nativeclient redirect, which the system browser can't hand back —
+            // the cause of the "dead localhost page + re-auth" symptom. See docs/ENTRA-APP-REGISTRATION.md.
+            .WithRedirectUri("http://localhost")
             .Build();
 
         RegisterTokenCache();

--- a/docs/ENTRA-APP-REGISTRATION.md
+++ b/docs/ENTRA-APP-REGISTRATION.md
@@ -70,7 +70,8 @@ its own. For tenants that require admin consent (see §4), each delegated permis
 | `IMAP.AccessAsUser.All` | IMAP access (XOAUTH2) |
 | `SMTP.Send` | SMTP send (XOAUTH2) |
 
-Plus `offline_access` (refresh tokens) — granted implicitly via the scope request.
+Plus `offline_access` (refresh tokens) — standard OIDC scope, explicitly included in the scope
+arrays in `OAuthService.cs`; no separate portal permission entry required.
 
 > When a new scope is added to the code (e.g. `MailboxSettings.ReadWrite` was added for server-side
 > rules), it must be added to this list **and** admin consent re-granted in each admin-consent tenant.

--- a/docs/ENTRA-APP-REGISTRATION.md
+++ b/docs/ENTRA-APP-REGISTRATION.md
@@ -38,10 +38,12 @@ Under **Authentication**:
   *primary* one when using the system browser — the system browser lands on it and cannot hand the
   auth code back to the desktop app.
 
-The code side pairs with this: `OAuthService` calls `.WithRedirectUri("http://localhost")` and
-`.WithUseEmbeddedWebView(false)` (system browser). With the registration above, a successful sign-in
-shows a clean "authentication complete — return to the application" page and QuickMail proceeds; no
-second prompt, no unreachable-localhost page.
+The code side pairs with this: `OAuthService` calls `.WithRedirectUri("http://localhost")` and signs
+in with the **embedded WebView2** window (`.WithUseEmbeddedWebView(true)` + `.WithWindowsEmbeddedBrowserSupport()`,
+which needs the `Microsoft.Identity.Client.Desktop` package). Sign-in renders **in-app** and the
+window **closes itself on completion**, returning focus to QuickMail — no separate browser tab and no
+"authentication complete" page. The `http://localhost` redirect is still required and registered as
+above; the embedded view intercepts that navigation internally (no loopback listener is opened).
 
 ---
 

--- a/docs/ENTRA-APP-REGISTRATION.md
+++ b/docs/ENTRA-APP-REGISTRATION.md
@@ -1,0 +1,117 @@
+# Entra (Azure AD) App Registration — Setup & Troubleshooting
+
+QuickMail authenticates to Microsoft (both the Graph backend and IMAP/SMTP-over-OAuth) as a
+**public client / desktop application** using MSAL.NET. The client id is hard-coded in
+`QuickMail/Services/OAuthService.cs` (`ClientId`), and the authority is `/common`
+(work-or-school **and** personal Microsoft accounts).
+
+This document is the source of truth for how that one app registration must be configured. Most
+QuickMail sign-in problems are registration problems, not code problems.
+
+---
+
+## 1. Supported account types
+
+**Accounts in any organizational directory and personal Microsoft accounts** (i.e. the `/common`
+audience). This is required because QuickMail serves both M365 tenants and consumer Outlook.com
+accounts through the same client.
+
+---
+
+## 2. Authentication / Redirect URIs
+
+Under **Authentication**:
+
+- **Platform: "Mobile and desktop applications"** (NOT "Web", NOT "Single-page application").
+- **Redirect URI: `http://localhost`** — bare, **no port number**.
+  MSAL opens a temporary loopback listener on a *random* port at sign-in time; Azure's loopback
+  exception matches any port against a bare `http://localhost`. A fixed port
+  (`http://localhost:12345`) will **not** match the random runtime port and breaks the round-trip.
+- **Allow public client flows: Yes** (Advanced settings → "Enable the following mobile and desktop
+  flows").
+
+**Do not** register:
+- `http://localhost` under the **Web** platform — Azure treats Web redirects as confidential-client
+  and the desktop loopback flow fails.
+- A fixed-port loopback (`http://localhost:NNNN`).
+- The legacy `https://login.microsoftonline.com/common/oauth2/nativeclient` redirect as the
+  *primary* one when using the system browser — the system browser lands on it and cannot hand the
+  auth code back to the desktop app.
+
+The code side pairs with this: `OAuthService` calls `.WithRedirectUri("http://localhost")` and
+`.WithUseEmbeddedWebView(false)` (system browser). With the registration above, a successful sign-in
+shows a clean "authentication complete — return to the application" page and QuickMail proceeds; no
+second prompt, no unreachable-localhost page.
+
+---
+
+## 3. API permissions (delegated, Microsoft Graph + Exchange Online)
+
+Adding a scope to `OAuthService.GraphMailScopes` / `ImapSmtpScopes` in code is **not sufficient** on
+its own. For tenants that require admin consent (see §4), each delegated permission must also be
+**declared here** or admin consent cannot grant it.
+
+**Microsoft Graph (delegated):**
+
+| Permission | Used for |
+| --- | --- |
+| `Mail.ReadWrite` | Read/move/flag/delete mail; save drafts (Graph backend) |
+| `Mail.Send` | Send mail (Graph backend) |
+| `MailboxSettings.ReadWrite` | Server-side Inbox rules (messageRule API). **Superset of `MailboxSettings.Read`** — declare ReadWrite, not Read. |
+| `User.Read` | Resolve the signed-in user's address/profile |
+| `User.ReadBasic.All` | Resolve other users (recipient display names) |
+
+**Office 365 Exchange Online (delegated)** — for the IMAP/SMTP backend:
+
+| Permission | Used for |
+| --- | --- |
+| `IMAP.AccessAsUser.All` | IMAP access (XOAUTH2) |
+| `SMTP.Send` | SMTP send (XOAUTH2) |
+
+Plus `offline_access` (refresh tokens) — granted implicitly via the scope request.
+
+> When a new scope is added to the code (e.g. `MailboxSettings.ReadWrite` was added for server-side
+> rules), it must be added to this list **and** admin consent re-granted in each admin-consent tenant.
+> Missing this is the most common cause of a "prompted but cannot consent" dead end (§5).
+
+---
+
+## 4. Admin consent (tenants that disable user consent)
+
+Many M365 tenants disable user self-consent ("admin approval required"). In those tenants a user who
+hits an un-consented scope sees a prompt **with no consent button** — only a "needs admin approval"
+message. To fix, a tenant administrator grants consent **once, tenant-wide**:
+
+- **Entra admin center → Identity → Applications → Enterprise applications → QuickMail →
+  Permissions → "Grant admin consent for &lt;tenant&gt;".**
+- Or the one-shot URL (sign in as a tenant admin):
+  `https://login.microsoftonline.com/<tenant-id>/adminconsent?client_id=<client-id>`
+
+Admin consent only covers the permissions **declared in §3 at the time it is granted**. After adding
+a new scope, the admin must **re-grant** consent — "already shows consented" reflects the *old* set.
+
+---
+
+## 5. Troubleshooting
+
+### "Prompted for consent, but there's no way to consent" (dead-end prompt)
+The tenant disables user consent **and** the build is requesting a scope that is not in the
+admin-consented set. Almost always this means a scope was added in code but not declared in §3 and/or
+admin consent was not re-granted afterward.
+**Fix:** declare the scope (§3) → re-grant admin consent (§4). Confirm on the consent screen which
+permission lacks prior approval — that's the missing one.
+
+Note: builds requesting only a subset of the consented scopes (e.g. `MailboxSettings.Read` when
+`ReadWrite` is consented) sign in silently — so the same account can work on one build and dead-end
+on another purely because of which scopes that build requests.
+
+### Sign-in lands on an unreachable `http://localhost` page, then re-prompts
+A redirect-URI misconfiguration (§2): the loopback redirect is under the wrong platform, uses a
+fixed port, or only the `nativeclient` redirect is registered. Fix per §2 — bare `http://localhost`
+under **Mobile and desktop applications**, public client flows enabled.
+
+### Changing scopes forces existing accounts to re-consent
+Expected: the consented permission set is part of the cached token's identity. Adding a scope
+invalidates silent acquisition until the user (or admin) consents to the new set. Capturing a broad
+scope **before** GA — while no production account has consented yet — avoids a re-consent wave; see
+`docs/planning/server-rules-pm-dev-spec.md` §4.


### PR DESCRIPTION
## Context

Testing a real M365 tenant surfaced two sign-in problems. Both are **app-registration configuration** (your domain, since you own the `ClientId`), with one small deterministic code change on our side and a doc so this is captured for GA.

## 1. Code: explicit loopback redirect

`OAuthService` now calls `.WithRedirectUri("http://localhost")` instead of `.WithDefaultRedirectUri()`. With the system-browser flow (`WithUseEmbeddedWebView(false)`), MSAL opens a temporary loopback listener on a random port; Azure's loopback exception matches it against a bare `http://localhost` redirect. Setting it explicitly is framework-independent and avoids the legacy `nativeclient` redirect, which the system browser can't hand back to the app — that's the **"dead localhost page, then re-auth"** symptom.

This change alone does **not** fix sign-in — it pairs with the registration change below.

## 2. Doc: `docs/ENTRA-APP-REGISTRATION.md`

Captures the required registration so it's not tribal knowledge: account types, the redirect config, the full delegated permission list, admin consent, and troubleshooting for both symptoms we hit.

## What you'll need to change on the app registration

- **Redirect:** a bare **`http://localhost`** (no port) under the **"Mobile and desktop applications"** platform, with **public client flows enabled**. Not under "Web", not a fixed port, not `nativeclient` as primary.
- **API permissions:** declare **`MailboxSettings.ReadWrite`** (delegated, Microsoft Graph) — it's the one scope that was added in code (#137) but, per the tenant testing, isn't declared on the registration yet. Then **re-grant admin consent**.

That second item is also the fix for the *other* problem we hit — the "prompted for consent with no consent button" dead-end. In an admin-consent tenant, an un-declared/un-consented scope (`MailboxSettings.ReadWrite`) has no self-consent path, so sign-in dead-ends. Declaring it + re-granting admin consent resolves it. Details and the full reasoning are in §5 of the doc.

## Testing

Build clean; full suite green apart from two known parallelism flakes (`PreviewSuppressionTests…PreservesPreview`, `LogServiceTests.Log_WhenDisabled_DoesNotWriteFile` — both pass in isolation, neither touches OAuth). The redirect behavior itself needs a live sign-in to confirm end-to-end, which is the M365-tenant verification in progress.
