### PR TITLE
Harden theme-file handling against untrusted files (#183)

### DIFF
--- a/QuickMail.Tests/ThemeDefinitionTests.cs
+++ b/QuickMail.Tests/ThemeDefinitionTests.cs
@@ -139,6 +139,66 @@ public class ThemeDefinitionTests
     }
 
     [Theory]
+    [InlineData("../../escape")]     // path traversal
+    [InlineData("a/b")]
+    [InlineData("a\\b")]
+    [InlineData("a:b")]
+    [InlineData("has space")]
+    [InlineData("emoji\U0001F600")]
+    public void Parse_InvalidIdCharset_IsRejected(string id)
+    {
+        var json = MinimalJson.Replace("\"id\": \"test-theme\"", $"\"id\": {System.Text.Json.JsonSerializer.Serialize(id)}");
+        var ex = Assert.Throws<ThemeFormatException>(() => ThemeDefinition.Parse(json));
+        Assert.Contains("id", ex.Message);
+    }
+
+    [Theory]
+    [InlineData("my-theme")]
+    [InlineData("Quill")]
+    [InlineData("theme.v2_final")]
+    [InlineData("0f9c8b7a6d5e4f3a2b1c0d9e8f7a6b5c")] // guid "N"
+    public void Parse_ValidId_IsAccepted(string id)
+    {
+        var json = MinimalJson.Replace("\"id\": \"test-theme\"", $"\"id\": \"{id}\"");
+        Assert.Equal(id, ThemeDefinition.Parse(json).Id);
+    }
+
+    [Fact]
+    public void Parse_OverlongId_IsRejected()
+    {
+        var json = MinimalJson.Replace("\"id\": \"test-theme\"", $"\"id\": \"{new string('a', 200)}\"");
+        var ex = Assert.Throws<ThemeFormatException>(() => ThemeDefinition.Parse(json));
+        Assert.Contains("id", ex.Message);
+    }
+
+    [Theory]
+    [InlineData("line\\nbreak")]  // JSON \n → real newline in the value
+    [InlineData("nul\\u0000char")]
+    [InlineData("tab\\tchar")]
+    public void Parse_NameWithControlChar_IsRejected(string nameLiteral)
+    {
+        var json = MinimalJson.Replace("\"name\": \"Test Theme\"", $"\"name\": \"{nameLiteral}\"");
+        var ex = Assert.Throws<ThemeFormatException>(() => ThemeDefinition.Parse(json));
+        Assert.Contains("name", ex.Message);
+    }
+
+    [Fact]
+    public void Parse_OverlongName_IsRejected()
+    {
+        var json = MinimalJson.Replace("\"name\": \"Test Theme\"", $"\"name\": \"{new string('a', 200)}\"");
+        var ex = Assert.Throws<ThemeFormatException>(() => ThemeDefinition.Parse(json));
+        Assert.Contains("name", ex.Message);
+    }
+
+    [Fact]
+    public void Parse_NameWithSpacesAndParens_IsAccepted()
+    {
+        // The import flow appends " (imported)" to names — must remain parseable.
+        var json = MinimalJson.Replace("\"name\": \"Test Theme\"", "\"name\": \"Ember (imported)\"");
+        Assert.Equal("Ember (imported)", ThemeDefinition.Parse(json).Name);
+    }
+
+    [Theory]
     [InlineData("Segoe UI")]
     [InlineData("Times New Roman")]
     [InlineData("Comic Sans MS")]

--- a/QuickMail.Tests/ThemeDefinitionTests.cs
+++ b/QuickMail.Tests/ThemeDefinitionTests.cs
@@ -138,6 +138,59 @@ public class ThemeDefinitionTests
         Assert.Throws<ThemeFormatException>(() => ThemeDefinition.Parse("this is not json"));
     }
 
+    [Theory]
+    [InlineData("Segoe UI")]
+    [InlineData("Times New Roman")]
+    [InlineData("Comic Sans MS")]
+    [InlineData("Cascadia Code")]
+    [InlineData("PT Sans-Narrow")]
+    public void Parse_LegitimateFontFamily_IsAccepted(string font)
+    {
+        var json = MinimalJson.Replace("\"fontFamily\": \"Segoe UI\"", $"\"fontFamily\": \"{font}\"");
+        var theme = ThemeDefinition.Parse(json);
+        Assert.Equal(font, theme.Typography.FontFamily);
+    }
+
+    [Theory]
+    [InlineData("file:///C:/evil.ttf#X")]          // URI location#family — the core threat
+    [InlineData("\\\\attacker\\share\\evil.ttf#X")] // UNC path
+    [InlineData("pack://application:,,,/x#Y")]      // pack URI
+    [InlineData("Segoe UI#Arial")]                  // bare '#'
+    [InlineData("C:/Windows/Fonts/x")]              // path separators + ':'
+    public void Parse_MaliciousFontFamily_IsRejected(string font)
+    {
+        var json = MinimalJson.Replace("\"fontFamily\": \"Segoe UI\"", $"\"fontFamily\": {System.Text.Json.JsonSerializer.Serialize(font)}");
+        var ex = Assert.Throws<ThemeFormatException>(() => ThemeDefinition.Parse(json));
+        Assert.Contains("fontFamily", ex.Message);
+    }
+
+    [Fact]
+    public void Parse_MaliciousMonoFontFamily_IsRejected()
+    {
+        var json = MinimalJson.Replace("\"monoFontFamily\": \"Cascadia Code\"", "\"monoFontFamily\": \"file:///C:/evil.ttf#X\"");
+        var ex = Assert.Throws<ThemeFormatException>(() => ThemeDefinition.Parse(json));
+        Assert.Contains("monoFontFamily", ex.Message);
+    }
+
+    [Theory]
+    [InlineData("Segoe UI", true)]
+    [InlineData("", false)]
+    [InlineData("  ", false)]
+    [InlineData("evil#font", false)]
+    [InlineData("a/b", false)]
+    [InlineData("a\\b", false)]
+    [InlineData("a:b", false)]
+    public void IsValidFontFamily_ClassifiesValues(string value, bool expected)
+    {
+        Assert.Equal(expected, ThemeDefinition.IsValidFontFamily(value));
+    }
+
+    [Fact]
+    public void IsValidFontFamily_OverlongValue_IsRejected()
+    {
+        Assert.False(ThemeDefinition.IsValidFontFamily(new string('a', 200)));
+    }
+
     [Fact]
     public void HexToArgb_ParsesAllThreeForms()
     {

--- a/QuickMail.Tests/ThemeServiceTests.cs
+++ b/QuickMail.Tests/ThemeServiceTests.cs
@@ -289,6 +289,63 @@ public class ThemeServiceTests : IDisposable
     }
 
     [StaFact]
+    public void ImportTheme_OversizedFile_IsRejectedBeforeParsing()
+    {
+        using var svc = NewService();
+        svc.Initialize(Config("parchment"));
+
+        var path = Path.Combine(_dir, "huge.quickmailtheme");
+        Directory.CreateDirectory(_dir);
+        // One byte over the cap is enough; content need not be valid JSON — the
+        // size check must fire before any read/parse.
+        File.WriteAllBytes(path, new byte[ThemeDefinition.MaxFileBytes + 1]);
+
+        var ex = Assert.Throws<ThemeFormatException>(() => svc.ImportTheme(path));
+        Assert.Contains("too large", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [StaFact]
+    public void ReadThemeFile_OversizedFile_Throws()
+    {
+        Directory.CreateDirectory(_dir);
+        var path = Path.Combine(_dir, "huge.json");
+        File.WriteAllBytes(path, new byte[ThemeDefinition.MaxFileBytes + 1]);
+
+        Assert.Throws<ThemeFormatException>(() => ThemeStore.ReadThemeFile(path));
+    }
+
+    [StaFact]
+    public void LoadUserThemes_SkipsOversizedFile()
+    {
+        var themesFolder = Path.Combine(_dir, "themes");
+        Directory.CreateDirectory(themesFolder);
+        File.WriteAllBytes(Path.Combine(themesFolder, "huge.json"), new byte[ThemeDefinition.MaxFileBytes + 1]);
+
+        var store = new ThemeStore(new ProfileContext(_dir));
+        // The oversized file is skipped (logged), not thrown, and never appears.
+        Assert.Empty(store.LoadUserThemes());
+    }
+
+    [StaFact]
+    public void SaveUserTheme_MaliciousIdWithSeparators_StaysInThemesFolder()
+    {
+        var store = new ThemeStore(new ProfileContext(_dir));
+        var theme = ThemeDefinition.Parse("""
+            { "formatVersion": 1, "id": "../../escape", "name": "Escape", "base": "light" }
+            """);
+
+        store.SaveUserTheme(theme);
+
+        // The id's separators are sanitized to '-', so the file lands directly in the
+        // themes folder and nothing is written outside it.
+        var themesFolder = Path.Combine(_dir, "themes");
+        var written = Directory.GetFiles(themesFolder, "*.json");
+        Assert.Single(written);
+        Assert.Equal(Path.GetFullPath(themesFolder),
+            Path.GetFullPath(Path.GetDirectoryName(written[0])!));
+    }
+
+    [StaFact]
     public void DeleteUserTheme_WhenActive_FallsBackToSystem()
     {
         using var svc = NewService();

--- a/QuickMail.Tests/ThemeServiceTests.cs
+++ b/QuickMail.Tests/ThemeServiceTests.cs
@@ -219,6 +219,21 @@ public class ThemeServiceTests : IDisposable
     }
 
     [StaFact]
+    public void BuildMessageCss_InvalidFontOverride_DoesNotReachCss()
+    {
+        using var svc = NewService();
+        // A hand-edited config font that tries to break out of the CSS string.
+        svc.Initialize(Config("parchment", font: "x;} body{display:none"));
+
+        var css = svc.BuildMessageCss(forceOnContent: false);
+
+        // The invalid override is rejected; the CSS falls back to the theme font and
+        // the injection payload never appears in the reading-pane CSS.
+        Assert.DoesNotContain("display:none", css);
+        Assert.DoesNotContain("x;}", css);
+    }
+
+    [StaFact]
     public void BuildMessageCss_ForceOnContent_AppendsImportantOverrides()
     {
         using var svc = NewService();
@@ -330,9 +345,10 @@ public class ThemeServiceTests : IDisposable
     public void SaveUserTheme_MaliciousIdWithSeparators_StaysInThemesFolder()
     {
         var store = new ThemeStore(new ProfileContext(_dir));
-        var theme = ThemeDefinition.Parse("""
-            { "formatVersion": 1, "id": "../../escape", "name": "Escape", "base": "light" }
-            """);
+        // Parse now rejects a traversal id outright, so build the object directly to
+        // exercise PathForId's sanitization + containment for a theme that did not
+        // come through Parse (belt-and-suspenders).
+        var theme = new ThemeDefinition { Id = "../../escape", Name = "Escape", Base = "light" };
 
         store.SaveUserTheme(theme);
 

--- a/QuickMail/Models/ThemeDefinition.cs
+++ b/QuickMail/Models/ThemeDefinition.cs
@@ -55,6 +55,17 @@ public class ThemeDefinition
     public const double MinBaseFontSize = 9;
     public const double MaxBaseFontSize = 24;
 
+    /// <summary>
+    /// Maximum size, in bytes, of a theme file we will read. A legitimate theme is
+    /// a few KB; a much larger file (dropped into the themes folder or chosen at
+    /// import) is rejected before <c>File.ReadAllText</c> so an untrusted file can't
+    /// force a large allocation. Enforced by both load paths (folder scan, import).
+    /// </summary>
+    public const long MaxFileBytes = 256 * 1024;
+
+    /// <summary>Longest font-family value we accept from a theme file.</summary>
+    private const int MaxFontFamilyLength = 128;
+
     public int FormatVersion { get; set; } = CurrentFormatVersion;
 
     /// <summary>Stable identifier, e.g. "quill" or a Guid string for user themes.</summary>
@@ -169,9 +180,9 @@ public class ThemeDefinition
         if (raw.Typography != null)
         {
             if (!string.IsNullOrWhiteSpace(raw.Typography.FontFamily))
-                theme.Typography.FontFamily = raw.Typography.FontFamily.Trim();
+                theme.Typography.FontFamily = ValidateFontFamily(raw.Typography.FontFamily.Trim(), "fontFamily");
             if (!string.IsNullOrWhiteSpace(raw.Typography.MonoFontFamily))
-                theme.Typography.MonoFontFamily = raw.Typography.MonoFontFamily.Trim();
+                theme.Typography.MonoFontFamily = ValidateFontFamily(raw.Typography.MonoFontFamily.Trim(), "monoFontFamily");
             if (raw.Typography.BaseFontSize is double size)
             {
                 if (double.IsNaN(size) || size < MinBaseFontSize || size > MaxBaseFontSize)
@@ -254,6 +265,42 @@ public class ThemeDefinition
         };
         foreach (var (k, v) in Colors) copy.Colors[k] = v;
         return copy;
+    }
+
+    // ── Font-family validation ──────────────────────────────────────────────────
+
+    /// <summary>
+    /// True when <paramref name="value"/> is a plain font-family name safe to hand
+    /// to <c>new FontFamily(...)</c>. A WPF <c>FontFamily</c> string is not just a
+    /// family name: a value containing <c>#</c> is treated as
+    /// <c>baseUri#familyName</c>, so a theme could point the font loader at an
+    /// attacker-chosen resource (e.g. <c>file:///C:/evil.ttf#X</c>, a UNC/remote
+    /// URI, or a pack URI). We therefore allow only characters that appear in real
+    /// family names — letters, digits, spaces, and a small punctuation set — and
+    /// reject URI schemes, <c>#</c>, path separators, and <c>:</c> by construction.
+    /// </summary>
+    public static bool IsValidFontFamily(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value) || value.Length > MaxFontFamilyLength)
+            return false;
+        foreach (var ch in value)
+        {
+            if (char.IsLetterOrDigit(ch)) continue;
+            // Punctuation seen in legitimate family names ("Times New Roman",
+            // "Comic Sans MS", "Bahnschrift SemiBold", "PT Sans-Narrow").
+            if (ch is ' ' or '-' or '_' or '.' or '&' or '\'') continue;
+            return false;
+        }
+        return true;
+    }
+
+    private static string ValidateFontFamily(string value, string jsonKey)
+    {
+        if (!IsValidFontFamily(value))
+            throw new ThemeFormatException(
+                $"The \"{jsonKey}\" value \"{value}\" is not a plain font-family name. " +
+                "Use only letters, digits, spaces, and simple punctuation, e.g. \"Segoe UI\".");
+        return value;
     }
 
     // ── Hex validation ────────────────────────────────────────────────────────

--- a/QuickMail/Models/ThemeDefinition.cs
+++ b/QuickMail/Models/ThemeDefinition.cs
@@ -66,6 +66,16 @@ public class ThemeDefinition
     /// <summary>Longest font-family value we accept from a theme file.</summary>
     private const int MaxFontFamilyLength = 128;
 
+    /// <summary>
+    /// Longest accepted theme <see cref="Id"/> and <see cref="Name"/>. Both come
+    /// from an untrusted file; with the file-size cap allowing up to
+    /// <see cref="MaxFileBytes"/>, an unbounded name/id would otherwise flow into
+    /// screen-reader announcements, the command palette, log lines, and (for id) a
+    /// filename — so they are length- and content-limited at parse time.
+    /// </summary>
+    private const int MaxIdLength = 64;
+    private const int MaxNameLength = 100;
+
     public int FormatVersion { get; set; } = CurrentFormatVersion;
 
     /// <summary>Stable identifier, e.g. "quill" or a Guid string for user themes.</summary>
@@ -157,8 +167,8 @@ public class ThemeDefinition
         var theme = new ThemeDefinition
         {
             FormatVersion = version,
-            Id   = raw.Id.Trim(),
-            Name = raw.Name.Trim(),
+            Id   = ValidateId(raw.Id.Trim()),
+            Name = ValidateName(raw.Name.Trim()),
             Base = baseName,
         };
 
@@ -265,6 +275,49 @@ public class ThemeDefinition
         };
         foreach (var (k, v) in Colors) copy.Colors[k] = v;
         return copy;
+    }
+
+    // ── Id / name validation ────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Validates the theme id. The id becomes both an on-disk filename
+    /// (<c>{id}.json</c>) and a <c>CommandRegistry</c> command id persisted to
+    /// config.ini, so it is restricted to an ASCII-safe charset — letters, digits,
+    /// '.', '_', '-'. This keeps id↔filename 1:1 (no lossy sanitization collisions)
+    /// and avoids Unicode-normalization surprises. Empty/whitespace is rejected by
+    /// the caller before this runs.
+    /// </summary>
+    private static string ValidateId(string id)
+    {
+        if (id.Length > MaxIdLength)
+            throw new ThemeFormatException(
+                $"The \"id\" is too long ({id.Length} characters). Keep it under {MaxIdLength}.");
+        foreach (var ch in id)
+        {
+            if (char.IsAsciiLetterOrDigit(ch) || ch is '.' or '_' or '-') continue;
+            throw new ThemeFormatException(
+                $"The \"id\" value \"{id}\" contains an unsupported character. " +
+                "Use only letters, digits, '.', '_', or '-'.");
+        }
+        return id;
+    }
+
+    /// <summary>
+    /// Validates the display name. It is shown in menus and read aloud by screen
+    /// readers, so it is length-capped and must not contain control characters
+    /// (a line break or NUL would corrupt an announcement, menu, or log line).
+    /// Empty/whitespace is rejected by the caller before this runs.
+    /// </summary>
+    private static string ValidateName(string name)
+    {
+        if (name.Length > MaxNameLength)
+            throw new ThemeFormatException(
+                $"The \"name\" is too long ({name.Length} characters). Keep it under {MaxNameLength}.");
+        foreach (var ch in name)
+            if (char.IsControl(ch))
+                throw new ThemeFormatException(
+                    "The \"name\" contains a control character (such as a line break), which is not allowed.");
+        return name;
     }
 
     // ── Font-family validation ──────────────────────────────────────────────────

--- a/QuickMail/Services/ThemeService.cs
+++ b/QuickMail/Services/ThemeService.cs
@@ -535,7 +535,13 @@ public class ThemeService : IThemeService
         var sb = new StringBuilder();
         var t = _resolved;
 
-        var fontName = _fontFamilyOverride.Length > 0 ? _fontFamilyOverride : t.Typography.FontFamily;
+        // The theme font is validated at parse; the config override is not, and this
+        // CSS --qm-font is a second sink into the reading-pane WebView2. Validate the
+        // override here too so an invalid value can't reach the CSS string (the
+        // quote-strip below is a further belt on top of the charset allowlist).
+        var fontName = _fontFamilyOverride.Length > 0 && ThemeDefinition.IsValidFontFamily(_fontFamilyOverride)
+            ? _fontFamilyOverride
+            : t.Typography.FontFamily;
         var fontSize = Math.Round(t.Typography.BaseFontSize * _textScale, 1)
             .ToString(CultureInfo.InvariantCulture);
 

--- a/QuickMail/Services/ThemeService.cs
+++ b/QuickMail/Services/ThemeService.cs
@@ -251,7 +251,11 @@ public class ThemeService : IThemeService
         string json;
         try
         {
-            json = System.IO.File.ReadAllText(filePath);
+            json = ThemeStore.ReadThemeFile(filePath);
+        }
+        catch (ThemeFormatException)
+        {
+            throw; // already a friendly, user-facing message (e.g. file too large)
         }
         catch (Exception ex)
         {
@@ -506,6 +510,14 @@ public class ThemeService : IThemeService
 
     private static FontFamily SafeFontFamily(string name, string fallback)
     {
+        // Choke point for every font name that becomes a live FontFamily. Theme
+        // values are already validated at parse time; this also guards the config
+        // AppearanceFontFamily override, which reaches here without going through
+        // ThemeDefinition.Parse. A FontFamily string containing '#' is treated as
+        // baseUri#familyName, so an unvalidated value could point the loader at an
+        // arbitrary file/URI — reject anything that isn't a plain family name.
+        if (!ThemeDefinition.IsValidFontFamily(name))
+            return new FontFamily(fallback);
         try
         {
             return new FontFamily(name);

--- a/QuickMail/Services/ThemeStore.cs
+++ b/QuickMail/Services/ThemeStore.cs
@@ -77,7 +77,7 @@ public class ThemeStore
         {
             try
             {
-                var theme = ThemeDefinition.Parse(File.ReadAllText(file));
+                var theme = ThemeDefinition.Parse(ReadThemeFile(file));
                 theme.IsBuiltIn = false;
                 // A user file must not shadow a built-in id or duplicate another user id.
                 if (LoadBuiltIns().Any(b => string.Equals(b.Id, theme.Id, StringComparison.OrdinalIgnoreCase))
@@ -119,6 +119,33 @@ public class ThemeStore
     {
         // Theme ids come from JSON files; sanitize so an id can't escape the folder.
         var safe = string.Concat(id.Select(c => Path.GetInvalidFileNameChars().Contains(c) ? '-' : c));
-        return Path.Combine(_themesFolder, safe + ".json");
+        var result = Path.Combine(_themesFolder, safe + ".json");
+
+        // Belt-and-suspenders containment: the resolved path must be a direct child
+        // of the themes folder. The sanitization above already strips separators and
+        // ':', so this can't fire today — it's here so a future change to id handling
+        // can't silently reintroduce path traversal.
+        var folder = Path.TrimEndingDirectorySeparator(Path.GetFullPath(_themesFolder));
+        var resolvedParent = Path.GetDirectoryName(Path.GetFullPath(result));
+        if (!string.Equals(resolvedParent, folder, StringComparison.OrdinalIgnoreCase))
+            throw new InvalidOperationException(
+                $"Theme id \"{id}\" resolves to a path outside the themes folder.");
+
+        return result;
+    }
+
+    /// <summary>
+    /// Reads a theme file, rejecting anything larger than
+    /// <see cref="ThemeDefinition.MaxFileBytes"/> before allocating. Shared by the
+    /// folder loader and by import so an untrusted file can't force a large read.
+    /// </summary>
+    public static string ReadThemeFile(string path)
+    {
+        var length = new FileInfo(path).Length;
+        if (length > ThemeDefinition.MaxFileBytes)
+            throw new ThemeFormatException(
+                $"The theme file is too large ({length / 1024} KB). " +
+                $"Theme files must be under {ThemeDefinition.MaxFileBytes / 1024} KB.");
+        return File.ReadAllText(path);
     }
 }


### PR DESCRIPTION
Fixes #183.

Theme files are an explicitly shareable artifact — Export produces a `.quickmailtheme`, Import accepts one, and users can drop files into `{profile}\themes\`. Their parse/consume path is therefore attacker-influenced input. This is defensive hardening of our own app, addressing all three items in the issue.

## 1. Font-family validation (main concern)
A WPF `FontFamily` string is **not** just a family name — a value containing `#` is treated as `baseUri#familyName`, so a theme could specify `file:///C:/evil.ttf#X`, a UNC/remote URI, or a pack URI, pointing the font loader at an attacker-chosen resource.

- `ThemeDefinition.Parse` now validates `fontFamily`/`monoFontFamily` to plain family names (letters, digits, spaces, and simple punctuation only — no URI schemes, `#`, path separators `/ \`, or `:`) and throws a friendly `ThemeFormatException` naming the key on rejection.
- `ThemeService.SafeFontFamily` — the choke point where every font name becomes a live `FontFamily`, and the only place the config `AppearanceFontFamily` override reaches — validates again via `ThemeDefinition.IsValidFontFamily` and falls back to the default. Belt-and-suspenders for the parse guard, and primary protection for the config-override path.

## 2. File size cap (DoS / resource exhaustion)
Both load paths used `File.ReadAllText` with no limit. New `ThemeStore.ReadThemeFile` rejects files over **256 KB** (a legit theme is a few KB) via `FileInfo.Length` **before** reading. Folder load skips+logs the file; Import surfaces the friendly "too large" message.

## 3. Path containment (defense-in-depth)
`PathForId` already sanitizes the id by replacing `Path.GetInvalidFileNameChars()`. It now additionally asserts the resolved path is a **direct child** of the themes folder, so a future change to id handling can't silently reintroduce traversal.

## Tests
Added to `ThemeDefinitionTests` and `ThemeServiceTests`:
- Legitimate font families accepted; malicious values (`file://…#X`, UNC, pack URI, bare `#`, path+`:`) rejected for both `fontFamily` and `monoFontFamily`; `IsValidFontFamily` classification + length cap.
- Oversized file rejected at Import, at `ReadThemeFile`, and skipped by folder load.
- Malicious `../../escape` id stays contained in the themes folder.

Full suite: **1040 passing.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)