### PR TITLE
Fix red main CI: make bug-report app token injectable (hermetic tests)

### DIFF
--- a/QuickMail.Tests/BugReportServiceTests.cs
+++ b/QuickMail.Tests/BugReportServiceTests.cs
@@ -54,10 +54,11 @@ public class BugReportServiceTests
     private static BugReportService MakeService(
         Func<HttpRequestMessage, HttpResponseMessage> responder,
         out FakeHttpMessageHandler handler,
-        FakeCredentialService? credentials = null)
+        FakeCredentialService? credentials = null,
+        string appOwnedToken = "")   // hermetic: never inherit the CI-baked compiled-in token
     {
         handler = new FakeHttpMessageHandler(responder);
-        return new BugReportService(credentials ?? new FakeCredentialService(), handler);
+        return new BugReportService(credentials ?? new FakeCredentialService(), handler, appOwnedToken);
     }
 
     [Fact]
@@ -71,6 +72,24 @@ public class BugReportServiceTests
         Assert.False(result.Success);
         Assert.False(handlerCalled);
         Assert.Null(result.IssueUrl);
+    }
+
+    [Fact]
+    public async Task SubmitAsync_UsesAppOwnedToken_WhenNoStoredSecret()
+    {
+        // No per-user stored secret; only the app-owned token is available (the normal
+        // release path). Submit must use it and cache it into the credential store.
+        var credentials = new FakeCredentialService();
+        var service = MakeService(_ => new HttpResponseMessage(HttpStatusCode.Created)
+        {
+            Content = new StringContent("{\"html_url\":\"https://github.com/kellylford/QuickMail/issues/1\"}"),
+        }, out var handler, credentials, appOwnedToken: "app-token");
+
+        var result = await service.SubmitAsync(SampleReport());
+
+        Assert.True(result.Success);
+        Assert.Equal("app-token", handler.LastRequest!.Headers.Authorization!.Parameter);
+        Assert.Equal("app-token", credentials.GetSecret("QuickMail.BugReportService.AppOwnedToken"));
     }
 
     [Fact]

--- a/QuickMail/Services/BugReportService.cs
+++ b/QuickMail/Services/BugReportService.cs
@@ -29,6 +29,7 @@ public partial class BugReportService : IBugReportService, IDisposable
     private static readonly string[] IssueLabels = ["bug", "user-reported"];
 
     private readonly ICredentialService _credentials;
+    private readonly string _appOwnedToken;
     private readonly HttpClient _http;
     private readonly CancellationTokenSource _cts = new();
     private bool _disposed;
@@ -38,10 +39,13 @@ public partial class BugReportService : IBugReportService, IDisposable
     }
 
     // Internal overload so tests can substitute a fake HttpMessageHandler instead of hitting
-    // the real GitHub API.
-    internal BugReportService(ICredentialService credentials, HttpMessageHandler handler)
+    // the real GitHub API, and pin the app-owned token. The compiled-in AppOwnedToken is baked
+    // in at build time (empty in most builds, a real secret on release CI), so tests must inject
+    // a known value rather than depend on whichever the build happens to carry.
+    internal BugReportService(ICredentialService credentials, HttpMessageHandler handler, string? appOwnedToken = null)
     {
         _credentials = credentials;
+        _appOwnedToken = appOwnedToken ?? AppOwnedToken;
         _http = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(15) };
         _http.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("QuickMail", Helpers.AppVersion.Display));
         _http.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github+json"));
@@ -144,10 +148,10 @@ public partial class BugReportService : IBugReportService, IDisposable
         var stored = _credentials.GetSecret(TokenCredentialKey);
         if (!string.IsNullOrWhiteSpace(stored)) return stored;
 
-        if (string.IsNullOrWhiteSpace(AppOwnedToken)) return null;
+        if (string.IsNullOrWhiteSpace(_appOwnedToken)) return null;
 
-        _credentials.SaveSecret(TokenCredentialKey, AppOwnedToken);
-        return AppOwnedToken;
+        _credentials.SaveSecret(TokenCredentialKey, _appOwnedToken);
+        return _appOwnedToken;
     }
 
     public void Dispose()


### PR DESCRIPTION
## Problem
`main`'s CI (`QuickMail` build/test job) has been **red since #187 merged** — failing on `BugReportServiceTests.SubmitAsync_NoTokenAvailable_FailsWithoutHttpCall` (1 failed / 1072 passed). This blocks the release, since the release workflow keys off a green `main`.

## Root cause
Release CI generates the gitignored `QuickMail/Services/BugReportService.Credentials.cs` with a **real** fine-grained token (so release binaries can submit issues). `BugReportService.ResolveToken()` falls back to that compiled-in `AppOwnedToken` when no per-user secret is stored. So on CI the "no token available" precondition the test assumes is **false** — `SubmitAsync` proceeds, and `Assert.False(result.Success)` / `Assert.False(handlerCalled)` fail. The test had no way to force the baked-in token empty. (Locally it passed only because the dev/example credentials file has an empty token.)

## Fix
Make the app-owned token **injectable** via the internal test-only constructor (`appOwnedToken`, defaulting to the compiled-in `AppOwnedToken` in production — no behavior change for the app). The test helper `MakeService` now injects `""`, so the whole `BugReportServiceTests` suite is **hermetic** — independent of whichever token the build bakes in. Added a positive test for the app-token fallback (no stored secret → uses and caches the injected app token).

No production behavior change: `App.xaml.cs` uses the public constructor, which still defaults to `AppOwnedToken`.

## Verification
Reproduced the exact CI scenario locally by baking a **real** (non-empty) token into `BugReportService.Credentials.cs`, then ran the suite: **1074 passing, 0 failing** (previously this test failed in that scenario). Also passes with the empty-token dev credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)