### PR TITLE
Account manager: hide Test Connection button for Graph accounts

### DIFF
--- a/QuickMail/Views/AccountManagerDialog.xaml
+++ b/QuickMail/Views/AccountManagerDialog.xaml
@@ -229,6 +229,7 @@
                     Content="_Test Connection"
                     Command="{Binding TestConnectionCommand}"
                     AutomationProperties.Name="Test IMAP connection with current settings"
+                    Visibility="{Binding IsImapBackend, Converter={StaticResource BoolToVisibility}}"
                     MinWidth="120" Margin="6,0,0,0"/>
             <Button DockPanel.Dock="Right"
                     Content="_Save"


### PR DESCRIPTION
Fixes #142.

## What

In the Manage Accounts dialog, the **Test Connection** button (labeled "Test IMAP connection with current settings") was visible even when the selected account is a **Microsoft Graph** account, which has no IMAP/SMTP settings to test.

It now binds `Visibility` to `IsImapBackend` — the exact flag this dialog already uses to hide the IMAP/SMTP settings panels for Graph accounts — so the button only appears for IMAP accounts.

One-line XAML change in `AccountManagerDialog.xaml`. Build clean; full suite green apart from the known `PreviewSuppressionTests` flake, and `XamlParseTests` confirms the dialog still loads.
