### PR TITLE
Add in-app bug reporting that does not require a GitHub account

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,6 +39,19 @@ jobs:
           }
           "@ | Set-Content -Path "QuickMail/Services/GoogleOAuthService.Credentials.cs" -Encoding UTF8
 
+      - name: Write bug-report credentials
+        shell: pwsh
+        env:
+          BUG_REPORT_TOKEN: ${{ secrets.BUG_REPORT_TOKEN }}
+        run: |
+          @"
+          namespace QuickMail.Services;
+          public partial class BugReportService
+          {
+              private const string AppOwnedToken = "$env:BUG_REPORT_TOKEN";
+          }
+          "@ | Set-Content -Path "QuickMail/Services/BugReportService.Credentials.cs" -Encoding UTF8
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
         with:

--- a/.github/workflows/quickmail.yml
+++ b/.github/workflows/quickmail.yml
@@ -34,6 +34,19 @@ jobs:
           }
           "@ | Set-Content -Path "QuickMail/Services/GoogleOAuthService.Credentials.cs" -Encoding UTF8
 
+      - name: Write bug-report credentials
+        shell: pwsh
+        env:
+          BUG_REPORT_TOKEN: ${{ secrets.BUG_REPORT_TOKEN }}
+        run: |
+          @"
+          namespace QuickMail.Services;
+          public partial class BugReportService
+          {
+              private const string AppOwnedToken = "$env:BUG_REPORT_TOKEN";
+          }
+          "@ | Set-Content -Path "QuickMail/Services/BugReportService.Credentials.cs" -Encoding UTF8
+
       - name: Test
         run: dotnet test QuickMail.Tests/QuickMail.Tests.csproj -c Release --logger "trx;LogFileName=results.trx"
 

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ Thumbs.db
 # Google OAuth client credentials (real values — copy from docs/GoogleOAuthService.Credentials.example)
 **/GoogleOAuthService.Credentials.cs
 
+# Bug-report app-owned GitHub token (real values — copy from docs/BugReportService.Credentials.example)
+**/BugReportService.Credentials.cs
+
 # Claude Code worktrees and local session data
 .claude/worktrees/
 .claude/settings.local.json

--- a/QuickMail.Tests/BugReportServiceTests.cs
+++ b/QuickMail.Tests/BugReportServiceTests.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using QuickMail.Models;
+using QuickMail.Services;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>In-memory credential store so tests can observe/seed what SubmitAsync reads and writes.</summary>
+sealed class FakeCredentialService : ICredentialService
+{
+    private readonly Dictionary<string, string> _secrets = new();
+
+    public void SavePassword(Guid accountId, string password) { }
+    public string? GetPassword(Guid accountId) => null;
+    public void DeletePassword(Guid accountId) { }
+
+    public void SaveSecret(string key, string value) => _secrets[key] = value;
+    public string? GetSecret(string key) => _secrets.TryGetValue(key, out var v) ? v : null;
+    public void DeleteSecret(string key) => _secrets.Remove(key);
+}
+
+/// <summary>Routes requests to a caller-supplied responder instead of the network.</summary>
+sealed class FakeHttpMessageHandler : HttpMessageHandler
+{
+    private readonly Func<HttpRequestMessage, HttpResponseMessage> _responder;
+    public HttpRequestMessage? LastRequest { get; private set; }
+    public string? LastRequestBody { get; private set; }
+
+    public FakeHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> responder) => _responder = responder;
+
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        LastRequest = request;
+        LastRequestBody = request.Content is null ? null : await request.Content.ReadAsStringAsync(cancellationToken);
+        return _responder(request);
+    }
+}
+
+public class BugReportServiceTests
+{
+    private static BugReportModel SampleReport(string summary = "Something broke") => new()
+    {
+        Summary = summary,
+        WhatHappened = "It broke when I clicked the button.",
+        WhatExpected = "It should not break.",
+        StepsToReproduce = "1. Click button\n2. Observe crash",
+    };
+
+    private static BugReportService MakeService(
+        Func<HttpRequestMessage, HttpResponseMessage> responder,
+        out FakeHttpMessageHandler handler,
+        FakeCredentialService? credentials = null)
+    {
+        handler = new FakeHttpMessageHandler(responder);
+        return new BugReportService(credentials ?? new FakeCredentialService(), handler);
+    }
+
+    [Fact]
+    public async Task SubmitAsync_NoTokenAvailable_FailsWithoutHttpCall()
+    {
+        var handlerCalled = false;
+        var service = MakeService(_ => { handlerCalled = true; return new HttpResponseMessage(HttpStatusCode.OK); }, out _);
+
+        var result = await service.SubmitAsync(SampleReport());
+
+        Assert.False(result.Success);
+        Assert.False(handlerCalled);
+        Assert.Null(result.IssueUrl);
+    }
+
+    [Fact]
+    public async Task SubmitAsync_Success_ReturnsIssueUrl()
+    {
+        var credentials = new FakeCredentialService();
+        credentials.SaveSecret("QuickMail.BugReportService.AppOwnedToken", "fake-token");
+
+        var service = MakeService(req => new HttpResponseMessage(HttpStatusCode.Created)
+        {
+            Content = new StringContent("{\"html_url\":\"https://github.com/kellylford/QuickMail/issues/999\"}"),
+        }, out var handler, credentials);
+
+        var result = await service.SubmitAsync(SampleReport());
+
+        Assert.True(result.Success);
+        Assert.Equal("https://github.com/kellylford/QuickMail/issues/999", result.IssueUrl);
+        Assert.Equal("Bearer", handler.LastRequest!.Headers.Authorization!.Scheme);
+        Assert.Equal("fake-token", handler.LastRequest!.Headers.Authorization!.Parameter);
+        Assert.Contains("user-reported", handler.LastRequestBody);
+        Assert.DoesNotContain("quickmail.log", handler.LastRequestBody, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task SubmitAsync_RevokedToken_FailsGracefully()
+    {
+        var credentials = new FakeCredentialService();
+        credentials.SaveSecret("QuickMail.BugReportService.AppOwnedToken", "bad-token");
+
+        var service = MakeService(_ => new HttpResponseMessage(HttpStatusCode.Unauthorized), out _, credentials);
+
+        var result = await service.SubmitAsync(SampleReport());
+
+        Assert.False(result.Success);
+        Assert.NotNull(result.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task SubmitAsync_NetworkFailure_FailsGracefully()
+    {
+        var credentials = new FakeCredentialService();
+        credentials.SaveSecret("QuickMail.BugReportService.AppOwnedToken", "fake-token");
+
+        var service = MakeService(_ => throw new HttpRequestException("offline"), out _, credentials);
+
+        var result = await service.SubmitAsync(SampleReport());
+
+        Assert.False(result.Success);
+        Assert.NotNull(result.ErrorMessage);
+    }
+
+    [Fact]
+    public void BuildFallbackUrl_EncodesSpecialCharacters()
+    {
+        var service = MakeService(_ => new HttpResponseMessage(HttpStatusCode.OK), out _);
+        var report = SampleReport("Crash with \"quotes\" & ampersands\nand newlines");
+
+        var url = service.BuildFallbackUrl(report);
+
+        Assert.StartsWith("https://github.com/kellylford/QuickMail/issues/new?", url);
+        Assert.DoesNotContain("\"", url);
+        Assert.DoesNotContain("\n", url);
+    }
+
+    [Fact]
+    public void BuildReportText_ContainsOnlyUserTextAndMetadata_NoLogContent()
+    {
+        var service = MakeService(_ => new HttpResponseMessage(HttpStatusCode.OK), out _);
+        var report = SampleReport();
+
+        var text = service.BuildReportText(report);
+
+        Assert.Contains(report.WhatHappened, text);
+        Assert.Contains(report.WhatExpected, text);
+        Assert.Contains(report.StepsToReproduce, text);
+        Assert.Contains("QuickMail version", text);
+        Assert.Contains("OS:", text);
+        Assert.DoesNotContain("quickmail.log", text, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/QuickMail.Tests/BugReportServiceTests.cs
+++ b/QuickMail.Tests/BugReportServiceTests.cs
@@ -136,6 +136,22 @@ public class BugReportServiceTests
     }
 
     [Fact]
+    public void BuildFallbackUrl_VeryLongReport_TruncatesBodyInsteadOfProducingAnUnusableUrl()
+    {
+        var service = MakeService(_ => new HttpResponseMessage(HttpStatusCode.OK), out _);
+        var report = SampleReport();
+        report.WhatHappened = new string('x', 10_000);
+
+        var url = service.BuildFallbackUrl(report);
+
+        // The encoded body must stay well short of what could fail via ShellExecute, and the
+        // truncated content should not just be silently cut — it should point the user back to
+        // the clipboard copy, which always has the full untruncated text.
+        Assert.True(url.Length < 6000, $"Fallback URL was {url.Length} chars — expected truncation to keep it well under browser/shell limits.");
+        Assert.Contains(Uri.EscapeDataString("truncated"), url);
+    }
+
+    [Fact]
     public void BuildReportText_ContainsOnlyUserTextAndMetadata_NoLogContent()
     {
         var service = MakeService(_ => new HttpResponseMessage(HttpStatusCode.OK), out _);

--- a/QuickMail.Tests/CommandRegistryTests.cs
+++ b/QuickMail.Tests/CommandRegistryTests.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Windows.Input;
 using QuickMail.Models;
 using QuickMail.Services;
+using QuickMail.ViewModels;
 using Xunit;
 
 namespace QuickMail.Tests;
@@ -228,5 +229,26 @@ public class CommandRegistryTests
         // Both live defaults must still fire — the orphan binding shouldn't suppress them.
         Assert.Equal("mail.reply",   reg.FindByGesture(Key.R, ModifierKeys.Control)!.Id);
         Assert.Equal("mail.forward", reg.FindByGesture(Key.F, ModifierKeys.Control)!.Id);
+    }
+
+    [Fact]
+    public void MainViewModel_RegistersReportBugCommand_InHelpCategoryWithNoDefaultHotkey()
+    {
+        var registry = new CommandRegistry();
+        var vm = new MainViewModel(
+            new StubImapMailService(), new StubAccountService(), new StubCredentialService(),
+            new StubLocalStoreService(), new StubOAuthService(), new StubSyncService(),
+            new StubConfigService(), registry, new StubViewService(), new StubRuleService(),
+            new StubSmtpService());
+        Assert.NotNull(vm);
+
+        var cmd = registry.FindById("help.reportBug");
+        Assert.NotNull(cmd);
+        Assert.Equal("Help", cmd!.Category);
+        Assert.Equal(Key.None, cmd.DefaultKey);
+
+        // Adjacent existing Help commands still resolve — the new registration didn't disturb them.
+        Assert.Equal("help.userGuide", registry.FindByGesture(Key.F1, ModifierKeys.None)!.Id);
+        Assert.NotNull(registry.FindById("help.about"));
     }
 }

--- a/QuickMail.Tests/ReportBugViewModelTests.cs
+++ b/QuickMail.Tests/ReportBugViewModelTests.cs
@@ -1,0 +1,126 @@
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows;
+using QuickMail.Models;
+using QuickMail.Services;
+using QuickMail.ViewModels;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+sealed class FakeBugReportService : IBugReportService
+{
+    public BugReportResult NextResult = BugReportResult.Succeeded("https://github.com/kellylford/QuickMail/issues/1");
+    public BugReportModel? LastSubmitted;
+
+    public Task<BugReportResult> SubmitAsync(BugReportModel report, CancellationToken cancellationToken = default)
+    {
+        LastSubmitted = report;
+        return Task.FromResult(NextResult);
+    }
+
+    public string BuildFallbackUrl(BugReportModel report) =>
+        $"https://github.com/kellylford/QuickMail/issues/new?title={report.Summary}";
+
+    public string BuildReportText(BugReportModel report) => $"BODY:{report.WhatHappened}";
+}
+
+public class ReportBugViewModelTests
+{
+    private static ReportBugViewModel Make(out FakeBugReportService service)
+    {
+        service = new FakeBugReportService();
+        return new ReportBugViewModel(service);
+    }
+
+    [Fact]
+    public async Task Send_BlankSummary_DoesNotCallServiceAndAnnouncesValidationError()
+    {
+        var vm = Make(out var service);
+        string? announced = null;
+        vm.AnnouncementRequested += (text, _) => announced = text;
+
+        await vm.SendCommand.ExecuteAsync(null);
+
+        Assert.Null(service.LastSubmitted);
+        Assert.Equal("Enter a summary before sending.", announced);
+    }
+
+    [Fact]
+    public async Task Send_Success_SetsIssueUrlAndRaisesSendSucceeded()
+    {
+        var vm = Make(out var service);
+        vm.Summary = "Something broke";
+        vm.WhatHappened = "It broke.";
+        service.NextResult = BugReportResult.Succeeded("https://github.com/kellylford/QuickMail/issues/42");
+
+        var succeeded = false;
+        vm.SendSucceeded += (_, _) => succeeded = true;
+
+        await vm.SendCommand.ExecuteAsync(null);
+
+        Assert.True(vm.IsSent);
+        Assert.False(vm.IsSending);
+        Assert.Equal("https://github.com/kellylford/QuickMail/issues/42", vm.IssueUrl);
+        Assert.True(succeeded);
+        Assert.Equal("Close", vm.CancelButtonLabel);
+    }
+
+    [Fact]
+    public async Task Send_Failure_ReEnablesSendAndRaisesSendFailed()
+    {
+        var vm = Make(out var service);
+        vm.Summary = "Something broke";
+        vm.WhatHappened = "It broke.";
+        service.NextResult = BugReportResult.Failed("no token");
+
+        var failed = false;
+        vm.SendFailed += (_, _) => failed = true;
+
+        await vm.SendCommand.ExecuteAsync(null);
+
+        Assert.False(vm.IsSent);
+        Assert.False(vm.IsSending);
+        Assert.True(vm.CanSend); // Send is re-enabled, not stuck disabled
+        Assert.True(failed);
+        Assert.Equal("Cancel", vm.CancelButtonLabel);
+    }
+
+    [Fact]
+    public void PreviewText_ReflectsCurrentFieldValues_NoLogContent()
+    {
+        var vm = Make(out _);
+        vm.WhatHappened = "the crash details";
+
+        Assert.Contains("the crash details", vm.PreviewText);
+        Assert.DoesNotContain("quickmail.log", vm.PreviewText);
+    }
+
+    // Note: CopyAndOpenCommand with a non-blank summary is intentionally not exercised here —
+    // it calls ExternalUriPolicy.TryOpenExternal, which would launch a real browser during the
+    // test run (see ExternalUriPolicyTests, which for the same reason only tests blocked
+    // schemes, never an allowed one). The blank-summary guard below is safe to test because it
+    // returns before either the clipboard or ExternalUriPolicy is touched.
+    [StaFact]
+    public void CopyAndOpen_BlankSummary_DoesNotCopyOrOpen()
+    {
+        var vm = Make(out var service);
+        Clipboard.SetText("unchanged");
+
+        vm.CopyAndOpenCommand.Execute(null);
+
+        Assert.Equal("unchanged", Clipboard.GetText());
+    }
+
+    [Fact]
+    public void Cancel_RaisesCloseRequested()
+    {
+        var vm = Make(out _);
+        var closed = false;
+        vm.CloseRequested += (_, _) => closed = true;
+
+        vm.CancelCommand.Execute(null);
+
+        Assert.True(closed);
+    }
+}

--- a/QuickMail.Tests/StubServices.cs
+++ b/QuickMail.Tests/StubServices.cs
@@ -72,6 +72,14 @@ sealed class StubCredentialService : ICredentialService
     public void DeleteSecret(string key) { }
 }
 
+sealed class StubBugReportService : IBugReportService
+{
+    public Task<BugReportResult> SubmitAsync(BugReportModel report, CancellationToken cancellationToken = default) =>
+        Task.FromResult(BugReportResult.Failed("stub"));
+    public string BuildFallbackUrl(BugReportModel report) => "https://github.com/kellylford/QuickMail/issues/new";
+    public string BuildReportText(BugReportModel report) => report.WhatHappened;
+}
+
 sealed class StubGoogleOAuthService : IGoogleOAuthService
 {
     public Task<string> GetAccessTokenAsync(string username, CancellationToken ct = default) => Task.FromResult(string.Empty);

--- a/QuickMail.Tests/UnitTest1.cs
+++ b/QuickMail.Tests/UnitTest1.cs
@@ -266,6 +266,15 @@ public class XamlParseTests
     }
 
     [StaFact]
+    public void ReportBugWindow_XamlParsesWithoutException()
+    {
+        EnsureApplication();
+        var window = new ReportBugWindow(new StubBugReportService());
+        Assert.NotNull(window);
+        window.Close();
+    }
+
+    [StaFact]
     public void SpellCheckDialog_XamlParsesWithoutException()
     {
         EnsureApplication();

--- a/QuickMail/App.xaml.cs
+++ b/QuickMail/App.xaml.cs
@@ -21,6 +21,7 @@ public partial class App : Application
     private GraphMailService? _graphBackend;
     private UpdateCheckService? _updateCheckService;
     private ThemeService? _themeService;
+    private BugReportService? _bugReportService;
 
     protected override void OnStartup(StartupEventArgs e)
     {
@@ -151,6 +152,7 @@ public partial class App : Application
             var calendarService = new CalendarService(calendarProvider);
 
             _updateCheckService = new UpdateCheckService();
+            _bugReportService   = new BugReportService(credentialService);
             var mainVm = new MainViewModel(
                 mailRouter, accountService, credentialService, localStore, oauthService, syncService, configService, commandRegistry, viewService, ruleService, smtpService,
                 onlineMode: onlineMode, flagService: flagService, calendarService: calendarService, changeNotifier: _changeNotifier, updateCheckService: _updateCheckService,
@@ -158,7 +160,7 @@ public partial class App : Application
             mainVm.RegisterAccountBackend = a => mailRouter.RegisterAccount(a.Id, BackendFor(a));
             mainVm.LoadAccountList(accounts);
 
-            var mainWindow = new MainWindow(mainVm, smtpService, accountService, credentialService, mailRouter, oauthService, commandRegistry, contactService, configService, localStore, viewService, ruleService, templateService, featureGate, flagService, customDictionary, themeService);
+            var mainWindow = new MainWindow(mainVm, smtpService, accountService, credentialService, mailRouter, oauthService, commandRegistry, contactService, configService, localStore, viewService, ruleService, templateService, featureGate, flagService, customDictionary, themeService, _bugReportService);
             mainWindow.Show();
         }
         catch (Exception ex)
@@ -181,6 +183,7 @@ public partial class App : Application
         _contactService?.Dispose();
         _templateService?.Dispose();
         _updateCheckService?.Dispose();
+        _bugReportService?.Dispose();
         _themeService?.Dispose();   // unsubscribes SystemParameters/SystemEvents static events
         base.OnExit(e);
     }

--- a/QuickMail/Models/BugReportModel.cs
+++ b/QuickMail/Models/BugReportModel.cs
@@ -1,0 +1,13 @@
+namespace QuickMail.Models;
+
+/// <summary>
+/// The content of a user-submitted bug report. Contains only what the user typed —
+/// no log content, by explicit product decision (see docs/planning/bug-reporting-pm-dev-spec.md §4.2).
+/// </summary>
+public sealed class BugReportModel
+{
+    public string Summary { get; set; } = string.Empty;
+    public string WhatHappened { get; set; } = string.Empty;
+    public string WhatExpected { get; set; } = string.Empty;
+    public string StepsToReproduce { get; set; } = string.Empty;
+}

--- a/QuickMail/Services/BugReportService.cs
+++ b/QuickMail/Services/BugReportService.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Web;
+using QuickMail.Models;
+
+namespace QuickMail.Services;
+
+/// <summary>
+/// Submits user-initiated bug reports directly to GitHub Issues using an app-owned,
+/// narrowly-scoped credential (see docs/planning/bug-reporting-pm-dev-spec.md, Decision A) —
+/// the user is never asked to sign into GitHub. Falls back to a pre-filled issue URL +
+/// clipboard text (<see cref="BuildFallbackUrl"/>/<see cref="BuildReportText"/>) if the
+/// direct path is unavailable or fails.
+/// </summary>
+public partial class BugReportService : IBugReportService, IDisposable
+{
+    private const string RepoOwner = "kellylford";
+    private const string RepoName  = "QuickMail";
+    private const string ApiUrl    = $"https://api.github.com/repos/{RepoOwner}/{RepoName}/issues";
+
+    // Distinct from CredentialService's per-account "QuickMail:{Guid}" key shape — this is a
+    // single app-owned secret, not tied to any mail account.
+    private const string TokenCredentialKey = "QuickMail.BugReportService.AppOwnedToken";
+
+    private static readonly string[] IssueLabels = ["bug", "user-reported"];
+
+    private readonly ICredentialService _credentials;
+    private readonly HttpClient _http;
+    private readonly CancellationTokenSource _cts = new();
+    private bool _disposed;
+
+    public BugReportService(ICredentialService credentials) : this(credentials, new HttpClientHandler())
+    {
+    }
+
+    // Internal overload so tests can substitute a fake HttpMessageHandler instead of hitting
+    // the real GitHub API.
+    internal BugReportService(ICredentialService credentials, HttpMessageHandler handler)
+    {
+        _credentials = credentials;
+        _http = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(15) };
+        _http.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("QuickMail", Helpers.AppVersion.Display));
+        _http.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github+json"));
+    }
+
+    public async Task<BugReportResult> SubmitAsync(BugReportModel report, CancellationToken cancellationToken = default)
+    {
+        var token = ResolveToken();
+        if (string.IsNullOrWhiteSpace(token))
+            return BugReportResult.Failed("No app-owned credential is available for automatic submission.");
+
+        try
+        {
+            using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _cts.Token);
+            using var request = new HttpRequestMessage(HttpMethod.Post, ApiUrl);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+            var payload = JsonSerializer.Serialize(new
+            {
+                title = report.Summary,
+                body = BuildReportText(report),
+                labels = IssueLabels,
+            });
+            request.Content = new StringContent(payload, Encoding.UTF8, "application/json");
+
+            using var response = await _http.SendAsync(request, linked.Token).ConfigureAwait(false);
+            var responseText = await response.Content.ReadAsStringAsync(linked.Token).ConfigureAwait(false);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                LogService.Log($"BugReportService: submit failed, status={(int)response.StatusCode}");
+                return BugReportResult.Failed($"GitHub returned status {(int)response.StatusCode}.");
+            }
+
+            using var doc = JsonDocument.Parse(responseText);
+            var issueUrl = doc.RootElement.TryGetProperty("html_url", out var urlEl) ? urlEl.GetString() : null;
+            if (string.IsNullOrEmpty(issueUrl))
+                return BugReportResult.Failed("GitHub did not return an issue URL.");
+
+            return BugReportResult.Succeeded(issueUrl);
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or JsonException
+                                       or OperationCanceledException or ObjectDisposedException)
+        {
+            LogService.Log("BugReportService: submit exception", ex);
+            return BugReportResult.Failed("Could not reach GitHub.");
+        }
+    }
+
+    public string BuildFallbackUrl(BugReportModel report)
+    {
+        var title = HttpUtility.UrlEncode(report.Summary ?? string.Empty);
+        var body  = HttpUtility.UrlEncode(BuildReportText(report));
+        return $"https://github.com/{RepoOwner}/{RepoName}/issues/new?title={title}&body={body}&labels=bug,user-reported";
+    }
+
+    public string BuildReportText(BugReportModel report)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("### What happened");
+        sb.AppendLine(report.WhatHappened);
+
+        if (!string.IsNullOrWhiteSpace(report.WhatExpected))
+        {
+            sb.AppendLine().AppendLine("### What you expected");
+            sb.AppendLine(report.WhatExpected);
+        }
+
+        if (!string.IsNullOrWhiteSpace(report.StepsToReproduce))
+        {
+            sb.AppendLine().AppendLine("### Steps to reproduce");
+            sb.AppendLine(report.StepsToReproduce);
+        }
+
+        sb.AppendLine().AppendLine("### Environment");
+        sb.AppendLine($"- QuickMail version: {Helpers.AppVersion.Display}");
+        sb.AppendLine($"- OS: {Environment.OSVersion.VersionString}");
+        sb.AppendLine($"- .NET runtime: {Environment.Version}");
+
+        return sb.ToString();
+    }
+
+    // Checks the credential store first (in case a future settings UI ever lets a user override
+    // it), otherwise falls back to the build-embedded token and caches it into the store — same
+    // resolve-then-cache shape as Quill's effective_github_token(), adapted to this codebase's
+    // existing ICredentialService rather than a new storage mechanism.
+    private string? ResolveToken()
+    {
+        var stored = _credentials.GetSecret(TokenCredentialKey);
+        if (!string.IsNullOrWhiteSpace(stored)) return stored;
+
+        if (string.IsNullOrWhiteSpace(AppOwnedToken)) return null;
+
+        _credentials.SaveSecret(TokenCredentialKey, AppOwnedToken);
+        return AppOwnedToken;
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        _cts.Cancel();
+        _cts.Dispose();
+        _http.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/QuickMail/Services/BugReportService.cs
+++ b/QuickMail/Services/BugReportService.cs
@@ -5,7 +5,6 @@ using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Web;
 using QuickMail.Models;
 
 namespace QuickMail.Services;
@@ -92,12 +91,23 @@ public partial class BugReportService : IBugReportService, IDisposable
         }
     }
 
+    // Browsers/shell APIs impose practical URL length limits; a very long report would
+    // otherwise silently fail to open via ShellExecute. The full, untruncated text always
+    // reaches the user separately via clipboard copy (ReportBugViewModel.CopyAndOpen), so
+    // truncating just this URL loses nothing the user can't already paste in full.
+    private const int MaxFallbackUrlBodyLength = 4000;
+
     public string BuildFallbackUrl(BugReportModel report)
     {
-        var title = HttpUtility.UrlEncode(report.Summary ?? string.Empty);
-        var body  = HttpUtility.UrlEncode(BuildReportText(report));
+        var title = Uri.EscapeDataString(report.Summary ?? string.Empty);
+        var body  = Uri.EscapeDataString(Truncate(BuildReportText(report), MaxFallbackUrlBodyLength));
         return $"https://github.com/{RepoOwner}/{RepoName}/issues/new?title={title}&body={body}&labels=bug,user-reported";
     }
+
+    private static string Truncate(string text, int maxLength) =>
+        text.Length <= maxLength
+            ? text
+            : text[..maxLength] + "\n\n…(truncated — the full report was copied to your clipboard)";
 
     public string BuildReportText(BugReportModel report)
     {

--- a/QuickMail/Services/IBugReportService.cs
+++ b/QuickMail/Services/IBugReportService.cs
@@ -1,0 +1,43 @@
+using System.Threading;
+using System.Threading.Tasks;
+using QuickMail.Models;
+
+namespace QuickMail.Services;
+
+/// <summary>Result of a bug-report submission attempt.</summary>
+public sealed class BugReportResult
+{
+    public bool Success { get; }
+    public string? IssueUrl { get; }
+    public string? ErrorMessage { get; }
+
+    private BugReportResult(bool success, string? issueUrl, string? errorMessage)
+    {
+        Success = success;
+        IssueUrl = issueUrl;
+        ErrorMessage = errorMessage;
+    }
+
+    public static BugReportResult Succeeded(string issueUrl) => new(true, issueUrl, null);
+    public static BugReportResult Failed(string errorMessage) => new(false, null, errorMessage);
+}
+
+public interface IBugReportService
+{
+    /// <summary>
+    /// Submits the report directly to GitHub using the app-owned credential. Never throws —
+    /// failures (missing credential, network error, non-success API response) are reported
+    /// via <see cref="BugReportResult.Success"/> being false.
+    /// </summary>
+    Task<BugReportResult> SubmitAsync(BugReportModel report, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Builds a pre-filled GitHub "new issue" URL for the fallback path. The user still needs
+    /// their own GitHub account to submit through this URL — see the fallback-path nuance in
+    /// docs/planning/bug-reporting-pm-dev-spec.md §2.1.
+    /// </summary>
+    string BuildFallbackUrl(BugReportModel report);
+
+    /// <summary>The full report text, formatted exactly as it would be sent, for clipboard copy.</summary>
+    string BuildReportText(BugReportModel report);
+}

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -1446,6 +1446,10 @@ public partial class MainViewModel : ObservableObject, IDisposable
         registry.Register(new CommandDefinition(
             id: "help.about", category: "Help", title: "About QuickMail",
             execute: () => AboutRequested?.Invoke(this, EventArgs.Empty)));
+
+        registry.Register(new CommandDefinition(
+            id: "help.reportBug", category: "Help", title: "Report a Bug",
+            execute: () => ReportBugRequested?.Invoke(this, EventArgs.Empty)));
     }
 
     // ── Startup ──────────────────────────────────────────────────────────────────
@@ -3921,6 +3925,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
     public event EventHandler<MailRule>? CreateRuleFromMessageRequested;
     public event EventHandler? TutorialRequested;
     public event EventHandler? AboutRequested;
+    public event EventHandler? ReportBugRequested;
 
     /// <summary>
     /// Raised when a Properties dialog should be shown. The View subscribes and

--- a/QuickMail/ViewModels/ReportBugViewModel.cs
+++ b/QuickMail/ViewModels/ReportBugViewModel.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using QuickMail.Helpers;
+using QuickMail.Models;
+using QuickMail.Services;
+
+namespace QuickMail.ViewModels;
+
+/// <summary>
+/// Backs the "Report a Bug" window. Holds only what the user typed plus non-sensitive
+/// auto-collected metadata — never reads the log file (see
+/// docs/planning/bug-reporting-pm-dev-spec.md §4.2, an explicit product decision, not an
+/// oversight to "improve" later without a new design pass).
+/// </summary>
+public partial class ReportBugViewModel : ObservableObject, IDisposable
+{
+    private readonly IBugReportService _bugReportService;
+    private CancellationTokenSource? _sendCts;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(PreviewText))]
+    private string _summary = string.Empty;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(PreviewText))]
+    private string _whatHappened = string.Empty;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(PreviewText))]
+    private string _whatExpected = string.Empty;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(PreviewText))]
+    private string _stepsToReproduce = string.Empty;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(CanSend))]
+    private bool _isSending;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(CancelButtonLabel))]
+    private bool _isSent;
+
+    [ObservableProperty]
+    private string? _issueUrl;
+
+    [ObservableProperty]
+    private string _statusMessage = string.Empty;
+
+    public bool CanSend => !IsSending;
+
+    /// <summary>"Cancel" before a send succeeds, "Close" afterward — one button, state-reflecting label.</summary>
+    public string CancelButtonLabel => IsSent ? "Close" : "Cancel";
+
+    /// <summary>Exactly what will be submitted — shown read-only before the user sends.</summary>
+    public string PreviewText => _bugReportService.BuildReportText(BuildModel());
+
+    public event Action<string, AnnouncementCategory>? AnnouncementRequested;
+    public event EventHandler? CloseRequested;
+
+    /// <summary>Fired after a successful send — the View moves focus to the issue-link control.</summary>
+    public event EventHandler? SendSucceeded;
+
+    /// <summary>Fired after a failed send — the View moves focus to the fallback button.</summary>
+    public event EventHandler? SendFailed;
+
+    public ReportBugViewModel(IBugReportService bugReportService)
+    {
+        _bugReportService = bugReportService;
+    }
+
+    private BugReportModel BuildModel() => new()
+    {
+        Summary          = Summary,
+        WhatHappened     = WhatHappened,
+        WhatExpected     = WhatExpected,
+        StepsToReproduce = StepsToReproduce,
+    };
+
+    [RelayCommand]
+    private async Task SendAsync()
+    {
+        if (string.IsNullOrWhiteSpace(Summary))
+        {
+            AnnouncementRequested?.Invoke("Enter a summary before sending.", AnnouncementCategory.Result);
+            return;
+        }
+
+        _sendCts?.Cancel();
+        _sendCts = new CancellationTokenSource();
+
+        IsSending     = true;
+        StatusMessage = "Sending report…";
+        AnnouncementRequested?.Invoke(StatusMessage, AnnouncementCategory.Status);
+
+        var result = await _bugReportService.SubmitAsync(BuildModel(), _sendCts.Token);
+
+        IsSending = false;
+
+        if (result.Success)
+        {
+            IsSent        = true;
+            IssueUrl      = result.IssueUrl;
+            StatusMessage = $"Report sent. Issue created: {result.IssueUrl}.";
+            AnnouncementRequested?.Invoke(StatusMessage, AnnouncementCategory.Result);
+            SendSucceeded?.Invoke(this, EventArgs.Empty);
+        }
+        else
+        {
+            StatusMessage = "Could not send the report automatically. Your report is ready to copy.";
+            AnnouncementRequested?.Invoke(StatusMessage, AnnouncementCategory.Result);
+            SendFailed?.Invoke(this, EventArgs.Empty);
+        }
+    }
+
+    [RelayCommand]
+    private void CopyAndOpen()
+    {
+        if (string.IsNullOrWhiteSpace(Summary))
+        {
+            AnnouncementRequested?.Invoke("Enter a summary before sending.", AnnouncementCategory.Result);
+            return;
+        }
+
+        var model = BuildModel();
+        Clipboard.SetText($"{Summary}\n\n{_bugReportService.BuildReportText(model)}");
+        StatusMessage = "Report copied. Opening GitHub in your browser.";
+        AnnouncementRequested?.Invoke(StatusMessage, AnnouncementCategory.Result);
+        ExternalUriPolicy.TryOpenExternal(_bugReportService.BuildFallbackUrl(model));
+    }
+
+    [RelayCommand]
+    private void OpenIssue()
+    {
+        if (!string.IsNullOrEmpty(IssueUrl))
+            ExternalUriPolicy.TryOpenExternal(IssueUrl);
+    }
+
+    [RelayCommand]
+    private void Cancel() => CloseRequested?.Invoke(this, EventArgs.Empty);
+
+    /// <summary>Cancels any in-flight Send so it doesn't outlive the window. Called from OnClosed.</summary>
+    public void Dispose()
+    {
+        _sendCts?.Cancel();
+        _sendCts?.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/QuickMail/Views/MainWindow.xaml
+++ b/QuickMail/Views/MainWindow.xaml
@@ -539,6 +539,10 @@
                           AutomationProperties.Name="Keyboard Tutorial"
                           Click="MenuKeyboardTutorial_Click"/>
                 <Separator/>
+                <MenuItem Header="_Report a Bug"
+                          AutomationProperties.Name="Report a Bug"
+                          Click="MenuReportBug_Click"/>
+                <Separator/>
                 <MenuItem Header="_About QuickMail"
                           AutomationProperties.Name="About QuickMail"
                           Click="MenuAbout_Click"/>

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -173,6 +173,7 @@ public partial class MainWindow : Window
     private readonly IFlagService? _flagService;
     private readonly ICustomDictionaryService? _customDictionary;
     private readonly IThemeService? _themeService;
+    private readonly IBugReportService? _bugReportService;
 
     // Last High Contrast state announced, so an HC transition is announced once
     // with the HC wording and everything else as "Theme changed to …".
@@ -211,7 +212,8 @@ public partial class MainWindow : Window
         IFeatureGate featureGate,
         IFlagService? flagService = null,
         ICustomDictionaryService? customDictionary = null,
-        IThemeService? themeService = null)
+        IThemeService? themeService = null,
+        IBugReportService? bugReportService = null)
     {
         _vm = vm;
         _smtp = smtp;
@@ -230,6 +232,7 @@ public partial class MainWindow : Window
         _flagService = flagService;
         _customDictionary = customDictionary;
         _themeService = themeService;
+        _bugReportService = bugReportService;
 
         InitializeComponent();
         DataContext = vm;
@@ -290,6 +293,7 @@ public partial class MainWindow : Window
         vm.CreateRuleFromMessageRequested += (_, template) => OpenRulesManager(template);
         vm.TutorialRequested += (_, _) => ShowTutorial();
         vm.AboutRequested += (_, _) => ShowAboutDialog();
+        vm.ReportBugRequested += (_, _) => ShowReportBugWindow();
         vm.PropertiesRequested += propertiesVm =>
         {
             var win = new PropertiesWindow(propertiesVm) { Owner = this };
@@ -2720,6 +2724,23 @@ public partial class MainWindow : Window
     {
         var dlg = new AboutDialog { Owner = this };
         dlg.ShowDialog();
+    }
+
+    // Modeless — see the class doc comment on ReportBugWindow for why (editable text
+    // fields opened over this window's live WebView2 reading pane).
+    private void ShowReportBugWindow()
+    {
+        if (_bugReportService == null) return;
+
+        var previousFocus = Keyboard.FocusedElement as IInputElement;
+        var window = new ReportBugWindow(_bugReportService) { Owner = this };
+        window.Closed += (_, _) => previousFocus?.Focus();
+        window.Show();
+    }
+
+    private void MenuReportBug_Click(object sender, RoutedEventArgs e)
+    {
+        ShowReportBugWindow();
     }
 
     private void MenuAbout_Click(object sender, RoutedEventArgs e)

--- a/QuickMail/Views/ReportBugWindow.xaml
+++ b/QuickMail/Views/ReportBugWindow.xaml
@@ -4,7 +4,8 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         mc:Ignorable="d"
-        Title="Report a Bug"
+        Title="Report a Bug - QuickMail"
+        AutomationProperties.Name="Report a Bug - QuickMail"
         Height="620" Width="520"
         MinHeight="480" MinWidth="420"
         WindowStartupLocation="CenterOwner"
@@ -70,16 +71,28 @@
                    Text="Preview — exactly what will be sent:"
                    Margin="0,8,0,2"/>
 
-        <!-- ── Preview (F6 stop 2) ── -->
+        <!-- ── Preview (F6 stop 2) ──
+             Deliberately NOT IsReadOnly: a read-only TextBox doesn't support the same
+             character-by-character arrow-key navigation with a screen reader that an
+             editable one does. This is a genuine editable TextBox with edits blocked in
+             code-behind (PreviewBox_PreviewKeyDown / PreviewBox_PreviewTextInput / the Cut
+             and Delete CommandBindings below), so navigation behaves identically to the
+             fields above it while the content still can't actually be changed. -->
         <TextBox x:Name="PreviewBox"
                  Grid.Row="2"
                  Text="{Binding PreviewText, Mode=OneWay}"
                  AutomationProperties.Name="Preview"
-                 IsReadOnly="True"
                  AcceptsReturn="True"
                  TextWrapping="Wrap"
                  VerticalScrollBarVisibility="Auto"
-                 Margin="0,0,0,8"/>
+                 PreviewTextInput="PreviewBox_PreviewTextInput"
+                 PreviewKeyDown="PreviewBox_PreviewKeyDown"
+                 Margin="0,0,0,8">
+            <TextBox.CommandBindings>
+                <CommandBinding Command="ApplicationCommands.Cut" CanExecute="DisallowEdit_CanExecute"/>
+                <CommandBinding Command="ApplicationCommands.Delete" CanExecute="DisallowEdit_CanExecute"/>
+            </TextBox.CommandBindings>
+        </TextBox>
 
         <TextBlock Grid.Row="3"
                    Text="{Binding StatusMessage}"

--- a/QuickMail/Views/ReportBugWindow.xaml
+++ b/QuickMail/Views/ReportBugWindow.xaml
@@ -1,0 +1,122 @@
+<Window x:Class="QuickMail.Views.ReportBugWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        mc:Ignorable="d"
+        Title="Report a Bug"
+        Height="620" Width="520"
+        MinHeight="480" MinWidth="420"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="CanResizeWithGrip"
+        ShowInTaskbar="False"
+        PreviewKeyDown="Window_PreviewKeyDown"
+        Background="{DynamicResource Theme.WindowBackground}"
+        Foreground="{DynamicResource Theme.TextPrimary}"
+        FontFamily="{DynamicResource Theme.FontFamily}"
+        FontSize="{DynamicResource Theme.FontSizeBase}">
+
+    <Window.Resources>
+        <BooleanToVisibilityConverter x:Key="BoolToVisibility"/>
+    </Window.Resources>
+
+    <Grid Margin="12">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- ── Form fields (F6 stop 1) ── -->
+        <StackPanel x:Name="FormPanel" Grid.Row="0">
+            <TextBlock Text="Summary:" Margin="0,0,0,2"/>
+            <TextBox x:Name="SummaryBox"
+                     Text="{Binding Summary, UpdateSourceTrigger=PropertyChanged}"
+                     AutomationProperties.Name="Summary"
+                     MaxLength="200"
+                     Margin="0,0,0,8"/>
+
+            <TextBlock Text="What happened:" Margin="0,0,0,2"/>
+            <TextBox Text="{Binding WhatHappened, UpdateSourceTrigger=PropertyChanged}"
+                     AutomationProperties.Name="What happened"
+                     AcceptsReturn="True"
+                     TextWrapping="Wrap"
+                     Height="70"
+                     VerticalScrollBarVisibility="Auto"
+                     Margin="0,0,0,8"/>
+
+            <TextBlock Text="What you expected:" Margin="0,0,0,2"/>
+            <TextBox Text="{Binding WhatExpected, UpdateSourceTrigger=PropertyChanged}"
+                     AutomationProperties.Name="What you expected"
+                     AcceptsReturn="True"
+                     TextWrapping="Wrap"
+                     Height="50"
+                     VerticalScrollBarVisibility="Auto"
+                     Margin="0,0,0,8"/>
+
+            <TextBlock Text="Steps to reproduce:" Margin="0,0,0,2"/>
+            <TextBox Text="{Binding StepsToReproduce, UpdateSourceTrigger=PropertyChanged}"
+                     AutomationProperties.Name="Steps to reproduce"
+                     AcceptsReturn="True"
+                     TextWrapping="Wrap"
+                     Height="60"
+                     VerticalScrollBarVisibility="Auto"/>
+        </StackPanel>
+
+        <TextBlock Grid.Row="1"
+                   Text="Preview — exactly what will be sent:"
+                   Margin="0,8,0,2"/>
+
+        <!-- ── Preview (F6 stop 2) ── -->
+        <TextBox x:Name="PreviewBox"
+                 Grid.Row="2"
+                 Text="{Binding PreviewText, Mode=OneWay}"
+                 AutomationProperties.Name="Preview"
+                 IsReadOnly="True"
+                 AcceptsReturn="True"
+                 TextWrapping="Wrap"
+                 VerticalScrollBarVisibility="Auto"
+                 Margin="0,0,0,8"/>
+
+        <TextBlock Grid.Row="3"
+                   Text="{Binding StatusMessage}"
+                   Margin="0,0,0,4"
+                   TextWrapping="Wrap"/>
+
+        <Button x:Name="IssueLinkButton"
+                Grid.Row="4"
+                Content="{Binding IssueUrl, StringFormat='Open issue: {0}'}"
+                AutomationProperties.Name="Open issue in browser"
+                Command="{Binding OpenIssueCommand}"
+                Visibility="{Binding IsSent, Converter={StaticResource BoolToVisibility}}"
+                HorizontalAlignment="Left"
+                Margin="0,0,0,8"/>
+
+        <StackPanel Grid.Row="5"
+                    Orientation="Horizontal"
+                    HorizontalAlignment="Right">
+            <Button x:Name="SendButton"
+                    Content="_Send"
+                    IsDefault="True"
+                    AutomationProperties.Name="Send"
+                    Command="{Binding SendCommand}"
+                    IsEnabled="{Binding CanSend}"
+                    MinWidth="80"
+                    Margin="0,0,8,0"/>
+            <Button x:Name="CopyAndOpenButton"
+                    Content="_Copy report and open GitHub"
+                    AutomationProperties.Name="Copy report and open GitHub"
+                    Command="{Binding CopyAndOpenCommand}"
+                    MinWidth="80"
+                    Margin="0,0,8,0"/>
+            <Button x:Name="CancelButton"
+                    Content="{Binding CancelButtonLabel}"
+                    AutomationProperties.Name="{Binding CancelButtonLabel}"
+                    Command="{Binding CancelCommand}"
+                    MinWidth="80"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/QuickMail/Views/ReportBugWindow.xaml.cs
+++ b/QuickMail/Views/ReportBugWindow.xaml.cs
@@ -89,12 +89,43 @@ public partial class ReportBugWindow : Window
         }
     }
 
-    // Two logical F6 stops: the form fields, and the read-only preview. With exactly two
-    // stops, F6 and Shift+F6 both just toggle — there is no distinct "forward"/"reverse".
+    // Two logical F6 stops: the form fields, and the preview. With exactly two stops, F6 and
+    // Shift+F6 both just toggle — there is no distinct "forward"/"reverse".
     private void CycleFocus()
     {
         System.Windows.Controls.TextBox target = PreviewBox.IsKeyboardFocusWithin ? SummaryBox : PreviewBox;
         target.Focus();
+    }
+
+    // PreviewBox is intentionally not IsReadOnly (see the XAML comment above it) so a screen
+    // reader can arrow through it exactly like the editable fields above. These three handlers
+    // are what keep it non-editable instead: block every typed character, block the specific
+    // keys that would modify content (arrows/Home/End/paging/Ctrl+C/Ctrl+A all pass through
+    // untouched), and block Cut/Delete however they're invoked (keyboard, context menu, or the
+    // Edit menu). None of this affects what's actually submitted — SendAsync always rebuilds the
+    // report text fresh from the underlying fields, never from whatever this TextBox displays.
+    private void PreviewBox_PreviewTextInput(object sender, TextCompositionEventArgs e) => e.Handled = true;
+
+    private void PreviewBox_PreviewKeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.Key is Key.Delete or Key.Back)
+        {
+            e.Handled = true;
+        }
+        else if (e.Key == Key.Enter && Keyboard.Modifiers == ModifierKeys.None)
+        {
+            e.Handled = true;
+        }
+        else if (Keyboard.Modifiers == ModifierKeys.Control && e.Key is Key.V or Key.X)
+        {
+            e.Handled = true;
+        }
+    }
+
+    private void DisallowEdit_CanExecute(object sender, CanExecuteRoutedEventArgs e)
+    {
+        e.CanExecute = false;
+        e.Handled = true;
     }
 
     private void OpenCommandPalette()

--- a/QuickMail/Views/ReportBugWindow.xaml.cs
+++ b/QuickMail/Views/ReportBugWindow.xaml.cs
@@ -29,9 +29,9 @@ public partial class ReportBugWindow : Window
         DataContext = _vm;
 
         _vm.AnnouncementRequested += OnAnnouncementRequested;
-        _vm.CloseRequested        += (_, _) => Close();
-        _vm.SendSucceeded         += (_, _) => IssueLinkButton.Focus();
-        _vm.SendFailed            += (_, _) => CopyAndOpenButton.Focus();
+        _vm.CloseRequested        += OnCloseRequested;
+        _vm.SendSucceeded         += OnSendSucceeded;
+        _vm.SendFailed            += OnSendFailed;
 
         RegisterCommands();
 
@@ -40,6 +40,13 @@ public partial class ReportBugWindow : Window
 
     private void OnAnnouncementRequested(string text, AnnouncementCategory category) =>
         AccessibilityHelper.Announce(this, text, category: category);
+
+    // Named handlers (not lambdas) so OnClosed can unsubscribe them individually. Without this,
+    // a Send still in flight when the window closes resumes after Dispose() and — with the
+    // lambda still subscribed — calls Focus() on a control belonging to an already-closed window.
+    private void OnCloseRequested(object? sender, EventArgs e) => Close();
+    private void OnSendSucceeded(object? sender, EventArgs e) => IssueLinkButton.Focus();
+    private void OnSendFailed(object? sender, EventArgs e) => CopyAndOpenButton.Focus();
 
     private void RegisterCommands()
     {
@@ -101,6 +108,9 @@ public partial class ReportBugWindow : Window
     protected override void OnClosed(EventArgs e)
     {
         _vm.AnnouncementRequested -= OnAnnouncementRequested;
+        _vm.CloseRequested        -= OnCloseRequested;
+        _vm.SendSucceeded         -= OnSendSucceeded;
+        _vm.SendFailed            -= OnSendFailed;
         _vm.Dispose();
         base.OnClosed(e);
     }

--- a/QuickMail/Views/ReportBugWindow.xaml.cs
+++ b/QuickMail/Views/ReportBugWindow.xaml.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Windows;
+using System.Windows.Input;
+using QuickMail.Models;
+using QuickMail.Services;
+using QuickMail.ViewModels;
+
+namespace QuickMail.Views;
+
+/// <summary>
+/// "Report a Bug" window. Modeless by design (<see cref="Window.Show"/>, never
+/// <see cref="Window.ShowDialog"/>) — it has multiple editable TextBoxes and is opened over
+/// MainWindow, which hosts a live WebView2 reading pane. That combination is the exact
+/// profile documented in CLAUDE.md's Modal Dialog Rules as able to deadlock the UI thread
+/// (the GrabAddressesDialog incident); see docs/planning/bug-reporting-pm-dev-spec.md,
+/// Decision C.
+/// </summary>
+[SuppressMessage("Design", "CA1001", Justification = "_vm.Dispose() is called explicitly in OnClosed below; WPF does not call Dispose on Window instances, so implementing IDisposable on the Window itself would never be invoked.")]
+public partial class ReportBugWindow : Window
+{
+    private readonly ReportBugViewModel _vm;
+    private readonly CommandRegistry _registry = new();
+
+    public ReportBugWindow(IBugReportService bugReportService)
+    {
+        _vm = new ReportBugViewModel(bugReportService);
+        InitializeComponent();
+        DataContext = _vm;
+
+        _vm.AnnouncementRequested += OnAnnouncementRequested;
+        _vm.CloseRequested        += (_, _) => Close();
+        _vm.SendSucceeded         += (_, _) => IssueLinkButton.Focus();
+        _vm.SendFailed            += (_, _) => CopyAndOpenButton.Focus();
+
+        RegisterCommands();
+
+        Loaded += (_, _) => SummaryBox.Focus();
+    }
+
+    private void OnAnnouncementRequested(string text, AnnouncementCategory category) =>
+        AccessibilityHelper.Announce(this, text, category: category);
+
+    private void RegisterCommands()
+    {
+        _registry.Register(new CommandDefinition(
+            id: "reportbug.send", category: "Help", title: "Send Report",
+            execute: () => _vm.SendCommand.Execute(null),
+            defaultKey: Key.Enter, defaultModifiers: ModifierKeys.Control));
+
+        _registry.Register(new CommandDefinition(
+            id: "reportbug.copyAndOpen", category: "Help", title: "Copy Report and Open GitHub",
+            execute: () => _vm.CopyAndOpenCommand.Execute(null)));
+
+        _registry.Register(new CommandDefinition(
+            id: "reportbug.cancel", category: "Help", title: "Cancel / Close",
+            execute: () => _vm.CancelCommand.Execute(null),
+            defaultKey: Key.Escape, defaultModifiers: ModifierKeys.None));
+    }
+
+    private void Window_PreviewKeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.P && Keyboard.Modifiers == (ModifierKeys.Control | ModifierKeys.Shift))
+        {
+            OpenCommandPalette();
+            e.Handled = true;
+            return;
+        }
+
+        if (e.Key == Key.F6)
+        {
+            CycleFocus();
+            e.Handled = true;
+            return;
+        }
+
+        var cmd = _registry.FindByGesture(e.Key, Keyboard.Modifiers);
+        if (cmd != null && (cmd.IsAvailable?.Invoke() ?? true))
+        {
+            cmd.Execute();
+            e.Handled = true;
+        }
+    }
+
+    // Two logical F6 stops: the form fields, and the read-only preview. With exactly two
+    // stops, F6 and Shift+F6 both just toggle — there is no distinct "forward"/"reverse".
+    private void CycleFocus()
+    {
+        System.Windows.Controls.TextBox target = PreviewBox.IsKeyboardFocusWithin ? SummaryBox : PreviewBox;
+        target.Focus();
+    }
+
+    private void OpenCommandPalette()
+    {
+        var previousFocus = Keyboard.FocusedElement as IInputElement;
+        var palette = new CommandPaletteWindow(_registry) { Owner = this };
+        palette.ShowDialog();
+        (previousFocus ?? SummaryBox).Focus();
+    }
+
+    protected override void OnClosed(EventArgs e)
+    {
+        _vm.AnnouncementRequested -= OnAnnouncementRequested;
+        _vm.Dispose();
+        base.OnClosed(e);
+    }
+}

--- a/docs/BugReportService.Credentials.example
+++ b/docs/BugReportService.Credentials.example
@@ -1,0 +1,25 @@
+// To build QuickMail with in-app bug-report submission enabled:
+//
+// 1. In GitHub, create a fine-grained personal access token scoped to ONLY:
+//        Repository access: kellylford/QuickMail (this repo only)
+//        Permissions:       Issues -> Read and write
+//    No other repository access, no other permissions. Fine-grained tokens
+//    cannot be created via API/CLI — this is a manual step in the GitHub UI
+//    (Settings -> Developer settings -> Fine-grained tokens).
+// 2. Copy this file to:
+//        QuickMail/Services/BugReportService.Credentials.cs
+// 3. Fill in the token below.
+// 4. That file is gitignored and will never be committed.
+//
+// The distributed release binary includes the baked-in token; end users do
+// not need to configure anything. Without this file (or with the placeholder
+// left in place), the app-owned submission path is unavailable and the
+// feature falls back to the clipboard + browser path automatically — the
+// build still compiles and runs correctly either way.
+
+namespace QuickMail.Services;
+
+public partial class BugReportService
+{
+    private const string AppOwnedToken = "";
+}

--- a/docs/planning/bug-reporting-pm-dev-spec.md
+++ b/docs/planning/bug-reporting-pm-dev-spec.md
@@ -1,0 +1,368 @@
+# In-App Bug Reporting (No GitHub Sign-In Required) — PM & Dev Specification
+
+> Status: **Approved for implementation.** Open questions resolved 2026-07-06 (see §13.2 for decisions).
+>
+> **Tracking:** [Issue #186](https://github.com/kellylford/QuickMail/issues/186)
+
+---
+
+## Section 1: Executive Summary
+
+QuickMail today has no in-app way to report a bug — the only path is manually navigating to GitHub and filing an issue, which requires the reporter to have and sign into a GitHub account. That's a real barrier for non-developer users, and specifically for screen reader users who hit a rough edge and just want to describe it, not create a GitHub account first. This spec adds a **Help → Report a Bug** command that collects a short description, repro steps, and expected behavior, then submits it as a GitHub issue on `kellylford/QuickMail` **on the user's behalf**, using an app-owned credential rather than the user's own GitHub sign-in. If the direct submission path is unavailable (offline, credential missing), the app falls back to copying the report to the clipboard and opening a pre-filled GitHub issue form — the same two-path resilience pattern used by the Quill project (`../quill`), which QuickMail's evaluation of that project's design confirmed works well.
+
+---
+
+## Section 2: User Problem & Opportunity
+
+### 2.1 Current state (verified)
+
+| Surface | Today | Pain | Who feels it |
+|---|---|---|---|
+| Bug reporting | No `Help` menu command exists for reporting a bug — confirmed via `grep` for "report a bug"/"ReportBug"/"issues/new" across `MainWindow.xaml.cs` and `MainViewModel.cs`: no matches | The only path is manually going to `github.com/kellylford/QuickMail/issues/new` | All users; disproportionately non-developers and users without an existing GitHub account |
+| `Help` menu | Registered commands are `help.userGuide` (`ViewModels/MainViewModel.cs:1343`), `help.keyboardTutorial` (`:1443`), `help.about` (`:1447`) — no bug-report entry | No discoverable in-app entry point | Same |
+| Credential storage | `ICredentialService` (`Services/ICredentialService.cs:5-15`) already exposes `SaveSecret(string key, string value)` / `GetSecret(string key)` backed by Windows Credential Manager, used today for account passwords and OAuth secrets | Storage mechanism already exists; nothing currently uses it for an app-owned (non-per-account) secret | N/A — this is an asset, not a pain point |
+| External link launching | All `Process.Start`/ShellExecute calls must go through `Helpers.ExternalUriPolicy.TryOpenExternal` (`Helpers/ExternalUriPolicy.cs`), an allow-list of `http`/`https`/`mailto` schemes | N/A — existing safeguard this feature must reuse, not bypass | N/A |
+| Diagnostics | `LogService` (`Services/LogService.cs`) appends to `quickmail.log` under the active profile dir, but has no public accessor for the log file path today | A "attach recent log lines" feature needs a small addition (`LogService.LogFilePath`) | Developer triaging a report |
+| Version info | `Helpers.AppVersion.Display` (`Helpers/AppVersion.cs`) already computes a display version string, reused by the About dialog, SMTP User-Agent, and the update checker | Reusable as-is for the report's version field | N/A |
+
+**Reference implementation studied:** `../quill` (Python/wxPython) implements this via an app-owned GitHub token stored in OS-encrypted credential storage (`quill/core/feedback_token.py`, `quill/core/github/token_store.py`), submitting directly to the GitHub Issues API (`quill/core/issue_submit.py:55-92`), with a clipboard + pre-filled-issue-URL fallback (`quill/core/diagnostics.py:239-258`) if the token path is unavailable. Quill's stack is not portable to .NET, but the architecture — app-owned token, direct API submission, URL fallback, secret redaction before send — carries over directly.
+
+**Important nuance carried over from the Quill evaluation:** only the direct-API-with-app-owned-token path actually removes the GitHub sign-in requirement. The clipboard+URL fallback still opens `github.com`'s own issue form, which requires the user to be signed into *some* GitHub account to submit there. The fallback exists purely for resilience (offline, token revoked, API down) — it is not a second no-sign-in path, and this spec's acceptance criteria must not conflate the two.
+
+### 2.2 Target personas
+
+- **A non-developer user hitting a bug.** No GitHub account, doesn't want to create one. Wants to describe what happened and hit "Send" — done.
+- **A screen reader user reporting an accessibility rough edge.** May be frustrated in the moment; wants the shortest possible path from "this is wrong" to "reported," fully keyboard- and screen-reader-operable, with no surprise focus loss or silent failures.
+- **A user without internet access at the moment of reporting.** Wants to prepare a report now and finish sending it later without the app silently dropping the report.
+- **Kelly (developer/maintainer).** Wants incoming reports to already carry version/OS/log context so triage doesn't start with a round of "what version were you on?" — and wants no secrets (passwords, tokens) ever able to leak into a report.
+
+### 2.3 Why now
+
+- `ICredentialService.SaveSecret`/`GetSecret` already exists and is exactly the right shape for storing an app-owned token — no new storage mechanism needed.
+- `ExternalUriPolicy` already exists to safely hand URLs to the shell — the fallback path reuses it as-is.
+- The Quill investigation (this session) already did the comparative design work; the architecture is de-risked before this spec, not decided during it.
+
+---
+
+## Section 3: Design Principles
+
+1. **No GitHub account required for the primary path.** The app authenticates as itself (a narrowly-scoped, app-owned token), not as the user. The user never needs to sign into anything.
+2. **Never send anything the user hasn't seen.** A preview of the exact report content (including any log excerpt) is shown before the user confirms sending — no silent background collection.
+3. **Redact before it leaves the machine.** Passwords, tokens, and secret-shaped values are stripped from any included log excerpt, independent of user review, as a defense-in-depth backstop.
+4. **Fail loud, never fail silent.** If direct submission fails (network, API error, missing token), the user is told and is offered the fallback (clipboard + browser) — never a report that silently vanished.
+5. **Small blast radius if the embedded credential is ever extracted.** The app-owned token is a fine-grained GitHub PAT scoped to *only* `Issues: Write` on the single `kellylford/QuickMail` repository — no code, contents, admin, or other-repo scope. Worst case of extraction is spam issues on one repo, not a security compromise.
+
+---
+
+## Section 4: Feature Scope & Acceptance Criteria
+
+### 4.1 In scope (v1)
+
+| Feature | Setting / Shortcut | Default | Notes |
+|---|---|---|---|
+| "Report a Bug" command | `Help` menu, command `help.reportBug`, no default hotkey (discoverable via menu and Command Palette) | — | Opens `ReportBugWindow` |
+| Report form | — | — | Fields: summary (required), what happened (required), what you expected (optional), steps to reproduce (optional), include recent log excerpt (checkbox, default **off**) |
+| Redacted preview | — | — | Read-only text block showing exactly what will be sent, including the redacted log excerpt if included |
+| Direct submission | "Send" button | — | POSTs to GitHub Issues API using the app-owned token via `IBugReportService` |
+| Clipboard + browser fallback | "Copy report and open GitHub" button | — | Always visible, not just on failure — user can choose it directly |
+| Auto-collected context | — | Always included | App version (`AppVersion.Display`), OS version (`Environment.OSVersion`), .NET runtime version, active profile mode (normal/`--online`/`--profileDir`) |
+| Token provisioning | — | — | Fine-grained PAT (`Issues: Write` only, `kellylford/QuickMail` only), shipped embedded in the build, stored into `ICredentialService` on first use |
+
+### 4.2 Explicitly out of scope (v1)
+
+- **Screenshots or diagnostics bundles.** Unlike Quill, v1 does not attach screenshots, settings snapshots, or a document/message snapshot. A report is text only. (Console/log-image capture already has its own separate spec — `docs/planning/debug-screenshot-capture-pm-dev-spec.md` — and is not wired into this feature.)
+- **Crash-time auto-reporting.** This spec covers the user-initiated `Help -> Report a Bug` flow only. Hooking this into an unhandled-exception handler is a possible v2, not built here.
+- **Name/email fields.** Quill's legacy form collects optional name/email; this spec does not, since GitHub issues created by the app-owned token are already attributed to that account, and there's no user account to attach contact info to. If the maintainer wants to follow up, the GitHub issue thread is the channel.
+- **Screen-reader-name dropdown.** Per the project's "don't name a specific screen reader product in UI text" rule, there is no dropdown of AT product names. If a user wants to mention their AT, it goes in the free-text "what happened" field, same as any other detail.
+- **Rate limiting / spam prevention / captcha.** Same posture as Quill: relies on GitHub's own API rate limits. Not implemented in v1.
+- **Retry queue for offline submissions.** If direct submission fails, the user gets the fallback button in the same dialog. There is no persisted "pending reports" queue that auto-retries later.
+- **A generic feedback/feature-request channel.** This is a bug-report path specifically; feature requests still go through the existing manual GitHub flow (`.github/ISSUE_TEMPLATE/feature_request.md`).
+- **Any application log content, in any form.** This is an absolute no for v1, decided explicitly (not a default that could be revisited casually): logging is off by default, so a "collect logs" feature wouldn't even help most reporters; and when logging *is* on, `quickmail.log` can contain message subjects, sender/recipient names, and other content the user does not want copied into a public GitHub issue. Showing a preview before send is **not** treated as sufficient mitigation for this risk — the risk is the user not noticing or not understanding what a raw log line contains, not merely being unaware sending is about to happen. There is no log-excerpt checkbox, no log reading, and no log redaction helper in this feature at all. If log-assisted triage is wanted later, it needs its own explicit opt-in design, not a checkbox bolted onto this dialog.
+
+### 4.3 Acceptance criteria
+
+- `Help -> Report a Bug` opens a modeless window with focus on the Summary field.
+- Submitting with a valid app-owned token and network available creates a GitHub issue on `kellylford/QuickMail`, labeled `bug` and `user-reported`, and the dialog shows the resulting issue URL.
+- With the token missing, revoked, or the network unavailable, the Send action fails gracefully, tells the user what happened, and the "Copy report and open GitHub" fallback still works.
+- The report body sent to GitHub contains only what the user typed (summary, what happened, expected, steps) plus app version/OS/runtime metadata — no log content of any kind.
+- The dialog is fully operable with keyboard only and announces correctly with a screen reader (see §6, §7).
+
+---
+
+## Section 5: Architecture & Technical Decisions
+
+### 5.1 Key architectural decisions
+
+**Decision A — App-owned fine-grained PAT, stored via existing `ICredentialService.SaveSecret`.**
+
+**Alternatives:**
+1. Classic PAT with broad scope, embedded in the binary. **Con:** extractable via decompilation; if extracted, an attacker has broad account access. Rejected.
+2. A small serverless relay (Azure Function / Cloudflare Worker) holding the real token server-side, called by the app over HTTPS. **Con:** introduces a backend QuickMail doesn't otherwise have, plus hosting cost and an availability dependency the current architecture has no equivalent for. Rejected for v1 — noted as the natural v2 upgrade if abuse becomes a real problem.
+3. **Fine-grained GitHub PAT scoped to `Issues: Write` on `kellylford/QuickMail` only, embedded in the build, persisted into `ICredentialService` on first use.** **Chosen.** GitHub fine-grained tokens support exactly this single-repo, single-permission scoping, so the worst case if the token is ever extracted from the binary is spam issue creation on one repo — bounded and cheap to revoke/rotate, not a security compromise. This matches how Quill's own `feedback_hub` token is scoped (an app-owned credential, not a user credential) and reuses `ICredentialService.SaveSecret`/`GetSecret` exactly as it's already used for OAuth secrets — no new storage mechanism.
+
+**Rationale:** QuickMail has no backend today (per `docs/ARCHITECTURE.md`, the DI root is entirely local services), and standing one up (alternative 2) is disproportionate to the risk a correctly-scoped fine-grained token already bounds. If real abuse is observed post-ship, migrating to alternative 2 is a contained follow-up (swap the submission call in `IBugReportService`, no UI change).
+
+**Where the token value itself lives (resolved in §13.2):** this codebase already has a working pattern for exactly this problem — `GoogleOAuthService`'s Client ID/Secret are `const` fields in `GoogleOAuthService.Credentials.cs`, a file that is gitignored (`.gitignore:28`) and populated from a checked-in `docs/GoogleOAuthService.Credentials.example` template. Fine-grained GitHub PATs cannot be minted via API/CLI (GitHub requires creating them through the web UI), so this has to be a value the maintainer pastes in once, not something generated programmatically. The bug-report token follows the identical shape: a gitignored `BugReportService.Credentials.cs` partial-class file holding `private const string AppOwnedToken`, with a `docs/BugReportService.Credentials.example` template. Builds without the file compile fine (the feature degrades to fallback-only — see §5.1 note below), exactly mirroring how the app already behaves for contributors who don't set up Google OAuth.
+
+**Degradation without a token:** if `AppOwnedToken` is empty/placeholder (a contributor's local build, or the example file wasn't replaced), `IBugReportService.SubmitAsync` returns a failure immediately without attempting the HTTP call, and the UI falls back exactly as it would for a network failure — same code path as Decision C's failure handling, no special-case branch needed.
+
+**Decision B — Direct HTTP call via `HttpClient`, no GitHub SDK dependency.**
+
+**Alternatives:**
+1. Octokit.net NuGet package. **Con:** a full-featured GitHub SDK for a single `POST /repos/{owner}/{repo}/issues` call is a disproportionate dependency.
+2. **Plain `HttpClient` POST to the GitHub REST API.** **Chosen.** One JSON POST with an `Authorization: Bearer <token>` header and an `Accept: application/vnd.github+json` header; no new dependency.
+
+**Rationale:** Matches the codebase's existing preference for direct, minimal-dependency implementations (e.g., `ImapService`/`SmtpService` are hand-rolled, not wrapped SDKs).
+
+**Decision C — Modeless window (`.Show()`, not `.ShowDialog()`).**
+
+Per the enforced Modal Dialog Rules in `CLAUDE.md`: `ReportBugWindow` is opened over `MainWindow`, which hosts a live WebView2 (the reading pane), and contains multiple editable `TextBox` fields. That combination is the exact profile that has previously deadlocked the UI thread (`GrabAddressesDialog`, documented in `CLAUDE.md` and memory `grab_addresses_lockup.md`). `ReportBugWindow` follows the same fix already proven there: `new ReportBugWindow(...) { Owner = mainWindow }.Show()`, with Cancel/Escape wired explicitly to `Close()` (no `DialogResult`/`IsCancel` reliance), following the exact pattern in `GrabAddressesDialog.xaml.cs:64-75`.
+
+**Decision D — No log content, and therefore no redaction helper, in v1.**
+
+Per an explicit decision (§13.2, §4.2): this feature never reads `quickmail.log` or any other log file. Quill's design includes a redacted log excerpt as an opt-in; this spec deliberately does not carry that piece over. The submitted report body is limited to what the user typed plus non-sensitive auto-collected metadata (app version, OS version, .NET runtime version, profile mode) — none of which needs redaction. There is no `BugReportRedactor`, no `LogService.LogFilePath` accessor, and no log-related UI in this feature.
+
+**Decision E — No new service dependency graph beyond the existing DI root.**
+
+`IBugReportService`/`BugReportService` is constructed in `App.xaml.cs` alongside the other services, taking `ICredentialService` and `HttpClient` (a single shared instance, not one per call) as constructor dependencies — same wiring pattern as every other service in the DI root.
+
+### 5.2 Runtime mode compatibility
+
+| Mode | Effect |
+|---|---|
+| Normal | Full functionality — direct submission and fallback both available |
+| `--online` | No interaction — this feature never calls `LocalStoreService` |
+| `--profileDir <path>` | No interaction — this feature never reads the log file (Decision D), so profile-specific log isolation is not a concern here |
+
+### 5.3 Code reuse and duplication risks
+
+- Token storage: reuses `ICredentialService.SaveSecret`/`GetSecret` verbatim — no new storage code.
+- URL launching for the fallback path: reuses `Helpers.ExternalUriPolicy.TryOpenExternal` verbatim — the fallback URL is `https://github.com/...` (an allow-listed scheme), so no changes to the allow-list are needed.
+- Version/OS info: reuses `Helpers.AppVersion.Display` as-is.
+- Credential-file build pattern: reuses the exact shape of `GoogleOAuthService.Credentials.cs`/`.example` — no new "how do we bake in a secret" mechanism.
+- No existing dialog does anything close to this, so there is no risk of silently duplicating an existing "send a report" code path.
+
+### 5.4 Shared component audit (mandatory)
+
+| Component | File | Other consumers | Change needed | Risk / mitigation |
+|---|---|---|---|---|
+| `ICredentialService` | `Services/ICredentialService.cs` | `AccountService` (per-account passwords), `OAuthService` (OAuth secrets) | **None to the interface.** `SaveSecret("github.bugreport.token", ...)`/`GetSecret(...)` used with a new, distinct key — no collision with any existing key naming (account secrets are keyed by `Guid accountId`, not a string literal) | Low. Verify the new key name doesn't collide with any existing `SaveSecret` call site — confirmed none exist today (grep for `SaveSecret(` across the codebase before implementation). |
+| `Helpers.ExternalUriPolicy` | `Helpers/ExternalUriPolicy.cs` | Message-body link clicks (reading pane, preview windows) | **None.** The fallback URL is `https://github.com/...`, already inside the `http`/`https`/`mailto` allow-list | None — read-only reuse. |
+| `Helpers.AppVersion` | `Helpers/AppVersion.cs` | About dialog, `MimeMessageBuilder.AppUserAgent`, `UpdateCheckService` | **None.** Read-only reuse of `AppVersion.Display` | None. |
+| `GoogleOAuthService.Credentials.cs` pattern | `QuickMail/Services/GoogleOAuthService.Credentials.cs` (gitignored), `docs/GoogleOAuthService.Credentials.example` | Google OAuth only, today | **Add** a sibling `BugReportService.Credentials.cs` (gitignored) + `docs/BugReportService.Credentials.example`, same shape, new file names — does not touch the Google files | None — parallel new files, no shared code. |
+| `CommandRegistry` / `MainViewModel.RegisterCommands` | `ViewModels/MainViewModel.cs` (Help category block, ~line 1343-1449) | Every registered command | **Add** one `CommandDefinition` for `help.reportBug`, category `"Help"`, no default hotkey | Low — additive only, follows the exact pattern of the three existing `help.*` registrations immediately adjacent. |
+| `App.xaml.cs` DI root | `App.xaml.cs` | Owns every service | **Add** construction of `IBugReportService`/`BugReportService` (and a shared `HttpClient` if one doesn't already exist for this purpose) | Low — additive, follows existing DI root pattern. |
+
+**Summary:** This feature adds one new service (`IBugReportService`), one new window (`ReportBugWindow`), one new gitignored credentials file (following the existing `GoogleOAuthService.Credentials.cs` shape), one new `Help` command registration, and reuses `ICredentialService`, `ExternalUriPolicy`, and `AppVersion` entirely as-is. No existing consumer of any touched component changes behavior. It reads no log file and touches `LogService` not at all.
+
+---
+
+## Section 6: Keyboard Walkthrough (Mandatory)
+
+### Path: Open and submit a bug report (happy path)
+
+1. User is anywhere in the app, presses **Alt** to reach the menu bar, navigates to **Help → Report a Bug** (or opens the Command Palette with `Ctrl+Shift+P` and activates "Report a Bug"). **Expected:** `ReportBugWindow` opens modelessly over `MainWindow`. Focus lands on the **Summary** field. Screen reader announces "Report a Bug window. Summary, edit."
+2. User types a one-line summary, presses **Tab**. **Expected:** Focus moves to **What happened** (multi-line). Screen reader announces "What happened, edit, required."
+3. User types a description, presses **Tab** through **What you expected** and **Steps to reproduce** (both optional, multi-line). **Expected:** Standard tab order, no surprises.
+4. User Tabs to **Preview** (read-only, focusable for review — shows exactly what will be sent: the four text fields plus app version/OS/runtime metadata, nothing else) then to the action buttons: **Send**, **Copy report and open GitHub**, **Cancel**.
+5. User activates **Send**. **Expected:** Buttons disable, a `Status` announcement fires: "Sending report…". On success, a `Result` announcement fires: "Report sent. Issue #NNN created." and the window shows the returned issue URL as a clickable-via-`ExternalUriPolicy` link, plus a **Close** button. Focus moves to the issue URL text.
+6. User presses **Escape** (or activates **Close**). **Expected:** Window closes. Focus returns to whatever had focus in `MainWindow` before **Report a Bug** was opened.
+
+### Path: Submission fails (no token / offline)
+
+1. Steps 1-4 as above. User activates **Send**. **Expected:** `Status` announcement "Sending report…", then on failure a `Result` announcement: "Could not send the report automatically. Your report is ready to copy." Focus moves to the **"Copy report and open GitHub"** button; the **Send** button is re-enabled (not left permanently disabled) in case the user wants to retry (e.g., after reconnecting).
+2. User activates **"Copy report and open GitHub"**. **Expected:** Full report text (summary through steps to reproduce, plus the log excerpt if included) is copied to the clipboard; a `Result` announcement fires: "Report copied. Opening GitHub in your browser."; `ExternalUriPolicy.TryOpenExternal` opens a pre-filled `kellylford/QuickMail` new-issue URL in the default browser. **Note for this path:** the user will need a GitHub account to complete submission there — this is expected and is not a bug (see §2.1 nuance).
+
+### Path: Validation failure
+
+1. User Tabs directly to **Send** without entering a Summary. **Expected:** Send is a no-op; a `Result` announcement fires: "Enter a summary before sending." Focus moves back to the **Summary** field.
+
+### Path: Cancel without sending
+
+1. User opens the window, types a partial report, presses **Escape**. **Expected:** Window closes immediately, no confirmation prompt (a partially-typed bug report is low-stakes, unlike an in-progress compose — no "discard changes?" dialog). Focus returns to the originating control in `MainWindow`.
+
+### Path: F6 ring (window-level, per New Window Checklist)
+
+1. User presses **F6** inside `ReportBugWindow`. **Expected:** Cycles between the form pane and the preview pane (two logical stops: form fields, preview region). `Shift+F6` cycles backward.
+
+---
+
+## Section 7: Accessibility Checklist (Mandatory)
+
+- **`AutomationProperties.Name`** — New short labels only: "Summary", "What happened", "What you expected", "Steps to reproduce", "Preview", "Send", "Copy report and open GitHub", "Cancel", "Close". No role names, no instructions baked in.
+- **`AnnouncementCategory`** — "Sending report…" / "Could not send…" / "Report sent…" use `AnnouncementCategory.Status`/`Result` per the existing convention (background progress = `Status`, outcome = `Result`); both respect user settings (`AnnounceStatus`, `AnnounceResults`) — this feature does not force any announcement, since none of it is a meta-setting-toggle announcement.
+- **Screen reader browse mode** — No WebView2 in this window; not applicable.
+- **Focus restoration** — Captured before `ReportBugWindow.Show()` (the control focused in `MainWindow` at invocation time) and restored explicitly in the window's `Closed` handler, following the New Window Checklist pattern.
+- **F6 ring** — Two stops (form, preview) local to `ReportBugWindow`; `MainWindow`'s own F6 ring is unaffected since this is a separate top-level window, not a new pane within `MainWindow`.
+- **Checkbox / radio groups** — None in this feature (the log-excerpt checkbox from the original Quill-derived draft was removed — see §4.2).
+- **Color-only information** — None. Send success/failure is communicated via text announcement and visible status text, not color alone.
+
+**Answer:** Introduces one new window with 9 short-labeled controls, no WebView2, no checkboxes, no radio groups. Announcements: `Status` for in-flight send, `Result` for outcome. F6 ring is local to the new window (2 stops); `MainWindow`'s F6 ring is unchanged.
+
+---
+
+## Section 8: Acceptance Walkthrough (Mandatory)
+
+### Scenario: Successful direct submission
+
+**Setup:** App running, valid app-owned token present in `ICredentialService`, network available.
+
+1. Open **Help → Report a Bug**. **Verify:** Window opens, focus on Summary, screen reader announces the field name and "required" if applicable.
+2. Fill in Summary + What happened; leave the rest default. Activate **Send**. **Verify:** Buttons disable during send; a real GitHub issue is created on `kellylford/QuickMail` with labels `bug` and `user-reported`; the dialog shows the returned issue URL; a `Result` announcement is heard.
+3. Activate **Close**. **Verify:** Window closes; focus returns to the control that had focus before the window opened.
+
+### Scenario: No log content in the report
+
+**Setup:** App running normally (logging on or off, doesn't matter for this feature).
+
+1. Open **Report a Bug**, fill in all four text fields, view **Preview**. **Verify:** The preview contains only the four typed fields plus app version/OS/runtime metadata. No log file is read (confirm by checking `quickmail.log`'s file modified timestamp is unchanged after opening/using the dialog).
+
+### Scenario: Fallback path
+
+**Setup:** Temporarily remove/corrupt the stored token via `ICredentialService.DeleteSecret` for the bug-report key, or disconnect network.
+
+1. Fill in a report, activate **Send**. **Verify:** A `Result` announcement reports the failure; the **Send** button is re-enabled, not stuck disabled.
+2. Activate **"Copy report and open GitHub."** **Verify:** Clipboard contains the full report text (spot-check by pasting into Notepad); default browser opens a `github.com/kellylford/QuickMail/issues/new` URL with title/body pre-filled from the report fields.
+
+### Scenario: Validation
+
+1. Open the window, leave Summary blank, activate **Send.** **Verify:** No network call is made (check via a breakpoint or a temporary log line — remove before commit); a `Result` announcement asks for a summary; focus returns to Summary.
+
+### Scenario: `--online` mode — no regression
+
+1. Launch with `--online`. Open **Report a Bug**, submit a report. **Verify:** Feature works identically — no `LocalStoreService` calls occur, no crash, no behavior difference from normal mode.
+
+### Scenario: Screen reader pass
+
+1. Tab through every control in `ReportBugWindow` with a screen reader running. **Verify:** Every `AutomationProperties.Name` reads as the short label from §7 (no doubled role announcements, no baked-in instructions). Verify the one-time `Hint` on first checking the log checkbox is heard exactly once per window instance (not repeated on subsequent checks/unchecks in the same window).
+
+### Scenario: No regression on existing `Help` commands
+
+1. After adding `help.reportBug`, activate **Help → Open User Guide** and **Help → About QuickMail.** **Verify:** Both still work exactly as before (confirms the new registration didn't disturb the adjacent `help.userGuide`/`help.about` entries in `MainViewModel.RegisterCommands`).
+
+---
+
+## Section 9: Success Metrics
+
+- **Behavioral:** A user with no GitHub account can go from "something's wrong" to a filed GitHub issue with zero sign-in prompts.
+- **Keyboard-centric:** Every step in §6's happy path is achievable with keyboard only.
+- **No regressions:** Existing `Help` menu commands (`help.userGuide`, `help.keyboardTutorial`, `help.about`) work unchanged; no existing `SaveSecret` key collides with the new one.
+- **Safety:** No log content of any kind ever appears in a submitted or previewed report — verified by the "No log content in the report" scenario in §8.
+- **Resilience:** Submission failure never loses the user's typed content — the fallback always has the full report text ready to copy.
+- **Online mode:** Feature behaves identically with `--online` set.
+
+---
+
+## Section 10: Implementation Phases
+
+### Phase 1: Credentials file scaffolding
+
+**Goal:** `BugReportService.Credentials.cs` (gitignored) and `docs/BugReportService.Credentials.example` exist, following the exact shape of `GoogleOAuthService.Credentials.cs`/`.example`; `.gitignore` updated; the real file is populated locally with a placeholder value for development (a real token is a manual step for the maintainer before release, not part of this implementation).
+
+**Deliverables:** `docs/BugReportService.Credentials.example`; `.gitignore` entry; a local (gitignored) `QuickMail/Services/BugReportService.Credentials.cs` with a placeholder token so the build compiles.
+
+**Tests:** None (no logic yet).
+
+**Risk:** None — purely additive scaffolding. **Duration:** 30 min.
+
+### Phase 2: `IBugReportService` (headless, no UI)
+
+**Goal:** `IBugReportService.SubmitAsync(BugReportModel)` posts to the GitHub Issues API and returns `(issueUrl, error)`; token retrieval/provisioning via `ICredentialService` works (falling back to the placeholder-detection behavior in §5.1); `BuildFallbackUrl(BugReportModel)` produces a correct pre-filled GitHub issue URL.
+
+**Deliverables:** `Services/IBugReportService.cs`, `Services/BugReportService.cs`, `Models/BugReportModel.cs`.
+
+**Tests:** `BugReportServiceTests` — mock `HttpClient` (via a test `HttpMessageHandler`) to cover success, 401 (bad/revoked token), missing/placeholder token (immediate graceful failure, no HTTP call attempted), network failure, and confirm the fallback URL is correctly encoded and never throws on unusual characters (quotes, ampersands, newlines) in report fields.
+
+**Risk:** GitHub API response shape assumptions (issue URL field name) — verify against the real API docs/a live test call before finalizing the response model. **Duration:** 3-4 h.
+
+### Phase 3: `ReportBugWindow` UI + `Help` command wiring
+
+**Goal:** The window from §6/§7 exists, is modeless, wires Cancel/Escape explicitly, restores focus on close, has a working F6 ring, and is reachable via `Help -> Report a Bug` and the Command Palette.
+
+**Deliverables:** `Views/ReportBugWindow.xaml` (+ `.xaml.cs`), `ViewModels/ReportBugViewModel.cs`, one `CommandDefinition` addition in `MainViewModel.RegisterCommands`, one `MenuItem` in the `Help` menu XAML.
+
+**Tests:** `XamlParseTests` extension (window loads without `XamlParseException`); `CommandRegistryTests` extension (new command registers correctly); a `ReportBugViewModelTests` class covering validation (blank summary), the log-checkbox-toggles-preview behavior, and success/failure state transitions (mocking `IBugReportService`).
+
+**Risk:** Modal-dialog deadlock class of bug if `.ShowDialog()` is used by mistake — mitigated by Decision C being explicit and by testing the window opened over `MainWindow` with the reading pane active. **Duration:** 4-6 h.
+
+---
+
+## Section 11: Files to Create / Modify
+
+### Create
+
+| File | Purpose | Lines (est.) |
+|---|---|---|
+| `docs/BugReportService.Credentials.example` | Template for the gitignored token file, mirroring `GoogleOAuthService.Credentials.example` | 15-20 |
+| `QuickMail/Services/BugReportService.Credentials.cs` (gitignored, not committed) | Real/placeholder `const string AppOwnedToken` | 10 |
+| `Models/BugReportModel.cs` | Report data (summary, description, expected, steps) | 15-25 |
+| `Services/IBugReportService.cs` | Interface (`SubmitAsync`, `BuildFallbackUrl`) | 15-20 |
+| `Services/BugReportService.cs` | GitHub API POST, token provisioning via `ICredentialService`, fallback URL builder | 90-140 |
+| `Views/ReportBugWindow.xaml` / `.xaml.cs` | The window itself | 140-190 |
+| `ViewModels/ReportBugViewModel.cs` | Form state, validation, send/fallback commands | 90-140 |
+
+### Modify
+
+| File | Changes | Lines (est.) |
+|---|---|---|
+| `.gitignore` | Add `**/BugReportService.Credentials.cs` entry | +2 |
+| `App.xaml.cs` | Construct `IBugReportService`, wire into DI root | +10 |
+| `ViewModels/MainViewModel.cs` | Register `help.reportBug` command near existing `help.*` block (~line 1343-1449) | +10 |
+| `Views/MainWindow.xaml` | Add "Report a Bug" `MenuItem` under `Help` | +5 |
+
+---
+
+## Section 12: Tests to Add
+
+| Test Class | Test Methods | Coverage |
+|---|---|---|
+| `BugReportServiceTests` | Success (issue URL returned), 401/revoked token, missing/placeholder token (no HTTP call attempted), network failure, fallback URL encoding with special characters, submitted body contains only user text + metadata (no log content) | Submission logic + fallback |
+| `ReportBugViewModelTests` | Blank-summary validation, log-checkbox toggling updates preview, send success/failure state transitions, fallback command copies full text | Form/VM behavior |
+| `XamlParseTests` (extend) | `ReportBugWindow` loads without `XamlParseException` | Regression guard |
+| `CommandRegistryTests` (extend) | `help.reportBug` registers with category `Help`, no default hotkey collision | Command registration |
+
+---
+
+## Section 13: Known Risks & Open Questions
+
+### 13.1 Risks
+
+| Risk | Probability | Impact | Mitigation |
+|---|---|---|---|
+| Embedded fine-grained PAT is extracted from the binary | Medium (any embedded secret in a distributed binary is extractable) | Minor (scoped to `Issues: Write` on one repo only) | Decision A's scoping bounds the blast radius; token is revocable/rotatable if abused; noted as the trigger for a v2 migration to a serverless relay if it becomes a real problem |
+| `ReportBugWindow` accidentally implemented with `.ShowDialog()` | Low (explicit in spec) | Blocker (UI-thread deadlock class of bug) | Decision C is explicit and cites the exact prior incident; code review gate |
+| GitHub API rate-limits or blocks the app-owned token account | Low | Minor | Fallback path (clipboard + browser) remains available regardless of API-side issues |
+| New `SaveSecret` key collides with an existing key | Low | Minor | Verified in §5.4 that no existing call site uses this key name; re-verify at implementation time with a fresh grep |
+| A user pastes sensitive content directly into a free-text field (Summary/What happened/etc.) | Low | Minor | Out of scope to defend against — this is user-authored content they can see in the Preview before sending, same trust model as any text field in the app (e.g., Compose). Not equivalent to the rejected log-collection risk, which was about *automatically* surfacing content the user didn't author or choose to type. |
+
+### 13.2 Open questions — resolved 2026-07-06
+
+- **Token provisioning mechanism at build time.** **Resolved:** follow the exact existing pattern used for Google OAuth credentials in this codebase — a gitignored `QuickMail/Services/BugReportService.Credentials.cs` partial-class file with a `const string AppOwnedToken`, plus a checked-in `docs/BugReportService.Credentials.example` template (see §5.1). The maintainer creates the actual fine-grained PAT manually in the GitHub UI (this cannot be done via API/CLI) and pastes it into the local file before a release build; the placeholder value in the example file causes the feature to degrade gracefully to fallback-only (§5.1 "Degradation without a token").
+- **Issue labels.** **Resolved:** `bug` + a new `user-reported` label, both applied to every issue this feature creates.
+- **Proactive offline detection vs. attempt-then-fail.** **Resolved:** attempt-then-fail, as proposed — no proactive connectivity check.
+- **Log collection.** **Resolved: absolute no for v1, not merely deferred.** Logging is off by default, so a log-excerpt feature helps only a subset of reporters; and when logging is on, `quickmail.log` can contain email subjects, sender/recipient names, and other content a user would not want copied into a public GitHub issue. A preview shown before sending is explicitly **not** accepted as sufficient mitigation — the risk is the user not recognizing what a raw log line contains, not merely being unaware that sending is imminent. This removed the log-excerpt checkbox, the `BugReportRedactor` helper, and the `LogService.LogFilePath` accessor from the spec entirely (see §4.2, Decision D, §10 Phase 1).
+
+---
+
+## Section 15: Implementation Guidance for AI
+
+### 15.1 Adjustments you're expected to make
+
+- The exact GitHub Issues API request/response shape (field names, required headers) should be verified against GitHub's current REST API docs at implementation time rather than assumed from this spec — APIs can add required fields.
+- The precise wording of announcements in §6 is illustrative; keep the category assignments (`Status`/`Result`/`Hint`) and the *timing* (once per window instance for the log-checkbox hint) but you may adjust exact phrasing for consistency with nearby existing announcement strings.
+- Whether `BugReportModel` is a plain record or a class with `INotifyPropertyChanged` is your call, based on whether `ReportBugViewModel` needs to bind directly to it or copies its fields into observable properties — follow whatever pattern `ComposeViewModel` already uses for its own draft model, for consistency.
+
+### 15.2 When to ask for clarification
+
+- All open questions from §13.2 are resolved — do not re-litigate them during implementation. In particular: **do not add any log-reading, log-excerpt, or redaction code to this feature** — that was explicitly rejected, not deferred.
+- If the GitHub Issues API's actual required-scope behavior for fine-grained tokens differs from what's assumed in Decision A (e.g., if `Issues: Write` alone turns out to be insufficient for some reason), stop and confirm before widening the token's scope, since minimal scope is a named security principle (§3.5), not an incidental detail.
+- The real fine-grained PAT value is a manual step for the maintainer (cannot be created via API/CLI). Implementation should ship with `BugReportService.Credentials.cs` populated with a placeholder so the build compiles and tests pass; do not block implementation on obtaining a real token.
+
+### 15.3 After implementation: acceptance walkthrough preview
+
+After you build this, the user will run the Acceptance Walkthrough in §8. The steps most likely to catch bugs in this specific implementation:
+- §8 "No log content in the report" — confirms the feature genuinely never touches the log file, which is the highest-stakes requirement in this spec.
+- §8 "Fallback path" — confirms the failure path doesn't leave Send permanently disabled and doesn't lose the user's typed content.
+- §8 "No regression on existing Help commands" — confirms the new command registration didn't disturb the three adjacent existing ones.
+
+If any of these fail, document the failure; it will be addressed in the code-review session.


### PR DESCRIPTION
## Summary
- Adds **Help → Report a Bug**: submits reports directly to GitHub Issues (`kellylford/QuickMail`) using an app-owned, narrowly-scoped credential (`Issues: Write` on this repo only) stored via the existing `ICredentialService` — the user never signs into GitHub.
- Falls back to a clipboard copy + pre-filled GitHub issue URL if the token is unavailable or the request fails.
- Collects **no log content** in v1 — an explicit product decision (see spec §4.2/§13.2), not an oversight: logging is off by default, and when on, log content can include email subjects/names the user wouldn't want in a public issue. A preview-before-send is not treated as sufficient mitigation for that risk.
- Token provisioning follows the exact existing pattern used for Google OAuth credentials in this repo (`GoogleOAuthService.Credentials.cs`, gitignored + `.example` template) — see `docs/BugReportService.Credentials.example`.
- Full PM/dev spec: `docs/planning/bug-reporting-pm-dev-spec.md`.

Closes #186.

## Test plan
- [x] `dotnet build` — 0 warnings, 0 errors (main project)
- [x] `dotnet test` — 1030/1031 passing; the 1 failure (`GroupsTabFocusTests.TabFromGroupsList_SkipsNameBox_AndLandsOnNewButton`) is unrelated pre-existing flakiness, confirmed by re-running it in isolation (passes)
- [x] New unit tests: `BugReportServiceTests` (success/401/network-failure/fallback-URL-encoding/no-log-content), `ReportBugViewModelTests` (validation, send success/failure state transitions, cancel), `CommandRegistryTests` extension (`help.reportBug` registers correctly, no collision), `XamlParseTests` extension (`ReportBugWindow` parses)
- [ ] Manual acceptance walkthrough (§8 of the spec) — needs a real fine-grained PAT populated in the gitignored `QuickMail/Services/BugReportService.Credentials.cs` and a live run in the app; not done in this session

🤖 Generated with [Claude Code](https://claude.com/claude-code)