### PR TITLE
Mitigate intermittent AppHangB1 on compose open: defer spell-check enablement (#181)

### DIFF
--- a/QuickMail.Tests/ComposeWindowSpellCheckTests.cs
+++ b/QuickMail.Tests/ComposeWindowSpellCheckTests.cs
@@ -1,0 +1,72 @@
+// Regression guard for issue #181: spell-check must not be enabled during
+// ComposeWindow construction (InitializeComponent) — that ran WPF's speller COM
+// activation synchronously on the STA thread and could hang the app. Instead it is
+// enabled from code, deferred to Background dispatcher priority. These tests verify
+// the deferral actually lands (a future edit dropping an editor from the enable set,
+// or the deferral silently never firing, would otherwise pass unnoticed and silently
+// disable spell-check on the compose editors).
+
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Threading;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+[Collection("WpfTests")]
+public class ComposeWindowSpellCheckTests
+{
+    private static QuickMail.Views.ComposeWindow NewHeadlessComposeWindow()
+    {
+        var vm = new QuickMail.ViewModels.ComposeViewModel(
+            new StubSmtpService(),
+            new StubAccountService(),
+            new StubCredentialService(),
+            new StubImapMailService(),
+            new StubTemplateService());
+
+        return new QuickMail.Views.ComposeWindow(
+            vm, new StubContactService(), new StubTemplateService(), new StubConfigService())
+        {
+            WindowStyle = WindowStyle.None,
+            ShowInTaskbar = false,
+            ShowActivated = false,
+            ConfirmSaveOnClose = null, // headless — discard on close, no dialog
+        };
+    }
+
+    [StaFact]
+    public void SpellCheck_IsNotEnabledDuringConstruction_ButEnabledAfterBackgroundIdle()
+    {
+        var window = NewHeadlessComposeWindow();
+
+        var subject = window.FindName("SubjectBox") as TextBox;
+        var body = window.FindName("BodyBox") as TextBox;
+        var richBody = window.FindName("RichBodyBox") as RichTextBox;
+        Assert.NotNull(subject);
+        Assert.NotNull(body);
+        Assert.NotNull(richBody);
+
+        // Before the window is shown and the dispatcher idles, the speller must NOT
+        // have been turned on synchronously (that is the #181 hang path).
+        Assert.False(SpellCheck.GetIsEnabled(subject!));
+        Assert.False(SpellCheck.GetIsEnabled(body!));
+        Assert.False(SpellCheck.GetIsEnabled(richBody!));
+
+        window.Show();
+        try
+        {
+            // Drain the dispatcher queue down to Background priority — this runs the
+            // deferred EnableSpellCheckDeferred callback queued during construction.
+            window.Dispatcher.Invoke(() => { }, DispatcherPriority.Background);
+
+            Assert.True(SpellCheck.GetIsEnabled(subject!));
+            Assert.True(SpellCheck.GetIsEnabled(body!));
+            Assert.True(SpellCheck.GetIsEnabled(richBody!));
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+}

--- a/QuickMail/Views/ComposeWindow.xaml
+++ b/QuickMail/Views/ComposeWindow.xaml
@@ -317,7 +317,6 @@
                      AutomationProperties.LabeledBy="{Binding ElementName=SubjectLabel}"
                      AutomationProperties.Name="Subject"
                      AutomationProperties.AcceleratorKey="Alt+U"
-                     SpellCheck.IsEnabled="True"
                      IsInactiveSelectionHighlightEnabled="True"
                      Margin="0,4" TabIndex="4"/>
 
@@ -411,7 +410,6 @@
                          AutomationProperties.AcceleratorKey="Alt+Y"
                          AcceptsReturn="True" AcceptsTab="True"
                          TextWrapping="Wrap"
-                         SpellCheck.IsEnabled="True"
                          IsInactiveSelectionHighlightEnabled="True"
                          VerticalScrollBarVisibility="Auto"
                          FontFamily="{DynamicResource Theme.FontFamily}"
@@ -425,7 +423,6 @@
                              AutomationProperties.Name="Message body"
                              AutomationProperties.AcceleratorKey="Alt+Y"
                              AcceptsReturn="True" AcceptsTab="True"
-                             SpellCheck.IsEnabled="True"
                              IsInactiveSelectionHighlightEnabled="True"
                              VerticalScrollBarVisibility="Auto"
                              FontFamily="{DynamicResource Theme.FontFamily}"

--- a/QuickMail/Views/ComposeWindow.xaml.cs
+++ b/QuickMail/Views/ComposeWindow.xaml.cs
@@ -115,12 +115,16 @@ public partial class ComposeWindow : Window
         InitializeComponent();
         DataContext = vm;
 
-        // Register the user's custom dictionary on all spell-checked editors and
-        // keep the registration fresh when words are added (WPF only re-reads a
-        // lexicon on remove + re-add of its Uri). Paired unsubscribe is in Closed.
+        // Spell-check is turned on in code (not via SpellCheck.IsEnabled in XAML) and
+        // deferred to Background priority — see EnableSpellCheckDeferred for why (#181).
+        EnableSpellCheckDeferred();
+
+        // Keep the custom-dictionary registration fresh when words are added (WPF only
+        // re-reads a lexicon on remove + re-add of its Uri). The initial registration
+        // runs inside EnableSpellCheckDeferred, after the speller is enabled. Paired
+        // unsubscribe is in Closed.
         if (_customDictionary != null)
         {
-            RegisterCustomDictionary();
             _customDictionary.DictionaryChanged += RegisterCustomDictionary;
             Closed += (_, _) => _customDictionary.DictionaryChanged -= RegisterCustomDictionary;
         }
@@ -834,6 +838,31 @@ public partial class ComposeWindow : Window
     /// Remove-then-add forces WPF to re-read the file, which is how a word added
     /// mid-session stops being flagged without reopening the window.
     /// </summary>
+    /// <summary>
+    /// Turns on spell-checking for the compose editors, deferred to Background
+    /// dispatcher priority so it runs after the window has shown.
+    ///
+    /// Enabling <see cref="SpellCheck"/> spins up WPF's Natural-Language speller,
+    /// whose COM class-object activation (<c>NLGSpellerInterop.NlGetClassObject</c>)
+    /// is a synchronous, pump-waiting call on the STA UI thread. When it ran during
+    /// <c>InitializeComponent()</c> — while the window's control tree was being built
+    /// — it could intermittently never return and freeze the whole app (AppHangB1,
+    /// issue #181), a window badly widened by x64-on-ARM64 emulation. Deferring to
+    /// Background priority moves the activation off the construction path to a point
+    /// where the dispatcher is already pumping normally, so it no longer blocks the
+    /// window from opening. Registering the custom dictionary also touches the
+    /// speller, so it runs in the same deferred callback, after enabling.
+    /// </summary>
+    private void EnableSpellCheckDeferred()
+    {
+        Dispatcher.BeginInvoke(DispatcherPriority.Background, new Action(() =>
+        {
+            foreach (var editor in new TextBoxBase[] { SubjectBox, BodyBox, RichBodyBox })
+                SpellCheck.SetIsEnabled(editor, true);
+            RegisterCustomDictionary();
+        }));
+    }
+
     private void RegisterCustomDictionary()
     {
         if (_customDictionary == null) return;

--- a/QuickMail/Views/ComposeWindow.xaml.cs
+++ b/QuickMail/Views/ComposeWindow.xaml.cs
@@ -104,6 +104,11 @@ public partial class ComposeWindow : Window
     private DispatcherTimer? _spellingTypingTimer;
     private static readonly TimeSpan SpellingTypingDelay = TimeSpan.FromMilliseconds(500);
 
+    // True once the WPF speller has been enabled on the editors. Enabling is deferred
+    // off the construction path (issue #181); EnsureSpellCheckEnabled flips this exactly
+    // once, from either the deferred pre-warm or a spell-check entry point.
+    private bool _spellCheckEnabled;
+
     public ComposeWindow(ComposeViewModel vm, IContactService contactService, ITemplateService templateService, IConfigService configService, ICustomDictionaryService? customDictionary = null, IThemeService? themeService = null)
     {
         _vm = vm;
@@ -834,13 +839,8 @@ public partial class ComposeWindow : Window
     }
 
     /// <summary>
-    /// (Re-)registers the custom dictionary lexicon on every spell-checked editor.
-    /// Remove-then-add forces WPF to re-read the file, which is how a word added
-    /// mid-session stops being flagged without reopening the window.
-    /// </summary>
-    /// <summary>
-    /// Turns on spell-checking for the compose editors, deferred to Background
-    /// dispatcher priority so it runs after the window has shown.
+    /// Pre-warms spell-checking at Background dispatcher priority so it runs after the
+    /// window has shown.
     ///
     /// Enabling <see cref="SpellCheck"/> spins up WPF's Natural-Language speller,
     /// whose COM class-object activation (<c>NLGSpellerInterop.NlGetClassObject</c>)
@@ -850,19 +850,43 @@ public partial class ComposeWindow : Window
     /// issue #181), a window badly widened by x64-on-ARM64 emulation. Deferring to
     /// Background priority moves the activation off the construction path to a point
     /// where the dispatcher is already pumping normally, so it no longer blocks the
-    /// window from opening. Registering the custom dictionary also touches the
-    /// speller, so it runs in the same deferred callback, after enabling.
+    /// window from opening.
     /// </summary>
     private void EnableSpellCheckDeferred()
     {
         Dispatcher.BeginInvoke(DispatcherPriority.Background, new Action(() =>
         {
-            foreach (var editor in new TextBoxBase[] { SubjectBox, BodyBox, RichBodyBox })
-                SpellCheck.SetIsEnabled(editor, true);
-            RegisterCustomDictionary();
+            // The window may have closed before this queued op ran; nothing to enable.
+            if (!IsLoaded) return;
+            EnsureSpellCheckEnabled();
         }));
     }
 
+    /// <summary>
+    /// Enables spell-check on the three editors and registers the custom dictionary,
+    /// exactly once. Idempotent. Called from the deferred pre-warm
+    /// (<see cref="EnableSpellCheckDeferred"/>) and, as a safety net, from every
+    /// spell-check entry point (F7 dialog, Next/Previous misspelling, navigation
+    /// announcement) so a spell action taken in the brief window before the deferred
+    /// callback fires never runs against a disabled speller — which would silently
+    /// return no errors and falsely report "no misspellings" (#181 follow-up). The
+    /// custom dictionary is registered after enabling, since it also touches the
+    /// speller.
+    /// </summary>
+    private void EnsureSpellCheckEnabled()
+    {
+        if (_spellCheckEnabled) return;
+        _spellCheckEnabled = true;
+        foreach (var editor in new TextBoxBase[] { SubjectBox, BodyBox, RichBodyBox })
+            SpellCheck.SetIsEnabled(editor, true);
+        RegisterCustomDictionary();
+    }
+
+    /// <summary>
+    /// (Re-)registers the custom dictionary lexicon on every spell-checked editor.
+    /// Remove-then-add forces WPF to re-read the file, which is how a word added
+    /// mid-session stops being flagged without reopening the window.
+    /// </summary>
     private void RegisterCustomDictionary()
     {
         if (_customDictionary == null) return;
@@ -889,6 +913,7 @@ public partial class ComposeWindow : Window
 
     private void AnnounceSpellingAtCurrentPosition()
     {
+        EnsureSpellCheckEnabled();
         if (_vm.CurrentMode == ComposeMode.Html)
         {
             AnnounceSpellingAtRichPosition();
@@ -1328,6 +1353,8 @@ public partial class ComposeWindow : Window
 
     private void CheckSpelling()
     {
+        EnsureSpellCheckEnabled();
+
         // One session at a time: a second F7 returns to the open dialog.
         if (_spellCheckDialog != null)
         {
@@ -1439,6 +1466,7 @@ public partial class ComposeWindow : Window
 
     private void NavigateSpellingError(bool forward)
     {
+        EnsureSpellCheckEnabled();
         if (_vm.CurrentMode == ComposeMode.Html)
         {
             NavigateSpellingErrorInRichBox(forward);


### PR DESCRIPTION
> **Status: mitigation, not a confirmed fix — do not merge until verified on the ARM64 repro.**
> Independent review (see comments) established that this relocates the blocking speller COM activation off the window-construction path but does **not** make it async — the same `NlGetClassObject` call still runs on the STA UI thread, just at a healthier moment. It very likely reduces recurrence, but per #181's own guidance it should be confirmed with a `/debug` capture on the Windows-on-ARM machine (showing `InitializeComponent` no longer blocks) before merging and closing #181.

Relates to #181 — intermittent "QuickMail not responding" (AppHangB1) while opening the compose window (reply / reply-all / new / forward).

## Root cause (confirmed)
A live full-dump SOS managed stack pinned the hang to WPF's spell-checker COM initialization on the STA UI thread:

```
WaitHandle.WaitMultipleIgnoringSyncContext
  ← InterfaceMarshaler.ConvertToManaged
  ← System.Windows.Documents.NLGSpellerInterop+UnsafeNlMethods.NlGetClassObject
```

`ComposeWindow.xaml` set `SpellCheck.IsEnabled="True"` on the three editors. During `InitializeComponent()` — while WPF builds the control tree — enabling spell-check spins up the Natural-Language speller, and `NlGetClassObject` does a synchronous COM class-object activation that **pump-waits on the STA UI thread**. It intermittently never returns, freezing the app. The window is badly widened by running win-x64 under **x64 emulation on ARM64**. The app's own reply/compose code has no `.Wait()`/`.Result` on any UI path — framework behavior.

## What this PR does (mitigation)
- Removes `SpellCheck.IsEnabled="True"` from the three editors in `ComposeWindow.xaml`.
- Pre-warms spell-check from code in `EnableSpellCheckDeferred()`, queued at `DispatcherPriority.Background`, so the speller's COM activation runs **after** the window is shown and the dispatcher is pumping normally — off the fragile construction path. This does not make the call async; it moves *when* it runs to a much healthier moment, which should sharply reduce the hang's probability.

## Review follow-ups included
- **Early-spell-check guard:** an idempotent `EnsureSpellCheckEnabled()` is also called from every spell entry point (F7 dialog, Next/Prev misspelling, navigation announcement), so a spell action taken before the Background pre-warm fires enables on-demand instead of falsely reporting "no misspellings" (a previously observed symptom).
- **Closed-window guard:** the deferred callback bails with `if (!IsLoaded) return;`.
- **Test:** `ComposeWindowSpellCheckTests` asserts spell-check is off during construction and on after the dispatcher drains to Background priority, for all three editors.

## User-visible behavior — unchanged
Spell-check turns on a beat after the window appears; F7, red squiggles, and spelling announcements all work as before, and are now guaranteed enabled on first use.

## Verification
- Build clean (Release); full suite green (the lone failure is the known flaky clipboard test `PropertiesViewModelTests.CopyRow`, which passes in isolation).
- ⚠️ **Outstanding:** confirm on the ARM64 machine where the hang reproduces (intermittent, timing/emulation-dependent) that opening a reply no longer freezes — ideally with the `/debug` tracer showing `InitializeComponent` completing. Until then this is a mitigation, not a verified close of #181.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
