### PR TITLE
Bump version to 0.7.9.1 and add release notes

### DIFF
--- a/QuickMail/Helpers/AppVersion.cs
+++ b/QuickMail/Helpers/AppVersion.cs
@@ -1,0 +1,23 @@
+using System.Reflection;
+
+namespace QuickMail.Helpers;
+
+/// <summary>
+/// The running application version as a display string, sourced from the assembly version.
+/// The 4th (revision) component is shown only when it is non-zero, so normal releases read
+/// "0.7.9" while a hotfix reads "0.7.9.1". Using this everywhere keeps the About dialog, the
+/// Help "running version" entry, the SMTP User-Agent, and the update check in agreement — and,
+/// because the update check parses this string, a hotfix build compares at full precision and
+/// does not mistake its own release for a newer one.
+/// </summary>
+public static class AppVersion
+{
+    public static string Display { get; } = Compute();
+
+    private static string Compute()
+    {
+        var v = Assembly.GetExecutingAssembly().GetName().Version;
+        if (v is null) return "0.0.0";
+        return v.Revision > 0 ? v.ToString(4) : v.ToString(3);
+    }
+}

--- a/QuickMail/QuickMail.csproj
+++ b/QuickMail/QuickMail.csproj
@@ -6,9 +6,9 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
-    <Version>0.7.9</Version>
-    <AssemblyVersion>0.7.9</AssemblyVersion>
-    <FileVersion>0.7.9</FileVersion>
+    <Version>0.7.9.1</Version>
+    <AssemblyVersion>0.7.9.1</AssemblyVersion>
+    <FileVersion>0.7.9.1</FileVersion>
     <!-- Keep the product/informational version clean digits. By default the SDK appends
          "+<git commit sha>" to AssemblyInformationalVersion, which is what File Explorer's
          Product version and screen readers report programmatically — so suppress it. -->

--- a/QuickMail/Services/MimeMessageBuilder.cs
+++ b/QuickMail/Services/MimeMessageBuilder.cs
@@ -2,7 +2,6 @@ using System;
 using System.Buffers.Text;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -20,8 +19,7 @@ namespace QuickMail.Services;
 public static class MimeMessageBuilder
 {
     /// <summary>The User-Agent string for outgoing mail — one source of truth for every sender.</summary>
-    internal static readonly string AppUserAgent =
-        "QuickMail/" + (Assembly.GetExecutingAssembly().GetName().Version?.ToString(3) ?? "0");
+    internal static readonly string AppUserAgent = "QuickMail/" + AppVersion.Display;
 
     /// <summary>
     /// Serializes a <see cref="MimeMessage"/> to base64-encoded ASCII bytes — the form Graph's

--- a/QuickMail/Services/UpdateCheckService.cs
+++ b/QuickMail/Services/UpdateCheckService.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Reflection;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -13,9 +12,10 @@ public class UpdateCheckService : IUpdateCheckService, IDisposable
 {
     private const string ApiUrl = "https://api.github.com/repos/kellylford/QuickMail/releases/latest";
 
-    // Reflection result is static for the lifetime of the app — compute once.
-    private static readonly string _currentVersion =
-        Assembly.GetExecutingAssembly().GetName().Version?.ToString(3) ?? "0.0.0";
+    // Reflection result is static for the lifetime of the app — compute once. Uses the shared
+    // display version so a hotfix build (e.g. 0.7.9.1) compares at full precision and does not
+    // treat its own release as a newer version.
+    private static readonly string _currentVersion = Helpers.AppVersion.Display;
 
     private readonly HttpClient _http;
     // Internal lifetime token: cancelled in Dispose() so an in-flight request on app exit

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -4,7 +4,6 @@ using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
@@ -454,11 +453,10 @@ public partial class MainViewModel : ObservableObject, IDisposable
     [ObservableProperty]
     private bool _showMessageStatus;
 
-    // Running version, clean digits (AssemblyVersion), e.g. "0.7.9". Same source the About dialog
-    // and update check use. Deliberately not the informational/product version, which the SDK can
-    // suffix with a git commit hash.
-    private static readonly string CurrentVersion =
-        Assembly.GetExecutingAssembly().GetName().Version?.ToString(3) ?? "0.0.0";
+    // Running version for the Help "running version" entry, e.g. "0.7.9" (or "0.7.9.1" for a
+    // hotfix). Shared with the About dialog and update check via AppVersion; deliberately not the
+    // informational/product version, which the SDK can suffix with a git commit hash.
+    private static readonly string CurrentVersion = Helpers.AppVersion.Display;
 
     // Resting state of the update entry: no newer release, so surface the running version instead
     // (issue #169) so the Help menu always answers "what am I running?".

--- a/QuickMail/Views/AboutDialog.xaml.cs
+++ b/QuickMail/Views/AboutDialog.xaml.cs
@@ -1,4 +1,3 @@
-using System.Reflection;
 using System.Windows;
 using System.Windows.Navigation;
 
@@ -12,8 +11,7 @@ public partial class AboutDialog : Window
     public AboutDialog()
     {
         InitializeComponent();
-        var version = Assembly.GetExecutingAssembly().GetName().Version?.ToString(3) ?? "0.6.6";
-        VersionText.Text = $"Version {version}";
+        VersionText.Text = $"Version {Helpers.AppVersion.Display}";
         Loaded += (_, _) => LicenseLink.Focus();
     }
 

--- a/docs/release-notes-v0.7.9.1.md
+++ b/docs/release-notes-v0.7.9.1.md
@@ -1,0 +1,52 @@
+# QuickMail v0.7.9.1 Release Notes
+
+## Download
+
+Two options are available for v0.7.9.1:
+
+| Download | When to use |
+|----------|-------------|
+| **`quickmail-v0.7.9.1-setup.exe`** — Windows installer | Recommended for most users. Installs per-user with no elevation required, checks for the WebView2 Runtime, and registers an uninstaller. |
+| **`QuickMail.exe`** — standalone portable executable | No installation required. Copy it anywhere and run. |
+
+Both downloads include the .NET 8 runtime — you do not need to install .NET separately.
+
+This is a small follow-up release on top of v0.7.9; there are no functional changes to mail handling.
+
+---
+
+## Bug Fixes
+
+- **Stray underscores across the interface are gone (issue #168).** In several places the interface showed literal underscore characters — field labels in the Manage Accounts and Add Account dialogs (for example "_Account Name", "SMTP H_ost"), the From and Subject labels in Compose, the Insert Link labels, and every button on the main toolbar ("_New", "Reply _All", "For_ward", "Refres_h"). Those underscores are the markers that turn a letter into a keyboard access key, and in these spots they were being drawn on screen instead of doing their job — which also meant a screen reader read the underscore aloud as part of the field name. Field labels now register their access key correctly (the underscore becomes an underline shown when you press Alt, and screen readers announce a clean name). Toolbar buttons no longer carry access keys at all, matching how standard Windows toolbars work — they read as plain text (New, Reply, Reply All, Forward, Delete, Refresh, Empty Trash, Accounts, User Guide) and are still reachable by their existing Ctrl shortcuts, tooltips, and Tab/arrow navigation.
+
+- **The Help menu now shows the running version (issue #169).** When you check for updates and you are already up to date, the entry reads "No updates available — running version 0.7.9.1", so you can always confirm which build you are on. The version reported to your screen reader and to File Explorer is now clean digits as well, rather than a long string with an appended build identifier.
+
+---
+
+## Thank You to Contributors
+
+Special thanks to **Brian Vogel (@britechguy)** for reporting issue #168, which flagged the stray underscores scattered through the interface. Those characters had lingered longer than they should have — a good reminder that even when you navigate QuickMail by screen reader every day, it is easy to stop noticing a rough edge you have walked past a hundred times. Thank you, Brian, for the careful eye and the clear report; this is exactly the kind of feedback that keeps the app honest and makes it better for everyone.
+
+Thank you, as always, to everyone who contributes to QuickMail through code, bug reports, feature suggestions, and other feedback.
+
+---
+
+## Internal
+
+### Access-key cleanup (issue #168)
+
+- **Field labels** in `AccountManagerDialog`, `AddAccountDialog`, `ComposeWindow` (From/Subject), and `InsertLinkDialog` were `TextBlock`s with underscore mnemonics. `TextBlock` does not process access keys, so the underscore rendered literally and, because each label is the field's `AutomationProperties.LabeledBy` source, a screen reader announced "underscore Account Name" as the field name. They are now `Label` controls with a `Target` binding (the pattern `AddressBookWindow` already used), so the mnemonic renders as an underline and the accessible name is clean.
+
+- **Mnemonic letters were reworked** to remove access-key collisions (both within the dialogs and against the top-level menu letters), rather than the earlier self-colliding scheme that forced mid-word placements.
+
+- **Toolbar buttons** rendered their underscores literally because a WPF `ToolBar` re-templates its child buttons with a flat template whose `ContentPresenter` leaves `RecognizesAccessKey = false`. Verified with a `RenderTargetBitmap` probe: plain buttons, menu items, and labels recognize the key; only `ToolBar` children do not. Rather than force the mnemonic through `AccessText`, the toolbar access keys were removed — every toolbar button already has a Ctrl accelerator, a tooltip, and an `AutomationProperties.Name`. Menu (`MenuItem.Header`) mnemonics were left unchanged, as they render correctly and are standard.
+
+### Running version and version reporting (issue #169)
+
+- The Help "check for updates" entry now appends the running version at rest, sourced from a shared `Helpers.AppVersion.Display` helper.
+- `IncludeSourceRevisionInInformationalVersion` is set to `false`, so the informational/product version is clean digits (`0.7.9.1`) instead of `0.7.9.1+<git sha>` — that value is what File Explorer's Product version and screen readers report programmatically.
+- `AppVersion.Display` shows the 4th (revision) component only when it is non-zero, so normal releases read "0.7.9" and a hotfix reads "0.7.9.1". It is used by the About dialog, the Help entry, the SMTP User-Agent, and the update check. Because the update check parses this string, the hotfix build compares at full precision and does not mistake its own release for a newer one.
+
+### Version
+
+- Bumped to `0.7.9.1` (`Version`, `AssemblyVersion`, `FileVersion`).


### PR DESCRIPTION
Hotfix release rolling up the #168 (underscore cleanup) and #169 (running version) work already merged to main.

## Changes
- `Version` / `AssemblyVersion` / `FileVersion` → **0.7.9.1**
- New `Helpers.AppVersion.Display` — shows the 4th (revision) component only when non-zero, so normal releases read `0.7.9` and a hotfix reads `0.7.9.1`. Now used by the About dialog, the Help "running version" entry, the SMTP User-Agent, and the update check.
  - **Why it matters:** the running-version display (added in #169) now correctly shows `0.7.9.1`, and the update check compares at full precision — a 0.7.9.1 build no longer risks treating its own release as a newer version (a latent issue with the old `ToString(3)` truncation on a 4-part version).
- `docs/release-notes-v0.7.9.1.md` added, matching the v0.7.8.1 hotfix format, with a thank-you to the issue #168 reporter.

## Verification
- Build clean (0 warnings / 0 errors)
- Full test suite: **925 passed, 0 failed**
- Confirmed the built assembly reports `0.7.9.1` and `AppVersion.Display` = `0.7.9.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)