### PR TITLE
Fix Fable5CR code review findings (all except #13)

### DIFF
--- a/QuickMail.Tests/AttachmentSafetyTests.cs
+++ b/QuickMail.Tests/AttachmentSafetyTests.cs
@@ -1,0 +1,93 @@
+using QuickMail.Helpers;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+public class AttachmentSafetyTests
+{
+    [Theory]
+    [InlineData("report.pdf", "report.pdf")]
+    [InlineData("photo with spaces.jpg", "photo with spaces.jpg")]
+    [InlineData("Ünïcödé name.txt", "Ünïcödé name.txt")]
+    public void SanitizeFileName_LeavesOrdinaryNamesAlone(string input, string expected)
+    {
+        Assert.Equal(expected, AttachmentSafety.SanitizeFileName(input));
+    }
+
+    [Theory]
+    [InlineData(@"..\..\Startup\evil.exe", "evil.exe")]
+    [InlineData("../../Startup/evil.exe", "evil.exe")]
+    [InlineData(@"C:\Users\victim\evil.exe", "evil.exe")]
+    [InlineData("/etc/passwd", "passwd")]
+    [InlineData(@"\\server\share\payload.dll", "payload.dll")]
+    [InlineData(@"sub\dir\name.txt", "name.txt")]
+    public void SanitizeFileName_StripsDirectoryComponents(string input, string expected)
+    {
+        Assert.Equal(expected, AttachmentSafety.SanitizeFileName(input));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("..")]
+    [InlineData(@"trailing\")]
+    public void SanitizeFileName_FallsBackWhenNothingUsableRemains(string? input)
+    {
+        Assert.Equal("attachment", AttachmentSafety.SanitizeFileName(input));
+    }
+
+    [Fact]
+    public void SanitizeFileName_ReplacesInvalidFileNameChars()
+    {
+        var result = AttachmentSafety.SanitizeFileName("bad<name>|with:chars?.txt");
+        Assert.DoesNotContain('<', result);
+        Assert.DoesNotContain('>', result);
+        Assert.DoesNotContain('|', result);
+        Assert.DoesNotContain(':', result);
+        Assert.DoesNotContain('?', result);
+        Assert.EndsWith(".txt", result);
+    }
+
+    [Fact]
+    public void SanitizeFileName_TrimsTrailingDotsAndSpaces()
+    {
+        // Windows silently drops trailing dots/spaces, which enables extension spoofing
+        // ("evil.exe ." would be created as "evil.exe").
+        Assert.Equal("evil.exe", AttachmentSafety.SanitizeFileName("evil.exe . "));
+        Assert.Equal("report.pdf", AttachmentSafety.SanitizeFileName("report.pdf..."));
+    }
+
+    [Theory]
+    [InlineData("setup.exe")]
+    [InlineData("SETUP.EXE")]
+    [InlineData("script.ps1")]
+    [InlineData("shortcut.lnk")]
+    [InlineData("page.hta")]
+    [InlineData("legacy.com")]
+    [InlineData("macro.wsf")]
+    [InlineData("encoded.vbe")]
+    [InlineData("snapin.msc")]
+    [InlineData("panel.cpl")]
+    [InlineData("keys.reg")]
+    [InlineData("mount-me.iso")]
+    [InlineData("installer.application")]
+    public void IsDangerousExtension_FlagsExecutableTypes(string name)
+    {
+        Assert.True(AttachmentSafety.IsDangerousExtension(name));
+    }
+
+    [Theory]
+    [InlineData("report.pdf")]
+    [InlineData("photo.jpg")]
+    [InlineData("notes.txt")]
+    [InlineData("data.csv")]
+    [InlineData("archive.zip")]
+    [InlineData("noextension")]
+    [InlineData(null)]
+    [InlineData("")]
+    public void IsDangerousExtension_AllowsDocumentTypes(string? name)
+    {
+        Assert.False(AttachmentSafety.IsDangerousExtension(name));
+    }
+}

--- a/QuickMail.Tests/ComposeViewModelAttachmentTests.cs
+++ b/QuickMail.Tests/ComposeViewModelAttachmentTests.cs
@@ -1,0 +1,76 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using QuickMail.ViewModels;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// Covers the View-callback pattern for the Add Attachments file dialog
+/// (CLAUDE.md MVVM rules: Win32 dialogs live in the View; the VM requests paths).
+/// </summary>
+public class ComposeViewModelAttachmentTests
+{
+    private static ComposeViewModel MakeVm() => new(
+        new StubSmtpService(),
+        new StubAccountService(),
+        new StubCredentialService(),
+        new StubImapMailService(),
+        new TrackedTemplateService());
+
+    [Fact]
+    public async Task AddAttachments_UnwiredPicker_AddsNothing()
+    {
+        var vm = MakeVm();
+
+        // Headless/test context: no picker wired — the command must no-op, not crash.
+        await vm.AddAttachmentsCommand.ExecuteAsync(null);
+
+        Assert.Empty(vm.Attachments);
+    }
+
+    [Fact]
+    public async Task AddAttachments_PickerCancelled_AddsNothing()
+    {
+        var vm = MakeVm();
+        vm.OpenFilePathsRequested = () => null;
+
+        await vm.AddAttachmentsCommand.ExecuteAsync(null);
+
+        Assert.Empty(vm.Attachments);
+    }
+
+    [Fact]
+    public async Task AddAttachments_PickerReturnsFiles_AddsEachAsAttachment()
+    {
+        var tempFile = Path.Combine(Path.GetTempPath(), $"QM-ATT-{Guid.NewGuid():N}.txt");
+        await File.WriteAllTextAsync(tempFile, "attachment content");
+        try
+        {
+            var vm = MakeVm();
+            vm.OpenFilePathsRequested = () => [tempFile];
+
+            await vm.AddAttachmentsCommand.ExecuteAsync(null);
+
+            var att = Assert.Single(vm.Attachments);
+            Assert.Equal(Path.GetFileName(tempFile), att.FileName);
+            Assert.True(att.FileSize > 0);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public async Task AddAttachments_MissingFileFromPicker_IsSkipped()
+    {
+        var vm = MakeVm();
+        vm.OpenFilePathsRequested = () => [Path.Combine(Path.GetTempPath(), "QM-does-not-exist.bin")];
+
+        await vm.AddAttachmentsCommand.ExecuteAsync(null);
+
+        Assert.Empty(vm.Attachments);
+    }
+}

--- a/QuickMail.Tests/ConfigServiceSaveTests.cs
+++ b/QuickMail.Tests/ConfigServiceSaveTests.cs
@@ -1,0 +1,58 @@
+using System;
+using System.IO;
+using QuickMail.Models;
+using QuickMail.Services;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+public class ConfigServiceSaveTests
+{
+    private static ProfileContext MakeTempProfile()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"QM-CFG-{Guid.NewGuid():N}");
+        return new ProfileContext(tempDir);
+    }
+
+    [Fact]
+    public void SaveThenLoad_RoundTripsSettings()
+    {
+        var profile = MakeTempProfile();
+        var service = new ConfigService(profile);
+
+        var config = service.Load();
+        config.AnnounceHints = !config.AnnounceHints;
+        service.Save(config);
+
+        var reloaded = new ConfigService(profile).Load();
+        Assert.Equal(config.AnnounceHints, reloaded.AnnounceHints);
+    }
+
+    [Fact]
+    public void Save_LeavesNoTempFileBehind()
+    {
+        var profile = MakeTempProfile();
+        var service = new ConfigService(profile);
+
+        service.Save(service.Load());
+        service.Save(service.Load()); // second save exercises the overwrite path
+
+        var leftovers = Directory.GetFiles(profile.ProfileDir, "*.tmp");
+        Assert.Empty(leftovers);
+    }
+
+    [Fact]
+    public void Save_OverwritesExistingConfigCompletely()
+    {
+        var profile = MakeTempProfile();
+        var service = new ConfigService(profile);
+
+        var config = service.Load();
+        service.Save(config);
+        service.Save(config);
+
+        // The file must be valid, parseable config after repeated in-place saves.
+        var reloaded = new ConfigService(profile).Load();
+        Assert.NotNull(reloaded);
+    }
+}

--- a/QuickMail.Tests/ExternalUriPolicyTests.cs
+++ b/QuickMail.Tests/ExternalUriPolicyTests.cs
@@ -1,0 +1,65 @@
+using QuickMail.Helpers;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+public class ExternalUriPolicyTests
+{
+    [Theory]
+    [InlineData("http://example.com")]
+    [InlineData("https://example.com/path?query=1#frag")]
+    [InlineData("HTTPS://EXAMPLE.COM")]
+    [InlineData("mailto:kelly@example.com")]
+    [InlineData("mailto:kelly@example.com?subject=Hi%20there")]
+    public void IsAllowed_PermitsHttpHttpsAndMailto(string uri)
+    {
+        Assert.True(ExternalUriPolicy.IsAllowed(uri));
+    }
+
+    [Theory]
+    [InlineData("file:///C:/Windows/System32/calc.exe")]
+    [InlineData("file://attacker-server/share/payload.exe")]
+    [InlineData("javascript:alert(1)")]
+    [InlineData("search-ms:query=foo")]
+    [InlineData("ms-msdt:/id PCWDiagnostic")]
+    [InlineData("ms-settings:network")]
+    [InlineData("data:text/html,<b>x</b>")]
+    [InlineData("ftp://example.com/file")]
+    [InlineData("skype:someone?call")]
+    [InlineData("ldap://example.com")]
+    [InlineData("quickmail:ics-accept")]
+    [InlineData("about:blank")]
+    public void IsAllowed_BlocksEverythingElse(string uri)
+    {
+        Assert.False(ExternalUriPolicy.IsAllowed(uri));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not a uri at all")]
+    [InlineData("example.com/no-scheme")]
+    [InlineData("//protocol-relative.example.com")]
+    public void IsAllowed_BlocksMissingOrRelativeUris(string? uri)
+    {
+        Assert.False(ExternalUriPolicy.IsAllowed(uri));
+    }
+
+    [Theory]
+    // Scheme confusion attempts: the allowed scheme name embedded somewhere it doesn't count.
+    [InlineData("file://http/https")]
+    [InlineData("vbscript:http://example.com")]
+    [InlineData(" javascript:alert(1)")]
+    public void IsAllowed_IsNotFooledByEmbeddedSchemeNames(string uri)
+    {
+        Assert.False(ExternalUriPolicy.IsAllowed(uri));
+    }
+
+    [Fact]
+    public void TryOpenExternal_ReturnsFalseForBlockedUri_WithoutThrowing()
+    {
+        Assert.False(ExternalUriPolicy.TryOpenExternal("file:///C:/evil.exe"));
+        Assert.False(ExternalUriPolicy.TryOpenExternal(null));
+    }
+}

--- a/QuickMail.Tests/MainViewModelLifecycleTests.cs
+++ b/QuickMail.Tests/MainViewModelLifecycleTests.cs
@@ -1,0 +1,44 @@
+using System.Threading.Tasks;
+using QuickMail.ViewModels;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// Covers the MainViewModel disposal contract added for the Fable5CR review:
+/// Dispose cancels/releases all operation CTS slots and must be safe to call
+/// at any point in the VM lifecycle, including twice.
+/// </summary>
+public class MainViewModelLifecycleTests
+{
+    private static MainViewModel MakeVm() => new(
+        new StubImapMailService(), new StubAccountService(), new StubCredentialService(),
+        new StubLocalStoreService(), new StubOAuthService(), new StubSyncService(),
+        new StubConfigService(), new StubCommandRegistry(), new StubViewService(),
+        new StubRuleService(), new StubSmtpService(),
+        uiDispatcher: new StubUiDispatcher());
+
+    [Fact]
+    public void Dispose_BeforeAnyLoad_DoesNotThrow()
+    {
+        var vm = MakeVm();
+        vm.Dispose();
+    }
+
+    [Fact]
+    public void Dispose_IsIdempotent()
+    {
+        var vm = MakeVm();
+        vm.Dispose();
+        vm.Dispose();
+    }
+
+    [Fact]
+    public async Task Dispose_AfterInitialLoad_DoesNotThrow()
+    {
+        var vm = MakeVm();
+        await vm.InitialLoadAsync();
+        vm.Dispose();
+        vm.Dispose();
+    }
+}

--- a/QuickMail.Tests/MessageBodyHtmlBuilderTests.cs
+++ b/QuickMail.Tests/MessageBodyHtmlBuilderTests.cs
@@ -45,4 +45,74 @@ public class MessageBodyHtmlBuilderTests
         var result = MessageBodyHtmlBuilder.StripHeavyHtml(html);
         Assert.Contains("Keep this", result);
     }
+
+    [Fact]
+    public void TryStripHeavyHtml_NormalInput_ReturnsTrueAndStrips()
+    {
+        const string html = "<body><script>alert(1)</script><p onclick=\"x()\">Hello</p></body>";
+
+        var ok = MessageBodyHtmlBuilder.TryStripHeavyHtml(html, out var stripped);
+
+        Assert.True(ok);
+        Assert.DoesNotContain("<script", stripped, System.StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("onclick", stripped, System.StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Hello", stripped);
+    }
+
+    [Fact]
+    public void TryStripHeavyHtml_Timeout_ReturnsFalse()
+    {
+        // A 1-tick timeout cannot complete any pass over a non-trivial document, which
+        // simulates a message crafted to stall the stripping regexes.
+        var html = string.Concat(System.Linq.Enumerable.Repeat(
+            "<div style=\"color:red\"><p onclick=\"x()\">content</p></div>", 5000));
+
+        var ok = MessageBodyHtmlBuilder.TryStripHeavyHtml(
+            html, System.TimeSpan.FromTicks(1), out _);
+
+        Assert.False(ok);
+    }
+
+    [Fact]
+    public void TryBuildSanitizedHtmlDocument_Timeout_FailsClosed()
+    {
+        var html = string.Concat(System.Linq.Enumerable.Repeat(
+            "<div style=\"color:red\"><p onclick=\"x()\">content</p></div>", 5000));
+
+        var ok = MessageBodyHtmlBuilder.TryBuildSanitizedHtmlDocument(
+            "Subject", html, System.TimeSpan.FromTicks(1), out var document);
+
+        // The partially stripped document must be discarded, never rendered.
+        Assert.False(ok);
+        Assert.Equal(string.Empty, document);
+    }
+
+    [Fact]
+    public void TryBuildSanitizedHtmlDocument_NormalInput_ProducesCspDocument()
+    {
+        var ok = MessageBodyHtmlBuilder.TryBuildSanitizedHtmlDocument(
+            "Subject", "<p>Body text</p>", out var document);
+
+        Assert.True(ok);
+        Assert.Contains("Content-Security-Policy", document);
+        Assert.Contains("script-src 'none'", document);
+        Assert.Contains("Body text", document);
+    }
+
+    [Fact]
+    public void BuildMessageHtml_ComplexHtml_FallsBackToReaderMode()
+    {
+        // Over the table-count threshold: the builder must switch to the simplified body.
+        var tables = string.Concat(System.Linq.Enumerable.Repeat("<table><tr><td>x</td></tr></table>", 501));
+        var detail = new QuickMail.Models.MailMessageDetail
+        {
+            HtmlBody = "<html><body>" + tables + "</body></html>",
+            PlainTextBody = "Plain fallback text",
+        };
+
+        var html = MessageBodyHtmlBuilder.BuildMessageHtml(detail);
+
+        Assert.Contains("Plain fallback text", html);
+        Assert.Contains("simplified body", html);
+    }
 }

--- a/QuickMail.Tests/StubServices.cs
+++ b/QuickMail.Tests/StubServices.cs
@@ -284,3 +284,10 @@ sealed class StubCalendarService : ICalendarService
         return Task.CompletedTask;
     }
 }
+
+/// <summary>Runs everything inline — VM unit tests are single-threaded by design.</summary>
+sealed class StubUiDispatcher : IUiDispatcher
+{
+    public void Invoke(Action action) => action();
+    public void Post(Action action) => action();
+}

--- a/QuickMail.Tests/TaskFaultLoggingTests.cs
+++ b/QuickMail.Tests/TaskFaultLoggingTests.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Threading.Tasks;
+using QuickMail.Helpers;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+public class TaskFaultLoggingTests
+{
+    [Fact]
+    public async Task LogFaults_FaultedTask_DoesNotPropagate()
+    {
+        var task = Task.FromException(new InvalidOperationException("boom"));
+
+        task.LogFaults("test context");
+
+        // Give the observer continuation a moment; the fault must be swallowed (and logged),
+        // never rethrown onto the caller or left unobserved.
+        await Task.Delay(50);
+    }
+
+    [Fact]
+    public async Task LogFaults_CancelledTask_DoesNotPropagate()
+    {
+        var task = Task.FromCanceled(new System.Threading.CancellationToken(canceled: true));
+
+        task.LogFaults("test context");
+
+        await Task.Delay(50);
+    }
+
+    [Fact]
+    public async Task LogFaults_CompletedTask_DoesNothing()
+    {
+        Task.CompletedTask.LogFaults("test context");
+        await Task.Delay(10);
+    }
+}

--- a/QuickMail/App.xaml.cs
+++ b/QuickMail/App.xaml.cs
@@ -18,6 +18,7 @@ public partial class App : Application
     private ChangeNotifierRouter? _changeNotifier;
     private GraphChangeNotifier? _graphNotifier;
     private ImapMailService? _imapBackend;
+    private GraphMailService? _graphBackend;
     private UpdateCheckService? _updateCheckService;
 
     protected override void OnStartup(StartupEventArgs e)
@@ -88,7 +89,8 @@ public partial class App : Application
             var oauthService      = new OAuthRouter(msOAuthService, googleOAuth);
             _imapBackend          = new ImapMailService(oauthService, configService);
             var imapBackend       = _imapBackend;
-            var graphBackend      = new GraphMailService(msOAuthService, configService);
+            _graphBackend         = new GraphMailService(msOAuthService, configService);
+            var graphBackend      = _graphBackend;
             _graphSendMail        = new GraphSendMailService(msOAuthService);
             var smtpService       = new SmtpService(oauthService, _graphSendMail);
 
@@ -165,6 +167,7 @@ public partial class App : Application
         _changeNotifier?.Dispose(); // stops all watchers (IDLE + Graph poll) + severs the event chain
         _graphNotifier?.Dispose();  // disposes the Graph poll CTS (StopWatchers already ran; idempotent)
         _imapBackend?.Dispose();    // closes connection pools (StopWatchers already ran, and is idempotent)
+        _graphBackend?.Dispose();   // releases GraphClient/HttpClient; after the notifiers, which poll through its client
         _graphSendMail?.Dispose();
         _contactService?.Dispose();
         _templateService?.Dispose();

--- a/QuickMail/Helpers/AtomicFile.cs
+++ b/QuickMail/Helpers/AtomicFile.cs
@@ -1,0 +1,29 @@
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace QuickMail.Helpers;
+
+/// <summary>
+/// Writes files via a sibling temp file + rename so a crash or power loss mid-write can
+/// never leave a truncated file — the old content survives intact until the new content
+/// is fully on disk. Every service that persists settings-like state (accounts, views,
+/// config, rules, templates, contacts, flags) writes through this helper.
+/// </summary>
+public static class AtomicFile
+{
+    public static void WriteAllText(string path, string content, Encoding? encoding = null)
+    {
+        var tempPath = path + ".tmp";
+        if (encoding is null) File.WriteAllText(tempPath, content);
+        else File.WriteAllText(tempPath, content, encoding);
+        File.Move(tempPath, path, overwrite: true);
+    }
+
+    public static async Task WriteAllTextAsync(string path, string content)
+    {
+        var tempPath = path + ".tmp";
+        await File.WriteAllTextAsync(tempPath, content).ConfigureAwait(false);
+        File.Move(tempPath, path, overwrite: true);
+    }
+}

--- a/QuickMail/Helpers/AttachmentSafety.cs
+++ b/QuickMail/Helpers/AttachmentSafety.cs
@@ -1,0 +1,60 @@
+using System;
+using System.IO;
+using System.Linq;
+
+namespace QuickMail.Helpers;
+
+/// <summary>
+/// Shared safety checks for attachment filenames. Attachment names are server-supplied
+/// (and therefore attacker-controlled), so every path that writes an attachment to disk
+/// must go through <see cref="SanitizeFileName"/>, and every path that launches one must
+/// consult <see cref="IsDangerousExtension"/> first.
+/// </summary>
+public static class AttachmentSafety
+{
+    /// <summary>
+    /// Extensions Windows will execute (directly or via a registered handler) rather than
+    /// open in a viewer. Kept in one place so the open-attachment confirmations in
+    /// MainViewModel and ComposeViewModel can never drift apart again.
+    /// </summary>
+    private static readonly string[] DangerousExtensions =
+    [
+        ".exe", ".bat", ".cmd", ".com", ".pif", ".scr", ".msi", ".msp", ".msix",
+        ".ps1", ".psm1", ".vbs", ".vbe", ".js", ".jse", ".wsf", ".wsh", ".ws",
+        ".hta", ".jar", ".msc", ".cpl", ".reg", ".scf", ".lnk", ".url",
+        ".chm", ".application", ".appref-ms", ".iso", ".img", ".vhd", ".vhdx",
+    ];
+
+    public static bool IsDangerousExtension(string? fileName)
+    {
+        if (string.IsNullOrEmpty(fileName)) return false;
+        var ext = Path.GetExtension(fileName).ToLowerInvariant();
+        return DangerousExtensions.Contains(ext);
+    }
+
+    /// <summary>
+    /// Reduces a server-supplied attachment name to a bare, writable filename:
+    /// strips directory components (defeats "../../Startup/evil.exe" and absolute paths),
+    /// replaces characters invalid in Windows filenames, and trims trailing dots/spaces
+    /// (which Windows silently drops, enabling extension spoofing). Never returns empty.
+    /// </summary>
+    public static string SanitizeFileName(string? fileName)
+    {
+        if (string.IsNullOrWhiteSpace(fileName)) return "attachment";
+
+        // Path.GetFileName does not treat '/' as a separator inside invalid-char sequences
+        // on all inputs, so normalize both separator styles before stripping directories.
+        var name = fileName.Replace('/', '\\');
+        name = Path.GetFileName(name);
+
+        var invalid = Path.GetInvalidFileNameChars();
+        if (name.IndexOfAny(invalid) >= 0)
+        {
+            var chars = name.Select(c => invalid.Contains(c) ? '_' : c).ToArray();
+            name = new string(chars);
+        }
+
+        name = name.TrimEnd('.', ' ');
+        return name.Length == 0 ? "attachment" : name;
+    }
+}

--- a/QuickMail/Helpers/ExternalUriPolicy.cs
+++ b/QuickMail/Helpers/ExternalUriPolicy.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Diagnostics;
+using QuickMail.Services;
+
+namespace QuickMail.Helpers;
+
+/// <summary>
+/// Gatekeeper for URIs that leave the app via ShellExecute (links activated in message
+/// bodies, preview windows, etc.). Message content is untrusted: the HTML sanitizer does
+/// not rewrite anchor hrefs, so without this allow-list a crafted message could launch
+/// any registered protocol handler (file:, search-ms:, ms-msdt:, …) the moment the user
+/// activates a link. Only schemes a mail client legitimately hands to the OS are allowed.
+/// </summary>
+public static class ExternalUriPolicy
+{
+    private static readonly string[] AllowedSchemes = ["http", "https", "mailto"];
+
+    /// <summary>True when the URI is absolute and uses an allow-listed scheme.</summary>
+    public static bool IsAllowed(string? uri)
+    {
+        if (string.IsNullOrWhiteSpace(uri)) return false;
+        if (!Uri.TryCreate(uri, UriKind.Absolute, out var parsed)) return false;
+
+        foreach (var scheme in AllowedSchemes)
+            if (string.Equals(parsed.Scheme, scheme, StringComparison.OrdinalIgnoreCase))
+                return true;
+        return false;
+    }
+
+    /// <summary>
+    /// Opens the URI with the default handler if its scheme is allow-listed;
+    /// otherwise logs and drops it. Returns true when the URI was handed to the shell.
+    /// </summary>
+    public static bool TryOpenExternal(string? uri)
+    {
+        if (!IsAllowed(uri))
+        {
+            LogService.Log($"ExternalUriPolicy: blocked non-allow-listed URI: {Truncate(uri)}");
+            return false;
+        }
+
+        try
+        {
+            Process.Start(new ProcessStartInfo(uri!) { UseShellExecute = true });
+            return true;
+        }
+        catch (Exception ex)
+        {
+            LogService.Log($"ExternalUriPolicy: open failed for {Truncate(uri)}", ex);
+            return false;
+        }
+    }
+
+    private static string Truncate(string? uri) =>
+        uri is null ? "(null)" : uri.Length <= 200 ? uri : uri[..200] + "…";
+}

--- a/QuickMail/Helpers/MessageBodyHtmlBuilder.cs
+++ b/QuickMail/Helpers/MessageBodyHtmlBuilder.cs
@@ -28,8 +28,12 @@ public static class MessageBodyHtmlBuilder
     public static string BuildMessageHtml(MailMessageDetail detail)
     {
         var htmlBody = detail.HtmlBody ?? string.Empty;
-        if (!string.IsNullOrWhiteSpace(htmlBody) && !ShouldUseReaderMode(htmlBody))
-            return BuildSanitizedHtmlDocument(detail.Subject, htmlBody);
+        // Fail closed: if any stripping pass times out we cannot claim the HTML is
+        // sanitized, so fall through to the plain-text (reader mode) rendering instead
+        // of showing partially stripped markup.
+        if (!string.IsNullOrWhiteSpace(htmlBody) && !ShouldUseReaderMode(htmlBody)
+            && TryBuildSanitizedHtmlDocument(detail.Subject, htmlBody, out var sanitized))
+            return sanitized;
 
         var text = !string.IsNullOrWhiteSpace(detail.PlainTextBody)
             ? detail.PlainTextBody
@@ -45,9 +49,28 @@ public static class MessageBodyHtmlBuilder
         html.Length > MaxRichHtmlRenderChars ||
         CountOccurrences(html, "<table") > MaxRichHtmlTableCount;
 
-    public static string BuildSanitizedHtmlDocument(string? subject, string html)
+    /// <summary>
+    /// Builds the full sanitized document for the reading pane. Returns false when any
+    /// stripping pass timed out — the output must then be discarded and the caller must
+    /// fall back to plain-text rendering (a partially stripped document is not sanitized).
+    /// </summary>
+    public static bool TryBuildSanitizedHtmlDocument(string? subject, string html, out string document) =>
+        TryBuildSanitizedHtmlDocument(subject, html, HtmlRegexTimeout, out document);
+
+    internal static bool TryBuildSanitizedHtmlDocument(
+        string? subject, string html, TimeSpan timeout, out string document)
     {
-        var body     = StripHeavyHtml(html);
+        if (!TryStripHeavyHtml(html, timeout, out var body))
+        {
+            document = string.Empty;
+            return false;
+        }
+        document = ComposeSanitizedDocument(subject, body);
+        return true;
+    }
+
+    private static string ComposeSanitizedDocument(string? subject, string body)
+    {
         var titleTag = $"<title>{WebUtility.HtmlEncode(subject ?? string.Empty)}</title>";
         const string cspTag =
             "<meta http-equiv=\"Content-Security-Policy\" " +
@@ -112,22 +135,59 @@ public static class MessageBodyHtmlBuilder
         catch (RegexMatchTimeoutException) { return encoded; }
     }
 
+    /// <summary>
+    /// Best-effort stripping for non-rendered consumers (e.g. HtmlToText, whose output is
+    /// HTML-encoded before display). Rendering paths must use <see cref="TryStripHeavyHtml"/>
+    /// and fail closed on a false return.
+    /// </summary>
     public static string StripHeavyHtml(string html)
     {
+        TryStripHeavyHtml(html, HtmlRegexTimeout, out var body);
+        return body;
+    }
+
+    public static bool TryStripHeavyHtml(string html, out string stripped) =>
+        TryStripHeavyHtml(html, HtmlRegexTimeout, out stripped);
+
+    /// <summary>
+    /// SECURITY NOTE: this regex pass is defense-in-depth, not the security boundary.
+    /// Regex-based HTML stripping is structurally bypassable (e.g. slash-separated
+    /// attributes, malformed nesting); the strict CSP injected by
+    /// ComposeSanitizedDocument — script-src 'none', default-src 'none' — is what actually
+    /// prevents execution and remote loads. Never weaken that CSP on the assumption that
+    /// this stripping protects the document. Returns false when any pass timed out, in
+    /// which case <paramref name="stripped"/> holds a PARTIALLY stripped document that
+    /// must not be rendered.
+    /// </summary>
+    internal static bool TryStripHeavyHtml(string html, TimeSpan timeout, out string stripped)
+    {
+        var complete = true;
+        string Step(string input, string pattern, RegexOptions options, string replacement = "")
+        {
+            try { return Regex.Replace(input, pattern, replacement, options, timeout); }
+            catch (RegexMatchTimeoutException)
+            {
+                LogService.Log($"HTML cleanup timed out for pattern: {pattern}");
+                complete = false;
+                return input;
+            }
+        }
+
         var body = html;
         // Remove elements hidden via inline display:none (e.g. newsletter preheader padding divs).
         // Must run before style-attribute stripping, which would make these visible.
-        body = SafeRegexReplace(body,
+        body = Step(body,
             @"<(div|span|p)\b[^>]*\bstyle\s*=\s*(?:""[^""]*display\s*:\s*none[^""]*""|'[^']*display\s*:\s*none[^']*')[^>]*>.*?</\1>",
-            string.Empty, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-        body = SafeRegexReplace(body, "<!--.*?-->", string.Empty, RegexOptions.Singleline);
-        body = SafeRegexReplace(body, "<script\\b.*?</script>", string.Empty, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-        body = SafeRegexReplace(body, "<style\\b.*?</style>", string.Empty, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-        body = SafeRegexReplace(body, "<svg\\b.*?</svg>", string.Empty, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-        body = SafeRegexReplace(body, "<(iframe|object|embed|video|audio|canvas|form)\\b.*?</\\1>", string.Empty, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-        body = SafeRegexReplace(body, "<(img|link|base|input|button|meta)\\b[^>]*>", string.Empty, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-        body = SafeRegexReplace(body, "\\s(on\\w+|style|src|srcset|background)\\s*=\\s*(\"[^\"]*\"|'[^']*'|[^\\s>]+)", string.Empty, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-        return body;
+            RegexOptions.IgnoreCase | RegexOptions.Singleline);
+        body = Step(body, "<!--.*?-->", RegexOptions.Singleline);
+        body = Step(body, "<script\\b.*?</script>", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+        body = Step(body, "<style\\b.*?</style>", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+        body = Step(body, "<svg\\b.*?</svg>", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+        body = Step(body, "<(iframe|object|embed|video|audio|canvas|form)\\b.*?</\\1>", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+        body = Step(body, "<(img|link|base|input|button|meta)\\b[^>]*>", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+        body = Step(body, "\\s(on\\w+|style|src|srcset|background)\\s*=\\s*(\"[^\"]*\"|'[^']*'|[^\\s>]+)", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+        stripped = body;
+        return complete;
     }
 
     public static string RemoveTitle(string html) =>

--- a/QuickMail/Helpers/MessageBodyHtmlBuilder.cs
+++ b/QuickMail/Helpers/MessageBodyHtmlBuilder.cs
@@ -164,13 +164,9 @@ public static class MessageBodyHtmlBuilder
         var complete = true;
         string Step(string input, string pattern, RegexOptions options, string replacement = "")
         {
-            try { return Regex.Replace(input, pattern, replacement, options, timeout); }
-            catch (RegexMatchTimeoutException)
-            {
-                LogService.Log($"HTML cleanup timed out for pattern: {pattern}");
+            if (!TryRegexReplace(input, pattern, replacement, options, timeout, out var result))
                 complete = false;
-                return input;
-            }
+            return result;
         }
 
         var body = html;
@@ -222,11 +218,28 @@ public static class MessageBodyHtmlBuilder
 
     public static string SafeRegexReplace(string input, string pattern, string replacement, RegexOptions options)
     {
-        try { return Regex.Replace(input, pattern, replacement, options, HtmlRegexTimeout); }
+        TryRegexReplace(input, pattern, replacement, options, HtmlRegexTimeout, out var result);
+        return result;
+    }
+
+    /// <summary>
+    /// Single home for the timeout-guarded regex replace: on timeout logs the pattern,
+    /// hands back the input unchanged, and returns false.
+    /// </summary>
+    private static bool TryRegexReplace(
+        string input, string pattern, string replacement, RegexOptions options,
+        TimeSpan timeout, out string result)
+    {
+        try
+        {
+            result = Regex.Replace(input, pattern, replacement, options, timeout);
+            return true;
+        }
         catch (RegexMatchTimeoutException)
         {
             LogService.Log($"HTML cleanup timed out for pattern: {pattern}");
-            return input;
+            result = input;
+            return false;
         }
     }
 

--- a/QuickMail/Helpers/TaskFaultLogging.cs
+++ b/QuickMail/Helpers/TaskFaultLogging.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Threading.Tasks;
+using QuickMail.Services;
+
+namespace QuickMail.Helpers;
+
+/// <summary>
+/// Deliberate fire-and-forget for tasks whose failure should be logged, not surfaced.
+/// A bare <c>_ = SomethingAsync()</c> only reports faults through the
+/// UnobservedTaskException handler at finalization time (if ever); routing through
+/// <see cref="LogFaults"/> logs them promptly with a context string.
+/// </summary>
+public static class TaskFaultLogging
+{
+    public static void LogFaults(this Task task, string context)
+    {
+        _ = ObserveAsync(task, context);
+    }
+
+    private static async Task ObserveAsync(Task task, string context)
+    {
+        try
+        {
+            await task.ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // Cancellation is a normal outcome for background work.
+        }
+        catch (Exception ex)
+        {
+            LogService.Log($"Background task failed: {context}", ex);
+        }
+    }
+}

--- a/QuickMail/Services/AccountService.cs
+++ b/QuickMail/Services/AccountService.cs
@@ -41,7 +41,8 @@ public class AccountService : IAccountService
     {
         Directory.CreateDirectory(_dataFolder);
         var json = JsonSerializer.Serialize(accounts, JsonOptions);
-        File.WriteAllText(_accountsFile, json);
+        // Atomic: a crash mid-write must not truncate accounts.json (all account config).
+        Helpers.AtomicFile.WriteAllText(_accountsFile, json);
     }
 
     public void SetDefaultAccount(Guid accountId)

--- a/QuickMail/Services/ConfigService.cs
+++ b/QuickMail/Services/ConfigService.cs
@@ -81,15 +81,27 @@ public class ConfigService : IConfigService
     {
         _cached = config;
         Directory.CreateDirectory(_dataFolder);
-        File.WriteAllText(_configFile, BuildFileText(config), Encoding.UTF8);
+        WriteAtomic(_configFile, BuildFileText(config));
 
         // Save custom hotkeys to separate JSON file (only write when non-empty)
         if (config.CustomHotkeys.Count > 0)
-            File.WriteAllText(_hotkeysFile, JsonSerializer.Serialize(config.CustomHotkeys, JsonOptions), Encoding.UTF8);
+            WriteAtomic(_hotkeysFile, JsonSerializer.Serialize(config.CustomHotkeys, JsonOptions));
         else if (File.Exists(_hotkeysFile))
             File.Delete(_hotkeysFile);
 
         Views.AccessibilityHelper.Configure(config);
+    }
+
+    /// <summary>
+    /// Writes via a sibling temp file + atomic rename so a crash or power loss mid-write
+    /// can never leave a truncated config — the old file survives intact until the new
+    /// content is fully on disk.
+    /// </summary>
+    private static void WriteAtomic(string path, string content)
+    {
+        var tempPath = path + ".tmp";
+        File.WriteAllText(tempPath, content, Encoding.UTF8);
+        File.Move(tempPath, path, overwrite: true);
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────────

--- a/QuickMail/Services/ConfigService.cs
+++ b/QuickMail/Services/ConfigService.cs
@@ -81,27 +81,15 @@ public class ConfigService : IConfigService
     {
         _cached = config;
         Directory.CreateDirectory(_dataFolder);
-        WriteAtomic(_configFile, BuildFileText(config));
+        Helpers.AtomicFile.WriteAllText(_configFile, BuildFileText(config), Encoding.UTF8);
 
         // Save custom hotkeys to separate JSON file (only write when non-empty)
         if (config.CustomHotkeys.Count > 0)
-            WriteAtomic(_hotkeysFile, JsonSerializer.Serialize(config.CustomHotkeys, JsonOptions));
+            Helpers.AtomicFile.WriteAllText(_hotkeysFile, JsonSerializer.Serialize(config.CustomHotkeys, JsonOptions), Encoding.UTF8);
         else if (File.Exists(_hotkeysFile))
             File.Delete(_hotkeysFile);
 
         Views.AccessibilityHelper.Configure(config);
-    }
-
-    /// <summary>
-    /// Writes via a sibling temp file + atomic rename so a crash or power loss mid-write
-    /// can never leave a truncated config — the old file survives intact until the new
-    /// content is fully on disk.
-    /// </summary>
-    private static void WriteAtomic(string path, string content)
-    {
-        var tempPath = path + ".tmp";
-        File.WriteAllText(tempPath, content, Encoding.UTF8);
-        File.Move(tempPath, path, overwrite: true);
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────────

--- a/QuickMail/Services/ContactService.cs
+++ b/QuickMail/Services/ContactService.cs
@@ -436,8 +436,6 @@ public class ContactService : IContactService, IDisposable
     private async Task WriteJsonAtomicallyAsync<T>(string path, T payload)
     {
         var json = JsonSerializer.Serialize(payload, _jsonOptions);
-        var tempPath = path + ".tmp";
-        await File.WriteAllTextAsync(tempPath, json);
-        File.Move(tempPath, path, overwrite: true);
+        await Helpers.AtomicFile.WriteAllTextAsync(path, json);
     }
 }

--- a/QuickMail/Services/FlagService.cs
+++ b/QuickMail/Services/FlagService.cs
@@ -76,9 +76,7 @@ public class FlagService : IFlagService
     public async Task SaveFlagDefinitionsAsync(List<FlagDefinition> flags)
     {
         var json = JsonSerializer.Serialize(flags, JsonOpts);
-        var tmp  = _flagsFile + ".tmp";
-        await File.WriteAllTextAsync(tmp, json);
-        File.Move(tmp, _flagsFile, overwrite: true);
+        await Helpers.AtomicFile.WriteAllTextAsync(_flagsFile, json);
         FlagDefinitionsChanged?.Invoke(this, EventArgs.Empty);
     }
 

--- a/QuickMail/Services/IUiDispatcher.cs
+++ b/QuickMail/Services/IUiDispatcher.cs
@@ -1,0 +1,47 @@
+using System;
+
+namespace QuickMail.Services;
+
+/// <summary>
+/// Marshals work onto the UI thread. ViewModels take this instead of touching
+/// System.Windows.Threading.Dispatcher directly (CLAUDE.md MVVM rules), which also
+/// lets tests run VM code paths without a live WPF Application.
+/// </summary>
+public interface IUiDispatcher
+{
+    /// <summary>Runs the action on the UI thread synchronously (blocks until done).</summary>
+    void Invoke(Action action);
+
+    /// <summary>Queues the action onto the UI thread without waiting for it.</summary>
+    void Post(Action action);
+}
+
+/// <summary>
+/// WPF implementation. Marshals only when the current Application is the real QuickMail
+/// App: unit tests create a vanilla System.Windows.Application on a StaFact STA thread
+/// that never runs a WPF message pump, so queueing onto that dispatcher would park the
+/// work forever (30s test timeouts). With no pumped dispatcher available the action runs
+/// inline on the calling thread — there is no UI thread to protect.
+/// </summary>
+public sealed class WpfUiDispatcher : IUiDispatcher
+{
+    public void Invoke(Action action)
+    {
+        var dispatcher = PumpedDispatcher();
+        if (dispatcher is null || dispatcher.CheckAccess()) action();
+        else dispatcher.Invoke(action);
+    }
+
+    public void Post(Action action)
+    {
+        var dispatcher = PumpedDispatcher();
+        if (dispatcher is null || dispatcher.CheckAccess()) action();
+        else dispatcher.InvokeAsync(action);
+    }
+
+    private static System.Windows.Threading.Dispatcher? PumpedDispatcher()
+    {
+        var dispatcher = System.Windows.Application.Current is App app ? app.Dispatcher : null;
+        return dispatcher is { Thread.IsAlive: true } ? dispatcher : null;
+    }
+}

--- a/QuickMail/Services/OAuthService.cs
+++ b/QuickMail/Services/OAuthService.cs
@@ -66,11 +66,24 @@ public class OAuthService : IOAuthService
             // Enables the embedded WebView2 browser on net8.0-windows (Microsoft.Identity.Client.Desktop).
             .WithWindowsEmbeddedBrowserSupport()
             .Build();
-
-        RegisterTokenCache();
     }
 
-    private void RegisterTokenCache()
+    // Registered lazily on first token use rather than in the constructor: the service is
+    // built on the UI thread during startup, and MsalCacheHelper.CreateAsync does file I/O
+    // and DPAPI work that shouldn't be waited on synchronously there. The registration task
+    // is created once and shared, so concurrent first calls await the same registration.
+    private Task? _cacheRegistration;
+    private readonly object _cacheRegistrationLock = new();
+
+    private Task EnsureTokenCacheAsync()
+    {
+        lock (_cacheRegistrationLock)
+        {
+            return _cacheRegistration ??= RegisterTokenCacheAsync();
+        }
+    }
+
+    private async Task RegisterTokenCacheAsync()
     {
         Directory.CreateDirectory(_cacheDir);
 
@@ -78,7 +91,7 @@ public class OAuthService : IOAuthService
         var storageProps = new StorageCreationPropertiesBuilder(CacheFileName, _cacheDir)
             .Build();
 
-        var helper = MsalCacheHelper.CreateAsync(storageProps).GetAwaiter().GetResult();
+        var helper = await MsalCacheHelper.CreateAsync(storageProps).ConfigureAwait(false);
         helper.RegisterCache(_msal.UserTokenCache);
 
         LogService.Log("OAuthService: token cache registered.");
@@ -89,6 +102,7 @@ public class OAuthService : IOAuthService
 
     public async Task<string> GetAccessTokenAsync(AccountModel account, string[] scopes, CancellationToken ct = default)
     {
+        await EnsureTokenCacheAsync();
         var msalAccounts = await _msal.GetAccountsAsync();
         var msalAccount  = msalAccounts.FirstOrDefault(a =>
             string.Equals(a.Username, account.Username, StringComparison.OrdinalIgnoreCase));
@@ -116,6 +130,7 @@ public class OAuthService : IOAuthService
 
     public async Task<OAuthResult> SignInInteractiveAsync(AccountModel account, string[] scopes, CancellationToken ct = default)
     {
+        await EnsureTokenCacheAsync();
         LogService.Log($"OAuthService: starting interactive sign-in for {account.Username}");
 
         var builder = _msal.AcquireTokenInteractive(scopes)
@@ -136,6 +151,7 @@ public class OAuthService : IOAuthService
 
     public async Task SignOutAsync(AccountModel account)
     {
+        await EnsureTokenCacheAsync();
         var msalAccounts = await _msal.GetAccountsAsync();
         var msalAccount  = msalAccounts.FirstOrDefault(a =>
             string.Equals(a.Username, account.Username, StringComparison.OrdinalIgnoreCase));

--- a/QuickMail/Services/OAuthService.cs
+++ b/QuickMail/Services/OAuthService.cs
@@ -79,6 +79,11 @@ public class OAuthService : IOAuthService
     {
         lock (_cacheRegistrationLock)
         {
+            // A failed registration must not be cached: a transient fault (cache file
+            // briefly locked, DPAPI hiccup) would otherwise disable every OAuth operation
+            // until app restart. Drop the completed-unsuccessful task so this call retries.
+            if (_cacheRegistration is { IsCompleted: true, IsCompletedSuccessfully: false })
+                _cacheRegistration = null;
             return _cacheRegistration ??= RegisterTokenCacheAsync();
         }
     }

--- a/QuickMail/Services/RuleService.cs
+++ b/QuickMail/Services/RuleService.cs
@@ -60,10 +60,7 @@ public class RuleService : IRuleService
         var dir = Path.GetDirectoryName(_filePath)!;
         Directory.CreateDirectory(dir);
 
-        // Atomic write: write to temp file, then rename.
-        var tempPath = _filePath + ".tmp";
-        File.WriteAllText(tempPath, JsonSerializer.Serialize(rules, JsonOptions));
-        File.Move(tempPath, _filePath, overwrite: true);
+        Helpers.AtomicFile.WriteAllText(_filePath, JsonSerializer.Serialize(rules, JsonOptions));
         _loaded = true;
     }
 

--- a/QuickMail/Services/SyncService.cs
+++ b/QuickMail/Services/SyncService.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
+using QuickMail.Helpers;
 using QuickMail.Models;
 
 namespace QuickMail.Services;
@@ -109,7 +110,8 @@ public class SyncService : ISyncService
         // They run sequentially — fire-and-forget the whole batch so SyncAllAccounts
         // returns promptly and the status bar updates, while previews trickle in.
         if (!previewJobs.IsEmpty)
-            _ = FetchAllPreviewsAsync(previewJobs.ToList(), ct);
+            FetchAllPreviewsAsync(previewJobs.ToList(), ct)
+                .LogFaults("sync: preview fetch batch");
     }
 
     private async Task FetchAllPreviewsAsync(
@@ -119,7 +121,19 @@ public class SyncService : ISyncService
         foreach (var (account, folder, incoming) in jobs)
         {
             if (ct.IsCancellationRequested) return;
-            await FetchAndApplyPreviewsAsync(account, folder, incoming, ct);
+            try
+            {
+                await FetchAndApplyPreviewsAsync(account, folder, incoming, ct);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+            catch (Exception ex)
+            {
+                // One folder's preview failure must not kill the rest of the batch.
+                LogService.Log($"Preview fetch failed for {account.AccountLabel}/{folder.DisplayName}", ex);
+            }
         }
     }
 

--- a/QuickMail/Services/TemplateService.cs
+++ b/QuickMail/Services/TemplateService.cs
@@ -126,8 +126,6 @@ public class TemplateService : ITemplateService, IDisposable
     private async Task SaveAsyncLocked()
     {
         var json = JsonSerializer.Serialize(_cache, WriteOptions);
-        var tempPath = _filePath + ".tmp";
-        await File.WriteAllTextAsync(tempPath, json);
-        File.Move(tempPath, _filePath, overwrite: true);
+        await Helpers.AtomicFile.WriteAllTextAsync(_filePath, json);
     }
 }

--- a/QuickMail/Services/ViewService.cs
+++ b/QuickMail/Services/ViewService.cs
@@ -37,6 +37,7 @@ public class ViewService : IViewService
     public void Save(List<SavedView> views)
     {
         Directory.CreateDirectory(_dataFolder);
-        File.WriteAllText(_viewsFile, JsonSerializer.Serialize(views, JsonOptions));
+        // Atomic: a crash mid-write must not truncate views.json (all saved views).
+        Helpers.AtomicFile.WriteAllText(_viewsFile, JsonSerializer.Serialize(views, JsonOptions));
     }
 }

--- a/QuickMail/ViewModels/ComposeViewModel.cs
+++ b/QuickMail/ViewModels/ComposeViewModel.cs
@@ -8,7 +8,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
-using Microsoft.Win32;
 using MimeKit;
 using QuickMail.Helpers;
 using QuickMail.Models;
@@ -577,12 +576,19 @@ public partial class ComposeViewModel : ObservableObject, IDisposable
         StatusText = $"Template saved as '{template.Title}'.";
     }
 
+    /// <summary>
+    /// Set by the View to show a multi-select Open File dialog (CLAUDE.md MVVM rules:
+    /// Win32 dialogs are View-layer). Returns the chosen paths, or null when cancelled
+    /// or unwired (headless/tests).
+    /// </summary>
+    public Func<string[]?>? OpenFilePathsRequested { get; set; }
+
     [RelayCommand]
     private async Task AddAttachmentsAsync()
     {
-        var dlg = new OpenFileDialog { Multiselect = true, Title = "Add Attachments" };
-        if (dlg.ShowDialog() != true) return;
-        foreach (var path in dlg.FileNames)
+        var paths = OpenFilePathsRequested?.Invoke();
+        if (paths == null) return;
+        foreach (var path in paths)
             await AddAttachmentFromPathAsync(path);
     }
 
@@ -626,22 +632,22 @@ public partial class ComposeViewModel : ObservableObject, IDisposable
         }
     }
 
-    private static readonly string[] DangerousExtensions =
-        [".exe", ".bat", ".cmd", ".ps1", ".msi", ".scr", ".vbs", ".js", ".jar"];
-
     [RelayCommand]
-    private void OpenComposeAttachment(AttachmentModel? attachment)
+    private async Task OpenComposeAttachmentAsync(AttachmentModel? attachment)
     {
         if (attachment?.Content == null) return;
 
-        var ext = Path.GetExtension(attachment.FileName).ToLowerInvariant();
-        if (DangerousExtensions.Contains(ext))
+        // Sanitized: forwarded/replied attachments carry server-supplied names, so a
+        // crafted name (path separators, absolute path) must not escape the temp folder.
+        var safeFileName = AttachmentSafety.SanitizeFileName(attachment.FileName);
+
+        if (AttachmentSafety.IsDangerousExtension(safeFileName))
         {
             // CLAUDE.md MVVM Rules: ViewModels must not call MessageBox directly.
             // If the View hasn't wired a confirmation handler, treat that as deny so
             // we never silently open something potentially dangerous.
             var confirmed = ConfirmationRequested?.Invoke(
-                $"'{attachment.FileName}' is an executable file type. Opening it could be dangerous. Continue?",
+                $"'{safeFileName}' is an executable file type. Opening it could be dangerous. Continue?",
                 "Security Warning") ?? false;
             if (!confirmed) return;
         }
@@ -650,8 +656,8 @@ public partial class ComposeViewModel : ObservableObject, IDisposable
         // from different messages or sessions) don't overwrite each other in %TEMP%\QuickMail.
         var tempDir = Path.Combine(Path.GetTempPath(), "QuickMail", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(tempDir);
-        var tempPath = Path.Combine(tempDir, attachment.FileName);
-        File.WriteAllBytes(tempPath, attachment.Content);
+        var tempPath = Path.Combine(tempDir, safeFileName);
+        await File.WriteAllBytesAsync(tempPath, attachment.Content);
         Process.Start(new ProcessStartInfo(tempPath) { UseShellExecute = true });
     }
 

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -2445,7 +2445,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
                     Conversations = new ObservableCollection<ConversationGroup>(groups);
                 }
             });
-        });
+        }).LogFaults("conversation rebuild");
     }
 
     private void ScheduleSenderGroupRebuild()
@@ -2479,7 +2479,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
                     SenderGroups = new ObservableCollection<SenderGroup>(groups);
                 }
             });
-        });
+        }).LogFaults("sender group rebuild");
     }
 
     private void ScheduleToGroupRebuild()
@@ -2513,7 +2513,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
                     ToGroups = new ObservableCollection<SenderGroup>(groups);
                 }
             });
-        });
+        }).LogFaults("to-recipient group rebuild");
     }
 
     [RelayCommand]
@@ -4887,11 +4887,8 @@ public partial class MainViewModel : ObservableObject, IDisposable
     [RelayCommand]
     private void ViewUserGuide()
     {
-        Process.Start(new ProcessStartInfo
-        {
-            FileName = "https://kellylford.github.io/QuickMail/",
-            UseShellExecute = true
-        });
+        // All ShellExecute launches go through the allow-list. See ExternalUriPolicy.
+        Helpers.ExternalUriPolicy.TryOpenExternal("https://kellylford.github.io/QuickMail/");
     }
 #pragma warning restore CA1822
 

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -10,14 +10,13 @@ using System.Windows;
 using System.Windows.Input;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
-using Microsoft.Win32;
 using QuickMail.Helpers;
 using QuickMail.Models;
 using QuickMail.Services;
 
 namespace QuickMail.ViewModels;
 
-public partial class MainViewModel : ObservableObject
+public partial class MainViewModel : ObservableObject, IDisposable
 {
     private readonly IMailService _imap;
     private readonly IChangeNotifier? _changeNotifier;
@@ -34,6 +33,8 @@ public partial class MainViewModel : ObservableObject
     private readonly IFlagService? _flagService;
     private readonly ICalendarService? _calendarService;
     private readonly IUpdateCheckService? _updateCheckService;
+    // UI-thread marshaller — ViewModels must not touch Dispatcher directly (CLAUDE.md MVVM rules).
+    private readonly IUiDispatcher _ui;
 
     // Separate CTS per operation type so they can't cancel each other accidentally
     private CancellationTokenSource? _connectCts;
@@ -61,6 +62,33 @@ public partial class MainViewModel : ObservableObject
         var previous = Interlocked.Exchange(ref slot, cts);
         try { previous?.Cancel(); previous?.Dispose(); } catch { /* best effort */ }
         token = cts.Token;
+    }
+
+    /// <summary>
+    /// Called by MainWindow.OnClosed (app shutdown). Cancels all in-flight operations so
+    /// background work (sync, prefetch, message loads) unwinds via OperationCanceledException
+    /// instead of being killed with the process, then releases the CTS handles and timer.
+    /// </summary>
+    public void Dispose()
+    {
+        DrainCts(ref _connectCts);
+        DrainCts(ref _folderCts);
+        DrainCts(ref _messageLoadCts);
+        DrainCts(ref _messageActionCts);
+        DrainCts(ref _flagActionCts);
+        DrainCts(ref _prefetchCts);
+        DrainCts(ref _bgSyncCts);
+        _calendarHarvestTimer?.Dispose();
+        _calendarHarvestTimer = null;
+        GC.SuppressFinalize(this);
+    }
+
+    private static void DrainCts(ref CancellationTokenSource? slot)
+    {
+        var cts = Interlocked.Exchange(ref slot, null);
+        // Cancel before Dispose so in-flight tasks get OperationCanceledException
+        // rather than ObjectDisposedException.
+        try { cts?.Cancel(); cts?.Dispose(); } catch { /* best effort at shutdown */ }
     }
 
     // How many days of mail to sync (0 = all); set via the Sync Range menu
@@ -699,9 +727,11 @@ public partial class MainViewModel : ObservableObject
         IFlagService? flagService = null,
         ICalendarService? calendarService = null,
         IChangeNotifier? changeNotifier = null,
-        IUpdateCheckService? updateCheckService = null)
+        IUpdateCheckService? updateCheckService = null,
+        IUiDispatcher? uiDispatcher = null)
     {
         _imap            = imap;
+        _ui              = uiDispatcher ?? new WpfUiDispatcher();
         _changeNotifier  = changeNotifier;
         _accountService  = accountService;
         _credentials     = credentials;
@@ -1064,7 +1094,7 @@ public partial class MainViewModel : ObservableObject
             if (!IsCurrentFolderLoad(loadVersion, expectedFolder)) return;
 
             if (!OnlineMode && newMessages.Count > 0)
-                _ = _localStore.UpsertSummariesAsync(newMessages);
+                _localStore.UpsertSummariesAsync(newMessages).LogFaults("local store: upsert summaries");
 
             var count = Messages.Count;
             StatusText = count == 0
@@ -1362,7 +1392,7 @@ public partial class MainViewModel : ObservableObject
             if (_onReachabilityChanged != null)
                 _changeNotifier.AccountReachabilityChanged -= _onReachabilityChanged;
 
-            _onReachabilityChanged = (accountId, isReachable) => InvokeOnUi(() =>
+            _onReachabilityChanged = (accountId, isReachable) => _ui.Post(() =>
             {
                 var account = accountList.FirstOrDefault(a => a.Id == accountId);
                 if (account != null)
@@ -1649,7 +1679,7 @@ public partial class MainViewModel : ObservableObject
     // Called on a ThreadPool thread by the change notifier when new mail lands in an inbox.
     // Runs a targeted sync for that account's INBOX so the message appears in the list. Accounts and
     // _cachedFolders are UI-thread-owned, so resolve them on the UI thread before the background sync.
-    private void OnInboxNewMailDetected(Guid accountId) => InvokeOnUi(() =>
+    private void OnInboxNewMailDetected(Guid accountId) => _ui.Post(() =>
     {
         var account = Accounts.FirstOrDefault(a => a.Id == accountId);
         if (account is null) return;
@@ -1677,22 +1707,6 @@ public partial class MainViewModel : ObservableObject
             }
         });
     });
-
-    // Marshals a ThreadPool callback onto the UI thread. Runs inline when already on the UI thread,
-    // when there is no Application, or when the current Application is not the real QuickMail App
-    // (unit tests create a vanilla System.Windows.Application as the process-wide Application.Current
-    // on a StaFact STA thread that never runs a WPF message pump — InvokeAsync would queue work
-    // onto that pump-less dispatcher and it would never execute, causing 30s test timeouts).
-    // In production Application.Current is always a QuickMail.App with a pumped dispatcher, so the
-    // marshal path is taken exactly when it should be.
-    private static void InvokeOnUi(Action action)
-    {
-        var dispatcher = Application.Current is App app ? app.Dispatcher : null;
-        if (dispatcher is null || dispatcher.CheckAccess() || !dispatcher.Thread.IsAlive)
-            action();
-        else
-            dispatcher.InvokeAsync(action);
-    }
 
     private void OnMessagesRemoved(IReadOnlyList<MailMessageSummary> removed)
     {
@@ -2418,7 +2432,7 @@ public partial class MainViewModel : ObservableObject
                 _                           => built.OrderByDescending(g => g.Messages.Count > 0 ? g.Messages[0].Date : DateTimeOffset.MinValue),
             };
             var groups = ordered.ToList();
-            App.Current.Dispatcher.InvokeAsync(() =>
+            _ui.Post(() =>
             {
                 if (version == _conversationRebuildVersion)
                 {
@@ -2452,7 +2466,7 @@ public partial class MainViewModel : ObservableObject
                 _                           => built.OrderBy(g => g.SenderKey, StringComparer.OrdinalIgnoreCase),
             };
             var groups = ordered.ToList();
-            App.Current.Dispatcher.InvokeAsync(() =>
+            _ui.Post(() =>
             {
                 if (version == _senderGroupRebuildVersion)
                 {
@@ -2486,7 +2500,7 @@ public partial class MainViewModel : ObservableObject
                 _                           => built.OrderBy(g => g.SenderKey, StringComparer.OrdinalIgnoreCase),
             };
             var groups = ordered.ToList();
-            App.Current.Dispatcher.InvokeAsync(() =>
+            _ui.Post(() =>
             {
                 if (version == _toGroupRebuildVersion)
                 {
@@ -2706,7 +2720,7 @@ public partial class MainViewModel : ObservableObject
             SetMessages(list);
             StatusText = list.Count == 0 ? "No messages" : $"{list.Count} messages loaded.";
             if (!OnlineMode)
-                _ = _localStore.UpsertSummariesAsync(list);
+                _localStore.UpsertSummariesAsync(list).LogFaults("local store: upsert summaries");
 
             if (IsConversationsView)
                 ScheduleConversationRebuild();
@@ -2779,7 +2793,8 @@ public partial class MainViewModel : ObservableObject
             summary.HasAttachments = detail.Attachments.Count > 0;
             if (!OnlineMode)
             {
-                _ = _localStore.UpdateIsReadAsync(summary.AccountId, summary.FolderName, summary.MessageId, true);
+                _localStore.UpdateIsReadAsync(summary.AccountId, summary.FolderName, summary.MessageId, true)
+                    .LogFaults("local store: update is-read");
 
                 // Extract preview and persist if not already set.
                 if (string.IsNullOrEmpty(summary.Preview))
@@ -2789,7 +2804,8 @@ public partial class MainViewModel : ObservableObject
                     if (!string.IsNullOrEmpty(preview))
                     {
                         summary.Preview = preview;
-                        _ = _localStore.UpdatePreviewAsync(summary.AccountId, summary.FolderName, summary.MessageId, preview);
+                        _localStore.UpdatePreviewAsync(summary.AccountId, summary.FolderName, summary.MessageId, preview)
+                            .LogFaults("local store: update preview");
                     }
                 }
             }
@@ -3024,7 +3040,7 @@ public partial class MainViewModel : ObservableObject
 
                 SetMessages(repaired);
                 if (!OnlineMode)
-                    _ = _localStore.UpsertSummariesAsync(repaired);
+                    _localStore.UpsertSummariesAsync(repaired).LogFaults("local store: upsert repaired summaries");
 
                 var totalCount = Messages.Count;
                 StatusText = totalCount == 0
@@ -3077,7 +3093,7 @@ public partial class MainViewModel : ObservableObject
                 return;
 
             if (newMessages.Count > 0)
-                _ = _localStore.UpsertSummariesAsync(newMessages);
+                _localStore.UpsertSummariesAsync(newMessages).LogFaults("local store: upsert summaries");
 
             var count = Messages.Count;
             StatusText = count == 0
@@ -3481,7 +3497,7 @@ public partial class MainViewModel : ObservableObject
             if (!IsCurrentFolderLoad(loadVersion, expectedFolder)) return;
 
             if (newMessages.Count > 0)
-                _ = _localStore.UpsertSummariesAsync(newMessages);
+                _localStore.UpsertSummariesAsync(newMessages).LogFaults("local store: upsert summaries");
 
             var count = Messages.Count;
             StatusText = count == 0
@@ -3541,7 +3557,7 @@ public partial class MainViewModel : ObservableObject
                 ? $"No messages in {displayName}."
                 : $"{sorted.Count} messages in {displayName}.";
             if (!OnlineMode)
-                _ = _localStore.UpsertSummariesAsync(sorted);
+                _localStore.UpsertSummariesAsync(sorted).LogFaults("local store: upsert summaries");
         }
         catch (OperationCanceledException)
         {
@@ -3610,13 +3626,15 @@ public partial class MainViewModel : ObservableObject
         var label = unread.Count == 1 ? "message" : $"{unread.Count} messages";
         StatusText = $"Marked {label} as read.";
 
-        _ = _localStore.UpdateIsReadBatchAsync(
-            unread.Select(m => (m.AccountId, m.FolderName, m.MessageId)), true);
+        _localStore.UpdateIsReadBatchAsync(
+                unread.Select(m => (m.AccountId, m.FolderName, m.MessageId)), true)
+            .LogFaults("local store: update is-read batch");
 
         foreach (var group in unread.GroupBy(m => (m.AccountId, m.FolderName)))
         {
             var uids = group.Select(m => m.MessageId).ToList();
-            _ = _imap.MarkReadBatchAsync(group.Key.AccountId, group.Key.FolderName, uids);
+            _imap.MarkReadBatchAsync(group.Key.AccountId, group.Key.FolderName, uids)
+                .LogFaults($"mark read batch ({group.Key.FolderName}, {uids.Count} messages)");
         }
 
         return Task.CompletedTask;
@@ -4010,7 +4028,7 @@ public partial class MainViewModel : ObservableObject
                 using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
                 detail = await _imap.GetMessageDetailAsync(
                     summary.AccountId, summary.FolderName, summary.MessageId, cts.Token);
-                _ = _localStore.UpsertDetailAsync(detail);
+                _localStore.UpsertDetailAsync(detail).LogFaults("local store: upsert detail");
             }
 
             return detail;
@@ -4275,6 +4293,19 @@ public partial class MainViewModel : ObservableObject
     /// Parameters: message, title. Returns true when the user confirms.
     /// </summary>
     public Func<string, string, bool>? ConfirmationRequested { get; set; }
+
+    /// <summary>
+    /// Set by the View to show a Save File dialog (CLAUDE.md MVVM rules: Win32 dialogs
+    /// are View-layer). Parameter: suggested filename. Returns the chosen full path,
+    /// or null when cancelled or unwired (headless/tests).
+    /// </summary>
+    public Func<string, string?>? SaveFilePathRequested { get; set; }
+
+    /// <summary>
+    /// Set by the View to show a folder picker. Parameter: dialog title.
+    /// Returns the chosen folder path, or null when cancelled or unwired.
+    /// </summary>
+    public Func<string, string?>? SaveFolderPathRequested { get; set; }
 
     [RelayCommand]
     private async Task DeleteAccountAsync(AccountModel? account)
@@ -4866,9 +4897,6 @@ public partial class MainViewModel : ObservableObject
 
     // ── Attachment commands ─────────────────────────────────────────────────────
 
-    private static readonly string[] DangerousExtensions =
-        [".exe", ".bat", ".cmd", ".ps1", ".msi", ".scr", ".vbs", ".js", ".jar"];
-
     [RelayCommand]
     private async Task SaveAttachmentAsync(AttachmentModel? attachment)
     {
@@ -4895,13 +4923,11 @@ public partial class MainViewModel : ObservableObject
             IsBusy = false;
         }
 
-        var dlg = new SaveFileDialog
-        {
-            FileName = att.FileName,
-            Title    = "Save Attachment",
-        };
-        if (dlg.ShowDialog() != true) return;
-        await File.WriteAllBytesAsync(dlg.FileName, att.Content!);
+        // Sanitized: a crafted server-supplied name with path separators or invalid
+        // characters must not reach the dialog (or steer the write outside the chosen folder).
+        var savePath = SaveFilePathRequested?.Invoke(AttachmentSafety.SanitizeFileName(att.FileName));
+        if (savePath == null) return;
+        await File.WriteAllBytesAsync(savePath, att.Content!);
         StatusText = $"Saved {att.FileName}.";
     }
 
@@ -4910,9 +4936,8 @@ public partial class MainViewModel : ObservableObject
     {
         if (MessageDetail == null || MessageDetail.Attachments.Count == 0) return;
 
-        var dlg = new OpenFolderDialog { Title = "Choose folder to save attachments" };
-        if (dlg.ShowDialog() != true) return;
-        var folder = dlg.FolderName;
+        var folder = SaveFolderPathRequested?.Invoke("Choose folder to save attachments");
+        if (folder == null) return;
 
         IsBusy = true;
         StatusText = "Saving attachments…";
@@ -4928,10 +4953,9 @@ public partial class MainViewModel : ObservableObject
 
                 if (att.Content != null)
                 {
-                    // Strip directory components from the server-supplied filename to
-                    // prevent path traversal writing outside the chosen save folder.
-                    var safeFileName = Path.GetFileName(att.FileName);
-                    if (string.IsNullOrEmpty(safeFileName)) safeFileName = "attachment";
+                    // Sanitized so a crafted server-supplied filename can't write
+                    // outside the chosen save folder.
+                    var safeFileName = AttachmentSafety.SanitizeFileName(att.FileName);
                     await File.WriteAllBytesAsync(Path.Combine(folder, safeFileName), att.Content);
                 }
             }
@@ -4971,13 +4995,11 @@ public partial class MainViewModel : ObservableObject
             IsBusy = false;
         }
 
-        // Strip any directory components from the server-supplied filename to prevent
-        // path traversal (e.g. a crafted name like "../../Startup/evil.exe").
-        var safeFileName = Path.GetFileName(att.FileName);
-        if (string.IsNullOrEmpty(safeFileName)) safeFileName = "attachment";
+        // Sanitized so a crafted server-supplied name (e.g. "../../Startup/evil.exe")
+        // can't escape the temp folder.
+        var safeFileName = AttachmentSafety.SanitizeFileName(att.FileName);
 
-        var ext = Path.GetExtension(safeFileName).ToLowerInvariant();
-        if (DangerousExtensions.Contains(ext))
+        if (AttachmentSafety.IsDangerousExtension(safeFileName))
         {
             if (ConfirmationRequested?.Invoke(
                 $"'{safeFileName}' is an executable file type. Opening it could be dangerous. Continue?",
@@ -5005,7 +5027,7 @@ public partial class MainViewModel : ObservableObject
                 _changeNotifier.AccountReachabilityChanged -= _onReachabilityChanged;
 
             var accountList = Accounts.ToList();
-            _onReachabilityChanged = (accountId, isReachable) => InvokeOnUi(() =>
+            _onReachabilityChanged = (accountId, isReachable) => _ui.Post(() =>
             {
                 var account = accountList.FirstOrDefault(a => a.Id == accountId);
                 if (account != null)
@@ -5017,19 +5039,26 @@ public partial class MainViewModel : ObservableObject
             _changeNotifier.AccountReachabilityChanged += _onReachabilityChanged;
         }
 
-        // Reconnect any accounts that aren't already connected (e.g. newly added OAuth2 accounts)
+        // Reconnect any accounts that aren't already connected (e.g. newly added OAuth2 accounts).
+        // _cachedFolders is UI-thread-owned: snapshot the connected set here (still on the UI
+        // thread) and marshal every write back through _ui so the background loop never
+        // touches the dictionary directly.
+        var alreadyConnected = new HashSet<Guid>(_cachedFolders.Keys);
+        var accountsToConnect = Accounts.Where(a => !alreadyConnected.Contains(a.Id)).ToList();
         _ = Task.Run(async () =>
         {
-            foreach (var account in Accounts)
+            foreach (var account in accountsToConnect)
             {
-                if (_cachedFolders.ContainsKey(account.Id)) continue;
                 var result = await ConnectOneAccountAsync(account);
-                App.Current.Dispatcher.Invoke(() => ApplyAccountStatus(account, result.Folders));
-                if (result.Folders != null)
+                _ui.Invoke(() =>
                 {
-                    _cachedFolders[result.Id] = result.Folders;
-                    App.Current.Dispatcher.Invoke(RebuildFolderListFromCache);
-                }
+                    ApplyAccountStatus(account, result.Folders);
+                    if (result.Folders != null)
+                    {
+                        _cachedFolders[result.Id] = result.Folders;
+                        RebuildFolderListFromCache();
+                    }
+                });
             }
         });
     }
@@ -5277,7 +5306,7 @@ public partial class MainViewModel : ObservableObject
         // Reset the timer — if a previous harvest was pending, it gets pushed back 2s.
         _calendarHarvestTimer ??= new System.Threading.Timer(_ =>
         {
-            System.Windows.Application.Current?.Dispatcher.InvokeAsync(async () =>
+            _ui.Post(async () =>
             {
                 if (_calendarService == null || CalendarVm == null) return;
                 await _calendarService.RefreshAsync();
@@ -5300,8 +5329,10 @@ public partial class MainViewModel : ObservableObject
 #pragma warning restore CA1822
     {
         // The specific release when one was found; otherwise the general releases page.
+        // UpdateReleaseUrl comes from the GitHub API response, so route it through the
+        // external-URI allow-list like any other externally sourced link.
         var url = string.IsNullOrEmpty(UpdateReleaseUrl) ? ReleasesPageUrl : UpdateReleaseUrl;
-        Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
+        Helpers.ExternalUriPolicy.TryOpenExternal(url);
     }
 
     // Startup check: silent when already up to date (announcing "no updates" on every launch

--- a/QuickMail/Views/AboutDialog.xaml.cs
+++ b/QuickMail/Views/AboutDialog.xaml.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using System.Reflection;
 using System.Windows;
 using System.Windows.Navigation;
@@ -20,7 +19,8 @@ public partial class AboutDialog : Window
 
     private void LicenseLink_RequestNavigate(object sender, RequestNavigateEventArgs e)
     {
-        Process.Start(new ProcessStartInfo { FileName = e.Uri.AbsoluteUri, UseShellExecute = true });
+        // All ShellExecute launches go through the allow-list. See ExternalUriPolicy.
+        Helpers.ExternalUriPolicy.TryOpenExternal(e.Uri.AbsoluteUri);
         e.Handled = true;
     }
 }

--- a/QuickMail/Views/ComposeWindow.xaml.cs
+++ b/QuickMail/Views/ComposeWindow.xaml.cs
@@ -53,7 +53,7 @@ internal sealed class AddressSuggestion
     public AddressSuggestion(GroupModel g)   { Group   = g; }
 }
 
-[SuppressMessage("Design", "CA1001", Justification = "Window cleans up _autocompleteCts in OnClosing; WPF never calls Dispose on a Window, so implementing IDisposable would be dead code.")]
+[SuppressMessage("Design", "CA1001", Justification = "_autocompleteCts is cancelled and disposed in OnClosed; WPF never calls Dispose on a Window, so implementing IDisposable would be dead code.")]
 public partial class ComposeWindow : Window
 {
     private readonly ComposeViewModel   _vm;
@@ -128,6 +128,14 @@ public partial class ComposeWindow : Window
         vm.ConfirmationRequested = (message, title) =>
             MessageBox.Show(this, message, title, MessageBoxButton.YesNo, MessageBoxImage.Warning)
             == MessageBoxResult.Yes;
+
+        // Win32 file dialogs are View-layer (CLAUDE.md MVVM rules); the VM requests
+        // paths and the View owns the dialog.
+        vm.OpenFilePathsRequested = () =>
+        {
+            var dlg = new Microsoft.Win32.OpenFileDialog { Multiselect = true, Title = "Add Attachments" };
+            return dlg.ShowDialog(this) == true ? dlg.FileNames : null;
+        };
 
         // Wire the template picker so the VM stays out of System.Windows.
         vm.InsertTemplateRequested += () =>
@@ -233,8 +241,11 @@ public partial class ComposeWindow : Window
         var searchToken = _activeAddressControl.CurrentInputText.Trim();
         if (searchToken.Length < 1) { AutoCompletePopup.IsOpen = false; return; }
 
-        _autocompleteCts?.Cancel();
+        // Cancel and dispose the superseded CTS (its token was already captured by the
+        // in-flight search, which unwinds via OperationCanceledException).
+        var previous = _autocompleteCts;
         _autocompleteCts = new CancellationTokenSource();
+        try { previous?.Cancel(); previous?.Dispose(); } catch { /* best effort */ }
 
         try
         {
@@ -567,6 +578,10 @@ public partial class ComposeWindow : Window
 
     protected override void OnClosed(EventArgs e)
     {
+        // Cancel before Dispose so a still-running autocomplete search unwinds via
+        // OperationCanceledException rather than ObjectDisposedException.
+        try { _autocompleteCts?.Cancel(); _autocompleteCts?.Dispose(); } catch { /* best effort */ }
+        _autocompleteCts = null;
         _vm.Dispose();
         base.OnClosed(e);
     }

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -245,6 +245,22 @@ public partial class MainWindow : Window
         vm.ConfirmationRequested = (message, title) =>
             MessageBox.Show(message, title, MessageBoxButton.YesNo, MessageBoxImage.Warning)
             == MessageBoxResult.Yes;
+        // Win32 file dialogs are View-layer (CLAUDE.md MVVM rules); the VM requests a
+        // path and the View owns the dialog.
+        vm.SaveFilePathRequested = suggestedName =>
+        {
+            var dlg = new Microsoft.Win32.SaveFileDialog
+            {
+                FileName = suggestedName,
+                Title    = "Save Attachment",
+            };
+            return dlg.ShowDialog(this) == true ? dlg.FileName : null;
+        };
+        vm.SaveFolderPathRequested = title =>
+        {
+            var dlg = new Microsoft.Win32.OpenFolderDialog { Title = title };
+            return dlg.ShowDialog(this) == true ? dlg.FolderName : null;
+        };
         vm.RulesManagerRequested += (_, _) => OpenRulesManager();
         vm.CreateRuleFromMessageRequested += (_, template) => OpenRulesManager(template);
         vm.TutorialRequested += (_, _) => ShowTutorial();
@@ -490,6 +506,9 @@ public partial class MainWindow : Window
     {
         foreach (var w in _openComposeWindows.ToList())
             w.Close();
+        // Cancels all in-flight VM operations (sync, prefetch, loads) and releases
+        // their CTS handles. OnClosed, not OnClosing — the close cannot be cancelled here.
+        _vm.Dispose();
         base.OnClosed(e);
     }
 
@@ -2249,18 +2268,10 @@ public partial class MainWindow : Window
             _vm.DeclineInviteCommand.Execute(null);
     }
 
-    private static void OpenExternal(string uri)
-    {
-        if (string.IsNullOrWhiteSpace(uri)) return;
-        try
-        {
-            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(uri) { UseShellExecute = true });
-        }
-        catch (Exception ex)
-        {
-            LogService.Log($"OpenExternal {uri}", ex);
-        }
-    }
+    // Message content is untrusted; only allow-listed schemes (http/https/mailto)
+    // may leave the app via ShellExecute. See ExternalUriPolicy.
+    private static void OpenExternal(string uri) =>
+        Helpers.ExternalUriPolicy.TryOpenExternal(uri);
 
     // When the WebView2 host receives WPF keyboard focus (e.g. Tab from a header field),
     // push focus into the HTML document body so the user can read/navigate content.

--- a/QuickMail/Views/MarkdownPreviewWindow.xaml.cs
+++ b/QuickMail/Views/MarkdownPreviewWindow.xaml.cs
@@ -96,15 +96,9 @@ public partial class MarkdownPreviewWindow : Window
                     uri.StartsWith("about:", StringComparison.OrdinalIgnoreCase))
                     return;
                 args.Cancel = true;
-                if (!uri.StartsWith("data:", StringComparison.OrdinalIgnoreCase))
-                {
-                    try
-                    {
-                        System.Diagnostics.Process.Start(
-                            new System.Diagnostics.ProcessStartInfo(uri) { UseShellExecute = true });
-                    }
-                    catch { /* best effort */ }
-                }
+                // Only allow-listed schemes (http/https/mailto) may leave the app
+                // via ShellExecute; data: and everything else is dropped. See ExternalUriPolicy.
+                Helpers.ExternalUriPolicy.TryOpenExternal(uri);
             };
 
             PreviewBody.CoreWebView2.NavigateToString(_html);

--- a/QuickMail/Views/MessageWindow.xaml.cs
+++ b/QuickMail/Views/MessageWindow.xaml.cs
@@ -515,14 +515,8 @@ public partial class MessageWindow : Window
     /// </summary>
     public event EventHandler<MessageWindowViewModel>? MoveToMainWindowRequested;
 
-    private static void OpenExternal(string uri)
-    {
-        if (string.IsNullOrWhiteSpace(uri)) return;
-        try
-        {
-            System.Diagnostics.Process.Start(
-                new System.Diagnostics.ProcessStartInfo(uri) { UseShellExecute = true });
-        }
-        catch (Exception ex) { LogService.Log($"MessageWindow.OpenExternal {uri}", ex); }
-    }
+    // Message content is untrusted; only allow-listed schemes (http/https/mailto)
+    // may leave the app via ShellExecute. See ExternalUriPolicy.
+    private static void OpenExternal(string uri) =>
+        Helpers.ExternalUriPolicy.TryOpenExternal(uri);
 }


### PR DESCRIPTION
Fixes the findings from the Fable5CR comprehensive code review (#164), excluding finding #13 (AutomationProperties.Name text — deferred to be handled separately) and finding #6 (Microsoft Graph disposal — isolated on `fable5CR-graph` for @CityDweller's visibility, see the stacked PR).

## Security
- **New `Helpers/ExternalUriPolicy.cs`** — http/https/mailto allow-list for every URI that leaves the app via ShellExecute: reading-pane links, MessageWindow links, markdown preview, and the update-page URL from the GitHub API. Everything else is logged and dropped. Closes the hole where a crafted HTML message link (`file:`, `search-ms:`, any registered protocol) would launch its handler on activation.
- **New `Helpers/AttachmentSafety.cs`** — one shared filename sanitizer (strips directory components, invalid characters, trailing dots/spaces) and one expanded dangerous-extension list (adds `.lnk`, `.hta`, `.com`, `.pif`, `.wsf`, `.wsh`, `.vbe`, `.jse`, `.msc`, `.cpl`, `.reg`, `.scf`, `.chm`, `.application`, `.iso`, and more). Closes the path-traversal gap in ComposeViewModel's attachment open and removes the duplicated per-VM lists that had already drifted.
- **Sanitizer fails closed** — a regex timeout in any `StripHeavyHtml` pass now falls back to reader mode instead of rendering partially stripped HTML; a SECURITY NOTE documents that CSP is the actual boundary.

## Resource management
- `MainViewModel` implements `IDisposable` (7 CTS slots + calendar timer), disposed from `MainWindow.OnClosed`.
- ComposeWindow's autocomplete CTS is cancelled/disposed on replace and in `OnClosed`; its CA1001 justification now states what the code actually does.
- `ConfigService` writes `config.ini` and `hotkeys.json` atomically (temp file + rename) so a crash mid-write can't truncate settings.

## MVVM (CLAUDE.md enforced rules)
- **New `Services/IUiDispatcher`** replaces all Dispatcher calls in `MainViewModel`; the WPF implementation absorbs the App-aware `InvokeOnUi` logic so StaFact tests keep their pump-less-dispatcher protection.
- Win32 file dialogs moved out of ViewModels behind View-wired callbacks (`SaveFilePathRequested`, `SaveFolderPathRequested`, `OpenFilePathsRequested`).
- `_cachedFolders` writes now stay on the UI thread (snapshot before the reconnect loop, marshalled mutation).

## Reliability
- **New `Task.LogFaults(context)`** helper for deliberate fire-and-forget so failures are logged promptly instead of surfacing (maybe) at finalization; applied to local-store writes, mark-read batches, and the preview fetch batch.
- Per-folder catch in `SyncService` preview batch — one folder's failure no longer kills the rest.
- MSAL token-cache registration is lazy/async on first token use instead of sync-over-async in the OAuthService constructor.

## Tests
82 new tests: `ExternalUriPolicyTests`, `AttachmentSafetyTests`, sanitizer fail-closed cases in `MessageBodyHtmlBuilderTests`, `ConfigServiceSaveTests`, `MainViewModelLifecycleTests`, `ComposeViewModelAttachmentTests`, `TaskFaultLoggingTests`. Full suite: **879/879 passing**.

Suggested manual check: the Save Attachment / Save All / Add Attachments dialogs now open through View callbacks — behavior should be identical, but those paths have no automated UI coverage.

Closes #164 (together with the stacked Graph PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
