### PR TITLE
Fix root cause: UILanguage silently discarded on every restart

### DIFF
--- a/QuickMail.Tests/ConfigServiceSaveTests.cs
+++ b/QuickMail.Tests/ConfigServiceSaveTests.cs
@@ -29,6 +29,28 @@ public class ConfigServiceSaveTests
     }
 
     [Fact]
+    public void SaveThenLoad_RoundTripsUILanguageAndCalendarSettings()
+    {
+        // Regression test: UILanguage, ShowDeclinedEvents, and CalendarPaneOpen were being
+        // written by Save() after the "[windowing]" section header, so ParseFile silently
+        // dropped them on the next Load() (they're only recognized under "[global]"). This
+        // meant changing the UI language in Settings appeared to do nothing after a restart.
+        var profile = MakeTempProfile();
+        var service = new ConfigService(profile);
+
+        var config = service.Load();
+        config.UILanguage = "de";
+        config.ShowDeclinedEvents = !config.ShowDeclinedEvents;
+        config.CalendarPaneOpen = !config.CalendarPaneOpen;
+        service.Save(config);
+
+        var reloaded = new ConfigService(profile).Load();
+        Assert.Equal("de", reloaded.UILanguage);
+        Assert.Equal(config.ShowDeclinedEvents, reloaded.ShowDeclinedEvents);
+        Assert.Equal(config.CalendarPaneOpen, reloaded.CalendarPaneOpen);
+    }
+
+    [Fact]
     public void Save_LeavesNoTempFileBehind()
     {
         var profile = MakeTempProfile();

--- a/QuickMail/Services/ConfigService.cs
+++ b/QuickMail/Services/ConfigService.cs
@@ -511,7 +511,27 @@ public class ConfigService : IConfigService
         sb.AppendLine("# Default is the built-in flag (00000000-0000-0000-0000-000000000001).");
         sb.AppendLine();
 
+        // ── Calendar ──────────────────────────────────────────────────────────────
+
+        sb.AppendLine($"ShowDeclinedEvents = {(config.ShowDeclinedEvents ? "on" : "off")}");
+        sb.AppendLine("# Whether declined calendar events appear in the calendar list.");
+        sb.AppendLine($"CalendarPaneOpen = {(config.CalendarPaneOpen ? "on" : "off")}");
+        sb.AppendLine("# Whether the calendar pane was open when the app last closed.");
+        sb.AppendLine();
+
+        // ── Localization ──────────────────────────────────────────────────────────
+
+        sb.AppendLine($"UILanguage = {config.UILanguage}");
+        sb.AppendLine("# UI language as a culture tag (e.g. es, de, fr). Empty = follow the Windows");
+        sb.AppendLine("# display language when available, else English. Restart required to apply.");
+        sb.AppendLine();
+
         // ── [windowing] ──────────────────────────────────────────────────────────
+        // NOTE: ShowDeclinedEvents, CalendarPaneOpen, and UILanguage above are parsed under
+        // the [global] section (see ParseFile) — they must stay above this header. They were
+        // previously written after it by mistake, so every one of these three settings was
+        // silently dropped back to its default on the very next load (this is why changing
+        // the UI language in Settings appeared to have no effect after a restart).
 
         sb.AppendLine("[windowing]");
         sb.AppendLine();
@@ -530,21 +550,6 @@ public class ConfigService : IConfigService
         sb.AppendLine($"ConfirmCloseTabWithUnsaved = {(config.Windowing.ConfirmCloseTabWithUnsaved ? "on" : "off")}");
         sb.AppendLine("# Confirm before closing a tab with unsaved changes.");
         sb.AppendLine("# Values: on, off.");
-        sb.AppendLine();
-
-        // ── Calendar ──────────────────────────────────────────────────────────────
-
-        sb.AppendLine($"ShowDeclinedEvents = {(config.ShowDeclinedEvents ? "on" : "off")}");
-        sb.AppendLine("# Whether declined calendar events appear in the calendar list.");
-        sb.AppendLine($"CalendarPaneOpen = {(config.CalendarPaneOpen ? "on" : "off")}");
-        sb.AppendLine("# Whether the calendar pane was open when the app last closed.");
-        sb.AppendLine();
-
-        // ── Localization ──────────────────────────────────────────────────────────
-
-        sb.AppendLine($"UILanguage = {config.UILanguage}");
-        sb.AppendLine("# UI language as a culture tag (e.g. es, de, fr). Empty = follow the Windows");
-        sb.AppendLine("# display language when available, else English. Restart required to apply.");
         sb.AppendLine();
 
         // ── [account:guid] overrides ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary
This is the actual root cause of the bug Kelly hit — even after #196 fixed the ViewModel string-localization gap, switching the UI language to German still showed English everywhere on restart. Confirmed via a standalone diagnostic harness that the ResourceManager/satellite-assembly/culture mechanism works correctly in isolation, which pointed upstream to the config layer.

**The bug**: `ConfigService.Save()` writes `UILanguage` (and `ShowDeclinedEvents`/`CalendarPaneOpen`) *after* the `[windowing]` section header, so they land physically inside `[windowing]` in `config.ini`. `ParseFile` only recognizes `uilanguage` when the current section is `global` — so reading it back under `windowing` silently drops it every time, resetting `UILanguage` to empty (→ falls back to the OS display language) on every load. The setting looked saved (it's right there in the file) but was discarded on every single restart, regardless of what the user picked in Settings.

**The fix**: move those three settings back above the `[windowing]` header, with a comment explaining why they must stay there.

**Verified end-to-end** with a real running build: before the fix, the menu bar showed `File/Message/View/Tools/Help` in English despite `UILanguage=de`; after the fix, the same build shows `Datei/Nachricht/Ansicht/Extras/Hilfe` and the window title reads `Alle E-Mails - QuickMail`.

Also fixed Kelly's real profile `config.ini` directly so the fix takes effect without her needing to re-pick German in Settings.

## Test plan
- [x] Added `SaveThenLoad_RoundTripsUILanguageAndCalendarSettings` — verified it **fails** against the pre-fix code (reverted the fix, reran, confirmed red) and **passes** with the fix
- [x] `dotnet build` — 0 errors
- [x] `dotnet test` (full suite, excluding two pre-existing clipboard-dependent tests) — 1061/1061 passed
- [x] Manual end-to-end verification via UI Automation against a real built exe with a real profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)