### PR TITLE
Clean up access-key underscores and show running version (#168, #169)

### DIFF
--- a/QuickMail/QuickMail.csproj
+++ b/QuickMail/QuickMail.csproj
@@ -9,6 +9,10 @@
     <Version>0.7.9</Version>
     <AssemblyVersion>0.7.9</AssemblyVersion>
     <FileVersion>0.7.9</FileVersion>
+    <!-- Keep the product/informational version clean digits. By default the SDK appends
+         "+<git commit sha>" to AssemblyInformationalVersion, which is what File Explorer's
+         Product version and screen readers report programmatically — so suppress it. -->
+    <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     <AnalysisMode>Recommended</AnalysisMode>
     <!-- Single-file publish: native DLLs (WebView2Loader, SQLite) extract to temp on first run -->
     <PublishSingleFile>true</PublishSingleFile>

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
@@ -453,12 +454,22 @@ public partial class MainViewModel : ObservableObject, IDisposable
     [ObservableProperty]
     private bool _showMessageStatus;
 
+    // Running version, clean digits (AssemblyVersion), e.g. "0.7.9". Same source the About dialog
+    // and update check use. Deliberately not the informational/product version, which the SDK can
+    // suffix with a git commit hash.
+    private static readonly string CurrentVersion =
+        Assembly.GetExecutingAssembly().GetName().Version?.ToString(3) ?? "0.0.0";
+
+    // Resting state of the update entry: no newer release, so surface the running version instead
+    // (issue #169) so the Help menu always answers "what am I running?".
+    private static readonly string NoUpdateText = $"No updates available — running version {CurrentVersion}";
+
     // Help-menu label for the update entry. Always shown so users know the check exists and is
-    // available on demand; "No updates available" is the resting state, replaced with the version
+    // available on demand; NoUpdateText is the resting state, replaced with the version
     // string when a newer release is found. UpdateReleaseUrl being non-empty is the signal that an
     // update is actually available (drives the status-bar button and the menu's activation behavior).
     [ObservableProperty]
-    private string _updateAvailableText = "No updates available";
+    private string _updateAvailableText = NoUpdateText;
 
     [ObservableProperty]
     private string _updateReleaseUrl = string.Empty;
@@ -5353,7 +5364,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
             }
             else
             {
-                UpdateAvailableText = "No updates available";
+                UpdateAvailableText = NoUpdateText;
                 UpdateReleaseUrl    = string.Empty;
             }
         }

--- a/QuickMail/Views/AccountManagerDialog.xaml
+++ b/QuickMail/Views/AccountManagerDialog.xaml
@@ -29,7 +29,7 @@
         <DockPanel Grid.Column="0" Grid.Row="0">
             <TextBlock DockPanel.Dock="Top" Text="Accounts" FontWeight="SemiBold" Margin="0,0,0,4"/>
             <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" Margin="0,4,0,0">
-                <Button Content="_New"
+                <Button Content="Ne_w"
                         Click="NewButton_Click"
                         AutomationProperties.Name="Add new account"
                         MinWidth="60" Margin="0,0,4,0"/>
@@ -185,13 +185,13 @@
                 <!-- SMTP Settings -->
                 <TextBlock Text="Outgoing Mail (SMTP)" FontWeight="SemiBold" Margin="0,0,0,6"/>
 
-                <Label x:Name="LblSmtpHost" Content="SMTP _Host:" Target="{Binding ElementName=SmtpHostBox}" Padding="0" Margin="0,4,0,2"/>
+                <Label x:Name="LblSmtpHost" Content="SMTP H_ost:" Target="{Binding ElementName=SmtpHostBox}" Padding="0" Margin="0,4,0,2"/>
                 <TextBox x:Name="SmtpHostBox"
                          Text="{Binding SmtpHost, UpdateSourceTrigger=PropertyChanged}"
                          AutomationProperties.LabeledBy="{Binding ElementName=LblSmtpHost}"
                          TabIndex="7"/>
 
-                <Label x:Name="LblSmtpPort" Content="SMTP _Port:" Target="{Binding ElementName=SmtpPortBox}" Padding="0" Margin="0,6,0,2"/>
+                <Label x:Name="LblSmtpPort" Content="SMTP Po_rt:" Target="{Binding ElementName=SmtpPortBox}" Padding="0" Margin="0,6,0,2"/>
                 <TextBox x:Name="SmtpPortBox"
                          Text="{Binding SmtpPort, UpdateSourceTrigger=PropertyChanged}"
                          AutomationProperties.LabeledBy="{Binding ElementName=LblSmtpPort}"
@@ -202,7 +202,7 @@
                           AutomationProperties.Name="SMTP implicit SSL on connect, port 465. Uncheck to use STARTTLS on port 587."
                           Margin="0,6" TabIndex="9"/>
 
-                <CheckBox Content="Accept invalid _certificates"
+                <CheckBox Content="Accept invalid certi_ficates"
                           IsChecked="{Binding SmtpAcceptInvalidCert}"
                           AutomationProperties.Name="SMTP accept invalid SSL certificates"
                           Margin="0,0,0,6" TabIndex="10"/>

--- a/QuickMail/Views/AccountManagerDialog.xaml
+++ b/QuickMail/Views/AccountManagerDialog.xaml
@@ -74,27 +74,31 @@
                 <TextBlock Text="Account Settings" FontWeight="SemiBold" FontSize="13" Margin="0,0,0,8"/>
 
                 <!-- Account Name -->
-                <TextBlock x:Name="LblAccountName" Text="_Account Name:" Margin="0,4,0,2"/>
-                <TextBox Text="{Binding AccountName, UpdateSourceTrigger=PropertyChanged}"
+                <Label x:Name="LblAccountName" Content="Account _Name:" Target="{Binding ElementName=AccountNameBox}" Padding="0" Margin="0,4,0,2"/>
+                <TextBox x:Name="AccountNameBox"
+                         Text="{Binding AccountName, UpdateSourceTrigger=PropertyChanged}"
                          AutomationProperties.LabeledBy="{Binding ElementName=LblAccountName}"
                          TabIndex="0"/>
 
                 <!-- Sender Display Name -->
-                <TextBlock x:Name="LblDisplayName" Text="Sender _Display Name:" Margin="0,8,0,2"/>
-                <TextBox Text="{Binding DisplayName, UpdateSourceTrigger=PropertyChanged}"
+                <Label x:Name="LblDisplayName" Content="Sender _Display Name:" Target="{Binding ElementName=DisplayNameBox}" Padding="0" Margin="0,8,0,2"/>
+                <TextBox x:Name="DisplayNameBox"
+                         Text="{Binding DisplayName, UpdateSourceTrigger=PropertyChanged}"
                          AutomationProperties.LabeledBy="{Binding ElementName=LblDisplayName}"
                          TabIndex="1"/>
 
                 <!-- Username -->
-                <TextBlock x:Name="LblUsername" Text="_Email / Username:" Margin="0,8,0,2"/>
-                <TextBox Text="{Binding Username, UpdateSourceTrigger=PropertyChanged}"
+                <Label x:Name="LblUsername" Content="_Email / Username:" Target="{Binding ElementName=UsernameBox}" Padding="0" Margin="0,8,0,2"/>
+                <TextBox x:Name="UsernameBox"
+                         Text="{Binding Username, UpdateSourceTrigger=PropertyChanged}"
                          AutomationProperties.LabeledBy="{Binding ElementName=LblUsername}"
                          TabIndex="2"/>
 
                 <!-- Authentication type — hidden for Microsoft 365 (Graph), which is always OAuth. -->
                 <StackPanel Visibility="{Binding IsImapBackend, Converter={StaticResource BoolToVisibility}}">
-                    <TextBlock x:Name="LblAuthType" Text="_Authentication:" Margin="0,8,0,2"/>
-                    <ComboBox SelectedIndex="{Binding AuthTypeIndex, Mode=TwoWay}"
+                    <Label x:Name="LblAuthType" Content="_Authentication:" Target="{Binding ElementName=AuthTypeCombo}" Padding="0" Margin="0,8,0,2"/>
+                    <ComboBox x:Name="AuthTypeCombo"
+                              SelectedIndex="{Binding AuthTypeIndex, Mode=TwoWay}"
                               AutomationProperties.LabeledBy="{Binding ElementName=LblAuthType}"
                               AutomationProperties.Name="Authentication method"
                               TabIndex="3">
@@ -106,7 +110,7 @@
 
                 <!-- Password panel -->
                 <StackPanel Visibility="{Binding IsPasswordAuth, Converter={StaticResource BoolToVisibility}}">
-                    <TextBlock x:Name="LblPassword" Text="_Password:" Margin="0,0,0,2"/>
+                    <Label x:Name="LblPassword" Content="_Password:" Target="{Binding ElementName=PasswordBox}" Padding="0" Margin="0,0,0,2"/>
                     <PasswordBox x:Name="PasswordBox"
                                  AutomationProperties.LabeledBy="{Binding ElementName=LblPassword}"
                                  AutomationProperties.HelpText="Password is stored in Windows Credential Manager"
@@ -154,13 +158,15 @@
                 <!-- IMAP Settings -->
                 <TextBlock Text="Incoming Mail (IMAP)" FontWeight="SemiBold" Margin="0,0,0,6"/>
 
-                <TextBlock x:Name="LblImapHost" Text="IMAP _Host:" Margin="0,4,0,2"/>
-                <TextBox Text="{Binding ImapHost, UpdateSourceTrigger=PropertyChanged}"
+                <Label x:Name="LblImapHost" Content="IMAP _Host:" Target="{Binding ElementName=ImapHostBox}" Padding="0" Margin="0,4,0,2"/>
+                <TextBox x:Name="ImapHostBox"
+                         Text="{Binding ImapHost, UpdateSourceTrigger=PropertyChanged}"
                          AutomationProperties.LabeledBy="{Binding ElementName=LblImapHost}"
                          TabIndex="4"/>
 
-                <TextBlock x:Name="LblImapPort" Text="IMAP _Port:" Margin="0,6,0,2"/>
-                <TextBox Text="{Binding ImapPort, UpdateSourceTrigger=PropertyChanged}"
+                <Label x:Name="LblImapPort" Content="IMAP _Port:" Target="{Binding ElementName=ImapPortBox}" Padding="0" Margin="0,6,0,2"/>
+                <TextBox x:Name="ImapPortBox"
+                         Text="{Binding ImapPort, UpdateSourceTrigger=PropertyChanged}"
                          AutomationProperties.LabeledBy="{Binding ElementName=LblImapPort}"
                          TabIndex="4"/>
 
@@ -179,13 +185,15 @@
                 <!-- SMTP Settings -->
                 <TextBlock Text="Outgoing Mail (SMTP)" FontWeight="SemiBold" Margin="0,0,0,6"/>
 
-                <TextBlock x:Name="LblSmtpHost" Text="SMTP H_ost:" Margin="0,4,0,2"/>
-                <TextBox Text="{Binding SmtpHost, UpdateSourceTrigger=PropertyChanged}"
+                <Label x:Name="LblSmtpHost" Content="SMTP _Host:" Target="{Binding ElementName=SmtpHostBox}" Padding="0" Margin="0,4,0,2"/>
+                <TextBox x:Name="SmtpHostBox"
+                         Text="{Binding SmtpHost, UpdateSourceTrigger=PropertyChanged}"
                          AutomationProperties.LabeledBy="{Binding ElementName=LblSmtpHost}"
                          TabIndex="7"/>
 
-                <TextBlock x:Name="LblSmtpPort" Text="SMTP Po_rt:" Margin="0,6,0,2"/>
-                <TextBox Text="{Binding SmtpPort, UpdateSourceTrigger=PropertyChanged}"
+                <Label x:Name="LblSmtpPort" Content="SMTP _Port:" Target="{Binding ElementName=SmtpPortBox}" Padding="0" Margin="0,6,0,2"/>
+                <TextBox x:Name="SmtpPortBox"
+                         Text="{Binding SmtpPort, UpdateSourceTrigger=PropertyChanged}"
                          AutomationProperties.LabeledBy="{Binding ElementName=LblSmtpPort}"
                          TabIndex="8"/>
 
@@ -194,7 +202,7 @@
                           AutomationProperties.Name="SMTP implicit SSL on connect, port 465. Uncheck to use STARTTLS on port 587."
                           Margin="0,6" TabIndex="9"/>
 
-                <CheckBox Content="Accept invalid certi_ficates"
+                <CheckBox Content="Accept invalid _certificates"
                           IsChecked="{Binding SmtpAcceptInvalidCert}"
                           AutomationProperties.Name="SMTP accept invalid SSL certificates"
                           Margin="0,0,0,6" TabIndex="10"/>
@@ -204,8 +212,9 @@
 
                 <!-- Signature -->
                 <TextBlock Text="Email Signature" FontWeight="SemiBold" Margin="0,0,0,6"/>
-                <TextBlock x:Name="LblSignature" Text="_Signature (plain text, appended to new messages):" Margin="0,4,0,2"/>
-                <TextBox Text="{Binding Signature, UpdateSourceTrigger=PropertyChanged}"
+                <Label x:Name="LblSignature" Content="_Signature (plain text, appended to new messages):" Target="{Binding ElementName=SignatureBox}" Padding="0" Margin="0,4,0,2"/>
+                <TextBox x:Name="SignatureBox"
+                         Text="{Binding Signature, UpdateSourceTrigger=PropertyChanged}"
                          AutomationProperties.LabeledBy="{Binding ElementName=LblSignature}"
                          AutomationProperties.HelpText="This text is automatically added to the end of new messages, replies, and forwards"
                          AcceptsReturn="True"

--- a/QuickMail/Views/AddAccountDialog.xaml
+++ b/QuickMail/Views/AddAccountDialog.xaml
@@ -148,13 +148,13 @@
 
                 <TextBlock Text="Outgoing Mail (SMTP)" FontWeight="SemiBold" Margin="0,0,0,6"/>
 
-                <Label x:Name="LblSmtpHost" Content="SMTP _Host:" Target="{Binding ElementName=SmtpHostBox}" Padding="0" Margin="0,4,0,2"/>
+                <Label x:Name="LblSmtpHost" Content="SMTP H_ost:" Target="{Binding ElementName=SmtpHostBox}" Padding="0" Margin="0,4,0,2"/>
                 <TextBox x:Name="SmtpHostBox"
                          Text="{Binding SmtpHost, UpdateSourceTrigger=PropertyChanged}"
                          AutomationProperties.LabeledBy="{Binding ElementName=LblSmtpHost}"
                          TabIndex="7"/>
 
-                <Label x:Name="LblSmtpPort" Content="SMTP _Port:" Target="{Binding ElementName=SmtpPortBox}" Padding="0" Margin="0,6,0,2"/>
+                <Label x:Name="LblSmtpPort" Content="SMTP Po_rt:" Target="{Binding ElementName=SmtpPortBox}" Padding="0" Margin="0,6,0,2"/>
                 <TextBox x:Name="SmtpPortBox"
                          Text="{Binding SmtpPort, UpdateSourceTrigger=PropertyChanged}"
                          AutomationProperties.LabeledBy="{Binding ElementName=LblSmtpPort}"
@@ -165,7 +165,7 @@
                           AutomationProperties.Name="SMTP implicit SSL on connect, port 465. Uncheck to use STARTTLS on port 587."
                           Margin="0,6" TabIndex="9"/>
 
-                <CheckBox Content="Accept invalid _certificates"
+                <CheckBox Content="Accept invalid certi_ficates"
                           IsChecked="{Binding SmtpAcceptInvalidCert}"
                           AutomationProperties.Name="SMTP accept invalid SSL certificates"
                           Margin="0,0,0,6" TabIndex="10"/>

--- a/QuickMail/Views/AddAccountDialog.xaml
+++ b/QuickMail/Views/AddAccountDialog.xaml
@@ -28,7 +28,7 @@
                 <!-- Backend selector — shown only when the feature gate offers more than one backend.
                      Default users (single backend) see no extra UI, identical to before. -->
                 <StackPanel Visibility="{Binding ShowBackendPicker, Converter={StaticResource BoolToVisibility}}">
-                    <TextBlock x:Name="LblBackend" Text="Account _Type:" Margin="0,0,0,2"/>
+                    <Label x:Name="LblBackend" Content="Account _Type:" Target="{Binding ElementName=BackendComboBox}" Padding="0" Margin="0,0,0,2"/>
                     <ComboBox x:Name="BackendComboBox"
                               ItemsSource="{Binding AvailableBackends}"
                               SelectedItem="{Binding SelectedBackend, Mode=TwoWay}"
@@ -40,26 +40,29 @@
 
                 <TextBlock Text="Account Details" FontWeight="SemiBold" FontSize="13" Margin="0,0,0,8"/>
 
-                <TextBlock x:Name="LblAccountName" Text="_Account Name:" Margin="0,4,0,2"/>
+                <Label x:Name="LblAccountName" Content="Account _Name:" Target="{Binding ElementName=AccountNameBox}" Padding="0" Margin="0,4,0,2"/>
                 <TextBox x:Name="AccountNameBox"
                          Text="{Binding AccountName, UpdateSourceTrigger=PropertyChanged}"
                          AutomationProperties.LabeledBy="{Binding ElementName=LblAccountName}"
                          TabIndex="0"/>
 
-                <TextBlock x:Name="LblDisplayName" Text="Sender _Display Name:" Margin="0,8,0,2"/>
-                <TextBox Text="{Binding DisplayName, UpdateSourceTrigger=PropertyChanged}"
+                <Label x:Name="LblDisplayName" Content="Sender _Display Name:" Target="{Binding ElementName=DisplayNameBox}" Padding="0" Margin="0,8,0,2"/>
+                <TextBox x:Name="DisplayNameBox"
+                         Text="{Binding DisplayName, UpdateSourceTrigger=PropertyChanged}"
                          AutomationProperties.LabeledBy="{Binding ElementName=LblDisplayName}"
                          TabIndex="1"/>
 
-                <TextBlock x:Name="LblUsername" Text="_Email / Username:" Margin="0,8,0,2"/>
-                <TextBox Text="{Binding Username, UpdateSourceTrigger=PropertyChanged}"
+                <Label x:Name="LblUsername" Content="_Email / Username:" Target="{Binding ElementName=UsernameBox}" Padding="0" Margin="0,8,0,2"/>
+                <TextBox x:Name="UsernameBox"
+                         Text="{Binding Username, UpdateSourceTrigger=PropertyChanged}"
                          AutomationProperties.LabeledBy="{Binding ElementName=LblUsername}"
                          TabIndex="2"/>
 
                 <!-- Authentication type — hidden for Microsoft 365 (Graph), which is always OAuth. -->
                 <StackPanel Visibility="{Binding IsImapBackend, Converter={StaticResource BoolToVisibility}}">
-                    <TextBlock x:Name="LblAuthType" Text="_Authentication:" Margin="0,8,0,2"/>
-                    <ComboBox SelectedIndex="{Binding AuthTypeIndex, Mode=TwoWay}"
+                    <Label x:Name="LblAuthType" Content="_Authentication:" Target="{Binding ElementName=AuthTypeCombo}" Padding="0" Margin="0,8,0,2"/>
+                    <ComboBox x:Name="AuthTypeCombo"
+                              SelectedIndex="{Binding AuthTypeIndex, Mode=TwoWay}"
                               AutomationProperties.LabeledBy="{Binding ElementName=LblAuthType}"
                               AutomationProperties.Name="Authentication method"
                               TabIndex="3">
@@ -71,7 +74,7 @@
 
                 <!-- Password panel (hidden for OAuth2) -->
                 <StackPanel Visibility="{Binding IsPasswordAuth, Converter={StaticResource BoolToVisibility}}">
-                    <TextBlock x:Name="LblPassword" Text="_Password:" Margin="0,0,0,2"/>
+                    <Label x:Name="LblPassword" Content="_Password:" Target="{Binding ElementName=PasswordBox}" Padding="0" Margin="0,0,0,2"/>
                     <PasswordBox x:Name="PasswordBox"
                                  AutomationProperties.LabeledBy="{Binding ElementName=LblPassword}"
                                  AutomationProperties.HelpText="Password is stored in Windows Credential Manager"
@@ -119,13 +122,15 @@
 
                 <TextBlock Text="Incoming Mail (IMAP)" FontWeight="SemiBold" Margin="0,0,0,6"/>
 
-                <TextBlock x:Name="LblImapHost" Text="IMAP _Host:" Margin="0,4,0,2"/>
-                <TextBox Text="{Binding ImapHost, UpdateSourceTrigger=PropertyChanged}"
+                <Label x:Name="LblImapHost" Content="IMAP _Host:" Target="{Binding ElementName=ImapHostBox}" Padding="0" Margin="0,4,0,2"/>
+                <TextBox x:Name="ImapHostBox"
+                         Text="{Binding ImapHost, UpdateSourceTrigger=PropertyChanged}"
                          AutomationProperties.LabeledBy="{Binding ElementName=LblImapHost}"
                          TabIndex="4"/>
 
-                <TextBlock x:Name="LblImapPort" Text="IMAP _Port:" Margin="0,6,0,2"/>
-                <TextBox Text="{Binding ImapPort, UpdateSourceTrigger=PropertyChanged}"
+                <Label x:Name="LblImapPort" Content="IMAP _Port:" Target="{Binding ElementName=ImapPortBox}" Padding="0" Margin="0,6,0,2"/>
+                <TextBox x:Name="ImapPortBox"
+                         Text="{Binding ImapPort, UpdateSourceTrigger=PropertyChanged}"
                          AutomationProperties.LabeledBy="{Binding ElementName=LblImapPort}"
                          TabIndex="4"/>
 
@@ -143,13 +148,15 @@
 
                 <TextBlock Text="Outgoing Mail (SMTP)" FontWeight="SemiBold" Margin="0,0,0,6"/>
 
-                <TextBlock x:Name="LblSmtpHost" Text="SMTP H_ost:" Margin="0,4,0,2"/>
-                <TextBox Text="{Binding SmtpHost, UpdateSourceTrigger=PropertyChanged}"
+                <Label x:Name="LblSmtpHost" Content="SMTP _Host:" Target="{Binding ElementName=SmtpHostBox}" Padding="0" Margin="0,4,0,2"/>
+                <TextBox x:Name="SmtpHostBox"
+                         Text="{Binding SmtpHost, UpdateSourceTrigger=PropertyChanged}"
                          AutomationProperties.LabeledBy="{Binding ElementName=LblSmtpHost}"
                          TabIndex="7"/>
 
-                <TextBlock x:Name="LblSmtpPort" Text="SMTP Po_rt:" Margin="0,6,0,2"/>
-                <TextBox Text="{Binding SmtpPort, UpdateSourceTrigger=PropertyChanged}"
+                <Label x:Name="LblSmtpPort" Content="SMTP _Port:" Target="{Binding ElementName=SmtpPortBox}" Padding="0" Margin="0,6,0,2"/>
+                <TextBox x:Name="SmtpPortBox"
+                         Text="{Binding SmtpPort, UpdateSourceTrigger=PropertyChanged}"
                          AutomationProperties.LabeledBy="{Binding ElementName=LblSmtpPort}"
                          TabIndex="8"/>
 
@@ -158,7 +165,7 @@
                           AutomationProperties.Name="SMTP implicit SSL on connect, port 465. Uncheck to use STARTTLS on port 587."
                           Margin="0,6" TabIndex="9"/>
 
-                <CheckBox Content="Accept invalid certi_ficates"
+                <CheckBox Content="Accept invalid _certificates"
                           IsChecked="{Binding SmtpAcceptInvalidCert}"
                           AutomationProperties.Name="SMTP accept invalid SSL certificates"
                           Margin="0,0,0,6" TabIndex="10"/>
@@ -168,8 +175,9 @@
 
                 <!-- Signature -->
                 <TextBlock Text="Email Signature" FontWeight="SemiBold" Margin="0,0,0,6"/>
-                <TextBlock x:Name="LblSignature" Text="_Signature (plain text, appended to new messages):" Margin="0,4,0,2"/>
-                <TextBox Text="{Binding Signature, UpdateSourceTrigger=PropertyChanged}"
+                <Label x:Name="LblSignature" Content="_Signature (plain text, appended to new messages):" Target="{Binding ElementName=SignatureBox}" Padding="0" Margin="0,4,0,2"/>
+                <TextBox x:Name="SignatureBox"
+                         Text="{Binding Signature, UpdateSourceTrigger=PropertyChanged}"
                          AutomationProperties.LabeledBy="{Binding ElementName=LblSignature}"
                          AutomationProperties.HelpText="This text is automatically added to the end of new messages, replies, and forwards"
                          AcceptsReturn="True"

--- a/QuickMail/Views/ComposeWindow.xaml
+++ b/QuickMail/Views/ComposeWindow.xaml
@@ -253,9 +253,11 @@
             </Grid.ColumnDefinitions>
 
             <!-- From -->
-            <TextBlock Grid.Row="0" Grid.Column="0"
-                       Text="Fro_m:"
-                       VerticalAlignment="Center" Margin="0,4"/>
+            <Label Grid.Row="0" Grid.Column="0"
+                   x:Name="FromLabel"
+                   Content="Fro_m:"
+                   Target="{Binding ElementName=FromCombo}"
+                   Padding="0" VerticalAlignment="Center" Margin="0,4"/>
             <ComboBox Grid.Row="0" Grid.Column="1"
                       x:Name="FromCombo"
                       ItemsSource="{Binding SenderAccounts}"
@@ -298,9 +300,10 @@
                      Margin="0,4" TabIndex="3"/>
 
             <!-- Subject -->
-            <TextBlock Grid.Row="4" Grid.Column="0"
-                       x:Name="SubjectLabel" Text="S_ubject:"
-                       VerticalAlignment="Center" Margin="0,4"/>
+            <Label Grid.Row="4" Grid.Column="0"
+                   x:Name="SubjectLabel" Content="S_ubject:"
+                   Target="{Binding ElementName=SubjectBox}"
+                   Padding="0" VerticalAlignment="Center" Margin="0,4"/>
             <TextBox Grid.Row="4" Grid.Column="1"
                      x:Name="SubjectBox"
                      Text="{Binding Subject, UpdateSourceTrigger=PropertyChanged}"

--- a/QuickMail/Views/InsertLinkDialog.xaml
+++ b/QuickMail/Views/InsertLinkDialog.xaml
@@ -17,18 +17,20 @@
             <ColumnDefinition Width="*"/>
         </Grid.ColumnDefinitions>
 
-        <TextBlock Grid.Row="0" Grid.Column="0"
-                   x:Name="UrlLabel" Text="_URL:"
-                   VerticalAlignment="Center" Margin="0,4,8,4"/>
+        <Label Grid.Row="0" Grid.Column="0"
+               x:Name="UrlLabel" Content="_URL:"
+               Target="{Binding ElementName=UrlBox}"
+               Padding="0" VerticalAlignment="Center" Margin="0,4,8,4"/>
         <TextBox Grid.Row="0" Grid.Column="1"
                  x:Name="UrlBox"
                  AutomationProperties.LabeledBy="{Binding ElementName=UrlLabel}"
                  Margin="0,4" TabIndex="0"
                  TextChanged="UrlBox_TextChanged"/>
 
-        <TextBlock Grid.Row="1" Grid.Column="0"
-                   x:Name="TextLabel" Text="_Display text:"
-                   VerticalAlignment="Center" Margin="0,4,8,4"/>
+        <Label Grid.Row="1" Grid.Column="0"
+               x:Name="TextLabel" Content="_Display text:"
+               Target="{Binding ElementName=DisplayTextBox}"
+               Padding="0" VerticalAlignment="Center" Margin="0,4,8,4"/>
         <TextBox Grid.Row="1" Grid.Column="1"
                  x:Name="DisplayTextBox"
                  AutomationProperties.LabeledBy="{Binding ElementName=TextLabel}"

--- a/QuickMail/Views/MainWindow.xaml
+++ b/QuickMail/Views/MainWindow.xaml
@@ -561,7 +561,7 @@
                     AutomationProperties.Name="Forward"
                     AutomationProperties.AcceleratorKey="Ctrl+F"
                     ToolTip="Forward (Ctrl+F)"
-                    Content="_Forward"/>
+                    Content="For_ward"/>
             <Separator/>
             <Button Style="{StaticResource ToolbarButton}"
                     Command="{Binding DeleteMessageCommand}"
@@ -575,7 +575,7 @@
                     AutomationProperties.Name="Refresh"
                     AutomationProperties.AcceleratorKey="F5"
                     ToolTip="Refresh (F5)"
-                    Content="Refres_h"/>
+                    Content="R_efresh"/>
             <Button x:Name="SyncRangeButton"
                     Style="{StaticResource ToolbarButton}"
                     Content="{Binding SyncRangeLabel}"
@@ -659,7 +659,7 @@
                     Command="{Binding ManageAccountsCommand}"
                     AutomationProperties.Name="Manage email accounts"
                     ToolTip="Manage email accounts"
-                    Content="Accoun_ts"/>
+                    Content="Ac_counts"/>
             <Separator/>
             <Button Style="{StaticResource ToolbarButton}"
                     Command="{Binding ViewUserGuideCommand}"


### PR DESCRIPTION
Fixes #168 and #169.

## #168 — Underscores riddling the UI

**Root cause.** Form field labels were `TextBlock`s with an underscore mnemonic (`Text="_Account Name:"`). `TextBlock` cannot process access-key mnemonics, so the underscore rendered **literally** on screen — and because each label is the field's `AutomationProperties.LabeledBy` source, a screen reader announced "underscore Account Name" as the field's name. The mnemonic letters were also self-colliding (`A` claimed by both `_Account` and `_Authentication`; `P` by both `_Password` and `_Port`), which is why some were shoved mid-word (`H_ost`, `Po_rt`).

**Fix.**
- Converted the broken label `TextBlock`s to `Label` + `Target` (the pattern `AddressBookWindow` already used correctly) with clean word-start mnemonics, in `AccountManagerDialog`, `AddAccountDialog`, `ComposeWindow` (From/Subject — kept the `m`/`u` letters that match the deliberate `Alt+M`/`Alt+U` code-behind), and `InsertLinkDialog`. The `LabeledBy`/`Target` associations render the mnemonic as an underline and give a clean accessible name.
- Reworked the toolbar mnemonics that collided with the top-level menu letters (F=File, M=Message, V=View, H=Help):

  | Button | Was | Now |
  |---|---|---|
  | Forward | `_Forward` (F ↔ File) | `For_ward` (Alt+W) |
  | Refresh | `Refres_h` (h ↔ Help) | `R_efresh` (Alt+E) |
  | Accounts | `Accoun_ts` (t ↔ Empty Trash) | `Ac_counts` (Alt+C) |

  Forward/Refresh can't be word-start because `F` is the File menu and `R` is Reply — an inherent constraint, not sloppiness. All toolbar buttons already carry clean `AutomationProperties.Name`s, so only the visible underline moved.
- Fixed the mid-word `certi_ficates` checkbox → `_certificates` in both account dialogs.
- **Menu mnemonics left untouched** — standard Windows convention, working, and not part of the report.

## #169 — Help update entry should show current version

The "check for updates" Help entry now appends the running version when up to date:
`No updates available — running version 0.7.9`.

While checking how the version is stored: the **informational/product version** (`AssemblyInformationalVersion`) — what File Explorer's *Product version* shows and what screen readers report programmatically — was `0.7.9+6cb1347…` because the SDK appends the git commit SHA by default. Set `IncludeSourceRevisionInInformationalVersion=false` so it's clean digits (`0.7.9`), matching `AssemblyVersion`/`FileVersion`. The displayed string uses `AssemblyVersion` (same source as the About dialog and the update check).

## Verification
- `dotnet build` clean (0 warnings / 0 errors)
- Full test suite: **925 passed, 0 failed** (incl. XAML-parse STA tests)
- Confirmed built `QuickMail.dll` ProductVersion is now `0.7.9` (was `0.7.9+<sha>`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)