### PR TITLE
Dispose GraphMailService in App.OnExit (Fable5CR finding #6)

### DIFF
--- a/QuickMail/App.xaml.cs
+++ b/QuickMail/App.xaml.cs
@@ -18,6 +18,7 @@ public partial class App : Application
     private ChangeNotifierRouter? _changeNotifier;
     private GraphChangeNotifier? _graphNotifier;
     private ImapMailService? _imapBackend;
+    private GraphMailService? _graphBackend;
     private UpdateCheckService? _updateCheckService;
 
     protected override void OnStartup(StartupEventArgs e)
@@ -88,7 +89,8 @@ public partial class App : Application
             var oauthService      = new OAuthRouter(msOAuthService, googleOAuth);
             _imapBackend          = new ImapMailService(oauthService, configService);
             var imapBackend       = _imapBackend;
-            var graphBackend      = new GraphMailService(msOAuthService, configService);
+            _graphBackend         = new GraphMailService(msOAuthService, configService);
+            var graphBackend      = _graphBackend;
             _graphSendMail        = new GraphSendMailService(msOAuthService);
             var smtpService       = new SmtpService(oauthService, _graphSendMail);
 
@@ -165,6 +167,7 @@ public partial class App : Application
         _changeNotifier?.Dispose(); // stops all watchers (IDLE + Graph poll) + severs the event chain
         _graphNotifier?.Dispose();  // disposes the Graph poll CTS (StopWatchers already ran; idempotent)
         _imapBackend?.Dispose();    // closes connection pools (StopWatchers already ran, and is idempotent)
+        _graphBackend?.Dispose();   // releases GraphClient/HttpClient; after the notifiers, which poll through its client
         _graphSendMail?.Dispose();
         _contactService?.Dispose();
         _templateService?.Dispose();


### PR DESCRIPTION
Finding #6 from the Fable5CR code review (#164), isolated on its own branch because it touches the Microsoft Graph backend contributed by @CityDweller (Timothy Spaulding) — flagging for his visibility.

**What changed:** `GraphMailService` implements `IDisposable` (via `IMailService`) and its `Dispose()` releases the `GraphClient`, which owns an `HttpClient` — but `App.xaml.cs` created it as a local variable and never disposed it. This PR stores the instance in a field (`_graphBackend`) like the other backends and disposes it in `App.OnExit`, ordered after the change notifiers (which delta-poll through its `GraphClient`) have been disposed.

**No behavior change in the Graph code itself** — this is purely ownership/disposal wiring in the composition root.

Stacked on `fable5CR` (base of this PR) so it shows only the one Graph commit; merge that PR first.

Tests: all 53 Graph-related tests pass; full suite 879/879 on the base branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
