### PR TITLE
Theming and visual design system (spec #177, all phases)

### DIFF
--- a/QuickMail.Tests/AppearanceSettingsTests.cs
+++ b/QuickMail.Tests/AppearanceSettingsTests.cs
@@ -1,0 +1,155 @@
+using System;
+using System.IO;
+using System.Linq;
+using QuickMail.Services;
+using QuickMail.ViewModels;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>Appearance settings: config.ini round-trip and SettingsViewModel persistence.</summary>
+public class AppearanceSettingsTests
+{
+    private static ProfileContext MakeTempProfile()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"QM-Appearance-{Guid.NewGuid():N}");
+        return new ProfileContext(tempDir);
+    }
+
+    // ── ConfigService round-trip ──────────────────────────────────────────────
+
+    [Fact]
+    public void AppearanceKeys_RoundTripThroughConfigIni()
+    {
+        var profile = MakeTempProfile();
+        var service = new ConfigService(profile);
+
+        var config = service.Load();
+        config.AppearanceThemeId = "ember";
+        config.AppearanceTextScale = 1.5;
+        config.AppearanceFontFamily = "Verdana";
+        config.AppearanceUnderlineLinks = true;
+        config.AppearanceThickFocus = true;
+        config.AppearanceForceMessageTheme = true;
+        service.Save(config);
+
+        var reloaded = new ConfigService(profile).Load();
+        Assert.Equal("ember", reloaded.AppearanceThemeId);
+        Assert.Equal(1.5, reloaded.AppearanceTextScale);
+        Assert.Equal("Verdana", reloaded.AppearanceFontFamily);
+        Assert.True(reloaded.AppearanceUnderlineLinks);
+        Assert.True(reloaded.AppearanceThickFocus);
+        Assert.True(reloaded.AppearanceForceMessageTheme);
+    }
+
+    [Fact]
+    public void FreshConfig_DefaultsToSystemThemeAtHundredPercent()
+    {
+        var profile = MakeTempProfile();
+        var config = new ConfigService(profile).Load();
+
+        Assert.Equal("system", config.AppearanceThemeId);
+        Assert.Equal(1.0, config.AppearanceTextScale);
+        Assert.Equal(string.Empty, config.AppearanceFontFamily);
+        Assert.False(config.AppearanceUnderlineLinks);
+        Assert.False(config.AppearanceThickFocus);
+        Assert.False(config.AppearanceForceMessageTheme);
+
+        // The written file documents the theme setting for hand-editing.
+        var ini = File.ReadAllText(Path.Combine(profile.ProfileDir, "config.ini"));
+        Assert.Contains("AppearanceThemeId = system", ini);
+    }
+
+    [Fact]
+    public void TextScale_OutOfRangeValue_IsClampedOnLoad()
+    {
+        var profile = MakeTempProfile();
+        var service = new ConfigService(profile);
+        service.Save(service.Load()); // write defaults
+
+        var path = Path.Combine(profile.ProfileDir, "config.ini");
+        var ini = File.ReadAllText(path).Replace("AppearanceTextScale = 1", "AppearanceTextScale = 9");
+        File.WriteAllText(path, ini);
+
+        Assert.Equal(2.0, new ConfigService(profile).Load().AppearanceTextScale);
+    }
+
+    // ── SettingsViewModel ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void SettingsViewModel_LoadsAppearanceFields()
+    {
+        var config = new StubConfigService();
+        var cfg = config.Load();
+        cfg.AppearanceThemeId = "dark";
+        cfg.AppearanceTextScale = 1.25;
+        cfg.AppearanceFontFamily = "Verdana";
+        cfg.AppearanceUnderlineLinks = true;
+        config.Save(cfg);
+
+        var vm = new SettingsViewModel(config, new StubCommandRegistry(),
+            new StubThemeService(), ["Arial", "Verdana"]);
+
+        Assert.Equal("dark", vm.AppearanceThemeId);
+        Assert.Equal(125, vm.AppearanceTextScalePercent);
+        Assert.Equal("Verdana", vm.AppearanceFontOption);
+        Assert.True(vm.AppearanceUnderlineLinks);
+        Assert.Contains(vm.ThemeOptions, t => t.Id == "system");
+        Assert.Equal(SettingsViewModel.ThemeDefaultFontLabel, vm.FontOptions[0]);
+    }
+
+    [Fact]
+    public void SettingsViewModel_Save_PersistsAppearanceFields()
+    {
+        var config = new StubConfigService();
+        var vm = new SettingsViewModel(config, new StubCommandRegistry(),
+            new StubThemeService(), ["Arial", "Verdana"]);
+
+        vm.AppearanceThemeId = "heather";
+        vm.AppearanceTextScalePercent = 150;
+        vm.AppearanceFontOption = "Arial";
+        vm.AppearanceUnderlineLinks = true;
+        vm.AppearanceThickFocus = true;
+        vm.AppearanceForceMessageTheme = true;
+        vm.SaveCommand.Execute(null);
+
+        var saved = config.Load();
+        Assert.Equal("heather", saved.AppearanceThemeId);
+        Assert.Equal(1.5, saved.AppearanceTextScale);
+        Assert.Equal("Arial", saved.AppearanceFontFamily);
+        Assert.True(saved.AppearanceUnderlineLinks);
+        Assert.True(saved.AppearanceThickFocus);
+        Assert.True(saved.AppearanceForceMessageTheme);
+    }
+
+    [Fact]
+    public void SettingsViewModel_ThemeDefaultFontOption_SavesEmptyString()
+    {
+        var config = new StubConfigService();
+        var cfg = config.Load();
+        cfg.AppearanceFontFamily = "Verdana";
+        config.Save(cfg);
+
+        var vm = new SettingsViewModel(config, new StubCommandRegistry(),
+            new StubThemeService(), ["Verdana"]);
+        vm.AppearanceFontOption = SettingsViewModel.ThemeDefaultFontLabel;
+        vm.SaveCommand.Execute(null);
+
+        Assert.Equal(string.Empty, config.Load().AppearanceFontFamily);
+    }
+
+    [Fact]
+    public void SettingsViewModel_UninstalledConfiguredFont_StaysSelectable()
+    {
+        var config = new StubConfigService();
+        var cfg = config.Load();
+        cfg.AppearanceFontFamily = "Some Missing Font";
+        config.Save(cfg);
+
+        var vm = new SettingsViewModel(config, new StubCommandRegistry(),
+            new StubThemeService(), ["Arial"]);
+
+        Assert.Equal("Some Missing Font", vm.AppearanceFontOption);
+        Assert.Contains("Some Missing Font", vm.FontOptions);
+    }
+}

--- a/QuickMail.Tests/BuiltInThemeTests.cs
+++ b/QuickMail.Tests/BuiltInThemeTests.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using QuickMail.Models;
+using QuickMail.Services;
+using QuickMail.Theming;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// Every built-in theme must parse from its embedded resource and — resolved
+/// against its base — pass the WCAG contrast policy from the theming spec §6.
+/// Contrast is a unit test, not a review comment: a palette change that breaks
+/// AA fails the build.
+/// </summary>
+public class BuiltInThemeTests
+{
+    private static ThemeStore NewStore()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), $"QM-ThemeTests-{Guid.NewGuid():N}");
+        return new ThemeStore(new ProfileContext(dir));
+    }
+
+    private static IReadOnlyList<ThemeDefinition> ResolvedBuiltIns()
+    {
+        var store = NewStore();
+        var builtIns = store.LoadBuiltIns();
+        var light = builtIns.First(t => t.Id == "quill");
+        var dark  = builtIns.First(t => t.Id == "dark");
+        return builtIns.Select(t => t.ResolveAgainst(t.Base == "dark" ? dark : light)).ToList();
+    }
+
+    [Fact]
+    public void AllBuiltInsParse_AndCarryTheExpectedLineup()
+    {
+        var ids = NewStore().LoadBuiltIns().Select(t => t.Id).ToList();
+        Assert.Equal(new[] { "quill", "dark", "ember", "fjord", "heather" }, ids);
+    }
+
+    [Fact]
+    public void BaseThemes_DefineEveryToken()
+    {
+        var builtIns = NewStore().LoadBuiltIns();
+        foreach (var id in new[] { "quill", "dark" })
+        {
+            var theme = builtIns.First(t => t.Id == id);
+            var missing = ThemeKeys.ColorTokens.Keys.Where(k => !theme.Colors.ContainsKey(k)).ToList();
+            Assert.True(missing.Count == 0, $"{id} is missing tokens: {string.Join(", ", missing)}");
+        }
+    }
+
+    [Fact]
+    public void EveryBuiltIn_ResolvesToACompleteTheme()
+    {
+        foreach (var theme in ResolvedBuiltIns())
+            Assert.True(theme.IsComplete, $"{theme.Id} did not resolve to a complete token set");
+    }
+
+    // ── WCAG contrast policy (§6) ─────────────────────────────────────────────
+
+    public static IEnumerable<object[]> BuiltInIds() =>
+        new[] { "quill", "dark", "ember", "fjord", "heather" }.Select(id => new object[] { id });
+
+    [Theory]
+    [MemberData(nameof(BuiltInIds))]
+    public void ContrastPolicy_TextTokens_MeetAA(string id)
+    {
+        var t = ResolvedBuiltIns().First(x => x.Id == id);
+        var backgrounds = new[] { "windowBackground", "surfaceBackground", "chromeBackground", "inputBackground" };
+
+        foreach (var bg in backgrounds)
+        {
+            AssertContrast(t, "textPrimary", bg, 4.5);
+            AssertContrast(t, "textSecondary", bg, 4.5);
+            // Disabled text is exempt from AA per WCAG, but must stay perceivable.
+            AssertContrast(t, "textDisabled", bg, 3.0);
+            AssertContrast(t, "hyperlink", bg, 4.5);
+        }
+
+        AssertContrast(t, "textOnAccent", "accent", 4.5);
+        AssertContrast(t, "selectionText", "selectionBackground", 4.5);
+    }
+
+    [Theory]
+    [MemberData(nameof(BuiltInIds))]
+    public void ContrastPolicy_NonTextIndicators_MeetThreeToOne(string id)
+    {
+        var t = ResolvedBuiltIns().First(x => x.Id == id);
+        foreach (var bg in new[] { "windowBackground", "surfaceBackground" })
+        {
+            AssertContrast(t, "accent", bg, 3.0);
+            AssertContrast(t, "focusIndicator", bg, 3.0);
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(BuiltInIds))]
+    public void ContrastPolicy_StatusColors_MeetAA(string id)
+    {
+        var t = ResolvedBuiltIns().First(x => x.Id == id);
+        foreach (var status in new[] { "error", "warning", "success", "info" })
+        {
+            AssertContrast(t, status, status + "Background", 4.5);
+            AssertContrast(t, status, "windowBackground", 4.5);
+        }
+    }
+
+    private static void AssertContrast(ThemeDefinition theme, string fg, string bg, double minimum)
+    {
+        var ratio = ContrastRatio(theme.ColorOf(fg), theme.ColorOf(bg));
+        Assert.True(ratio >= minimum,
+            $"{theme.Id}: {fg} ({theme.ColorOf(fg)}) on {bg} ({theme.ColorOf(bg)}) is {ratio:F2}:1, needs {minimum}:1");
+    }
+
+    // WCAG 2.x relative luminance and contrast ratio.
+    private static double ContrastRatio(string hexA, string hexB)
+    {
+        var la = RelativeLuminance(hexA);
+        var lb = RelativeLuminance(hexB);
+        var (light, dark) = la >= lb ? (la, lb) : (lb, la);
+        return (light + 0.05) / (dark + 0.05);
+    }
+
+    private static double RelativeLuminance(string hex)
+    {
+        var (_, r, g, b) = ThemeDefinition.HexToArgb(hex);
+        return 0.2126 * Linear(r) + 0.7152 * Linear(g) + 0.0722 * Linear(b);
+    }
+
+    private static double Linear(byte channel)
+    {
+        var c = channel / 255.0;
+        return c <= 0.03928 ? c / 12.92 : Math.Pow((c + 0.055) / 1.055, 2.4);
+    }
+}

--- a/QuickMail.Tests/BuiltInThemeTests.cs
+++ b/QuickMail.Tests/BuiltInThemeTests.cs
@@ -27,7 +27,7 @@ public class BuiltInThemeTests
     {
         var store = NewStore();
         var builtIns = store.LoadBuiltIns();
-        var light = builtIns.First(t => t.Id == "quill");
+        var light = builtIns.First(t => t.Id == "parchment");
         var dark  = builtIns.First(t => t.Id == "dark");
         return builtIns.Select(t => t.ResolveAgainst(t.Base == "dark" ? dark : light)).ToList();
     }
@@ -36,14 +36,14 @@ public class BuiltInThemeTests
     public void AllBuiltInsParse_AndCarryTheExpectedLineup()
     {
         var ids = NewStore().LoadBuiltIns().Select(t => t.Id).ToList();
-        Assert.Equal(new[] { "quill", "dark", "ember", "fjord", "heather" }, ids);
+        Assert.Equal(new[] { "parchment", "dark", "ember", "fjord", "heather" }, ids);
     }
 
     [Fact]
     public void BaseThemes_DefineEveryToken()
     {
         var builtIns = NewStore().LoadBuiltIns();
-        foreach (var id in new[] { "quill", "dark" })
+        foreach (var id in new[] { "parchment", "dark" })
         {
             var theme = builtIns.First(t => t.Id == id);
             var missing = ThemeKeys.ColorTokens.Keys.Where(k => !theme.Colors.ContainsKey(k)).ToList();
@@ -61,7 +61,7 @@ public class BuiltInThemeTests
     // ── WCAG contrast policy (§6) ─────────────────────────────────────────────
 
     public static IEnumerable<object[]> BuiltInIds() =>
-        new[] { "quill", "dark", "ember", "fjord", "heather" }.Select(id => new object[] { id });
+        new[] { "parchment", "dark", "ember", "fjord", "heather" }.Select(id => new object[] { id });
 
     [Theory]
     [MemberData(nameof(BuiltInIds))]

--- a/QuickMail.Tests/MessageBodyHtmlBuilderTests.cs
+++ b/QuickMail.Tests/MessageBodyHtmlBuilderTests.cs
@@ -80,7 +80,7 @@ public class MessageBodyHtmlBuilderTests
             "<div style=\"color:red\"><p onclick=\"x()\">content</p></div>", 5000));
 
         var ok = MessageBodyHtmlBuilder.TryBuildSanitizedHtmlDocument(
-            "Subject", html, System.TimeSpan.FromTicks(1), out var document);
+            "Subject", html, themeCss: null, System.TimeSpan.FromTicks(1), out var document);
 
         // The partially stripped document must be discarded, never rendered.
         Assert.False(ok);

--- a/QuickMail.Tests/StubServices.cs
+++ b/QuickMail.Tests/StubServices.cs
@@ -291,3 +291,83 @@ sealed class StubUiDispatcher : IUiDispatcher
     public void Invoke(Action action) => action();
     public void Post(Action action) => action();
 }
+
+/// <summary>
+/// In-memory theme service: a fixed light theme, no OS probes, no Application
+/// resources. Records applied ids so tests can assert theme switching.
+/// </summary>
+sealed class StubThemeService : IThemeService
+{
+    private readonly List<ThemeDefinition> _userThemes = [];
+
+    public string ConfiguredThemeId { get; private set; } = "system";
+    public bool IsHighContrastActive { get; set; }
+    public string UserThemesFolder { get; set; } = string.Empty;
+    public List<string> AppliedThemeIds { get; } = [];
+
+    public event EventHandler? ThemeChanged;
+
+    public ThemeDefinition ResolvedTheme { get; set; } = BuildDefaultResolved();
+
+    private static ThemeDefinition BuildDefaultResolved()
+    {
+        var theme = new ThemeDefinition { Id = "quill", Name = "Quill", Base = "light", IsBuiltIn = true };
+        foreach (var key in QuickMail.Theming.ThemeKeys.ColorTokens.Keys)
+            theme.Colors[key] = "#000000";
+        return theme;
+    }
+
+    public IReadOnlyList<ThemeDefinition> GetAvailableThemes()
+    {
+        var list = new List<ThemeDefinition>
+        {
+            new() { Id = "system", Name = "System", Base = "light", IsBuiltIn = true },
+            new() { Id = "quill",  Name = "Quill",  Base = "light", IsBuiltIn = true },
+            new() { Id = "dark",   Name = "Quill Dark", Base = "dark", IsBuiltIn = true },
+        };
+        list.AddRange(_userThemes);
+        return list;
+    }
+
+    public void ApplyTheme(string themeId)
+    {
+        ConfiguredThemeId = themeId;
+        AppliedThemeIds.Add(themeId);
+        ThemeChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    public ThemeDefinition ImportTheme(string filePath)
+    {
+        var theme = ThemeDefinition.Parse(System.IO.File.ReadAllText(filePath));
+        _userThemes.Add(theme);
+        return theme;
+    }
+
+    public void ExportTheme(string themeId, string filePath)
+    {
+        ThemeDefinition? theme = null;
+        foreach (var t in GetAvailableThemes())
+            if (string.Equals(t.Id, themeId, StringComparison.OrdinalIgnoreCase)) { theme = t; break; }
+        if (theme is null) throw new InvalidOperationException($"No theme {themeId}.");
+        System.IO.File.WriteAllText(filePath, theme.ToJson());
+    }
+
+    public void SaveUserTheme(ThemeDefinition theme)
+    {
+        _userThemes.RemoveAll(t => string.Equals(t.Id, theme.Id, StringComparison.OrdinalIgnoreCase));
+        _userThemes.Add(theme);
+    }
+
+    public void DeleteUserTheme(string themeId)
+    {
+        _userThemes.RemoveAll(t => string.Equals(t.Id, themeId, StringComparison.OrdinalIgnoreCase));
+        if (string.Equals(ConfiguredThemeId, themeId, StringComparison.OrdinalIgnoreCase))
+            ApplyTheme("system");
+    }
+
+    public void ApplyVisionSettings(ConfigModel config) { }
+
+    public string BuildMessageCss(bool forceOnContent) => string.Empty;
+
+    public void Dispose() { }
+}

--- a/QuickMail.Tests/StubServices.cs
+++ b/QuickMail.Tests/StubServices.cs
@@ -301,6 +301,10 @@ sealed class StubThemeService : IThemeService
     private readonly List<ThemeDefinition> _userThemes = [];
 
     public string ConfiguredThemeId { get; private set; } = "system";
+    public string ConfiguredThemeName =>
+        string.Equals(ConfiguredThemeId, "system", StringComparison.OrdinalIgnoreCase)
+            ? $"System, showing {ResolvedTheme.Name}"
+            : ResolvedTheme.Name;
     public bool IsHighContrastActive { get; set; }
     public string UserThemesFolder { get; set; } = string.Empty;
     public List<string> AppliedThemeIds { get; } = [];
@@ -366,6 +370,9 @@ sealed class StubThemeService : IThemeService
     }
 
     public void ApplyVisionSettings(ConfigModel config) { }
+
+    public void ApplyAppearance(ConfigModel config) =>
+        ApplyTheme(string.IsNullOrWhiteSpace(config.AppearanceThemeId) ? "system" : config.AppearanceThemeId);
 
     public string BuildMessageCss(bool forceOnContent) => string.Empty;
 

--- a/QuickMail.Tests/StubServices.cs
+++ b/QuickMail.Tests/StubServices.cs
@@ -315,7 +315,7 @@ sealed class StubThemeService : IThemeService
 
     private static ThemeDefinition BuildDefaultResolved()
     {
-        var theme = new ThemeDefinition { Id = "quill", Name = "Quill", Base = "light", IsBuiltIn = true };
+        var theme = new ThemeDefinition { Id = "parchment", Name = "Parchment", Base = "light", IsBuiltIn = true };
         foreach (var key in QuickMail.Theming.ThemeKeys.ColorTokens.Keys)
             theme.Colors[key] = "#000000";
         return theme;
@@ -326,8 +326,8 @@ sealed class StubThemeService : IThemeService
         var list = new List<ThemeDefinition>
         {
             new() { Id = "system", Name = "System", Base = "light", IsBuiltIn = true },
-            new() { Id = "quill",  Name = "Quill",  Base = "light", IsBuiltIn = true },
-            new() { Id = "dark",   Name = "Quill Dark", Base = "dark", IsBuiltIn = true },
+            new() { Id = "parchment", Name = "Parchment", Base = "light", IsBuiltIn = true },
+            new() { Id = "dark",      Name = "Parchment Dark", Base = "dark", IsBuiltIn = true },
         };
         list.AddRange(_userThemes);
         return list;

--- a/QuickMail.Tests/StubServices.cs
+++ b/QuickMail.Tests/StubServices.cs
@@ -369,6 +369,20 @@ sealed class StubThemeService : IThemeService
             ApplyTheme("system");
     }
 
+    public ThemeDefinition ResolveForPreview(string themeId)
+    {
+        ThemeDefinition? match = null;
+        foreach (var t in GetAvailableThemes())
+            if (string.Equals(t.Id, themeId, StringComparison.OrdinalIgnoreCase)) { match = t; break; }
+
+        var full = (match ?? ResolvedTheme).Clone();
+        if (string.IsNullOrEmpty(full.Name)) full.Name = ResolvedTheme.Name;
+        var fill = BuildDefaultResolved();
+        foreach (var key in QuickMail.Theming.ThemeKeys.ColorTokens.Keys)
+            if (!full.Colors.ContainsKey(key)) full.Colors[key] = fill.Colors[key];
+        return full;
+    }
+
     public void ApplyVisionSettings(ConfigModel config) { }
 
     public void ApplyAppearance(ConfigModel config) =>

--- a/QuickMail.Tests/ThemeDefinitionTests.cs
+++ b/QuickMail.Tests/ThemeDefinitionTests.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Linq;
+using QuickMail.Models;
+using QuickMail.Theming;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+public class ThemeDefinitionTests
+{
+    private const string MinimalJson = """
+        {
+          "formatVersion": 1,
+          "id": "test-theme",
+          "name": "Test Theme",
+          "base": "light",
+          "colors": { "accent": "#8F4531", "windowBackground": "#FBF7F2" },
+          "typography": { "fontFamily": "Segoe UI", "monoFontFamily": "Cascadia Code", "baseFontSize": 13 }
+        }
+        """;
+
+    [Fact]
+    public void Parse_MinimalTheme_ReadsAllFields()
+    {
+        var theme = ThemeDefinition.Parse(MinimalJson);
+
+        Assert.Equal("test-theme", theme.Id);
+        Assert.Equal("Test Theme", theme.Name);
+        Assert.Equal("light", theme.Base);
+        Assert.Equal("#8F4531", theme.Colors["accent"]);
+        Assert.Equal("#FBF7F2", theme.Colors["windowBackground"]);
+        Assert.Equal("Segoe UI", theme.Typography.FontFamily);
+        Assert.Equal("Cascadia Code", theme.Typography.MonoFontFamily);
+        Assert.Equal(13, theme.Typography.BaseFontSize);
+    }
+
+    [Fact]
+    public void RoundTrip_ToJsonThenParse_PreservesEverything()
+    {
+        var original = ThemeDefinition.Parse(MinimalJson);
+        var reparsed = ThemeDefinition.Parse(original.ToJson());
+
+        Assert.Equal(original.Id, reparsed.Id);
+        Assert.Equal(original.Name, reparsed.Name);
+        Assert.Equal(original.Base, reparsed.Base);
+        Assert.Equal(original.Colors, reparsed.Colors);
+        Assert.Equal(original.Typography.FontFamily, reparsed.Typography.FontFamily);
+        Assert.Equal(original.Typography.MonoFontFamily, reparsed.Typography.MonoFontFamily);
+        Assert.Equal(original.Typography.BaseFontSize, reparsed.Typography.BaseFontSize);
+    }
+
+    [Fact]
+    public void ResolveAgainst_SparseTheme_FillsMissingKeysFromBase()
+    {
+        var baseTheme = new ThemeDefinition { Id = "base", Name = "Base", Base = "light" };
+        foreach (var key in ThemeKeys.ColorTokens.Keys)
+            baseTheme.Colors[key] = "#111111";
+
+        var sparse = ThemeDefinition.Parse(MinimalJson);
+        var resolved = sparse.ResolveAgainst(baseTheme);
+
+        Assert.True(resolved.IsComplete);
+        Assert.Equal("#8F4531", resolved.ColorOf("accent"));          // own value wins
+        Assert.Equal("#111111", resolved.ColorOf("textPrimary"));     // missing → base
+        Assert.Equal(ThemeKeys.ColorTokens.Count, resolved.Colors.Count);
+    }
+
+    [Fact]
+    public void Parse_UnknownColorKey_IsToleratedAndDropped()
+    {
+        var json = MinimalJson.Replace("\"accent\":", "\"futureToken\": \"#123456\", \"accent\":");
+        var theme = ThemeDefinition.Parse(json);
+
+        Assert.False(theme.Colors.ContainsKey("futureToken"));
+        Assert.Equal("#8F4531", theme.Colors["accent"]);
+    }
+
+    [Theory]
+    [InlineData("blue")]
+    [InlineData("#12")]
+    [InlineData("#12345")]
+    [InlineData("#GGGGGG")]
+    [InlineData("")]
+    public void Parse_InvalidHex_ThrowsWithFriendlyMessage(string bad)
+    {
+        var json = MinimalJson.Replace("#8F4531", bad);
+        var ex = Assert.Throws<ThemeFormatException>(() => ThemeDefinition.Parse(json));
+        // The message must name the key and the bad value — it is shown to the user.
+        Assert.Contains("accent", ex.Message);
+        Assert.Contains("hex", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Parse_ShortHex_IsExpandedAndNormalized()
+    {
+        var json = MinimalJson.Replace("#8F4531", "#abc");
+        var theme = ThemeDefinition.Parse(json);
+        Assert.Equal("#AABBCC", theme.Colors["accent"]);
+    }
+
+    [Fact]
+    public void Parse_NewerFormatVersion_IsRejected()
+    {
+        var json = MinimalJson.Replace("\"formatVersion\": 1", "\"formatVersion\": 99");
+        var ex = Assert.Throws<ThemeFormatException>(() => ThemeDefinition.Parse(json));
+        Assert.Contains("newer version", ex.Message);
+    }
+
+    [Theory]
+    [InlineData(4)]
+    [InlineData(80)]
+    public void Parse_BaseFontSizeOutOfRange_IsRejected(double size)
+    {
+        var json = MinimalJson.Replace("\"baseFontSize\": 13", $"\"baseFontSize\": {size}");
+        var ex = Assert.Throws<ThemeFormatException>(() => ThemeDefinition.Parse(json));
+        Assert.Contains("baseFontSize", ex.Message);
+    }
+
+    [Fact]
+    public void Parse_MissingId_ThrowsWithFriendlyMessage()
+    {
+        var json = MinimalJson.Replace("\"id\": \"test-theme\",", string.Empty);
+        var ex = Assert.Throws<ThemeFormatException>(() => ThemeDefinition.Parse(json));
+        Assert.Contains("id", ex.Message);
+    }
+
+    [Fact]
+    public void Parse_UnknownBase_ThrowsWithFriendlyMessage()
+    {
+        var json = MinimalJson.Replace("\"base\": \"light\"", "\"base\": \"sepia\"");
+        var ex = Assert.Throws<ThemeFormatException>(() => ThemeDefinition.Parse(json));
+        Assert.Contains("sepia", ex.Message);
+    }
+
+    [Fact]
+    public void Parse_NotJson_ThrowsThemeFormatException()
+    {
+        Assert.Throws<ThemeFormatException>(() => ThemeDefinition.Parse("this is not json"));
+    }
+
+    [Fact]
+    public void HexToArgb_ParsesAllThreeForms()
+    {
+        Assert.Equal(((byte)255, (byte)0xAA, (byte)0xBB, (byte)0xCC), ThemeDefinition.HexToArgb("#ABC"));
+        Assert.Equal(((byte)255, (byte)0x3D, (byte)0x5A, (byte)0x80), ThemeDefinition.HexToArgb("#3D5A80"));
+        Assert.Equal(((byte)0x80, (byte)0x3D, (byte)0x5A, (byte)0x80), ThemeDefinition.HexToArgb("#803D5A80"));
+    }
+}

--- a/QuickMail.Tests/ThemeDescriberTests.cs
+++ b/QuickMail.Tests/ThemeDescriberTests.cs
@@ -21,17 +21,17 @@ public class ThemeDescriberTests : IDisposable
     {
         var store = new ThemeStore(new ProfileContext(_dir));
         var theme = store.LoadBuiltIns().First(t => t.Id == id);
-        var baseTheme = store.LoadBuiltIns().First(t => t.Id == (theme.Base == "dark" ? "dark" : "quill"));
+        var baseTheme = store.LoadBuiltIns().First(t => t.Id == (theme.Base == "dark" ? "dark" : "parchment"));
         return theme.ResolveAgainst(baseTheme);
     }
 
     [Theory]
     [InlineData("#FFFFFF", "white")]
     [InlineData("#000000", "black")]
-    [InlineData("#3D5A80", "blue")]     // Quill accent
-    [InlineData("#B3261E", "red")]      // Quill error
-    [InlineData("#2E6B3E", "green")]    // Quill success
-    [InlineData("#8A5A00", "orange")]   // Quill warning (dark amber)
+    [InlineData("#3D5A80", "blue")]     // Parchment accent
+    [InlineData("#B3261E", "red")]      // Parchment error
+    [InlineData("#2E6B3E", "green")]    // Parchment success
+    [InlineData("#8A5A00", "orange")]   // Parchment warning (dark amber)
     public void DescribeColor_NamesTheHueFamily(string hex, string expectedWord)
     {
         var text = ThemeDescriber.DescribeColor(hex);
@@ -42,17 +42,17 @@ public class ThemeDescriberTests : IDisposable
     [Fact]
     public void DescribeColor_WarmOffWhite_ReadsAsOffWhite()
     {
-        // Quill window background is a very light, slightly warm neutral.
+        // Parchment window background is a very light, slightly warm neutral.
         var text = ThemeDescriber.DescribeColor("#FBFAF8");
         Assert.Contains("off-white", text, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
-    public void Describe_Quill_CoversFontsAndEveryTokenGroup_WithUsage()
+    public void Describe_Parchment_CoversFontsAndEveryTokenGroup_WithUsage()
     {
-        var text = ThemeDescriber.Describe(Resolved("quill"));
+        var text = ThemeDescriber.Describe(Resolved("parchment"));
 
-        Assert.Contains("Quill", text);
+        Assert.Contains("Parchment", text);
         Assert.Contains("light theme", text);
         Assert.Contains("Fonts", text);
         Assert.Contains("Segoe UI", text);
@@ -76,7 +76,7 @@ public class ThemeDescriberTests : IDisposable
     [Fact]
     public void Describe_System_SaysItFollowsTheOs()
     {
-        var text = ThemeDescriber.Describe(Resolved("quill"), isSystem: true);
+        var text = ThemeDescriber.Describe(Resolved("parchment"), isSystem: true);
         Assert.Contains("follows the Windows light and dark setting", text);
     }
 }

--- a/QuickMail.Tests/ThemeDescriberTests.cs
+++ b/QuickMail.Tests/ThemeDescriberTests.cs
@@ -1,0 +1,82 @@
+using System;
+using System.IO;
+using System.Linq;
+using QuickMail.Helpers;
+using QuickMail.Models;
+using QuickMail.Services;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+public class ThemeDescriberTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(Path.GetTempPath(), $"QM-DescriberTests-{Guid.NewGuid():N}");
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_dir)) Directory.Delete(_dir, recursive: true); } catch { }
+    }
+
+    private ThemeDefinition Resolved(string id)
+    {
+        var store = new ThemeStore(new ProfileContext(_dir));
+        var theme = store.LoadBuiltIns().First(t => t.Id == id);
+        var baseTheme = store.LoadBuiltIns().First(t => t.Id == (theme.Base == "dark" ? "dark" : "quill"));
+        return theme.ResolveAgainst(baseTheme);
+    }
+
+    [Theory]
+    [InlineData("#FFFFFF", "white")]
+    [InlineData("#000000", "black")]
+    [InlineData("#3D5A80", "blue")]     // Quill accent
+    [InlineData("#B3261E", "red")]      // Quill error
+    [InlineData("#2E6B3E", "green")]    // Quill success
+    [InlineData("#8A5A00", "orange")]   // Quill warning (dark amber)
+    public void DescribeColor_NamesTheHueFamily(string hex, string expectedWord)
+    {
+        var text = ThemeDescriber.DescribeColor(hex);
+        Assert.Contains(expectedWord, text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(ThemeDefinition.NormalizeHex(hex), text);   // the hex is always shown
+    }
+
+    [Fact]
+    public void DescribeColor_WarmOffWhite_ReadsAsOffWhite()
+    {
+        // Quill window background is a very light, slightly warm neutral.
+        var text = ThemeDescriber.DescribeColor("#FBFAF8");
+        Assert.Contains("off-white", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Describe_Quill_CoversFontsAndEveryTokenGroup_WithUsage()
+    {
+        var text = ThemeDescriber.Describe(Resolved("quill"));
+
+        Assert.Contains("Quill", text);
+        Assert.Contains("light theme", text);
+        Assert.Contains("Fonts", text);
+        Assert.Contains("Segoe UI", text);
+
+        // Section headers present.
+        Assert.Contains("Backgrounds and borders", text);
+        Assert.Contains("Text", text);
+        Assert.Contains("Accent and selection", text);
+        Assert.Contains("Status colors", text);
+
+        // A token line carries both a color and a "where it is used" clause.
+        Assert.Contains("Window background:", text);
+        Assert.Contains("the main window", text);
+        Assert.Contains("Hyperlink:", text);
+
+        // Every one of the 26 tokens is described (each line has an em dash usage clause).
+        var usageLines = text.Split('\n').Count(l => l.Contains(" — "));
+        Assert.True(usageLines >= 26, $"expected at least 26 described tokens, got {usageLines}");
+    }
+
+    [Fact]
+    public void Describe_System_SaysItFollowsTheOs()
+    {
+        var text = ThemeDescriber.Describe(Resolved("quill"), isSystem: true);
+        Assert.Contains("follows the Windows light and dark setting", text);
+    }
+}

--- a/QuickMail.Tests/ThemeManagerViewModelTests.cs
+++ b/QuickMail.Tests/ThemeManagerViewModelTests.cs
@@ -65,6 +65,23 @@ public class ThemeManagerViewModelTests : IDisposable
     }
 
     [Fact]
+    public void Apply_WhenEffectivePaletteUnchanged_AnnouncesSoItIsNotSilent()
+    {
+        // When applying a theme that resolves to the same palette (e.g. System
+        // already shows the built-in you pick), the service raises no ThemeChanged
+        // event, so the main window stays silent — the VM must announce instead.
+        var vm = NewVm();
+        var announced = new List<(string Text, AnnouncementCategory Category)>();
+        vm.AnnouncementRequested += (text, cat) => announced.Add((text, cat));
+
+        vm.SelectedTheme = vm.Themes.First(t => t.Id == "parchment");
+        vm.ApplyCommand.Execute(null);
+
+        Assert.Contains(announced, a => a.Text.StartsWith("Theme changed to", StringComparison.Ordinal)
+                                        && a.Category == AnnouncementCategory.Status);
+    }
+
+    [Fact]
     public void Duplicate_OpensNamePanelPrefilled_ThenCreatesUserTheme()
     {
         var vm = NewVm();

--- a/QuickMail.Tests/ThemeManagerViewModelTests.cs
+++ b/QuickMail.Tests/ThemeManagerViewModelTests.cs
@@ -34,7 +34,7 @@ public class ThemeManagerViewModelTests : IDisposable
         _themes.ApplyTheme("dark");
         var vm = NewVm();
 
-        Assert.Equal(new[] { "system", "quill", "dark" }, vm.Themes.Select(t => t.Id));
+        Assert.Equal(new[] { "system", "parchment", "dark" }, vm.Themes.Select(t => t.Id));
         Assert.Equal("dark", vm.SelectedTheme?.Id);
         Assert.True(vm.Themes.First(t => t.Id == "dark").IsCurrent);
     }
@@ -42,12 +42,12 @@ public class ThemeManagerViewModelTests : IDisposable
     [Fact]
     public void AccessibleName_CarriesKindAndCurrentMarker()
     {
-        _themes.ApplyTheme("quill");
+        _themes.ApplyTheme("parchment");
         var vm = NewVm();
 
-        Assert.Equal("Quill, built-in, current theme",
-            vm.Themes.First(t => t.Id == "quill").AccessibleName);
-        Assert.Equal("Quill Dark, built-in",
+        Assert.Equal("Parchment, built-in, current theme",
+            vm.Themes.First(t => t.Id == "parchment").AccessibleName);
+        Assert.Equal("Parchment Dark, built-in",
             vm.Themes.First(t => t.Id == "dark").AccessibleName);
     }
 
@@ -68,22 +68,22 @@ public class ThemeManagerViewModelTests : IDisposable
     public void Duplicate_OpensNamePanelPrefilled_ThenCreatesUserTheme()
     {
         var vm = NewVm();
-        vm.SelectedTheme = vm.Themes.First(t => t.Id == "quill");
+        vm.SelectedTheme = vm.Themes.First(t => t.Id == "parchment");
         var announced = new List<string>();
         vm.AnnouncementRequested += (text, _) => announced.Add(text);
 
         vm.DuplicateCommand.Execute(null);
         Assert.True(vm.IsNamePanelOpen);
-        Assert.Equal("Quill copy", vm.EditName);
+        Assert.Equal("Parchment copy", vm.EditName);
 
         vm.ConfirmNameCommand.Execute(null);
 
         Assert.False(vm.IsNamePanelOpen);
-        var copy = vm.Themes.FirstOrDefault(t => t.Name == "Quill copy");
+        var copy = vm.Themes.FirstOrDefault(t => t.Name == "Parchment copy");
         Assert.NotNull(copy);
         Assert.False(copy!.IsBuiltIn);
         Assert.Equal(copy.Id, vm.SelectedTheme?.Id);
-        Assert.Contains("Theme Quill copy created.", announced);
+        Assert.Contains("Theme Parchment copy created.", announced);
     }
 
     [Fact]
@@ -100,7 +100,7 @@ public class ThemeManagerViewModelTests : IDisposable
         AddUserTheme();
         var vm = NewVm();
 
-        vm.SelectedTheme = vm.Themes.First(t => t.Id == "quill");
+        vm.SelectedTheme = vm.Themes.First(t => t.Id == "parchment");
         Assert.False(vm.CanRename);
 
         vm.SelectedTheme = vm.Themes.First(t => t.Id == "custom");
@@ -160,7 +160,7 @@ public class ThemeManagerViewModelTests : IDisposable
     public void Delete_IsDisabledForBuiltIns()
     {
         var vm = NewVm();
-        vm.SelectedTheme = vm.Themes.First(t => t.Id == "quill");
+        vm.SelectedTheme = vm.Themes.First(t => t.Id == "parchment");
         Assert.False(vm.CanDelete);
     }
 
@@ -169,22 +169,22 @@ public class ThemeManagerViewModelTests : IDisposable
     {
         Directory.CreateDirectory(_dir);
         var vm = NewVm();
-        var path = Path.Combine(_dir, "quill.quickmailtheme");
+        var path = Path.Combine(_dir, "parchment.quickmailtheme");
 
-        vm.SelectedTheme = vm.Themes.First(t => t.Id == "quill");
+        vm.SelectedTheme = vm.Themes.First(t => t.Id == "parchment");
         vm.ExportPathRequested = _ => path;
         vm.ExportCommand.Execute(null);
         Assert.True(File.Exists(path));
 
         // Give the exported copy a fresh id so the stub lists it as a new theme.
-        var json = File.ReadAllText(path).Replace("\"quill\"", "\"quill-2\"");
+        var json = File.ReadAllText(path).Replace("\"parchment\"", "\"parchment-2\"");
         File.WriteAllText(path, json);
 
         vm.ImportPathRequested = () => path;
         vm.ImportCommand.Execute(null);
 
-        Assert.Contains(vm.Themes, t => t.Id == "quill-2");
-        Assert.Equal("quill-2", vm.SelectedTheme?.Id);
+        Assert.Contains(vm.Themes, t => t.Id == "parchment-2");
+        Assert.Equal("parchment-2", vm.SelectedTheme?.Id);
     }
 
     [Fact]
@@ -211,11 +211,11 @@ public class ThemeManagerViewModelTests : IDisposable
     {
         var vm = NewVm();
 
-        vm.SelectedTheme = vm.Themes.First(t => t.Id == "quill");
-        var quillText = vm.SelectedThemeDescription;
-        Assert.False(string.IsNullOrWhiteSpace(quillText));
-        Assert.Contains("Window background", quillText);   // a "where it is used" line
-        Assert.Contains("Fonts", quillText);
+        vm.SelectedTheme = vm.Themes.First(t => t.Id == "parchment");
+        var parchmentText = vm.SelectedThemeDescription;
+        Assert.False(string.IsNullOrWhiteSpace(parchmentText));
+        Assert.Contains("Window background", parchmentText);   // a "where it is used" line
+        Assert.Contains("Fonts", parchmentText);
 
         var changed = false;
         vm.PropertyChanged += (_, e) =>

--- a/QuickMail.Tests/ThemeManagerViewModelTests.cs
+++ b/QuickMail.Tests/ThemeManagerViewModelTests.cs
@@ -1,0 +1,221 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using QuickMail.Models;
+using QuickMail.ViewModels;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+public class ThemeManagerViewModelTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(Path.GetTempPath(), $"QM-ThemeMgrTests-{Guid.NewGuid():N}");
+    private readonly StubThemeService _themes = new();
+    private readonly StubConfigService _config = new();
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_dir)) Directory.Delete(_dir, recursive: true); } catch { }
+    }
+
+    private ThemeManagerViewModel NewVm() => new(_themes, _config);
+
+    private ThemeDefinition AddUserTheme(string id = "custom", string name = "Custom")
+    {
+        var theme = new ThemeDefinition { Id = id, Name = name, Base = "light" };
+        _themes.SaveUserTheme(theme);
+        return theme;
+    }
+
+    [Fact]
+    public void Construction_ListsThemes_AndSelectsTheConfiguredOne()
+    {
+        _themes.ApplyTheme("dark");
+        var vm = NewVm();
+
+        Assert.Equal(new[] { "system", "quill", "dark" }, vm.Themes.Select(t => t.Id));
+        Assert.Equal("dark", vm.SelectedTheme?.Id);
+        Assert.True(vm.Themes.First(t => t.Id == "dark").IsCurrent);
+    }
+
+    [Fact]
+    public void AccessibleName_CarriesKindAndCurrentMarker()
+    {
+        _themes.ApplyTheme("quill");
+        var vm = NewVm();
+
+        Assert.Equal("Quill, built-in, current theme",
+            vm.Themes.First(t => t.Id == "quill").AccessibleName);
+        Assert.Equal("Quill Dark, built-in",
+            vm.Themes.First(t => t.Id == "dark").AccessibleName);
+    }
+
+    [Fact]
+    public void Apply_AppliesAndPersistsTheConfiguredTheme()
+    {
+        var vm = NewVm();
+        vm.SelectedTheme = vm.Themes.First(t => t.Id == "dark");
+
+        vm.ApplyCommand.Execute(null);
+
+        Assert.Contains("dark", _themes.AppliedThemeIds);
+        Assert.Equal("dark", _config.Load().AppearanceThemeId);
+        Assert.True(vm.Themes.First(t => t.Id == "dark").IsCurrent);
+    }
+
+    [Fact]
+    public void Duplicate_OpensNamePanelPrefilled_ThenCreatesUserTheme()
+    {
+        var vm = NewVm();
+        vm.SelectedTheme = vm.Themes.First(t => t.Id == "quill");
+        var announced = new List<string>();
+        vm.AnnouncementRequested += (text, _) => announced.Add(text);
+
+        vm.DuplicateCommand.Execute(null);
+        Assert.True(vm.IsNamePanelOpen);
+        Assert.Equal("Quill copy", vm.EditName);
+
+        vm.ConfirmNameCommand.Execute(null);
+
+        Assert.False(vm.IsNamePanelOpen);
+        var copy = vm.Themes.FirstOrDefault(t => t.Name == "Quill copy");
+        Assert.NotNull(copy);
+        Assert.False(copy!.IsBuiltIn);
+        Assert.Equal(copy.Id, vm.SelectedTheme?.Id);
+        Assert.Contains("Theme Quill copy created.", announced);
+    }
+
+    [Fact]
+    public void Duplicate_IsUnavailableForSystem()
+    {
+        var vm = NewVm();
+        vm.SelectedTheme = vm.Themes.First(t => t.Id == "system");
+        Assert.False(vm.CanDuplicate);
+    }
+
+    [Fact]
+    public void Rename_ChangesUserThemeName_AndIsDisabledForBuiltIns()
+    {
+        AddUserTheme();
+        var vm = NewVm();
+
+        vm.SelectedTheme = vm.Themes.First(t => t.Id == "quill");
+        Assert.False(vm.CanRename);
+
+        vm.SelectedTheme = vm.Themes.First(t => t.Id == "custom");
+        Assert.True(vm.CanRename);
+
+        vm.RenameCommand.Execute(null);
+        Assert.Equal("Custom", vm.EditName);
+        vm.EditName = "My Colors";
+        vm.ConfirmNameCommand.Execute(null);
+
+        Assert.Equal("My Colors", vm.Themes.First(t => t.Id == "custom").Name);
+    }
+
+    [Fact]
+    public void CancelName_ClosesThePanelWithoutChanges()
+    {
+        AddUserTheme();
+        var vm = NewVm();
+        vm.SelectedTheme = vm.Themes.First(t => t.Id == "custom");
+
+        vm.RenameCommand.Execute(null);
+        vm.EditName = "Ignored";
+        vm.CancelNameCommand.Execute(null);
+
+        Assert.False(vm.IsNamePanelOpen);
+        Assert.Equal("Custom", vm.Themes.First(t => t.Id == "custom").Name);
+    }
+
+    [Fact]
+    public void Delete_Confirmed_RemovesTheme_AndLandsOnANeighbor()
+    {
+        AddUserTheme();
+        var vm = NewVm();
+        vm.SelectedTheme = vm.Themes.First(t => t.Id == "custom");
+        vm.ConfirmDeleteRequested = (_, _) => true;
+
+        vm.DeleteCommand.Execute(null);
+
+        Assert.DoesNotContain(vm.Themes, t => t.Id == "custom");
+        Assert.NotNull(vm.SelectedTheme);
+    }
+
+    [Fact]
+    public void Delete_Declined_KeepsTheTheme()
+    {
+        AddUserTheme();
+        var vm = NewVm();
+        vm.SelectedTheme = vm.Themes.First(t => t.Id == "custom");
+        vm.ConfirmDeleteRequested = (_, _) => false;
+
+        vm.DeleteCommand.Execute(null);
+
+        Assert.Contains(vm.Themes, t => t.Id == "custom");
+    }
+
+    [Fact]
+    public void Delete_IsDisabledForBuiltIns()
+    {
+        var vm = NewVm();
+        vm.SelectedTheme = vm.Themes.First(t => t.Id == "quill");
+        Assert.False(vm.CanDelete);
+    }
+
+    [Fact]
+    public void ExportThenImport_RoundTripsThroughTheFilePickers()
+    {
+        Directory.CreateDirectory(_dir);
+        var vm = NewVm();
+        var path = Path.Combine(_dir, "quill.quickmailtheme");
+
+        vm.SelectedTheme = vm.Themes.First(t => t.Id == "quill");
+        vm.ExportPathRequested = _ => path;
+        vm.ExportCommand.Execute(null);
+        Assert.True(File.Exists(path));
+
+        // Give the exported copy a fresh id so the stub lists it as a new theme.
+        var json = File.ReadAllText(path).Replace("\"quill\"", "\"quill-2\"");
+        File.WriteAllText(path, json);
+
+        vm.ImportPathRequested = () => path;
+        vm.ImportCommand.Execute(null);
+
+        Assert.Contains(vm.Themes, t => t.Id == "quill-2");
+        Assert.Equal("quill-2", vm.SelectedTheme?.Id);
+    }
+
+    [Fact]
+    public void Import_MalformedFile_ReportsTheError_AndLeavesTheListUnchanged()
+    {
+        Directory.CreateDirectory(_dir);
+        var path = Path.Combine(_dir, "broken.quickmailtheme");
+        File.WriteAllText(path, "{ not a theme");
+
+        var vm = NewVm();
+        var countBefore = vm.Themes.Count;
+        string? error = null;
+        vm.ErrorRequested += message => error = message;
+        vm.ImportPathRequested = () => path;
+
+        vm.ImportCommand.Execute(null);
+
+        Assert.NotNull(error);
+        Assert.Equal(countBefore, vm.Themes.Count);
+    }
+
+    [Fact]
+    public void OpenThemesFolder_RaisesTheFolderRequest()
+    {
+        _themes.UserThemesFolder = @"C:\somewhere\themes";
+        var vm = NewVm();
+        string? opened = null;
+        vm.OpenFolderRequested += folder => opened = folder;
+
+        vm.OpenThemesFolderCommand.Execute(null);
+
+        Assert.Equal(@"C:\somewhere\themes", opened);
+    }
+}

--- a/QuickMail.Tests/ThemeManagerViewModelTests.cs
+++ b/QuickMail.Tests/ThemeManagerViewModelTests.cs
@@ -207,6 +207,28 @@ public class ThemeManagerViewModelTests : IDisposable
     }
 
     [Fact]
+    public void SelectedThemeDescription_DescribesTheSelection_AndUpdatesOnChange()
+    {
+        var vm = NewVm();
+
+        vm.SelectedTheme = vm.Themes.First(t => t.Id == "quill");
+        var quillText = vm.SelectedThemeDescription;
+        Assert.False(string.IsNullOrWhiteSpace(quillText));
+        Assert.Contains("Window background", quillText);   // a "where it is used" line
+        Assert.Contains("Fonts", quillText);
+
+        var changed = false;
+        vm.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(vm.SelectedThemeDescription)) changed = true;
+        };
+
+        vm.SelectedTheme = vm.Themes.First(t => t.Id == "system");
+        Assert.True(changed, "changing the selection should raise SelectedThemeDescription");
+        Assert.Contains("follows the Windows light and dark setting", vm.SelectedThemeDescription);
+    }
+
+    [Fact]
     public void OpenThemesFolder_RaisesTheFolderRequest()
     {
         _themes.UserThemesFolder = @"C:\somewhere\themes";

--- a/QuickMail.Tests/ThemeRegressionGuardTests.cs
+++ b/QuickMail.Tests/ThemeRegressionGuardTests.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// Regression guards: no new hardcoded colors or numeric font sizes in view XAML.
+/// Every color must come from a Theme.* token so all six themes and the High
+/// Contrast passthrough stay correct; every font size must come from a
+/// Theme.FontSize* token so the text-scale setting reaches it.
+/// </summary>
+public class ThemeRegressionGuardTests
+{
+    /// <summary>Deliberate exceptions, reviewed case by case. Keep this list short.</summary>
+    private static readonly Dictionary<string, string[]> Allowlist = new(StringComparer.OrdinalIgnoreCase)
+    {
+        // Translucent backdrop scrim — intentionally not themed.
+        ["TutorialOverlay.xaml"] = ["#CC1E1E1E"],
+        // Flag color swatches are user data, not chrome; the white focus ring and
+        // check ring must stay visible on every user-chosen swatch color.
+        ["FlagManagerWindow.xaml"] = ["White", "#80FFFFFF"],
+        // Tiny unread-count badge overlay: fixed geometry, deliberately unscaled.
+        ["MainWindow.xaml"] = ["FontSize=\"9\""],
+    };
+
+    // (?<![A-Za-z]) keeps e.g. DockPanel's LastChildFill from matching as Fill.
+    private static readonly Regex BrushAttribute = new(
+        "(?<![A-Za-z])(?:Foreground|Background|BorderBrush|Stroke|Fill)=\"(?<value>[^\"{][^\"]*)\"",
+        RegexOptions.Compiled);
+
+    private static readonly Regex NumericFontSize = new(
+        "FontSize=\"(?<value>[0-9][0-9.]*)\"",
+        RegexOptions.Compiled);
+
+    private static string? FindRepoRoot()
+    {
+        for (var dir = new DirectoryInfo(AppContext.BaseDirectory); dir != null; dir = dir.Parent)
+        {
+            if (Directory.Exists(Path.Combine(dir.FullName, "QuickMail", "Views")))
+                return dir.FullName;
+        }
+        return null;
+    }
+
+    private static IEnumerable<string> ViewXamlFiles(string root) =>
+        Directory.EnumerateFiles(Path.Combine(root, "QuickMail", "Views"), "*.xaml")
+            .Concat(Directory.EnumerateFiles(Path.Combine(root, "QuickMail", "Controls"), "*.xaml"));
+
+    private static bool IsAllowed(string fileName, string offendingText) =>
+        Allowlist.TryGetValue(fileName, out var allowed)
+        && allowed.Any(a => offendingText.Contains(a, StringComparison.OrdinalIgnoreCase));
+
+    [Fact]
+    public void ViewXaml_HasNoHardcodedBrushColors()
+    {
+        var root = FindRepoRoot();
+        Assert.False(root is null, "Repo source tree not found from test base directory.");
+
+        var violations = new List<string>();
+        foreach (var file in ViewXamlFiles(root!))
+        {
+            var name = Path.GetFileName(file);
+            var lines = File.ReadAllLines(file);
+            for (int i = 0; i < lines.Length; i++)
+            {
+                foreach (Match m in BrushAttribute.Matches(lines[i]))
+                {
+                    var value = m.Groups["value"].Value;
+                    if (value == "Transparent") continue;      // structural, not a color choice
+                    if (IsAllowed(name, m.Value) || IsAllowed(name, value)) continue;
+                    violations.Add($"{name}:{i + 1}: {m.Value}");
+                }
+            }
+        }
+
+        Assert.True(violations.Count == 0,
+            "Hardcoded brush colors in view XAML — use a Theme.* token (or extend the reviewed allowlist):\n"
+            + string.Join("\n", violations));
+    }
+
+    [Fact]
+    public void ViewXaml_HasNoNumericFontSizes()
+    {
+        var root = FindRepoRoot();
+        Assert.False(root is null, "Repo source tree not found from test base directory.");
+
+        var violations = new List<string>();
+        foreach (var file in ViewXamlFiles(root!))
+        {
+            var name = Path.GetFileName(file);
+            var lines = File.ReadAllLines(file);
+            for (int i = 0; i < lines.Length; i++)
+            {
+                foreach (Match m in NumericFontSize.Matches(lines[i]))
+                {
+                    if (IsAllowed(name, m.Value)) continue;
+                    violations.Add($"{name}:{i + 1}: {m.Value}");
+                }
+            }
+        }
+
+        Assert.True(violations.Count == 0,
+            "Numeric FontSize in view XAML — use Theme.FontSizeSmall/Base/Large/Header so text scaling applies:\n"
+            + string.Join("\n", violations));
+    }
+}

--- a/QuickMail.Tests/ThemeRegressionGuardTests.cs
+++ b/QuickMail.Tests/ThemeRegressionGuardTests.cs
@@ -46,9 +46,19 @@ public class ThemeRegressionGuardTests
         return null;
     }
 
-    private static IEnumerable<string> ViewXamlFiles(string root) =>
-        Directory.EnumerateFiles(Path.Combine(root, "QuickMail", "Views"), "*.xaml")
-            .Concat(Directory.EnumerateFiles(Path.Combine(root, "QuickMail", "Controls"), "*.xaml"));
+    // Views + Controls + Styles. Styles/ holds the implicit control templates
+    // (ThemedControls.xaml, AccessibleStyles.xaml) — the place a hardcoded color is
+    // most likely to slip back in during retemplating, so it must be guarded too.
+    private static IEnumerable<string> ViewXamlFiles(string root)
+    {
+        foreach (var sub in new[] { "Views", "Controls", "Styles" })
+        {
+            var dir = Path.Combine(root, "QuickMail", sub);
+            if (!Directory.Exists(dir)) continue;
+            foreach (var file in Directory.EnumerateFiles(dir, "*.xaml"))
+                yield return file;
+        }
+    }
 
     private static bool IsAllowed(string fileName, string offendingText) =>
         Allowlist.TryGetValue(fileName, out var allowed)

--- a/QuickMail.Tests/ThemeServiceTests.cs
+++ b/QuickMail.Tests/ThemeServiceTests.cs
@@ -1,0 +1,283 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Windows;
+using System.Windows.Media;
+using QuickMail.Models;
+using QuickMail.Services;
+using QuickMail.Theming;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+// In the WpfTests collection: the service publishes into Application.Current.Resources
+// when an Application exists, so these must not run in parallel with other WPF tests.
+[Collection("WpfTests")]
+public class ThemeServiceTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(Path.GetTempPath(), $"QM-ThemeSvcTests-{Guid.NewGuid():N}");
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_dir)) Directory.Delete(_dir, recursive: true); } catch { }
+    }
+
+    /// <summary>Service wired for tests: fixed OS probes, no ThemedControls pack URI load.</summary>
+    private ThemeService NewService(bool highContrast = false, bool osLight = true)
+    {
+        var service = new ThemeService(new ThemeStore(new ProfileContext(_dir)))
+        {
+            HighContrastProbe = () => highContrast,
+            OsLightModeProbe = () => osLight,
+            EnableThemedControls = false,
+        };
+        return service;
+    }
+
+    private static ConfigModel Config(string themeId = "system", double scale = 1.0,
+        string font = "", bool underline = false, bool thickFocus = false) => new()
+    {
+        AppearanceThemeId = themeId,
+        AppearanceTextScale = scale,
+        AppearanceFontFamily = font,
+        AppearanceUnderlineLinks = underline,
+        AppearanceThickFocus = thickFocus,
+    };
+
+    // ── Resolution ────────────────────────────────────────────────────────────
+
+    [StaFact]
+    public void System_FollowsOsLightAndDark()
+    {
+        using var svc = NewService(osLight: true);
+        svc.Initialize(Config("system"));
+        Assert.Equal("quill", svc.ResolvedTheme.Id);
+
+        using var dark = NewService(osLight: false);
+        dark.Initialize(Config("system"));
+        Assert.Equal("dark", dark.ResolvedTheme.Id);
+    }
+
+    [StaFact]
+    public void UnknownThemeId_FallsBackToSystem_WithoutThrowing()
+    {
+        using var svc = NewService(osLight: true);
+        svc.Initialize(Config("no-such-theme"));
+        Assert.Equal("quill", svc.ResolvedTheme.Id);
+    }
+
+    [StaFact]
+    public void ApplyTheme_SwitchesResolvedThemeAndRaisesThemeChanged()
+    {
+        using var svc = NewService();
+        svc.Initialize(Config("system"));
+
+        var raised = 0;
+        svc.ThemeChanged += (_, _) => raised++;
+
+        svc.ApplyTheme("ember");
+        Assert.Equal("ember", svc.ConfiguredThemeId);
+        Assert.Equal("ember", svc.ResolvedTheme.Id);
+        Assert.True(svc.ResolvedTheme.IsComplete);
+        Assert.Equal(1, raised);
+
+        // Re-applying the same theme is a no-op: no event, no dictionary churn.
+        svc.ApplyTheme("ember");
+        Assert.Equal(1, raised);
+    }
+
+    [StaFact]
+    public void ApplyTheme_NonPersistent_LeavesConfiguredIdUntouched()
+    {
+        using var svc = NewService();
+        svc.Initialize(Config("system"));
+
+        svc.ApplyTheme("fjord", persist: false);   // the Phase 5 per-view hook
+
+        Assert.Equal("system", svc.ConfiguredThemeId);
+        Assert.Equal("fjord", svc.ResolvedTheme.Id);
+    }
+
+    // ── High Contrast passthrough ─────────────────────────────────────────────
+
+    [StaFact]
+    public void HighContrast_ResolvesEveryTokenFromSystemColors()
+    {
+        using var svc = NewService(highContrast: true);
+        svc.Initialize(Config("ember"));
+
+        Assert.True(svc.IsHighContrastActive);
+        var t = svc.ResolvedTheme;
+        Assert.Equal("high-contrast", t.Id);
+        Assert.True(t.IsComplete);
+
+        static string Hex(Color c) => $"#{c.R:X2}{c.G:X2}{c.B:X2}";
+        Assert.Equal(Hex(SystemColors.WindowColor),     t.ColorOf("windowBackground"));
+        Assert.Equal(Hex(SystemColors.WindowTextColor), t.ColorOf("textPrimary"));
+        Assert.Equal(Hex(SystemColors.HighlightColor),  t.ColorOf("selectionBackground"));
+        Assert.Equal(Hex(SystemColors.HotTrackColor),   t.ColorOf("accent"));
+        // Status colors have no visual opinion in HC — text carries the meaning.
+        Assert.Equal(Hex(SystemColors.WindowTextColor), t.ColorOf("error"));
+        Assert.Equal(Hex(SystemColors.WindowColor),     t.ColorOf("errorBackground"));
+
+        // The configured id survives HC; leaving HC restores it.
+        Assert.Equal("ember", svc.ConfiguredThemeId);
+    }
+
+    // ── Token dictionary ──────────────────────────────────────────────────────
+
+    [StaFact]
+    public void TokenDictionary_ContainsEveryTokenAsFrozenBrush_PlusTypographyAndFocus()
+    {
+        using var svc = NewService();
+        svc.Initialize(Config("quill"));
+
+        var dict = svc.BuildTokenDictionary(svc.ResolvedTheme);
+
+        foreach (var resourceKey in ThemeKeys.ColorTokens.Values)
+        {
+            var brush = Assert.IsType<SolidColorBrush>(dict[resourceKey]);
+            Assert.True(brush.IsFrozen, $"{resourceKey} brush must be frozen");
+        }
+        Assert.IsType<FontFamily>(dict[ThemeKeys.FontFamily]);
+        Assert.IsType<FontFamily>(dict[ThemeKeys.FontFamilyMono]);
+        Assert.Equal(13.0, dict[ThemeKeys.FontSizeBase]);
+        Assert.Equal(11.0, dict[ThemeKeys.FontSizeSmall]);
+        Assert.Equal(15.0, dict[ThemeKeys.FontSizeLarge]);
+        Assert.Equal(18.0, dict[ThemeKeys.FontSizeHeader]);
+        Assert.Equal(2.0, dict[ThemeKeys.FocusThickness]);
+    }
+
+    [StaFact]
+    public void TokenDictionary_AppliesTextScaleAndVisionSettings()
+    {
+        using var svc = NewService();
+        svc.Initialize(Config("quill", scale: 1.5, font: "Verdana", thickFocus: true));
+
+        var dict = svc.BuildTokenDictionary(svc.ResolvedTheme);
+
+        Assert.Equal(19.5, dict[ThemeKeys.FontSizeBase]);
+        Assert.Equal(4.0, dict[ThemeKeys.FocusThickness]);
+        Assert.Equal("Verdana", ((FontFamily)dict[ThemeKeys.FontFamily]).Source);
+    }
+
+    // ── WebView2 CSS bridge ───────────────────────────────────────────────────
+
+    [StaFact]
+    public void BuildMessageCss_EmitsAllColorVariables()
+    {
+        using var svc = NewService();
+        svc.Initialize(Config("quill"));
+
+        var css = svc.BuildMessageCss(forceOnContent: false);
+
+        foreach (var v in new[] { "--qm-bg", "--qm-text", "--qm-text-muted", "--qm-surface",
+                                  "--qm-border", "--qm-accent", "--qm-link", "--qm-font", "--qm-font-size" })
+            Assert.Contains(v, css);
+        Assert.DoesNotContain("!important", css);
+    }
+
+    [StaFact]
+    public void BuildMessageCss_ForceOnContent_AppendsImportantOverrides()
+    {
+        using var svc = NewService();
+        svc.Initialize(Config("quill"));
+
+        var css = svc.BuildMessageCss(forceOnContent: true);
+        Assert.Contains("background-color:var(--qm-bg) !important", css);
+        Assert.Contains("color:var(--qm-text) !important", css);
+    }
+
+    [StaFact]
+    public void BuildMessageCss_UnderlineLinks_EmitsUnderlineRule()
+    {
+        using var svc = NewService();
+        svc.Initialize(Config("quill", underline: true));
+
+        Assert.Contains("text-decoration:underline", svc.BuildMessageCss(forceOnContent: false));
+    }
+
+    [StaFact]
+    public void BuildMessageCss_HighContrast_EmitsNoColorVariables()
+    {
+        using var svc = NewService(highContrast: true);
+        svc.Initialize(Config("quill"));
+
+        var css = svc.BuildMessageCss(forceOnContent: true);
+
+        // Typography still applies in HC; colors are the browser's business.
+        Assert.Contains("--qm-font", css);
+        foreach (var v in new[] { "--qm-bg", "--qm-text:", "--qm-link", "--qm-accent" })
+            Assert.DoesNotContain(v, css);
+        Assert.DoesNotContain("!important", css); // force-on-content is inert in HC
+    }
+
+    // ── Import / export ───────────────────────────────────────────────────────
+
+    [StaFact]
+    public void ExportThenImport_RoundTrips_WithReIdOnCollision()
+    {
+        using var svc = NewService();
+        svc.Initialize(Config("quill"));
+
+        var exportPath = Path.Combine(_dir, "exported.quickmailtheme");
+        svc.ExportTheme("ember", exportPath);
+        Assert.True(File.Exists(exportPath));
+
+        // "ember" already exists, so the import must re-id and rename.
+        var imported = svc.ImportTheme(exportPath);
+        Assert.NotEqual("ember", imported.Id);
+        Assert.Equal("Ember (imported)", imported.Name);
+        Assert.Contains(svc.GetAvailableThemes(), t => t.Id == imported.Id);
+
+        // The imported copy carries Ember's palette.
+        Assert.Equal("#8F4531", imported.Colors["accent"]);
+    }
+
+    [StaFact]
+    public void ImportTheme_MalformedFile_ThrowsFriendlyThemeFormatException()
+    {
+        using var svc = NewService();
+        svc.Initialize(Config("quill"));
+
+        var path = Path.Combine(_dir, "broken.quickmailtheme");
+        Directory.CreateDirectory(_dir);
+        File.WriteAllText(path, "not json at all");
+
+        Assert.Throws<ThemeFormatException>(() => svc.ImportTheme(path));
+    }
+
+    [StaFact]
+    public void DeleteUserTheme_WhenActive_FallsBackToSystem()
+    {
+        using var svc = NewService();
+        svc.Initialize(Config("quill"));
+
+        var custom = new ThemeDefinition { Id = "my-theme", Name = "Mine", Base = "light" };
+        svc.SaveUserTheme(custom);
+        svc.ApplyTheme("my-theme");
+        Assert.Equal("my-theme", svc.ConfiguredThemeId);
+
+        svc.DeleteUserTheme("my-theme");
+
+        Assert.Equal("system", svc.ConfiguredThemeId);
+        Assert.DoesNotContain(svc.GetAvailableThemes(), t => t.Id == "my-theme");
+    }
+
+    [StaFact]
+    public void CorruptUserThemeFile_IsSkipped_AndDoesNotBlockLoading()
+    {
+        var themesDir = Path.Combine(_dir, "themes");
+        Directory.CreateDirectory(themesDir);
+        File.WriteAllText(Path.Combine(themesDir, "broken.json"), "{ definitely not a theme");
+        File.WriteAllText(Path.Combine(themesDir, "good.json"),
+            new ThemeDefinition { Id = "good", Name = "Good", Base = "light" }.ToJson());
+
+        using var svc = NewService();
+        svc.Initialize(Config("system"));
+
+        var themes = svc.GetAvailableThemes();
+        Assert.Contains(themes, t => t.Id == "good");
+        Assert.Equal(1, themes.Count(t => !t.IsBuiltIn && t.Id != "system"));
+    }
+}

--- a/QuickMail.Tests/ThemeServiceTests.cs
+++ b/QuickMail.Tests/ThemeServiceTests.cs
@@ -51,7 +51,7 @@ public class ThemeServiceTests : IDisposable
     {
         using var svc = NewService(osLight: true);
         svc.Initialize(Config("system"));
-        Assert.Equal("quill", svc.ResolvedTheme.Id);
+        Assert.Equal("parchment", svc.ResolvedTheme.Id);
 
         using var dark = NewService(osLight: false);
         dark.Initialize(Config("system"));
@@ -63,7 +63,7 @@ public class ThemeServiceTests : IDisposable
     {
         using var svc = NewService(osLight: true);
         svc.Initialize(Config("no-such-theme"));
-        Assert.Equal("quill", svc.ResolvedTheme.Id);
+        Assert.Equal("parchment", svc.ResolvedTheme.Id);
     }
 
     [StaFact]
@@ -123,11 +123,11 @@ public class ThemeServiceTests : IDisposable
     {
         using var light = NewService(osLight: true);
         light.Initialize(Config("system"));
-        Assert.Equal("System, showing Quill", light.ConfiguredThemeName);
+        Assert.Equal("System, showing Parchment", light.ConfiguredThemeName);
 
         using var dark = NewService(osLight: false);
         dark.Initialize(Config("system"));
-        Assert.Equal("System, showing Quill Dark", dark.ConfiguredThemeName);
+        Assert.Equal("System, showing Parchment Dark", dark.ConfiguredThemeName);
     }
 
     [StaFact]
@@ -171,7 +171,7 @@ public class ThemeServiceTests : IDisposable
     public void TokenDictionary_ContainsEveryTokenAsFrozenBrush_PlusTypographyAndFocus()
     {
         using var svc = NewService();
-        svc.Initialize(Config("quill"));
+        svc.Initialize(Config("parchment"));
 
         var dict = svc.BuildTokenDictionary(svc.ResolvedTheme);
 
@@ -193,7 +193,7 @@ public class ThemeServiceTests : IDisposable
     public void TokenDictionary_AppliesTextScaleAndVisionSettings()
     {
         using var svc = NewService();
-        svc.Initialize(Config("quill", scale: 1.5, font: "Verdana", thickFocus: true));
+        svc.Initialize(Config("parchment", scale: 1.5, font: "Verdana", thickFocus: true));
 
         var dict = svc.BuildTokenDictionary(svc.ResolvedTheme);
 
@@ -208,7 +208,7 @@ public class ThemeServiceTests : IDisposable
     public void BuildMessageCss_EmitsAllColorVariables()
     {
         using var svc = NewService();
-        svc.Initialize(Config("quill"));
+        svc.Initialize(Config("parchment"));
 
         var css = svc.BuildMessageCss(forceOnContent: false);
 
@@ -222,7 +222,7 @@ public class ThemeServiceTests : IDisposable
     public void BuildMessageCss_ForceOnContent_AppendsImportantOverrides()
     {
         using var svc = NewService();
-        svc.Initialize(Config("quill"));
+        svc.Initialize(Config("parchment"));
 
         var css = svc.BuildMessageCss(forceOnContent: true);
         Assert.Contains("background-color:var(--qm-bg) !important", css);
@@ -233,7 +233,7 @@ public class ThemeServiceTests : IDisposable
     public void BuildMessageCss_UnderlineLinks_EmitsUnderlineRule()
     {
         using var svc = NewService();
-        svc.Initialize(Config("quill", underline: true));
+        svc.Initialize(Config("parchment", underline: true));
 
         Assert.Contains("text-decoration:underline", svc.BuildMessageCss(forceOnContent: false));
     }
@@ -242,7 +242,7 @@ public class ThemeServiceTests : IDisposable
     public void BuildMessageCss_HighContrast_EmitsNoColorVariables()
     {
         using var svc = NewService(highContrast: true);
-        svc.Initialize(Config("quill"));
+        svc.Initialize(Config("parchment"));
 
         var css = svc.BuildMessageCss(forceOnContent: true);
 
@@ -259,7 +259,7 @@ public class ThemeServiceTests : IDisposable
     public void ExportThenImport_RoundTrips_WithReIdOnCollision()
     {
         using var svc = NewService();
-        svc.Initialize(Config("quill"));
+        svc.Initialize(Config("parchment"));
 
         var exportPath = Path.Combine(_dir, "exported.quickmailtheme");
         svc.ExportTheme("ember", exportPath);
@@ -279,7 +279,7 @@ public class ThemeServiceTests : IDisposable
     public void ImportTheme_MalformedFile_ThrowsFriendlyThemeFormatException()
     {
         using var svc = NewService();
-        svc.Initialize(Config("quill"));
+        svc.Initialize(Config("parchment"));
 
         var path = Path.Combine(_dir, "broken.quickmailtheme");
         Directory.CreateDirectory(_dir);
@@ -292,7 +292,7 @@ public class ThemeServiceTests : IDisposable
     public void DeleteUserTheme_WhenActive_FallsBackToSystem()
     {
         using var svc = NewService();
-        svc.Initialize(Config("quill"));
+        svc.Initialize(Config("parchment"));
 
         var custom = new ThemeDefinition { Id = "my-theme", Name = "Mine", Base = "light" };
         svc.SaveUserTheme(custom);

--- a/QuickMail.Tests/ThemeServiceTests.cs
+++ b/QuickMail.Tests/ThemeServiceTests.cs
@@ -98,6 +98,47 @@ public class ThemeServiceTests : IDisposable
         Assert.Equal("fjord", svc.ResolvedTheme.Id);
     }
 
+    [StaFact]
+    public void ApplyAppearance_ThemeAndVisionTogether_RaisesThemeChangedOnce()
+    {
+        using var svc = NewService();
+        svc.Initialize(Config("system"));
+
+        var raised = 0;
+        svc.ThemeChanged += (_, _) => raised++;
+
+        // A combined Settings save: new theme id AND a vision setting (thick focus).
+        // Both mutations must coalesce into a single re-publish / single event.
+        svc.ApplyAppearance(Config("ember", thickFocus: true));
+
+        Assert.Equal("ember", svc.ConfiguredThemeId);
+        Assert.Equal("ember", svc.ResolvedTheme.Id);
+        Assert.Equal(1, raised);
+    }
+
+    // ── Announcement naming ───────────────────────────────────────────────────
+
+    [StaFact]
+    public void ConfiguredThemeName_System_NamesTheResolvedBase()
+    {
+        using var light = NewService(osLight: true);
+        light.Initialize(Config("system"));
+        Assert.Equal("System, showing Quill", light.ConfiguredThemeName);
+
+        using var dark = NewService(osLight: false);
+        dark.Initialize(Config("system"));
+        Assert.Equal("System, showing Quill Dark", dark.ConfiguredThemeName);
+    }
+
+    [StaFact]
+    public void ConfiguredThemeName_RealTheme_IsItsOwnName()
+    {
+        using var svc = NewService();
+        svc.Initialize(Config("ember"));
+        Assert.Equal(svc.ResolvedTheme.Name, svc.ConfiguredThemeName);
+        Assert.DoesNotContain("System", svc.ConfiguredThemeName);
+    }
+
     // ── High Contrast passthrough ─────────────────────────────────────────────
 
     [StaFact]

--- a/QuickMail.Tests/UnitTest1.cs
+++ b/QuickMail.Tests/UnitTest1.cs
@@ -418,6 +418,25 @@ public class XamlParseTests
         window.Close();
     }
 
+    [StaFact]
+    public void ThemedControls_XamlParsesWithoutException()
+    {
+        EnsureApplication();
+        var uri = new Uri("pack://application:,,,/QuickMail;component/Styles/ThemedControls.xaml", UriKind.Absolute);
+        var dict = new ResourceDictionary { Source = uri };
+        Assert.True(dict.Count > 0);
+    }
+
+    [StaFact]
+    public void ThemeManagerWindow_XamlParsesWithoutException()
+    {
+        EnsureApplication();
+        var vm = new ThemeManagerViewModel(new StubThemeService(), new StubConfigService());
+        var window = new ThemeManagerWindow(vm);
+        Assert.NotNull(window);
+        window.Close();
+    }
+
     private static (StubImapMailService imap, StubAccountService accounts, StubCredentialService creds,
         StubLocalStoreService store, StubSyncService sync, StubConfigService config,
         StubCommandRegistry registry, StubContactService contacts, StubTemplateService templates)

--- a/QuickMail/App.xaml.cs
+++ b/QuickMail/App.xaml.cs
@@ -20,6 +20,7 @@ public partial class App : Application
     private ImapMailService? _imapBackend;
     private GraphMailService? _graphBackend;
     private UpdateCheckService? _updateCheckService;
+    private ThemeService? _themeService;
 
     protected override void OnStartup(StartupEventArgs e)
     {
@@ -128,6 +129,12 @@ public partial class App : Application
             LogService.Format  = startupCfg.LogFormat;
             LogService.Enabled = startupCfg.EnableLogging;
 
+            // Theme tokens must be published before the first window parses so every
+            // Theme.* DynamicResource resolves on first render.
+            _themeService = new ThemeService(new ThemeStore(profile));
+            _themeService.Initialize(startupCfg);
+            var themeService = _themeService;
+
             // Feature gate: CLI --feature/--no-feature > config.ini [features] section > built-in defaults.
             var (enableFlags, disableFlags) = ParseFeatureFlags(e.Args);
             var featureGate = new ConfigFeatureGate(startupCfg, enableFlags, disableFlags);
@@ -146,11 +153,12 @@ public partial class App : Application
             _updateCheckService = new UpdateCheckService();
             var mainVm = new MainViewModel(
                 mailRouter, accountService, credentialService, localStore, oauthService, syncService, configService, commandRegistry, viewService, ruleService, smtpService,
-                onlineMode: onlineMode, flagService: flagService, calendarService: calendarService, changeNotifier: _changeNotifier, updateCheckService: _updateCheckService);
+                onlineMode: onlineMode, flagService: flagService, calendarService: calendarService, changeNotifier: _changeNotifier, updateCheckService: _updateCheckService,
+                themeService: themeService);
             mainVm.RegisterAccountBackend = a => mailRouter.RegisterAccount(a.Id, BackendFor(a));
             mainVm.LoadAccountList(accounts);
 
-            var mainWindow = new MainWindow(mainVm, smtpService, accountService, credentialService, mailRouter, oauthService, commandRegistry, contactService, configService, localStore, viewService, ruleService, templateService, featureGate, flagService, customDictionary);
+            var mainWindow = new MainWindow(mainVm, smtpService, accountService, credentialService, mailRouter, oauthService, commandRegistry, contactService, configService, localStore, viewService, ruleService, templateService, featureGate, flagService, customDictionary, themeService);
             mainWindow.Show();
         }
         catch (Exception ex)
@@ -173,6 +181,7 @@ public partial class App : Application
         _contactService?.Dispose();
         _templateService?.Dispose();
         _updateCheckService?.Dispose();
+        _themeService?.Dispose();   // unsubscribes SystemParameters/SystemEvents static events
         base.OnExit(e);
     }
 

--- a/QuickMail/Controls/TokenizedAddressBox.xaml
+++ b/QuickMail/Controls/TokenizedAddressBox.xaml
@@ -14,8 +14,8 @@
             <Setter Property="Padding" Value="6,1"/>
             <Setter Property="Margin" Value="2,2"/>
             <Setter Property="VerticalAlignment" Value="Center"/>
-            <Setter Property="Background" Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"/>
-            <Setter Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}"/>
+            <Setter Property="Background" Value="{DynamicResource Theme.ChromeBackground}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource Theme.InputBorder}"/>
             <Setter Property="Template">
                 <Setter.Value>
                     <ControlTemplate TargetType="Button">
@@ -31,12 +31,12 @@
                         <ControlTemplate.Triggers>
                             <Trigger Property="IsKeyboardFocused" Value="True">
                                 <Setter TargetName="ChipBorder" Property="BorderBrush"
-                                        Value="{DynamicResource {x:Static SystemColors.HotTrackBrushKey}}"/>
+                                        Value="{DynamicResource Theme.Accent}"/>
                                 <Setter TargetName="ChipBorder" Property="BorderThickness" Value="2"/>
                             </Trigger>
                             <Trigger Property="IsMouseOver" Value="True">
                                 <Setter TargetName="ChipBorder" Property="Background"
-                                        Value="{DynamicResource {x:Static SystemColors.ControlLightBrushKey}}"/>
+                                        Value="{DynamicResource Theme.AccentSubtle}"/>
                             </Trigger>
                         </ControlTemplate.Triggers>
                     </ControlTemplate>
@@ -47,8 +47,8 @@
 
     <Border x:Name="OuterBorder"
             BorderThickness="1"
-            BorderBrush="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}"
-            Background="{DynamicResource {x:Static SystemColors.WindowBrushKey}}"
+            BorderBrush="{DynamicResource Theme.InputBorder}"
+            Background="{DynamicResource Theme.InputBackground}"
             Padding="2"
             MinHeight="26">
         <ScrollViewer VerticalScrollBarVisibility="Auto"

--- a/QuickMail/Controls/TokenizedAddressBox.xaml.cs
+++ b/QuickMail/Controls/TokenizedAddressBox.xaml.cs
@@ -96,9 +96,8 @@ public partial class TokenizedAddressBox : UserControl
             }, System.Windows.Threading.DispatcherPriority.Background);
 
         IsKeyboardFocusWithinChanged += (_, _) =>
-            OuterBorder.BorderBrush = IsKeyboardFocusWithin
-                ? SystemColors.HotTrackBrush
-                : SystemColors.ControlDarkBrush;
+            OuterBorder.SetResourceReference(Border.BorderBrushProperty,
+                IsKeyboardFocusWithin ? Theming.ThemeKeys.Accent : Theming.ThemeKeys.InputBorder);
     }
 
     private void OnLoaded(object sender, RoutedEventArgs e)
@@ -293,8 +292,10 @@ public partial class TokenizedAddressBox : UserControl
     {
         if (isInvalid)
         {
-            btn.Background = new SolidColorBrush(Color.FromRgb(0xFF, 0xEE, 0xEE));
-            btn.BorderBrush = Brushes.Red;
+            // Resource references (not brush copies) so the error state restyles
+            // live on theme change and stays visually distinct in every theme.
+            btn.SetResourceReference(BackgroundProperty, Theming.ThemeKeys.ErrorBackground);
+            btn.SetResourceReference(BorderBrushProperty, Theming.ThemeKeys.Error);
         }
         else
         {
@@ -311,8 +312,8 @@ public partial class TokenizedAddressBox : UserControl
         var btn = (Button)ChipPanel.Children[index];
         if (selected)
         {
-            btn.Background = SystemColors.HighlightBrush;
-            btn.Foreground = SystemColors.HighlightTextBrush;
+            btn.SetResourceReference(BackgroundProperty, Theming.ThemeKeys.SelectionBackground);
+            btn.SetResourceReference(ForegroundProperty, Theming.ThemeKeys.SelectionText);
         }
         else
         {

--- a/QuickMail/Helpers/MessageBodyHtmlBuilder.cs
+++ b/QuickMail/Helpers/MessageBodyHtmlBuilder.cs
@@ -25,14 +25,20 @@ public static class MessageBodyHtmlBuilder
     private static readonly char[] AutoLinkTrailingPunct =
         ['.', ',', ';', ':', '!', '?', ')', ']', '}', '>', '\''];
 
-    public static string BuildMessageHtml(MailMessageDetail detail)
+    /// <param name="themeCss">
+    /// Optional theme CSS from <see cref="IThemeService.BuildMessageCss"/> — the
+    /// <c>:root { --qm-* }</c> variable block. When null the document's CSS
+    /// variables are absent and the <c>var(--qm-*, fallback)</c> declarations
+    /// resolve to their system-color fallbacks (the pre-theming behavior).
+    /// </param>
+    public static string BuildMessageHtml(MailMessageDetail detail, string? themeCss = null)
     {
         var htmlBody = detail.HtmlBody ?? string.Empty;
         // Fail closed: if any stripping pass times out we cannot claim the HTML is
         // sanitized, so fall through to the plain-text (reader mode) rendering instead
         // of showing partially stripped markup.
         if (!string.IsNullOrWhiteSpace(htmlBody) && !ShouldUseReaderMode(htmlBody)
-            && TryBuildSanitizedHtmlDocument(detail.Subject, htmlBody, out var sanitized))
+            && TryBuildSanitizedHtmlDocument(detail.Subject, htmlBody, themeCss, out var sanitized))
             return sanitized;
 
         var text = !string.IsNullOrWhiteSpace(detail.PlainTextBody)
@@ -42,7 +48,7 @@ public static class MessageBodyHtmlBuilder
         var note = !string.IsNullOrWhiteSpace(htmlBody)
             ? "This message uses complex HTML, so QuickMail is showing a simplified body."
             : null;
-        return BuildPlainTextHtmlDocument(detail.Subject, text, note);
+        return BuildPlainTextHtmlDocument(detail.Subject, text, note, themeCss);
     }
 
     public static bool ShouldUseReaderMode(string html) =>
@@ -55,21 +61,31 @@ public static class MessageBodyHtmlBuilder
     /// fall back to plain-text rendering (a partially stripped document is not sanitized).
     /// </summary>
     public static bool TryBuildSanitizedHtmlDocument(string? subject, string html, out string document) =>
-        TryBuildSanitizedHtmlDocument(subject, html, HtmlRegexTimeout, out document);
+        TryBuildSanitizedHtmlDocument(subject, html, null, HtmlRegexTimeout, out document);
+
+    public static bool TryBuildSanitizedHtmlDocument(string? subject, string html, string? themeCss, out string document) =>
+        TryBuildSanitizedHtmlDocument(subject, html, themeCss, HtmlRegexTimeout, out document);
 
     internal static bool TryBuildSanitizedHtmlDocument(
-        string? subject, string html, TimeSpan timeout, out string document)
+        string? subject, string html, string? themeCss, TimeSpan timeout, out string document)
     {
         if (!TryStripHeavyHtml(html, timeout, out var body))
         {
             document = string.Empty;
             return false;
         }
-        document = ComposeSanitizedDocument(subject, body);
+        document = ComposeSanitizedDocument(subject, body, themeCss);
         return true;
     }
 
-    private static string ComposeSanitizedDocument(string? subject, string body)
+    /// <summary>
+    /// The theme <c>:root</c> variable block as a style tag, or empty. Emitted
+    /// before the default CSS so the <c>var(--qm-*)</c> references resolve.
+    /// </summary>
+    private static string ThemeStyleTag(string? themeCss) =>
+        string.IsNullOrEmpty(themeCss) ? string.Empty : "<style>" + themeCss + "</style>";
+
+    private static string ComposeSanitizedDocument(string? subject, string body, string? themeCss)
     {
         var titleTag = $"<title>{WebUtility.HtmlEncode(subject ?? string.Empty)}</title>";
         const string cspTag =
@@ -77,25 +93,33 @@ public static class MessageBodyHtmlBuilder
             "content=\"default-src 'none'; script-src 'none'; object-src 'none'; " +
             "frame-src 'none'; img-src 'none'; media-src 'none'; connect-src 'none'; " +
             "form-action 'none'; base-uri 'none'; style-src 'unsafe-inline';\">";
+        // Defaults only — sender-styled HTML still wins unless the user opts into
+        // force-theme (which arrives inside themeCss as !important rules). The
+        // var() fallbacks are the CSS system colors, so with no theme CSS the
+        // document renders exactly as before theming existed.
         const string css =
-            "<style>html,body{margin:0;padding:8px 12px;font-family:Segoe UI,Arial,sans-serif;" +
-            "font-size:13px;line-height:1.45;word-break:break-word;background:Window;color:WindowText;}" +
-            "table{max-width:100%;border-collapse:collapse;}td,th{vertical-align:top;}a{color:#0645ad;}</style>";
+            "<style>html,body{margin:0;padding:8px 12px;" +
+            "font-family:var(--qm-font, 'Segoe UI', Arial, sans-serif);" +
+            "font-size:var(--qm-font-size, 13px);line-height:1.45;word-break:break-word;" +
+            "background:var(--qm-bg, Canvas);color:var(--qm-text, CanvasText);}" +
+            "table{max-width:100%;border-collapse:collapse;}td,th{vertical-align:top;}" +
+            "a{color:var(--qm-link, #0645ad);}</style>";
+        var styleBlock = ThemeStyleTag(themeCss) + css;
 
         var headIdx = body.IndexOf("<head>", StringComparison.OrdinalIgnoreCase);
         if (headIdx >= 0)
         {
             body = RemoveTitle(body);
-            body = body.Insert(headIdx + 6, "<meta charset=\"utf-8\">" + titleTag + cspTag + css);
+            body = body.Insert(headIdx + 6, "<meta charset=\"utf-8\">" + titleTag + cspTag + styleBlock);
             return EnsureBodyFocusable(body);
         }
 
         return "<!DOCTYPE html><html lang=\"en\"><head><meta charset=\"utf-8\">" +
-               titleTag + cspTag + css +
+               titleTag + cspTag + styleBlock +
                "</head><body tabindex=\"0\">" + body + "</body></html>";
     }
 
-    public static string BuildPlainTextHtmlDocument(string? subject, string text, string? note)
+    public static string BuildPlainTextHtmlDocument(string? subject, string text, string? note, string? themeCss = null)
     {
         var clipped  = Truncate(text ?? string.Empty, MaxReaderTextChars);
         var encoded  = WebUtility.HtmlEncode(clipped);
@@ -108,10 +132,14 @@ public static class MessageBodyHtmlBuilder
         return "<!DOCTYPE html><html lang=\"en\"><head><meta charset=\"utf-8\">" +
                titleTag +
                "<meta http-equiv=\"Content-Security-Policy\" content=\"default-src 'none'; style-src 'unsafe-inline';\">" +
-               "<style>html,body{margin:0;padding:8px 12px;font-family:Segoe UI,Arial,sans-serif;" +
-               "font-size:13px;white-space:pre-wrap;word-break:break-word;background:Window;color:WindowText;}" +
-               "a{color:#0645ad;}" +
-               ".note{white-space:normal;border-left:3px solid #777;padding-left:8px;margin:0 0 12px 0;color:#555;}</style>" +
+               ThemeStyleTag(themeCss) +
+               "<style>html,body{margin:0;padding:8px 12px;" +
+               "font-family:var(--qm-font, 'Segoe UI', Arial, sans-serif);" +
+               "font-size:var(--qm-font-size, 13px);white-space:pre-wrap;word-break:break-word;" +
+               "background:var(--qm-bg, Canvas);color:var(--qm-text, CanvasText);}" +
+               "a{color:var(--qm-link, #0645ad);}" +
+               ".note{white-space:normal;border-left:3px solid var(--qm-border, #777);" +
+               "padding-left:8px;margin:0 0 12px 0;color:var(--qm-text-muted, #555);}</style>" +
                "</head><body tabindex=\"0\">" + noteHtml + linked + "</body></html>";
     }
 

--- a/QuickMail/Helpers/RichTextDocumentConverter.cs
+++ b/QuickMail/Helpers/RichTextDocumentConverter.cs
@@ -44,7 +44,20 @@ public static class RichTextDocumentConverter
     /// <summary>Run text shown for images whose alt text is empty (round-trips back to alt="").</summary>
     public const string ImageAltPlaceholder = "(image)";
 
-    private static readonly FontFamily CodeFont = new("Consolas");
+    private static readonly FontFamily FallbackCodeFont = new("Consolas");
+
+    /// <summary>
+    /// TextElement/Freezable properties cannot use SetResourceReference, so theme
+    /// tokens are read once per document build via TryFindResource with a hardcoded
+    /// fallback (never FindResource — it throws when the app resources are absent,
+    /// e.g. in unit tests). A document built before a theme switch keeps its colors
+    /// until it is rebuilt — bounded per message.
+    /// </summary>
+    private static Brush ThemeBrush(string resourceKey, Brush fallback) =>
+        Application.Current?.TryFindResource(resourceKey) as Brush ?? fallback;
+
+    private static FontFamily CodeFont =>
+        Application.Current?.TryFindResource(Theming.ThemeKeys.FontFamilyMono) as FontFamily ?? FallbackCodeFont;
 
     /// <summary>Heading visual sizes relative to the editor's default 13px body text.</summary>
     public static double HeadingFontSize(int level) => level switch
@@ -176,7 +189,7 @@ public static class RichTextDocumentConverter
                         if (inner is Paragraph qp)
                         {
                             qp.Margin = new Thickness(20, qp.Margin.Top, 0, qp.Margin.Bottom);
-                            qp.Foreground = Brushes.DarkSlateGray;
+                            qp.Foreground = ThemeBrush(Theming.ThemeKeys.TextSecondary, Brushes.DarkSlateGray);
                         }
                         yield return inner;
                     }
@@ -260,7 +273,7 @@ public static class RichTextDocumentConverter
                 AddInlines(cp.Inlines, cellNode.Children, new InlineStyle());
                 var cell = new TableCell(cp)
                 {
-                    BorderBrush = Brushes.Gray,
+                    BorderBrush = ThemeBrush(Theming.ThemeKeys.Border, Brushes.Gray),
                     BorderThickness = new Thickness(0.5),
                     Padding = new Thickness(6, 2, 6, 2),
                     Tag = (isHeader ? "TH" : "TD") + alignment switch

--- a/QuickMail/Helpers/ThemeDescriber.cs
+++ b/QuickMail/Helpers/ThemeDescriber.cs
@@ -1,0 +1,267 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Text.RegularExpressions;
+using QuickMail.Models;
+using QuickMail.Theming;
+
+namespace QuickMail.Helpers;
+
+/// <summary>
+/// Produces a plain-text, screen-reader-friendly description of a resolved theme:
+/// what each color is (a spoken descriptor plus the nearest documented CSS/X11
+/// color name and the hex), and where it is used in the app, plus the fonts. It
+/// is the text behind the Theme Manager's read-only "Theme description" box, so
+/// someone who cannot see the swatches can still understand what a theme does.
+///
+/// Input must be a fully resolved theme (every token present) — call
+/// <c>IThemeService.ResolveForPreview</c> first. This helper is deliberately
+/// string-only on its public surface so a ViewModel can consume it without
+/// touching the UI layer.
+/// </summary>
+public static class ThemeDescriber
+{
+    /// <summary>Token → (spoken label, where it is used). Grouped into the sections below.</summary>
+    private static readonly (string Header, (string Key, string Label, string Usage)[] Tokens)[] Sections =
+    {
+        ("Backgrounds and borders", new[]
+        {
+            ("windowBackground",  "Window background",   "the main window and the message reading area"),
+            ("surfaceBackground", "Panel background",    "raised surfaces — the message list, the folder tree, and dialogs"),
+            ("chromeBackground",  "Toolbar background",  "the menu bar, toolbars, and the status bar"),
+            ("inputBackground",   "Input background",    "inside text boxes, search fields, and dropdowns"),
+            ("border",            "Border",              "lines around controls and between panels"),
+            ("borderSubtle",      "Subtle border",       "faint dividers, such as between list rows"),
+            ("inputBorder",       "Input border",        "the outline of text boxes and dropdowns"),
+        }),
+        ("Text", new[]
+        {
+            ("textPrimary",   "Primary text",   "body text — messages, list items, and labels"),
+            ("textSecondary", "Secondary text", "supporting detail — timestamps, previews, and hints"),
+            ("textDisabled",  "Disabled text",  "labels on disabled buttons and unavailable options"),
+            ("textOnAccent",  "Text on accent", "text drawn on top of the accent color, such as on a selected button"),
+        }),
+        ("Accent and selection", new[]
+        {
+            ("accent",              "Accent",              "primary highlights — default buttons and the unread marker"),
+            ("accentSubtle",        "Subtle accent",       "soft accent fills, such as hover backgrounds"),
+            ("hyperlink",           "Hyperlink",           "clickable links in messages and text"),
+            ("selectionBackground", "Selection background", "the highlighted background of the selected list or tree item"),
+            ("selectionText",       "Selection text",      "text of the selected item, over the selection background"),
+            ("selectionInactive",   "Inactive selection",  "the selected item when its list does not have keyboard focus"),
+            ("focusIndicator",      "Focus outline",       "the keyboard focus rectangle around the focused control"),
+        }),
+        ("Status colors", new[]
+        {
+            ("error",             "Error",                  "error text and icons"),
+            ("errorBackground",   "Error background",       "the fill behind error messages"),
+            ("warning",           "Warning",                "warning text and icons"),
+            ("warningBackground", "Warning background",     "the fill behind warnings"),
+            ("success",           "Success",                "success text and confirmations"),
+            ("successBackground", "Success background",     "the fill behind success messages"),
+            ("info",              "Information",            "informational text and icons"),
+            ("infoBackground",    "Information background", "the fill behind informational messages"),
+        }),
+    };
+
+    /// <summary>
+    /// Builds the full description for a resolved theme. When <paramref name="isSystem"/>
+    /// is true the theme is the virtual System entry and the text says so, then
+    /// describes the base it currently resolves to.
+    /// </summary>
+    public static string Describe(ThemeDefinition theme, bool isSystem = false)
+    {
+        var sb = new StringBuilder();
+
+        if (isSystem)
+        {
+            sb.AppendLine("System theme — follows the Windows light and dark setting.");
+            sb.AppendLine($"It currently shows the {theme.Name} colors, described below.");
+        }
+        else
+        {
+            var baseWord = string.Equals(theme.Base, "dark", StringComparison.OrdinalIgnoreCase) ? "dark" : "light";
+            sb.AppendLine($"{theme.Name} — a {baseWord} theme.");
+        }
+        sb.AppendLine();
+
+        if (theme.IsComplete)
+        {
+            var bg = DescribeColorShort(theme.ColorOf("windowBackground"));
+            var txt = DescribeColorShort(theme.ColorOf("textPrimary"));
+            var accent = DescribeColorShort(theme.ColorOf("accent"));
+            sb.AppendLine("Overall");
+            sb.AppendLine($"{Article(bg, capital: true)} {bg} background with {txt} text and " +
+                          $"{Article(accent, capital: false)} {accent} accent.");
+            sb.AppendLine();
+        }
+
+        sb.AppendLine("Fonts");
+        sb.AppendLine($"Interface font: {theme.Typography.FontFamily}, base size {Number(theme.Typography.BaseFontSize)} pixels.");
+        sb.AppendLine($"Code font: {theme.Typography.MonoFontFamily}.");
+        sb.AppendLine();
+
+        foreach (var (header, tokens) in Sections)
+        {
+            sb.AppendLine(header);
+            foreach (var (key, label, usage) in tokens)
+            {
+                if (!theme.Colors.TryGetValue(key, out var hex))
+                    continue;
+                sb.AppendLine($"{label}: {DescribeColor(hex)} — {usage}.");
+            }
+            sb.AppendLine();
+        }
+
+        return sb.ToString().TrimEnd();
+    }
+
+    // ── Color naming ────────────────────────────────────────────────────────────
+
+    /// <summary>e.g. "dark blue (#3D5A80, like Steel Blue)".</summary>
+    public static string DescribeColor(string hex)
+    {
+        var (_, r, g, b) = ThemeDefinition.HexToArgb(hex);
+        return $"{Descriptor(r, g, b)} ({ThemeDefinition.NormalizeHex(hex)}, like {NearestName(r, g, b)})";
+    }
+
+    /// <summary>The spoken descriptor only, e.g. "warm off-white" — for the one-line overall summary.</summary>
+    public static string DescribeColorShort(string hex)
+    {
+        var (_, r, g, b) = ThemeDefinition.HexToArgb(hex);
+        return Descriptor(r, g, b);
+    }
+
+    /// <summary>Lightness + saturation + hue in words, or a neutral descriptor for near-grays.</summary>
+    private static string Descriptor(byte r, byte g, byte b)
+    {
+        var (h, _, l) = ToHsl(r, g, b);
+        // Absolute chroma, not HSL saturation: near-white and near-black colors get
+        // wildly inflated HSL saturation from a 2-3 unit RGB spread, which would call
+        // an off-white background "pale orange". Chroma stays honest at the extremes.
+        double chroma = (Math.Max(r, Math.Max(g, b)) - Math.Min(r, Math.Min(g, b))) / 255.0;
+
+        // Near-neutral: describe as black/white/off-white/gray with a warm/cool tinge.
+        if (chroma < 0.10)
+        {
+            var warmCool = r - b >= 6 ? "warm " : (b - r >= 6 ? "cool " : "");
+            if (l >= 0.985 && warmCool.Length == 0) return "white";
+            if (l >= 0.90) return (warmCool + "off-white").Trim();
+            if (l <= 0.06) return "black";
+            var grayLight = l <= 0.20 ? "very dark " : l <= 0.38 ? "dark " : l >= 0.72 ? "light " : "";
+            return (grayLight + warmCool + "gray").Trim();
+        }
+
+        var lightWord = l switch
+        {
+            < 0.18 => "very dark",
+            < 0.38 => "dark",
+            < 0.60 => "medium",
+            < 0.78 => "light",
+            _      => "pale",
+        };
+        var satWord = chroma < 0.30 ? "muted" : chroma > 0.55 ? "vivid" : "";
+
+        var parts = new List<string> { lightWord };
+        if (satWord.Length > 0) parts.Add(satWord);
+        parts.Add(HueName(h));
+        return string.Join(" ", parts);
+    }
+
+    private static string HueName(double h)
+    {
+        h = ((h % 360) + 360) % 360;
+        return h switch
+        {
+            < 15  => "red",
+            < 45  => "orange",
+            < 70  => "yellow",
+            < 95  => "yellow-green",
+            < 150 => "green",
+            < 175 => "teal",
+            < 200 => "cyan",
+            < 240 => "blue",
+            < 270 => "indigo",
+            < 300 => "purple",
+            < 330 => "magenta",
+            < 345 => "pink",
+            _     => "red",
+        };
+    }
+
+    private static (double H, double S, double L) ToHsl(byte r, byte g, byte b)
+    {
+        double rd = r / 255.0, gd = g / 255.0, bd = b / 255.0;
+        double max = Math.Max(rd, Math.Max(gd, bd));
+        double min = Math.Min(rd, Math.Min(gd, bd));
+        double l = (max + min) / 2.0;
+        double h = 0, s = 0;
+        double d = max - min;
+        if (d > 1e-6)
+        {
+            s = l > 0.5 ? d / (2.0 - max - min) : d / (max + min);
+            if (max == rd)      h = (gd - bd) / d + (gd < bd ? 6 : 0);
+            else if (max == gd) h = (bd - rd) / d + 2;
+            else                h = (rd - gd) / d + 4;
+            h *= 60;
+        }
+        return (h, s, l);
+    }
+
+    // ── Nearest documented name (the CSS / X11 set WPF exposes) ──────────────────
+
+    private static readonly Lazy<List<(string Name, byte R, byte G, byte B)>> NamedColors =
+        new(BuildNamedColors);
+
+    private static List<(string, byte, byte, byte)> BuildNamedColors()
+    {
+        var list = new List<(string, byte, byte, byte)>();
+        foreach (var p in typeof(System.Windows.Media.Colors)
+                     .GetProperties(BindingFlags.Public | BindingFlags.Static))
+        {
+            if (p.PropertyType != typeof(System.Windows.Media.Color))
+                continue;
+            var c = (System.Windows.Media.Color)p.GetValue(null)!;
+            if (c.A == 0) continue; // skip Transparent
+            list.Add((Spaced(p.Name), c.R, c.G, c.B));
+        }
+        return list;
+    }
+
+    private static string NearestName(byte r, byte g, byte b)
+    {
+        var best = "gray";
+        double bestDist = double.MaxValue;
+        foreach (var (name, cr, cg, cb) in NamedColors.Value)
+        {
+            // Redmean: a cheap perceptual RGB distance, better than plain Euclidean.
+            double rmean = (r + (double)cr) / 2.0;
+            double dr = r - cr, dg = g - cg, db = b - cb;
+            double dist = (512 + rmean) * dr * dr / 256.0 + 4 * dg * dg + (767 - rmean) * db * db / 256.0;
+            if (dist < bestDist)
+            {
+                bestDist = dist;
+                best = name;
+            }
+        }
+        return best;
+    }
+
+    /// <summary>"SteelBlue" → "Steel Blue".</summary>
+    private static string Spaced(string pascal) =>
+        Regex.Replace(pascal, "(?<=[a-z])(?=[A-Z])", " ");
+
+    private static string Number(double value) =>
+        value.ToString("0.#", CultureInfo.InvariantCulture);
+
+    /// <summary>"a" / "an" (capitalized on request) for the word that follows.</summary>
+    private static string Article(string word, bool capital)
+    {
+        var vowel = word.Length > 0 && "aeiou".Contains(char.ToLowerInvariant(word[0]));
+        var article = vowel ? "an" : "a";
+        return capital ? char.ToUpperInvariant(article[0]) + article[1..] : article;
+    }
+}

--- a/QuickMail/Helpers/ThemePersistence.cs
+++ b/QuickMail/Helpers/ThemePersistence.cs
@@ -1,0 +1,21 @@
+using QuickMail.Services;
+
+namespace QuickMail.Helpers;
+
+/// <summary>
+/// Writes the theme service's currently configured theme id into config.ini.
+/// Shared by <c>MainViewModel</c> (Apply / Next / Previous) and
+/// <c>ThemeManagerViewModel</c> (Apply / Delete) so the apply-then-persist
+/// write-back lives in exactly one place. The theme service itself never writes
+/// config — it exposes hex strings only, per the MVVM boundary — so persistence
+/// is the ViewModel's job, and this is the single copy of that job.
+/// </summary>
+internal static class ThemePersistence
+{
+    public static void PersistConfiguredTheme(IThemeService themeService, IConfigService configService)
+    {
+        var cfg = configService.Load();
+        cfg.AppearanceThemeId = themeService.ConfiguredThemeId;
+        configService.Save(cfg);
+    }
+}

--- a/QuickMail/Models/ConfigModel.cs
+++ b/QuickMail/Models/ConfigModel.cs
@@ -47,6 +47,30 @@ public class ConfigModel
     /// </summary>
     public int GraphPollSeconds { get; set; } = 60;
 
+    // ── Appearance ────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The active theme id. "system" follows the OS light/dark setting and yields
+    /// entirely to Windows High Contrast; other values name a built-in ("quill",
+    /// "dark", "ember", "fjord", "heather") or a user theme id.
+    /// </summary>
+    public string AppearanceThemeId { get; set; } = "system";
+
+    /// <summary>App-wide text scale. Discrete steps 1.0/1.1/1.25/1.5/1.75/2.0.</summary>
+    public double AppearanceTextScale { get; set; } = 1.0;
+
+    /// <summary>Font family override applied app-wide. Empty = use the theme's font.</summary>
+    public string AppearanceFontFamily { get; set; } = string.Empty;
+
+    /// <summary>Always underline hyperlinks in message content. Default off.</summary>
+    public bool AppearanceUnderlineLinks { get; set; } = false;
+
+    /// <summary>Thicker keyboard focus indicators (2px → 4px). Default off.</summary>
+    public bool AppearanceThickFocus { get; set; } = false;
+
+    /// <summary>Override sender HTML colors/fonts with theme colors in the reading pane. Default off.</summary>
+    public bool AppearanceForceMessageTheme { get; set; } = false;
+
     // ── Screen reader announcement settings ──────────────────────────────────────
 
     /// <summary>Master switch for all custom screen reader announcements from QuickMail code.</summary>

--- a/QuickMail/Models/ConfigModel.cs
+++ b/QuickMail/Models/ConfigModel.cs
@@ -51,7 +51,7 @@ public class ConfigModel
 
     /// <summary>
     /// The active theme id. "system" follows the OS light/dark setting and yields
-    /// entirely to Windows High Contrast; other values name a built-in ("quill",
+    /// entirely to Windows High Contrast; other values name a built-in ("parchment",
     /// "dark", "ember", "fjord", "heather") or a user theme id.
     /// </summary>
     public string AppearanceThemeId { get; set; } = "system";

--- a/QuickMail/Models/ThemeDefinition.cs
+++ b/QuickMail/Models/ThemeDefinition.cs
@@ -1,0 +1,306 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using QuickMail.Theming;
+
+namespace QuickMail.Models;
+
+/// <summary>
+/// Thrown when a theme file cannot be parsed or fails validation. The message is
+/// written in plain language and is shown to the user verbatim (e.g. on import),
+/// so it must name the specific problem: which key, which value, what was expected.
+/// </summary>
+public class ThemeFormatException : Exception
+{
+    public ThemeFormatException() { }
+    public ThemeFormatException(string message) : base(message) { }
+    public ThemeFormatException(string message, Exception inner) : base(message, inner) { }
+}
+
+/// <summary>Typography block of a theme. All members optional in JSON.</summary>
+public class ThemeTypography
+{
+    /// <summary>UI font family, e.g. "Segoe UI".</summary>
+    public string FontFamily { get; set; } = "Segoe UI";
+
+    /// <summary>Monospace font family for code content.</summary>
+    public string MonoFontFamily { get; set; } = "Consolas";
+
+    /// <summary>Base UI font size in device-independent pixels, before user scaling.</summary>
+    public double BaseFontSize { get; set; } = 13;
+
+    public ThemeTypography Clone() => new()
+    {
+        FontFamily     = FontFamily,
+        MonoFontFamily = MonoFontFamily,
+        BaseFontSize   = BaseFontSize,
+    };
+}
+
+/// <summary>
+/// A theme: sparse camelCase color map over a light/dark base, plus typography.
+/// Serialized as documented JSON in .quickmailtheme files and {profile}\themes\.
+/// Colors hold hex strings only — never System.Windows.Media types — so ViewModels
+/// can consume a theme without touching the UI layer.
+/// </summary>
+public class ThemeDefinition
+{
+    /// <summary>The newest theme file format this build understands.</summary>
+    public const int CurrentFormatVersion = 1;
+
+    /// <summary>Minimum and maximum accepted BaseFontSize.</summary>
+    public const double MinBaseFontSize = 9;
+    public const double MaxBaseFontSize = 24;
+
+    public int FormatVersion { get; set; } = CurrentFormatVersion;
+
+    /// <summary>Stable identifier, e.g. "quill" or a Guid string for user themes.</summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>Display name, e.g. "Quill".</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>"light" or "dark" — which built-in supplies missing color keys.</summary>
+    public string Base { get; set; } = "light";
+
+    /// <summary>Sparse camelCase token name → hex color (#RGB / #RRGGBB / #AARRGGBB).</summary>
+    public Dictionary<string, string> Colors { get; set; } = new(StringComparer.Ordinal);
+
+    public ThemeTypography Typography { get; set; } = new();
+
+    /// <summary>True for themes shipped as embedded resources. Not serialized.</summary>
+    [JsonIgnore]
+    public bool IsBuiltIn { get; set; }
+
+    // ── JSON ──────────────────────────────────────────────────────────────────
+
+    private static readonly JsonSerializerOptions ReadOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        AllowTrailingCommas = true,
+        ReadCommentHandling = JsonCommentHandling.Skip,
+    };
+
+    private static readonly JsonSerializerOptions WriteOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    private sealed class ThemeJson
+    {
+        public int? FormatVersion { get; set; }
+        public string? Id { get; set; }
+        public string? Name { get; set; }
+        public string? Base { get; set; }
+        public Dictionary<string, string>? Colors { get; set; }
+        public TypographyJson? Typography { get; set; }
+    }
+
+    private sealed class TypographyJson
+    {
+        public string? FontFamily { get; set; }
+        public string? MonoFontFamily { get; set; }
+        public double? BaseFontSize { get; set; }
+    }
+
+    /// <summary>
+    /// Parses and validates theme JSON. Throws <see cref="ThemeFormatException"/>
+    /// with a plain-language message on any problem. Unknown color keys are
+    /// tolerated and dropped so older builds keep reading newer files.
+    /// </summary>
+    public static ThemeDefinition Parse(string json)
+    {
+        ThemeJson? raw;
+        try
+        {
+            raw = JsonSerializer.Deserialize<ThemeJson>(json, ReadOptions);
+        }
+        catch (JsonException ex)
+        {
+            throw new ThemeFormatException($"The file is not valid JSON: {ex.Message}", ex);
+        }
+
+        if (raw is null)
+            throw new ThemeFormatException("The file is empty.");
+
+        var version = raw.FormatVersion ?? 1;
+        if (version > CurrentFormatVersion)
+            throw new ThemeFormatException(
+                $"This theme uses format version {version}, which was created by a newer version of QuickMail. " +
+                "Update QuickMail to use it.");
+
+        if (string.IsNullOrWhiteSpace(raw.Id))
+            throw new ThemeFormatException("The theme has no \"id\". Every theme needs a short identifier, e.g. \"my-theme\".");
+        if (string.IsNullOrWhiteSpace(raw.Name))
+            throw new ThemeFormatException("The theme has no \"name\". Give it a display name, e.g. \"My Theme\".");
+
+        var baseName = (raw.Base ?? "light").Trim().ToLowerInvariant();
+        if (baseName is not ("light" or "dark"))
+            throw new ThemeFormatException(
+                $"The \"base\" value \"{raw.Base}\" is not recognized. Use \"light\" or \"dark\".");
+
+        var theme = new ThemeDefinition
+        {
+            FormatVersion = version,
+            Id   = raw.Id.Trim(),
+            Name = raw.Name.Trim(),
+            Base = baseName,
+        };
+
+        if (raw.Colors != null)
+        {
+            foreach (var (key, value) in raw.Colors)
+            {
+                // Unknown keys tolerated: newer app versions may add tokens.
+                if (!ThemeKeys.ColorTokens.ContainsKey(key))
+                    continue;
+                if (!IsValidHexColor(value))
+                    throw new ThemeFormatException(
+                        $"The color \"{key}\" has the value \"{value}\", which is not a hex color. " +
+                        "Use #RGB, #RRGGBB, or #AARRGGBB, e.g. \"#3D5A80\".");
+                theme.Colors[key] = NormalizeHex(value);
+            }
+        }
+
+        if (raw.Typography != null)
+        {
+            if (!string.IsNullOrWhiteSpace(raw.Typography.FontFamily))
+                theme.Typography.FontFamily = raw.Typography.FontFamily.Trim();
+            if (!string.IsNullOrWhiteSpace(raw.Typography.MonoFontFamily))
+                theme.Typography.MonoFontFamily = raw.Typography.MonoFontFamily.Trim();
+            if (raw.Typography.BaseFontSize is double size)
+            {
+                if (double.IsNaN(size) || size < MinBaseFontSize || size > MaxBaseFontSize)
+                    throw new ThemeFormatException(
+                        $"The \"baseFontSize\" value {size} is out of range. Use a size between {MinBaseFontSize} and {MaxBaseFontSize}.");
+                theme.Typography.BaseFontSize = size;
+            }
+        }
+
+        return theme;
+    }
+
+    /// <summary>Serializes the theme as indented, camelCase JSON (the .quickmailtheme format).</summary>
+    public string ToJson()
+    {
+        var raw = new ThemeJson
+        {
+            FormatVersion = FormatVersion,
+            Id = Id,
+            Name = Name,
+            Base = Base,
+            Colors = new Dictionary<string, string>(Colors, StringComparer.Ordinal),
+            Typography = new TypographyJson
+            {
+                FontFamily = Typography.FontFamily,
+                MonoFontFamily = Typography.MonoFontFamily,
+                BaseFontSize = Typography.BaseFontSize,
+            },
+        };
+        return JsonSerializer.Serialize(raw, WriteOptions);
+    }
+
+    // ── Resolution ────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Returns a fully-populated copy: every color token present, missing keys
+    /// filled from <paramref name="baseTheme"/> (the built-in Light or Dark theme
+    /// selected by <see cref="Base"/>). The base theme must itself be complete.
+    /// </summary>
+    public ThemeDefinition ResolveAgainst(ThemeDefinition baseTheme)
+    {
+        var resolved = new ThemeDefinition
+        {
+            FormatVersion = FormatVersion,
+            Id = Id,
+            Name = Name,
+            Base = Base,
+            IsBuiltIn = IsBuiltIn,
+            Typography = Typography.Clone(),
+        };
+        foreach (var (jsonKey, _) in ThemeKeys.ColorTokens)
+        {
+            if (Colors.TryGetValue(jsonKey, out var hex))
+                resolved.Colors[jsonKey] = hex;
+            else if (baseTheme.Colors.TryGetValue(jsonKey, out var baseHex))
+                resolved.Colors[jsonKey] = baseHex;
+            else
+                throw new ThemeFormatException(
+                    $"The base theme \"{baseTheme.Id}\" is missing the color \"{jsonKey}\". Built-in themes must define every token.");
+        }
+        return resolved;
+    }
+
+    /// <summary>True when every color token has a value (i.e. the theme is fully resolved).</summary>
+    public bool IsComplete => ThemeKeys.ColorTokens.Keys.All(Colors.ContainsKey);
+
+    /// <summary>The hex value of a token by camelCase name. Throws if absent — call on resolved themes only.</summary>
+    public string ColorOf(string jsonKey) => Colors[jsonKey];
+
+    public ThemeDefinition Clone()
+    {
+        var copy = new ThemeDefinition
+        {
+            FormatVersion = FormatVersion,
+            Id = Id,
+            Name = Name,
+            Base = Base,
+            IsBuiltIn = IsBuiltIn,
+            Typography = Typography.Clone(),
+        };
+        foreach (var (k, v) in Colors) copy.Colors[k] = v;
+        return copy;
+    }
+
+    // ── Hex validation ────────────────────────────────────────────────────────
+
+    /// <summary>Accepts #RGB, #RRGGBB, or #AARRGGBB.</summary>
+    public static bool IsValidHexColor(string? value)
+    {
+        if (string.IsNullOrEmpty(value) || value[0] != '#')
+            return false;
+        var digits = value.Length - 1;
+        if (digits is not (3 or 6 or 8))
+            return false;
+        for (int i = 1; i < value.Length; i++)
+            if (!Uri.IsHexDigit(value[i]))
+                return false;
+        return true;
+    }
+
+    /// <summary>Normalizes to uppercase #RRGGBB / #AARRGGBB (expands #RGB).</summary>
+    public static string NormalizeHex(string value)
+    {
+        var v = value.ToUpperInvariant();
+        if (v.Length == 4) // #RGB → #RRGGBB
+            return string.Create(7, v, (span, src) =>
+            {
+                span[0] = '#';
+                span[1] = span[2] = src[1];
+                span[3] = span[4] = src[2];
+                span[5] = span[6] = src[3];
+            });
+        return v;
+    }
+
+    /// <summary>Parses a normalized hex color into A/R/G/B bytes (A=255 when absent).</summary>
+    public static (byte A, byte R, byte G, byte B) HexToArgb(string hex)
+    {
+        var v = NormalizeHex(hex);
+        if (v.Length == 9)
+            return (
+                byte.Parse(v.AsSpan(1, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture),
+                byte.Parse(v.AsSpan(3, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture),
+                byte.Parse(v.AsSpan(5, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture),
+                byte.Parse(v.AsSpan(7, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture));
+        return (
+            255,
+            byte.Parse(v.AsSpan(1, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture),
+            byte.Parse(v.AsSpan(3, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture),
+            byte.Parse(v.AsSpan(5, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture));
+    }
+}

--- a/QuickMail/QuickMail.csproj
+++ b/QuickMail/QuickMail.csproj
@@ -24,6 +24,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- Built-in themes ship inside the assembly; ThemeStore parses them with the same loader as user theme files. -->
+    <EmbeddedResource Include="Themes\BuiltIn\*.json" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="AdysTech.CredentialManager" Version="3.1.0" />
     <PackageReference Include="Google.Apis.Auth" Version="1.75.0" />
     <PackageReference Include="Markdig" Version="1.3.2" />

--- a/QuickMail/Services/ConfigService.cs
+++ b/QuickMail/Services/ConfigService.cs
@@ -221,6 +221,20 @@ public class ConfigService : IConfigService
                     case "graphpollseconds":
                         if (int.TryParse(value, out var gps)) config.GraphPollSeconds = Math.Clamp(gps, 30, 600);
                         break;
+                    case "appearancethemeid":
+                        if (!string.IsNullOrWhiteSpace(value)) config.AppearanceThemeId = value;
+                        break;
+                    case "appearancetextscale":
+                        if (double.TryParse(value, System.Globalization.NumberStyles.Float,
+                                System.Globalization.CultureInfo.InvariantCulture, out var scale))
+                            config.AppearanceTextScale = Math.Clamp(scale, 1.0, 2.0);
+                        break;
+                    case "appearancefontfamily":
+                        config.AppearanceFontFamily = value;
+                        break;
+                    case "appearanceunderlinelinks":   config.AppearanceUnderlineLinks   = ParseBool(value); break;
+                    case "appearancethickfocus":       config.AppearanceThickFocus       = ParseBool(value); break;
+                    case "appearanceforcemessagetheme": config.AppearanceForceMessageTheme = ParseBool(value); break;
                     case "customannouncements":  config.CustomAnnouncements = ParseBool(value); break;
                     case "announcehints":        config.AnnounceHints        = ParseBool(value); break;
                     case "announcestatus":       config.AnnounceStatus       = ParseBool(value); break;
@@ -362,6 +376,37 @@ public class ConfigService : IConfigService
         sb.AppendLine($"GraphPollSeconds = {Math.Clamp(config.GraphPollSeconds, 30, 600)}");
         sb.AppendLine("# Poll interval (seconds) for the Microsoft Graph new-mail watcher.");
         sb.AppendLine("# Default is 60. Values: 30-600. IMAP accounts use IDLE and ignore this.");
+        sb.AppendLine();
+
+        sb.AppendLine($"AppearanceThemeId = {config.AppearanceThemeId}");
+        sb.AppendLine("# The active theme. \"system\" follows the Windows light/dark setting and");
+        sb.AppendLine("# yields entirely to Windows High Contrast.");
+        sb.AppendLine("# Built-in values: system, quill, dark, ember, fjord, heather.");
+        sb.AppendLine("# User themes (from the Theme Manager) are referenced by their id.");
+        sb.AppendLine();
+
+        sb.AppendLine($"AppearanceTextScale = {config.AppearanceTextScale.ToString(System.Globalization.CultureInfo.InvariantCulture)}");
+        sb.AppendLine("# App-wide text size scale. Values: 1.0, 1.1, 1.25, 1.5, 1.75, 2.0.");
+        sb.AppendLine();
+
+        if (!string.IsNullOrEmpty(config.AppearanceFontFamily))
+        {
+            sb.AppendLine($"AppearanceFontFamily = {config.AppearanceFontFamily}");
+            sb.AppendLine("# Font family override applied app-wide. Remove to use the theme's font.");
+            sb.AppendLine();
+        }
+
+        sb.AppendLine($"AppearanceUnderlineLinks = {(config.AppearanceUnderlineLinks ? "on" : "off")}");
+        sb.AppendLine("# Always underline hyperlinks in message content. Values: on, off.");
+        sb.AppendLine();
+
+        sb.AppendLine($"AppearanceThickFocus = {(config.AppearanceThickFocus ? "on" : "off")}");
+        sb.AppendLine("# Thicker keyboard focus indicators. Values: on, off.");
+        sb.AppendLine();
+
+        sb.AppendLine($"AppearanceForceMessageTheme = {(config.AppearanceForceMessageTheme ? "on" : "off")}");
+        sb.AppendLine("# Override sender colors and fonts in message content with theme colors.");
+        sb.AppendLine("# Values: on, off.");
         sb.AppendLine();
 
         sb.AppendLine($"CustomAnnouncements = {(config.CustomAnnouncements ? "on" : "off")}");

--- a/QuickMail/Services/ConfigService.cs
+++ b/QuickMail/Services/ConfigService.cs
@@ -381,7 +381,7 @@ public class ConfigService : IConfigService
         sb.AppendLine($"AppearanceThemeId = {config.AppearanceThemeId}");
         sb.AppendLine("# The active theme. \"system\" follows the Windows light/dark setting and");
         sb.AppendLine("# yields entirely to Windows High Contrast.");
-        sb.AppendLine("# Built-in values: system, quill, dark, ember, fjord, heather.");
+        sb.AppendLine("# Built-in values: system, parchment, dark, ember, fjord, heather.");
         sb.AppendLine("# User themes (from the Theme Manager) are referenced by their id.");
         sb.AppendLine();
 

--- a/QuickMail/Services/IThemeService.cs
+++ b/QuickMail/Services/IThemeService.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using QuickMail.Models;
+
+namespace QuickMail.Services;
+
+/// <summary>
+/// Applies semantic theme tokens to the application and resolves the effective
+/// theme from the configured id, the OS light/dark preference, and Windows High
+/// Contrast. Exposes colors as hex strings only — never System.Windows.Media
+/// types — so ViewModels can consume the theme without touching the View layer.
+/// </summary>
+public interface IThemeService : IDisposable
+{
+    /// <summary>The configured theme id, e.g. "system", "quill", "dark", or a user theme id.</summary>
+    string ConfiguredThemeId { get; }
+
+    /// <summary>
+    /// The effective theme after System/HC resolution — fully populated, hex strings only.
+    /// Under High Contrast this reflects the live SystemColors palette.
+    /// </summary>
+    ThemeDefinition ResolvedTheme { get; }
+
+    /// <summary>True while Windows High Contrast is active.</summary>
+    bool IsHighContrastActive { get; }
+
+    /// <summary>The user themes folder ({profile}\themes), for "Open themes folder".</summary>
+    string UserThemesFolder { get; }
+
+    /// <summary>
+    /// All selectable themes in display order: System (virtual), the built-ins,
+    /// then user themes.
+    /// </summary>
+    IReadOnlyList<ThemeDefinition> GetAvailableThemes();
+
+    /// <summary>
+    /// Applies a theme by id and re-publishes the token dictionary. An unknown id
+    /// falls back to "system" without throwing. The caller persists the id to config.
+    /// </summary>
+    void ApplyTheme(string themeId);
+
+    /// <summary>
+    /// Imports a theme file, re-identifying on id collision and renaming on name
+    /// collision, and saves it into the themes folder.
+    /// Throws <see cref="ThemeFormatException"/> with a user-presentable message.
+    /// </summary>
+    ThemeDefinition ImportTheme(string filePath);
+
+    /// <summary>Exports a theme (built-in or user) to a .quickmailtheme JSON file.</summary>
+    void ExportTheme(string themeId, string filePath);
+
+    /// <summary>Saves (creates or overwrites) a user theme and refreshes if it is active.</summary>
+    void SaveUserTheme(ThemeDefinition theme);
+
+    /// <summary>Deletes a user theme. If it was active, falls back to "system".</summary>
+    void DeleteUserTheme(string themeId);
+
+    /// <summary>
+    /// Re-reads the vision-assist settings (text scale, font family override,
+    /// underline links, thick focus) from config and re-publishes the tokens.
+    /// Called after the Settings dialog saves.
+    /// </summary>
+    void ApplyVisionSettings(ConfigModel config);
+
+    /// <summary>
+    /// The token → CSS-variable bridge for WebView2 documents. Emits the
+    /// <c>--qm-*</c> variables in a <c>:root</c> block; color variables are omitted
+    /// under High Contrast so the browser's forced-colors handling wins. When
+    /// <paramref name="forceOnContent"/> is true, appends rules that override
+    /// sender-authored colors with theme colors.
+    /// </summary>
+    string BuildMessageCss(bool forceOnContent);
+
+    /// <summary>
+    /// Raised on the Dispatcher thread after the effective theme changes (theme
+    /// switch, OS light/dark flip, or High Contrast transition).
+    /// </summary>
+    event EventHandler? ThemeChanged;
+}

--- a/QuickMail/Services/IThemeService.cs
+++ b/QuickMail/Services/IThemeService.cs
@@ -42,6 +42,14 @@ public interface IThemeService : IDisposable
     IReadOnlyList<ThemeDefinition> GetAvailableThemes();
 
     /// <summary>
+    /// Fully resolves a theme by id (every token filled from its light/dark base)
+    /// for display and description, without applying it or consulting High
+    /// Contrast. The virtual "system" id resolves to whichever base the OS
+    /// currently selects. An unknown id falls back to the system base.
+    /// </summary>
+    ThemeDefinition ResolveForPreview(string themeId);
+
+    /// <summary>
     /// Applies a theme by id and re-publishes the token dictionary. An unknown id
     /// falls back to "system" without throwing. The caller persists the id to config.
     /// </summary>

--- a/QuickMail/Services/IThemeService.cs
+++ b/QuickMail/Services/IThemeService.cs
@@ -12,7 +12,7 @@ namespace QuickMail.Services;
 /// </summary>
 public interface IThemeService : IDisposable
 {
-    /// <summary>The configured theme id, e.g. "system", "quill", "dark", or a user theme id.</summary>
+    /// <summary>The configured theme id, e.g. "system", "parchment", "dark", or a user theme id.</summary>
     string ConfiguredThemeId { get; }
 
     /// <summary>

--- a/QuickMail/Services/IThemeService.cs
+++ b/QuickMail/Services/IThemeService.cs
@@ -16,6 +16,14 @@ public interface IThemeService : IDisposable
     string ConfiguredThemeId { get; }
 
     /// <summary>
+    /// The display name to announce for the current selection. For the virtual
+    /// System theme this reads "System, showing …" (qualified with the base it
+    /// currently resolves to) so cycling to System never announces the resolved
+    /// built-in name as if the user had selected it directly.
+    /// </summary>
+    string ConfiguredThemeName { get; }
+
+    /// <summary>
     /// The effective theme after System/HC resolution — fully populated, hex strings only.
     /// Under High Contrast this reflects the live SystemColors palette.
     /// </summary>
@@ -61,6 +69,14 @@ public interface IThemeService : IDisposable
     /// Called after the Settings dialog saves.
     /// </summary>
     void ApplyVisionSettings(ConfigModel config);
+
+    /// <summary>
+    /// Applies the configured theme id and the vision-assist settings together in
+    /// a single re-publish, so a combined Settings save raises <see cref="ThemeChanged"/>
+    /// at most once (no double announcement, no double reading-pane re-render).
+    /// The caller is responsible for persisting config.
+    /// </summary>
+    void ApplyAppearance(ConfigModel config);
 
     /// <summary>
     /// The token → CSS-variable bridge for WebView2 documents. Emits the

--- a/QuickMail/Services/ThemeService.cs
+++ b/QuickMail/Services/ThemeService.cs
@@ -71,7 +71,7 @@ public class ThemeService : IThemeService
     {
         _store = store;
         // Safe default so ResolvedTheme is never null even before Initialize.
-        _resolved = BuiltInById("quill").ResolveAgainst(BuiltInById("quill"));
+        _resolved = BuiltInById("parchment").ResolveAgainst(BuiltInById("parchment"));
     }
 
     public string ConfiguredThemeId => _configuredThemeId;
@@ -79,8 +79,8 @@ public class ThemeService : IThemeService
     /// <summary>
     /// The display name to announce for the current selection. For the virtual
     /// System theme this is "System" qualified with the base it currently shows
-    /// (e.g. "System, showing Quill") — so cycling to System never announces the
-    /// resolved built-in name as if the user had picked it directly.
+    /// (e.g. "System, showing Parchment") — so cycling to System never announces
+    /// the resolved built-in name as if the user had picked it directly.
     /// </summary>
     public string ConfiguredThemeName =>
         string.Equals(_configuredThemeId, SystemThemeId, StringComparison.OrdinalIgnoreCase)
@@ -302,7 +302,7 @@ public class ThemeService : IThemeService
 
     /// <summary>The complete built-in that supplies missing keys for a given base name.</summary>
     private ThemeDefinition BaseTheme(string baseName) =>
-        BuiltInById(baseName == "dark" ? "dark" : "quill");
+        BuiltInById(baseName == "dark" ? "dark" : "parchment");
 
     private ThemeDefinition ResolveEffectiveTheme()
     {
@@ -320,7 +320,7 @@ public class ThemeService : IThemeService
     {
         var id = string.IsNullOrWhiteSpace(themeId) ? SystemThemeId : themeId.Trim();
         if (string.Equals(id, SystemThemeId, StringComparison.OrdinalIgnoreCase))
-            id = OsLightModeProbe() ? "quill" : "dark";
+            id = OsLightModeProbe() ? "parchment" : "dark";
 
         var theme = _store.LoadBuiltIns()
                         .Concat(_store.LoadUserThemes())
@@ -329,7 +329,7 @@ public class ThemeService : IThemeService
         {
             // Unknown id — fall back to system resolution, never throw.
             LogService.Log($"Theme id \"{id}\" not found; falling back to system.");
-            theme = OsLightModeProbe() ? BuiltInById("quill") : BuiltInById("dark");
+            theme = OsLightModeProbe() ? BuiltInById("parchment") : BuiltInById("dark");
         }
 
         return theme.ResolveAgainst(BaseTheme(theme.Base));

--- a/QuickMail/Services/ThemeService.cs
+++ b/QuickMail/Services/ThemeService.cs
@@ -308,8 +308,17 @@ public class ThemeService : IThemeService
     {
         if (HighContrastProbe())
             return BuildHighContrastTheme();
+        return ResolveForPreview(_activeThemeId);
+    }
 
-        var id = _activeThemeId;
+    /// <summary>
+    /// Resolves a theme id to a complete theme for display/description, ignoring
+    /// High Contrast. Shared by the effective-theme path (non-HC) and the Theme
+    /// Manager's description box.
+    /// </summary>
+    public ThemeDefinition ResolveForPreview(string themeId)
+    {
+        var id = string.IsNullOrWhiteSpace(themeId) ? SystemThemeId : themeId.Trim();
         if (string.Equals(id, SystemThemeId, StringComparison.OrdinalIgnoreCase))
             id = OsLightModeProbe() ? "quill" : "dark";
 
@@ -318,7 +327,7 @@ public class ThemeService : IThemeService
                         .FirstOrDefault(t => string.Equals(t.Id, id, StringComparison.OrdinalIgnoreCase));
         if (theme is null)
         {
-            // Unknown configured id — fall back to system resolution, never throw.
+            // Unknown id — fall back to system resolution, never throw.
             LogService.Log($"Theme id \"{id}\" not found; falling back to system.");
             theme = OsLightModeProbe() ? BuiltInById("quill") : BuiltInById("dark");
         }

--- a/QuickMail/Services/ThemeService.cs
+++ b/QuickMail/Services/ThemeService.cs
@@ -425,10 +425,16 @@ public class ThemeService : IThemeService
         }
     }
 
-    private string BuildSignature(ThemeDefinition resolved) =>
-        $"{_isHighContrast}|{resolved.Id}|{string.Join(",", resolved.Colors.OrderBy(kv => kv.Key, StringComparer.Ordinal).Select(kv => kv.Value))}"
-        + $"|{resolved.Typography.FontFamily}|{resolved.Typography.MonoFontFamily}|{resolved.Typography.BaseFontSize}"
-        + $"|{_textScale}|{_fontFamilyOverride}|{_underlineLinks}|{_thickFocus}";
+    private string BuildSignature(ThemeDefinition resolved)
+    {
+        // Format doubles with InvariantCulture (like the rest of this file) so the
+        // signature is locale-stable — it is only compared to itself today, but a
+        // comma-decimal locale would otherwise make it inconsistent if ever logged.
+        var c = CultureInfo.InvariantCulture;
+        return $"{_isHighContrast}|{resolved.Id}|{string.Join(",", resolved.Colors.OrderBy(kv => kv.Key, StringComparer.Ordinal).Select(kv => kv.Value))}"
+            + $"|{resolved.Typography.FontFamily}|{resolved.Typography.MonoFontFamily}|{resolved.Typography.BaseFontSize.ToString(c)}"
+            + $"|{_textScale.ToString(c)}|{_fontFamilyOverride}|{_underlineLinks}|{_thickFocus}";
+    }
 
     private void PublishDictionary(ThemeDefinition resolved)
     {

--- a/QuickMail/Services/ThemeService.cs
+++ b/QuickMail/Services/ThemeService.cs
@@ -75,6 +75,18 @@ public class ThemeService : IThemeService
     }
 
     public string ConfiguredThemeId => _configuredThemeId;
+
+    /// <summary>
+    /// The display name to announce for the current selection. For the virtual
+    /// System theme this is "System" qualified with the base it currently shows
+    /// (e.g. "System, showing Quill") — so cycling to System never announces the
+    /// resolved built-in name as if the user had picked it directly.
+    /// </summary>
+    public string ConfiguredThemeName =>
+        string.Equals(_configuredThemeId, SystemThemeId, StringComparison.OrdinalIgnoreCase)
+            ? $"System, showing {_resolved.Name}"
+            : _resolved.Name;
+
     public ThemeDefinition ResolvedTheme => _resolved;
     public bool IsHighContrastActive => _isHighContrast;
     public string UserThemesFolder => _store.ThemesFolder;
@@ -188,6 +200,22 @@ public class ThemeService : IThemeService
     public void ApplyVisionSettings(ConfigModel config)
     {
         ReadVisionSettings(config);
+        Refresh(raiseEvent: true);
+    }
+
+    /// <summary>
+    /// Applies the configured theme id and the vision-assist settings from config
+    /// in a single re-publish. A combined Settings save (theme + font/scale/focus)
+    /// must not raise <see cref="ThemeChanged"/> twice — that would speak the
+    /// "Theme changed" announcement twice and re-render an open message's WebView2
+    /// back-to-back. Both mutations land before one <see cref="Refresh"/>.
+    /// </summary>
+    public void ApplyAppearance(ConfigModel config)
+    {
+        ReadVisionSettings(config);
+        var id = string.IsNullOrWhiteSpace(config.AppearanceThemeId) ? SystemThemeId : config.AppearanceThemeId.Trim();
+        _activeThemeId = id;
+        _configuredThemeId = id;
         Refresh(raiseEvent: true);
     }
 

--- a/QuickMail/Services/ThemeService.cs
+++ b/QuickMail/Services/ThemeService.cs
@@ -1,0 +1,536 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Windows;
+using System.Windows.Media;
+using System.Windows.Threading;
+using Microsoft.Win32;
+using QuickMail.Models;
+using QuickMail.Theming;
+
+namespace QuickMail.Services;
+
+/// <summary>
+/// Builds the semantic token dictionary (Theme.* DynamicResources) and keeps it in
+/// sync with the configured theme, the OS light/dark preference, and Windows High
+/// Contrast.
+///
+/// Publication is an atomic replacement of one merged dictionary — never an
+/// in-place mutate/Clear, which creates transient missing-resource states while
+/// DynamicResource listeners re-resolve. Under High Contrast every token is
+/// rebuilt from live SystemColors and the ThemedControls dictionary is withdrawn
+/// so controls fall back to WPF's built-in HC-aware templates: QuickMail has no
+/// visual opinion when HC is on.
+/// </summary>
+public class ThemeService : IThemeService
+{
+    /// <summary>The virtual theme id that follows the OS: light↔dark and HC passthrough.</summary>
+    public const string SystemThemeId = "system";
+
+    private const string ThemedControlsUri = "pack://application:,,,/Styles/ThemedControls.xaml";
+
+    private readonly ThemeStore _store;
+
+    // Effective state.
+    private string _configuredThemeId = SystemThemeId;
+    private string _activeThemeId = SystemThemeId;   // differs from configured only for non-persistent applies (Phase 5)
+    private ThemeDefinition _resolved;
+    private bool _isHighContrast;
+
+    // Vision-assist settings (from config; applied via ApplyVisionSettings).
+    private double _textScale = 1.0;
+    private string _fontFamilyOverride = string.Empty;
+    private bool _underlineLinks;
+    private bool _thickFocus;
+
+    // Published dictionaries (tracked by reference for atomic replacement).
+    private ResourceDictionary? _publishedTokens;
+    private ResourceDictionary? _themedControls;
+    private bool _themedControlsInserted;
+
+    private Dispatcher? _dispatcher;
+    private DispatcherTimer? _debounceTimer;
+    private bool _initialized;
+    private bool _disposed;
+    private string _lastPublishedSignature = string.Empty;
+
+    /// <summary>Test hook: overrides the OS light/dark probe (default reads AppsUseLightTheme).</summary>
+    internal Func<bool> OsLightModeProbe { get; set; } = ReadOsLightMode;
+
+    /// <summary>Test hook: overrides the High Contrast probe (default reads SystemParameters.HighContrast).</summary>
+    internal Func<bool> HighContrastProbe { get; set; } = () => SystemParameters.HighContrast;
+
+    /// <summary>Test hook: when false, skips loading Styles/ThemedControls.xaml (needs a pack URI host).</summary>
+    internal bool EnableThemedControls { get; set; } = true;
+
+    public event EventHandler? ThemeChanged;
+
+    public ThemeService(ThemeStore store)
+    {
+        _store = store;
+        // Safe default so ResolvedTheme is never null even before Initialize.
+        _resolved = BuiltInById("quill").ResolveAgainst(BuiltInById("quill"));
+    }
+
+    public string ConfiguredThemeId => _configuredThemeId;
+    public ThemeDefinition ResolvedTheme => _resolved;
+    public bool IsHighContrastActive => _isHighContrast;
+    public string UserThemesFolder => _store.ThemesFolder;
+
+    // ── Lifecycle ─────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Applies the configured theme and vision settings and subscribes to OS
+    /// change signals. Call once at startup, before the first window is created,
+    /// on the UI thread.
+    /// </summary>
+    public void Initialize(ConfigModel config)
+    {
+        // The calling thread's dispatcher — Initialize runs on the UI thread at
+        // startup, so this is the application dispatcher in production and the
+        // test thread's dispatcher under xUnit STA.
+        _dispatcher = Dispatcher.CurrentDispatcher;
+        ReadVisionSettings(config);
+        _configuredThemeId = string.IsNullOrWhiteSpace(config.AppearanceThemeId)
+            ? SystemThemeId
+            : config.AppearanceThemeId.Trim();
+        _activeThemeId = _configuredThemeId;
+
+        Refresh(raiseEvent: false);
+
+        // HighContrast: canonical WPF signal, raised on the UI thread.
+        SystemParameters.StaticPropertyChanged += OnSystemParametersChanged;
+        // OS light/dark (and HC palette edits): fires on a non-UI thread, in bursts.
+        SystemEvents.UserPreferenceChanged += OnUserPreferenceChanged;
+
+        _initialized = true;
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        if (_initialized)
+        {
+            SystemParameters.StaticPropertyChanged -= OnSystemParametersChanged;
+            SystemEvents.UserPreferenceChanged -= OnUserPreferenceChanged;
+        }
+        _debounceTimer?.Stop();
+        GC.SuppressFinalize(this);
+    }
+
+    // ── OS change detection ───────────────────────────────────────────────────
+
+    private void OnSystemParametersChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(SystemParameters.HighContrast))
+            ScheduleRefresh();
+    }
+
+    private void OnUserPreferenceChanged(object sender, UserPreferenceChangedEventArgs e)
+    {
+        if (e.Category is UserPreferenceCategory.General or UserPreferenceCategory.Color)
+        {
+            // Non-UI thread: marshal before touching WPF objects.
+            _dispatcher?.BeginInvoke(ScheduleRefresh);
+        }
+    }
+
+    /// <summary>Debounces bursts of preference-change signals into one Refresh (~250 ms).</summary>
+    private void ScheduleRefresh()
+    {
+        if (_dispatcher is null || !_dispatcher.CheckAccess())
+        {
+            _dispatcher?.BeginInvoke(ScheduleRefresh);
+            return;
+        }
+        _debounceTimer ??= CreateDebounceTimer();
+        _debounceTimer.Stop();
+        _debounceTimer.Start();
+    }
+
+    private DispatcherTimer CreateDebounceTimer()
+    {
+        var timer = new DispatcherTimer(DispatcherPriority.Background, _dispatcher!)
+        {
+            Interval = TimeSpan.FromMilliseconds(250),
+        };
+        timer.Tick += (_, _) =>
+        {
+            timer.Stop();
+            if (!_disposed)
+                Refresh(raiseEvent: true);
+        };
+        return timer;
+    }
+
+    // ── Theme selection ───────────────────────────────────────────────────────
+
+    public void ApplyTheme(string themeId) => ApplyTheme(themeId, persist: true);
+
+    /// <summary>
+    /// Applies a theme. With <paramref name="persist"/> false the configured id is
+    /// untouched — the hook for per-view themes (Phase 5); the caller persists the
+    /// configured id to config.ini either way (the service never writes config).
+    /// </summary>
+    internal void ApplyTheme(string themeId, bool persist)
+    {
+        var id = string.IsNullOrWhiteSpace(themeId) ? SystemThemeId : themeId.Trim();
+        _activeThemeId = id;
+        if (persist)
+            _configuredThemeId = id;
+        Refresh(raiseEvent: true);
+    }
+
+    /// <summary>Re-reads vision-assist settings (scale, font, underline, focus) and re-publishes.</summary>
+    public void ApplyVisionSettings(ConfigModel config)
+    {
+        ReadVisionSettings(config);
+        Refresh(raiseEvent: true);
+    }
+
+    private void ReadVisionSettings(ConfigModel config)
+    {
+        _textScale = Math.Clamp(config.AppearanceTextScale, 1.0, 2.0);
+        _fontFamilyOverride = config.AppearanceFontFamily?.Trim() ?? string.Empty;
+        _underlineLinks = config.AppearanceUnderlineLinks;
+        _thickFocus = config.AppearanceThickFocus;
+    }
+
+    public IReadOnlyList<ThemeDefinition> GetAvailableThemes()
+    {
+        var list = new List<ThemeDefinition>
+        {
+            new()
+            {
+                Id = SystemThemeId,
+                Name = "System",
+                Base = "light",
+                IsBuiltIn = true,
+            },
+        };
+        list.AddRange(_store.LoadBuiltIns());
+        list.AddRange(_store.LoadUserThemes());
+        return list;
+    }
+
+    // ── User theme management ─────────────────────────────────────────────────
+
+    public ThemeDefinition ImportTheme(string filePath)
+    {
+        string json;
+        try
+        {
+            json = System.IO.File.ReadAllText(filePath);
+        }
+        catch (Exception ex)
+        {
+            throw new ThemeFormatException($"The file could not be read: {ex.Message}", ex);
+        }
+
+        var theme = ThemeDefinition.Parse(json);
+        theme.IsBuiltIn = false;
+
+        var existing = GetAvailableThemes();
+        if (existing.Any(t => string.Equals(t.Id, theme.Id, StringComparison.OrdinalIgnoreCase)))
+            theme.Id = Guid.NewGuid().ToString("N");
+        if (existing.Any(t => string.Equals(t.Name, theme.Name, StringComparison.OrdinalIgnoreCase)))
+            theme.Name += " (imported)";
+
+        _store.SaveUserTheme(theme);
+        return theme;
+    }
+
+    public void ExportTheme(string themeId, string filePath)
+    {
+        var theme = GetAvailableThemes().FirstOrDefault(t =>
+                string.Equals(t.Id, themeId, StringComparison.OrdinalIgnoreCase))
+            ?? throw new InvalidOperationException($"No theme with id \"{themeId}\".");
+        if (theme.Id == SystemThemeId)
+            throw new InvalidOperationException("The System theme follows the OS and cannot be exported.");
+        Helpers.AtomicFile.WriteAllText(filePath, theme.ToJson());
+    }
+
+    public void SaveUserTheme(ThemeDefinition theme)
+    {
+        _store.SaveUserTheme(theme);
+        if (string.Equals(_activeThemeId, theme.Id, StringComparison.OrdinalIgnoreCase))
+            Refresh(raiseEvent: true);
+    }
+
+    public void DeleteUserTheme(string themeId)
+    {
+        _store.DeleteUserTheme(themeId);
+        if (string.Equals(_activeThemeId, themeId, StringComparison.OrdinalIgnoreCase))
+            ApplyTheme(SystemThemeId);
+    }
+
+    // ── Resolution ────────────────────────────────────────────────────────────
+
+    private ThemeDefinition BuiltInById(string id) =>
+        _store.LoadBuiltIns().First(t => string.Equals(t.Id, id, StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>The complete built-in that supplies missing keys for a given base name.</summary>
+    private ThemeDefinition BaseTheme(string baseName) =>
+        BuiltInById(baseName == "dark" ? "dark" : "quill");
+
+    private ThemeDefinition ResolveEffectiveTheme()
+    {
+        if (HighContrastProbe())
+            return BuildHighContrastTheme();
+
+        var id = _activeThemeId;
+        if (string.Equals(id, SystemThemeId, StringComparison.OrdinalIgnoreCase))
+            id = OsLightModeProbe() ? "quill" : "dark";
+
+        var theme = _store.LoadBuiltIns()
+                        .Concat(_store.LoadUserThemes())
+                        .FirstOrDefault(t => string.Equals(t.Id, id, StringComparison.OrdinalIgnoreCase));
+        if (theme is null)
+        {
+            // Unknown configured id — fall back to system resolution, never throw.
+            LogService.Log($"Theme id \"{id}\" not found; falling back to system.");
+            theme = OsLightModeProbe() ? BuiltInById("quill") : BuiltInById("dark");
+        }
+
+        return theme.ResolveAgainst(BaseTheme(theme.Base));
+    }
+
+    /// <summary>
+    /// In High Contrast QuickMail has no visual opinion: every token resolves to
+    /// the live SystemColors palette. Status colors map to WindowText/Window — HC
+    /// palettes don't guarantee distinguishable red/green, and status information
+    /// is always conveyed in text as well.
+    /// </summary>
+    private static ThemeDefinition BuildHighContrastTheme()
+    {
+        static string Hex(Color c) => $"#{c.R:X2}{c.G:X2}{c.B:X2}";
+
+        var window     = Hex(SystemColors.WindowColor);
+        var windowText = Hex(SystemColors.WindowTextColor);
+        var control    = Hex(SystemColors.ControlColor);
+        var grayText   = Hex(SystemColors.GrayTextColor);
+        var border     = Hex(SystemColors.ActiveBorderColor);
+        var hotTrack   = Hex(SystemColors.HotTrackColor);
+        var highlight  = Hex(SystemColors.HighlightColor);
+        var highlightText = Hex(SystemColors.HighlightTextColor);
+
+        var theme = new ThemeDefinition
+        {
+            Id = "high-contrast",
+            Name = "High Contrast",
+            Base = "light",
+            IsBuiltIn = true,
+            // Font/scale still apply — typography matters more to low-vision HC users.
+            Typography = new ThemeTypography(),
+        };
+
+        var colors = theme.Colors;
+        colors["windowBackground"]    = window;
+        colors["surfaceBackground"]   = control;
+        colors["chromeBackground"]    = control;
+        colors["inputBackground"]     = window;
+        colors["border"]              = border;
+        colors["borderSubtle"]        = border;
+        colors["inputBorder"]         = border;
+        colors["textPrimary"]         = windowText;
+        colors["textSecondary"]       = grayText;
+        colors["textDisabled"]        = grayText;
+        colors["textOnAccent"]        = window;
+        colors["accent"]              = hotTrack;
+        colors["accentSubtle"]        = control;
+        colors["hyperlink"]           = hotTrack;
+        colors["selectionBackground"] = highlight;
+        colors["selectionText"]       = highlightText;
+        colors["selectionInactive"]   = control;
+        colors["focusIndicator"]      = windowText;
+        colors["error"]               = windowText;
+        colors["errorBackground"]     = window;
+        colors["warning"]             = windowText;
+        colors["warningBackground"]   = window;
+        colors["success"]             = windowText;
+        colors["successBackground"]   = window;
+        colors["info"]                = windowText;
+        colors["infoBackground"]      = window;
+        return theme;
+    }
+
+    // ── Publication ───────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Recomputes the effective theme; if it changed, atomically replaces the
+    /// token dictionary, inserts/withdraws ThemedControls, and raises ThemeChanged.
+    /// </summary>
+    private void Refresh(bool raiseEvent)
+    {
+        var wasHc = _isHighContrast;
+        _isHighContrast = HighContrastProbe();
+        var resolved = ResolveEffectiveTheme();
+
+        var signature = BuildSignature(resolved);
+        if (signature == _lastPublishedSignature && wasHc == _isHighContrast)
+            return; // effective theme unchanged — no dictionary churn, no event
+
+        _resolved = resolved;
+        _lastPublishedSignature = signature;
+
+        PublishDictionary(resolved);
+
+        if (raiseEvent)
+        {
+            // Raised on the Dispatcher thread per the interface contract.
+            if (_dispatcher is null || _dispatcher.CheckAccess())
+                ThemeChanged?.Invoke(this, EventArgs.Empty);
+            else
+                _dispatcher.BeginInvoke(() => ThemeChanged?.Invoke(this, EventArgs.Empty));
+        }
+    }
+
+    private string BuildSignature(ThemeDefinition resolved) =>
+        $"{_isHighContrast}|{resolved.Id}|{string.Join(",", resolved.Colors.OrderBy(kv => kv.Key, StringComparer.Ordinal).Select(kv => kv.Value))}"
+        + $"|{resolved.Typography.FontFamily}|{resolved.Typography.MonoFontFamily}|{resolved.Typography.BaseFontSize}"
+        + $"|{_textScale}|{_fontFamilyOverride}|{_underlineLinks}|{_thickFocus}";
+
+    private void PublishDictionary(ThemeDefinition resolved)
+    {
+        var app = Application.Current;
+        if (app is null)
+            return; // unit tests without an Application — resolution still works
+
+        var merged = app.Resources.MergedDictionaries;
+        var tokens = BuildTokenDictionary(resolved);
+
+        var index = _publishedTokens is null ? -1 : merged.IndexOf(_publishedTokens);
+        if (index >= 0)
+            merged[index] = tokens;          // atomic swap in place
+        else
+            merged.Add(tokens);              // first publication: after AccessibleStyles
+        _publishedTokens = tokens;
+
+        // ThemedControls: present in normal themes, withdrawn under HC so WPF's
+        // built-in HC-aware templates take over.
+        if (EnableThemedControls)
+        {
+            if (_isHighContrast)
+            {
+                if (_themedControlsInserted && _themedControls != null)
+                {
+                    merged.Remove(_themedControls);
+                    _themedControlsInserted = false;
+                }
+            }
+            else
+            {
+                _themedControls ??= new ResourceDictionary { Source = new Uri(ThemedControlsUri) };
+                if (!_themedControlsInserted)
+                {
+                    merged.Add(_themedControls);
+                    _themedControlsInserted = true;
+                }
+            }
+        }
+    }
+
+    /// <summary>Builds the frozen token dictionary for a resolved theme. Internal for tests.</summary>
+    internal ResourceDictionary BuildTokenDictionary(ThemeDefinition resolved)
+    {
+        var dict = new ResourceDictionary();
+
+        foreach (var (jsonKey, resourceKey) in ThemeKeys.ColorTokens)
+        {
+            var (a, r, g, b) = ThemeDefinition.HexToArgb(resolved.Colors[jsonKey]);
+            var brush = new SolidColorBrush(Color.FromArgb(a, r, g, b));
+            brush.Freeze();
+            dict[resourceKey] = brush;
+        }
+
+        var fontName = _fontFamilyOverride.Length > 0 ? _fontFamilyOverride : resolved.Typography.FontFamily;
+        dict[ThemeKeys.FontFamily] = SafeFontFamily(fontName, "Segoe UI");
+        dict[ThemeKeys.FontFamilyMono] = SafeFontFamily(resolved.Typography.MonoFontFamily, "Consolas");
+
+        var baseSize = Math.Round(resolved.Typography.BaseFontSize * _textScale, 1);
+        dict[ThemeKeys.FontSizeBase] = baseSize;
+        dict[ThemeKeys.FontSizeSmall] = Math.Max(9, baseSize - 2);
+        dict[ThemeKeys.FontSizeLarge] = baseSize + 2;
+        dict[ThemeKeys.FontSizeHeader] = baseSize + 5;
+
+        dict[ThemeKeys.FocusThickness] = _thickFocus ? 4.0 : 2.0;
+
+        return dict;
+    }
+
+    private static FontFamily SafeFontFamily(string name, string fallback)
+    {
+        try
+        {
+            return new FontFamily(name);
+        }
+        catch (ArgumentException)
+        {
+            return new FontFamily(fallback);
+        }
+    }
+
+    // ── WebView2 bridge ───────────────────────────────────────────────────────
+
+    public string BuildMessageCss(bool forceOnContent)
+    {
+        var sb = new StringBuilder();
+        var t = _resolved;
+
+        var fontName = _fontFamilyOverride.Length > 0 ? _fontFamilyOverride : t.Typography.FontFamily;
+        var fontSize = Math.Round(t.Typography.BaseFontSize * _textScale, 1)
+            .ToString(CultureInfo.InvariantCulture);
+
+        sb.Append(":root{");
+        sb.Append("--qm-font:'").Append(fontName.Replace("'", string.Empty)).Append("',system-ui,sans-serif;");
+        sb.Append("--qm-font-size:").Append(fontSize).Append("px;");
+        if (!_isHighContrast)
+        {
+            // Color variables are omitted under HC — WebView2's forced-colors
+            // handling is correct natively and must win.
+            sb.Append("--qm-bg:").Append(t.ColorOf("windowBackground")).Append(';');
+            sb.Append("--qm-text:").Append(t.ColorOf("textPrimary")).Append(';');
+            sb.Append("--qm-text-muted:").Append(t.ColorOf("textSecondary")).Append(';');
+            sb.Append("--qm-surface:").Append(t.ColorOf("surfaceBackground")).Append(';');
+            sb.Append("--qm-border:").Append(t.ColorOf("border")).Append(';');
+            sb.Append("--qm-accent:").Append(t.ColorOf("accent")).Append(';');
+            sb.Append("--qm-link:").Append(t.ColorOf("hyperlink")).Append(';');
+        }
+        sb.Append('}');
+
+        if (_underlineLinks)
+            sb.Append("a{text-decoration:underline !important;}");
+
+        if (forceOnContent && !_isHighContrast)
+        {
+            sb.Append("*{background-color:var(--qm-bg) !important;color:var(--qm-text) !important;}");
+            sb.Append("a{color:var(--qm-link) !important;}");
+        }
+
+        return sb.ToString();
+    }
+
+    // ── OS probes ─────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// True when Windows "choose your default app mode" is Light. .NET 8 has no
+    /// managed API (Application.ThemeMode is .NET 9+), so read the registry value
+    /// the OS itself uses.
+    /// </summary>
+    private static bool ReadOsLightMode()
+    {
+        try
+        {
+            using var key = Registry.CurrentUser.OpenSubKey(
+                @"Software\Microsoft\Windows\CurrentVersion\Themes\Personalize");
+            return key?.GetValue("AppsUseLightTheme") is not int v || v != 0;
+        }
+        catch
+        {
+            return true;
+        }
+    }
+}

--- a/QuickMail/Services/ThemeStore.cs
+++ b/QuickMail/Services/ThemeStore.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using QuickMail.Models;
+
+namespace QuickMail.Services;
+
+/// <summary>
+/// Loads the built-in themes from embedded resources and persists user themes as
+/// one JSON file per theme in {profile}\themes\ — a theme is an individually
+/// shareable artifact, unlike views.json which holds the whole collection.
+/// A missing or corrupt user theme file is skipped with a log line and never
+/// blocks startup.
+/// </summary>
+public class ThemeStore
+{
+    /// <summary>Embedded built-in theme resources, in display order.</summary>
+    private static readonly string[] BuiltInResourceNames =
+    {
+        "QuickMail.Themes.BuiltIn.light.json",
+        "QuickMail.Themes.BuiltIn.dark.json",
+        "QuickMail.Themes.BuiltIn.ember.json",
+        "QuickMail.Themes.BuiltIn.fjord.json",
+        "QuickMail.Themes.BuiltIn.heather.json",
+    };
+
+    private readonly string _themesFolder;
+    private IReadOnlyList<ThemeDefinition>? _builtIns;
+
+    public ThemeStore(ProfileContext profile)
+    {
+        _themesFolder = Path.Combine(profile.ProfileDir, "themes");
+    }
+
+    /// <summary>The user themes folder ({profile}\themes). Created on first write.</summary>
+    public string ThemesFolder => _themesFolder;
+
+    /// <summary>The five built-in themes, fully parsed. Cached after first load.</summary>
+    public IReadOnlyList<ThemeDefinition> LoadBuiltIns()
+    {
+        if (_builtIns != null) return _builtIns;
+
+        var assembly = typeof(ThemeStore).Assembly;
+        var list = new List<ThemeDefinition>(BuiltInResourceNames.Length);
+        foreach (var resourceName in BuiltInResourceNames)
+        {
+            using var stream = assembly.GetManifestResourceStream(resourceName)
+                ?? throw new InvalidOperationException($"Embedded theme resource missing: {resourceName}");
+            using var reader = new StreamReader(stream);
+            var theme = ThemeDefinition.Parse(reader.ReadToEnd());
+            theme.IsBuiltIn = true;
+            list.Add(theme);
+        }
+        _builtIns = list;
+        return _builtIns;
+    }
+
+    /// <summary>
+    /// All user themes from {profile}\themes\*.json, sorted by name.
+    /// Files that fail to parse are skipped and logged.
+    /// </summary>
+    public List<ThemeDefinition> LoadUserThemes()
+    {
+        var result = new List<ThemeDefinition>();
+        if (!Directory.Exists(_themesFolder))
+            return result;
+
+        foreach (var file in Directory.EnumerateFiles(_themesFolder, "*.json").OrderBy(f => f, StringComparer.OrdinalIgnoreCase))
+        {
+            try
+            {
+                var theme = ThemeDefinition.Parse(File.ReadAllText(file));
+                theme.IsBuiltIn = false;
+                // A user file must not shadow a built-in id or duplicate another user id.
+                if (LoadBuiltIns().Any(b => string.Equals(b.Id, theme.Id, StringComparison.OrdinalIgnoreCase))
+                    || result.Any(t => string.Equals(t.Id, theme.Id, StringComparison.OrdinalIgnoreCase)))
+                {
+                    LogService.Log($"Theme file skipped (duplicate id \"{theme.Id}\"): {file}");
+                    continue;
+                }
+                result.Add(theme);
+            }
+            catch (Exception ex)
+            {
+                LogService.Log($"Theme file skipped ({ex.Message}): {file}");
+            }
+        }
+        return result.OrderBy(t => t.Name, StringComparer.CurrentCultureIgnoreCase).ToList();
+    }
+
+    /// <summary>Writes a user theme to {profile}\themes\{id}.json atomically.</summary>
+    public void SaveUserTheme(ThemeDefinition theme)
+    {
+        if (theme.IsBuiltIn)
+            throw new InvalidOperationException("Built-in themes cannot be saved to the themes folder.");
+        Directory.CreateDirectory(_themesFolder);
+        Helpers.AtomicFile.WriteAllText(PathForId(theme.Id), theme.ToJson());
+    }
+
+    /// <summary>Deletes a user theme file. No-op if absent.</summary>
+    public void DeleteUserTheme(string themeId)
+    {
+        var path = PathForId(themeId);
+        if (File.Exists(path))
+            File.Delete(path);
+    }
+
+    private string PathForId(string id)
+    {
+        // Theme ids come from JSON files; sanitize so an id can't escape the folder.
+        var safe = string.Concat(id.Select(c => Path.GetInvalidFileNameChars().Contains(c) ? '-' : c));
+        return Path.Combine(_themesFolder, safe + ".json");
+    }
+}

--- a/QuickMail/Services/ThemeStore.cs
+++ b/QuickMail/Services/ThemeStore.cs
@@ -28,6 +28,7 @@ public class ThemeStore
 
     private readonly string _themesFolder;
     private IReadOnlyList<ThemeDefinition>? _builtIns;
+    private IReadOnlyList<ThemeDefinition>? _userThemes;
 
     public ThemeStore(ProfileContext profile)
     {
@@ -59,13 +60,18 @@ public class ThemeStore
 
     /// <summary>
     /// All user themes from {profile}\themes\*.json, sorted by name.
-    /// Files that fail to parse are skipped and logged.
+    /// Files that fail to parse are skipped and logged. Cached after first load
+    /// (mirroring <see cref="LoadBuiltIns"/>) and invalidated by
+    /// <see cref="SaveUserTheme"/> / <see cref="DeleteUserTheme"/>, so the hot
+    /// paths (theme apply, Next/Previous cycling, OS refresh) do no disk I/O.
     /// </summary>
-    public List<ThemeDefinition> LoadUserThemes()
+    public IReadOnlyList<ThemeDefinition> LoadUserThemes()
     {
+        if (_userThemes != null) return _userThemes;
+
         var result = new List<ThemeDefinition>();
         if (!Directory.Exists(_themesFolder))
-            return result;
+            return _userThemes = result;
 
         foreach (var file in Directory.EnumerateFiles(_themesFolder, "*.json").OrderBy(f => f, StringComparer.OrdinalIgnoreCase))
         {
@@ -87,7 +93,7 @@ public class ThemeStore
                 LogService.Log($"Theme file skipped ({ex.Message}): {file}");
             }
         }
-        return result.OrderBy(t => t.Name, StringComparer.CurrentCultureIgnoreCase).ToList();
+        return _userThemes = result.OrderBy(t => t.Name, StringComparer.CurrentCultureIgnoreCase).ToList();
     }
 
     /// <summary>Writes a user theme to {profile}\themes\{id}.json atomically.</summary>
@@ -97,6 +103,7 @@ public class ThemeStore
             throw new InvalidOperationException("Built-in themes cannot be saved to the themes folder.");
         Directory.CreateDirectory(_themesFolder);
         Helpers.AtomicFile.WriteAllText(PathForId(theme.Id), theme.ToJson());
+        _userThemes = null; // invalidate cache; next load re-reads the folder
     }
 
     /// <summary>Deletes a user theme file. No-op if absent.</summary>
@@ -105,6 +112,7 @@ public class ThemeStore
         var path = PathForId(themeId);
         if (File.Exists(path))
             File.Delete(path);
+        _userThemes = null; // invalidate cache; next load re-reads the folder
     }
 
     private string PathForId(string id)

--- a/QuickMail/Styles/AccessibleStyles.xaml
+++ b/QuickMail/Styles/AccessibleStyles.xaml
@@ -1,13 +1,17 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
-    <!-- Visible keyboard focus ring for all controls -->
+    <!-- Visible keyboard focus ring for all controls.
+         Theme.FocusIndicator resolves to the theme's high-visibility ring color
+         (WindowText under Windows High Contrast); Theme.FocusThickness doubles
+         when the "thicker focus indicators" setting is on. -->
     <Style x:Key="FocusVisual">
         <Setter Property="Control.Template">
             <Setter.Value>
                 <ControlTemplate>
-                    <Rectangle Margin="2" StrokeThickness="2"
-                               Stroke="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}"
+                    <Rectangle Margin="2"
+                               StrokeThickness="{DynamicResource Theme.FocusThickness}"
+                               Stroke="{DynamicResource Theme.FocusIndicator}"
                                StrokeDashArray="2 1"
                                SnapsToDevicePixels="True"/>
                 </ControlTemplate>
@@ -39,6 +43,13 @@
     <Style TargetType="TextBox">
         <Setter Property="FocusVisualStyle" Value="{StaticResource FocusVisual}"/>
         <Setter Property="Padding" Value="4,2"/>
+    </Style>
+
+    <!-- Column headers are mouse-clickable but never keyboard tab stops.
+         Lives here (not only in ThemedControls) so the rule also holds under
+         High Contrast, when ThemedControls is withdrawn. -->
+    <Style TargetType="GridViewColumnHeader">
+        <Setter Property="Focusable" Value="False"/>
     </Style>
 
     <!-- Toolbar button style: Tab enters the toolbar from outside; Arrow keys navigate
@@ -89,7 +100,7 @@
                         <Trigger Property="IsKeyboardFocused" Value="True">
                             <Setter TargetName="border" Property="BorderThickness" Value="1"/>
                             <Setter TargetName="border" Property="BorderBrush"
-                                    Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}"/>
+                                    Value="{DynamicResource Theme.FocusIndicator}"/>
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -134,15 +145,15 @@
                         <Trigger Property="IsKeyboardFocused" Value="True">
                             <Setter TargetName="border" Property="BorderThickness" Value="1"/>
                             <Setter TargetName="border" Property="BorderBrush"
-                                    Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}"/>
+                                    Value="{DynamicResource Theme.FocusIndicator}"/>
                         </Trigger>
                         <Trigger Property="IsMouseOver" Value="True">
                             <Setter TargetName="border" Property="Background"
-                                    Value="{DynamicResource {x:Static SystemColors.ControlLightBrushKey}}"/>
+                                    Value="{DynamicResource Theme.AccentSubtle}"/>
                         </Trigger>
                         <Trigger Property="IsPressed" Value="True">
                             <Setter TargetName="border" Property="Background"
-                                    Value="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}"/>
+                                    Value="{DynamicResource Theme.Border}"/>
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>

--- a/QuickMail/Styles/ThemedControls.xaml
+++ b/QuickMail/Styles/ThemedControls.xaml
@@ -1,0 +1,1083 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!-- ══════════════════════════════════════════════════════════════════════
+         ThemedControls.xaml — implicit, token-driven control templates.
+
+         Merged AFTER the theme token dictionary in normal themes and WITHDRAWN
+         under Windows High Contrast, where WPF's built-in HC-aware templates
+         must win. Every color below is a Theme.* DynamicResource; no literals.
+
+         Each retemplate preserves the control's keyboard behavior and UIA
+         patterns: behavior lives in the control classes, and the required
+         named parts (PART_Popup, PART_ContentHost, PART_Track,
+         PART_SelectedContentHost, PART_EditableTextBox, PART_HeaderGripper)
+         are all present.
+         ══════════════════════════════════════════════════════════════════════ -->
+
+    <!-- ── Button ─────────────────────────────────────────────────────────── -->
+
+    <Style TargetType="Button">
+        <Setter Property="FocusVisualStyle" Value="{DynamicResource FocusVisual}"/>
+        <Setter Property="Padding" Value="8,4"/>
+        <Setter Property="MinHeight" Value="28"/>
+        <Setter Property="Background" Value="{DynamicResource Theme.SurfaceBackground}"/>
+        <Setter Property="Foreground" Value="{DynamicResource Theme.TextPrimary}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource Theme.Border}"/>
+        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="border"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="2"
+                            SnapsToDevicePixels="True">
+                        <ContentPresenter Margin="{TemplateBinding Padding}"
+                                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                          RecognizesAccessKey="True"
+                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsDefaulted" Value="True">
+                            <Setter TargetName="border" Property="BorderBrush" Value="{DynamicResource Theme.Accent}"/>
+                        </Trigger>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="border" Property="Background" Value="{DynamicResource Theme.AccentSubtle}"/>
+                        </Trigger>
+                        <Trigger Property="IsPressed" Value="True">
+                            <Setter TargetName="border" Property="Background" Value="{DynamicResource Theme.SelectionBackground}"/>
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Foreground" Value="{DynamicResource Theme.TextDisabled}"/>
+                            <Setter TargetName="border" Property="BorderBrush" Value="{DynamicResource Theme.BorderSubtle}"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!-- ── ToggleButton ───────────────────────────────────────────────────── -->
+
+    <Style TargetType="ToggleButton">
+        <Setter Property="FocusVisualStyle" Value="{DynamicResource FocusVisual}"/>
+        <Setter Property="Padding" Value="8,4"/>
+        <Setter Property="MinHeight" Value="28"/>
+        <Setter Property="Background" Value="{DynamicResource Theme.SurfaceBackground}"/>
+        <Setter Property="Foreground" Value="{DynamicResource Theme.TextPrimary}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource Theme.Border}"/>
+        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="ToggleButton">
+                    <Border x:Name="border"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="2"
+                            SnapsToDevicePixels="True">
+                        <ContentPresenter Margin="{TemplateBinding Padding}"
+                                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                          RecognizesAccessKey="True"/>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="border" Property="Background" Value="{DynamicResource Theme.AccentSubtle}"/>
+                        </Trigger>
+                        <Trigger Property="IsChecked" Value="True">
+                            <Setter TargetName="border" Property="Background" Value="{DynamicResource Theme.SelectionBackground}"/>
+                            <Setter TargetName="border" Property="BorderBrush" Value="{DynamicResource Theme.Accent}"/>
+                            <Setter Property="Foreground" Value="{DynamicResource Theme.SelectionText}"/>
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Foreground" Value="{DynamicResource Theme.TextDisabled}"/>
+                            <Setter TargetName="border" Property="BorderBrush" Value="{DynamicResource Theme.BorderSubtle}"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!-- Themed toolbar variants — same keys as AccessibleStyles so windows that
+         reference them via DynamicResource pick these up in normal themes and
+         fall back to the plain versions when this dictionary is withdrawn. -->
+    <Style x:Key="ToolbarButton" TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
+        <Setter Property="MinWidth" Value="75"/>
+        <Setter Property="Margin" Value="2,0"/>
+        <Setter Property="Background" Value="Transparent"/>
+        <Setter Property="BorderBrush" Value="Transparent"/>
+    </Style>
+
+    <Style x:Key="ToolbarToggleButton" TargetType="ToggleButton" BasedOn="{StaticResource {x:Type ToggleButton}}">
+        <Setter Property="MinWidth" Value="75"/>
+        <Setter Property="Margin" Value="2,0"/>
+        <Setter Property="Background" Value="Transparent"/>
+        <Setter Property="BorderBrush" Value="Transparent"/>
+    </Style>
+
+    <!-- ── Text input ─────────────────────────────────────────────────────── -->
+
+    <Style TargetType="TextBox">
+        <Setter Property="FocusVisualStyle" Value="{DynamicResource FocusVisual}"/>
+        <Setter Property="Padding" Value="4,2"/>
+        <Setter Property="Background" Value="{DynamicResource Theme.InputBackground}"/>
+        <Setter Property="Foreground" Value="{DynamicResource Theme.TextPrimary}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource Theme.InputBorder}"/>
+        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="CaretBrush" Value="{DynamicResource Theme.TextPrimary}"/>
+        <Setter Property="SelectionBrush" Value="{DynamicResource Theme.Accent}"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="TextBox">
+                    <Border x:Name="border"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="2"
+                            SnapsToDevicePixels="True">
+                        <ScrollViewer x:Name="PART_ContentHost"
+                                      Margin="{TemplateBinding Padding}"
+                                      Focusable="False"
+                                      HorizontalScrollBarVisibility="Hidden"
+                                      VerticalScrollBarVisibility="Hidden"/>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsKeyboardFocusWithin" Value="True">
+                            <Setter TargetName="border" Property="BorderBrush" Value="{DynamicResource Theme.Accent}"/>
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Foreground" Value="{DynamicResource Theme.TextDisabled}"/>
+                            <Setter TargetName="border" Property="Background" Value="{DynamicResource Theme.SurfaceBackground}"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style TargetType="RichTextBox">
+        <Setter Property="FocusVisualStyle" Value="{DynamicResource FocusVisual}"/>
+        <Setter Property="Background" Value="{DynamicResource Theme.InputBackground}"/>
+        <Setter Property="Foreground" Value="{DynamicResource Theme.TextPrimary}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource Theme.InputBorder}"/>
+        <Setter Property="CaretBrush" Value="{DynamicResource Theme.TextPrimary}"/>
+        <Setter Property="SelectionBrush" Value="{DynamicResource Theme.Accent}"/>
+    </Style>
+
+    <Style TargetType="PasswordBox">
+        <Setter Property="FocusVisualStyle" Value="{DynamicResource FocusVisual}"/>
+        <Setter Property="Padding" Value="4,2"/>
+        <Setter Property="Background" Value="{DynamicResource Theme.InputBackground}"/>
+        <Setter Property="Foreground" Value="{DynamicResource Theme.TextPrimary}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource Theme.InputBorder}"/>
+        <Setter Property="CaretBrush" Value="{DynamicResource Theme.TextPrimary}"/>
+        <Setter Property="SelectionBrush" Value="{DynamicResource Theme.Accent}"/>
+    </Style>
+
+    <!-- ── CheckBox / RadioButton ─────────────────────────────────────────── -->
+
+    <Style TargetType="CheckBox">
+        <Setter Property="FocusVisualStyle" Value="{DynamicResource FocusVisual}"/>
+        <Setter Property="Foreground" Value="{DynamicResource Theme.TextPrimary}"/>
+        <Setter Property="VerticalContentAlignment" Value="Center"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="CheckBox">
+                    <Grid Background="Transparent" SnapsToDevicePixels="True">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+                        <Border x:Name="box" Width="15" Height="15" Margin="0,0,6,0"
+                                VerticalAlignment="Center"
+                                Background="{DynamicResource Theme.InputBackground}"
+                                BorderBrush="{DynamicResource Theme.InputBorder}"
+                                BorderThickness="1" CornerRadius="2">
+                            <Grid>
+                                <Path x:Name="check" Visibility="Collapsed"
+                                      Data="M 2,7 L 6,10.5 L 11.5,3"
+                                      Stroke="{DynamicResource Theme.Accent}" StrokeThickness="2"
+                                      StrokeStartLineCap="Round" StrokeEndLineCap="Round"/>
+                                <Rectangle x:Name="indeterminate" Visibility="Collapsed"
+                                           Margin="3" Fill="{DynamicResource Theme.Accent}"/>
+                            </Grid>
+                        </Border>
+                        <ContentPresenter Grid.Column="1"
+                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                          RecognizesAccessKey="True"/>
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsChecked" Value="True">
+                            <Setter TargetName="check" Property="Visibility" Value="Visible"/>
+                        </Trigger>
+                        <Trigger Property="IsChecked" Value="{x:Null}">
+                            <Setter TargetName="indeterminate" Property="Visibility" Value="Visible"/>
+                        </Trigger>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="box" Property="BorderBrush" Value="{DynamicResource Theme.Accent}"/>
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Foreground" Value="{DynamicResource Theme.TextDisabled}"/>
+                            <Setter TargetName="box" Property="BorderBrush" Value="{DynamicResource Theme.BorderSubtle}"/>
+                            <Setter TargetName="check" Property="Stroke" Value="{DynamicResource Theme.TextDisabled}"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style TargetType="RadioButton">
+        <Setter Property="FocusVisualStyle" Value="{DynamicResource FocusVisual}"/>
+        <Setter Property="Foreground" Value="{DynamicResource Theme.TextPrimary}"/>
+        <Setter Property="VerticalContentAlignment" Value="Center"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="RadioButton">
+                    <Grid Background="Transparent" SnapsToDevicePixels="True">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+                        <Ellipse x:Name="ring" Width="15" Height="15" Margin="0,0,6,0"
+                                 VerticalAlignment="Center"
+                                 Fill="{DynamicResource Theme.InputBackground}"
+                                 Stroke="{DynamicResource Theme.InputBorder}" StrokeThickness="1"/>
+                        <Ellipse x:Name="dot" Width="7" Height="7" Margin="4,0,10,0"
+                                 HorizontalAlignment="Left" VerticalAlignment="Center"
+                                 Fill="{DynamicResource Theme.Accent}" Visibility="Collapsed"/>
+                        <ContentPresenter Grid.Column="1"
+                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                          RecognizesAccessKey="True"/>
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsChecked" Value="True">
+                            <Setter TargetName="dot" Property="Visibility" Value="Visible"/>
+                        </Trigger>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="ring" Property="Stroke" Value="{DynamicResource Theme.Accent}"/>
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Foreground" Value="{DynamicResource Theme.TextDisabled}"/>
+                            <Setter TargetName="ring" Property="Stroke" Value="{DynamicResource Theme.BorderSubtle}"/>
+                            <Setter TargetName="dot" Property="Fill" Value="{DynamicResource Theme.TextDisabled}"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!-- ── ComboBox ───────────────────────────────────────────────────────── -->
+
+    <Style TargetType="ComboBoxItem">
+        <Setter Property="FocusVisualStyle" Value="{DynamicResource FocusVisual}"/>
+        <Setter Property="Padding" Value="6,3"/>
+        <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="ComboBoxItem">
+                    <Border x:Name="border"
+                            Background="Transparent"
+                            Padding="{TemplateBinding Padding}"
+                            SnapsToDevicePixels="True">
+                        <ContentPresenter/>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsHighlighted" Value="True">
+                            <Setter TargetName="border" Property="Background" Value="{DynamicResource Theme.SelectionBackground}"/>
+                            <Setter Property="Foreground" Value="{DynamicResource Theme.SelectionText}"/>
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Foreground" Value="{DynamicResource Theme.TextDisabled}"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style TargetType="ComboBox">
+        <Setter Property="FocusVisualStyle" Value="{DynamicResource FocusVisual}"/>
+        <Setter Property="Background" Value="{DynamicResource Theme.InputBackground}"/>
+        <Setter Property="Foreground" Value="{DynamicResource Theme.TextPrimary}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource Theme.InputBorder}"/>
+        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="Padding" Value="6,3"/>
+        <Setter Property="MinHeight" Value="26"/>
+        <Setter Property="ScrollViewer.CanContentScroll" Value="True"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="ComboBox">
+                    <Grid SnapsToDevicePixels="True">
+                        <Border x:Name="border"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="2"/>
+                        <!-- Transparent toggle over the whole control opens the dropdown;
+                             keyboard behavior (F4, Alt+Down, typeahead) lives in ComboBox itself. -->
+                        <ToggleButton x:Name="toggle"
+                                      Focusable="False"
+                                      IsTabStop="False"
+                                      ClickMode="Press"
+                                      Background="Transparent"
+                                      BorderBrush="Transparent"
+                                      IsChecked="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}">
+                            <ToggleButton.Template>
+                                <ControlTemplate TargetType="ToggleButton">
+                                    <Border Background="Transparent"/>
+                                </ControlTemplate>
+                            </ToggleButton.Template>
+                        </ToggleButton>
+                        <ContentPresenter x:Name="contentSite"
+                                          Margin="{TemplateBinding Padding}"
+                                          Content="{TemplateBinding SelectionBoxItem}"
+                                          ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}"
+                                          ContentTemplateSelector="{TemplateBinding ItemTemplateSelector}"
+                                          VerticalAlignment="Center"
+                                          HorizontalAlignment="Left"
+                                          IsHitTestVisible="False"/>
+                        <TextBox x:Name="PART_EditableTextBox"
+                                 Visibility="Hidden"
+                                 Margin="1"
+                                 Padding="{TemplateBinding Padding}"
+                                 Background="Transparent"
+                                 BorderThickness="0"
+                                 HorizontalAlignment="Stretch"
+                                 VerticalContentAlignment="Center"
+                                 Focusable="True"
+                                 IsReadOnly="{TemplateBinding IsReadOnly}"/>
+                        <Path x:Name="arrow"
+                              HorizontalAlignment="Right" VerticalAlignment="Center"
+                              Margin="0,0,8,0"
+                              Data="M 0,0 L 4,4 L 8,0"
+                              Stroke="{DynamicResource Theme.TextSecondary}" StrokeThickness="1.5"
+                              IsHitTestVisible="False"/>
+                        <Popup x:Name="PART_Popup"
+                               Placement="Bottom"
+                               IsOpen="{TemplateBinding IsDropDownOpen}"
+                               AllowsTransparency="True"
+                               Focusable="False"
+                               PopupAnimation="None">
+                            <Border x:Name="dropDownBorder"
+                                    Background="{DynamicResource Theme.SurfaceBackground}"
+                                    BorderBrush="{DynamicResource Theme.Border}"
+                                    BorderThickness="1"
+                                    CornerRadius="2"
+                                    MinWidth="{Binding ActualWidth, ElementName=border}"
+                                    MaxHeight="{TemplateBinding MaxDropDownHeight}"
+                                    Margin="0,2,8,8">
+                                <Border.Effect>
+                                    <DropShadowEffect BlurRadius="8" ShadowDepth="2" Opacity="0.25"/>
+                                </Border.Effect>
+                                <ScrollViewer SnapsToDevicePixels="True">
+                                    <ItemsPresenter KeyboardNavigation.DirectionalNavigation="Contained"/>
+                                </ScrollViewer>
+                            </Border>
+                        </Popup>
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsEditable" Value="True">
+                            <Setter TargetName="PART_EditableTextBox" Property="Visibility" Value="Visible"/>
+                            <Setter TargetName="contentSite" Property="Visibility" Value="Hidden"/>
+                        </Trigger>
+                        <Trigger Property="IsKeyboardFocusWithin" Value="True">
+                            <Setter TargetName="border" Property="BorderBrush" Value="{DynamicResource Theme.Accent}"/>
+                        </Trigger>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="border" Property="BorderBrush" Value="{DynamicResource Theme.Accent}"/>
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Foreground" Value="{DynamicResource Theme.TextDisabled}"/>
+                            <Setter TargetName="border" Property="Background" Value="{DynamicResource Theme.SurfaceBackground}"/>
+                            <Setter TargetName="arrow" Property="Stroke" Value="{DynamicResource Theme.TextDisabled}"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!-- ── ScrollBar ──────────────────────────────────────────────────────── -->
+
+    <Style x:Key="ThemedScrollBarThumb" TargetType="Thumb">
+        <Setter Property="IsTabStop" Value="False"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Thumb">
+                    <Border x:Name="thumb" Background="{DynamicResource Theme.Border}" CornerRadius="4" Margin="2"/>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="thumb" Property="Background" Value="{DynamicResource Theme.TextSecondary}"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="ThemedScrollBarPageButton" TargetType="RepeatButton">
+        <Setter Property="IsTabStop" Value="False"/>
+        <Setter Property="Focusable" Value="False"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="RepeatButton">
+                    <Rectangle Fill="Transparent"/>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style TargetType="ScrollBar">
+        <Setter Property="Background" Value="{DynamicResource Theme.ChromeBackground}"/>
+        <Setter Property="Width" Value="14"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="ScrollBar">
+                    <Border Background="{TemplateBinding Background}">
+                        <Track x:Name="PART_Track" IsDirectionReversed="True">
+                            <Track.DecreaseRepeatButton>
+                                <RepeatButton Style="{StaticResource ThemedScrollBarPageButton}" Command="ScrollBar.PageUpCommand"/>
+                            </Track.DecreaseRepeatButton>
+                            <Track.Thumb>
+                                <Thumb Style="{StaticResource ThemedScrollBarThumb}"/>
+                            </Track.Thumb>
+                            <Track.IncreaseRepeatButton>
+                                <RepeatButton Style="{StaticResource ThemedScrollBarPageButton}" Command="ScrollBar.PageDownCommand"/>
+                            </Track.IncreaseRepeatButton>
+                        </Track>
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+        <Style.Triggers>
+            <Trigger Property="Orientation" Value="Horizontal">
+                <Setter Property="Width" Value="Auto"/>
+                <Setter Property="Height" Value="14"/>
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="ScrollBar">
+                            <Border Background="{TemplateBinding Background}">
+                                <Track x:Name="PART_Track">
+                                    <Track.DecreaseRepeatButton>
+                                        <RepeatButton Style="{StaticResource ThemedScrollBarPageButton}" Command="ScrollBar.PageLeftCommand"/>
+                                    </Track.DecreaseRepeatButton>
+                                    <Track.Thumb>
+                                        <Thumb Style="{StaticResource ThemedScrollBarThumb}"/>
+                                    </Track.Thumb>
+                                    <Track.IncreaseRepeatButton>
+                                        <RepeatButton Style="{StaticResource ThemedScrollBarPageButton}" Command="ScrollBar.PageRightCommand"/>
+                                    </Track.IncreaseRepeatButton>
+                                </Track>
+                            </Border>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
+    <!-- ── Menus ──────────────────────────────────────────────────────────── -->
+
+    <Style TargetType="Menu">
+        <Setter Property="Background" Value="{DynamicResource Theme.ChromeBackground}"/>
+        <Setter Property="Foreground" Value="{DynamicResource Theme.TextPrimary}"/>
+    </Style>
+
+    <Style TargetType="ContextMenu">
+        <Setter Property="Background" Value="{DynamicResource Theme.SurfaceBackground}"/>
+        <Setter Property="Foreground" Value="{DynamicResource Theme.TextPrimary}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource Theme.Border}"/>
+        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="ContextMenu">
+                    <Border Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="2" Padding="2">
+                        <ItemsPresenter Grid.IsSharedSizeScope="True"
+                                        KeyboardNavigation.DirectionalNavigation="Cycle"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!-- Menu separators (inside menus WPF looks up MenuItem.SeparatorStyleKey). -->
+    <Style x:Key="{x:Static MenuItem.SeparatorStyleKey}" TargetType="Separator">
+        <Setter Property="Height" Value="1"/>
+        <Setter Property="Margin" Value="26,3,4,3"/>
+        <Setter Property="Background" Value="{DynamicResource Theme.BorderSubtle}"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Separator">
+                    <Rectangle Height="1" Fill="{TemplateBinding Background}"/>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!-- MenuItem — one template per role, per the documented WPF pattern.
+         PART_Popup and the check/icon/gesture columns are preserved so keyboard
+         access, checkable items, and screen reader announcements are unchanged. -->
+    <Style TargetType="MenuItem">
+        <Setter Property="Foreground" Value="{DynamicResource Theme.TextPrimary}"/>
+        <Setter Property="Template" Value="{DynamicResource ThemedSubmenuItemTemplate}"/>
+        <Style.Triggers>
+            <Trigger Property="Role" Value="TopLevelHeader">
+                <Setter Property="Template" Value="{DynamicResource ThemedTopLevelHeaderTemplate}"/>
+            </Trigger>
+            <Trigger Property="Role" Value="TopLevelItem">
+                <Setter Property="Template" Value="{DynamicResource ThemedTopLevelItemTemplate}"/>
+            </Trigger>
+            <Trigger Property="Role" Value="SubmenuHeader">
+                <Setter Property="Template" Value="{DynamicResource ThemedSubmenuHeaderTemplate}"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
+    <ControlTemplate x:Key="ThemedTopLevelHeaderTemplate" TargetType="MenuItem">
+        <Border x:Name="border" Background="Transparent" SnapsToDevicePixels="True">
+            <Grid>
+                <ContentPresenter Margin="8,4" ContentSource="Header" RecognizesAccessKey="True"/>
+                <Popup x:Name="PART_Popup"
+                       Placement="Bottom"
+                       IsOpen="{TemplateBinding IsSubmenuOpen}"
+                       AllowsTransparency="True"
+                       Focusable="False"
+                       PopupAnimation="None">
+                    <Border Background="{DynamicResource Theme.SurfaceBackground}"
+                            BorderBrush="{DynamicResource Theme.Border}"
+                            BorderThickness="1" CornerRadius="2" Padding="2"
+                            Margin="0,1,8,8">
+                        <Border.Effect>
+                            <DropShadowEffect BlurRadius="8" ShadowDepth="2" Opacity="0.25"/>
+                        </Border.Effect>
+                        <ScrollViewer CanContentScroll="True"
+                                      VerticalScrollBarVisibility="Auto">
+                            <ItemsPresenter Grid.IsSharedSizeScope="True"
+                                            KeyboardNavigation.DirectionalNavigation="Cycle"/>
+                        </ScrollViewer>
+                    </Border>
+                </Popup>
+            </Grid>
+        </Border>
+        <ControlTemplate.Triggers>
+            <Trigger Property="IsHighlighted" Value="True">
+                <Setter TargetName="border" Property="Background" Value="{DynamicResource Theme.AccentSubtle}"/>
+            </Trigger>
+            <Trigger Property="IsSubmenuOpen" Value="True">
+                <Setter TargetName="border" Property="Background" Value="{DynamicResource Theme.SelectionBackground}"/>
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Foreground" Value="{DynamicResource Theme.TextDisabled}"/>
+            </Trigger>
+        </ControlTemplate.Triggers>
+    </ControlTemplate>
+
+    <ControlTemplate x:Key="ThemedTopLevelItemTemplate" TargetType="MenuItem">
+        <Border x:Name="border" Background="Transparent" SnapsToDevicePixels="True">
+            <ContentPresenter Margin="8,4" ContentSource="Header" RecognizesAccessKey="True"/>
+        </Border>
+        <ControlTemplate.Triggers>
+            <Trigger Property="IsHighlighted" Value="True">
+                <Setter TargetName="border" Property="Background" Value="{DynamicResource Theme.AccentSubtle}"/>
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Foreground" Value="{DynamicResource Theme.TextDisabled}"/>
+            </Trigger>
+        </ControlTemplate.Triggers>
+    </ControlTemplate>
+
+    <ControlTemplate x:Key="ThemedSubmenuItemTemplate" TargetType="MenuItem">
+        <Border x:Name="border" Background="Transparent" SnapsToDevicePixels="True">
+            <Grid Margin="2,3">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="22" SharedSizeGroup="MenuItemIconColumnGroup"/>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIGTColumnGroup"/>
+                    <ColumnDefinition Width="14"/>
+                </Grid.ColumnDefinitions>
+                <ContentPresenter x:Name="icon" ContentSource="Icon" VerticalAlignment="Center" Margin="2,0"/>
+                <Path x:Name="checkMark" Visibility="Collapsed"
+                      VerticalAlignment="Center" HorizontalAlignment="Center"
+                      Data="M 0,4 L 3,7 L 8,0"
+                      Stroke="{DynamicResource Theme.Accent}" StrokeThickness="2"
+                      StrokeStartLineCap="Round" StrokeEndLineCap="Round"/>
+                <ContentPresenter Grid.Column="1" ContentSource="Header"
+                                  Margin="4,1" VerticalAlignment="Center"
+                                  RecognizesAccessKey="True"/>
+                <TextBlock Grid.Column="2" Margin="16,1,4,1" VerticalAlignment="Center"
+                           Text="{TemplateBinding InputGestureText}"
+                           Foreground="{DynamicResource Theme.TextSecondary}"/>
+            </Grid>
+        </Border>
+        <ControlTemplate.Triggers>
+            <Trigger Property="Icon" Value="{x:Null}">
+                <Setter TargetName="icon" Property="Visibility" Value="Collapsed"/>
+            </Trigger>
+            <Trigger Property="IsChecked" Value="True">
+                <Setter TargetName="checkMark" Property="Visibility" Value="Visible"/>
+                <Setter TargetName="icon" Property="Visibility" Value="Collapsed"/>
+            </Trigger>
+            <Trigger Property="IsHighlighted" Value="True">
+                <Setter TargetName="border" Property="Background" Value="{DynamicResource Theme.SelectionBackground}"/>
+                <Setter Property="Foreground" Value="{DynamicResource Theme.SelectionText}"/>
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Foreground" Value="{DynamicResource Theme.TextDisabled}"/>
+            </Trigger>
+        </ControlTemplate.Triggers>
+    </ControlTemplate>
+
+    <ControlTemplate x:Key="ThemedSubmenuHeaderTemplate" TargetType="MenuItem">
+        <Border x:Name="border" Background="Transparent" SnapsToDevicePixels="True">
+            <Grid Margin="2,3">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="22" SharedSizeGroup="MenuItemIconColumnGroup"/>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIGTColumnGroup"/>
+                    <ColumnDefinition Width="14"/>
+                </Grid.ColumnDefinitions>
+                <ContentPresenter x:Name="icon" ContentSource="Icon" VerticalAlignment="Center" Margin="2,0"/>
+                <ContentPresenter Grid.Column="1" ContentSource="Header"
+                                  Margin="4,1" VerticalAlignment="Center"
+                                  RecognizesAccessKey="True"/>
+                <Path Grid.Column="3" HorizontalAlignment="Center" VerticalAlignment="Center"
+                      Data="M 0,0 L 4,4 L 0,8"
+                      Stroke="{DynamicResource Theme.TextSecondary}" StrokeThickness="1.5"/>
+                <Popup x:Name="PART_Popup"
+                       Placement="Right"
+                       HorizontalOffset="-2"
+                       IsOpen="{TemplateBinding IsSubmenuOpen}"
+                       AllowsTransparency="True"
+                       Focusable="False"
+                       PopupAnimation="None">
+                    <Border Background="{DynamicResource Theme.SurfaceBackground}"
+                            BorderBrush="{DynamicResource Theme.Border}"
+                            BorderThickness="1" CornerRadius="2" Padding="2"
+                            Margin="0,0,8,8">
+                        <Border.Effect>
+                            <DropShadowEffect BlurRadius="8" ShadowDepth="2" Opacity="0.25"/>
+                        </Border.Effect>
+                        <ScrollViewer CanContentScroll="True"
+                                      VerticalScrollBarVisibility="Auto">
+                            <ItemsPresenter Grid.IsSharedSizeScope="True"
+                                            KeyboardNavigation.DirectionalNavigation="Cycle"/>
+                        </ScrollViewer>
+                    </Border>
+                </Popup>
+            </Grid>
+        </Border>
+        <ControlTemplate.Triggers>
+            <Trigger Property="Icon" Value="{x:Null}">
+                <Setter TargetName="icon" Property="Visibility" Value="Collapsed"/>
+            </Trigger>
+            <Trigger Property="IsHighlighted" Value="True">
+                <Setter TargetName="border" Property="Background" Value="{DynamicResource Theme.SelectionBackground}"/>
+                <Setter Property="Foreground" Value="{DynamicResource Theme.SelectionText}"/>
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Foreground" Value="{DynamicResource Theme.TextDisabled}"/>
+            </Trigger>
+        </ControlTemplate.Triggers>
+    </ControlTemplate>
+
+    <!-- ── Tabs ───────────────────────────────────────────────────────────── -->
+
+    <Style TargetType="TabControl">
+        <Setter Property="Background" Value="{DynamicResource Theme.WindowBackground}"/>
+        <Setter Property="Foreground" Value="{DynamicResource Theme.TextPrimary}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource Theme.Border}"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="TabControl">
+                    <Grid ClipToBounds="True" SnapsToDevicePixels="True" KeyboardNavigation.TabNavigation="Local">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="*"/>
+                        </Grid.RowDefinitions>
+                        <TabPanel x:Name="headerPanel"
+                                  Panel.ZIndex="1"
+                                  IsItemsHost="True"
+                                  Margin="0,0,0,-1"
+                                  KeyboardNavigation.TabIndex="1"/>
+                        <Border x:Name="contentPanel"
+                                Grid.Row="1"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="1"
+                                KeyboardNavigation.TabNavigation="Local"
+                                KeyboardNavigation.DirectionalNavigation="Contained"
+                                KeyboardNavigation.TabIndex="2">
+                            <ContentPresenter x:Name="PART_SelectedContentHost"
+                                              ContentSource="SelectedContent"
+                                              Margin="{TemplateBinding Padding}"/>
+                        </Border>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style TargetType="TabItem">
+        <Setter Property="FocusVisualStyle" Value="{DynamicResource FocusVisual}"/>
+        <Setter Property="Foreground" Value="{DynamicResource Theme.TextSecondary}"/>
+        <Setter Property="Padding" Value="12,6"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="TabItem">
+                    <Border x:Name="border"
+                            Background="{DynamicResource Theme.ChromeBackground}"
+                            BorderBrush="{DynamicResource Theme.Border}"
+                            BorderThickness="1,1,1,1"
+                            Margin="0,2,-1,0"
+                            SnapsToDevicePixels="True">
+                        <Grid>
+                            <Rectangle x:Name="accentBar" Height="3" VerticalAlignment="Top"
+                                       Fill="{DynamicResource Theme.Accent}" Visibility="Collapsed"/>
+                            <ContentPresenter ContentSource="Header"
+                                              Margin="{TemplateBinding Padding}"
+                                              HorizontalAlignment="Center" VerticalAlignment="Center"
+                                              RecognizesAccessKey="True"/>
+                        </Grid>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsSelected" Value="True">
+                            <Setter TargetName="border" Property="Background" Value="{DynamicResource Theme.WindowBackground}"/>
+                            <Setter TargetName="border" Property="BorderThickness" Value="1,1,1,0"/>
+                            <Setter TargetName="border" Property="Margin" Value="0,0,-1,0"/>
+                            <Setter TargetName="accentBar" Property="Visibility" Value="Visible"/>
+                            <Setter Property="Foreground" Value="{DynamicResource Theme.TextPrimary}"/>
+                            <Setter Property="Panel.ZIndex" Value="1"/>
+                        </Trigger>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="border" Property="Background" Value="{DynamicResource Theme.AccentSubtle}"/>
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Foreground" Value="{DynamicResource Theme.TextDisabled}"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!-- ── Lists & trees ──────────────────────────────────────────────────── -->
+
+    <Style TargetType="ListBox">
+        <Setter Property="Background" Value="{DynamicResource Theme.SurfaceBackground}"/>
+        <Setter Property="Foreground" Value="{DynamicResource Theme.TextPrimary}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource Theme.Border}"/>
+    </Style>
+
+    <Style TargetType="ListView">
+        <Setter Property="Background" Value="{DynamicResource Theme.SurfaceBackground}"/>
+        <Setter Property="Foreground" Value="{DynamicResource Theme.TextPrimary}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource Theme.Border}"/>
+    </Style>
+
+    <Style TargetType="TreeView">
+        <Setter Property="Background" Value="{DynamicResource Theme.SurfaceBackground}"/>
+        <Setter Property="Foreground" Value="{DynamicResource Theme.TextPrimary}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource Theme.Border}"/>
+    </Style>
+
+    <Style TargetType="ListBoxItem">
+        <Setter Property="FocusVisualStyle" Value="{DynamicResource FocusVisual}"/>
+        <Setter Property="Padding" Value="4,2"/>
+        <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="ListBoxItem">
+                    <Border x:Name="border"
+                            Background="Transparent"
+                            Padding="{TemplateBinding Padding}"
+                            SnapsToDevicePixels="True">
+                        <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="border" Property="Background" Value="{DynamicResource Theme.AccentSubtle}"/>
+                        </Trigger>
+                        <Trigger Property="IsSelected" Value="True">
+                            <Setter TargetName="border" Property="Background" Value="{DynamicResource Theme.SelectionBackground}"/>
+                            <Setter Property="Foreground" Value="{DynamicResource Theme.SelectionText}"/>
+                        </Trigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsSelected" Value="True"/>
+                                <Condition Property="Selector.IsSelectionActive" Value="False"/>
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="border" Property="Background" Value="{DynamicResource Theme.SelectionInactive}"/>
+                            <Setter Property="Foreground" Value="{DynamicResource Theme.TextPrimary}"/>
+                        </MultiTrigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Foreground" Value="{DynamicResource Theme.TextDisabled}"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!-- Plain (non-GridView) ListViewItem. -->
+    <Style TargetType="ListViewItem">
+        <Setter Property="FocusVisualStyle" Value="{DynamicResource FocusVisual}"/>
+        <Setter Property="Padding" Value="4,2"/>
+        <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="ListViewItem">
+                    <Border x:Name="border"
+                            Background="Transparent"
+                            Padding="{TemplateBinding Padding}"
+                            SnapsToDevicePixels="True">
+                        <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="border" Property="Background" Value="{DynamicResource Theme.AccentSubtle}"/>
+                        </Trigger>
+                        <Trigger Property="IsSelected" Value="True">
+                            <Setter TargetName="border" Property="Background" Value="{DynamicResource Theme.SelectionBackground}"/>
+                            <Setter Property="Foreground" Value="{DynamicResource Theme.SelectionText}"/>
+                        </Trigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsSelected" Value="True"/>
+                                <Condition Property="Selector.IsSelectionActive" Value="False"/>
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="border" Property="Background" Value="{DynamicResource Theme.SelectionInactive}"/>
+                            <Setter Property="Foreground" Value="{DynamicResource Theme.TextPrimary}"/>
+                        </MultiTrigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Foreground" Value="{DynamicResource Theme.TextDisabled}"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!-- ListViewItem under a GridView: WPF looks the container style up by this
+         key instead of the type. The template must host GridViewRowPresenter so
+         column layout is preserved. -->
+    <Style x:Key="{x:Static GridView.GridViewItemContainerStyleKey}" TargetType="ListViewItem">
+        <Setter Property="FocusVisualStyle" Value="{DynamicResource FocusVisual}"/>
+        <Setter Property="Padding" Value="2"/>
+        <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="ListViewItem">
+                    <Border x:Name="border"
+                            Background="Transparent"
+                            Padding="{TemplateBinding Padding}"
+                            SnapsToDevicePixels="True">
+                        <GridViewRowPresenter Content="{TemplateBinding Content}"
+                                              Columns="{TemplateBinding GridView.ColumnCollection}"/>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="border" Property="Background" Value="{DynamicResource Theme.AccentSubtle}"/>
+                        </Trigger>
+                        <Trigger Property="IsSelected" Value="True">
+                            <Setter TargetName="border" Property="Background" Value="{DynamicResource Theme.SelectionBackground}"/>
+                            <Setter Property="Foreground" Value="{DynamicResource Theme.SelectionText}"/>
+                        </Trigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsSelected" Value="True"/>
+                                <Condition Property="Selector.IsSelectionActive" Value="False"/>
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="border" Property="Background" Value="{DynamicResource Theme.SelectionInactive}"/>
+                            <Setter Property="Foreground" Value="{DynamicResource Theme.TextPrimary}"/>
+                        </MultiTrigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Foreground" Value="{DynamicResource Theme.TextDisabled}"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!-- Expander toggle used by the TreeViewItem template below. Not focusable:
+         Left/Right arrow expand/collapse comes from TreeViewItem itself. -->
+    <Style x:Key="ThemedTreeExpandToggle" TargetType="ToggleButton">
+        <Setter Property="Focusable" Value="False"/>
+        <Setter Property="IsTabStop" Value="False"/>
+        <Setter Property="Width" Value="16"/>
+        <Setter Property="Height" Value="16"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="ToggleButton">
+                    <Border Background="Transparent" Width="16" Height="16">
+                        <Path x:Name="glyph"
+                              HorizontalAlignment="Center" VerticalAlignment="Center"
+                              Data="M 0,0 L 4,4 L 0,8"
+                              Stroke="{DynamicResource Theme.TextSecondary}" StrokeThickness="1.5"/>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsChecked" Value="True">
+                            <Setter TargetName="glyph" Property="Data" Value="M 0,0 L 8,0 L 4,4 Z"/>
+                            <Setter TargetName="glyph" Property="Fill" Value="{DynamicResource Theme.TextSecondary}"/>
+                            <Setter TargetName="glyph" Property="Stroke" Value="{x:Null}"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!-- Full standard TreeViewItem template (expander + PART_Header + ItemsHost),
+         tokenized. The default template paints selection with hardcoded light
+         colors, so property-only styling is not enough here. -->
+    <Style TargetType="TreeViewItem">
+        <Setter Property="FocusVisualStyle" Value="{DynamicResource FocusVisual}"/>
+        <Setter Property="IsExpanded" Value="True"/>
+        <Setter Property="Foreground" Value="{DynamicResource Theme.TextPrimary}"/>
+        <Setter Property="Padding" Value="2,1"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="TreeViewItem">
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" MinWidth="18"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition/>
+                        </Grid.RowDefinitions>
+                        <ToggleButton x:Name="Expander"
+                                      Style="{StaticResource ThemedTreeExpandToggle}"
+                                      IsChecked="{Binding IsExpanded, RelativeSource={RelativeSource TemplatedParent}}"
+                                      ClickMode="Press"/>
+                        <Border x:Name="Bd" Grid.Column="1" Grid.ColumnSpan="2"
+                                Background="Transparent"
+                                Padding="{TemplateBinding Padding}"
+                                SnapsToDevicePixels="True">
+                            <ContentPresenter x:Name="PART_Header"
+                                              ContentSource="Header"
+                                              HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"/>
+                        </Border>
+                        <ItemsPresenter x:Name="ItemsHost"
+                                        Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="2"/>
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsExpanded" Value="False">
+                            <Setter TargetName="ItemsHost" Property="Visibility" Value="Collapsed"/>
+                        </Trigger>
+                        <Trigger Property="HasItems" Value="False">
+                            <Setter TargetName="Expander" Property="Visibility" Value="Hidden"/>
+                        </Trigger>
+                        <Trigger Property="IsSelected" Value="True">
+                            <Setter TargetName="Bd" Property="Background" Value="{DynamicResource Theme.SelectionBackground}"/>
+                            <Setter Property="Foreground" Value="{DynamicResource Theme.SelectionText}"/>
+                        </Trigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsSelected" Value="True"/>
+                                <Condition Property="IsSelectionActive" Value="False"/>
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="Bd" Property="Background" Value="{DynamicResource Theme.SelectionInactive}"/>
+                            <Setter Property="Foreground" Value="{DynamicResource Theme.TextPrimary}"/>
+                        </MultiTrigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Foreground" Value="{DynamicResource Theme.TextDisabled}"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!-- ── GridView column headers ────────────────────────────────────────── -->
+
+    <Style TargetType="GridViewColumnHeader">
+        <!-- Focusable=False mirrors AccessibleStyles: headers are never tab stops. -->
+        <Setter Property="Focusable" Value="False"/>
+        <Setter Property="Background" Value="{DynamicResource Theme.ChromeBackground}"/>
+        <Setter Property="Foreground" Value="{DynamicResource Theme.TextSecondary}"/>
+        <Setter Property="Padding" Value="6,4"/>
+        <Setter Property="HorizontalContentAlignment" Value="Left"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="GridViewColumnHeader">
+                    <Grid SnapsToDevicePixels="True">
+                        <Border x:Name="border"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{DynamicResource Theme.Border}"
+                                BorderThickness="0,0,1,1">
+                            <ContentPresenter Margin="{TemplateBinding Padding}"
+                                              HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                              VerticalAlignment="Center"
+                                              RecognizesAccessKey="True"/>
+                        </Border>
+                        <Thumb x:Name="PART_HeaderGripper"
+                               HorizontalAlignment="Right"
+                               Width="6" Margin="0,2"
+                               Cursor="SizeWE">
+                            <Thumb.Template>
+                                <ControlTemplate TargetType="Thumb">
+                                    <Rectangle Fill="Transparent" Width="6"/>
+                                </ControlTemplate>
+                            </Thumb.Template>
+                        </Thumb>
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="border" Property="Background" Value="{DynamicResource Theme.AccentSubtle}"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!-- ── Chrome pieces ──────────────────────────────────────────────────── -->
+
+    <Style TargetType="StatusBar">
+        <Setter Property="Background" Value="{DynamicResource Theme.ChromeBackground}"/>
+        <Setter Property="Foreground" Value="{DynamicResource Theme.TextPrimary}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource Theme.Accent}"/>
+        <Setter Property="BorderThickness" Value="0,1,0,0"/>
+    </Style>
+
+    <Style TargetType="ToolTip">
+        <Setter Property="Background" Value="{DynamicResource Theme.SurfaceBackground}"/>
+        <Setter Property="Foreground" Value="{DynamicResource Theme.TextPrimary}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource Theme.Border}"/>
+        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="Padding" Value="8,4"/>
+    </Style>
+
+    <Style TargetType="GroupBox">
+        <Setter Property="Foreground" Value="{DynamicResource Theme.TextPrimary}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource Theme.Border}"/>
+    </Style>
+
+    <Style TargetType="Label">
+        <Setter Property="Foreground" Value="{DynamicResource Theme.TextPrimary}"/>
+    </Style>
+
+    <Style TargetType="Hyperlink">
+        <Setter Property="Foreground" Value="{DynamicResource Theme.Hyperlink}"/>
+    </Style>
+
+    <Style TargetType="GridSplitter">
+        <Setter Property="Background" Value="{DynamicResource Theme.BorderSubtle}"/>
+    </Style>
+
+</ResourceDictionary>

--- a/QuickMail/Themes/BuiltIn/dark.json
+++ b/QuickMail/Themes/BuiltIn/dark.json
@@ -1,0 +1,39 @@
+{
+  "formatVersion": 1,
+  "id": "dark",
+  "name": "Quill Dark",
+  "base": "dark",
+  "colors": {
+    "windowBackground": "#1E2023",
+    "surfaceBackground": "#26292E",
+    "chromeBackground": "#2B2F34",
+    "inputBackground": "#26292E",
+    "border": "#3D4147",
+    "borderSubtle": "#33373C",
+    "inputBorder": "#4A4F56",
+    "textPrimary": "#E8E6E3",
+    "textSecondary": "#A8ACB3",
+    "textDisabled": "#767B83",
+    "textOnAccent": "#16202E",
+    "accent": "#8FB0D9",
+    "accentSubtle": "#2C3A4C",
+    "hyperlink": "#8FB8E8",
+    "selectionBackground": "#33465E",
+    "selectionText": "#E8E6E3",
+    "selectionInactive": "#2E3238",
+    "focusIndicator": "#E8E6E3",
+    "error": "#F0857C",
+    "errorBackground": "#3B2523",
+    "warning": "#E0B45C",
+    "warningBackground": "#3A3223",
+    "success": "#87C795",
+    "successBackground": "#233A2A",
+    "info": "#A3C4E8",
+    "infoBackground": "#24303C"
+  },
+  "typography": {
+    "fontFamily": "Segoe UI",
+    "monoFontFamily": "Cascadia Code",
+    "baseFontSize": 13
+  }
+}

--- a/QuickMail/Themes/BuiltIn/dark.json
+++ b/QuickMail/Themes/BuiltIn/dark.json
@@ -1,7 +1,7 @@
 {
   "formatVersion": 1,
   "id": "dark",
-  "name": "Quill Dark",
+  "name": "Parchment Dark",
   "base": "dark",
   "colors": {
     "windowBackground": "#1E2023",

--- a/QuickMail/Themes/BuiltIn/ember.json
+++ b/QuickMail/Themes/BuiltIn/ember.json
@@ -1,0 +1,17 @@
+{
+  "formatVersion": 1,
+  "id": "ember",
+  "name": "Ember",
+  "base": "light",
+  "colors": {
+    "accent": "#8F4531",
+    "windowBackground": "#FBF7F2",
+    "accentSubtle": "#F5E9E3",
+    "selectionBackground": "#F0DFD6"
+  },
+  "typography": {
+    "fontFamily": "Segoe UI",
+    "monoFontFamily": "Cascadia Code",
+    "baseFontSize": 13
+  }
+}

--- a/QuickMail/Themes/BuiltIn/fjord.json
+++ b/QuickMail/Themes/BuiltIn/fjord.json
@@ -1,0 +1,17 @@
+{
+  "formatVersion": 1,
+  "id": "fjord",
+  "name": "Fjord",
+  "base": "light",
+  "colors": {
+    "accent": "#2E6462",
+    "windowBackground": "#F8FAFA",
+    "accentSubtle": "#E4EFEE",
+    "selectionBackground": "#D8E8E7"
+  },
+  "typography": {
+    "fontFamily": "Segoe UI",
+    "monoFontFamily": "Cascadia Code",
+    "baseFontSize": 13
+  }
+}

--- a/QuickMail/Themes/BuiltIn/heather.json
+++ b/QuickMail/Themes/BuiltIn/heather.json
@@ -1,0 +1,17 @@
+{
+  "formatVersion": 1,
+  "id": "heather",
+  "name": "Heather",
+  "base": "light",
+  "colors": {
+    "accent": "#5E566E",
+    "windowBackground": "#FAF9FB",
+    "accentSubtle": "#ECEAF1",
+    "selectionBackground": "#E2DFE9"
+  },
+  "typography": {
+    "fontFamily": "Segoe UI",
+    "monoFontFamily": "Cascadia Code",
+    "baseFontSize": 13
+  }
+}

--- a/QuickMail/Themes/BuiltIn/light.json
+++ b/QuickMail/Themes/BuiltIn/light.json
@@ -1,7 +1,7 @@
 {
   "formatVersion": 1,
-  "id": "quill",
-  "name": "Quill",
+  "id": "parchment",
+  "name": "Parchment",
   "base": "light",
   "colors": {
     "windowBackground": "#FBFAF8",

--- a/QuickMail/Themes/BuiltIn/light.json
+++ b/QuickMail/Themes/BuiltIn/light.json
@@ -1,0 +1,39 @@
+{
+  "formatVersion": 1,
+  "id": "quill",
+  "name": "Quill",
+  "base": "light",
+  "colors": {
+    "windowBackground": "#FBFAF8",
+    "surfaceBackground": "#F5F3EF",
+    "chromeBackground": "#EFEDE8",
+    "inputBackground": "#FFFFFF",
+    "border": "#D8D4CC",
+    "borderSubtle": "#E9E6E0",
+    "inputBorder": "#B8B4AC",
+    "textPrimary": "#1F2328",
+    "textSecondary": "#5A6068",
+    "textDisabled": "#7E858C",
+    "textOnAccent": "#FFFFFF",
+    "accent": "#3D5A80",
+    "accentSubtle": "#E7EDF4",
+    "hyperlink": "#2A5D9E",
+    "selectionBackground": "#D6E2F0",
+    "selectionText": "#1F2328",
+    "selectionInactive": "#E6E7E9",
+    "focusIndicator": "#1F2328",
+    "error": "#B3261E",
+    "errorBackground": "#FBEAE9",
+    "warning": "#8A5A00",
+    "warningBackground": "#FBF3E2",
+    "success": "#2E6B3E",
+    "successBackground": "#E9F3EC",
+    "info": "#31597F",
+    "infoBackground": "#EAF0F7"
+  },
+  "typography": {
+    "fontFamily": "Segoe UI",
+    "monoFontFamily": "Cascadia Code",
+    "baseFontSize": 13
+  }
+}

--- a/QuickMail/Theming/ThemeKeys.cs
+++ b/QuickMail/Theming/ThemeKeys.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+
+namespace QuickMail.Theming;
+
+/// <summary>
+/// The single source of truth for semantic theme token names.
+///
+/// Each color token exists in two spellings:
+///   - the resource key published into Application.Current.Resources
+///     (e.g. "Theme.WindowBackground"), consumed by XAML via DynamicResource
+///     and by C# via SetResourceReference / TryFindResource; and
+///   - the camelCase JSON name used in .quickmailtheme files
+///     (e.g. "windowBackground").
+///
+/// <see cref="ColorTokens"/> maps camelCase JSON name → resource key and is the
+/// authoritative list of the 26 color tokens. Typography and vision-assist keys
+/// are resource-only (they come from the theme's typography block and user
+/// settings, not the colors map).
+/// </summary>
+public static class ThemeKeys
+{
+    private const string Prefix = "Theme.";
+
+    // ── Surfaces (7) ──────────────────────────────────────────────────────────
+    public const string WindowBackground  = Prefix + "WindowBackground";
+    public const string SurfaceBackground = Prefix + "SurfaceBackground";
+    public const string ChromeBackground  = Prefix + "ChromeBackground";
+    public const string InputBackground   = Prefix + "InputBackground";
+    public const string Border            = Prefix + "Border";
+    public const string BorderSubtle      = Prefix + "BorderSubtle";
+    public const string InputBorder       = Prefix + "InputBorder";
+
+    // ── Text (4) ──────────────────────────────────────────────────────────────
+    public const string TextPrimary   = Prefix + "TextPrimary";
+    public const string TextSecondary = Prefix + "TextSecondary";
+    public const string TextDisabled  = Prefix + "TextDisabled";
+    public const string TextOnAccent  = Prefix + "TextOnAccent";
+
+    // ── Accent / interaction (7) ──────────────────────────────────────────────
+    public const string Accent              = Prefix + "Accent";
+    public const string AccentSubtle        = Prefix + "AccentSubtle";
+    public const string Hyperlink           = Prefix + "Hyperlink";
+    public const string SelectionBackground = Prefix + "SelectionBackground";
+    public const string SelectionText       = Prefix + "SelectionText";
+    public const string SelectionInactive   = Prefix + "SelectionInactive";
+    public const string FocusIndicator      = Prefix + "FocusIndicator";
+
+    // ── Status (8) ────────────────────────────────────────────────────────────
+    public const string Error             = Prefix + "Error";
+    public const string ErrorBackground   = Prefix + "ErrorBackground";
+    public const string Warning           = Prefix + "Warning";
+    public const string WarningBackground = Prefix + "WarningBackground";
+    public const string Success           = Prefix + "Success";
+    public const string SuccessBackground = Prefix + "SuccessBackground";
+    public const string Info              = Prefix + "Info";
+    public const string InfoBackground    = Prefix + "InfoBackground";
+
+    // ── Typography (resource-only) ────────────────────────────────────────────
+    public const string FontFamily     = Prefix + "FontFamily";
+    public const string FontFamilyMono = Prefix + "FontFamilyMono";
+    public const string FontSizeBase   = Prefix + "FontSizeBase";
+    public const string FontSizeSmall  = Prefix + "FontSizeSmall";
+    public const string FontSizeLarge  = Prefix + "FontSizeLarge";
+    public const string FontSizeHeader = Prefix + "FontSizeHeader";
+
+    // ── Vision assist (resource-only) ─────────────────────────────────────────
+    public const string FocusThickness = Prefix + "FocusThickness";
+
+    /// <summary>camelCase JSON name → application resource key, for all 26 color tokens.</summary>
+    public static readonly IReadOnlyDictionary<string, string> ColorTokens =
+        new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["windowBackground"]    = WindowBackground,
+            ["surfaceBackground"]   = SurfaceBackground,
+            ["chromeBackground"]    = ChromeBackground,
+            ["inputBackground"]     = InputBackground,
+            ["border"]              = Border,
+            ["borderSubtle"]        = BorderSubtle,
+            ["inputBorder"]         = InputBorder,
+            ["textPrimary"]         = TextPrimary,
+            ["textSecondary"]       = TextSecondary,
+            ["textDisabled"]        = TextDisabled,
+            ["textOnAccent"]        = TextOnAccent,
+            ["accent"]              = Accent,
+            ["accentSubtle"]        = AccentSubtle,
+            ["hyperlink"]           = Hyperlink,
+            ["selectionBackground"] = SelectionBackground,
+            ["selectionText"]       = SelectionText,
+            ["selectionInactive"]   = SelectionInactive,
+            ["focusIndicator"]      = FocusIndicator,
+            ["error"]               = Error,
+            ["errorBackground"]     = ErrorBackground,
+            ["warning"]             = Warning,
+            ["warningBackground"]   = WarningBackground,
+            ["success"]             = Success,
+            ["successBackground"]   = SuccessBackground,
+            ["info"]                = Info,
+            ["infoBackground"]      = InfoBackground,
+        };
+}

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -961,16 +961,15 @@ public partial class MainViewModel : ObservableObject, IDisposable
         if (_themeService is null) return;
         var resolvedBefore = _themeService.ResolvedTheme.Id;
         _themeService.ApplyTheme(themeId);
-        var cfg = _configService.Load();
-        cfg.AppearanceThemeId = _themeService.ConfiguredThemeId;
-        _configService.Save(cfg);
+        Helpers.ThemePersistence.PersistConfiguredTheme(_themeService, _configService);
 
         // When the selection changes but the effective palette does not (e.g.
         // System → Quill while the OS is in light mode), ThemeChanged never fires
         // and the window's handler stays silent — announce the switch here so
-        // cycling always reports the new theme.
+        // cycling always reports the new theme. ConfiguredThemeName (not the
+        // resolved name) so cycling to System announces "System", not "Quill".
         if (_themeService.ResolvedTheme.Id == resolvedBefore)
-            Announce($"Theme changed to {_themeService.ResolvedTheme.Name}.", AnnouncementCategory.Status);
+            Announce($"Theme changed to {_themeService.ConfiguredThemeName}.", AnnouncementCategory.Status);
     }
 
     /// <summary>Steps to the next/previous theme in display order (System first, then built-ins, then user themes).</summary>
@@ -1233,13 +1232,10 @@ public partial class MainViewModel : ObservableObject, IDisposable
     {
         // Theme + vision-assist first, after the modal Settings dialog has closed —
         // ThemeChanged handlers rebuild UI and must never run inside a nested
-        // message loop (CLAUDE.md modal-dialog rules).
-        if (_themeService != null)
-        {
-            _themeService.ApplyVisionSettings(cfg);
-            if (!string.Equals(_themeService.ConfiguredThemeId, cfg.AppearanceThemeId, StringComparison.OrdinalIgnoreCase))
-                _themeService.ApplyTheme(cfg.AppearanceThemeId);
-        }
+        // message loop (CLAUDE.md modal-dialog rules). ApplyAppearance coalesces
+        // both mutations into one re-publish so a combined save (theme + a vision
+        // setting) raises ThemeChanged once, not twice.
+        _themeService?.ApplyAppearance(cfg);
 
         ShowMessageStatus = cfg.ShowMessageStatus;
         _announceFlagStatus = cfg.AnnounceFlagStatus;

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -964,10 +964,10 @@ public partial class MainViewModel : ObservableObject, IDisposable
         Helpers.ThemePersistence.PersistConfiguredTheme(_themeService, _configService);
 
         // When the selection changes but the effective palette does not (e.g.
-        // System → Quill while the OS is in light mode), ThemeChanged never fires
-        // and the window's handler stays silent — announce the switch here so
+        // System → Parchment while the OS is in light mode), ThemeChanged never
+        // fires and the window's handler stays silent — announce the switch here so
         // cycling always reports the new theme. ConfiguredThemeName (not the
-        // resolved name) so cycling to System announces "System", not "Quill".
+        // resolved name) so cycling to System announces "System", not "Parchment".
         if (_themeService.ResolvedTheme.Id == resolvedBefore)
             Announce($"Theme changed to {_themeService.ConfiguredThemeName}.", AnnouncementCategory.Status);
     }
@@ -5230,7 +5230,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
         if (invite == null) return string.Empty;
 
         // Card colors come from the resolved theme as hex strings (IThemeService
-        // never exposes UI types). Fallbacks match the Quill light palette for
+        // never exposes UI types). Fallbacks match the Parchment light palette for
         // tests that run without a theme service.
         var theme = _themeService?.ResolvedTheme;
         string Color(string token, string fallback) => theme?.ColorOf(token) ?? fallback;

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -33,6 +33,9 @@ public partial class MainViewModel : ObservableObject, IDisposable
     private readonly IFlagService? _flagService;
     private readonly ICalendarService? _calendarService;
     private readonly IUpdateCheckService? _updateCheckService;
+    // Exposes hex strings only, so consuming it here does not violate the
+    // no-UI-types-in-ViewModels rule. Null in tests that don't exercise theming.
+    private readonly IThemeService? _themeService;
     // UI-thread marshaller — ViewModels must not touch Dispatcher directly (CLAUDE.md MVVM rules).
     private readonly IUiDispatcher _ui;
 
@@ -737,7 +740,8 @@ public partial class MainViewModel : ObservableObject, IDisposable
         ICalendarService? calendarService = null,
         IChangeNotifier? changeNotifier = null,
         IUpdateCheckService? updateCheckService = null,
-        IUiDispatcher? uiDispatcher = null)
+        IUiDispatcher? uiDispatcher = null,
+        IThemeService? themeService = null)
     {
         _imap            = imap;
         _ui              = uiDispatcher ?? new WpfUiDispatcher();
@@ -755,6 +759,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
         _flagService          = flagService;
         _calendarService      = calendarService;
         _updateCheckService   = updateCheckService;
+        _themeService         = themeService;
         OnlineMode            = onlineMode;
 
         var cfg = _configService.Load();
@@ -788,6 +793,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
         // Load saved views and register their commands before the UI is shown.
         LoadSavedViews();
         RegisterCommands(commandRegistry);
+        RegisterThemeCommands();
         UpdateRulesStatusText();
     }
 
@@ -893,6 +899,97 @@ public partial class MainViewModel : ObservableObject, IDisposable
             execute:          () => _ = ApplyViewByIdAsync(capturedId, allFolders: false),
             defaultKey:       defaultKey,
             defaultModifiers: defaultMods));
+    }
+
+    // ── Theme commands ────────────────────────────────────────────────────────────
+
+    /// <summary>Raised when the user invokes "Manage themes"; the View opens the Theme Manager.</summary>
+    public event EventHandler? ThemeManagerRequested;
+
+    /// <summary>
+    /// Registers (or re-registers) the theme commands: manager, cycle, and one
+    /// hotkey-assignable apply command per available theme (like view.saved.{id}).
+    /// Called at startup and again after the Theme Manager closes with changes.
+    /// </summary>
+    public void RegisterThemeCommands()
+    {
+        if (_themeService is null) return;
+
+        var stale = _commandRegistry.GetAll()
+            .Where(c => c.Id.StartsWith("theme.", StringComparison.OrdinalIgnoreCase))
+            .Select(c => c.Id)
+            .ToList();
+        foreach (var id in stale)
+            _commandRegistry.Unregister(id);
+
+        _commandRegistry.Register(new CommandDefinition(
+            id: "theme.manager.open", category: "Settings", title: "Manage Themes",
+            execute: () => ThemeManagerRequested?.Invoke(this, EventArgs.Empty)));
+
+        _commandRegistry.Register(new CommandDefinition(
+            id: "theme.next", category: "Settings", title: "Next Theme",
+            execute: () => CycleTheme(+1)));
+
+        _commandRegistry.Register(new CommandDefinition(
+            id: "theme.previous", category: "Settings", title: "Previous Theme",
+            execute: () => CycleTheme(-1)));
+
+        var cfg = _configService.Load();
+        foreach (var theme in _themeService.GetAvailableThemes())
+        {
+            var commandId = $"theme.apply.{theme.Id}";
+            var binding = cfg.CustomHotkeys.FirstOrDefault(h => h.CommandId == commandId);
+            Key defaultKey = Key.None;
+            ModifierKeys defaultMods = ModifierKeys.None;
+            if (!string.IsNullOrEmpty(binding?.Gesture))
+                _ = GestureHelper.TryParse(binding.Gesture, out defaultKey, out defaultMods);
+
+            var capturedId = theme.Id;
+            _commandRegistry.Register(new CommandDefinition(
+                id: commandId,
+                category: "Settings",
+                title: $"Theme: {theme.Name}",
+                execute: () => ApplyThemeById(capturedId),
+                defaultKey: defaultKey,
+                defaultModifiers: defaultMods));
+        }
+    }
+
+    /// <summary>Applies a theme and persists the choice (the service never writes config).</summary>
+    public void ApplyThemeById(string themeId)
+    {
+        if (_themeService is null) return;
+        var resolvedBefore = _themeService.ResolvedTheme.Id;
+        _themeService.ApplyTheme(themeId);
+        var cfg = _configService.Load();
+        cfg.AppearanceThemeId = _themeService.ConfiguredThemeId;
+        _configService.Save(cfg);
+
+        // When the selection changes but the effective palette does not (e.g.
+        // System → Quill while the OS is in light mode), ThemeChanged never fires
+        // and the window's handler stays silent — announce the switch here so
+        // cycling always reports the new theme.
+        if (_themeService.ResolvedTheme.Id == resolvedBefore)
+            Announce($"Theme changed to {_themeService.ResolvedTheme.Name}.", AnnouncementCategory.Status);
+    }
+
+    /// <summary>Steps to the next/previous theme in display order (System first, then built-ins, then user themes).</summary>
+    private void CycleTheme(int direction)
+    {
+        if (_themeService is null) return;
+        var themes = _themeService.GetAvailableThemes();
+        if (themes.Count == 0) return;
+        var index = 0;
+        for (int i = 0; i < themes.Count; i++)
+        {
+            if (string.Equals(themes[i].Id, _themeService.ConfiguredThemeId, StringComparison.OrdinalIgnoreCase))
+            {
+                index = i;
+                break;
+            }
+        }
+        var next = themes[(index + direction + themes.Count) % themes.Count];
+        ApplyThemeById(next.Id);
     }
 
     // ── View application ──────────────────────────────────────────────────────────
@@ -1134,6 +1231,16 @@ public partial class MainViewModel : ObservableObject, IDisposable
 
     internal void ApplySettings(ConfigModel cfg)
     {
+        // Theme + vision-assist first, after the modal Settings dialog has closed —
+        // ThemeChanged handlers rebuild UI and must never run inside a nested
+        // message loop (CLAUDE.md modal-dialog rules).
+        if (_themeService != null)
+        {
+            _themeService.ApplyVisionSettings(cfg);
+            if (!string.Equals(_themeService.ConfiguredThemeId, cfg.AppearanceThemeId, StringComparison.OrdinalIgnoreCase))
+                _themeService.ApplyTheme(cfg.AppearanceThemeId);
+        }
+
         ShowMessageStatus = cfg.ShowMessageStatus;
         _announceFlagStatus = cfg.AnnounceFlagStatus;
         OnPropertyChanged(nameof(AnnounceFlagStatus));
@@ -5126,8 +5233,17 @@ public partial class MainViewModel : ObservableObject, IDisposable
         var invite = MessageDetail?.CalendarInvite;
         if (invite == null) return string.Empty;
 
+        // Card colors come from the resolved theme as hex strings (IThemeService
+        // never exposes UI types). Fallbacks match the Quill light palette for
+        // tests that run without a theme service.
+        var theme = _themeService?.ResolvedTheme;
+        string Color(string token, string fallback) => theme?.ColorOf(token) ?? fallback;
+        var cardBorder = Color("border", "#D8D4CC");
+        var cardBg     = Color("surfaceBackground", "#F5F3EF");
+        var cardText   = Color("textPrimary", "#1F2328");
+
         var sb = new System.Text.StringBuilder();
-        sb.Append("<div style=\"border:1px solid #888;border-radius:6px;padding:12px;margin:0 0 16px 0;background:#f5f5f5;color:#222;font-family:Segoe UI,Arial,sans-serif;font-size:13px;line-height:1.45;\" role=\"region\" aria-label=\"");
+        sb.Append($"<div style=\"border:1px solid {cardBorder};border-radius:6px;padding:12px;margin:0 0 16px 0;background:{cardBg};color:{cardText};font-family:Segoe UI,Arial,sans-serif;font-size:13px;line-height:1.45;\" role=\"region\" aria-label=\"");
         sb.Append(System.Net.WebUtility.HtmlEncode(invite.DisplaySummary));
         sb.Append("\">");
         sb.Append("<div style=\"font-weight:bold;font-size:15px;margin-bottom:8px;\">Event Invitation</div>");
@@ -5137,7 +5253,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
         var isCancel = string.Equals(invite.Method, "CANCEL", StringComparison.OrdinalIgnoreCase);
         if (isCancel)
         {
-            sb.Append("<div style=\"font-weight:bold;color:#d13438;margin-bottom:8px;\">This event has been cancelled by the organizer.</div>");
+            sb.Append($"<div style=\"font-weight:bold;color:{Color("error", "#B3261E")};margin-bottom:8px;\">This event has been cancelled by the organizer.</div>");
         }
 
         if (!string.IsNullOrWhiteSpace(invite.Summary))
@@ -5186,19 +5302,26 @@ public partial class MainViewModel : ObservableObject, IDisposable
             sb.Append("</div>");
         }
 
-        // Buttons: Accept, Tentative, Decline — hidden for cancellations.
+        // Buttons: Accept, Tentative, Decline — hidden for cancellations. Each uses
+        // its status color's pale background tint with the dark status text partner
+        // and a 1px status border, readable in light and dark themes alike; the
+        // verb text (not color) carries the meaning.
         if (!isCancel)
         {
+            void AppendButton(string href, string ariaLabel, string label, string fg, string bg, bool last = false)
+            {
+                sb.Append($"<a href=\"{href}\" role=\"button\" aria-label=\"{ariaLabel}\" ");
+                sb.Append($"style=\"display:inline-block;padding:6px 14px;{(last ? "" : "margin-right:8px;")}margin-bottom:4px;");
+                sb.Append($"background:{bg};color:{fg};border:1px solid {fg};border-radius:4px;text-decoration:none;font-weight:600;\">{label}</a>");
+            }
+
             sb.Append("<div style=\"margin-top:8px;\">");
-            sb.Append("<a href=\"quickmail:ics-accept\" role=\"button\" aria-label=\"Accept invitation\" ");
-            sb.Append("style=\"display:inline-block;padding:6px 14px;margin-right:8px;margin-bottom:4px;");
-            sb.Append("background:#107c10;color:#fff;border-radius:4px;text-decoration:none;font-weight:600;\">Accept</a>");
-            sb.Append("<a href=\"quickmail:ics-tentative\" role=\"button\" aria-label=\"Tentatively accept invitation\" ");
-            sb.Append("style=\"display:inline-block;padding:6px 14px;margin-right:8px;margin-bottom:4px;");
-            sb.Append("background:#ff8c00;color:#fff;border-radius:4px;text-decoration:none;font-weight:600;\">Tentative</a>");
-            sb.Append("<a href=\"quickmail:ics-decline\" role=\"button\" aria-label=\"Decline invitation\" ");
-            sb.Append("style=\"display:inline-block;padding:6px 14px;margin-bottom:4px;");
-            sb.Append("background:#d13438;color:#fff;border-radius:4px;text-decoration:none;font-weight:600;\">Decline</a>");
+            AppendButton("quickmail:ics-accept", "Accept invitation", "Accept",
+                Color("success", "#2E6B3E"), Color("successBackground", "#E9F3EC"));
+            AppendButton("quickmail:ics-tentative", "Tentatively accept invitation", "Tentative",
+                Color("warning", "#8A5A00"), Color("warningBackground", "#FBF3E2"));
+            AppendButton("quickmail:ics-decline", "Decline invitation", "Decline",
+                Color("error", "#B3261E"), Color("errorBackground", "#FBEAE9"), last: true);
             sb.Append("</div>");
         }
 

--- a/QuickMail/ViewModels/SettingsViewModel.cs
+++ b/QuickMail/ViewModels/SettingsViewModel.cs
@@ -114,6 +114,43 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty]
     private bool _confirmCloseTabWithUnsaved = true;
 
+    // ── Appearance ─────────────────────────────────────────────────────────────────
+
+    /// <summary>Sentinel shown in the font ComboBox for "use the theme's font".</summary>
+    public const string ThemeDefaultFontLabel = "(Theme default)";
+
+    /// <summary>One row of the theme ComboBox — id + display name only, no UI types.</summary>
+    public sealed record ThemeOption(string Id, string Name);
+
+    /// <summary>Selectable themes in display order. Empty when no theme service is wired (tests).</summary>
+    public ObservableCollection<ThemeOption> ThemeOptions { get; } = [];
+
+    /// <summary>Font choices: the theme-default sentinel followed by installed families.</summary>
+    public ObservableCollection<string> FontOptions { get; } = [];
+
+    /// <summary>True while Windows High Contrast supplies the colors; shows the notice in the tab.</summary>
+    public bool IsHighContrastActive { get; }
+
+    [ObservableProperty]
+    private string _appearanceThemeId = "system";
+
+    /// <summary>Bound to the text-size ComboBox by tag; values are percent (100–200).</summary>
+    [ObservableProperty]
+    private int _appearanceTextScalePercent = 100;
+
+    /// <summary>The selected font option; <see cref="ThemeDefaultFontLabel"/> means no override.</summary>
+    [ObservableProperty]
+    private string _appearanceFontOption = ThemeDefaultFontLabel;
+
+    [ObservableProperty]
+    private bool _appearanceUnderlineLinks;
+
+    [ObservableProperty]
+    private bool _appearanceThickFocus;
+
+    [ObservableProperty]
+    private bool _appearanceForceMessageTheme;
+
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(IsLogFormatActionFirst))]
     [NotifyPropertyChangedFor(nameof(IsLogFormatTimeFirst))]
@@ -139,10 +176,40 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty]
     private HotkeyRowViewModel? _selectedHotkey;
 
-    public SettingsViewModel(IConfigService configService, ICommandRegistry registry)
+    public SettingsViewModel(
+        IConfigService configService,
+        ICommandRegistry registry,
+        IThemeService? themeService = null,
+        System.Collections.Generic.IEnumerable<string>? fontFamilies = null)
     {
         _configService = configService;
         var cfg = configService.Load();
+
+        // Appearance: themes from the service; installed fonts from the View
+        // (font enumeration is a presentation concern the caller supplies).
+        if (themeService != null)
+        {
+            foreach (var t in themeService.GetAvailableThemes())
+                ThemeOptions.Add(new ThemeOption(t.Id, t.Name));
+            IsHighContrastActive = themeService.IsHighContrastActive;
+        }
+        FontOptions.Add(ThemeDefaultFontLabel);
+        if (fontFamilies != null)
+            foreach (var f in fontFamilies)
+                FontOptions.Add(f);
+
+        AppearanceThemeId = cfg.AppearanceThemeId;
+        AppearanceTextScalePercent = (int)System.Math.Round(cfg.AppearanceTextScale * 100);
+        if (AppearanceTextScalePercent is not (100 or 110 or 125 or 150 or 175 or 200))
+            AppearanceTextScalePercent = 100;
+        AppearanceFontOption = string.IsNullOrWhiteSpace(cfg.AppearanceFontFamily)
+            ? ThemeDefaultFontLabel
+            : cfg.AppearanceFontFamily;
+        if (AppearanceFontOption != ThemeDefaultFontLabel && !FontOptions.Contains(AppearanceFontOption))
+            FontOptions.Add(AppearanceFontOption); // keep an uninstalled configured font selectable
+        AppearanceUnderlineLinks    = cfg.AppearanceUnderlineLinks;
+        AppearanceThickFocus        = cfg.AppearanceThickFocus;
+        AppearanceForceMessageTheme = cfg.AppearanceForceMessageTheme;
 
         PreviewLines = cfg.PreviewLines;
         ShowMessageStatus = cfg.ShowMessageStatus;
@@ -195,6 +262,15 @@ public partial class SettingsViewModel : ObservableObject
     private void Save()
     {
         var cfg = _configService.Load();
+
+        cfg.AppearanceThemeId = AppearanceThemeId;
+        cfg.AppearanceTextScale = AppearanceTextScalePercent / 100.0;
+        cfg.AppearanceFontFamily = AppearanceFontOption == ThemeDefaultFontLabel
+            ? string.Empty
+            : AppearanceFontOption;
+        cfg.AppearanceUnderlineLinks    = AppearanceUnderlineLinks;
+        cfg.AppearanceThickFocus        = AppearanceThickFocus;
+        cfg.AppearanceForceMessageTheme = AppearanceForceMessageTheme;
 
         cfg.PreviewLines = PreviewLines;
         cfg.ShowMessageStatus = ShowMessageStatus;

--- a/QuickMail/ViewModels/ThemeManagerViewModel.cs
+++ b/QuickMail/ViewModels/ThemeManagerViewModel.cs
@@ -32,7 +32,21 @@ public partial class ThemeManagerViewModel : ObservableObject
     [NotifyPropertyChangedFor(nameof(CanRename))]
     [NotifyPropertyChangedFor(nameof(CanDelete))]
     [NotifyPropertyChangedFor(nameof(CanExport))]
+    [NotifyPropertyChangedFor(nameof(SelectedThemeDescription))]
     private ThemeRowViewModel? _selectedTheme;
+
+    /// <summary>
+    /// A read-only, screen-reader-friendly account of the selected theme — what
+    /// colors it uses and where, plus fonts. Backs the "Theme description" box so
+    /// a non-visual user can understand a theme without seeing its swatches.
+    /// Regenerated on each selection change (see NotifyPropertyChangedFor above).
+    /// </summary>
+    public string SelectedThemeDescription =>
+        SelectedTheme is null
+            ? string.Empty
+            : Helpers.ThemeDescriber.Describe(
+                _themeService.ResolveForPreview(SelectedTheme.Id),
+                isSystem: SelectedTheme.IsSystem);
 
     /// <summary>True while the inline name panel (duplicate/rename) is open.</summary>
     [ObservableProperty]

--- a/QuickMail/ViewModels/ThemeManagerViewModel.cs
+++ b/QuickMail/ViewModels/ThemeManagerViewModel.cs
@@ -123,11 +123,19 @@ public partial class ThemeManagerViewModel : ObservableObject
     private void Apply()
     {
         if (SelectedTheme is null) return;
+        var resolvedBefore = _themeService.ResolvedTheme.Id;
         _themeService.ApplyTheme(SelectedTheme.Id);
         PersistConfiguredTheme();
         RefreshCurrentMarkers();
-        // "Theme changed to …" is announced by the main window's ThemeChanged
-        // handler — no announcement here, so it is never doubled. Focus stays put.
+
+        // When the effective palette changes, the main window's ThemeChanged
+        // handler announces it — announcing here too would double it. But when the
+        // selection resolves to the same palette (e.g. System already shows the
+        // built-in you pick), ThemeChanged never fires, so announce here — Apply
+        // must never be silent. Mirrors MainViewModel.ApplyThemeById. Focus stays put.
+        if (_themeService.ResolvedTheme.Id == resolvedBefore)
+            AnnouncementRequested?.Invoke(
+                $"Theme changed to {_themeService.ConfiguredThemeName}.", AnnouncementCategory.Status);
     }
 
     [RelayCommand]

--- a/QuickMail/ViewModels/ThemeManagerViewModel.cs
+++ b/QuickMail/ViewModels/ThemeManagerViewModel.cs
@@ -1,0 +1,320 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using QuickMail.Models;
+using QuickMail.Services;
+
+namespace QuickMail.ViewModels;
+
+/// <summary>
+/// Backs the Theme Manager window: list, apply, duplicate, rename, delete,
+/// export, import, open themes folder. Follows the ViewManagerViewModel event
+/// pattern — the View owns every dialog, file picker, and announcement; this VM
+/// raises requests and exposes state only.
+/// </summary>
+public partial class ThemeManagerViewModel : ObservableObject
+{
+    private readonly IThemeService _themeService;
+    private readonly IConfigService _configService;
+
+    /// <summary>What the open name panel will do on OK.</summary>
+    private enum NameAction { None, Duplicate, Rename }
+    private NameAction _pendingNameAction = NameAction.None;
+
+    public ObservableCollection<ThemeRowViewModel> Themes { get; } = [];
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(CanApply))]
+    [NotifyPropertyChangedFor(nameof(CanDuplicate))]
+    [NotifyPropertyChangedFor(nameof(CanRename))]
+    [NotifyPropertyChangedFor(nameof(CanDelete))]
+    [NotifyPropertyChangedFor(nameof(CanExport))]
+    private ThemeRowViewModel? _selectedTheme;
+
+    /// <summary>True while the inline name panel (duplicate/rename) is open.</summary>
+    [ObservableProperty]
+    private bool _isNamePanelOpen;
+
+    [ObservableProperty]
+    private string _editName = string.Empty;
+
+    public bool CanApply     => SelectedTheme != null;
+    public bool CanDuplicate => SelectedTheme != null && !SelectedTheme.IsSystem;
+    public bool CanRename    => SelectedTheme is { IsBuiltIn: false };
+    public bool CanDelete    => SelectedTheme is { IsBuiltIn: false };
+    public bool CanExport    => SelectedTheme != null && !SelectedTheme.IsSystem;
+
+    // ── View requests ─────────────────────────────────────────────────────────
+
+    /// <summary>Announce text through AccessibilityHelper with the given category.</summary>
+    public event Action<string, AnnouncementCategory>? AnnouncementRequested;
+
+    /// <summary>The name panel opened; the View focuses the name box.</summary>
+    public event EventHandler? NameEditStarted;
+
+    /// <summary>Focus should return to the list item with this theme id.</summary>
+    public event Action<string>? FocusListItemRequested;
+
+    /// <summary>Show an error dialog with this plain-language message.</summary>
+    public event Action<string>? ErrorRequested;
+
+    /// <summary>Confirm deletion; returns true to proceed. Message, then title.</summary>
+    public Func<string, string, bool>? ConfirmDeleteRequested { get; set; }
+
+    /// <summary>Pick a save path for export; argument is the suggested file name.</summary>
+    public Func<string, string?>? ExportPathRequested { get; set; }
+
+    /// <summary>Pick a theme file to import.</summary>
+    public Func<string?>? ImportPathRequested { get; set; }
+
+    /// <summary>Open the user themes folder in the shell.</summary>
+    public event Action<string>? OpenFolderRequested;
+
+    public ThemeManagerViewModel(IThemeService themeService, IConfigService configService)
+    {
+        _themeService = themeService;
+        _configService = configService;
+        ReloadThemes(selectId: themeService.ConfiguredThemeId);
+    }
+
+    private void ReloadThemes(string? selectId)
+    {
+        Themes.Clear();
+        var configured = _themeService.ConfiguredThemeId;
+        foreach (var theme in _themeService.GetAvailableThemes())
+            Themes.Add(new ThemeRowViewModel(theme,
+                isCurrent: string.Equals(theme.Id, configured, StringComparison.OrdinalIgnoreCase)));
+
+        SelectedTheme = Themes.FirstOrDefault(t =>
+                string.Equals(t.Id, selectId, StringComparison.OrdinalIgnoreCase))
+            ?? Themes.FirstOrDefault();
+    }
+
+    private void RefreshCurrentMarkers()
+    {
+        var configured = _themeService.ConfiguredThemeId;
+        foreach (var row in Themes)
+            row.IsCurrent = string.Equals(row.Id, configured, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private void PersistConfiguredTheme()
+    {
+        var cfg = _configService.Load();
+        cfg.AppearanceThemeId = _themeService.ConfiguredThemeId;
+        _configService.Save(cfg);
+    }
+
+    // ── Commands ──────────────────────────────────────────────────────────────
+
+    [RelayCommand]
+    private void Apply()
+    {
+        if (SelectedTheme is null) return;
+        _themeService.ApplyTheme(SelectedTheme.Id);
+        PersistConfiguredTheme();
+        RefreshCurrentMarkers();
+        // "Theme changed to …" is announced by the main window's ThemeChanged
+        // handler — no announcement here, so it is never doubled. Focus stays put.
+    }
+
+    [RelayCommand]
+    private void Duplicate()
+    {
+        if (SelectedTheme is null || SelectedTheme.IsSystem) return;
+        _pendingNameAction = NameAction.Duplicate;
+        EditName = $"{SelectedTheme.Name} copy";
+        IsNamePanelOpen = true;
+        NameEditStarted?.Invoke(this, EventArgs.Empty);
+    }
+
+    [RelayCommand]
+    private void Rename()
+    {
+        if (SelectedTheme is not { IsBuiltIn: false }) return;
+        _pendingNameAction = NameAction.Rename;
+        EditName = SelectedTheme.Name;
+        IsNamePanelOpen = true;
+        NameEditStarted?.Invoke(this, EventArgs.Empty);
+    }
+
+    [RelayCommand]
+    private void ConfirmName()
+    {
+        var name = EditName.Trim();
+        if (name.Length == 0 || SelectedTheme is null)
+        {
+            CancelName();
+            return;
+        }
+
+        try
+        {
+            switch (_pendingNameAction)
+            {
+                case NameAction.Duplicate:
+                {
+                    var copy = SelectedTheme.Definition.Clone();
+                    copy.Id = Guid.NewGuid().ToString("N");
+                    copy.Name = name;
+                    copy.IsBuiltIn = false;
+                    _themeService.SaveUserTheme(copy);
+                    ReloadThemes(selectId: copy.Id);
+                    AnnouncementRequested?.Invoke($"Theme {name} created.", AnnouncementCategory.Result);
+                    FocusListItemRequested?.Invoke(copy.Id);
+                    break;
+                }
+                case NameAction.Rename:
+                {
+                    var renamed = SelectedTheme.Definition.Clone();
+                    renamed.Name = name;
+                    _themeService.SaveUserTheme(renamed);
+                    ReloadThemes(selectId: renamed.Id);
+                    AnnouncementRequested?.Invoke($"Theme renamed to {name}.", AnnouncementCategory.Result);
+                    FocusListItemRequested?.Invoke(renamed.Id);
+                    break;
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            ErrorRequested?.Invoke($"The theme could not be saved: {ex.Message}");
+        }
+        finally
+        {
+            _pendingNameAction = NameAction.None;
+            IsNamePanelOpen = false;
+        }
+    }
+
+    [RelayCommand]
+    private void CancelName()
+    {
+        _pendingNameAction = NameAction.None;
+        IsNamePanelOpen = false;
+        if (SelectedTheme != null)
+            FocusListItemRequested?.Invoke(SelectedTheme.Id);
+    }
+
+    [RelayCommand]
+    private void Delete()
+    {
+        if (SelectedTheme is not { IsBuiltIn: false } row) return;
+
+        var confirmed = ConfirmDeleteRequested?.Invoke(
+            $"Delete theme {row.Name}? This cannot be undone.", "Delete Theme") ?? false;
+        if (!confirmed) return;
+
+        var index = Themes.IndexOf(row);
+        try
+        {
+            // If the deleted theme was active the service falls back to System.
+            _themeService.DeleteUserTheme(row.Id);
+            PersistConfiguredTheme();
+        }
+        catch (Exception ex)
+        {
+            ErrorRequested?.Invoke($"The theme could not be deleted: {ex.Message}");
+            return;
+        }
+
+        ReloadThemes(selectId: null);
+        // Land on the next item, or the previous when the deleted one was last.
+        if (Themes.Count > 0)
+            SelectedTheme = Themes[Math.Min(index, Themes.Count - 1)];
+        AnnouncementRequested?.Invoke("Theme deleted.", AnnouncementCategory.Result);
+        if (SelectedTheme != null)
+            FocusListItemRequested?.Invoke(SelectedTheme.Id);
+    }
+
+    [RelayCommand]
+    private void Export()
+    {
+        if (SelectedTheme is null || SelectedTheme.IsSystem) return;
+
+        var path = ExportPathRequested?.Invoke($"{SelectedTheme.Name}.quickmailtheme");
+        if (string.IsNullOrEmpty(path)) return;
+
+        try
+        {
+            _themeService.ExportTheme(SelectedTheme.Id, path);
+            AnnouncementRequested?.Invoke("Theme exported.", AnnouncementCategory.Result);
+        }
+        catch (Exception ex)
+        {
+            ErrorRequested?.Invoke($"The theme could not be exported: {ex.Message}");
+        }
+    }
+
+    [RelayCommand]
+    private void Import()
+    {
+        var path = ImportPathRequested?.Invoke();
+        if (string.IsNullOrEmpty(path)) return;
+
+        try
+        {
+            var imported = _themeService.ImportTheme(path);
+            ReloadThemes(selectId: imported.Id);
+            AnnouncementRequested?.Invoke($"Theme {imported.Name} imported.", AnnouncementCategory.Result);
+            FocusListItemRequested?.Invoke(imported.Id);
+        }
+        catch (ThemeFormatException ex)
+        {
+            // Plain-language message from the parser, shown verbatim; the list is unchanged.
+            ErrorRequested?.Invoke(ex.Message);
+        }
+        catch (Exception ex)
+        {
+            ErrorRequested?.Invoke($"The theme could not be imported: {ex.Message}");
+        }
+    }
+
+    [RelayCommand]
+    private void OpenThemesFolder() => OpenFolderRequested?.Invoke(_themeService.UserThemesFolder);
+
+    // ── Row ───────────────────────────────────────────────────────────────────
+
+    public partial class ThemeRowViewModel : ObservableObject
+    {
+        public ThemeDefinition Definition { get; }
+
+        public string Id => Definition.Id;
+        public string Name => Definition.Name;
+        public bool IsBuiltIn => Definition.IsBuiltIn;
+        public bool IsSystem => string.Equals(Id, "system", StringComparison.OrdinalIgnoreCase);
+
+        [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(AccessibleName))]
+        [NotifyPropertyChangedFor(nameof(DetailLabel))]
+        private bool _isCurrent;
+
+        /// <summary>Secondary line under the theme name, e.g. "Built-in · current theme".</summary>
+        public string DetailLabel
+        {
+            get
+            {
+                var kind = IsBuiltIn ? "Built-in" : "Custom";
+                return IsCurrent ? $"{kind} · current theme" : kind;
+            }
+        }
+
+        /// <summary>List-item label for screen readers: name, kind, current marker.</summary>
+        public string AccessibleName
+        {
+            get
+            {
+                var kind = IsBuiltIn ? "built-in" : "custom";
+                return IsCurrent ? $"{Name}, {kind}, current theme" : $"{Name}, {kind}";
+            }
+        }
+
+        public ThemeRowViewModel(ThemeDefinition definition, bool isCurrent)
+        {
+            Definition = definition;
+            IsCurrent = isCurrent;
+        }
+    }
+}

--- a/QuickMail/ViewModels/ThemeManagerViewModel.cs
+++ b/QuickMail/ViewModels/ThemeManagerViewModel.cs
@@ -100,12 +100,8 @@ public partial class ThemeManagerViewModel : ObservableObject
             row.IsCurrent = string.Equals(row.Id, configured, StringComparison.OrdinalIgnoreCase);
     }
 
-    private void PersistConfiguredTheme()
-    {
-        var cfg = _configService.Load();
-        cfg.AppearanceThemeId = _themeService.ConfiguredThemeId;
-        _configService.Save(cfg);
-    }
+    private void PersistConfiguredTheme() =>
+        Helpers.ThemePersistence.PersistConfiguredTheme(_themeService, _configService);
 
     // ── Commands ──────────────────────────────────────────────────────────────
 

--- a/QuickMail/Views/AboutDialog.xaml
+++ b/QuickMail/Views/AboutDialog.xaml
@@ -6,7 +6,11 @@
         MinHeight="180" MinWidth="300"
         ResizeMode="NoResize"
         WindowStartupLocation="CenterOwner"
-        ShowInTaskbar="False">
+        ShowInTaskbar="False"
+        Background="{DynamicResource Theme.WindowBackground}"
+        Foreground="{DynamicResource Theme.TextPrimary}"
+        FontFamily="{DynamicResource Theme.FontFamily}"
+        FontSize="{DynamicResource Theme.FontSizeBase}">
 
     <DockPanel Margin="20">
 
@@ -20,7 +24,7 @@
 
         <StackPanel>
             <TextBlock Text="QuickMail"
-                       FontSize="18"
+                       FontSize="{DynamicResource Theme.FontSizeHeader}"
                        FontWeight="Bold"
                        Margin="0,0,0,6"/>
             <TextBlock x:Name="VersionText"

--- a/QuickMail/Views/AccountManagerDialog.xaml
+++ b/QuickMail/Views/AccountManagerDialog.xaml
@@ -9,7 +9,11 @@
         MinHeight="500" MinWidth="580"
         WindowStartupLocation="CenterOwner"
         ResizeMode="CanResize"
-        Loaded="Window_Loaded">
+        Loaded="Window_Loaded"
+        Background="{DynamicResource Theme.WindowBackground}"
+        Foreground="{DynamicResource Theme.TextPrimary}"
+        FontFamily="{DynamicResource Theme.FontFamily}"
+        FontSize="{DynamicResource Theme.FontSizeBase}">
 
     <Window.Resources>
         <BooleanToVisibilityConverter x:Key="BoolToVisibility"/>
@@ -58,7 +62,7 @@
                     <DataTemplate>
                         <StackPanel Orientation="Horizontal">
                             <TextBlock Text="{Binding AccountLabel}" VerticalAlignment="Center"/>
-                            <TextBlock Text=" - default" FontStyle="Italic" Foreground="DarkBlue"
+                            <TextBlock Text=" - default" FontStyle="Italic" Foreground="{DynamicResource Theme.Accent}"
                                        VerticalAlignment="Center"
                                        Visibility="{Binding IsDefault, Converter={StaticResource BoolToVisibility}}"/>
                         </StackPanel>
@@ -71,7 +75,7 @@
         <ScrollViewer Grid.Column="1" Grid.Row="0" Margin="10,0,0,0" VerticalScrollBarVisibility="Auto">
             <StackPanel IsEnabled="{Binding IsEditing}">
 
-                <TextBlock Text="Account Settings" FontWeight="SemiBold" FontSize="13" Margin="0,0,0,8"/>
+                <TextBlock Text="Account Settings" FontWeight="SemiBold" Margin="0,0,0,8"/>
 
                 <!-- Account Name -->
                 <Label x:Name="LblAccountName" Content="Account _Name:" Target="{Binding ElementName=AccountNameBox}" Padding="0" Margin="0,4,0,2"/>
@@ -118,12 +122,12 @@
                                  PasswordChanged="PasswordBox_PasswordChanged"/>
                     <!-- iCloud app-specific password hint -->
                     <Border Visibility="{Binding IsICloudAccount, Converter={StaticResource BoolToVisibility}}"
-                            Background="#FFF3E3"
-                            BorderBrush="#E08000"
+                            Background="{DynamicResource Theme.WarningBackground}"
+                            BorderBrush="{DynamicResource Theme.Warning}"
                             BorderThickness="1"
                             Padding="8,6"
                             Margin="0,6,0,0">
-                        <TextBlock TextWrapping="Wrap" FontSize="12"
+                        <TextBlock TextWrapping="Wrap"
                                    AutomationProperties.Name="iCloud requires an app-specific password, not your Apple ID password. Generate one at appleid.apple.com under Sign-In and Security, App-Specific Passwords.">
                             <Run FontWeight="SemiBold">iCloud requires an app-specific password.</Run>
                             <Run>Do not enter your Apple ID password. Generate one at</Run>
@@ -249,7 +253,7 @@
             <TextBlock VerticalAlignment="Center"
                        Text="{Binding StatusText}"
                        AutomationProperties.Name="Account manager status"
-                       Foreground="DarkBlue"/>
+                       Foreground="{DynamicResource Theme.Accent}"/>
         </DockPanel>
     </Grid>
 </Window>

--- a/QuickMail/Views/AddAccountDialog.xaml
+++ b/QuickMail/Views/AddAccountDialog.xaml
@@ -9,7 +9,11 @@
         MinHeight="540" MinWidth="360"
         WindowStartupLocation="CenterOwner"
         ResizeMode="CanResize"
-        Loaded="Window_Loaded">
+        Loaded="Window_Loaded"
+        Background="{DynamicResource Theme.WindowBackground}"
+        Foreground="{DynamicResource Theme.TextPrimary}"
+        FontFamily="{DynamicResource Theme.FontFamily}"
+        FontSize="{DynamicResource Theme.FontSizeBase}">
 
     <Window.Resources>
         <BooleanToVisibilityConverter x:Key="BoolToVisibility"/>
@@ -38,7 +42,7 @@
                     <Separator Margin="0,12"/>
                 </StackPanel>
 
-                <TextBlock Text="Account Details" FontWeight="SemiBold" FontSize="13" Margin="0,0,0,8"/>
+                <TextBlock Text="Account Details" FontWeight="SemiBold" Margin="0,0,0,8"/>
 
                 <Label x:Name="LblAccountName" Content="Account _Name:" Target="{Binding ElementName=AccountNameBox}" Padding="0" Margin="0,4,0,2"/>
                 <TextBox x:Name="AccountNameBox"
@@ -82,12 +86,12 @@
                                  PasswordChanged="PasswordBox_PasswordChanged"/>
                     <!-- iCloud app-specific password hint -->
                     <Border Visibility="{Binding IsICloudAccount, Converter={StaticResource BoolToVisibility}}"
-                            Background="#FFF3E3"
-                            BorderBrush="#E08000"
+                            Background="{DynamicResource Theme.WarningBackground}"
+                            BorderBrush="{DynamicResource Theme.Warning}"
                             BorderThickness="1"
                             Padding="8,6"
                             Margin="0,6,0,0">
-                        <TextBlock TextWrapping="Wrap" FontSize="12"
+                        <TextBlock TextWrapping="Wrap"
                                    AutomationProperties.Name="iCloud requires an app-specific password, not your Apple ID password. Generate one at appleid.apple.com under Sign-In and Security, App-Specific Passwords.">
                             <Run FontWeight="SemiBold">iCloud requires an app-specific password.</Run>
                             <Run>Do not enter your Apple ID password. Generate one at</Run>
@@ -193,7 +197,7 @@
         <TextBlock Grid.Row="1"
                    Text="{Binding StatusText}"
                    AutomationProperties.Name="Add account status"
-                   Foreground="DarkBlue"
+                   Foreground="{DynamicResource Theme.Accent}"
                    Margin="0,8,0,4"
                    TextWrapping="Wrap"/>
 

--- a/QuickMail/Views/AddressBookWindow.xaml
+++ b/QuickMail/Views/AddressBookWindow.xaml
@@ -11,7 +11,11 @@
         WindowStartupLocation="CenterOwner"
         ResizeMode="CanResizeWithGrip"
         AutomationProperties.Name="Address Book"
-        PreviewKeyDown="Window_PreviewKeyDown">
+        PreviewKeyDown="Window_PreviewKeyDown"
+        Background="{DynamicResource Theme.WindowBackground}"
+        Foreground="{DynamicResource Theme.TextPrimary}"
+        FontFamily="{DynamicResource Theme.FontFamily}"
+        FontSize="{DynamicResource Theme.FontSizeBase}">
 
     <Window.Resources>
         <BooleanToVisibilityConverter x:Key="BoolToVis"/>
@@ -157,7 +161,7 @@
 
                         <!-- Row 2: Error message (shown only when non-empty) -->
                         <TextBlock Grid.Row="2" Text="{Binding ContactError}"
-                                   Foreground="Red" Margin="0,4,0,0">
+                                   Foreground="{DynamicResource Theme.Error}" Margin="0,4,0,0">
                             <TextBlock.Style>
                                 <Style TargetType="TextBlock">
                                     <Setter Property="Visibility" Value="Collapsed"/>
@@ -195,7 +199,7 @@
                                             AutomationProperties.Name="{Binding Display}">
                                     <TextBlock Text="{Binding DisplayName}" FontWeight="SemiBold"/>
                                     <TextBlock Text="  &lt;"/>
-                                    <TextBlock Text="{Binding EmailAddress}" Foreground="#666"/>
+                                    <TextBlock Text="{Binding EmailAddress}" Foreground="{DynamicResource Theme.TextSecondary}"/>
                                     <TextBlock Text="&gt;"/>
                                 </StackPanel>
                             </DataTemplate>
@@ -243,7 +247,7 @@
                                         <TextBlock Text="{Binding Name}" FontWeight="SemiBold"/>
                                         <TextBlock Text="  "/>
                                         <TextBlock Text="{Binding Display, Converter={x:Static local:GroupSubtitleConverter.Instance}}"
-                                                   Foreground="#666"/>
+                                                   Foreground="{DynamicResource Theme.TextSecondary}"/>
                                     </StackPanel>
                                 </DataTemplate>
                             </ListView.ItemTemplate>
@@ -295,7 +299,7 @@
                                                 AutomationProperties.Name="{Binding Display}">
                                         <TextBlock Text="{Binding DisplayName}" FontWeight="SemiBold"/>
                                         <TextBlock Text="  &lt;"/>
-                                        <TextBlock Text="{Binding EmailAddress}" Foreground="#666"/>
+                                        <TextBlock Text="{Binding EmailAddress}" Foreground="{DynamicResource Theme.TextSecondary}"/>
                                         <TextBlock Text="&gt;"/>
                                     </StackPanel>
                                 </DataTemplate>

--- a/QuickMail/Views/CommandPaletteWindow.xaml
+++ b/QuickMail/Views/CommandPaletteWindow.xaml
@@ -16,10 +16,12 @@
         WindowStartupLocation="Manual"
         ShowInTaskbar="False"
         d:DataContext="{d:DesignInstance Type=vm:CommandPaletteViewModel}"
-        PreviewKeyDown="OnPreviewKeyDown">
+        PreviewKeyDown="OnPreviewKeyDown"
+        FontFamily="{DynamicResource Theme.FontFamily}"
+        FontSize="{DynamicResource Theme.FontSizeBase}">
 
-    <Border Background="{DynamicResource {x:Static SystemColors.WindowBrushKey}}"
-            BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}"
+    <Border Background="{DynamicResource Theme.WindowBackground}"
+            BorderBrush="{DynamicResource Theme.Border}"
             BorderThickness="1"
             CornerRadius="4">
         <Border.Effect>
@@ -61,18 +63,17 @@
 
                         <StackPanel Grid.Column="0" VerticalAlignment="Center">
                             <TextBlock Text="{Binding Title}"
-                                       FontSize="13"
                                        TextTrimming="CharacterEllipsis"/>
                             <TextBlock Text="{Binding Category}"
-                                       FontSize="11"
+                                       FontSize="{DynamicResource Theme.FontSizeSmall}"
                                        Opacity="0.6"
                                        Margin="0,1,0,0"/>
                         </StackPanel>
 
                         <TextBlock Grid.Column="1"
                                    Text="{Binding GestureText}"
-                                   FontSize="11"
-                                   FontFamily="Consolas"
+                                   FontSize="{DynamicResource Theme.FontSizeSmall}"
+                                   FontFamily="{DynamicResource Theme.FontFamilyMono}"
                                    Opacity="0.6"
                                    VerticalAlignment="Center"
                                    Margin="12,0,0,0"/>

--- a/QuickMail/Views/ComposeWindow.xaml
+++ b/QuickMail/Views/ComposeWindow.xaml
@@ -12,7 +12,11 @@
         MinHeight="360" MinWidth="480"
         WindowStartupLocation="CenterScreen"
         PreviewKeyDown="Window_PreviewKeyDown"
-        PreviewKeyUp="Window_PreviewKeyUp">
+        PreviewKeyUp="Window_PreviewKeyUp"
+        Background="{DynamicResource Theme.WindowBackground}"
+        Foreground="{DynamicResource Theme.TextPrimary}"
+        FontFamily="{DynamicResource Theme.FontFamily}"
+        FontSize="{DynamicResource Theme.FontSizeBase}">
 
     <Window.InputBindings>
         <KeyBinding Key="S" Modifiers="Alt"  Command="{Binding SendCommand}"/>
@@ -225,12 +229,12 @@
             <TextBlock DockPanel.Dock="Left"
                        VerticalAlignment="Center"
                        Text="{Binding AutoSaveText}"
-                       Foreground="Gray"
+                       Foreground="{DynamicResource Theme.TextSecondary}"
                        Margin="0,0,8,0"/>
             <TextBlock VerticalAlignment="Center"
                        Text="{Binding StatusText}"
                        AutomationProperties.Name="Send status"
-                       Foreground="DarkRed"/>
+                       Foreground="{DynamicResource Theme.Error}"/>
         </DockPanel>
 
         <!-- Form fields -->
@@ -374,8 +378,8 @@
             <!-- Attachment summary: file count and total size -->
             <TextBlock Grid.Row="8" Grid.Column="0" Grid.ColumnSpan="2"
                        Text="{Binding AttachmentSummaryText}"
-                       FontSize="11"
-                       Foreground="Gray"
+                       FontSize="{DynamicResource Theme.FontSizeSmall}"
+                       Foreground="{DynamicResource Theme.TextSecondary}"
                        VerticalAlignment="Bottom"
                        Margin="2,0,0,2">
                 <TextBlock.Style>
@@ -407,7 +411,7 @@
                          SpellCheck.IsEnabled="True"
                          IsInactiveSelectionHighlightEnabled="True"
                          VerticalScrollBarVisibility="Auto"
-                         FontFamily="Segoe UI"
+                         FontFamily="{DynamicResource Theme.FontFamily}"
                          Margin="0,4" TabIndex="7"
                          VerticalAlignment="Stretch"
                          PreviewKeyDown="BodyBox_PreviewKeyDown"/>
@@ -421,7 +425,7 @@
                              SpellCheck.IsEnabled="True"
                              IsInactiveSelectionHighlightEnabled="True"
                              VerticalScrollBarVisibility="Auto"
-                             FontFamily="Segoe UI"
+                             FontFamily="{DynamicResource Theme.FontFamily}"
                              Margin="0,4" TabIndex="7"
                              VerticalAlignment="Stretch"
                              TextChanged="RichBodyBox_TextChanged"/>
@@ -433,9 +437,9 @@
                StaysOpen="True"
                AllowsTransparency="True"
                PopupAnimation="None">
-            <Border BorderBrush="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}"
+            <Border BorderBrush="{DynamicResource Theme.Border}"
                     BorderThickness="1"
-                    Background="{DynamicResource {x:Static SystemColors.WindowBrushKey}}">
+                    Background="{DynamicResource Theme.WindowBackground}">
                 <ListBox x:Name="SuggestionList"
                          MaxHeight="200"
                          MinWidth="300"
@@ -455,8 +459,8 @@
                             <StackPanel>
                                 <TextBlock Text="{Binding PrimaryText}" FontWeight="SemiBold"/>
                                 <TextBlock Text="{Binding SecondaryText}"
-                                           Foreground="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"
-                                           FontSize="11"/>
+                                           Foreground="{DynamicResource Theme.TextSecondary}"
+                                           FontSize="{DynamicResource Theme.FontSizeSmall}"/>
                             </StackPanel>
                         </DataTemplate>
                     </ListBox.ItemTemplate>

--- a/QuickMail/Views/ComposeWindow.xaml.cs
+++ b/QuickMail/Views/ComposeWindow.xaml.cs
@@ -1516,6 +1516,16 @@ public partial class ComposeWindow : Window
             RichBodyBox.Selection.Select(RichBodyBox.Selection.End, RichBodyBox.Selection.End);
         };
 
+        // Compose is modeless and can stay open across a theme switch. The rich
+        // editor reads theme brushes (blockquote foreground, table borders, code
+        // font) once at build time, so those go stale on a switch — rebuild from
+        // the document's own HTML with fresh tokens. Paired unsubscribe in Closed.
+        if (_themeService != null)
+        {
+            _themeService.ThemeChanged += OnThemeChangedRefreshRichBody;
+            Closed += (_, _) => _themeService.ThemeChanged -= OnThemeChangedRefreshRichBody;
+        }
+
         SyncModeSelector();
     }
 
@@ -1536,6 +1546,31 @@ public partial class ComposeWindow : Window
 
         if (targetMode == ComposeMode.PlainText) return;
         _vm.SetMode(targetMode);
+    }
+
+    /// <summary>
+    /// Rebuilds the rich editor's document from its own HTML so theme-dependent
+    /// brushes (blockquote foreground, table borders, code font) pick up the new
+    /// theme. Runs off ThemeChanged; not a user edit, so the draft stays clean and
+    /// the caret is restored by offset. Same content ⇒ identical structure, so the
+    /// offset round-trips.
+    /// </summary>
+    private void OnThemeChangedRefreshRichBody(object? sender, EventArgs e)
+    {
+        if (RichBodyBox.Document.Blocks.Count == 0) return;
+
+        var html = RichTextDocumentConverter.ToHtml(RichBodyBox.Document);
+        var caretOffset = RichBodyBox.Document.ContentStart.GetOffsetToPosition(RichBodyBox.CaretPosition);
+
+        _suppressRichTextChanged = true;
+        _suppressFormattingAnnouncement = true;
+        _lastAnnouncedBlockType = null;
+        RichTextDocumentConverter.LoadInto(RichBodyBox.Document, html);
+        _suppressRichTextChanged = false;
+        _suppressFormattingAnnouncement = false;
+
+        RichBodyBox.CaretPosition =
+            RichBodyBox.Document.ContentStart.GetPositionAtOffset(caretOffset) ?? RichBodyBox.Document.ContentEnd;
     }
 
     private void RichBodyBox_TextChanged(object sender, TextChangedEventArgs e)

--- a/QuickMail/Views/ComposeWindow.xaml.cs
+++ b/QuickMail/Views/ComposeWindow.xaml.cs
@@ -61,6 +61,7 @@ public partial class ComposeWindow : Window
     private readonly ITemplateService   _templateService;
     private readonly IConfigService     _configService;
     private readonly ICustomDictionaryService? _customDictionary;
+    private readonly IThemeService? _themeService;
     private readonly CommandRegistry    _registry = new();
     private TokenizedAddressBox? _activeAddressControl;
     private CancellationTokenSource? _autocompleteCts;
@@ -103,13 +104,14 @@ public partial class ComposeWindow : Window
     private DispatcherTimer? _spellingTypingTimer;
     private static readonly TimeSpan SpellingTypingDelay = TimeSpan.FromMilliseconds(500);
 
-    public ComposeWindow(ComposeViewModel vm, IContactService contactService, ITemplateService templateService, IConfigService configService, ICustomDictionaryService? customDictionary = null)
+    public ComposeWindow(ComposeViewModel vm, IContactService contactService, ITemplateService templateService, IConfigService configService, ICustomDictionaryService? customDictionary = null, IThemeService? themeService = null)
     {
         _vm = vm;
         _contactService = contactService;
         _templateService = templateService;
         _configService = configService;
         _customDictionary = customDictionary;
+        _themeService = themeService;
         InitializeComponent();
         DataContext = vm;
 
@@ -1273,7 +1275,8 @@ public partial class ComposeWindow : Window
             return;
         }
         var fragment = _vm.GetBodyHtml();
-        _previewWindow = new MarkdownPreviewWindow(_vm.Subject, fragment) { Owner = this };
+        _previewWindow = new MarkdownPreviewWindow(_vm.Subject, fragment,
+            _themeService?.BuildMessageCss(forceOnContent: false)) { Owner = this };
         _previewWindow.Closed += (_, _) => { _previewWindow = null; FocusActiveEditor(); };
         _previewWindow.Show();
     }

--- a/QuickMail/Views/FlagManagerWindow.xaml
+++ b/QuickMail/Views/FlagManagerWindow.xaml
@@ -9,7 +9,11 @@
         Width="520" Height="440"
         MinWidth="420" MinHeight="340"
         WindowStartupLocation="CenterOwner"
-        ShowInTaskbar="False">
+        ShowInTaskbar="False"
+        Background="{DynamicResource Theme.WindowBackground}"
+        Foreground="{DynamicResource Theme.TextPrimary}"
+        FontFamily="{DynamicResource Theme.FontFamily}"
+        FontSize="{DynamicResource Theme.FontSizeBase}">
 
     <Window.Resources>
         <views:StringToBrushConverter x:Key="StringToBrushConverter"/>
@@ -101,7 +105,7 @@
                 <StackPanel>
                     <TextBlock Text="No flag selected."
                                Margin="0,8,0,0"
-                               Foreground="Gray">
+                               Foreground="{DynamicResource Theme.TextSecondary}">
                         <TextBlock.Style>
                             <Style TargetType="TextBlock">
                                 <Setter Property="Visibility" Value="Collapsed"/>
@@ -169,8 +173,8 @@
                                      AutomationProperties.Name="Flag name"
                                      Margin="0,0,0,2"/>
                             <TextBlock Text="{Binding RenameError}"
-                                       Foreground="Red"
-                                       FontSize="11"
+                                       Foreground="{DynamicResource Theme.Error}"
+                                       FontSize="{DynamicResource Theme.FontSizeSmall}"
                                        Margin="0,0,0,4">
                                 <TextBlock.Style>
                                     <Style TargetType="TextBlock">
@@ -205,8 +209,8 @@
                                     Background="{Binding SelectedFlag.ColorHex, Converter={StaticResource StringToBrushConverter}}"/>
                             <TextBlock Text="{Binding SelectedFlag.ColorHex}"
                                        VerticalAlignment="Center"
-                                       Foreground="Gray"
-                                       FontSize="11"/>
+                                       Foreground="{DynamicResource Theme.TextSecondary}"
+                                       FontSize="{DynamicResource Theme.FontSizeSmall}"/>
                         </StackPanel>
 
                         <!-- 12 preset color buttons (radio group) -->

--- a/QuickMail/Views/FlagPickerWindow.xaml
+++ b/QuickMail/Views/FlagPickerWindow.xaml
@@ -9,7 +9,11 @@
         Width="280" Height="340"
         ResizeMode="NoResize"
         WindowStartupLocation="CenterOwner"
-        ShowInTaskbar="False">
+        ShowInTaskbar="False"
+        Background="{DynamicResource Theme.WindowBackground}"
+        Foreground="{DynamicResource Theme.TextPrimary}"
+        FontFamily="{DynamicResource Theme.FontFamily}"
+        FontSize="{DynamicResource Theme.FontSizeBase}">
 
     <Window.Resources>
         <views:StringToBrushConverter x:Key="StringToBrushConverter"/>

--- a/QuickMail/Views/FolderPickerWindow.xaml
+++ b/QuickMail/Views/FolderPickerWindow.xaml
@@ -7,7 +7,11 @@
         MinHeight="220" MinWidth="300"
         WindowStartupLocation="CenterOwner"
         ResizeMode="CanResize"
-        ShowInTaskbar="False">
+        ShowInTaskbar="False"
+        Background="{DynamicResource Theme.WindowBackground}"
+        Foreground="{DynamicResource Theme.TextPrimary}"
+        FontFamily="{DynamicResource Theme.FontFamily}"
+        FontSize="{DynamicResource Theme.FontSizeBase}">
 
     <DockPanel Margin="10">
 
@@ -53,7 +57,7 @@
                                    TextTrimming="CharacterEllipsis"/>
                         <TextBlock Grid.Row="1"
                                    Text="{Binding AccountName}"
-                                   FontSize="11"
+                                   FontSize="{DynamicResource Theme.FontSizeSmall}"
                                    Opacity="0.75"
                                    TextTrimming="CharacterEllipsis">
                             <TextBlock.Style>

--- a/QuickMail/Views/FormattingListWindow.xaml
+++ b/QuickMail/Views/FormattingListWindow.xaml
@@ -7,7 +7,11 @@
         MinWidth="260"
         WindowStartupLocation="CenterOwner"
         ResizeMode="NoResize"
-        ShowInTaskbar="False">
+        ShowInTaskbar="False"
+        Background="{DynamicResource Theme.WindowBackground}"
+        Foreground="{DynamicResource Theme.TextPrimary}"
+        FontFamily="{DynamicResource Theme.FontFamily}"
+        FontSize="{DynamicResource Theme.FontSizeBase}">
     <DockPanel Margin="10">
         <Button DockPanel.Dock="Bottom"
                 Content="_Close"

--- a/QuickMail/Views/ForwardAttachmentDialogWindow.xaml
+++ b/QuickMail/Views/ForwardAttachmentDialogWindow.xaml
@@ -8,7 +8,11 @@
         WindowStartupLocation="CenterOwner"
         ResizeMode="CanResize"
         ShowInTaskbar="False"
-        PreviewKeyDown="Window_PreviewKeyDown">
+        PreviewKeyDown="Window_PreviewKeyDown"
+        Background="{DynamicResource Theme.WindowBackground}"
+        Foreground="{DynamicResource Theme.TextPrimary}"
+        FontFamily="{DynamicResource Theme.FontFamily}"
+        FontSize="{DynamicResource Theme.FontSizeBase}">
 
     <Grid Margin="12">
         <Grid.RowDefinitions>

--- a/QuickMail/Views/GrabAddressesDialog.xaml
+++ b/QuickMail/Views/GrabAddressesDialog.xaml
@@ -10,7 +10,11 @@
         WindowStartupLocation="CenterOwner"
         ResizeMode="CanResizeWithGrip"
         ShowInTaskbar="False"
-        PreviewKeyDown="Window_PreviewKeyDown">
+        PreviewKeyDown="Window_PreviewKeyDown"
+        Background="{DynamicResource Theme.WindowBackground}"
+        Foreground="{DynamicResource Theme.TextPrimary}"
+        FontFamily="{DynamicResource Theme.FontFamily}"
+        FontSize="{DynamicResource Theme.FontSizeBase}">
 
     <Grid Margin="12">
         <Grid.RowDefinitions>

--- a/QuickMail/Views/GroupManagerWindow.xaml
+++ b/QuickMail/Views/GroupManagerWindow.xaml
@@ -10,7 +10,11 @@
         WindowStartupLocation="CenterOwner"
         ShowInTaskbar="False"
         AutomationProperties.Name="Group Manager"
-        PreviewKeyDown="Window_PreviewKeyDown">
+        PreviewKeyDown="Window_PreviewKeyDown"
+        Background="{DynamicResource Theme.WindowBackground}"
+        Foreground="{DynamicResource Theme.TextPrimary}"
+        FontFamily="{DynamicResource Theme.FontFamily}"
+        FontSize="{DynamicResource Theme.FontSizeBase}">
 
     <Window.Resources>
         <Style x:Key="SectionLabel" TargetType="TextBlock">

--- a/QuickMail/Views/InsertLinkDialog.xaml
+++ b/QuickMail/Views/InsertLinkDialog.xaml
@@ -5,7 +5,11 @@
         Width="420" SizeToContent="Height"
         ResizeMode="NoResize"
         WindowStartupLocation="CenterOwner"
-        ShowInTaskbar="False">
+        ShowInTaskbar="False"
+        Background="{DynamicResource Theme.WindowBackground}"
+        Foreground="{DynamicResource Theme.TextPrimary}"
+        FontFamily="{DynamicResource Theme.FontFamily}"
+        FontSize="{DynamicResource Theme.FontSizeBase}">
     <Grid Margin="12">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>

--- a/QuickMail/Views/KeyCaptureDialog.xaml
+++ b/QuickMail/Views/KeyCaptureDialog.xaml
@@ -12,7 +12,11 @@
         ShowInTaskbar="False"
         Loaded="Window_Loaded"
         PreviewKeyDown="Window_PreviewKeyDown"
-        AutomationProperties.Name="Assign keyboard shortcut dialog">
+        AutomationProperties.Name="Assign keyboard shortcut dialog"
+        Background="{DynamicResource Theme.WindowBackground}"
+        Foreground="{DynamicResource Theme.TextPrimary}"
+        FontFamily="{DynamicResource Theme.FontFamily}"
+        FontSize="{DynamicResource Theme.FontSizeBase}">
 
     <Grid Margin="20" Focusable="True" x:Name="MainGrid">
         <Grid.RowDefinitions>
@@ -28,28 +32,26 @@
         <TextBlock x:Name="ListeningHeader"
                    Grid.Row="0"
                    Text="Press your desired key combination"
-                   FontSize="14"
+                   FontSize="{DynamicResource Theme.FontSizeLarge}"
                    FontWeight="SemiBold"
                    Margin="0,0,0,4"/>
         <TextBlock x:Name="ListeningHint"
                    Grid.Row="1"
                    Text="(with Ctrl, Shift, or Alt)"
-                   FontSize="12"
-                   Foreground="DimGray"
+                   Foreground="{DynamicResource Theme.TextSecondary}"
                    Margin="0,0,0,16"/>
 
         <!-- Captured key display -->
         <Border Grid.Row="2"
                 BorderThickness="1"
-                BorderBrush="LightGray"
-                Background="#F5F5F5"
+                BorderBrush="{DynamicResource Theme.Border}"
+                Background="{DynamicResource Theme.SurfaceBackground}"
                 Padding="12"
                 Margin="0,0,0,8"
                 CornerRadius="2">
             <TextBlock x:Name="CapturedKeyText"
                        Text="(waiting for input...)"
-                       FontSize="13"
-                       Foreground="DimGray"
+                       Foreground="{DynamicResource Theme.TextSecondary}"
                        TextAlignment="Center"
                        AutomationProperties.Name="Captured key combination"/>
         </Border>
@@ -58,8 +60,7 @@
         <TextBlock x:Name="ConflictText"
                    Grid.Row="3"
                    Visibility="Collapsed"
-                   FontSize="12"
-                   Foreground="#D32F2F"
+                   Foreground="{DynamicResource Theme.Error}"
                    TextWrapping="Wrap"
                    Margin="0,0,0,8"
                    AutomationProperties.LiveSetting="Polite"/>

--- a/QuickMail/Views/KeyCaptureDialog.xaml.cs
+++ b/QuickMail/Views/KeyCaptureDialog.xaml.cs
@@ -70,7 +70,8 @@ public partial class KeyCaptureDialog : Window
 
         var gesture = GestureHelper.Format(_capturedKey, _capturedModifiers);
         CapturedKeyText.Text = gesture;
-        CapturedKeyText.Foreground = System.Windows.Media.Brushes.Black;
+        CapturedKeyText.SetResourceReference(System.Windows.Controls.TextBlock.ForegroundProperty,
+            Theming.ThemeKeys.TextPrimary);
 
         ListeningHeader.Text = "Captured shortcut";
         ListeningHint.Visibility = Visibility.Collapsed;
@@ -111,8 +112,9 @@ public partial class KeyCaptureDialog : Window
         _capturedModifiers  = ModifierKeys.None;
         HasConflict         = false;
 
-        CapturedKeyText.Text       = "(waiting for input...)";
-        CapturedKeyText.Foreground = System.Windows.Media.Brushes.DimGray;
+        CapturedKeyText.Text = "(waiting for input...)";
+        CapturedKeyText.SetResourceReference(System.Windows.Controls.TextBlock.ForegroundProperty,
+            Theming.ThemeKeys.TextSecondary);
         ListeningHeader.Text       = "Press your desired key combination";
         ListeningHint.Visibility   = Visibility.Visible;
         ConflictText.Visibility    = Visibility.Collapsed;

--- a/QuickMail/Views/MainWindow.xaml
+++ b/QuickMail/Views/MainWindow.xaml
@@ -514,6 +514,29 @@
                           InputGestureText="Ctrl+Shift+P"/>
             </MenuItem>
 
+            <!-- Tools — always available (mirrors the Compose window's Tools menu) -->
+            <MenuItem Header="_Tools">
+                <MenuItem Header="Manage _Themes…"
+                          Click="MenuManageThemes_Click"
+                          AutomationProperties.Name="Manage Themes"/>
+                <MenuItem Header="_Next Theme"
+                          Click="MenuNextTheme_Click"/>
+                <MenuItem Header="Pre_vious Theme"
+                          Click="MenuPreviousTheme_Click"/>
+                <Separator/>
+                <MenuItem Header="Address _Book…"
+                          Click="MenuAddressBook_Click"
+                          InputGestureText="Ctrl+Shift+B"/>
+                <MenuItem Header="_Rules…"
+                          Command="{Binding OpenRulesManagerCommand}"
+                          InputGestureText="Ctrl+Shift+L"
+                          AutomationProperties.Name="Manage Rules"/>
+                <Separator/>
+                <MenuItem Header="Command _Palette…"
+                          Click="MenuCommandPalette_Click"
+                          InputGestureText="Ctrl+Shift+P"/>
+            </MenuItem>
+
             <!-- Help -->
             <MenuItem Header="_Help">
                 <MenuItem Header="{Binding UpdateAvailableText, Mode=OneWay}"

--- a/QuickMail/Views/MainWindow.xaml
+++ b/QuickMail/Views/MainWindow.xaml
@@ -9,7 +9,11 @@
         mc:Ignorable="d"
         Title="{Binding WindowTitle}"
         Height="650" Width="1000"
-        MinHeight="400" MinWidth="700">
+        MinHeight="400" MinWidth="700"
+        Background="{DynamicResource Theme.WindowBackground}"
+        Foreground="{DynamicResource Theme.TextPrimary}"
+        FontFamily="{DynamicResource Theme.FontFamily}"
+        FontSize="{DynamicResource Theme.FontSizeBase}">
 
     <Window.Resources>
         <local:BoolToFontWeightConverter x:Key="BoolToWeightConverter"/>
@@ -297,7 +301,7 @@
                         <Style TargetType="MenuItem" BasedOn="{StaticResource {x:Type MenuItem}}">
                             <Style.Triggers>
                                 <DataTrigger Binding="{Binding HasSelectedMessage}" Value="False">
-                                    <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
+                                    <Setter Property="Foreground" Value="{DynamicResource Theme.TextDisabled}"/>
                                 </DataTrigger>
                             </Style.Triggers>
                         </Style>
@@ -309,7 +313,7 @@
                         <Style TargetType="MenuItem" BasedOn="{StaticResource {x:Type MenuItem}}">
                             <Style.Triggers>
                                 <DataTrigger Binding="{Binding HasSelectedMessage}" Value="False">
-                                    <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
+                                    <Setter Property="Foreground" Value="{DynamicResource Theme.TextDisabled}"/>
                                 </DataTrigger>
                             </Style.Triggers>
                         </Style>
@@ -323,7 +327,7 @@
                         <Style TargetType="MenuItem" BasedOn="{StaticResource {x:Type MenuItem}}">
                             <Style.Triggers>
                                 <DataTrigger Binding="{Binding IsMessageOpen}" Value="False">
-                                    <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
+                                    <Setter Property="Foreground" Value="{DynamicResource Theme.TextDisabled}"/>
                                 </DataTrigger>
                             </Style.Triggers>
                         </Style>
@@ -537,47 +541,47 @@
                  KeyboardNavigation.DirectionalNavigation="Cycle"
                  PreviewKeyDown="Toolbar_PreviewKeyDown">
             <Button x:Name="ToolbarFirstButton"
-                    Style="{StaticResource ToolbarButton}"
+                    Style="{DynamicResource ToolbarButton}"
                     Command="{Binding NewMessageCommand}"
                     AutomationProperties.Name="New Message"
                     AutomationProperties.AcceleratorKey="Ctrl+N"
                     ToolTip="New Message (Ctrl+N)"
                     Content="New"/>
             <Separator/>
-            <Button Style="{StaticResource ToolbarButton}"
+            <Button Style="{DynamicResource ToolbarButton}"
                     Command="{Binding ReplyCommand}"
                     AutomationProperties.Name="Reply"
                     AutomationProperties.AcceleratorKey="Ctrl+R"
                     ToolTip="Reply (Ctrl+R)"
                     Content="Reply"/>
-            <Button Style="{StaticResource ToolbarButton}"
+            <Button Style="{DynamicResource ToolbarButton}"
                     Command="{Binding ReplyAllCommand}"
                     AutomationProperties.Name="Reply All"
                     AutomationProperties.AcceleratorKey="Ctrl+Shift+R"
                     ToolTip="Reply All (Ctrl+Shift+R)"
                     Content="Reply All"/>
-            <Button Style="{StaticResource ToolbarButton}"
+            <Button Style="{DynamicResource ToolbarButton}"
                     Command="{Binding ForwardCommand}"
                     AutomationProperties.Name="Forward"
                     AutomationProperties.AcceleratorKey="Ctrl+F"
                     ToolTip="Forward (Ctrl+F)"
                     Content="Forward"/>
             <Separator/>
-            <Button Style="{StaticResource ToolbarButton}"
+            <Button Style="{DynamicResource ToolbarButton}"
                     Command="{Binding DeleteMessageCommand}"
                     AutomationProperties.Name="Delete message"
                     AutomationProperties.AcceleratorKey="Delete"
                     ToolTip="Delete (Del)"
                     Content="Delete"/>
             <Separator/>
-            <Button Style="{StaticResource ToolbarButton}"
+            <Button Style="{DynamicResource ToolbarButton}"
                     Command="{Binding RefreshCommand}"
                     AutomationProperties.Name="Refresh"
                     AutomationProperties.AcceleratorKey="F5"
                     ToolTip="Refresh (F5)"
                     Content="Refresh"/>
             <Button x:Name="SyncRangeButton"
-                    Style="{StaticResource ToolbarButton}"
+                    Style="{DynamicResource ToolbarButton}"
                     Content="{Binding SyncRangeLabel}"
                     AutomationProperties.Name="Sync range"
                     ToolTip="Choose how many days of mail to sync"
@@ -616,7 +620,7 @@
             </Button>
             <Separator/>
             <Button x:Name="ViewModeButton"
-                    Style="{StaticResource ToolbarButton}"
+                    Style="{DynamicResource ToolbarButton}"
                     Content="{Binding ViewModeLabel}"
                     AutomationProperties.Name="View mode"
                     ToolTip="Select message view mode (Ctrl+Shift+V)"
@@ -648,20 +652,20 @@
                 </Button.ContextMenu>
             </Button>
             <Separator/>
-            <Button Style="{StaticResource ToolbarButton}"
+            <Button Style="{DynamicResource ToolbarButton}"
                     Command="{Binding EmptyTrashCommand}"
                     AutomationProperties.Name="Empty Trash"
                     AutomationProperties.AcceleratorKey="Ctrl+Shift+E"
                     ToolTip="Empty Trash (Ctrl+Shift+E)"
                     Content="Empty Trash"/>
             <Separator/>
-            <Button Style="{StaticResource ToolbarButton}"
+            <Button Style="{DynamicResource ToolbarButton}"
                     Command="{Binding ManageAccountsCommand}"
                     AutomationProperties.Name="Manage email accounts"
                     ToolTip="Manage email accounts"
                     Content="Accounts"/>
             <Separator/>
-            <Button Style="{StaticResource ToolbarButton}"
+            <Button Style="{DynamicResource ToolbarButton}"
                     Command="{Binding ViewUserGuideCommand}"
                     AutomationProperties.Name="View User Guide"
                     AutomationProperties.AcceleratorKey="F1"
@@ -692,7 +696,7 @@
 
                 <TextBlock Grid.Row="0" Text="Accounts" FontWeight="SemiBold" Padding="6,4"
                            Focusable="False"
-                           Background="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"/>
+                           Background="{DynamicResource Theme.ChromeBackground}"/>
 
                 <ListBox Grid.Row="1"
                          x:Name="AccountList"
@@ -725,8 +729,8 @@
                             <StackPanel>
                                 <local:AriaHiddenTextBlock Text="{Binding AccountLabel}"/>
                                 <local:AriaHiddenTextBlock Text="{Binding StatusLabel}"
-                                                           Foreground="DimGray"
-                                                           FontSize="11"
+                                                           Foreground="{DynamicResource Theme.TextSecondary}"
+                                                           FontSize="{DynamicResource Theme.FontSizeSmall}"
                                                            Margin="0,1,0,0"/>
                             </StackPanel>
                         </DataTemplate>
@@ -748,7 +752,7 @@
 
                 <TextBlock Grid.Row="2" Text="Folders" FontWeight="SemiBold" Padding="6,4"
                            Focusable="False"
-                           Background="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"/>
+                           Background="{DynamicResource Theme.ChromeBackground}"/>
 
                 <!-- True TreeView so screen readers announce level, expanded/collapsed state correctly. -->
                 <TreeView Grid.Row="3"
@@ -785,8 +789,8 @@
                                 </local:AriaHiddenTextBlock>
                                 <!-- Unread badge: "(5)" — collapsed when empty -->
                                 <local:AriaHiddenTextBlock Margin="4,0,0,0"
-                                                           Foreground="DimGray"
-                                                           FontSize="11"
+                                                           Foreground="{DynamicResource Theme.TextSecondary}"
+                                                           FontSize="{DynamicResource Theme.FontSizeSmall}"
                                                            Text="{Binding UnreadDisplay}">
                                     <local:AriaHiddenTextBlock.Style>
                                         <Style TargetType="local:AriaHiddenTextBlock">
@@ -827,8 +831,8 @@
                 <Border DockPanel.Dock="Top"
                         x:Name="TabStripBorder"
                         BorderThickness="0,0,0,1"
-                        BorderBrush="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}"
-                        Background="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"
+                        BorderBrush="{DynamicResource Theme.Border}"
+                        Background="{DynamicResource Theme.ChromeBackground}"
                         Visibility="{Binding ShowTabStrip, Converter={StaticResource BoolToVisibilityConverter}}">
                     <ListBox x:Name="TabStrip"
                              ItemsSource="{Binding OpenTabs}"
@@ -885,7 +889,7 @@
                 <!-- Body pane — hidden until IsMessageOpen; Escape returns to MessageList -->
                 <Border DockPanel.Dock="Bottom"
                         BorderThickness="0,1,0,0"
-                        BorderBrush="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}"
+                        BorderBrush="{DynamicResource Theme.Border}"
                         MinHeight="200"
                         Visibility="{Binding IsMessageOpen, Converter={StaticResource BoolToVisibilityConverter}}">
                     <DockPanel>
@@ -894,7 +898,7 @@
                                      Text="{Binding MessageDetail.Subject, FallbackValue='', Mode=OneWay}"
                                      IsReadOnly="True" IsReadOnlyCaretVisible="True"
                                      BorderThickness="0" Background="Transparent"
-                                     FontSize="13" FontWeight="SemiBold" TextWrapping="Wrap"
+                                     FontSize="{DynamicResource Theme.FontSizeBase}" FontWeight="SemiBold" TextWrapping="Wrap"
                                      AutomationProperties.Name="Subject"/>
                             <TextBox x:Name="FromField"
                                      Text="{Binding MessageDetail.From, FallbackValue='', Mode=OneWay}"
@@ -991,14 +995,14 @@
                                Text="{Binding SelectedFolder.DisplayName, FallbackValue='No folder selected'}"
                                FontWeight="SemiBold" Padding="6,4"
                                Focusable="False"
-                               Background="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"
+                               Background="{DynamicResource Theme.ChromeBackground}"
                                AutomationProperties.Name="Current folder"/>
 
                     <!-- Search bar — visible only while IsSearchActive -->
                     <Border DockPanel.Dock="Top"
                             Padding="6,4"
                             BorderThickness="0,0,0,1"
-                            BorderBrush="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}"
+                            BorderBrush="{DynamicResource Theme.Border}"
                             Visibility="{Binding IsSearchActive, Converter={StaticResource BoolToVisibilityConverter}}">
                         <DockPanel>
                             <Button DockPanel.Dock="Right"
@@ -1078,7 +1082,7 @@
                             <DataTemplate>
                                 <StackPanel>
                                     <TextBlock Text="{Binding Summary}" FontWeight="SemiBold" TextTrimming="CharacterEllipsis"/>
-                                    <TextBlock Text="{Binding DisplayLine}" FontSize="11" Foreground="DimGray" TextTrimming="CharacterEllipsis"/>
+                                    <TextBlock Text="{Binding DisplayLine}" FontSize="{DynamicResource Theme.FontSizeSmall}" Foreground="{DynamicResource Theme.TextSecondary}" TextTrimming="CharacterEllipsis"/>
                                 </StackPanel>
                             </DataTemplate>
                         </ListBox.ItemTemplate>
@@ -1108,12 +1112,10 @@
                                 </Style.Triggers>
                             </Style>
                         </ListView.Style>
-                        <ListView.Resources>
-                            <!-- Column headers are mouse-clickable but not keyboard tab stops -->
-                            <Style TargetType="GridViewColumnHeader">
-                                <Setter Property="Focusable" Value="False"/>
-                            </Style>
-                        </ListView.Resources>
+                        <!-- Column headers are mouse-clickable but not keyboard tab stops:
+                             Focusable=False comes from the app-wide GridViewColumnHeader styles
+                             (AccessibleStyles + ThemedControls), so the themed header template
+                             is not shadowed by a local style here. -->
                         <ListView.View>
                             <GridView>
                                 <GridViewColumn Width="{Binding ShowMessageStatus, Converter={StaticResource BoolToColumnWidthConverter}}">
@@ -1127,7 +1129,7 @@
                                     <GridViewColumn.CellTemplate>
                                         <DataTemplate>
                                             <TextBlock Text="{Binding StatusDisplay}"
-                                                       FontSize="11"
+                                                       FontSize="{DynamicResource Theme.FontSizeSmall}"
                                                        TextAlignment="Center"
                                                        TextTrimming="CharacterEllipsis"
                                                        Visibility="{Binding DataContext.ShowMessageStatus,
@@ -1175,13 +1177,13 @@
                                 </GridViewColumn>
                                 <GridViewColumn Width="24">
                                     <GridViewColumn.Header>
-                                        <TextBlock Text="&#x1F4CE;" FontSize="11"
+                                        <TextBlock Text="&#x1F4CE;" FontSize="{DynamicResource Theme.FontSizeSmall}"
                                                    ToolTip="Has attachments"
                                                    AutomationProperties.IsColumnHeader="True"/>
                                     </GridViewColumn.Header>
                                     <GridViewColumn.CellTemplate>
                                         <DataTemplate>
-                                            <TextBlock Text="&#x1F4CE;" FontSize="11" TextAlignment="Center">
+                                            <TextBlock Text="&#x1F4CE;" FontSize="{DynamicResource Theme.FontSizeSmall}" TextAlignment="Center">
                                                 <TextBlock.Style>
                                                     <Style TargetType="TextBlock">
                                                         <Setter Property="Visibility" Value="Collapsed"/>
@@ -1219,6 +1221,53 @@
                                                      RelativeSource="{RelativeSource AncestorType=Window}"/>
                                             <Binding Path="HasAttachments"/>
                                         </MultiBinding>
+                                    </Setter.Value>
+                                </Setter>
+                                <!-- Token-driven row template. The default GridView container paints
+                                     selection with hardcoded light colors that are unreadable on a
+                                     dark theme; under High Contrast the token brushes resolve to the
+                                     live SystemColors palette, so this stays HC-correct. The outer
+                                     Border keeps the flag color bar (BorderBrush/Thickness above);
+                                     the 3px inner bar is the additive unread cue — SemiBold text
+                                     remains the primary cue. -->
+                                <Setter Property="Template">
+                                    <Setter.Value>
+                                        <ControlTemplate TargetType="ListViewItem">
+                                            <Border BorderBrush="{TemplateBinding BorderBrush}"
+                                                    BorderThickness="{TemplateBinding BorderThickness}"
+                                                    SnapsToDevicePixels="True">
+                                                <Border x:Name="rowBg" Background="Transparent" Padding="2,1">
+                                                    <DockPanel>
+                                                        <Rectangle x:Name="unreadBar" DockPanel.Dock="Left"
+                                                                   Width="3" Margin="0,1,3,1"
+                                                                   Fill="{DynamicResource Theme.Accent}"
+                                                                   Visibility="Collapsed"/>
+                                                        <GridViewRowPresenter Content="{TemplateBinding Content}"
+                                                                              Columns="{TemplateBinding GridView.ColumnCollection}"/>
+                                                    </DockPanel>
+                                                </Border>
+                                            </Border>
+                                            <ControlTemplate.Triggers>
+                                                <DataTrigger Binding="{Binding IsRead}" Value="False">
+                                                    <Setter TargetName="unreadBar" Property="Visibility" Value="Visible"/>
+                                                </DataTrigger>
+                                                <Trigger Property="IsMouseOver" Value="True">
+                                                    <Setter TargetName="rowBg" Property="Background" Value="{DynamicResource Theme.AccentSubtle}"/>
+                                                </Trigger>
+                                                <Trigger Property="IsSelected" Value="True">
+                                                    <Setter TargetName="rowBg" Property="Background" Value="{DynamicResource Theme.SelectionBackground}"/>
+                                                    <Setter Property="Foreground" Value="{DynamicResource Theme.SelectionText}"/>
+                                                </Trigger>
+                                                <MultiTrigger>
+                                                    <MultiTrigger.Conditions>
+                                                        <Condition Property="IsSelected" Value="True"/>
+                                                        <Condition Property="Selector.IsSelectionActive" Value="False"/>
+                                                    </MultiTrigger.Conditions>
+                                                    <Setter TargetName="rowBg" Property="Background" Value="{DynamicResource Theme.SelectionInactive}"/>
+                                                    <Setter Property="Foreground" Value="{DynamicResource Theme.TextPrimary}"/>
+                                                </MultiTrigger>
+                                            </ControlTemplate.Triggers>
+                                        </ControlTemplate>
                                     </Setter.Value>
                                 </Setter>
                             </Style>
@@ -1297,7 +1346,7 @@
                                             <Run Text="{Binding Count, StringFormat=({0}), Mode=OneWay}"/>
                                         </TextBlock>
                                         <TextBlock Text="{Binding LastSenderName}"
-                                                   FontSize="11" Opacity="0.85"
+                                                   FontSize="{DynamicResource Theme.FontSizeSmall}" Opacity="0.85"
                                                    TextTrimming="CharacterEllipsis">
                                             <TextBlock.Style>
                                                 <Style TargetType="TextBlock">
@@ -1310,7 +1359,7 @@
                                             </TextBlock.Style>
                                         </TextBlock>
                                         <TextBlock Text="{Binding Preview}"
-                                                   FontSize="11" Opacity="0.7"
+                                                   FontSize="{DynamicResource Theme.FontSizeSmall}" Opacity="0.7"
                                                    TextTrimming="CharacterEllipsis">
                                             <TextBlock.Style>
                                                 <Style TargetType="TextBlock">
@@ -1436,7 +1485,7 @@
                                             <Run Text="{Binding Count, StringFormat=({0}), Mode=OneWay}"/>
                                         </TextBlock>
                                         <TextBlock Text="{Binding NewestSubject}"
-                                                   FontSize="11" Opacity="0.85"
+                                                   FontSize="{DynamicResource Theme.FontSizeSmall}" Opacity="0.85"
                                                    TextTrimming="CharacterEllipsis">
                                             <TextBlock.Style>
                                                 <Style TargetType="TextBlock">
@@ -1449,7 +1498,7 @@
                                             </TextBlock.Style>
                                         </TextBlock>
                                         <TextBlock Text="{Binding Preview}"
-                                                   FontSize="11" Opacity="0.7"
+                                                   FontSize="{DynamicResource Theme.FontSizeSmall}" Opacity="0.7"
                                                    TextTrimming="CharacterEllipsis">
                                             <TextBlock.Style>
                                                 <Style TargetType="TextBlock">
@@ -1572,7 +1621,7 @@
                                             <Run Text="{Binding Count, StringFormat=({0}), Mode=OneWay}"/>
                                         </TextBlock>
                                         <TextBlock Text="{Binding NewestSubject}"
-                                                   FontSize="11" Opacity="0.85"
+                                                   FontSize="{DynamicResource Theme.FontSizeSmall}" Opacity="0.85"
                                                    TextTrimming="CharacterEllipsis">
                                             <TextBlock.Style>
                                                 <Style TargetType="TextBlock">
@@ -1585,7 +1634,7 @@
                                             </TextBlock.Style>
                                         </TextBlock>
                                         <TextBlock Text="{Binding Preview}"
-                                                   FontSize="11" Opacity="0.7"
+                                                   FontSize="{DynamicResource Theme.FontSizeSmall}" Opacity="0.7"
                                                    TextTrimming="CharacterEllipsis">
                                             <TextBlock.Style>
                                                 <Style TargetType="TextBlock">

--- a/QuickMail/Views/MainWindow.xaml
+++ b/QuickMail/Views/MainWindow.xaml
@@ -261,9 +261,6 @@
                 <Separator/>
                 <MenuItem Header="_Manage Accounts…"
                           Command="{Binding ManageAccountsCommand}"/>
-                <MenuItem Header="Address _Book…"
-                          Click="MenuAddressBook_Click"
-                          InputGestureText="Ctrl+Shift+B"/>
                 <Separator/>
                 <MenuItem Header="S_ettings…"
                           Click="MenuSettings_Click"
@@ -333,12 +330,6 @@
                         </Style>
                     </MenuItem.Style>
                 </MenuItem>
-                <Separator/>
-                <MenuItem Header="_Rules…"
-                          Command="{Binding OpenRulesManagerCommand}"
-                          InputGestureText="Ctrl+Shift+L"
-                          AutomationProperties.Name="Manage Rules"
-                          AutomationProperties.AcceleratorKey="Ctrl+Shift+L"/>
             </MenuItem>
 
             <!-- View -->
@@ -509,13 +500,10 @@
                 <MenuItem Header="_Search Folders…"
                           Click="MenuSearchFolders_Click"
                           InputGestureText="Ctrl+Shift+F"/>
-                <MenuItem Header="Command _Palette…"
-                          Click="MenuCommandPalette_Click"
-                          InputGestureText="Ctrl+Shift+P"/>
             </MenuItem>
 
-            <!-- Tools — always available. Each command lives in exactly one menu,
-                 so this carries the theme actions (previously palette-only). -->
+            <!-- Tools — always available (mirrors the Compose window's Tools menu).
+                 Each command lives here only; not duplicated in File/Message/View. -->
             <MenuItem Header="_Tools">
                 <MenuItem Header="Manage _Themes…"
                           Click="MenuManageThemes_Click"
@@ -524,6 +512,19 @@
                           Click="MenuNextTheme_Click"/>
                 <MenuItem Header="Pre_vious Theme"
                           Click="MenuPreviousTheme_Click"/>
+                <Separator/>
+                <MenuItem Header="Address _Book…"
+                          Click="MenuAddressBook_Click"
+                          InputGestureText="Ctrl+Shift+B"/>
+                <MenuItem Header="_Rules…"
+                          Command="{Binding OpenRulesManagerCommand}"
+                          InputGestureText="Ctrl+Shift+L"
+                          AutomationProperties.Name="Manage Rules"
+                          AutomationProperties.AcceleratorKey="Ctrl+Shift+L"/>
+                <Separator/>
+                <MenuItem Header="Command _Palette…"
+                          Click="MenuCommandPalette_Click"
+                          InputGestureText="Ctrl+Shift+P"/>
             </MenuItem>
 
             <!-- Help -->

--- a/QuickMail/Views/MainWindow.xaml
+++ b/QuickMail/Views/MainWindow.xaml
@@ -514,7 +514,8 @@
                           InputGestureText="Ctrl+Shift+P"/>
             </MenuItem>
 
-            <!-- Tools — always available (mirrors the Compose window's Tools menu) -->
+            <!-- Tools — always available. Each command lives in exactly one menu,
+                 so this carries the theme actions (previously palette-only). -->
             <MenuItem Header="_Tools">
                 <MenuItem Header="Manage _Themes…"
                           Click="MenuManageThemes_Click"
@@ -523,18 +524,6 @@
                           Click="MenuNextTheme_Click"/>
                 <MenuItem Header="Pre_vious Theme"
                           Click="MenuPreviousTheme_Click"/>
-                <Separator/>
-                <MenuItem Header="Address _Book…"
-                          Click="MenuAddressBook_Click"
-                          InputGestureText="Ctrl+Shift+B"/>
-                <MenuItem Header="_Rules…"
-                          Command="{Binding OpenRulesManagerCommand}"
-                          InputGestureText="Ctrl+Shift+L"
-                          AutomationProperties.Name="Manage Rules"/>
-                <Separator/>
-                <MenuItem Header="Command _Palette…"
-                          Click="MenuCommandPalette_Click"
-                          InputGestureText="Ctrl+Shift+P"/>
             </MenuItem>
 
             <!-- Help -->

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -4409,6 +4409,16 @@ public partial class MainWindow : Window
         window.Show();
     }
 
+    // ── Tools menu (theme actions dispatch through the registered commands so the
+    //    Command Palette and any custom hotkeys stay the single source of truth) ──
+    private void MenuManageThemes_Click(object sender, RoutedEventArgs e) => OpenThemeManager();
+
+    private void MenuNextTheme_Click(object sender, RoutedEventArgs e)
+        => _registry.FindById("theme.next")?.Execute();
+
+    private void MenuPreviousTheme_Click(object sender, RoutedEventArgs e)
+        => _registry.FindById("theme.previous")?.Execute();
+
     private void MenuGrabAddresses_Click(object sender, RoutedEventArgs e)
         => GrabAddressesFromMessage();
 

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -178,6 +178,11 @@ public partial class MainWindow : Window
     // with the HC wording and everything else as "Theme changed to …".
     private bool _lastAnnouncedHighContrast;
 
+    // The single live Theme Manager, if open. The manager is modeless, so guard
+    // against stacking two over the same themes folder — a second open activates
+    // the existing one instead of creating a rival that could write concurrently.
+    private ThemeManagerWindow? _themeManagerWindow;
+
     private TutorialViewModel? _tutorialVm;
 
     // Tracks open compose windows so they can be explicitly closed when the main window
@@ -2140,7 +2145,7 @@ public partial class MainWindow : Window
         var hc = _themeService.IsHighContrastActive;
         var text = hc && !_lastAnnouncedHighContrast
             ? "High contrast is on; colors are supplied by Windows."
-            : $"Theme changed to {_themeService.ResolvedTheme.Name}.";
+            : $"Theme changed to {_themeService.ConfiguredThemeName}.";
         _lastAnnouncedHighContrast = hc;
         AccessibilityHelper.Announce(this, text, category: AnnouncementCategory.Status);
 
@@ -4381,16 +4386,26 @@ public partial class MainWindow : Window
     {
         if (_themeService is null) return;
 
+        // Single-instance: a second invocation activates the open manager rather
+        // than stacking a rival over the same {profile}\themes folder.
+        if (_themeManagerWindow != null)
+        {
+            _themeManagerWindow.Activate();
+            return;
+        }
+
         var previousFocus = Keyboard.FocusedElement as IInputElement;
         var vm = new ThemeManagerViewModel(_themeService, _configService);
         var window = new ThemeManagerWindow(vm) { Owner = this };
         window.Closed += (_, _) =>
         {
+            _themeManagerWindow = null;
             // Safe point for parent updates — no nested message loop is running.
             // Re-register theme.apply.{id} commands for imported/renamed/deleted themes.
             _vm.RegisterThemeCommands();
             previousFocus?.Focus();
         };
+        _themeManagerWindow = window;
         window.Show();
     }
 

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -172,6 +172,11 @@ public partial class MainWindow : Window
     private readonly ITemplateService _templateService;
     private readonly IFlagService? _flagService;
     private readonly ICustomDictionaryService? _customDictionary;
+    private readonly IThemeService? _themeService;
+
+    // Last High Contrast state announced, so an HC transition is announced once
+    // with the HC wording and everything else as "Theme changed to …".
+    private bool _lastAnnouncedHighContrast;
 
     private TutorialViewModel? _tutorialVm;
 
@@ -200,7 +205,8 @@ public partial class MainWindow : Window
         ITemplateService templateService,
         IFeatureGate featureGate,
         IFlagService? flagService = null,
-        ICustomDictionaryService? customDictionary = null)
+        ICustomDictionaryService? customDictionary = null,
+        IThemeService? themeService = null)
     {
         _vm = vm;
         _smtp = smtp;
@@ -218,9 +224,20 @@ public partial class MainWindow : Window
         _featureGate = featureGate;
         _flagService = flagService;
         _customDictionary = customDictionary;
+        _themeService = themeService;
 
         InitializeComponent();
         DataContext = vm;
+
+        if (_themeService != null)
+        {
+            _lastAnnouncedHighContrast = _themeService.IsHighContrastActive;
+            // Raised on the Dispatcher, never during a modal's nested message loop:
+            // settings-driven applies run after the dialog closes (ApplySettings) and
+            // OS-driven refreshes are debounced + dispatcher-posted by ThemeService.
+            _themeService.ThemeChanged += OnThemeChanged;
+            vm.ThemeManagerRequested += (_, _) => OpenThemeManager();
+        }
 
         vm.ComposeRequested += OpenComposeWindow;
         vm.SelectAttachmentsForForwardRequested += ShowForwardAttachmentDialogAsync;
@@ -2048,6 +2065,8 @@ public partial class MainWindow : Window
             MessageBody.CoreWebView2.Settings.AreDevToolsEnabled = false;
             MessageBody.CoreWebView2.Settings.IsStatusBarEnabled = false;
 
+            ApplyWebViewColorScheme();
+
             await MessageBody.CoreWebView2.AddScriptToExecuteOnDocumentCreatedAsync(
                 "window.addEventListener('keydown',function(e){"
                 +"if(e.key==='Escape'){window.chrome.webview.postMessage('escape');e.preventDefault();}"
@@ -2105,13 +2124,81 @@ public partial class MainWindow : Window
         }
     }
 
+    /// <summary>The theme's --qm-* CSS block for reading-pane documents, or null without a theme service.</summary>
+    private string? BuildReadingPaneThemeCss() =>
+        _themeService?.BuildMessageCss(_configService.Load().AppearanceForceMessageTheme);
+
+    /// <summary>
+    /// Handles an effective-theme change: announces it, updates the WebView2 color
+    /// scheme, and re-renders the open message with the new theme CSS. Never moves
+    /// focus — the reading-pane re-render is the only document-level change.
+    /// </summary>
+    private void OnThemeChanged(object? sender, EventArgs e)
+    {
+        if (_themeService is null) return;
+
+        var hc = _themeService.IsHighContrastActive;
+        var text = hc && !_lastAnnouncedHighContrast
+            ? "High contrast is on; colors are supplied by Windows."
+            : $"Theme changed to {_themeService.ResolvedTheme.Name}.";
+        _lastAnnouncedHighContrast = hc;
+        AccessibilityHelper.Announce(this, text, category: AnnouncementCategory.Status);
+
+        ApplyWebViewColorScheme();
+        _ = RerenderReadingPaneAsync();
+    }
+
+    /// <summary>Points WebView2's prefers-color-scheme at the resolved theme's base.</summary>
+    private void ApplyWebViewColorScheme()
+    {
+        if (!_webViewReady || _themeService is null) return;
+        try
+        {
+            MessageBody.CoreWebView2.Profile.PreferredColorScheme = _themeService.IsHighContrastActive
+                ? CoreWebView2PreferredColorScheme.Auto
+                : _themeService.ResolvedTheme.Base == "dark"
+                    ? CoreWebView2PreferredColorScheme.Dark
+                    : CoreWebView2PreferredColorScheme.Light;
+        }
+        catch (Exception ex)
+        {
+            LogService.Log("ApplyWebViewColorScheme", ex);
+        }
+    }
+
+    /// <summary>
+    /// Re-renders the currently open message with fresh theme CSS, without the
+    /// focus handoff that ShowMessageBodyAsync performs (theme switching must
+    /// never move focus). Scroll position resets — accepted; theme changes are rare.
+    /// </summary>
+    private async Task RerenderReadingPaneAsync()
+    {
+        if (!_webViewReady || !_vm.IsMessageOpen || _vm.MessageDetail is null) return;
+
+        // Invalidate any in-flight render so its deferred focus logic bails out.
+        var renderVersion = Interlocked.Increment(ref _messageBodyRenderVersion);
+        var detail   = _vm.MessageDetail;
+        var themeCss = BuildReadingPaneThemeCss();
+        var html = await Task.Run(() => MessageBodyHtmlBuilder.BuildMessageHtml(detail, themeCss));
+        if (renderVersion != _messageBodyRenderVersion) return;
+
+        var eventCardHtml = _vm.BuildEventCardHtml();
+        if (!string.IsNullOrEmpty(eventCardHtml))
+            html = InjectEventCard(html, eventCardHtml);
+
+        try { MessageBody.CoreWebView2.Stop(); }
+        catch (Exception ex) { LogService.Log("RerenderReadingPane/Stop", ex); }
+        MessageBody.CoreWebView2.NavigateToString(html);
+    }
+
     // Render the message body in the browser and move focus into it
     private async Task ShowMessageBodyAsync(MailMessageDetail detail)
     {
         if (!_webViewReady) return;
 
         var renderVersion = Interlocked.Increment(ref _messageBodyRenderVersion);
-        var html = await Task.Run(() => MessageBodyHtmlBuilder.BuildMessageHtml(detail));
+        var themeCss = BuildReadingPaneThemeCss();
+        var html = await Task.Run(() => MessageBodyHtmlBuilder.BuildMessageHtml(detail, themeCss));
         if (renderVersion != _messageBodyRenderVersion)
             return;
 
@@ -3664,7 +3751,7 @@ public partial class MainWindow : Window
     {
         var composeVm = new ComposeViewModel(_smtp, _accountService, _credentials, _imap, _templateService);
         composeVm.Seed(composeModel);
-        var window = new ComposeWindow(composeVm, _contactService, _templateService, _configService, _customDictionary);
+        var window = new ComposeWindow(composeVm, _contactService, _templateService, _configService, _customDictionary, _themeService);
         composeVm.CloseRequested += window.Close;
         _openComposeWindows.Add(window);
         window.Closed += (_, _) => _openComposeWindows.Remove(window);
@@ -3853,7 +3940,7 @@ public partial class MainWindow : Window
         // which causes screen readers to keep browse mode active for the message window's
         // WebView2 even after the user alt-tabs back to the main window. As an independent
         // window, the AT cleanly exits browse mode when focus leaves the message window.
-        var win = new MessageWindow(winVm, _imap, _localStore, _webViewEnvironment);
+        var win = new MessageWindow(winVm, _imap, _localStore, _webViewEnvironment, _themeService, _configService);
 
         // Wire mail action delegates so the window has full message operations.
         // Each delegate syncs MainViewModel selection to the window's current message
@@ -4249,7 +4336,7 @@ public partial class MainWindow : Window
         {
             if (pending?.IsLoaded == true) return pending;
             var cvm = new ComposeViewModel(_smtp, _accountService, _credentials, _imap, _templateService);
-            pending = new ComposeWindow(cvm, _contactService, _templateService, _configService, _customDictionary);
+            pending = new ComposeWindow(cvm, _contactService, _templateService, _configService, _customDictionary, _themeService);
             cvm.CloseRequested += pending.Close;
             var tracked = pending;
             _openComposeWindows.Add(tracked);
@@ -4268,14 +4355,43 @@ public partial class MainWindow : Window
 
     private void MenuSettings_Click(object sender, RoutedEventArgs e)
     {
-        var vm = new SettingsViewModel(_configService, _registry);
+        // Font enumeration is a View-layer concern; the VM receives plain strings.
+        var fontNames = System.Windows.Media.Fonts.SystemFontFamilies
+            .Select(f => f.Source)
+            .OrderBy(n => n, StringComparer.CurrentCultureIgnoreCase)
+            .ToList();
+        var vm = new SettingsViewModel(_configService, _registry, _themeService, fontNames);
         var dialog = new SettingsDialog(vm) { Owner = this };
         if (dialog.ShowDialog() == true)
         {
+            // The dialog's message loop is dead here, so ApplySettings may safely
+            // apply the theme (ThemeChanged handlers rebuild parent UI).
             var cfg = _configService.Load();
             _vm.ApplySettings(cfg);
             _registry.ApplyUserOverrides(cfg.CustomHotkeys);
         }
+    }
+
+    /// <summary>
+    /// Opens the Theme Manager (command palette: "Manage Themes"). Modeless per
+    /// the modal-dialog rules: Apply restyles this window (live WebView2) while
+    /// the manager is open, and its rename panel has an editable text field.
+    /// </summary>
+    private void OpenThemeManager()
+    {
+        if (_themeService is null) return;
+
+        var previousFocus = Keyboard.FocusedElement as IInputElement;
+        var vm = new ThemeManagerViewModel(_themeService, _configService);
+        var window = new ThemeManagerWindow(vm) { Owner = this };
+        window.Closed += (_, _) =>
+        {
+            // Safe point for parent updates — no nested message loop is running.
+            // Re-register theme.apply.{id} commands for imported/renamed/deleted themes.
+            _vm.RegisterThemeCommands();
+            previousFocus?.Focus();
+        };
+        window.Show();
     }
 
     private void MenuGrabAddresses_Click(object sender, RoutedEventArgs e)

--- a/QuickMail/Views/MarkdownPreviewWindow.xaml.cs
+++ b/QuickMail/Views/MarkdownPreviewWindow.xaml.cs
@@ -23,13 +23,19 @@ public partial class MarkdownPreviewWindow : Window
     private readonly CommandRegistry _registry = new();
     private readonly CancellationTokenSource _cts = new();
 
-    public MarkdownPreviewWindow(string? subject, string htmlFragment)
+    /// <param name="themeCss">
+    /// Optional theme CSS from <see cref="IThemeService.BuildMessageCss"/>. When
+    /// present, the preview palette aliases the <c>--qm-*</c> variables (one
+    /// variable set app-wide); when null, the legacy light/dark defaults apply
+    /// via prefers-color-scheme.
+    /// </param>
+    public MarkdownPreviewWindow(string? subject, string htmlFragment, string? themeCss = null)
     {
         Title = string.IsNullOrWhiteSpace(subject)
             ? "Compose — Preview — QuickMail"
             : $"{subject.Trim()} — Preview — QuickMail";
 
-        _html = BuildHtml(subject, htmlFragment);
+        _html = BuildHtml(subject, htmlFragment, themeCss);
         InitializeComponent();
         RegisterCommands();
         Loaded += OnLoaded;
@@ -191,17 +197,23 @@ public partial class MarkdownPreviewWindow : Window
 
     // ── HTML builder ─────────────────────────────────────────────────────────
 
-    private static string BuildHtml(string? subject, string fragment)
+    private static string BuildHtml(string? subject, string fragment, string? themeCss)
     {
         var isEmpty = string.IsNullOrWhiteSpace(fragment);
         var body = isEmpty
-            ? "<p style=\"color:#888;font-style:italic;\">No content to preview.</p>"
+            ? "<p style=\"color:var(--text-muted);font-style:italic;\">No content to preview.</p>"
             : fragment;
 
         var titleText = string.IsNullOrWhiteSpace(subject)
             ? "Preview"
             : $"Preview — {subject.Trim()}";
         var encodedTitle = System.Net.WebUtility.HtmlEncode(titleText);
+
+        // With theme CSS the palette aliases the shared --qm-* variables; without
+        // it (no theme service, e.g. tests) the legacy light/dark defaults apply.
+        var paletteCss = themeCss is null
+            ? LegacyPaletteCss
+            : themeCss + "\n" + ThemeAliasCss;
 
         return
             "<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n" +
@@ -210,14 +222,25 @@ public partial class MarkdownPreviewWindow : Window
             "<meta http-equiv=\"Content-Security-Policy\" " +
             "content=\"default-src 'none'; style-src 'unsafe-inline'; font-src 'unsafe-inline'; img-src data:;\">\n" +
             $"<title>{encodedTitle}</title>\n" +
-            "<style>\n" + PreviewCss + "\n</style>\n" +
+            "<style>\n" + paletteCss + PreviewCss + "\n</style>\n" +
             "</head>\n<body>\n" +
             body +
             "\n</body>\n</html>";
     }
 
-    private const string PreviewCss =
-        "*, *::before, *::after { box-sizing: border-box; }\n" +
+    /// <summary>Maps the preview's local variables onto the app-wide --qm-* theme variables.</summary>
+    private const string ThemeAliasCss =
+        ":root {\n" +
+        "  --font: var(--qm-font, 'Segoe UI', system-ui, sans-serif);\n" +
+        "  --font-mono: 'Cascadia Code', 'Consolas', 'Courier New', monospace;\n" +
+        "  --text: var(--qm-text, CanvasText); --text-muted: var(--qm-text-muted, GrayText);\n" +
+        "  --bg: var(--qm-bg, Canvas); --surface: var(--qm-surface, Canvas);\n" +
+        "  --border: var(--qm-border, GrayText);\n" +
+        "  --accent: var(--qm-link, LinkText); --quote-bg: var(--qm-surface, Canvas);\n" +
+        "}\n";
+
+    /// <summary>Pre-theming palette, used only when no theme CSS is supplied.</summary>
+    private const string LegacyPaletteCss =
         ":root {\n" +
         "  --font: 'Segoe UI', system-ui, -apple-system, sans-serif;\n" +
         "  --font-mono: 'Cascadia Code', 'Consolas', 'Courier New', monospace;\n" +
@@ -231,7 +254,10 @@ public partial class MarkdownPreviewWindow : Window
         "    --surface: #2a2a2a; --border: #404040;\n" +
         "    --accent: #4da6ff; --quote-bg: #252525;\n" +
         "  }\n" +
-        "}\n" +
+        "}\n";
+
+    private const string PreviewCss =
+        "*, *::before, *::after { box-sizing: border-box; }\n" +
         "html { scroll-behavior: smooth; }\n" +
         "body {\n" +
         "  font-family: var(--font); font-size: 15px; line-height: 1.7;\n" +

--- a/QuickMail/Views/MessageWindow.xaml
+++ b/QuickMail/Views/MessageWindow.xaml
@@ -13,7 +13,11 @@
         WindowStartupLocation="Manual"
         d:DataContext="{d:DesignInstance Type=vm:MessageWindowViewModel}"
         Closing="OnClosing"
-        PreviewKeyDown="OnPreviewKeyDown">
+        PreviewKeyDown="OnPreviewKeyDown"
+        Background="{DynamicResource Theme.WindowBackground}"
+        Foreground="{DynamicResource Theme.TextPrimary}"
+        FontFamily="{DynamicResource Theme.FontFamily}"
+        FontSize="{DynamicResource Theme.FontSizeBase}">
 
     <Window.Resources>
         <BooleanToVisibilityConverter x:Key="BoolToVisibilityConverter"/>
@@ -129,14 +133,14 @@
         <!-- Header fields -->
         <Border DockPanel.Dock="Top"
                 BorderThickness="0,0,0,1"
-                BorderBrush="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}"
+                BorderBrush="{DynamicResource Theme.Border}"
                 Padding="8,6,8,6">
             <StackPanel>
                 <TextBox x:Name="SubjectField"
                          Text="{Binding MessageDetail.Subject, FallbackValue='', Mode=OneWay}"
                          IsReadOnly="True" IsReadOnlyCaretVisible="True"
                          BorderThickness="0" Background="Transparent"
-                         FontSize="13" FontWeight="SemiBold" TextWrapping="Wrap"
+                         FontWeight="SemiBold" TextWrapping="Wrap"
                          AutomationProperties.Name="Subject"/>
                 <TextBox x:Name="FromField"
                          Text="{Binding MessageDetail.From, FallbackValue='', Mode=OneWay}"
@@ -224,14 +228,14 @@
                           AutomationProperties.Name="Message body"
                           KeyboardNavigation.IsTabStop="True"
                           GotKeyboardFocus="MessageBody_GotKeyboardFocus"/>
-            <Border Background="{DynamicResource {x:Static SystemColors.WindowBrushKey}}"
+            <Border Background="{DynamicResource Theme.WindowBackground}"
                     Visibility="{Binding IsLoading, Converter={StaticResource BoolToVisibilityConverter}}"
                     IsHitTestVisible="False">
                 <TextBlock Text="Loading…"
                            HorizontalAlignment="Center"
                            VerticalAlignment="Center"
-                           FontSize="14"
-                           Foreground="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"
+                           FontSize="{DynamicResource Theme.FontSizeLarge}"
+                           Foreground="{DynamicResource Theme.TextSecondary}"
                            AutomationProperties.LiveSetting="Polite"/>
             </Border>
         </Grid>

--- a/QuickMail/Views/MessageWindow.xaml.cs
+++ b/QuickMail/Views/MessageWindow.xaml.cs
@@ -38,6 +38,8 @@ public partial class MessageWindow : Window
     private readonly IMailService        _imap;
     private readonly ILocalStoreService  _localStore;
     private readonly CoreWebView2Environment? _sharedEnv;
+    private readonly IThemeService?      _themeService;
+    private readonly IConfigService?     _configService;
 
     // Local command registry for the command palette (issue 53).
     private readonly CommandRegistry _localRegistry = new();
@@ -49,15 +51,22 @@ public partial class MessageWindow : Window
         MessageWindowViewModel vm,
         IMailService imap,
         ILocalStoreService localStore,
-        CoreWebView2Environment? sharedEnv = null)
+        CoreWebView2Environment? sharedEnv = null,
+        IThemeService? themeService = null,
+        IConfigService? configService = null)
     {
-        _vm         = vm;
-        _imap       = imap;
-        _localStore = localStore;
-        _sharedEnv  = sharedEnv;
+        _vm            = vm;
+        _imap          = imap;
+        _localStore    = localStore;
+        _sharedEnv     = sharedEnv;
+        _themeService  = themeService;
+        _configService = configService;
 
         InitializeComponent();
         DataContext = vm;
+
+        if (_themeService != null)
+            _themeService.ThemeChanged += OnThemeChanged;
 
         vm.RequestClose            += _ => Close();
         vm.RequestMoveToMainWindow += OnMoveToMainWindowRequested;
@@ -140,6 +149,8 @@ public partial class MessageWindow : Window
             MessageBody.CoreWebView2.Settings.AreDefaultContextMenusEnabled = false;
             MessageBody.CoreWebView2.Settings.AreDevToolsEnabled             = false;
             MessageBody.CoreWebView2.Settings.IsStatusBarEnabled             = false;
+
+            ApplyWebViewColorScheme();
 
             // Relay Escape, Shift+Tab, F6 / Shift+F6, and Ctrl+W from inside the WebView.
             await MessageBody.CoreWebView2.AddScriptToExecuteOnDocumentCreatedAsync(
@@ -231,12 +242,48 @@ public partial class MessageWindow : Window
         }
     }
 
+    /// <summary>The theme's --qm-* CSS block for this window's documents, or null.</summary>
+    private string? BuildThemeCss() =>
+        _themeService?.BuildMessageCss(_configService?.Load().AppearanceForceMessageTheme ?? false);
+
+    /// <summary>Re-renders the open message with fresh theme CSS. Never moves focus.</summary>
+    private void OnThemeChanged(object? sender, EventArgs e)
+    {
+        ApplyWebViewColorScheme();
+        _ = Dispatcher.InvokeAsync(async () =>
+        {
+            if (!_webViewReady || _vm.MessageDetail is not { } detail) return;
+            var version = Interlocked.Increment(ref _renderVersion);
+            var html = await Task.Run(() => MessageBodyHtmlBuilder.BuildMessageHtml(detail, BuildThemeCss()));
+            if (version != _renderVersion) return;
+            try { MessageBody.CoreWebView2.Stop(); } catch { /* best effort */ }
+            MessageBody.CoreWebView2.NavigateToString(html);
+        });
+    }
+
+    private void ApplyWebViewColorScheme()
+    {
+        if (!_webViewReady || _themeService is null) return;
+        try
+        {
+            MessageBody.CoreWebView2.Profile.PreferredColorScheme = _themeService.IsHighContrastActive
+                ? CoreWebView2PreferredColorScheme.Auto
+                : _themeService.ResolvedTheme.Base == "dark"
+                    ? CoreWebView2PreferredColorScheme.Dark
+                    : CoreWebView2PreferredColorScheme.Light;
+        }
+        catch (Exception ex)
+        {
+            LogService.Log("MessageWindow.ApplyWebViewColorScheme", ex);
+        }
+    }
+
     private async Task ShowMessageBodyAsync(MailMessageDetail detail)
     {
         if (!_webViewReady) return;
 
         var version = Interlocked.Increment(ref _renderVersion);
-        var html = await Task.Run(() => MessageBodyHtmlBuilder.BuildMessageHtml(detail));
+        var html = await Task.Run(() => MessageBodyHtmlBuilder.BuildMessageHtml(detail, BuildThemeCss()));
         if (version != _renderVersion) return;
 
         var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -440,6 +487,8 @@ public partial class MessageWindow : Window
         // would otherwise call LoadSelectedMessageAsync on the disposed CTS.
         if (_vmPropertyChangedHandler != null)
             _vm.PropertyChanged -= _vmPropertyChangedHandler;
+        if (_themeService != null)
+            _themeService.ThemeChanged -= OnThemeChanged;
         _loadCts.Cancel();
         _loadCts.Dispose();
     }

--- a/QuickMail/Views/NewFolderDialog.xaml
+++ b/QuickMail/Views/NewFolderDialog.xaml
@@ -6,7 +6,11 @@
         MinHeight="140" MinWidth="260"
         WindowStartupLocation="CenterOwner"
         ResizeMode="NoResize"
-        ShowInTaskbar="False">
+        ShowInTaskbar="False"
+        Background="{DynamicResource Theme.WindowBackground}"
+        Foreground="{DynamicResource Theme.TextPrimary}"
+        FontFamily="{DynamicResource Theme.FontFamily}"
+        FontSize="{DynamicResource Theme.FontSizeBase}">
 
     <DockPanel Margin="12">
 

--- a/QuickMail/Views/PropertiesWindow.xaml
+++ b/QuickMail/Views/PropertiesWindow.xaml
@@ -7,7 +7,11 @@
         MinWidth="360" MinHeight="280"
         ResizeMode="CanResizeWithGrip"
         WindowStartupLocation="CenterOwner"
-        ShowInTaskbar="False">
+        ShowInTaskbar="False"
+        Background="{DynamicResource Theme.WindowBackground}"
+        Foreground="{DynamicResource Theme.TextPrimary}"
+        FontFamily="{DynamicResource Theme.FontFamily}"
+        FontSize="{DynamicResource Theme.FontSizeBase}">
 
     <Window.Resources>
         <local:NullToCollapsedConverter x:Key="NullToCollapsed"/>
@@ -58,7 +62,7 @@
                                 <DataTrigger Binding="{Binding IsHeader}" Value="True">
                                     <Setter Property="FontWeight" Value="SemiBold"/>
                                     <Setter Property="Background"
-                                        Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"/>
+                                        Value="{DynamicResource Theme.ChromeBackground}"/>
                                 </DataTrigger>
                             </Style.Triggers>
                         </Style>
@@ -76,7 +80,7 @@
                              TextWrapping="Wrap"
                              VerticalScrollBarVisibility="Auto"
                              MaxHeight="200"
-                             FontFamily="Consolas"
+                             FontFamily="{DynamicResource Theme.FontFamilyMono}"
                              AutomationProperties.Name="Raw message headers"/>
                 </Expander>
 

--- a/QuickMail/Views/RulesManagerWindow.xaml
+++ b/QuickMail/Views/RulesManagerWindow.xaml
@@ -7,7 +7,11 @@
         MinWidth="600" MinHeight="440"
         WindowStartupLocation="CenterOwner"
         ResizeMode="CanResizeWithGrip"
-        WindowStyle="ToolWindow">
+        WindowStyle="ToolWindow"
+        Background="{DynamicResource Theme.WindowBackground}"
+        Foreground="{DynamicResource Theme.TextPrimary}"
+        FontFamily="{DynamicResource Theme.FontFamily}"
+        FontSize="{DynamicResource Theme.FontSizeBase}">
 
     <Window.Resources>
         <BooleanToVisibilityConverter x:Key="BoolToVisibilityConverter"/>
@@ -88,7 +92,7 @@
                     <TextBox Text="{Binding SelectedRule.Name, UpdateSourceTrigger=PropertyChanged}"
                              Style="{StaticResource RuleTextBox}"
                              AutomationProperties.Name="Rule name"/>
-                    <TextBlock Text="{Binding NameError}" Foreground="Red"
+                    <TextBlock Text="{Binding NameError}" Foreground="{DynamicResource Theme.Error}"
                                KeyboardNavigation.IsTabStop="False"
                                AutomationProperties.LiveSetting="Assertive">
                         <TextBlock.Style>
@@ -175,7 +179,7 @@
                               Style="{StaticResource RuleCheckBox}"
                               AutomationProperties.Name="Must have attachments"/>
 
-                    <TextBlock Text="{Binding ConditionsError}" Foreground="Red"
+                    <TextBlock Text="{Binding ConditionsError}" Foreground="{DynamicResource Theme.Error}"
                                KeyboardNavigation.IsTabStop="False"
                                AutomationProperties.LiveSetting="Assertive">
                         <TextBlock.Style>
@@ -210,7 +214,7 @@
                             Width="140" Height="26" Margin="0,2,0,8"
                             HorizontalAlignment="Left"
                             AutomationProperties.Name="Choose target folder"/>
-                    <TextBlock Text="{Binding FolderError}" Foreground="Red"
+                    <TextBlock Text="{Binding FolderError}" Foreground="{DynamicResource Theme.Error}"
                                KeyboardNavigation.IsTabStop="False"
                                AutomationProperties.LiveSetting="Assertive">
                         <TextBlock.Style>

--- a/QuickMail/Views/SettingsDialog.xaml
+++ b/QuickMail/Views/SettingsDialog.xaml
@@ -8,8 +8,15 @@
         Height="560" Width="520"
         WindowStartupLocation="CenterOwner"
         ResizeMode="CanResizeWithGrip"
-        Background="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"
+        Background="{DynamicResource Theme.WindowBackground}"
+        Foreground="{DynamicResource Theme.TextPrimary}"
+        FontFamily="{DynamicResource Theme.FontFamily}"
+        FontSize="{DynamicResource Theme.FontSizeBase}"
         Loaded="Window_Loaded">
+
+    <Window.Resources>
+        <BooleanToVisibilityConverter x:Key="BoolToVisibilityConverter"/>
+    </Window.Resources>
 
     <Grid Margin="10">
         <Grid.RowDefinitions>
@@ -44,8 +51,8 @@
                                         <ComboBoxItem Tag="5" Content="5 lines"/>
                                     </ComboBox>
                                     <TextBlock Text="Takes effect after reopening a folder."
-                                               Foreground="DimGray"
-                                               FontSize="11"
+                                               Foreground="{DynamicResource Theme.TextSecondary}"
+                                               FontSize="{DynamicResource Theme.FontSizeSmall}"
                                                Margin="0,4,0,0"/>
                                 </StackPanel>
 
@@ -128,7 +135,7 @@
                                           IsChecked="{Binding ConfirmEmptyTrash, Mode=TwoWay}"
                                           AutomationProperties.Name="Show a confirmation dialog before permanently deleting all messages in trash"/>
                                 <TextBlock Text="Recommended: emptying trash cannot be undone."
-                                           Foreground="DimGray" FontSize="11" Margin="0,3,0,0"/>
+                                           Foreground="{DynamicResource Theme.TextSecondary}" FontSize="{DynamicResource Theme.FontSizeSmall}" Margin="0,3,0,0"/>
                             </StackPanel>
                         </GroupBox>
 
@@ -140,7 +147,7 @@
                                           IsChecked="{Binding AutoSaveDrafts, Mode=TwoWay}"
                                           AutomationProperties.Name="Automatically save the message as a draft while composing"/>
                                 <TextBlock Text="Auto-save is quiet: the time of the last save shows in the compose status row. A failed save is announced once."
-                                           Foreground="DimGray" FontSize="11" Margin="0,3,0,8" TextWrapping="Wrap"/>
+                                           Foreground="{DynamicResource Theme.TextSecondary}" FontSize="{DynamicResource Theme.FontSizeSmall}" Margin="0,3,0,8" TextWrapping="Wrap"/>
 
                                 <StackPanel Margin="0,0,0,8">
                                     <Label x:Name="AutoSaveIntervalLabel"
@@ -174,7 +181,7 @@
                                         <ComboBoxItem Tag="html" Content="HTML"/>
                                     </ComboBox>
                                     <TextBlock Text="Drafts and templates always reopen in plain text."
-                                               Foreground="DimGray" FontSize="11" Margin="0,3,0,0"/>
+                                               Foreground="{DynamicResource Theme.TextSecondary}" FontSize="{DynamicResource Theme.FontSizeSmall}" Margin="0,3,0,0"/>
                                 </StackPanel>
                             </StackPanel>
                         </GroupBox>
@@ -188,7 +195,7 @@
                                           FontWeight="SemiBold"
                                           AutomationProperties.Name="Enable all custom screen reader announcements from QuickMail"/>
                                 <TextBlock Text="When off, only native control announcements are spoken."
-                                           Foreground="DimGray" FontSize="11" Margin="0,2,0,8"/>
+                                           Foreground="{DynamicResource Theme.TextSecondary}" FontSize="{DynamicResource Theme.FontSizeSmall}" Margin="0,2,0,8"/>
 
                                 <CheckBox Content="Announce _hints and instructions"
                                           IsChecked="{Binding AnnounceHints, Mode=TwoWay}"
@@ -287,8 +294,8 @@
                                              AutomationProperties.Name="Action first"
                                              AutomationProperties.HelpText="Message then timestamp — easier to scan since the log is already chronological."/>
                                 <TextBlock Text="Example: Sync completed: 42 messages  [2024-11-15 14:23:45.123]"
-                                           Foreground="DimGray" FontSize="11" Margin="16,2,0,8"
-                                           FontFamily="Consolas"/>
+                                           Foreground="{DynamicResource Theme.TextSecondary}" FontSize="{DynamicResource Theme.FontSizeSmall}" Margin="16,2,0,8"
+                                           FontFamily="{DynamicResource Theme.FontFamilyMono}"/>
                                 <RadioButton Content="_Time first"
                                              IsChecked="{Binding IsLogFormatTimeFirst, Mode=TwoWay}"
                                              GroupName="LogFormat"
@@ -296,8 +303,8 @@
                                              AutomationProperties.Name="Time first"
                                              AutomationProperties.HelpText="Timestamp then message — the original log format."/>
                                 <TextBlock Text="Example: 2024-11-15 14:23:45.123  Sync completed: 42 messages"
-                                           Foreground="DimGray" FontSize="11" Margin="16,2,0,0"
-                                           FontFamily="Consolas"/>
+                                           Foreground="{DynamicResource Theme.TextSecondary}" FontSize="{DynamicResource Theme.FontSizeSmall}" Margin="16,2,0,0"
+                                           FontFamily="{DynamicResource Theme.FontFamilyMono}"/>
                             </StackPanel>
                         </GroupBox>
                     </StackPanel>
@@ -318,7 +325,7 @@
                                Text="Arrow to a command, then press Enter to assign a shortcut or Delete to restore the default."
                                TextWrapping="Wrap"
                                Margin="0,0,0,10"
-                               Foreground="DimGray"/>
+                               Foreground="{DynamicResource Theme.TextSecondary}"/>
 
                     <!-- Hotkeys ListView -->
                     <ListView Grid.Row="1"
@@ -374,7 +381,7 @@
                         <GroupBox Header="_Message Open Mode" Padding="10" Margin="0,0,0,15"
                                   AutomationProperties.Name="Message open mode settings">
                             <StackPanel>
-                                <TextBlock TextWrapping="Wrap" Margin="0,0,0,8" Foreground="DimGray" FontSize="11"
+                                <TextBlock TextWrapping="Wrap" Margin="0,0,0,8" Foreground="{DynamicResource Theme.TextSecondary}" FontSize="{DynamicResource Theme.FontSizeSmall}"
                                            Text="Choose where messages open when you press Enter or select one."/>
                                 <StackPanel KeyboardNavigation.TabNavigation="Once"
                                             KeyboardNavigation.DirectionalNavigation="Cycle">
@@ -385,7 +392,7 @@
                                                  AutomationProperties.Name="Reading pane"
                                                  AutomationProperties.HelpText="Opens messages in the reading pane below the message list. This is the default behaviour."/>
                                     <TextBlock Text="Enter opens a message in the reading pane below the list."
-                                               Foreground="DimGray" FontSize="11" Margin="16,2,0,8"/>
+                                               Foreground="{DynamicResource Theme.TextSecondary}" FontSize="{DynamicResource Theme.FontSizeSmall}" Margin="16,2,0,8"/>
                                     <RadioButton Content="_Tab"
                                                  IsChecked="{Binding IsTabMode, Mode=TwoWay}"
                                                  GroupName="MessageOpenMode"
@@ -394,7 +401,7 @@
                                                  AutomationProperties.HelpText="Opens messages in a tab strip above the message list."/>
                                     <TextBlock Text="Enter opens a message as a new tab. Ctrl+Tab cycles tabs. Ctrl+W closes."
                                                TextWrapping="Wrap"
-                                               Foreground="DimGray" FontSize="11" Margin="16,2,0,8"/>
+                                               Foreground="{DynamicResource Theme.TextSecondary}" FontSize="{DynamicResource Theme.FontSizeSmall}" Margin="16,2,0,8"/>
                                     <RadioButton Content="_Window"
                                                  IsChecked="{Binding IsWindowMode, Mode=TwoWay}"
                                                  GroupName="MessageOpenMode"
@@ -403,7 +410,7 @@
                                                  AutomationProperties.HelpText="Opens each message in its own window."/>
                                     <TextBlock Text="Enter opens a message in a new window. Use Ctrl+Enter in any mode to always open in a new window."
                                                TextWrapping="Wrap"
-                                               Foreground="DimGray" FontSize="11" Margin="16,2,0,0"/>
+                                               Foreground="{DynamicResource Theme.TextSecondary}" FontSize="{DynamicResource Theme.FontSizeSmall}" Margin="16,2,0,0"/>
                                 </StackPanel>
                             </StackPanel>
                         </GroupBox>
@@ -415,6 +422,96 @@
                                 <CheckBox Content="_Confirm before closing a tab with unsaved changes"
                                           IsChecked="{Binding ConfirmCloseTabWithUnsaved, Mode=TwoWay}"
                                           AutomationProperties.Name="Show a confirmation dialog before closing a tab that has unsaved draft changes"/>
+                            </StackPanel>
+                        </GroupBox>
+                    </StackPanel>
+                </ScrollViewer>
+            </TabItem>
+            <!-- Appearance Tab -->
+            <TabItem Header="A_ppearance" AutomationProperties.Name="Appearance">
+                <ScrollViewer VerticalScrollBarVisibility="Auto">
+                    <StackPanel Margin="10">
+                        <!-- High Contrast notice — visible only while Windows HC is active. -->
+                        <TextBlock Text="Windows High Contrast is active; theme colors are supplied by Windows. Your theme choice below is saved and returns when High Contrast is turned off."
+                                   TextWrapping="Wrap"
+                                   Margin="0,0,0,10"
+                                   Visibility="{Binding IsHighContrastActive, Converter={StaticResource BoolToVisibilityConverter}}"/>
+
+                        <!-- Theme Group -->
+                        <GroupBox Header="_Theme" Padding="10" Margin="0,0,0,15"
+                                  AutomationProperties.Name="Theme settings">
+                            <StackPanel>
+                                <Label x:Name="ThemeLabel"
+                                       Content="The_me:"
+                                       Target="{Binding ElementName=ThemeCombo}"
+                                       FontWeight="SemiBold"/>
+                                <ComboBox x:Name="ThemeCombo"
+                                          ItemsSource="{Binding ThemeOptions}"
+                                          DisplayMemberPath="Name"
+                                          SelectedValuePath="Id"
+                                          SelectedValue="{Binding AppearanceThemeId, Mode=TwoWay}"
+                                          AutomationProperties.LabeledBy="{Binding ElementName=ThemeLabel}"/>
+                                <TextBlock Text="System follows the Windows light or dark setting. Themes can be managed, shared, and imported from the Theme Manager (Command Palette: Manage Themes)."
+                                           TextWrapping="Wrap"
+                                           Foreground="{DynamicResource Theme.TextSecondary}"
+                                           FontSize="{DynamicResource Theme.FontSizeSmall}"
+                                           Margin="0,4,0,0"/>
+                            </StackPanel>
+                        </GroupBox>
+
+                        <!-- Text Group -->
+                        <GroupBox Header="Te_xt" Padding="10" Margin="0,0,0,15"
+                                  AutomationProperties.Name="Text settings">
+                            <StackPanel>
+                                <Label x:Name="FontLabel"
+                                       Content="_Font:"
+                                       Target="{Binding ElementName=FontCombo}"
+                                       FontWeight="SemiBold"/>
+                                <ComboBox x:Name="FontCombo"
+                                          ItemsSource="{Binding FontOptions}"
+                                          SelectedItem="{Binding AppearanceFontOption, Mode=TwoWay}"
+                                          AutomationProperties.LabeledBy="{Binding ElementName=FontLabel}"/>
+
+                                <StackPanel Margin="0,8,0,0">
+                                    <Label x:Name="TextSizeLabel"
+                                           Content="Text si_ze:"
+                                           Target="{Binding ElementName=TextSizeCombo}"
+                                           FontWeight="SemiBold"/>
+                                    <ComboBox x:Name="TextSizeCombo"
+                                              SelectedValue="{Binding AppearanceTextScalePercent, Mode=TwoWay}"
+                                              SelectedValuePath="Tag"
+                                              AutomationProperties.LabeledBy="{Binding ElementName=TextSizeLabel}">
+                                        <ComboBoxItem Tag="100" Content="100%"/>
+                                        <ComboBoxItem Tag="110" Content="110%"/>
+                                        <ComboBoxItem Tag="125" Content="125%"/>
+                                        <ComboBoxItem Tag="150" Content="150%"/>
+                                        <ComboBoxItem Tag="175" Content="175%"/>
+                                        <ComboBoxItem Tag="200" Content="200%"/>
+                                    </ComboBox>
+                                </StackPanel>
+                            </StackPanel>
+                        </GroupBox>
+
+                        <!-- Vision Group -->
+                        <GroupBox Header="_Vision" Padding="10"
+                                  AutomationProperties.Name="Vision settings">
+                            <StackPanel>
+                                <CheckBox Content="Always _underline links"
+                                          IsChecked="{Binding AppearanceUnderlineLinks, Mode=TwoWay}"
+                                          AutomationProperties.Name="Always underline links"/>
+                                <CheckBox Content="Thicker keyboard focus in_dicators"
+                                          IsChecked="{Binding AppearanceThickFocus, Mode=TwoWay}"
+                                          Margin="0,6,0,0"
+                                          AutomationProperties.Name="Thicker keyboard focus indicators"/>
+                                <CheckBox Content="Apply theme colors to message c_ontent"
+                                          IsChecked="{Binding AppearanceForceMessageTheme, Mode=TwoWay}"
+                                          Margin="0,6,0,0"
+                                          AutomationProperties.Name="Apply theme colors to message content"/>
+                                <TextBlock Text="Overrides the colors and fonts chosen by a message's sender. Turn on when messages arrive with hard-to-read colors."
+                                           TextWrapping="Wrap"
+                                           Foreground="{DynamicResource Theme.TextSecondary}"
+                                           FontSize="{DynamicResource Theme.FontSizeSmall}"
+                                           Margin="0,3,0,0"/>
                             </StackPanel>
                         </GroupBox>
                     </StackPanel>

--- a/QuickMail/Views/SpellCheckDialog.xaml
+++ b/QuickMail/Views/SpellCheckDialog.xaml
@@ -9,7 +9,11 @@
         MinHeight="320" MinWidth="480"
         WindowStartupLocation="CenterOwner"
         ShowInTaskbar="False"
-        PreviewKeyDown="Window_PreviewKeyDown">
+        PreviewKeyDown="Window_PreviewKeyDown"
+        Background="{DynamicResource Theme.WindowBackground}"
+        Foreground="{DynamicResource Theme.TextPrimary}"
+        FontFamily="{DynamicResource Theme.FontFamily}"
+        FontSize="{DynamicResource Theme.FontSizeBase}">
 
     <Grid Margin="12">
         <Grid.ColumnDefinitions>

--- a/QuickMail/Views/TabListWindow.xaml
+++ b/QuickMail/Views/TabListWindow.xaml
@@ -15,10 +15,12 @@
         WindowStartupLocation="Manual"
         ShowInTaskbar="False"
         PreviewKeyDown="OnPreviewKeyDown"
-        Loaded="OnLoaded">
+        Loaded="OnLoaded"
+        FontFamily="{DynamicResource Theme.FontFamily}"
+        FontSize="{DynamicResource Theme.FontSizeBase}">
 
-    <Border Background="{DynamicResource {x:Static SystemColors.WindowBrushKey}}"
-            BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}"
+    <Border Background="{DynamicResource Theme.WindowBackground}"
+            BorderBrush="{DynamicResource Theme.Border}"
             BorderThickness="1"
             CornerRadius="4">
         <Border.Effect>
@@ -30,7 +32,7 @@
                        Text="Open tabs"
                        FontWeight="SemiBold"
                        Padding="10,8,10,4"
-                       Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
+                       Foreground="{DynamicResource Theme.TextPrimary}"/>
 
             <ListBox x:Name="TabList"
                      Margin="4,0,4,4"
@@ -63,7 +65,7 @@
                                     Width="20" Height="20"
                                     Padding="0"
                                     Margin="8,0,0,0"
-                                    FontSize="10"
+                                    FontSize="{DynamicResource Theme.FontSizeSmall}"
                                     Tag="{Binding}"
                                     Click="CloseTabButton_Click"
                                     AutomationProperties.Name="Close this tab"

--- a/QuickMail/Views/TemplatePickerWindow.xaml
+++ b/QuickMail/Views/TemplatePickerWindow.xaml
@@ -6,7 +6,11 @@
         MinHeight="220" MinWidth="300"
         WindowStartupLocation="CenterOwner"
         ResizeMode="CanResize"
-        ShowInTaskbar="False">
+        ShowInTaskbar="False"
+        Background="{DynamicResource Theme.WindowBackground}"
+        Foreground="{DynamicResource Theme.TextPrimary}"
+        FontFamily="{DynamicResource Theme.FontFamily}"
+        FontSize="{DynamicResource Theme.FontSizeBase}">
 
     <DockPanel Margin="10">
 

--- a/QuickMail/Views/ThemeManagerWindow.xaml
+++ b/QuickMail/Views/ThemeManagerWindow.xaml
@@ -1,0 +1,144 @@
+<Window x:Class="QuickMail.Views.ThemeManagerWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:QuickMail.Views"
+        mc:Ignorable="d"
+        Title="Theme Manager"
+        Height="440" Width="560"
+        MinHeight="320" MinWidth="460"
+        WindowStartupLocation="CenterOwner"
+        Background="{DynamicResource Theme.WindowBackground}"
+        Foreground="{DynamicResource Theme.TextPrimary}"
+        FontFamily="{DynamicResource Theme.FontFamily}"
+        FontSize="{DynamicResource Theme.FontSizeBase}"
+        Loaded="Window_Loaded"
+        PreviewKeyDown="Window_PreviewKeyDown">
+
+    <Window.Resources>
+        <BooleanToVisibilityConverter x:Key="BoolToVis"/>
+    </Window.Resources>
+
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*"/>
+            <ColumnDefinition Width="Auto"/>
+        </Grid.ColumnDefinitions>
+
+        <!-- Theme list — F6 stop 1 -->
+        <ListBox x:Name="ThemesList"
+                 Grid.Row="0" Grid.Column="0"
+                 AutomationProperties.Name="Themes"
+                 ItemsSource="{Binding Themes}"
+                 SelectedItem="{Binding SelectedTheme, Mode=TwoWay}"
+                 GotKeyboardFocus="ThemesList_GotKeyboardFocus"
+                 KeyboardNavigation.TabNavigation="Once">
+            <ListBox.ItemContainerStyle>
+                <Style TargetType="ListBoxItem" BasedOn="{StaticResource {x:Type ListBoxItem}}">
+                    <Setter Property="AutomationProperties.Name" Value="{Binding AccessibleName}"/>
+                    <Setter Property="Padding" Value="6,4"/>
+                </Style>
+            </ListBox.ItemContainerStyle>
+            <ListBox.ItemTemplate>
+                <DataTemplate>
+                    <StackPanel>
+                        <local:AriaHiddenTextBlock Text="{Binding Name}" FontWeight="SemiBold"/>
+                        <local:AriaHiddenTextBlock Text="{Binding DetailLabel}"
+                                                   Foreground="{DynamicResource Theme.TextSecondary}"
+                                                   FontSize="{DynamicResource Theme.FontSizeSmall}"/>
+                    </StackPanel>
+                </DataTemplate>
+            </ListBox.ItemTemplate>
+        </ListBox>
+
+        <!-- Action buttons — F6 stop 2 -->
+        <StackPanel x:Name="ButtonColumn"
+                    Grid.Row="0" Grid.Column="1"
+                    Margin="10,0,0,0"
+                    KeyboardNavigation.TabNavigation="Continue">
+            <Button Content="_Apply"
+                    Command="{Binding ApplyCommand}"
+                    IsEnabled="{Binding CanApply}"
+                    MinWidth="140" Margin="0,0,0,6"
+                    AutomationProperties.Name="Apply"/>
+            <Button Content="D_uplicate"
+                    Command="{Binding DuplicateCommand}"
+                    IsEnabled="{Binding CanDuplicate}"
+                    MinWidth="140" Margin="0,0,0,6"
+                    AutomationProperties.Name="Duplicate"/>
+            <Button Content="_Rename"
+                    Command="{Binding RenameCommand}"
+                    IsEnabled="{Binding CanRename}"
+                    MinWidth="140" Margin="0,0,0,6"
+                    AutomationProperties.Name="Rename"/>
+            <Button Content="_Delete"
+                    Command="{Binding DeleteCommand}"
+                    IsEnabled="{Binding CanDelete}"
+                    MinWidth="140" Margin="0,0,0,6"
+                    AutomationProperties.Name="Delete"/>
+            <Button x:Name="ExportButton"
+                    Content="_Export…"
+                    Command="{Binding ExportCommand}"
+                    IsEnabled="{Binding CanExport}"
+                    MinWidth="140" Margin="0,12,0,6"
+                    AutomationProperties.Name="Export"/>
+            <Button x:Name="ImportButton"
+                    Content="_Import…"
+                    Command="{Binding ImportCommand}"
+                    MinWidth="140" Margin="0,0,0,6"
+                    AutomationProperties.Name="Import"/>
+            <Button Content="_Open themes folder"
+                    Command="{Binding OpenThemesFolderCommand}"
+                    MinWidth="140" Margin="0,12,0,0"
+                    AutomationProperties.Name="Open themes folder"/>
+        </StackPanel>
+
+        <!-- Inline name panel for Duplicate / Rename (no nested modal prompt —
+             modal + editable text over a live WebView2 is the documented
+             dispatcher-deadlock pattern). -->
+        <Border Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2"
+                Margin="0,10,0,0" Padding="8"
+                Background="{DynamicResource Theme.SurfaceBackground}"
+                BorderBrush="{DynamicResource Theme.Border}"
+                BorderThickness="1"
+                Visibility="{Binding IsNamePanelOpen, Converter={StaticResource BoolToVis}}">
+            <StackPanel Orientation="Horizontal">
+                <Label x:Name="NameLabel"
+                       Content="_Name:"
+                       Target="{Binding ElementName=NameBox}"
+                       VerticalAlignment="Center"/>
+                <TextBox x:Name="NameBox"
+                         Text="{Binding EditName, UpdateSourceTrigger=PropertyChanged}"
+                         MinWidth="220"
+                         VerticalAlignment="Center"
+                         AutomationProperties.LabeledBy="{Binding ElementName=NameLabel}"
+                         KeyDown="NameBox_KeyDown"/>
+                <Button Content="O_K"
+                        Command="{Binding ConfirmNameCommand}"
+                        MinWidth="70" Margin="8,0,0,0"
+                        AutomationProperties.Name="OK"/>
+                <Button Content="_Cancel"
+                        Command="{Binding CancelNameCommand}"
+                        MinWidth="70" Margin="6,0,0,0"
+                        AutomationProperties.Name="Cancel"/>
+            </StackPanel>
+        </Border>
+
+        <!-- Close -->
+        <StackPanel Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2"
+                    Orientation="Horizontal" HorizontalAlignment="Right"
+                    Margin="0,10,0,0">
+            <Button x:Name="CloseButton"
+                    Content="Clo_se"
+                    Click="CloseButton_Click"
+                    MinWidth="80"
+                    AutomationProperties.Name="Close"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/QuickMail/Views/ThemeManagerWindow.xaml
+++ b/QuickMail/Views/ThemeManagerWindow.xaml
@@ -6,8 +6,8 @@
         xmlns:local="clr-namespace:QuickMail.Views"
         mc:Ignorable="d"
         Title="Theme Manager"
-        Height="440" Width="560"
-        MinHeight="320" MinWidth="460"
+        Height="620" Width="580"
+        MinHeight="460" MinWidth="460"
         WindowStartupLocation="CenterOwner"
         Background="{DynamicResource Theme.WindowBackground}"
         Foreground="{DynamicResource Theme.TextPrimary}"
@@ -22,7 +22,9 @@
 
     <Grid Margin="10">
         <Grid.RowDefinitions>
-            <RowDefinition Height="*"/>
+            <RowDefinition Height="*" MinHeight="130"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*" MinHeight="150"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
@@ -99,10 +101,30 @@
                     AutomationProperties.Name="Open themes folder"/>
         </StackPanel>
 
+        <!-- Theme description — a read-only account of the selected theme's colors
+             and where they are used, for users who cannot see the swatches.
+             Read-only TextBox so a screen reader can arrow through the text. -->
+        <Label x:Name="DescriptionLabel"
+               Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2"
+               Content="Theme description"
+               Target="{Binding ElementName=DescriptionBox}"
+               Margin="0,10,0,2"/>
+        <TextBox x:Name="DescriptionBox"
+                 Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2"
+                 Text="{Binding SelectedThemeDescription, Mode=OneWay}"
+                 IsReadOnly="True"
+                 IsReadOnlyCaretVisible="True"
+                 TextWrapping="Wrap"
+                 AcceptsReturn="True"
+                 Padding="6"
+                 VerticalScrollBarVisibility="Auto"
+                 HorizontalScrollBarVisibility="Disabled"
+                 AutomationProperties.LabeledBy="{Binding ElementName=DescriptionLabel}"/>
+
         <!-- Inline name panel for Duplicate / Rename (no nested modal prompt —
              modal + editable text over a live WebView2 is the documented
              dispatcher-deadlock pattern). -->
-        <Border Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2"
+        <Border Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2"
                 Margin="0,10,0,0" Padding="8"
                 Background="{DynamicResource Theme.SurfaceBackground}"
                 BorderBrush="{DynamicResource Theme.Border}"
@@ -131,7 +153,7 @@
         </Border>
 
         <!-- Close -->
-        <StackPanel Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2"
+        <StackPanel Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
                     Orientation="Horizontal" HorizontalAlignment="Right"
                     Margin="0,10,0,0">
             <Button x:Name="CloseButton"

--- a/QuickMail/Views/ThemeManagerWindow.xaml.cs
+++ b/QuickMail/Views/ThemeManagerWindow.xaml.cs
@@ -136,13 +136,10 @@ public partial class ThemeManagerWindow : Window
             return;
         }
 
-        // F6 / Shift+F6: two-stop ring, theme list ↔ action buttons.
+        // F6 / Shift+F6: three-stop ring — theme list → action buttons → description.
         if (e.Key == Key.F6)
         {
-            if (ButtonColumn.IsKeyboardFocusWithin)
-                FocusSelectedListItem();
-            else
-                MoveFocusToButtons();
+            CycleFocus(backward: (Keyboard.Modifiers & ModifierKeys.Shift) != 0);
             e.Handled = true;
             return;
         }
@@ -158,6 +155,21 @@ public partial class ThemeManagerWindow : Window
     private void MoveFocusToButtons()
     {
         ButtonColumn.MoveFocus(new TraversalRequest(FocusNavigationDirection.First));
+    }
+
+    /// <summary>Moves through the F6 ring: theme list → action buttons → description box.</summary>
+    private void CycleFocus(bool backward)
+    {
+        int current = DescriptionBox.IsKeyboardFocusWithin ? 2
+                    : ButtonColumn.IsKeyboardFocusWithin  ? 1
+                    : 0;
+        int next = ((current + (backward ? -1 : 1)) % 3 + 3) % 3;
+        switch (next)
+        {
+            case 0: FocusSelectedListItem(); break;
+            case 1: MoveFocusToButtons();    break;
+            case 2: DescriptionBox.Focus();  break;
+        }
     }
 
     private void OpenLocalCommandPalette()

--- a/QuickMail/Views/ThemeManagerWindow.xaml.cs
+++ b/QuickMail/Views/ThemeManagerWindow.xaml.cs
@@ -1,0 +1,196 @@
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Threading;
+using QuickMail.Services;
+using QuickMail.ViewModels;
+
+namespace QuickMail.Views;
+
+/// <summary>
+/// Theme Manager — list, apply, duplicate, rename, delete, export, import.
+///
+/// Deliberately MODELESS (Show, not ShowDialog): applying a theme restyles the
+/// owner window (including its live WebView2 reading pane) immediately, and the
+/// duplicate/rename flow needs an editable text field — both are the documented
+/// modal-dialog hazard patterns. Because it is modeless, Escape and the Close
+/// button call Close() explicitly, and the opener restores focus on Closed.
+/// </summary>
+public partial class ThemeManagerWindow : Window
+{
+    private readonly ThemeManagerViewModel _vm;
+    private bool _listHintAnnounced;
+
+    public ThemeManagerWindow(ThemeManagerViewModel vm)
+    {
+        _vm = vm;
+        InitializeComponent();
+        DataContext = vm;
+
+        vm.AnnouncementRequested += (text, category) =>
+            AccessibilityHelper.Announce(this, text, interrupt: true, category: category);
+        vm.NameEditStarted += (_, _) => Dispatcher.InvokeAsync(() =>
+        {
+            NameBox.Focus();
+            NameBox.SelectAll();
+        }, DispatcherPriority.Input);
+        vm.FocusListItemRequested += _ => Dispatcher.InvokeAsync(
+            FocusSelectedListItem, DispatcherPriority.Input);
+        vm.ErrorRequested += message =>
+            MessageBox.Show(this, message, "Theme Manager", MessageBoxButton.OK, MessageBoxImage.Warning);
+        vm.ConfirmDeleteRequested = (message, title) =>
+            MessageBox.Show(this, message, title, MessageBoxButton.YesNo, MessageBoxImage.Warning,
+                MessageBoxResult.No) == MessageBoxResult.Yes;
+        vm.ExportPathRequested = suggestedName =>
+        {
+            var dlg = new Microsoft.Win32.SaveFileDialog
+            {
+                Title    = "Export Theme",
+                FileName = suggestedName,
+                Filter   = "QuickMail theme (*.quickmailtheme)|*.quickmailtheme|All files (*.*)|*.*",
+                DefaultExt = ".quickmailtheme",
+            };
+            return dlg.ShowDialog(this) == true ? dlg.FileName : null;
+        };
+        vm.ImportPathRequested = () =>
+        {
+            var dlg = new Microsoft.Win32.OpenFileDialog
+            {
+                Title  = "Import Theme",
+                Filter = "QuickMail theme (*.quickmailtheme;*.json)|*.quickmailtheme;*.json|All files (*.*)|*.*",
+            };
+            return dlg.ShowDialog(this) == true ? dlg.FileName : null;
+        };
+        vm.OpenFolderRequested += folder =>
+        {
+            try
+            {
+                System.IO.Directory.CreateDirectory(folder);
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+                {
+                    FileName = folder,
+                    UseShellExecute = true,
+                });
+            }
+            catch (Exception ex)
+            {
+                LogService.Log("OpenThemesFolder", ex);
+            }
+        };
+
+        AccessibilityHelper.RegisterDebugInputTrace(this);
+    }
+
+    private void Window_Loaded(object sender, RoutedEventArgs e)
+    {
+        ThemesList.Focus();
+        FocusSelectedListItem();
+    }
+
+    private void FocusSelectedListItem()
+    {
+        if (ThemesList.SelectedItem is null)
+        {
+            ThemesList.Focus();
+            return;
+        }
+        ThemesList.UpdateLayout();
+        if (ThemesList.ItemContainerGenerator.ContainerFromItem(ThemesList.SelectedItem)
+            is ListBoxItem item)
+            item.Focus();
+        else
+            ThemesList.Focus();
+    }
+
+    private void ThemesList_GotKeyboardFocus(object sender, KeyboardFocusChangedEventArgs e)
+    {
+        if (_listHintAnnounced) return;
+        _listHintAnnounced = true;
+        AccessibilityHelper.Announce(this, "Press Tab for actions on the selected theme.",
+            category: Models.AnnouncementCategory.Hint);
+    }
+
+    private void NameBox_KeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.Return)
+        {
+            _vm.ConfirmNameCommand.Execute(null);
+            e.Handled = true;
+        }
+    }
+
+    private void CloseButton_Click(object sender, RoutedEventArgs e) => Close();
+
+    private void Window_PreviewKeyDown(object sender, KeyEventArgs e)
+    {
+        // Escape: close the name panel first if open, otherwise the window.
+        // (Modeless window — IsCancel/DialogResult do not apply.)
+        if (e.Key == Key.Escape)
+        {
+            if (_vm.IsNamePanelOpen)
+                _vm.CancelNameCommand.Execute(null);
+            else
+                Close();
+            e.Handled = true;
+            return;
+        }
+
+        // F6 / Shift+F6: two-stop ring, theme list ↔ action buttons.
+        if (e.Key == Key.F6)
+        {
+            if (ButtonColumn.IsKeyboardFocusWithin)
+                FocusSelectedListItem();
+            else
+                MoveFocusToButtons();
+            e.Handled = true;
+            return;
+        }
+
+        // Ctrl+Shift+P: local command palette with the window-scoped actions.
+        if (e.Key == Key.P && Keyboard.Modifiers == (ModifierKeys.Control | ModifierKeys.Shift))
+        {
+            OpenLocalCommandPalette();
+            e.Handled = true;
+        }
+    }
+
+    private void MoveFocusToButtons()
+    {
+        ButtonColumn.MoveFocus(new TraversalRequest(FocusNavigationDirection.First));
+    }
+
+    private void OpenLocalCommandPalette()
+    {
+        var previousFocus = Keyboard.FocusedElement as IInputElement;
+        var registry = new CommandRegistry();
+        registry.Register(new Models.CommandDefinition(
+            id: "thememanager.apply", category: "Settings", title: "Apply Selected Theme",
+            execute: () => _vm.ApplyCommand.Execute(null)));
+        registry.Register(new Models.CommandDefinition(
+            id: "thememanager.duplicate", category: "Settings", title: "Duplicate Selected Theme",
+            execute: () => _vm.DuplicateCommand.Execute(null)));
+        registry.Register(new Models.CommandDefinition(
+            id: "thememanager.rename", category: "Settings", title: "Rename Selected Theme",
+            execute: () => _vm.RenameCommand.Execute(null)));
+        registry.Register(new Models.CommandDefinition(
+            id: "thememanager.delete", category: "Settings", title: "Delete Selected Theme",
+            execute: () => _vm.DeleteCommand.Execute(null)));
+        registry.Register(new Models.CommandDefinition(
+            id: "thememanager.export", category: "Settings", title: "Export Theme…",
+            execute: () => _vm.ExportCommand.Execute(null)));
+        registry.Register(new Models.CommandDefinition(
+            id: "thememanager.import", category: "Settings", title: "Import Theme…",
+            execute: () => _vm.ImportCommand.Execute(null)));
+        registry.Register(new Models.CommandDefinition(
+            id: "thememanager.openFolder", category: "Settings", title: "Open Themes Folder",
+            execute: () => _vm.OpenThemesFolderCommand.Execute(null)));
+        registry.Register(new Models.CommandDefinition(
+            id: "thememanager.close", category: "Settings", title: "Close Theme Manager",
+            execute: Close));
+
+        var palette = new CommandPaletteWindow(registry) { Owner = this };
+        palette.ShowDialog();
+        (previousFocus ?? ThemesList).Focus();
+    }
+}

--- a/QuickMail/Views/TutorialOverlay.xaml
+++ b/QuickMail/Views/TutorialOverlay.xaml
@@ -15,8 +15,8 @@
         <Border Background="#CC1E1E1E"/>
 
         <!-- Centered instruction card -->
-        <Border Background="#F0F0F0"
-                BorderBrush="#0078D4"
+        <Border Background="{DynamicResource Theme.SurfaceBackground}"
+                BorderBrush="{DynamicResource Theme.Accent}"
                 BorderThickness="2"
                 CornerRadius="8"
                 Padding="32,24"
@@ -27,8 +27,8 @@
                 AutomationProperties.Name="{Binding CurrentStep.InstructionText, FallbackValue='Keyboard tutorial'}">
             <StackPanel>
                 <!-- Step counter -->
-                <TextBlock FontSize="14"
-                           Foreground="#666666"
+                <TextBlock FontSize="{DynamicResource Theme.FontSizeLarge}"
+                           Foreground="{DynamicResource Theme.TextSecondary}"
                            Margin="0,0,0,12">
                     <Run Text="Step "/>
                     <Run Text="{Binding CurrentStepNumber, Mode=OneWay, FallbackValue=1}"/>
@@ -37,15 +37,15 @@
                 </TextBlock>
 
                 <!-- Instruction -->
-                <TextBlock FontSize="22"
+                <TextBlock FontSize="{DynamicResource Theme.FontSizeHeader}"
                            FontWeight="SemiBold"
                            TextWrapping="Wrap"
                            Margin="0,0,0,16"
                            Text="{Binding CurrentStep.InstructionText, FallbackValue='Press a key...'}"/>
 
                 <!-- Hint -->
-                <TextBlock FontSize="14"
-                           Foreground="#666666"
+                <TextBlock FontSize="{DynamicResource Theme.FontSizeLarge}"
+                           Foreground="{DynamicResource Theme.TextSecondary}"
                            TextWrapping="Wrap"
                            Text="Press Escape to skip the tutorial at any time."/>
             </StackPanel>

--- a/QuickMail/Views/ViewManagerWindow.xaml
+++ b/QuickMail/Views/ViewManagerWindow.xaml
@@ -9,7 +9,11 @@
         MinHeight="420" MinWidth="580"
         WindowStartupLocation="CenterOwner"
         ShowInTaskbar="False"
-        AutomationProperties.Name="View Manager">
+        AutomationProperties.Name="View Manager"
+        Background="{DynamicResource Theme.WindowBackground}"
+        Foreground="{DynamicResource Theme.TextPrimary}"
+        FontFamily="{DynamicResource Theme.FontFamily}"
+        FontSize="{DynamicResource Theme.FontSizeBase}">
 
     <Window.Resources>
         <Style x:Key="SectionLabel" TargetType="TextBlock">
@@ -18,8 +22,8 @@
         </Style>
         <Style x:Key="FieldLabel" TargetType="TextBlock">
             <Setter Property="Margin" Value="0,0,0,3"/>
-            <Setter Property="Foreground" Value="DimGray"/>
-            <Setter Property="FontSize" Value="11"/>
+            <Setter Property="Foreground" Value="{DynamicResource Theme.TextSecondary}"/>
+            <Setter Property="FontSize" Value="{DynamicResource Theme.FontSizeSmall}"/>
         </Style>
         <Style x:Key="ReadonlyField" TargetType="TextBox">
             <Setter Property="IsReadOnly" Value="True"/>
@@ -43,7 +47,7 @@
         </Grid.RowDefinitions>
 
         <!-- ── Current state strip ─────────────────────────────────────────── -->
-        <Border Grid.Row="0" Background="#F0F4FF" BorderBrush="#C0CCE8"
+        <Border Grid.Row="0" Background="{DynamicResource Theme.InfoBackground}" BorderBrush="{DynamicResource Theme.Info}"
                 BorderThickness="1" CornerRadius="3" Padding="10,7" Margin="0,0,0,10">
             <StackPanel Orientation="Horizontal">
                 <TextBlock Text="Current state: " FontWeight="SemiBold" VerticalAlignment="Center"/>
@@ -81,7 +85,7 @@
 
                     <!-- ── Empty state: nothing selected ─────────────────────────── -->
                     <TextBlock Text="Select a view from the list, or create a new one."
-                               Foreground="DimGray" Margin="0,8,0,0"
+                               Foreground="{DynamicResource Theme.TextSecondary}" Margin="0,8,0,0"
                                Visibility="{Binding HasNoSelectedView, Converter={StaticResource BoolToVis}}"/>
                     <Button x:Name="CreateNewViewButton"
                             Content="Create New View from Current State"
@@ -95,7 +99,7 @@
 
                     <!-- View name as a heading -->
                     <TextBlock Text="{Binding SelectedView.Name}"
-                               FontWeight="SemiBold" FontSize="14"
+                               FontWeight="SemiBold" FontSize="{DynamicResource Theme.FontSizeLarge}"
                                Margin="0,4,0,8"
                                TextTrimming="CharacterEllipsis"
                                Visibility="{Binding ShowReadOnly, Converter={StaticResource BoolToVis}}"/>
@@ -161,7 +165,7 @@
                         <TextBox Grid.Column="0"
                                  Text="{Binding EditHotkey, Mode=OneWay}"
                                  IsReadOnly="True" IsTabStop="False"
-                                 Background="#F5F5F5"
+                                 Background="{DynamicResource Theme.SurfaceBackground}"
                                  AutomationProperties.Name="Assigned shortcut"
                                  Margin="0,0,4,0"/>
                         <Button x:Name="SetHotkeyButton"
@@ -177,7 +181,7 @@
                                 AutomationProperties.Name="Clear keyboard shortcut"/>
                     </Grid>
                     <TextBlock Text="Also configurable in File → Settings → Keyboard Shortcuts."
-                               FontSize="10" Foreground="DimGray" Margin="0,3,0,0"
+                               FontSize="{DynamicResource Theme.FontSizeSmall}" Foreground="{DynamicResource Theme.TextSecondary}" Margin="0,3,0,0"
                                Visibility="{Binding ShowEditPanel, Converter={StaticResource BoolToVis}}"/>
 
                     <!-- Day Limit -->
@@ -201,7 +205,7 @@
                                  MaxLength="4"
                                  PreviewTextInput="DayLimitBox_PreviewTextInput"/>
                         <TextBlock Grid.Column="1" VerticalAlignment="Center" Margin="8,0,0,0"
-                                   Foreground="DimGray" FontSize="11"
+                                   Foreground="{DynamicResource Theme.TextSecondary}" FontSize="{DynamicResource Theme.FontSizeSmall}"
                                    Text="days"/>
                     </Grid>
 

--- a/docs/KEYBOARD-SHORTCUTS.md
+++ b/docs/KEYBOARD-SHORTCUTS.md
@@ -53,6 +53,10 @@
 | *(unassigned)* | `tabs.promote` | Move Tab to New Window |
 | *(unassigned)* | `mail.openInNewTab` | Open in New Tab |
 | *(unassigned)* | `mail.openInWindow` | Open in New Window |
+| *(unassigned)* | `theme.manager.open` | Manage Themes |
+| *(unassigned)* | `theme.next` | Next Theme |
+| *(unassigned)* | `theme.previous` | Previous Theme |
+| *(unassigned)* | `theme.apply.{id}` | Theme: [name] — one per available theme |
 
 ## Compose Window
 

--- a/docs/THEMING-TESTING-GUIDE.md
+++ b/docs/THEMING-TESTING-GUIDE.md
@@ -1,0 +1,144 @@
+# Theming — Usage and Testing Guide
+
+**Status:** Working guide for the `theming` branch. Not yet part of the user guide.
+**Spec:** `docs/planning/theming-visual-design-pm-dev-spec.md` (issue #177). Section references below (§7, §9) point there.
+
+This guide has two halves: a short orientation on how theming works, then a structured test pass. The test pass mirrors the spec's acceptance walkthroughs — the keyboard walkthrough in §7 is normative, so anything that doesn't match what you hear or see is a bug, not a follow-up.
+
+---
+
+## Part 1: How to use it
+
+### The short version
+
+- **Settings → Appearance tab** (Ctrl+, then Ctrl+Tab to Appearance, access key Alt+P) — pick a theme, font, text size, and the three vision toggles.
+- **Command Palette (Ctrl+Shift+P)** — type "theme" for: **Manage Themes** (the Theme Manager window), **Next Theme** / **Previous Theme** (cycle), and one **Theme: [name]** command per theme (each can be given a shortcut in Settings → Keyboard Shortcuts).
+- Everything applies immediately. Nothing requires a restart.
+
+### The themes
+
+| Theme | What it is |
+|---|---|
+| System (default) | Follows the Windows light/dark app setting. Light → Quill, dark → Quill Dark. |
+| Quill | The standard light look: warm off-whites, muted steel-blue accent. |
+| Quill Dark | The dark counterpart. |
+| Ember / Fjord / Heather | Warm, cool, and muted variations on the light look. |
+| (your themes) | Anything duplicated or imported in the Theme Manager. |
+
+### Vision settings (all off by default, all in the Appearance tab)
+
+- **Text size** — 100% to 200%, app-wide, independent of Windows display scaling.
+- **Font** — app-wide font override; "(Theme default)" restores the theme's font.
+- **Always underline links** — forces underlines on links in message content even when the sender removed them.
+- **Thicker keyboard focus indicators** — doubles the focus ring width (2px → 4px).
+- **Apply theme colors to message content** — overrides sender-chosen colors/fonts in the reading pane with your theme's. For messages that arrive with unreadable color choices.
+
+### Windows High Contrast
+
+When HC is on, QuickMail has no visual opinion: every color comes from your HC palette, and QuickMail's custom control styling is withdrawn so standard Windows rendering returns. Your theme choice is remembered and comes back when HC turns off. Font and text-size settings continue to apply during HC.
+
+### Theme files
+
+A theme is a plain JSON file in `{profile}\themes\` (one file per theme). Export writes the same JSON as a `.quickmailtheme` file you can move to another machine. To make your own: Theme Manager → select a built-in → **Duplicate** → **Open themes folder** → edit the copy in any text editor. Colors are hex (`#3D5A80`); any color you omit falls back to the built-in Light or Dark theme (whichever the file's `base` names). The full token list is documented in the user guide's Appearance section and in `QuickMail/Theming/ThemeKeys.cs`.
+
+The configured theme also lives in `config.ini` as `AppearanceThemeId` (with the other five `Appearance*` keys), so it can be hand-edited while the app is closed.
+
+---
+
+## Part 2: Test pass
+
+### Setup
+
+Use an isolated profile so nothing touches your real one, and turn on debug logging in case something needs diagnosing:
+
+```bat
+QuickMail.exe --profileDir C:\temp\qm-theme-test /debug
+```
+
+For the "default experience" scenario below, use a **fresh** (empty) profile directory. For the rest, any profile with an account and some mail is more useful. Run the whole pass keyboard-only; if focus is ever lost or stranded, that is a bug.
+
+### A. Default experience (fresh profile)
+
+1. Launch with a fresh profile, Windows in light mode, HC off.
+2. **Verify:** the app opens in the Quill look (warm off-white, not stark white). No new announcements at startup beyond the usual ones.
+3. Open `config.ini` in the profile directory. **Verify:** `AppearanceThemeId = system` is present with its comment block, plus the five other `Appearance*` keys.
+
+### B. Choosing a theme in Settings (§7 first walkthrough)
+
+1. Open a message so the reading pane is populated, then open Settings and move to the **Appearance** tab. **Expected:** the tab announces as "Appearance".
+2. Tab to the **Theme** combo box. **Expected:** announces the label and current value ("Theme", "System").
+3. Choose **Quill Dark**, then activate **Save**. **Expected:** the dialog closes; the whole app goes dark immediately; you hear "Theme changed to Quill Dark." (Status category); the open message re-renders with dark background; focus returns to where Settings was invoked from.
+4. Reopen Settings → Appearance. **Expected:** the Theme combo reads "Quill Dark".
+5. Restart the app. **Expected:** Quill Dark persists.
+6. Walk each remaining built-in theme in turn (Settings or the cycle commands). **Verify:** no unreadable text anywhere you check — message list, folder tree, menus, status bar, Settings itself, a compose window.
+
+### C. Dark theme deep pass (the riskiest area)
+
+With Quill Dark active, exercise each retemplated control with the keyboard and confirm both behavior and speech are unchanged from the light theme:
+
+- **Menus** — open each main menu, arrow through items, check submenus (View → Filter, flag submenus), check a checkable item, activate one with an access key. Verify InputGestureText still reads, disabled items still announce as dimmed/unavailable, and Escape closes levels one at a time.
+- **Message list** — arrow through rows; verify selection is visible (tinted, not white-on-white), unread rows are SemiBold with a small accent bar at the left edge, flag color bars still show, and column headers render.
+- **Trees** — folder tree, conversations, by-sender: expand/collapse with Left/Right, verify the expander glyphs and selection visuals, and that announcements (level, expanded state, unread counts) are unchanged.
+- **Combo boxes** — in Settings: open with F4/Alt+Down, arrow, typeahead, Escape to close without committing.
+- **Check boxes / radio buttons** — Settings General tab: Space toggles, radio groups still one tab stop with arrow cycling.
+- **Scroll bars, tabs, tooltips, status bar** — spot check visually.
+- **Compose** — type in every field; verify the caret is visible in the dark input backgrounds and text selection is visible.
+
+If any control here has broken keyboard behavior or wrong/missing speech, per §15.2 that control should ship untemplated rather than inaccessible — flag it and it comes out of `ThemedControls.xaml`.
+
+### D. Text size, font, and vision toggles (§9 vision-assist scenario)
+
+1. Set **Text size** to 150%. **Expected:** applies on Save with no restart; do a keyboard walkthrough of MainWindow, Settings, and Compose looking for clipped text or broken layouts. Try 200% too.
+2. Set a **Font** override (e.g. Verdana). **Expected:** applies app-wide and to the reading pane. "(Theme default)" restores.
+3. **Always underline links:** open an HTML message whose links aren't underlined. Toggle on → links underline; toggle off → back as authored.
+4. **Thicker keyboard focus indicators:** toggle on, Tab around MainWindow — the dashed focus ring is visibly thicker. Toggle off restores.
+5. **Apply theme colors to message content** (§7 last walkthrough): open a message with hard-to-read sender colors. Toggle on → the message re-renders in theme colors; your place in the app is preserved (reading-pane scroll may reset — accepted). Toggle off → sender's design returns.
+
+### E. OS adaptation, live (§9 — highest-risk acceptance)
+
+1. With Theme = **System**, toggle Windows dark mode (Settings → Personalization → Colors). **Expected:** the app follows within about a second, announces the change, no focus movement, no crash.
+2. With any theme active, turn on **High Contrast** (Left Alt+Left Shift+PrintScreen) while the app is running with a message open. **Expected:** within about a second the whole app takes your HC palette — including the message list, status bar, and reading pane; you hear "High contrast is on; colors are supplied by Windows." (Status); focus does not move; no dialog appears.
+3. Open Settings → Appearance during HC. **Expected:** a notice explains HC is supplying colors; the Theme combo is still present and operable (choosing records the preference for later).
+4. Turn HC off. **Expected:** your configured theme returns, announced as "Theme changed to [name]."
+5. Repeat the HC toggle with a compose window open as well.
+
+### F. Theme Manager (§7 manager walkthroughs)
+
+Note one deliberate deviation from the spec draft: the manager is a **modeless** window (this is the same pattern as Grab Addresses, for the same reason), so it stays open while themes apply behind it.
+
+1. Ctrl+Shift+P → type "theme" → **Manage Themes**. **Expected:** window opens with focus in the theme list; the list announces as "Themes" and the current item includes its kind and current-theme marker (e.g. "Quill, built-in, current theme"); a one-time hint offers Tab for actions.
+2. **Apply:** arrow to Ember, Tab to Apply, press Enter. **Expected:** the app restyles behind the window; "Theme changed to Ember."; focus stays on Apply.
+3. **F6 / Shift+F6:** cycles list ↔ buttons.
+4. **Duplicate:** select Quill, activate Duplicate. **Expected:** a name field appears prefilled "Quill copy" with focus in it; Enter (or OK) creates it; "Theme Quill copy created."; focus returns to the new item in the list.
+5. **Rename:** works on your copy; disabled (announced unavailable) on built-ins.
+6. **Export:** with the copy selected, activate Export. **Expected:** a standard Save dialog filtered to `*.quickmailtheme`, filename prefilled; on save, "Theme exported."
+7. **Delete:** delete the copy. **Expected:** confirmation ("This cannot be undone", focus on No); on Yes, the item disappears, focus lands on a neighboring list item, "Theme deleted." Delete the *active* theme and verify the app falls back to System.
+8. **Import:** import the exported file. **Expected:** it appears in the list (re-named "(imported)" if the name collides), focus moves to it, "Theme [name] imported."
+9. **Import error case:** rename any `.txt` file to `.quickmailtheme` and import it. **Expected:** a dialog states the specific problem in plain language; on dismiss the list is unchanged and focus returns to the manager. Also try a valid JSON with a bad color value (e.g. `"accent": "blue"`) — the error names the key and value.
+10. **Open themes folder** opens the profile's `themes` folder in Explorer.
+11. **Ctrl+Shift+P inside the manager** opens a local palette with the manager's own actions.
+12. **Escape** closes the window (name panel first, if open); focus returns to where you were before opening it.
+13. **Hand-edit check (§9):** edit a user theme's JSON to an invalid hex, reopen the manager. **Expected:** the broken theme is simply not listed, a line in `quickmail.log` says why, and the app runs normally.
+
+### G. Cycle and hotkey commands
+
+1. Ctrl+Shift+P → **Next Theme** repeatedly. **Expected:** each press announces the new theme name and cycles System → built-ins → your themes → around.
+2. Settings → Keyboard Shortcuts: find a **Theme: [name]** row, assign a shortcut, save, press it. **Expected:** that theme applies and announces.
+
+### H. Shared-component regressions (§9)
+
+1. **Compose invalid address:** type a bad address in To and commit it. **Verify:** the chip shows a distinct error state in both Quill and Quill Dark, and announces "Unrecognized:".
+2. **KeyCaptureDialog:** Settings → Keyboard Shortcuts → Set Shortcut; verify the captured-key text is readable in both themes.
+3. **Event card:** open a message with a calendar invite. **Verify:** the card and its Accept/Tentative/Decline buttons are readable in both themes (they now use the status tint style — pale background, dark status text).
+4. **Markdown preview:** in a Markdown compose, press F8. **Verify:** the preview follows the theme.
+5. **`--online` mode:** relaunch with `--online` and repeat scenario B. **Expected:** identical — theming never touches the local store.
+
+### I. What "pass" means
+
+- Every expected announcement above is heard, in the stated category (so it respects your Hints/Status/Results settings).
+- Theme switching never moves focus, collapses a tree, or clears a selection. The only re-render is the reading pane document.
+- No text anywhere is unreadable in any built-in theme.
+- HC on/off round-trips cleanly with no restart.
+- Keyboard behavior of every control is identical across themes.
+
+Anything that misses — note the theme, the control, what you heard versus what §7 says — and it gets fixed before this merges.

--- a/docs/THEMING-TESTING-GUIDE.md
+++ b/docs/THEMING-TESTING-GUIDE.md
@@ -19,9 +19,9 @@ This guide has two halves: a short orientation on how theming works, then a stru
 
 | Theme | What it is |
 |---|---|
-| System (default) | Follows the Windows light/dark app setting. Light → Quill, dark → Quill Dark. |
-| Quill | The standard light look: warm off-whites, muted steel-blue accent. |
-| Quill Dark | The dark counterpart. |
+| System (default) | Follows the Windows light/dark app setting. Light → Parchment, dark → Parchment Dark. |
+| Parchment | The standard light look: warm off-whites, muted steel-blue accent. |
+| Parchment Dark | The dark counterpart. |
 | Ember / Fjord / Heather | Warm, cool, and muted variations on the light look. |
 | (your themes) | Anything duplicated or imported in the Theme Manager. |
 
@@ -60,21 +60,21 @@ For the "default experience" scenario below, use a **fresh** (empty) profile dir
 ### A. Default experience (fresh profile)
 
 1. Launch with a fresh profile, Windows in light mode, HC off.
-2. **Verify:** the app opens in the Quill look (warm off-white, not stark white). No new announcements at startup beyond the usual ones.
+2. **Verify:** the app opens in the Parchment look (warm off-white, not stark white). No new announcements at startup beyond the usual ones.
 3. Open `config.ini` in the profile directory. **Verify:** `AppearanceThemeId = system` is present with its comment block, plus the five other `Appearance*` keys.
 
 ### B. Choosing a theme in Settings (§7 first walkthrough)
 
 1. Open a message so the reading pane is populated, then open Settings and move to the **Appearance** tab. **Expected:** the tab announces as "Appearance".
 2. Tab to the **Theme** combo box. **Expected:** announces the label and current value ("Theme", "System").
-3. Choose **Quill Dark**, then activate **Save**. **Expected:** the dialog closes; the whole app goes dark immediately; you hear "Theme changed to Quill Dark." (Status category); the open message re-renders with dark background; focus returns to where Settings was invoked from.
-4. Reopen Settings → Appearance. **Expected:** the Theme combo reads "Quill Dark".
-5. Restart the app. **Expected:** Quill Dark persists.
+3. Choose **Parchment Dark**, then activate **Save**. **Expected:** the dialog closes; the whole app goes dark immediately; you hear "Theme changed to Parchment Dark." (Status category); the open message re-renders with dark background; focus returns to where Settings was invoked from.
+4. Reopen Settings → Appearance. **Expected:** the Theme combo reads "Parchment Dark".
+5. Restart the app. **Expected:** Parchment Dark persists.
 6. Walk each remaining built-in theme in turn (Settings or the cycle commands). **Verify:** no unreadable text anywhere you check — message list, folder tree, menus, status bar, Settings itself, a compose window.
 
 ### C. Dark theme deep pass (the riskiest area)
 
-With Quill Dark active, exercise each retemplated control with the keyboard and confirm both behavior and speech are unchanged from the light theme:
+With Parchment Dark active, exercise each retemplated control with the keyboard and confirm both behavior and speech are unchanged from the light theme:
 
 - **Menus** — open each main menu, arrow through items, check submenus (View → Filter, flag submenus), check a checkable item, activate one with an access key. Verify InputGestureText still reads, disabled items still announce as dimmed/unavailable, and Escape closes levels one at a time.
 - **Message list** — arrow through rows; verify selection is visible (tinted, not white-on-white), unread rows are SemiBold with a small accent bar at the left edge, flag color bars still show, and column headers render.
@@ -106,10 +106,10 @@ If any control here has broken keyboard behavior or wrong/missing speech, per §
 
 Note one deliberate deviation from the spec draft: the manager is a **modeless** window (this is the same pattern as Grab Addresses, for the same reason), so it stays open while themes apply behind it.
 
-1. Ctrl+Shift+P → type "theme" → **Manage Themes**. **Expected:** window opens with focus in the theme list; the list announces as "Themes" and the current item includes its kind and current-theme marker (e.g. "Quill, built-in, current theme"); a one-time hint offers Tab for actions.
+1. Ctrl+Shift+P → type "theme" → **Manage Themes**. **Expected:** window opens with focus in the theme list; the list announces as "Themes" and the current item includes its kind and current-theme marker (e.g. "Parchment, built-in, current theme"); a one-time hint offers Tab for actions.
 2. **Apply:** arrow to Ember, Tab to Apply, press Enter. **Expected:** the app restyles behind the window; "Theme changed to Ember."; focus stays on Apply.
 3. **F6 / Shift+F6:** cycles list ↔ buttons.
-4. **Duplicate:** select Quill, activate Duplicate. **Expected:** a name field appears prefilled "Quill copy" with focus in it; Enter (or OK) creates it; "Theme Quill copy created."; focus returns to the new item in the list.
+4. **Duplicate:** select Parchment, activate Duplicate. **Expected:** a name field appears prefilled "Parchment copy" with focus in it; Enter (or OK) creates it; "Theme Parchment copy created."; focus returns to the new item in the list.
 5. **Rename:** works on your copy; disabled (announced unavailable) on built-ins.
 6. **Export:** with the copy selected, activate Export. **Expected:** a standard Save dialog filtered to `*.quickmailtheme`, filename prefilled; on save, "Theme exported."
 7. **Delete:** delete the copy. **Expected:** confirmation ("This cannot be undone", focus on No); on Yes, the item disappears, focus lands on a neighboring list item, "Theme deleted." Delete the *active* theme and verify the app falls back to System.
@@ -127,7 +127,7 @@ Note one deliberate deviation from the spec draft: the manager is a **modeless**
 
 ### H. Shared-component regressions (§9)
 
-1. **Compose invalid address:** type a bad address in To and commit it. **Verify:** the chip shows a distinct error state in both Quill and Quill Dark, and announces "Unrecognized:".
+1. **Compose invalid address:** type a bad address in To and commit it. **Verify:** the chip shows a distinct error state in both Parchment and Parchment Dark, and announces "Unrecognized:".
 2. **KeyCaptureDialog:** Settings → Keyboard Shortcuts → Set Shortcut; verify the captured-key text is readable in both themes.
 3. **Event card:** open a message with a calendar invite. **Verify:** the card and its Accept/Tentative/Decline buttons are readable in both themes (they now use the status tint style — pale background, dark status text).
 4. **Markdown preview:** in a Markdown compose, press F8. **Verify:** the preview follows the theme.

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -16,7 +16,10 @@ QuickMail is a keyboard and screen reader friendly email program for Windows. Al
 - [Flags](#flags)
 - [Mail Rules](#mail-rules)
 - [Saved Views](#saved-views)
+- [Calendar](#calendar)
+- [Tools Menu](#tools-menu)
 - [Settings](#settings)
+- [Themes](#themes)
 - [Screen Reader Announcements](#screen-reader-announcements)
 - [Keyboard Shortcuts](#keyboard-shortcuts)
 
@@ -92,6 +95,10 @@ You can also jump directly to any pane:
 
 Select **All Inboxes** at the top of the folder tree to see messages from all accounts merged into one list, sorted by date.
 
+### Moving and Copying Messages
+
+Select one or more messages (or a sender/recipient group, or a conversation) and choose **Move to Folder…** or **Copy to Folder…** from the context menu (Shift+F10) or the command palette. Both open a folder picker showing the same hierarchical tree used in the main folder panel — folders nested under their parent, with account names as headers when more than one account is present. Arrow through the tree and press Enter to complete the move or copy.
+
 ### Message List Views
 
 Press `Ctrl+Shift+V` (or use the **View** menu) to switch how messages are grouped:
@@ -120,6 +127,12 @@ Press **Ctrl+Shift+P** to open the command palette. Type any part of a command n
 ### Keyboard Customization
 
 Open **Settings → Keyboard** to reassign any shortcut to a different key. Type in the field for a command to capture a new key combination. Changes take effect immediately and survive restarts.
+
+### Checking for Updates
+
+QuickMail checks for a newer release in the background each time it starts. The top entry of the **Help** menu always shows the result: **"No updates available — running version X.Y.Z"** when you are current, or **"Update available: vX.Y.Z"** when a newer release exists. Activating the entry opens the matching page on the QuickMail releases site in your browser, so it is always useful — even when there is nothing new. If an update is found, a spoken announcement follows a few seconds after launch; the background check itself is silent when you are already up to date.
+
+The **Help** menu also has a **Keyboard Tutorial** entry, a short interactive walkthrough of core navigation (F6 pane cycling, Ctrl+1/2/3, the command palette, and Escape) for anyone new to the app.
 
 ---
 
@@ -289,6 +302,19 @@ Control announcement behavior in **Settings → Screen Reader Announcements**:
 
 Attach files with `Ctrl+Shift+A` in the compose window, by pasting files from the clipboard (`Ctrl+V`), or by dragging and dropping them onto the window. A screen reader announces how many files were attached.
 
+### Message Templates
+
+Save a message you write often — a standard reply, a form response — as a reusable template.
+
+- **Save as Template** (command palette) saves the current subject and body as a new template, titled from the subject line (or "Untitled" if the subject is empty).
+- **Insert Template…** (command palette) opens a search-and-select picker: type to filter by title, arrow to a template, and press **Insert** or Enter to add its subject (if the Subject field is empty) and body into the message you are composing.
+
+Templates can include `{sender}`, `{date}`, and `{time}` placeholders, which are replaced with your display name and today's date and time when the template is inserted. Templates are plain text; in HTML mode, only the text is inserted.
+
+### Checking Addresses
+
+Press `Ctrl+K` to check every address in the To, Cc, and Bcc fields. QuickMail looks up any bare name against your address book — if exactly one contact matches, it fills in that contact's address automatically. Addresses that are not valid and cannot be resolved are flagged as invalid. A screen reader announces how many addresses were resolved and how many are invalid.
+
 ### Sending
 
 | Shortcut | Action |
@@ -380,13 +406,17 @@ The flag name is announced before the read status when you navigate to a flagged
 
 Mail rules run automatically when mail arrives and can move, flag, mark as read, or delete messages based on sender, recipient, subject, or other criteria.
 
-Open the **Rules Manager** from the **Tools** menu or the command palette. Each rule has:
+Open the **Rules Manager** from the **Tools** menu (`Ctrl+Shift+L`) or the command palette. Each rule has:
 
 - **Conditions** — criteria the message must match (any or all)
 - **Actions** — what to do when conditions are met (move to folder, flag, mark read, delete)
 - **Active** toggle — turn a rule on or off without deleting it
 
 Rules run in order. Drag to reorder, or use the Move Up / Move Down commands.
+
+### Creating a Rule from a Message
+
+Select a message and choose **Create Rule from Message** from the context menu or the command palette. QuickMail opens a new rule pre-filled with a condition matching the sender and, if present, the subject — a quick starting point you can adjust before saving.
 
 ---
 
@@ -397,6 +427,36 @@ A saved view is a named filter you can return to instantly — for example, "Unr
 Open the **View Manager** from the **View** menu or the command palette. Create a view by choosing a folder (or All Inboxes), a message filter, and optionally a date limit. Assign a hotkey to jump to it directly.
 
 Press the assigned hotkey from anywhere in the main window to switch to that view immediately.
+
+---
+
+## Calendar
+
+QuickMail tracks upcoming appointments drawn from meeting-invitation emails (`.ics` attachments) in your mailbox. This is not a general-purpose calendar — it exists so that once you accept a meeting invitation in QuickMail, you have a place to see what you accepted.
+
+A **Calendar** node appears in the folder tree. Select it to replace the message list with a list of upcoming events, sorted by date and time.
+
+- **Arrow keys** move through the event list.
+- **Enter** opens the email the selected event came from. If that message is no longer in your local cache, QuickMail announces this and does nothing rather than attempting a failing fetch.
+- **T** filters the list to today's events.
+- **F5** refreshes the calendar.
+- **F6** cycles to the next pane as usual.
+
+### Responding to Invitations
+
+Open a meeting invitation email as you would any message. Below the invitation details (organizer, time, location, description), the message body shows three response links: **Accept**, **Tentative**, and **Decline**. Activating one records your response and updates the Calendar immediately — no restart or refresh needed. These links are not shown on a cancellation notice. When you receive an updated or cancelled invitation, the corresponding calendar entry updates or is removed automatically.
+
+---
+
+## Tools Menu
+
+The **Tools** menu is always available from the main window menu bar and groups together the commands used less often than day-to-day mail actions:
+
+- **Manage Themes…** — opens the [Theme Manager](#themes).
+- **Next Theme** / **Previous Theme** — cycle through your available themes.
+- **Address Book…** (`Ctrl+Shift+B`)
+- **Rules…** (`Ctrl+Shift+L`) — opens the [Rules Manager](#mail-rules).
+- **Command Palette…** (`Ctrl+Shift+P`)
 
 ---
 
@@ -448,7 +508,7 @@ Theme changes apply immediately — no restart. Open messages re-render in the n
 
 **Font** — override the app font. **(Theme default)** uses the theme's own font.
 
-**Text size** — scale all app text from 100% up to 200%, independent of Windows display scaling.
+**Text size** — a dropdown with fixed stops at 100%, 110%, 125%, 150%, 175%, and 200%, independent of Windows display scaling.
 
 **Vision settings:**
 
@@ -458,9 +518,34 @@ Theme changes apply immediately — no restart. Open messages re-render in the n
 
 **Windows High Contrast:** when High Contrast is on, QuickMail steps aside entirely — every color comes from your Windows High Contrast palette, and QuickMail's own styling is withdrawn. Your theme choice is remembered and returns when High Contrast is turned off. Font and text-size settings continue to apply.
 
+See [Themes](#themes) for the Theme Manager and a description of each built-in theme.
+
+### Screen Reader Announcements
+
+Control which categories of announcements QuickMail makes:
+
+| Setting | What it controls |
+|---------|-----------------|
+| Custom Announcements | Master on/off for all programmatic announcements |
+| Announce hints | Instructional tips ("Press Escape to return") |
+| Announce status | Background progress (sync, loading, connection state) |
+| Announce results | Action outcomes (messages moved, addresses saved, flag changes) |
+| Announce formatting while navigating | Block type announced when caret enters a new paragraph type in HTML compose |
+| Announce flag status | Flag name prepended to message row when navigating the list |
+| Announce spelling suggestions | Suggestions included when a misspelling is announced |
+| Spelling Suggestions Verbosity | Numbers with suggestions (default) or just suggestions |
+
+All settings default to on except **Announce flag status** and **Announce spelling while typing** (off by default). **Spelling Suggestions Verbosity** defaults to **Numbers with suggestions**. Turn off **Custom Announcements** to silence everything at once; turn it back on to restore your individual preferences.
+
+---
+
+## Themes
+
+QuickMail's color scheme is controlled through **Settings → Appearance** (see [Settings](#settings)) and managed in more detail through the **Theme Manager**.
+
 ### Theme Manager
 
-Open the Command Palette (**Ctrl+Shift+P**) and choose **Manage Themes** to open the Theme Manager. From the theme list, press Tab to reach the actions:
+Open the Command Palette (**Ctrl+Shift+P**) and choose **Manage Themes**, or choose **Manage Themes…** from the **Tools** menu. The Theme Manager is a separate, non-blocking window, so you can leave it open while you try a theme against real messages. From the theme list, press Tab to reach the actions:
 
 - **Apply** — switch to the selected theme immediately.
 - **Duplicate** — copy a theme as a starting point for your own. A name field appears with a suggested name.
@@ -469,7 +554,9 @@ Open the Command Palette (**Ctrl+Shift+P**) and choose **Manage Themes** to open
 - **Import…** — load a `.quickmailtheme` file. If a theme file has a problem, QuickMail tells you exactly what is wrong (for example, which color value is not a valid hex color).
 - **Open themes folder** — opens the folder where your themes are stored, for hand-editing.
 
-The Command Palette also offers **Next Theme** and **Previous Theme** to cycle through themes, and a **Theme: [name]** command for each theme — assign a keyboard shortcut to any of them in Settings → Keyboard Shortcuts.
+Below the theme list and actions, a read-only **Theme description** box always shows a plain-language account of the currently selected theme — its overall look, its fonts, and every individual color together with where in the app that color is used. This box is there so you can understand and compare themes by ear or by reading, without needing to see the colors. See [Built-in Themes](#built-in-themes) below for the description of each theme that ships with QuickMail.
+
+The Command Palette also offers **Next Theme** and **Previous Theme** to cycle through themes, and a **Theme: [name]** command for each theme. None of these have a default keyboard shortcut — assign one in **Settings → Keyboard** if you want direct access.
 
 **Editing a theme by hand:** a theme is a plain, documented JSON text file. Duplicate a built-in theme, choose **Open themes folder**, and edit the copy in any text editor. Colors are hex values like `#3D5A80`; any color you leave out is filled in from the built-in Light or Dark theme (whichever the file's `base` names). A typical minimal theme:
 
@@ -489,22 +576,23 @@ The Command Palette also offers **Next Theme** and **Previous Theme** to cycle t
 
 The full color token list: `windowBackground`, `surfaceBackground`, `chromeBackground`, `inputBackground`, `border`, `borderSubtle`, `inputBorder`, `textPrimary`, `textSecondary`, `textDisabled`, `textOnAccent`, `accent`, `accentSubtle`, `hyperlink`, `selectionBackground`, `selectionText`, `selectionInactive`, `focusIndicator`, `error`, `errorBackground`, `warning`, `warningBackground`, `success`, `successBackground`, `info`, `infoBackground`. Edits take effect the next time the theme is applied (reopen the Theme Manager and choose Apply, or restart).
 
-### Screen Reader Announcements
+### Built-in Themes
 
-Control which categories of announcements QuickMail makes:
+QuickMail ships with six themes. **System** follows Windows; the other five are always available regardless of your Windows setting. Each description below is a shorter version of what the Theme Manager's **Theme description** box reads for that theme — open the Theme Manager and select a theme to hear or read the full breakdown, including every individual color and exactly where it is used (message list, links, selection, focus outline, error/warning/success text, and so on).
 
-| Setting | What it controls |
-|---------|-----------------|
-| Custom Announcements | Master on/off for all programmatic announcements |
-| Announce hints | Instructional tips ("Press Escape to return") |
-| Announce status | Background progress (sync, loading, connection state) |
-| Announce results | Action outcomes (messages moved, addresses saved, flag changes) |
-| Announce formatting while navigating | Block type announced when caret enters a new paragraph type in HTML compose |
-| Announce flag status | Flag name prepended to message row when navigating the list |
-| Announce spelling suggestions | Suggestions included when a misspelling is announced |
-| Spelling Suggestions Verbosity | Numbers with suggestions (default) or just suggestions |
+**System** — follows the Windows light or dark setting. Whichever it resolves to today, it currently displays the same colors as Parchment (below): an off-white background, very dark cool-gray text, and a dark muted-blue accent.
 
-All settings default to on except **Announce flag status** and **Announce spelling while typing** (off by default). **Spelling Suggestions Verbosity** defaults to **Numbers with suggestions**. Turn off **Custom Announcements** to silence everything at once; turn it back on to restore your individual preferences.
+**Parchment** (light, default) — an off-white background (Snow) with very dark cool-gray text and a dark muted-blue accent (Dark Slate Blue) used for buttons and the unread marker. Panels and toolbars use warm off-white tones (White Smoke, Linen); links are medium blue. This is QuickMail's standard light look.
+
+**Parchment Dark** — the dark counterpart to Parchment: a very dark gray background with light gray text and a light muted-blue accent. Panels and toolbars use slightly lighter dark-gray tones for depth; links are light blue. Status colors (error, warning, success, information) are lightened versions of Parchment's, chosen for contrast against the dark background.
+
+**Ember** — a warm light theme: a warm off-white background (Floral White) with very dark cool-gray text and a dark red accent (Sienna) in place of Parchment's blue. Selection highlights use a pale muted orange rather than blue. Links remain medium blue for consistency across themes.
+
+**Fjord** — a cool light theme: an off-white background with a faint cool cast (Ghost White) and a dark muted-cyan accent (Dark Slate Gray) in place of Parchment's blue. Selection highlights use a light cool gray-green.
+
+**Heather** — a muted light theme: an off-white background (Ghost White) with a cool gray accent (Dim Gray) instead of a saturated color. Selection highlights use a light cool gray-lavender. This is the most subdued of the built-in themes.
+
+The four light themes are close cousins. Ember, Fjord, and Heather each change only four colors from Parchment: the main window background tint, the accent color, the soft accent-fill color, and the selection highlight. Everything else — panels and toolbars, borders, body and secondary text, the medium-blue hyperlink color, the focus outline, and the four status colors (error, warning, success, information) — is inherited unchanged from Parchment. Parchment Dark is the only theme with a fully dark palette.
 
 ---
 
@@ -545,10 +633,15 @@ Every announcement is optional and controlled by the settings above. No custom s
 | `Ctrl+Shift+V` | View menu |
 | `Ctrl+Shift+G` | Grab Addresses from Message |
 | `Ctrl+Shift+B` | Address Book |
+| `Ctrl+Shift+L` | Rules Manager |
 | `Ctrl+,` | Settings |
 | `F1` | User Guide |
 | `Shift+,` | First message in group |
 | `Shift+.` | Last message in group |
+
+**Move to Folder…** and **Copy to Folder…** are available from the context menu (Shift+F10) or the command palette; they have no default keyboard shortcut. **Manage Themes**, **Next Theme**, and **Previous Theme** are likewise command-palette-only unless you assign a shortcut yourself in Settings → Keyboard.
+
+**Calendar list** (when the Calendar folder is selected): `T` filters to today's events; `Enter` opens the source invitation email; `F5` refreshes; arrow keys browse.
 
 ### Tabs
 
@@ -587,5 +680,8 @@ Every announcement is optional and controlled by the settings above. No custom s
 | `Ctrl+T` | Announce formatting at cursor |
 | `Ctrl+Shift+T` | Show formatting in browsable list |
 | `Ctrl+Shift+A` | Add attachment |
+| `Ctrl+K` | Check addresses |
 | `Ctrl+Shift+P` | Command palette |
 | `Escape` | Close window (when no menu or dropdown is open) |
+
+**Insert Template…** and **Save as Template** are available from the command palette; they have no default keyboard shortcut.

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -432,6 +432,63 @@ Controls the order of timestamp and message text in each log line. **Action firs
 
 Reassign shortcuts for any registered command.
 
+### Appearance
+
+Choose how QuickMail looks and adjust it to your vision needs.
+
+**Theme** — the color scheme for the whole app:
+
+- **System** (default) — follows the Windows light or dark setting automatically.
+- **Quill** — the standard light look: warm off-whites with a muted steel-blue accent.
+- **Quill Dark** — the dark counterpart.
+- **Ember**, **Fjord**, **Heather** — warm, cool, and muted variations on the light look.
+- Any theme you created or imported in the Theme Manager also appears here.
+
+Theme changes apply immediately — no restart. Open messages re-render in the new colors.
+
+**Font** — override the app font. **(Theme default)** uses the theme's own font.
+
+**Text size** — scale all app text from 100% up to 200%, independent of Windows display scaling.
+
+**Vision settings:**
+
+- **Always underline links** — underlines every link in message content, even when the sender removed the underline.
+- **Thicker keyboard focus indicators** — doubles the width of the keyboard focus ring.
+- **Apply theme colors to message content** — overrides the colors and fonts chosen by a message's sender with your theme's colors. Turn on when messages arrive with hard-to-read colors; turn off to see messages as their senders designed them.
+
+**Windows High Contrast:** when High Contrast is on, QuickMail steps aside entirely — every color comes from your Windows High Contrast palette, and QuickMail's own styling is withdrawn. Your theme choice is remembered and returns when High Contrast is turned off. Font and text-size settings continue to apply.
+
+### Theme Manager
+
+Open the Command Palette (**Ctrl+Shift+P**) and choose **Manage Themes** to open the Theme Manager. From the theme list, press Tab to reach the actions:
+
+- **Apply** — switch to the selected theme immediately.
+- **Duplicate** — copy a theme as a starting point for your own. A name field appears with a suggested name.
+- **Rename** / **Delete** — for your own themes (built-ins cannot be changed or deleted).
+- **Export…** — save a theme as a `.quickmailtheme` file to share or move to another machine.
+- **Import…** — load a `.quickmailtheme` file. If a theme file has a problem, QuickMail tells you exactly what is wrong (for example, which color value is not a valid hex color).
+- **Open themes folder** — opens the folder where your themes are stored, for hand-editing.
+
+The Command Palette also offers **Next Theme** and **Previous Theme** to cycle through themes, and a **Theme: [name]** command for each theme — assign a keyboard shortcut to any of them in Settings → Keyboard Shortcuts.
+
+**Editing a theme by hand:** a theme is a plain, documented JSON text file. Duplicate a built-in theme, choose **Open themes folder**, and edit the copy in any text editor. Colors are hex values like `#3D5A80`; any color you leave out is filled in from the built-in Light or Dark theme (whichever the file's `base` names). A typical minimal theme:
+
+```json
+{
+  "formatVersion": 1,
+  "id": "my-theme",
+  "name": "My Theme",
+  "base": "light",
+  "colors": {
+    "accent": "#8F4531",
+    "windowBackground": "#FBF7F2"
+  },
+  "typography": { "fontFamily": "Segoe UI", "baseFontSize": 13 }
+}
+```
+
+The full color token list: `windowBackground`, `surfaceBackground`, `chromeBackground`, `inputBackground`, `border`, `borderSubtle`, `inputBorder`, `textPrimary`, `textSecondary`, `textDisabled`, `textOnAccent`, `accent`, `accentSubtle`, `hyperlink`, `selectionBackground`, `selectionText`, `selectionInactive`, `focusIndicator`, `error`, `errorBackground`, `warning`, `warningBackground`, `success`, `successBackground`, `info`, `infoBackground`. Edits take effect the next time the theme is applied (reopen the Theme Manager and choose Apply, or restart).
+
 ### Screen Reader Announcements
 
 Control which categories of announcements QuickMail makes:

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -439,8 +439,8 @@ Choose how QuickMail looks and adjust it to your vision needs.
 **Theme** — the color scheme for the whole app:
 
 - **System** (default) — follows the Windows light or dark setting automatically.
-- **Quill** — the standard light look: warm off-whites with a muted steel-blue accent.
-- **Quill Dark** — the dark counterpart.
+- **Parchment** — the standard light look: warm off-whites with a muted steel-blue accent.
+- **Parchment Dark** — the dark counterpart.
 - **Ember**, **Fjord**, **Heather** — warm, cool, and muted variations on the light look.
 - Any theme you created or imported in the Theme Manager also appears here.
 


### PR DESCRIPTION
Implements the full theming spec (docs/planning/theming-visual-design-pm-dev-spec.md) from #177 — all four phases.

## What this adds

**Token infrastructure (Phase 1)**
- 26 semantic color tokens + typography + focus thickness, published as `Theme.*` DynamicResources (`Theming/ThemeKeys.cs` is the single source of truth for names).
- `ThemeService`: builds frozen brush dictionaries and replaces them atomically in the application merged dictionaries; resolves the virtual `system` theme from the Windows light/dark setting; debounced, dispatcher-marshaled OS change detection; `IDisposable` with static-event unsubscription in `App.OnExit`.
- **High Contrast passthrough:** under Windows HC every token rebuilds from live SystemColors and `ThemedControls.xaml` is withdrawn so WPF's built-in HC-aware templates return — the app has no visual opinion in HC. The configured theme survives and returns when HC ends.
- `ThemeStore`: built-ins as embedded resources, user themes as one JSON file each in `{profile}\themes\`; corrupt files are skipped with a log line and never block startup.
- Six documented `[global]` config keys (theme id, text scale, font family, underline links, thick focus, force message theme).

**Quill default + Appearance tab (Phase 2)**
- Quill (warm off-white, steel-blue accent) ships as the light default; System follows the OS.
- Every window root inherits theme font/size/colors, so text scale (100–200%) and font override apply app-wide.
- WebView2 bridge: `BuildMessageCss` emits `--qm-*` variables consumed by `MessageBodyHtmlBuilder` (reading pane, MessageWindow) and the compose preview; the reading pane re-renders on theme change **without moving focus**; `PreferredColorScheme` tracks the theme base. With no theme CSS the documents fall back to CSS system colors — pre-theming behavior.
- Settings gains the **Appearance** tab (theme, font, text size, three vision toggles, HC notice).

**Dark + variants + control restyle (Phase 3)**
- `Styles/ThemedControls.xaml`: implicit token-driven templates for Button, ToggleButton, TextBox, CheckBox/Radio, ComboBox, ScrollBar, Menu/MenuItem/ContextMenu, TabControl, list/tree item containers, GridView headers, StatusBar, ToolTip. All required `PART_` names preserved; keyboard behavior and UIA patterns come from the control classes and are unchanged.
- Quill Dark plus Ember/Fjord/Heather accent variants (sparse overlays over Quill).

**Theme Manager + vision assist (Phase 4)**
- Theme Manager (Command Palette → Manage Themes): Apply, Duplicate, Rename, Delete, Export, Import, Open themes folder. **Deliberately modeless** with an inline name editor, per the modal-dialog rules — Apply restyles the owner window's live WebView2, and modal + editable text over a WebView2 is the documented dispatcher-deadlock pattern. Two-stop F6 ring, local Ctrl+Shift+P palette, focus restoration on close.
- `.quickmailtheme` export/import with plain-language validation errors (names the key and the bad value); import re-ids on collision.
- Commands: `theme.manager.open`, `theme.next`/`theme.previous` (announce the new theme name), and hotkey-assignable `theme.apply.{id}` per theme (the `view.saved.{id}` pattern).
- Vision toggles: always-underline links, thicker focus indicators (2px → 4px via `Theme.FocusThickness`), force theme colors onto message content (off by default; sender HTML renders as authored otherwise).

## Accessibility
- All announcements go through `AccessibilityHelper.Announce` with categories: theme/HC changes → Status, manager outcomes → Result, one first-focus list hint → Hint. Announced once, from one place — never doubled.
- Theme switching never moves focus, collapses trees, or clears selection; the only re-render is the reading-pane document.
- Every built-in theme passes the WCAG contrast policy **as a unit test** (4.5:1 text, 3:1 indicators, status colors on their tints and on the window background).

## Deviations from the spec draft
1. **Theme Manager is modeless** (spec sketched ShowDialog) — see above; same pattern and rationale as GrabAddressesDialog.
2. **Quill `textDisabled` is `#7E858C`**, not the draft's `#8A9099` — the draft value measured 2.90:1 on surface/chrome backgrounds and failed the 3:1 floor the contrast test enforces.
3. **Unread accent bar shares the row edge with the flag color bar** (flag 4px outer, unread 3px inner); SemiBold stays the primary unread cue.

## Tests
1003 tests pass, including new: `ThemeDefinitionTests`, `BuiltInThemeTests` (parse + WCAG contrast), `ThemeServiceTests` (HC passthrough, atomic apply, CSS bridge, import/export), `ThemeManagerViewModelTests`, `AppearanceSettingsTests` (config round-trip + VM persistence), `ThemeRegressionGuardTests` (no new hardcoded colors / numeric font sizes in view XAML outside a reviewed allowlist), and XamlParseTests for ThemedControls and ThemeManagerWindow. `build.bat smoke` passes.

## Docs
- User guide: Appearance settings, Theme Manager, HC behavior, hand-editing theme files with the full token list.
- `docs/THEMING-TESTING-GUIDE.md`: standalone usage + structured test-pass guide (not linked from the user guide yet); a test build is already posted on #177.

## Remaining before merge
The spec's manual acceptance gates (§9, §10): a screen-reader keyboard walkthrough of every retemplated control, live HC toggle while running, theme switch with a message open, the 150%+ text-scale walkthrough, and `--online` spot checks. The testing guide scripts all of these.

Closes #177.

🤖 Generated with [Claude Code](https://claude.com/claude-code)