### PR TITLE
Batch compose body loads into one UIA change block (#181, site 2)

### DIFF
--- a/QuickMail.Tests/ComposeUiaTextPatternTests.cs
+++ b/QuickMail.Tests/ComposeUiaTextPatternTests.cs
@@ -55,6 +55,58 @@ public class ComposeUiaTextPatternTests
     }
 
     [StaFact]
+    public void LoadInto_EditorOverload_BatchesLoadIntoOneChangeEvent()
+    {
+        // Issue #181: every change-block close on a live document raises a UIA
+        // text-changed event — a synchronous cross-process call to any
+        // listening screen reader, which can wedge the STA thread mid-load.
+        // TextChanged fires at the same change-block boundary, so it counts
+        // how many of those notifications a load produces.
+        var rtb = new RichTextBox();
+        var window = MakeHiddenWindow(rtb);
+        window.Show();
+        try
+        {
+            rtb.Document.Blocks.Clear();
+            rtb.Document.Blocks.Add(new Paragraph(new Run("original text")));
+
+            var peer = UIElementAutomationPeer.CreatePeerForElement(rtb);
+            var textProvider = peer.GetPattern(PatternInterface.Text) as ITextProvider;
+            Assert.NotNull(textProvider);
+
+            const string html = "<p>one</p><p>two</p><p>three</p><ul><li>four</li></ul>";
+
+            // The document-level overload closes a change block per mutation —
+            // this is the behavior the editor overload exists to avoid.
+            int unbatched = 0;
+            TextChangedEventHandler countUnbatched = (_, _) => unbatched++;
+            rtb.TextChanged += countUnbatched;
+            QuickMail.Helpers.RichTextDocumentConverter.LoadInto(rtb.Document, html);
+            rtb.TextChanged -= countUnbatched;
+            Assert.True(unbatched > 1,
+                $"expected one change event per block mutation without batching, got {unbatched}");
+
+            int batched = 0;
+            TextChangedEventHandler countBatched = (_, _) => batched++;
+            rtb.TextChanged += countBatched;
+            QuickMail.Helpers.RichTextDocumentConverter.LoadInto(rtb, html);
+            rtb.TextChanged -= countBatched;
+            Assert.Equal(1, batched);
+
+            // Batching must not break the in-place mutation guarantee: the
+            // peer created before the load still reads the new content.
+            var after = textProvider!.DocumentRange.GetText(-1);
+            Assert.Contains("one", after);
+            Assert.Contains("four", after);
+            Assert.DoesNotContain("original", after);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [StaFact]
     public void ComposeWindow_AllModes_ExposeBodyTextThroughUia()
     {
         var vm = new QuickMail.ViewModels.ComposeViewModel(

--- a/QuickMail/Helpers/RichTextDocumentConverter.cs
+++ b/QuickMail/Helpers/RichTextDocumentConverter.cs
@@ -97,11 +97,14 @@ public static class RichTextDocumentConverter
 
     /// <summary>
     /// Replaces the content of an existing document with the parsed HTML.
-    /// The editor must always load through this (never assign a new document to
-    /// <c>RichTextBox.Document</c>): the control's UIA automation peer binds to
-    /// the original document's text container at creation and never rebinds, so
+    /// Never assign a new document to <c>RichTextBox.Document</c> instead of
+    /// loading in place: the control's UIA automation peer binds to the
+    /// original document's text container at creation and never rebinds, so
     /// after a Document replacement screen readers permanently read the stale
-    /// (empty) document instead of what is on screen.
+    /// (empty) document instead of what is on screen. Call this overload
+    /// directly only for detached documents; a live editor must load through
+    /// <see cref="LoadInto(RichTextBox, string)"/> so the whole load is one
+    /// change block instead of one UIA event per block.
     /// </summary>
     public static void LoadInto(FlowDocument doc, string html)
     {

--- a/QuickMail/Helpers/RichTextDocumentConverter.cs
+++ b/QuickMail/Helpers/RichTextDocumentConverter.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Net;
 using System.Text;
 using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Documents;
 using System.Windows.Media;
 using QuickMail.Models;
@@ -110,6 +111,29 @@ public static class RichTextDocumentConverter
             doc.Blocks.Add(block);
         if (doc.Blocks.Count == 0)
             doc.Blocks.Add(new Paragraph());
+    }
+
+    /// <summary>
+    /// Loads HTML into a live editor's document inside a single change block.
+    /// Loads into an attached document must go through this overload: without
+    /// the outer change block, every Blocks mutation closes its own change
+    /// block and raises its own UIA text-changed event — a synchronous
+    /// cross-process call to any listening screen reader, per block added.
+    /// A long quoted reply body is hundreds of such round-trips, any one of
+    /// which can wedge the STA thread mid-load (issue #181). Batched, the
+    /// whole load raises exactly one event after the document is complete.
+    /// </summary>
+    public static void LoadInto(RichTextBox editor, string html)
+    {
+        editor.BeginChange();
+        try
+        {
+            LoadInto(editor.Document, html);
+        }
+        finally
+        {
+            editor.EndChange();
+        }
     }
 
     private static IEnumerable<Block> BuildBlocks(List<HtmlNode> nodes)

--- a/QuickMail/Views/ComposeWindow.xaml.cs
+++ b/QuickMail/Views/ComposeWindow.xaml.cs
@@ -1557,13 +1557,21 @@ public partial class ComposeWindow : Window
         _vm.LoadHtmlIntoEditorRequested += html =>
         {
             // Programmatic load is not a user edit — don't mark the draft dirty.
+            // finally: a stuck suppress flag would silently stop dirty-tracking
+            // for the window's lifetime.
             _suppressRichTextChanged = true;
             _suppressFormattingAnnouncement = true;
             _lastAnnouncedBlockType = null;
-            RichTextDocumentConverter.LoadInto(RichBodyBox, html);
-            RichBodyBox.CaretPosition = RichBodyBox.Document.ContentStart;
-            _suppressRichTextChanged = false;
-            _suppressFormattingAnnouncement = false;
+            try
+            {
+                RichTextDocumentConverter.LoadInto(RichBodyBox, html);
+                RichBodyBox.CaretPosition = RichBodyBox.Document.ContentStart;
+            }
+            finally
+            {
+                _suppressRichTextChanged = false;
+                _suppressFormattingAnnouncement = false;
+            }
         };
 
         _vm.InsertTextIntoEditorRequested += text =>
@@ -1622,9 +1630,15 @@ public partial class ComposeWindow : Window
         _suppressRichTextChanged = true;
         _suppressFormattingAnnouncement = true;
         _lastAnnouncedBlockType = null;
-        RichTextDocumentConverter.LoadInto(RichBodyBox, html);
-        _suppressRichTextChanged = false;
-        _suppressFormattingAnnouncement = false;
+        try
+        {
+            RichTextDocumentConverter.LoadInto(RichBodyBox, html);
+        }
+        finally
+        {
+            _suppressRichTextChanged = false;
+            _suppressFormattingAnnouncement = false;
+        }
 
         RichBodyBox.CaretPosition =
             RichBodyBox.Document.ContentStart.GetPositionAtOffset(caretOffset) ?? RichBodyBox.Document.ContentEnd;

--- a/QuickMail/Views/ComposeWindow.xaml.cs
+++ b/QuickMail/Views/ComposeWindow.xaml.cs
@@ -1560,7 +1560,7 @@ public partial class ComposeWindow : Window
             _suppressRichTextChanged = true;
             _suppressFormattingAnnouncement = true;
             _lastAnnouncedBlockType = null;
-            RichTextDocumentConverter.LoadInto(RichBodyBox.Document, html);
+            RichTextDocumentConverter.LoadInto(RichBodyBox, html);
             RichBodyBox.CaretPosition = RichBodyBox.Document.ContentStart;
             _suppressRichTextChanged = false;
             _suppressFormattingAnnouncement = false;
@@ -1622,7 +1622,7 @@ public partial class ComposeWindow : Window
         _suppressRichTextChanged = true;
         _suppressFormattingAnnouncement = true;
         _lastAnnouncedBlockType = null;
-        RichTextDocumentConverter.LoadInto(RichBodyBox.Document, html);
+        RichTextDocumentConverter.LoadInto(RichBodyBox, html);
         _suppressRichTextChanged = false;
         _suppressFormattingAnnouncement = false;
 


### PR DESCRIPTION
## Summary

Second fix for the #181 reply hang family. A live capture on 2026-07-07 (full managed stack via `dotnet-stack` on the wedged process) showed the STA UI thread permanently blocked in `AutomationInteropProvider.RaiseAutomationEvent`, raised from `TextContainer.EndChange` for a **single `Blocks.Add`** inside `RichTextDocumentConverter.LoadInto` while the quoted reply body was being loaded during compose-window open (`ReplyAll` → `Window.Show()` → `Loaded` → `SetMode` → `LoadInto`).

With an automation client attached, every block added to the live compose document closes its own change block and raises its own UIA text-changed event — a synchronous cross-process COM call. A long quoted reply is hundreds of those calls, and any one of them can pump-wait forever (see the issue for the full stack and environment analysis).

## Change

- New `LoadInto(RichTextBox, string)` overload in `RichTextDocumentConverter` wraps the entire load in `BeginChange()`/`EndChange()`, collapsing the per-block event storm to exactly **one** change notification raised after the document is complete.
- Both live-document call sites in `ComposeWindow` (the `LoadHtmlIntoEditorRequested` handler and the theme-refresh rebuild) now use it.
- The detached-document path (`FromHtml`) has no automation peer, so it is unchanged; the document is still mutated in place, preserving the UIA text-pattern binding guarded by `ComposeUiaTextPatternTests`.

## Testing

- New regression test `LoadInto_EditorOverload_BatchesLoadIntoOneChangeEvent`: asserts the unbatched document overload raises one `TextChanged` per mutation (>1), the batched overload raises exactly one, and a UIA text provider created before the load still reads the new content afterwards. `TextChanged` fires at the same change-block boundary as the UIA text-changed automation event on the hang stack.
- Full suite: 1079 passed, 0 failed.

## Caveats

- Like #190, this narrows the wedge window rather than eliminating it — the one remaining event is still a synchronous cross-process call, and WPF owns that behavior. Needs verification on the repro machine (open a long reply with `/debug` and a screen reader running) before #181 can be closed. Relates to #181; complements #190 (spell-checker site).
- **Undo granularity changes** (surfaced by independent review): the batched load is one undo unit, so a single Ctrl+Z after opening a reply now removes the entire seeded body instead of one block. One Ctrl+Y restores it. Arguably more coherent than the old per-block behavior; whether a programmatic seed should be undoable at all is a separate decision, out of scope here.
- Other synchronous cross-process UIA calls remain on the reply-open path (window-opened, focus-changed, selection-changed from the caret reset). A recurrence of the hang would indicate a **third** blocking site, not that this batching failed — the `/debug` trace would show where.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
