### PR TITLE
Fix #36: replace HelpText with user-controllable announcements and visible text

### DIFF
--- a/QuickMail/Views/AccountManagerDialog.xaml
+++ b/QuickMail/Views/AccountManagerDialog.xaml
@@ -109,9 +109,10 @@
                     <TextBlock x:Name="LblPassword" Text="_Password:" Margin="0,0,0,2"/>
                     <PasswordBox x:Name="PasswordBox"
                                  AutomationProperties.LabeledBy="{Binding ElementName=LblPassword}"
-                                 AutomationProperties.HelpText="Password is stored in Windows Credential Manager"
                                  TabIndex="5"
                                  PasswordChanged="PasswordBox_PasswordChanged"/>
+                    <TextBlock Text="Stored in Windows Credential Manager."
+                               Foreground="DimGray" FontSize="11" Margin="0,2,0,0"/>
                     <!-- iCloud app-specific password hint -->
                     <Border Visibility="{Binding IsICloudAccount, Converter={StaticResource BoolToVisibility}}"
                             Background="#FFF3E3"
@@ -204,10 +205,9 @@
 
                 <!-- Signature -->
                 <TextBlock Text="Email Signature" FontWeight="SemiBold" Margin="0,0,0,6"/>
-                <TextBlock x:Name="LblSignature" Text="_Signature (plain text, appended to new messages):" Margin="0,4,0,2"/>
+                <TextBlock x:Name="LblSignature" Text="_Signature (plain text, appended to new messages, replies, and forwards):" Margin="0,4,0,2"/>
                 <TextBox Text="{Binding Signature, UpdateSourceTrigger=PropertyChanged}"
                          AutomationProperties.LabeledBy="{Binding ElementName=LblSignature}"
-                         AutomationProperties.HelpText="This text is automatically added to the end of new messages, replies, and forwards"
                          AcceptsReturn="True"
                          TextWrapping="Wrap"
                          MinHeight="60"

--- a/QuickMail/Views/AddAccountDialog.xaml
+++ b/QuickMail/Views/AddAccountDialog.xaml
@@ -74,9 +74,10 @@
                     <TextBlock x:Name="LblPassword" Text="_Password:" Margin="0,0,0,2"/>
                     <PasswordBox x:Name="PasswordBox"
                                  AutomationProperties.LabeledBy="{Binding ElementName=LblPassword}"
-                                 AutomationProperties.HelpText="Password is stored in Windows Credential Manager"
                                  TabIndex="5"
                                  PasswordChanged="PasswordBox_PasswordChanged"/>
+                    <TextBlock Text="Stored in Windows Credential Manager."
+                               Foreground="DimGray" FontSize="11" Margin="0,2,0,0"/>
                     <!-- iCloud app-specific password hint -->
                     <Border Visibility="{Binding IsICloudAccount, Converter={StaticResource BoolToVisibility}}"
                             Background="#FFF3E3"
@@ -168,10 +169,9 @@
 
                 <!-- Signature -->
                 <TextBlock Text="Email Signature" FontWeight="SemiBold" Margin="0,0,0,6"/>
-                <TextBlock x:Name="LblSignature" Text="_Signature (plain text, appended to new messages):" Margin="0,4,0,2"/>
+                <TextBlock x:Name="LblSignature" Text="_Signature (plain text, appended to new messages, replies, and forwards):" Margin="0,4,0,2"/>
                 <TextBox Text="{Binding Signature, UpdateSourceTrigger=PropertyChanged}"
                          AutomationProperties.LabeledBy="{Binding ElementName=LblSignature}"
-                         AutomationProperties.HelpText="This text is automatically added to the end of new messages, replies, and forwards"
                          AcceptsReturn="True"
                          TextWrapping="Wrap"
                          MinHeight="60"

--- a/QuickMail/Views/ComposeWindow.xaml
+++ b/QuickMail/Views/ComposeWindow.xaml
@@ -260,7 +260,6 @@
                       DisplayMemberPath="AccountLabel"
                       AutomationProperties.Name="From account"
                       AutomationProperties.AcceleratorKey="Alt+M"
-                      AutomationProperties.HelpText="Choose which account to send from"
                       Margin="0,4" TabIndex="0"/>
 
             <!-- To -->
@@ -271,7 +270,6 @@
                      x:Name="ToBox"
                      AddressText="{Binding To, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                      AutomationProperties.LabeledBy="{Binding ElementName=ToLabel}"
-                     AutomationProperties.HelpText="Type an address and press comma, semicolon, or Tab to add it. Arrow keys navigate between addresses. Delete removes the focused address."
                      Margin="0,4" TabIndex="1"/>
 
             <!-- Cc -->

--- a/QuickMail/Views/ComposeWindow.xaml.cs
+++ b/QuickMail/Views/ComposeWindow.xaml.cs
@@ -67,6 +67,8 @@ public partial class ComposeWindow : Window
     // Set before moving focus into the autocomplete popup so the return trip
     // doesn't re-announce addresses the user is actively editing.
     private bool _suppressNextFocusAnnouncement;
+    // Ensures the address-field usage hint fires only once per compose window.
+    private bool _addressHintGiven;
     private int _lastAnnouncedSpellingIndex = -1;
     private TextPointer? _richSpellingWordStart;
     private TextPointer? _richSpellingWordEnd;
@@ -345,6 +347,13 @@ public partial class ComposeWindow : Window
             // reader lands on the edit cursor after all the chips and just says "Edit".
             if (!_suppressNextFocusAnnouncement)
             {
+                if (!_addressHintGiven)
+                {
+                    _addressHintGiven = true;
+                    AccessibilityHelper.Announce(this,
+                        "Type an address and press comma, semicolon, or Tab to add it. Arrow keys navigate between addresses. Delete removes the focused address.",
+                        category: AnnouncementCategory.Hint);
+                }
                 var box = (TokenizedAddressBox)sender;
                 var chips = box.GetChips();
                 if (chips.Count > 0)

--- a/QuickMail/Views/NewFolderDialog.xaml
+++ b/QuickMail/Views/NewFolderDialog.xaml
@@ -32,7 +32,6 @@
                        Focusable="False"/>
             <TextBox x:Name="FolderNameBox"
                      AutomationProperties.Name="Folder name"
-                     AutomationProperties.HelpText="Enter a name for the new folder"
                      MaxLength="255"
                      PreviewKeyDown="FolderNameBox_PreviewKeyDown"/>
         </StackPanel>

--- a/QuickMail/Views/RulesManagerWindow.xaml
+++ b/QuickMail/Views/RulesManagerWindow.xaml
@@ -131,8 +131,9 @@
                              Style="{StaticResource RuleTextBox}"
                              IsReadOnly="{Binding IsFromEnabled, Converter={StaticResource InverseBoolConverter}, FallbackValue=True}"
                              IsTabStop="{Binding IsFromEnabled}"
-                             AutomationProperties.Name="From contains"
-                             AutomationProperties.HelpText="e.g., manager@company.com or just company.com"/>
+                             AutomationProperties.Name="From contains"/>
+                    <TextBlock Text="Match a full address or domain only, e.g., company.com"
+                               Foreground="DimGray" FontSize="11" Margin="0,1,0,4"/>
 
                     <!-- To condition -->
                     <CheckBox Content="To"
@@ -143,8 +144,7 @@
                              Style="{StaticResource RuleTextBox}"
                              IsReadOnly="{Binding IsToEnabled, Converter={StaticResource InverseBoolConverter}, FallbackValue=True}"
                              IsTabStop="{Binding IsToEnabled}"
-                             AutomationProperties.Name="To contains"
-                             AutomationProperties.HelpText="e.g., team@company.com"/>
+                             AutomationProperties.Name="To contains"/>
 
                     <!-- Subject condition -->
                     <CheckBox Content="Subject"
@@ -155,8 +155,7 @@
                              Style="{StaticResource RuleTextBox}"
                              IsReadOnly="{Binding IsSubjectEnabled, Converter={StaticResource InverseBoolConverter}, FallbackValue=True}"
                              IsTabStop="{Binding IsSubjectEnabled}"
-                             AutomationProperties.Name="Subject contains"
-                             AutomationProperties.HelpText="e.g., Weekly Report"/>
+                             AutomationProperties.Name="Subject contains"/>
 
                     <!-- Body condition -->
                     <CheckBox Content="Body"
@@ -167,8 +166,9 @@
                              Style="{StaticResource RuleTextBox}"
                              IsReadOnly="{Binding IsBodyEnabled, Converter={StaticResource InverseBoolConverter}, FallbackValue=True}"
                              IsTabStop="{Binding IsBodyEnabled}"
-                             AutomationProperties.Name="Body contains"
-                             AutomationProperties.HelpText="Text to search in message body preview"/>
+                             AutomationProperties.Name="Body preview contains"/>
+                    <TextBlock Text="Matches against the message body preview, not the full body."
+                               Foreground="DimGray" FontSize="11" Margin="0,1,0,4"/>
 
                     <CheckBox Content="Has attachments"
                               IsChecked="{Binding SelectedRule.MustHaveAttachments}"

--- a/QuickMail/Views/SettingsDialog.xaml
+++ b/QuickMail/Views/SettingsDialog.xaml
@@ -213,8 +213,9 @@
                                 <CheckBox Content="Announce spelling errors while _navigating"
                                           IsChecked="{Binding AnnounceSpellingWhileNavigating, Mode=TwoWay}"
                                           Margin="16,4,0,0"
-                                          AutomationProperties.Name="Announce spelling errors when the caret moves into a misspelled word during navigation"
-                                          AutomationProperties.HelpText="F7 and Shift+F7 always announce spelling regardless of this setting"/>
+                                          AutomationProperties.Name="Announce spelling errors when the caret moves into a misspelled word during navigation"/>
+                                <TextBlock Text="F7 and Shift+F7 always announce spelling, regardless of this setting."
+                                           Foreground="DimGray" FontSize="11" Margin="32,0,0,4"/>
 
                                 <CheckBox Content="Announce spelling _suggestions"
                                           IsChecked="{Binding AnnounceSpellingSuggestions, Mode=TwoWay}"
@@ -230,14 +231,18 @@
                                                  IsChecked="{Binding IsVerbosityNumbersWithSuggestions, Mode=TwoWay}"
                                                  GroupName="SpellingSuggestionsVerbosity"
                                                  Checked="RadioButton_Checked"
-                                                 AutomationProperties.Name="Numbers with suggestions"
-                                                 AutomationProperties.HelpText="Each suggestion is preceded by its number, for example: 1: the, 2: then, 3: them"/>
+                                                 AutomationProperties.Name="Numbers with suggestions"/>
+                                    <TextBlock Text="Example: 1: the, 2: then, 3: them"
+                                               Foreground="DimGray" FontSize="11" Margin="16,2,0,8"
+                                               FontFamily="Consolas"/>
                                     <RadioButton Content="_Just suggestions"
                                                  IsChecked="{Binding IsVerbosityJustSuggestions, Mode=TwoWay}"
                                                  GroupName="SpellingSuggestionsVerbosity"
                                                  Checked="RadioButton_Checked"
-                                                 AutomationProperties.Name="Just suggestions"
-                                                 AutomationProperties.HelpText="Suggestions are read without numbers, for example: the, then, them"/>
+                                                 AutomationProperties.Name="Just suggestions"/>
+                                    <TextBlock Text="Example: the, then, them"
+                                               Foreground="DimGray" FontSize="11" Margin="16,2,0,0"
+                                               FontFamily="Consolas"/>
                                 </StackPanel>
 
                                 <CheckBox Content="Announce _formatting while navigating in HTML compose"
@@ -284,8 +289,7 @@
                                              IsChecked="{Binding IsLogFormatActionFirst, Mode=TwoWay}"
                                              GroupName="LogFormat"
                                              Checked="RadioButton_Checked"
-                                             AutomationProperties.Name="Action first"
-                                             AutomationProperties.HelpText="Message then timestamp — easier to scan since the log is already chronological."/>
+                                             AutomationProperties.Name="Action first"/>
                                 <TextBlock Text="Example: Sync completed: 42 messages  [2024-11-15 14:23:45.123]"
                                            Foreground="DimGray" FontSize="11" Margin="16,2,0,8"
                                            FontFamily="Consolas"/>
@@ -293,8 +297,7 @@
                                              IsChecked="{Binding IsLogFormatTimeFirst, Mode=TwoWay}"
                                              GroupName="LogFormat"
                                              Checked="RadioButton_Checked"
-                                             AutomationProperties.Name="Time first"
-                                             AutomationProperties.HelpText="Timestamp then message — the original log format."/>
+                                             AutomationProperties.Name="Time first"/>
                                 <TextBlock Text="Example: 2024-11-15 14:23:45.123  Sync completed: 42 messages"
                                            Foreground="DimGray" FontSize="11" Margin="16,2,0,0"
                                            FontFamily="Consolas"/>
@@ -382,16 +385,14 @@
                                                  IsChecked="{Binding IsReadingPaneMode, Mode=TwoWay}"
                                                  GroupName="MessageOpenMode"
                                                  Checked="RadioButton_Checked"
-                                                 AutomationProperties.Name="Reading pane"
-                                                 AutomationProperties.HelpText="Opens messages in the reading pane below the message list. This is the default behaviour."/>
+                                                 AutomationProperties.Name="Reading pane"/>
                                     <TextBlock Text="Enter opens a message in the reading pane below the list."
                                                Foreground="DimGray" FontSize="11" Margin="16,2,0,8"/>
                                     <RadioButton Content="_Tab"
                                                  IsChecked="{Binding IsTabMode, Mode=TwoWay}"
                                                  GroupName="MessageOpenMode"
                                                  Checked="RadioButton_Checked"
-                                                 AutomationProperties.Name="Tab"
-                                                 AutomationProperties.HelpText="Opens messages in a tab strip above the message list."/>
+                                                 AutomationProperties.Name="Tab"/>
                                     <TextBlock Text="Enter opens a message as a new tab. Ctrl+Tab cycles tabs. Ctrl+W closes."
                                                TextWrapping="Wrap"
                                                Foreground="DimGray" FontSize="11" Margin="16,2,0,8"/>
@@ -399,8 +400,7 @@
                                                  IsChecked="{Binding IsWindowMode, Mode=TwoWay}"
                                                  GroupName="MessageOpenMode"
                                                  Checked="RadioButton_Checked"
-                                                 AutomationProperties.Name="Window"
-                                                 AutomationProperties.HelpText="Opens each message in its own window."/>
+                                                 AutomationProperties.Name="Window"/>
                                     <TextBlock Text="Enter opens a message in a new window. Use Ctrl+Enter in any mode to always open in a new window."
                                                TextWrapping="Wrap"
                                                Foreground="DimGray" FontSize="11" Margin="16,2,0,0"/>


### PR DESCRIPTION
Closes #36 (partially — see issue comment for the remaining screen reader problem and options).

## What this PR does

Replaces all `AutomationProperties.HelpText` entries that were invisible to sighted users with visible text, and routes the one long instructional string (address field tutorial) through the user-controllable `AccessibilityHelper.Announce` system instead.

- **ComposeWindow**: removes instructional `HelpText` from the address token field; delivers it as a first-focus `Hint` announce (`_addressHintGiven` flag, respects `AnnounceHints` setting). Removes redundant `HelpText` from From combobox.
- **SettingsDialog**: F7/Shift+F7 spelling note is now a visible `TextBlock`; spelling verbosity radio buttons now have visible `TextBlock` examples; redundant `HelpText` removed from Log Format and Message Open Mode radio buttons (those already had visible descriptions).
- **NewFolderDialog**: redundant `HelpText` removed.
- **RulesManagerWindow**: From/Body `HelpText` converted to visible `TextBlock` notes; Body `AutomationProperties.Name` updated to "Body preview contains"; `HelpText` removed from To and Subject fields.
- **AccountManagerDialog / AddAccountDialog**: visible "Stored in Windows Credential Manager." note added below password field; signature label updated to include "replies and forwards".
- **CommandPaletteWindow**: unchanged — gesture text in `HelpText` is intentional keyboard shortcut metadata.

## Known limitation

The visible `TextBlock` elements added by this PR are not in the tab order and are not automatically read by screen readers. A JAWS user needs the JAWS cursor; an NVDA user needs object navigation to reach them. This is a WPF platform limitation: `AutomationProperties.DescribedBy` does not exist, `GetDescribedByCore()` is absent from `AutomationPeer` in all .NET versions through .NET 10, and `PasswordBox` is sealed. See the issue comment for the two options being considered for a follow-up pass.

## Test plan

- [ ] Open Compose window — address hint announces once on first focus of any address field, suppressed on return visits
- [ ] Toggle `AnnounceHints` off in Settings — confirm address hint is suppressed
- [ ] Settings → Screen Readers tab: F7/Shift+F7 note visible below "Announce spelling while navigating" checkbox
- [ ] Settings → Screen Readers tab → Spelling Suggestions Verbosity: example lines visible below each radio button
- [ ] Settings → Advanced → Log Format: renders correctly, no regression
- [ ] Settings → Windowing → Message Open Mode: renders correctly, no regression
- [ ] New Folder dialog: works normally
- [ ] Rules Manager: From field shows domain-matching note; Body field shows preview note
- [ ] Account Manager / Add Account: "Stored in Windows Credential Manager." visible below password field; signature label reads "replies and forwards"

🤖 Generated with [Claude Code](https://claude.com/claude-code)