### PR TITLE
Automatic updates via Velopack with MSI installer and update dialogs

### DIFF
--- a/.github/workflows/quickmail.yml
+++ b/.github/workflows/quickmail.yml
@@ -107,14 +107,25 @@ jobs:
 
       # --shortcuts StartMenuRoot: Start Menu entry only, no desktop shortcut
       # (matches the previous installer's default).
+      # --msi builds the wizard installer (welcome, license acceptance, conclusion pages)
+      # that is the user-facing download; the one-click Setup.exe is also produced but
+      # intentionally not shipped. --instLocation PerUser keeps the install in
+      # %LocalAppData% so background updates never need elevation. vpk requires the
+      # license file to carry a .txt/.md/.rtf extension, hence the copy.
       - name: Pack Velopack release
         if: startsWith(github.ref, 'refs/tags/v')
         shell: pwsh
         run: |
           $version = '${{ github.ref_name }}'.TrimStart('v')
+          Copy-Item LICENSE installer/velopack/license.txt
           vpk pack --packId QuickMail --packVersion $version --packDir publish `
             --mainExe QuickMail.exe --packTitle QuickMail --packAuthors "Kelly Ford" `
-            --shortcuts StartMenuRoot --outputDir installer/Output/Releases
+            --shortcuts StartMenuRoot --outputDir installer/Output/Releases `
+            --framework webview2 `
+            --msi --instLocation PerUser `
+            --instWelcome installer/velopack/welcome.txt `
+            --instLicense installer/velopack/license.txt `
+            --instConclusion installer/velopack/conclusion.txt
           # The download step above leaves the previous version's full .nupkg in this
           # folder (delta input). Remove it so the release upload glob below ships only
           # this version's packages — clients never fetch old assets from a new release.
@@ -127,11 +138,14 @@ jobs:
       # otherwise GitHub auto-generates notes from commits.
       #
       # Uploaded assets serve two consumers:
-      #  - people: QuickMail-win-Setup.exe (installer) and QuickMail.exe (portable)
+      #  - people: QuickMail-win.msi (wizard installer with license acceptance) and
+      #    QuickMail.exe (portable)
       #  - the in-app updater: RELEASES, releases.win.json, assets.win.json, and the
       #    .nupkg packages (full + delta), which Velopack's GithubSource reads from the
-      #    latest release. QuickMail-win-Portable.zip is intentionally not shipped —
-      #    the raw single-file QuickMail.exe remains the portable download.
+      #    latest release.
+      # Intentionally not shipped: QuickMail-win-Setup.exe (one-click, no wizard/license)
+      # and QuickMail-win-Portable.zip (the raw single-file QuickMail.exe remains the
+      # portable download).
       - name: Release
         if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v3
@@ -139,7 +153,7 @@ jobs:
           name: QuickMail ${{ github.ref_name }}
           files: |
             publish/QuickMail.exe
-            installer/Output/Releases/QuickMail-win-Setup.exe
+            installer/Output/Releases/QuickMail-win.msi
             installer/Output/Releases/*.nupkg
             installer/Output/Releases/RELEASES
             installer/Output/Releases/releases.win.json

--- a/.github/workflows/quickmail.yml
+++ b/.github/workflows/quickmail.yml
@@ -76,18 +76,62 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
-      - name: Install Inno Setup
+      # The release tag is the single source of truth for the Velopack package version.
+      # It must be SemVer (vpk rejects 4-part versions) and must match the csproj
+      # <Version>, which drives the in-app version display and the portable-exe
+      # update comparison — a mismatch would make installs mis-report their version.
+      - name: Verify tag matches csproj version
         if: startsWith(github.ref, 'refs/tags/v')
-        run: choco install innosetup --no-progress
-
-      - name: Build installer
-        if: startsWith(github.ref, 'refs/tags/v')
-        run: '& "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" installer\quickmail.iss'
         shell: pwsh
+        run: |
+          $tag = '${{ github.ref_name }}'.TrimStart('v')
+          $csproj = (Select-Xml -Path QuickMail/QuickMail.csproj -XPath '/Project/PropertyGroup/Version').Node.InnerText
+          if ($tag -ne $csproj) {
+            throw "Tag version '$tag' does not match csproj <Version> '$csproj'. Update the csproj or re-tag."
+          }
+
+      - name: Install vpk
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: dotnet tool install -g vpk
+
+      # Fetch the previous release's Velopack assets so vpk pack can generate a delta
+      # package. If this step is skipped or fails, packing still succeeds but ships a
+      # full package only — updates work, just as larger downloads.
+      # continue-on-error covers the first Velopack release, where the latest GitHub
+      # release predates Velopack and has no assets for vpk to download.
+      - name: Download previous release for delta generation
+        if: startsWith(github.ref, 'refs/tags/v')
+        continue-on-error: true
+        shell: pwsh
+        run: vpk download github --repoUrl https://github.com/kellylford/QuickMail --token ${{ secrets.GITHUB_TOKEN }} --outputDir installer/Output/Releases
+
+      # --shortcuts StartMenuRoot: Start Menu entry only, no desktop shortcut
+      # (matches the previous installer's default).
+      - name: Pack Velopack release
+        if: startsWith(github.ref, 'refs/tags/v')
+        shell: pwsh
+        run: |
+          $version = '${{ github.ref_name }}'.TrimStart('v')
+          vpk pack --packId QuickMail --packVersion $version --packDir publish `
+            --mainExe QuickMail.exe --packTitle QuickMail --packAuthors "Kelly Ford" `
+            --shortcuts StartMenuRoot --outputDir installer/Output/Releases
+          # The download step above leaves the previous version's full .nupkg in this
+          # folder (delta input). Remove it so the release upload glob below ships only
+          # this version's packages — clients never fetch old assets from a new release.
+          Get-ChildItem installer/Output/Releases/*.nupkg |
+            Where-Object { $_.Name -notmatch [regex]::Escape("-$version-") } |
+            Remove-Item
 
       # Create a GitHub Release when a version tag is pushed (e.g. v1.2.0)
       # Release notes are read from docs/release-notes-<tag>.md if present,
       # otherwise GitHub auto-generates notes from commits.
+      #
+      # Uploaded assets serve two consumers:
+      #  - people: QuickMail-win-Setup.exe (installer) and QuickMail.exe (portable)
+      #  - the in-app updater: RELEASES, releases.win.json, assets.win.json, and the
+      #    .nupkg packages (full + delta), which Velopack's GithubSource reads from the
+      #    latest release. QuickMail-win-Portable.zip is intentionally not shipped —
+      #    the raw single-file QuickMail.exe remains the portable download.
       - name: Release
         if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v3
@@ -95,5 +139,9 @@ jobs:
           name: QuickMail ${{ github.ref_name }}
           files: |
             publish/QuickMail.exe
-            installer/Output/quickmail-v*-setup.exe
+            installer/Output/Releases/QuickMail-win-Setup.exe
+            installer/Output/Releases/*.nupkg
+            installer/Output/Releases/RELEASES
+            installer/Output/Releases/releases.win.json
+            installer/Output/Releases/assets.win.json
           body_path: docs/release-notes-${{ github.ref_name }}.md

--- a/.github/workflows/quickmail.yml
+++ b/.github/workflows/quickmail.yml
@@ -77,17 +77,22 @@ jobs:
           retention-days: 7
 
       # The release tag is the single source of truth for the Velopack package version.
-      # It must be SemVer (vpk rejects 4-part versions) and must match the csproj
-      # <Version>, which drives the in-app version display and the portable-exe
-      # update comparison — a mismatch would make installs mis-report their version.
-      - name: Verify tag matches csproj version
+      # It must be SemVer (vpk rejects 4-part versions) and must match all three csproj
+      # version properties, which are set independently: <Version> feeds NuGet/display
+      # conventions, but <AssemblyVersion> is what Helpers/AppVersion.Display actually
+      # reads — it drives the About dialog, LastRunVersion tracking, and the portable-exe
+      # update comparison. A partial bump would ship an app that mis-reports its version
+      # and portable copies that perpetually announce the update they already have.
+      - name: Verify tag matches csproj versions
         if: startsWith(github.ref, 'refs/tags/v')
         shell: pwsh
         run: |
           $tag = '${{ github.ref_name }}'.TrimStart('v')
-          $csproj = (Select-Xml -Path QuickMail/QuickMail.csproj -XPath '/Project/PropertyGroup/Version').Node.InnerText
-          if ($tag -ne $csproj) {
-            throw "Tag version '$tag' does not match csproj <Version> '$csproj'. Update the csproj or re-tag."
+          foreach ($prop in 'Version', 'AssemblyVersion', 'FileVersion') {
+            $value = (Select-Xml -Path QuickMail/QuickMail.csproj -XPath "/Project/PropertyGroup/$prop").Node.InnerText
+            if ($tag -ne $value) {
+              throw "Tag version '$tag' does not match csproj <$prop> '$value'. Update the csproj or re-tag."
+            }
           }
 
       - name: Install vpk
@@ -126,12 +131,10 @@ jobs:
             --instWelcome installer/velopack/welcome.txt `
             --instLicense installer/velopack/license.txt `
             --instConclusion installer/velopack/conclusion.txt
-          # The download step above leaves the previous version's full .nupkg in this
-          # folder (delta input). Remove it so the release upload glob below ships only
-          # this version's packages — clients never fetch old assets from a new release.
-          Get-ChildItem installer/Output/Releases/*.nupkg |
-            Where-Object { $_.Name -notmatch [regex]::Escape("-$version-") } |
-            Remove-Item
+          # The previous version's full .nupkg (fetched above as the delta input) stays in
+          # the folder and is uploaded with the rest: vpk pack bakes an entry for every
+          # package it saw into RELEASES/releases.win.json, so deleting the file would
+          # publish feed metadata referencing an asset the release does not carry.
 
       # Create a GitHub Release when a version tag is pushed (e.g. v1.2.0)
       # Release notes are read from docs/release-notes-<tag>.md if present,
@@ -158,4 +161,8 @@ jobs:
             installer/Output/Releases/RELEASES
             installer/Output/Releases/releases.win.json
             installer/Output/Releases/assets.win.json
+          # Exact filenames above encode vpk's output naming; if a vpk upgrade renames an
+          # output, fail the release instead of silently publishing without the installer
+          # or the update feed (clients would then quietly stop seeing updates).
+          fail_on_unmatched_files: true
           body_path: docs/release-notes-${{ github.ref_name }}.md

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ startmail.bat
 startoffline.bat
 Tools/MailGenerator/credentials.ini
 /logs
+installer/velopack/license.txt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,14 +13,14 @@ build.bat            # debug build
 build.bat release    # release build
 build.bat run        # debug build + launch
 build.bat publish    # self-contained single-file win-x64 -> publish/QuickMail.exe
-build.bat installer  # publish + compile Inno Setup installer -> installer/Output/quickmail-v<version>-setup.exe
+build.bat installer  # publish + Velopack pack -> installer/Output/Releases/ (setup exe + update packages)
 build.bat smoke      # build + launch for 6s
 build.bat clean
 ```
 
 Or directly: `dotnet run --project QuickMail`.
 
-The `installer` target requires [Inno Setup 6](https://jrsoftware.org/isdl.php) (`ISCC.exe`). See `docs/INSTALLER.md` for installer details.
+The `installer` target requires the Velopack CLI (`dotnet tool install -g vpk`). See `docs/INSTALLER.md` for packaging and auto-update details. Packaging constraint: `App.xaml.cs` declares an explicit `Main` that must call `VelopackApp.Build().Run()` first — `vpk pack` verifies this via IL inspection and refuses to pack without it.
 
 Startup flags: `/debug` enables verbose file logging. `--profileDir <path>` overrides the data directory (default `%APPDATA%\QuickMail`); useful for isolated testing.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ Or directly: `dotnet run --project QuickMail`.
 
 The `installer` target requires the Velopack CLI (`dotnet tool install -g vpk`). See `docs/INSTALLER.md` for packaging and auto-update details. Packaging constraint: `App.xaml.cs` declares an explicit `Main` that must call `VelopackApp.Build().Run()` first — `vpk pack` verifies this via IL inspection and refuses to pack without it.
 
-Startup flags: `/debug` enables verbose file logging. `--profileDir <path>` overrides the data directory (default `%APPDATA%\QuickMail`); useful for isolated testing.
+Startup flags: `/debug` enables verbose file logging. `--profileDir <path>` overrides the data directory (default `%APPDATA%\QuickMail`); useful for isolated testing. `--updateFeed <path>` points the update check at a local folder of `vpk pack` output instead of GitHub Releases (see `docs/INSTALLER.md` for the local update-cycle test procedure).
 
 ## Tests
 

--- a/QuickMail/App.xaml.cs
+++ b/QuickMail/App.xaml.cs
@@ -221,7 +221,7 @@ public partial class App : Application
             var calendarProvider = new LocalCacheCalendarProvider(localStore);
             var calendarService = new CalendarService(calendarProvider);
 
-            _updateCheckService = new UpdateCheckService(ParseUpdateFeed(e.Args));
+            _updateCheckService = new UpdateCheckService(configService, ParseUpdateFeed(e.Args));
             _bugReportService   = new BugReportService(credentialService);
             var mainVm = new MainViewModel(
                 mailRouter, accountService, credentialService, localStore, oauthService, syncService, configService, commandRegistry, viewService, ruleService, smtpService,

--- a/QuickMail/App.xaml.cs
+++ b/QuickMail/App.xaml.cs
@@ -23,6 +23,19 @@ public partial class App : Application
     private ThemeService? _themeService;
     private BugReportService? _bugReportService;
 
+    // Explicit entry point (App.xaml compiles as Page; see csproj StartupObject). Velopack must
+    // run before any WPF initialization: on install/update/uninstall its hooks handle the event
+    // and exit the process, and on a normal launch after an update it finalizes the new version.
+    [STAThread]
+    public static void Main(string[] args)
+    {
+        Velopack.VelopackApp.Build().Run();
+
+        var app = new App();
+        app.InitializeComponent();
+        app.Run();
+    }
+
     protected override void OnStartup(StartupEventArgs e)
     {
         base.OnStartup(e);

--- a/QuickMail/App.xaml.cs
+++ b/QuickMail/App.xaml.cs
@@ -52,6 +52,9 @@ public partial class App : Application
                 "  --online              Run in fully online mode: fetch everything live from\n" +
                 "                        IMAP on every folder selection. Nothing is read from\n" +
                 "                        or written to the local SQLite cache.\n\n" +
+                "  --updateFeed <path>   Check for updates in <path> (a folder or URL of\n" +
+                "                        Velopack packages) instead of GitHub Releases.\n" +
+                "                        For testing update delivery.\n\n" +
                 "  --help                Show this message and exit.\n\n" +
                 "  /debug                Write verbose debug output to quickmail.log.",
                 "QuickMail",
@@ -164,7 +167,7 @@ public partial class App : Application
             var calendarProvider = new LocalCacheCalendarProvider(localStore);
             var calendarService = new CalendarService(calendarProvider);
 
-            _updateCheckService = new UpdateCheckService();
+            _updateCheckService = new UpdateCheckService(ParseUpdateFeed(e.Args));
             _bugReportService   = new BugReportService(credentialService);
             var mainVm = new MainViewModel(
                 mailRouter, accountService, credentialService, localStore, oauthService, syncService, configService, commandRegistry, viewService, ruleService, smtpService,
@@ -228,6 +231,21 @@ public partial class App : Application
                 if (arg.Equals(flag, StringComparison.OrdinalIgnoreCase))
                     return true;
         return false;
+    }
+
+    /// <summary>
+    /// Parses --updateFeed from args: a local folder or URL holding Velopack packages,
+    /// overriding the GitHub Releases source. Lets the full update cycle (check, download,
+    /// apply on relaunch) be tested against local vpk pack output without publishing.
+    /// </summary>
+    private static string? ParseUpdateFeed(string[] args)
+    {
+        for (int i = 0; i < args.Length - 1; i++)
+        {
+            if (string.Equals(args[i], "--updateFeed", StringComparison.OrdinalIgnoreCase))
+                return args[i + 1];
+        }
+        return null;
     }
 
     /// <summary>

--- a/QuickMail/App.xaml.cs
+++ b/QuickMail/App.xaml.cs
@@ -29,11 +29,65 @@ public partial class App : Application
     [STAThread]
     public static void Main(string[] args)
     {
-        Velopack.VelopackApp.Build().Run();
+        Velopack.VelopackApp.Build()
+            .OnBeforeUninstallFastCallback(_ => LaunchUninstallDataPrompt())
+            .Run();
 
         var app = new App();
         app.InitializeComponent();
         app.Run();
+    }
+
+    // Uninstall-time offer to remove user data, mirroring the old installer's prompt.
+    // Update.exe kills hook processes after ~30 seconds — far too short to leave a question
+    // pending — so the prompt runs in a detached PowerShell process that outlives the
+    // uninstall. The default answer keeps everything; only an explicit Yes deletes the
+    // default profile (%APPDATA%\QuickMail) and QuickMail entries in Windows Credential
+    // Manager. Custom --profileDir locations are never touched.
+    private static void LaunchUninstallDataPrompt()
+    {
+        try
+        {
+            var dataDir = System.IO.Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "QuickMail");
+            if (!System.IO.Directory.Exists(dataDir)) return;
+
+            var script = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "quickmail-uninstall-prompt.ps1");
+            System.IO.File.WriteAllText(script, """
+                Add-Type -AssemblyName System.Windows.Forms
+                $dir = Join-Path $env:APPDATA 'QuickMail'
+                if (-not (Test-Path $dir)) { exit }
+                $msg = "QuickMail has been uninstalled.`n`n" +
+                       "Do you also want to remove your QuickMail data? This permanently deletes all accounts, settings, contacts, rules, templates, saved views, and cached mail stored under:`n$dir`n`n" +
+                       "It also removes QuickMail's saved passwords and sign-ins from Windows Credential Manager.`n`n" +
+                       "Choose No to keep everything, so a future install picks up exactly where you left off."
+                $owner = New-Object System.Windows.Forms.Form -Property @{ TopMost = $true }
+                $r = [System.Windows.Forms.MessageBox]::Show($owner, $msg, 'QuickMail Uninstall',
+                    [System.Windows.Forms.MessageBoxButtons]::YesNo,
+                    [System.Windows.Forms.MessageBoxIcon]::Question,
+                    [System.Windows.Forms.MessageBoxDefaultButton]::Button2)
+                if ($r -eq [System.Windows.Forms.DialogResult]::Yes) {
+                    Remove-Item -LiteralPath $dir -Recurse -Force -ErrorAction SilentlyContinue
+                    (cmdkey /list) | ForEach-Object {
+                        if ($_ -match 'target=(QuickMail\S*)') { cmdkey /delete:$($Matches[1]) | Out-Null }
+                    }
+                }
+                Remove-Item -LiteralPath $PSCommandPath -Force -ErrorAction SilentlyContinue
+                """);
+
+            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = "powershell.exe",
+                Arguments = $"-NoProfile -ExecutionPolicy Bypass -STA -WindowStyle Hidden -File \"{script}\"",
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            });
+        }
+        catch (Exception ex)
+        {
+            // The uninstall itself must never fail or stall because of this prompt.
+            LogService.Debug($"Uninstall data prompt: {ex.Message}");
+        }
     }
 
     protected override void OnStartup(StartupEventArgs e)

--- a/QuickMail/App.xaml.cs
+++ b/QuickMail/App.xaml.cs
@@ -43,9 +43,14 @@ public partial class App : Application
     // pending — so the prompt runs in a detached PowerShell process that outlives the
     // uninstall. The default answer keeps everything; only an explicit Yes deletes the
     // default profile (%APPDATA%\QuickMail) and QuickMail entries in Windows Credential
-    // Manager. Custom --profileDir locations are never touched.
+    // Manager. Custom --profileDir locations are never touched. The whole mechanism is
+    // best-effort: on script-restricted machines (AppLocker, Constrained Language Mode)
+    // the prompt may never appear, in which case data is kept — the safe default.
+    // Diagnostics go to %TEMP%\quickmail-uninstall.log: LogService is not configured in
+    // the hook context (OnStartup never runs), so it cannot be used here.
     private static void LaunchUninstallDataPrompt()
     {
+        var diagLog = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "quickmail-uninstall.log");
         try
         {
             var dataDir = System.IO.Path.Combine(
@@ -54,6 +59,8 @@ public partial class App : Application
 
             var script = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "quickmail-uninstall-prompt.ps1");
             System.IO.File.WriteAllText(script, """
+                $log = Join-Path $env:TEMP 'quickmail-uninstall.log'
+                Add-Content -Path $log -Value "$(Get-Date -Format s) prompt script started"
                 Add-Type -AssemblyName System.Windows.Forms
                 $dir = Join-Path $env:APPDATA 'QuickMail'
                 if (-not (Test-Path $dir)) { exit }
@@ -66,11 +73,13 @@ public partial class App : Application
                     [System.Windows.Forms.MessageBoxButtons]::YesNo,
                     [System.Windows.Forms.MessageBoxIcon]::Question,
                     [System.Windows.Forms.MessageBoxDefaultButton]::Button2)
+                Add-Content -Path $log -Value "$(Get-Date -Format s) user answered: $r"
                 if ($r -eq [System.Windows.Forms.DialogResult]::Yes) {
                     Remove-Item -LiteralPath $dir -Recurse -Force -ErrorAction SilentlyContinue
                     (cmdkey /list) | ForEach-Object {
                         if ($_ -match 'target=(QuickMail\S*)') { cmdkey /delete:$($Matches[1]) | Out-Null }
                     }
+                    Add-Content -Path $log -Value "$(Get-Date -Format s) data removal completed"
                 }
                 Remove-Item -LiteralPath $PSCommandPath -Force -ErrorAction SilentlyContinue
                 """);
@@ -82,11 +91,15 @@ public partial class App : Application
                 UseShellExecute = false,
                 CreateNoWindow = true,
             });
+            System.IO.File.AppendAllText(diagLog, $"{DateTime.Now:s} uninstall hook: prompt process launched\r\n");
         }
         catch (Exception ex)
         {
             // The uninstall itself must never fail or stall because of this prompt.
-            LogService.Debug($"Uninstall data prompt: {ex.Message}");
+#pragma warning disable RCS1075 // this IS the last-resort diagnostics writer — a failure to write the diagnostic has no further channel and must not escape into the uninstall hook
+            try { System.IO.File.AppendAllText(diagLog, $"{DateTime.Now:s} uninstall hook failed: {ex}\r\n"); }
+            catch (Exception) { }
+#pragma warning restore RCS1075
         }
     }
 

--- a/QuickMail/Helpers/DesktopShortcut.cs
+++ b/QuickMail/Helpers/DesktopShortcut.cs
@@ -1,0 +1,48 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace QuickMail.Helpers;
+
+/// <summary>
+/// Creates and removes the QuickMail desktop shortcut. The shortcut targets the running
+/// executable; under a Velopack install that path (%LocalAppData%\QuickMail\current\QuickMail.exe)
+/// is stable across updates, so the link stays valid after the app updates itself.
+/// </summary>
+public static class DesktopShortcut
+{
+    private static string ShortcutPath =>
+        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Desktop), "QuickMail.lnk");
+
+    public static bool Exists() => File.Exists(ShortcutPath);
+
+    public static void Create()
+    {
+        var target = Environment.ProcessPath;
+        if (string.IsNullOrEmpty(target)) return;
+
+        // WScript.Shell is the only shell-link writer reachable without a COM interop assembly.
+        var shellType = Type.GetTypeFromProgID("WScript.Shell");
+        if (shellType is null) return;
+        dynamic shell = Activator.CreateInstance(shellType)!;
+        try
+        {
+            dynamic link = shell.CreateShortcut(ShortcutPath);
+            link.TargetPath = target;
+            link.WorkingDirectory = Path.GetDirectoryName(target);
+            link.Description = "QuickMail";
+            link.Save();
+        }
+        finally
+        {
+            Marshal.ReleaseComObject(shell);
+        }
+    }
+
+    public static void Delete()
+    {
+        try { File.Delete(ShortcutPath); }
+        catch (IOException) { }
+        catch (UnauthorizedAccessException) { }
+    }
+}

--- a/QuickMail/Helpers/DesktopShortcut.cs
+++ b/QuickMail/Helpers/DesktopShortcut.cs
@@ -16,14 +16,16 @@ public static class DesktopShortcut
 
     public static bool Exists() => File.Exists(ShortcutPath);
 
-    public static void Create()
+    /// <summary>Returns false when no shortcut was created (unknown process path, or the
+    /// WScript.Shell COM class is unavailable) so callers never report a false success.</summary>
+    public static bool Create()
     {
         var target = Environment.ProcessPath;
-        if (string.IsNullOrEmpty(target)) return;
+        if (string.IsNullOrEmpty(target)) return false;
 
         // WScript.Shell is the only shell-link writer reachable without a COM interop assembly.
         var shellType = Type.GetTypeFromProgID("WScript.Shell");
-        if (shellType is null) return;
+        if (shellType is null) return false;
         dynamic shell = Activator.CreateInstance(shellType)!;
         try
         {
@@ -32,6 +34,7 @@ public static class DesktopShortcut
             link.WorkingDirectory = Path.GetDirectoryName(target);
             link.Description = "QuickMail";
             link.Save();
+            return true;
         }
         finally
         {

--- a/QuickMail/Helpers/VelopackRuntime.cs
+++ b/QuickMail/Helpers/VelopackRuntime.cs
@@ -20,7 +20,7 @@ public static class VelopackRuntime
             // The source is never contacted here; construction only inspects the local
             // install layout via IsInstalled.
             return new UpdateManager(
-                new GithubSource("https://github.com/kellylford/QuickMail", accessToken: null, prerelease: false))
+                new GithubSource(Services.UpdateCheckService.RepoUrl, accessToken: null, prerelease: false))
                 .IsInstalled;
         }
         catch (Exception)

--- a/QuickMail/Helpers/VelopackRuntime.cs
+++ b/QuickMail/Helpers/VelopackRuntime.cs
@@ -1,0 +1,31 @@
+using System;
+using Velopack;
+using Velopack.Sources;
+
+namespace QuickMail.Helpers;
+
+/// <summary>
+/// True when this process runs from a Velopack install (%LocalAppData%\QuickMail\current\),
+/// as opposed to the portable exe or a dev build. Gates install-only behavior such as the
+/// first-run desktop shortcut offer.
+/// </summary>
+public static class VelopackRuntime
+{
+    public static bool IsInstalled { get; } = Compute();
+
+    private static bool Compute()
+    {
+        try
+        {
+            // The source is never contacted here; construction only inspects the local
+            // install layout via IsInstalled.
+            return new UpdateManager(
+                new GithubSource("https://github.com/kellylford/QuickMail", accessToken: null, prerelease: false))
+                .IsInstalled;
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+}

--- a/QuickMail/Models/ConfigModel.cs
+++ b/QuickMail/Models/ConfigModel.cs
@@ -154,6 +154,21 @@ public class ConfigModel
     /// The shortcut itself is not stored here — the .lnk file on the desktop is the source of truth.</summary>
     public bool DesktopShortcutPrompted { get; set; } = false;
 
+    // ── Updates ───────────────────────────────────────────────────────────────────
+
+    /// <summary>Download and install updates automatically (installed copies). When off, the
+    /// Help menu still reports available updates but nothing is downloaded or installed.
+    /// Read at the startup check, so a change takes effect the next time QuickMail starts.</summary>
+    public bool AutoUpdate { get; set; } = true;
+
+    /// <summary>Show the "QuickMail Update Installed" dialog on the first launch after an
+    /// update has been applied.</summary>
+    public bool ShowUpdateInstalledAlerts { get; set; } = true;
+
+    /// <summary>The app version recorded on the previous run. A mismatch on an installed copy
+    /// means an update was applied since; used to trigger the update-installed dialog.</summary>
+    public string LastRunVersion { get; set; } = string.Empty;
+
     // ── Windowing (Phase 6) ───────────────────────────────────────────────────────
 
     /// <summary>Tab and window management preferences.</summary>

--- a/QuickMail/Models/ConfigModel.cs
+++ b/QuickMail/Models/ConfigModel.cs
@@ -150,6 +150,10 @@ public class ConfigModel
     /// <summary>Whether the user has completed the first-run keyboard tutorial.</summary>
     public bool TutorialCompleted { get; set; } = false;
 
+    /// <summary>Whether the one-time desktop shortcut offer has been shown (installed copies only).
+    /// The shortcut itself is not stored here — the .lnk file on the desktop is the source of truth.</summary>
+    public bool DesktopShortcutPrompted { get; set; } = false;
+
     // ── Windowing (Phase 6) ───────────────────────────────────────────────────────
 
     /// <summary>Tab and window management preferences.</summary>

--- a/QuickMail/QuickMail.csproj
+++ b/QuickMail/QuickMail.csproj
@@ -9,6 +9,10 @@
     <Version>0.8.0</Version>
     <AssemblyVersion>0.8.0</AssemblyVersion>
     <FileVersion>0.8.0</FileVersion>
+    <!-- Velopack needs a hand-written Main that runs VelopackApp.Build().Run() before WPF
+         initializes (install/update/uninstall hooks run and may exit the process). App.xaml
+         therefore compiles as Page (no generated Main) and the entry point is declared here. -->
+    <StartupObject>QuickMail.App</StartupObject>
     <!-- Keep the product/informational version clean digits. By default the SDK appends
          "+<git commit sha>" to AssemblyInformationalVersion, which is what File Explorer's
          Product version and screen readers report programmatically — so suppress it. -->
@@ -22,6 +26,13 @@
     <SelfContained>true</SelfContained>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
   </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Compile App.xaml as Page instead of ApplicationDefinition so the SDK does not
+         generate a Main; the explicit Main in App.xaml.cs (see StartupObject) is used. -->
+    <ApplicationDefinition Remove="App.xaml" />
+    <Page Include="App.xaml" />
+  </ItemGroup>
 
   <ItemGroup>
     <!-- Built-in themes ship inside the assembly; ThemeStore parses them with the same loader as user theme files. -->
@@ -43,6 +54,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Velopack" Version="1.2.0" />
   </ItemGroup>
 
 </Project>

--- a/QuickMail/Services/ConfigService.cs
+++ b/QuickMail/Services/ConfigService.cs
@@ -253,6 +253,7 @@ public class ConfigService : IConfigService
                         break;
                     case "enablelogging": config.EnableLogging = ParseBool(value); break;
                     case "tutorialcompleted":    config.TutorialCompleted    = ParseBool(value); break;
+                    case "desktopshortcutprompted": config.DesktopShortcutPrompted = ParseBool(value); break;
                     case "defaultcomposemode":
                         config.DefaultComposeMode = value.ToLowerInvariant() switch
                         {
@@ -477,6 +478,11 @@ public class ConfigService : IConfigService
 
         sb.AppendLine($"TutorialCompleted = {(config.TutorialCompleted ? "on" : "off")}");
         sb.AppendLine("# Whether the first-run keyboard tutorial has been completed.");
+        sb.AppendLine("# Values: on, off.");
+        sb.AppendLine();
+
+        sb.AppendLine($"DesktopShortcutPrompted = {(config.DesktopShortcutPrompted ? "on" : "off")}");
+        sb.AppendLine("# Whether the one-time desktop shortcut offer has been shown (installed copies only).");
         sb.AppendLine("# Values: on, off.");
         sb.AppendLine();
 

--- a/QuickMail/Services/ConfigService.cs
+++ b/QuickMail/Services/ConfigService.cs
@@ -254,6 +254,9 @@ public class ConfigService : IConfigService
                     case "enablelogging": config.EnableLogging = ParseBool(value); break;
                     case "tutorialcompleted":    config.TutorialCompleted    = ParseBool(value); break;
                     case "desktopshortcutprompted": config.DesktopShortcutPrompted = ParseBool(value); break;
+                    case "autoupdate":              config.AutoUpdate              = ParseBool(value); break;
+                    case "showupdateinstalledalerts": config.ShowUpdateInstalledAlerts = ParseBool(value); break;
+                    case "lastrunversion":          config.LastRunVersion          = value; break;
                     case "defaultcomposemode":
                         config.DefaultComposeMode = value.ToLowerInvariant() switch
                         {
@@ -484,6 +487,23 @@ public class ConfigService : IConfigService
         sb.AppendLine($"DesktopShortcutPrompted = {(config.DesktopShortcutPrompted ? "on" : "off")}");
         sb.AppendLine("# Whether the one-time desktop shortcut offer has been shown (installed copies only).");
         sb.AppendLine("# Values: on, off.");
+        sb.AppendLine();
+
+        sb.AppendLine($"AutoUpdate = {(config.AutoUpdate ? "on" : "off")}");
+        sb.AppendLine("# Download and install updates automatically (installed copies).");
+        sb.AppendLine("# When off, the Help menu still reports available updates but nothing is");
+        sb.AppendLine("# downloaded or installed. Takes effect the next time QuickMail starts.");
+        sb.AppendLine("# Values: on, off.");
+        sb.AppendLine();
+
+        sb.AppendLine($"ShowUpdateInstalledAlerts = {(config.ShowUpdateInstalledAlerts ? "on" : "off")}");
+        sb.AppendLine("# Show a dialog on the first launch after an update has been installed.");
+        sb.AppendLine("# Values: on, off.");
+        sb.AppendLine();
+
+        sb.AppendLine($"LastRunVersion = {config.LastRunVersion}");
+        sb.AppendLine("# The app version recorded on the previous run. Maintained automatically;");
+        sb.AppendLine("# used to detect that an update was applied.");
         sb.AppendLine();
 
         sb.AppendLine($"DefaultComposeMode = {config.DefaultComposeMode switch

--- a/QuickMail/Services/IUpdateCheckService.cs
+++ b/QuickMail/Services/IUpdateCheckService.cs
@@ -7,4 +7,17 @@ namespace QuickMail.Services;
 public interface IUpdateCheckService
 {
     Task<UpdateInfo?> CheckForUpdateAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// True when the running copy updates itself (Velopack install) and CheckForUpdateAsync
+    /// found an update. The UI should then offer restart-to-update rather than a download link.
+    /// </summary>
+    bool SelfUpdatePending { get; }
+
+    /// <summary>
+    /// Waits for the pending update download to finish, then applies it and restarts the app
+    /// (the call does not return on success — the process exits). Returns false when there is
+    /// no pending self-update or applying failed; the failure is logged.
+    /// </summary>
+    Task<bool> RestartToUpdateAsync();
 }

--- a/QuickMail/Services/IUpdateCheckService.cs
+++ b/QuickMail/Services/IUpdateCheckService.cs
@@ -15,9 +15,11 @@ public interface IUpdateCheckService
     bool SelfUpdatePending { get; }
 
     /// <summary>
-    /// Waits for the pending update download to finish, then applies it and restarts the app
-    /// (the call does not return on success — the process exits). Returns false when there is
-    /// no pending self-update or applying failed; the failure is logged.
+    /// Waits for the pending update download to finish (retrying the download once if the
+    /// background attempt failed), then applies it and restarts the app (the call does not
+    /// return on success — the process exits). Returns false when there is no pending
+    /// self-update, the caller cancelled (e.g. the update dialog was dismissed), or applying
+    /// failed; failures are logged.
     /// </summary>
-    Task<bool> RestartToUpdateAsync();
+    Task<bool> RestartToUpdateAsync(CancellationToken cancellationToken = default);
 }

--- a/QuickMail/Services/UpdateCheckService.cs
+++ b/QuickMail/Services/UpdateCheckService.cs
@@ -25,10 +25,14 @@ public class UpdateCheckService : IUpdateCheckService, IDisposable
     // is cooperatively cancelled (clean OperationCanceledException) rather than left to either
     // the 10s HttpClient timeout or an ObjectDisposedException from disposing _http mid-request.
     private readonly CancellationTokenSource _cts = new();
+    // Test/debug override (--updateFeed): a local folder or URL holding vpk pack output,
+    // so the full download-and-apply cycle can be exercised without publishing a release.
+    private readonly string? _feedOverride;
     private bool _disposed;
 
-    public UpdateCheckService()
+    public UpdateCheckService(string? updateFeedOverride = null)
     {
+        _feedOverride = updateFeedOverride;
         _http = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
         _http.DefaultRequestHeaders.UserAgent.Add(
             new ProductInfoHeaderValue("QuickMail", _currentVersion));
@@ -46,11 +50,20 @@ public class UpdateCheckService : IUpdateCheckService, IDisposable
         return await CheckViaGitHubApiAsync(cancellationToken).ConfigureAwait(false);
     }
 
-    private static UpdateManager? CreateVelopackManager()
+    private UpdateManager? CreateVelopackManager()
     {
         try
         {
-            var mgr = new UpdateManager(new GithubSource(RepoUrl, accessToken: null, prerelease: false));
+            UpdateManager mgr;
+            if (_feedOverride is null)
+            {
+                mgr = new UpdateManager(new GithubSource(RepoUrl, accessToken: null, prerelease: false));
+            }
+            else
+            {
+                LogService.Log($"UpdateCheckService: using update feed override: {_feedOverride}");
+                mgr = new UpdateManager(_feedOverride);
+            }
             return mgr.IsInstalled ? mgr : null;
         }
         catch (Exception ex)

--- a/QuickMail/Services/UpdateCheckService.cs
+++ b/QuickMail/Services/UpdateCheckService.cs
@@ -28,6 +28,8 @@ public class UpdateCheckService : IUpdateCheckService, IDisposable
     // Test/debug override (--updateFeed): a local folder or URL holding vpk pack output,
     // so the full download-and-apply cycle can be exercised without publishing a release.
     private readonly string? _feedOverride;
+    // Supplies the AutoUpdate setting; null (tests) behaves as AutoUpdate on.
+    private readonly IConfigService? _configService;
     private bool _disposed;
 
     // Installed-path (Velopack) update state. Held so RestartToUpdateAsync can apply the
@@ -38,8 +40,9 @@ public class UpdateCheckService : IUpdateCheckService, IDisposable
     private volatile bool _downloadCompleted;
     private bool _restartRequested;
 
-    public UpdateCheckService(string? updateFeedOverride = null)
+    public UpdateCheckService(IConfigService? configService = null, string? updateFeedOverride = null)
     {
+        _configService = configService;
         _feedOverride = updateFeedOverride;
         _http = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
         _http.DefaultRequestHeaders.UserAgent.Add(
@@ -117,6 +120,18 @@ public class UpdateCheckService : IUpdateCheckService, IDisposable
                 return null;
 
             var version = update.TargetFullRelease.Version.ToString();
+            var whatsNewUrl = $"{RepoUrl}/releases/tag/v{version}";
+
+            // AutoUpdate off: notify-only. Report the update so the Help menu shows it, but
+            // stage nothing — SelfUpdatePending stays false, so activating the Help entry
+            // opens the release page (the pre-auto-update experience) instead of the
+            // restart-to-update dialog.
+            if (_configService?.Load().AutoUpdate == false)
+            {
+                LogService.Log($"Update {version} available; automatic updating is turned off.");
+                return new Models.UpdateInfo(version, whatsNewUrl);
+            }
+
             _velopackManager = mgr;
             _pendingUpdate = update;
 
@@ -140,7 +155,7 @@ public class UpdateCheckService : IUpdateCheckService, IDisposable
             });
 
             // The release-tag page serves as the "what's new" link in the update dialog.
-            return new Models.UpdateInfo(version, $"{RepoUrl}/releases/tag/v{version}");
+            return new Models.UpdateInfo(version, whatsNewUrl);
         }
         catch (Exception ex)
         {

--- a/QuickMail/Services/UpdateCheckService.cs
+++ b/QuickMail/Services/UpdateCheckService.cs
@@ -5,11 +5,14 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using QuickMail.Models;
+using Velopack;
+using Velopack.Sources;
 
 namespace QuickMail.Services;
 
 public class UpdateCheckService : IUpdateCheckService, IDisposable
 {
+    private const string RepoUrl = "https://github.com/kellylford/QuickMail";
     private const string ApiUrl = "https://api.github.com/repos/kellylford/QuickMail/releases/latest";
 
     // Reflection result is static for the lifetime of the app — compute once. Uses the shared
@@ -31,7 +34,72 @@ public class UpdateCheckService : IUpdateCheckService, IDisposable
             new ProductInfoHeaderValue("QuickMail", _currentVersion));
     }
 
-    public async Task<UpdateInfo?> CheckForUpdateAsync(CancellationToken cancellationToken = default)
+    public async Task<Models.UpdateInfo?> CheckForUpdateAsync(CancellationToken cancellationToken = default)
+    {
+        // Velopack path only applies when running from a Velopack install
+        // (%LocalAppData%\QuickMail\current\). The portable exe and dev builds fall through
+        // to the GitHub API check below, which can only notify — not silently update.
+        var mgr = CreateVelopackManager();
+        if (mgr is not null)
+            return await CheckViaVelopackAsync(mgr).ConfigureAwait(false);
+
+        return await CheckViaGitHubApiAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private static UpdateManager? CreateVelopackManager()
+    {
+        try
+        {
+            var mgr = new UpdateManager(new GithubSource(RepoUrl, accessToken: null, prerelease: false));
+            return mgr.IsInstalled ? mgr : null;
+        }
+        catch (Exception ex)
+        {
+            LogService.Debug($"UpdateCheckService: Velopack manager unavailable: {ex.Message}");
+            return null;
+        }
+    }
+
+    private async Task<Models.UpdateInfo?> CheckViaVelopackAsync(UpdateManager mgr)
+    {
+        try
+        {
+            var update = await mgr.CheckForUpdatesAsync().ConfigureAwait(false);
+            if (update is null)
+                return null;
+
+            var version = update.TargetFullRelease.Version.ToString();
+
+            // Download in the background on the service's lifetime token (not the caller's
+            // short check timeout — the package can be large). Once staged, Update.exe applies
+            // it after the app exits, so the next normal launch runs the new version. If the
+            // app exits mid-download, the next launch simply re-checks and resumes.
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    await mgr.DownloadUpdatesAsync(update, cancelToken: _cts.Token).ConfigureAwait(false);
+                    mgr.WaitExitThenApplyUpdates(update, silent: true, restart: false);
+                    LogService.Log($"Update {version} downloaded; it will be applied when QuickMail exits.");
+                }
+                catch (Exception ex)
+                {
+                    LogService.Debug($"UpdateCheckService: background download failed: {ex.Message}");
+                }
+            });
+
+            // Empty URL — the Help menu entry falls back to the releases page. The update
+            // itself needs no user action beyond an eventual restart.
+            return new Models.UpdateInfo(version, string.Empty);
+        }
+        catch (Exception ex)
+        {
+            LogService.Debug($"UpdateCheckService: Velopack check failed: {ex.Message}");
+            return null;
+        }
+    }
+
+    private async Task<Models.UpdateInfo?> CheckViaGitHubApiAsync(CancellationToken cancellationToken)
     {
         try
         {
@@ -51,7 +119,7 @@ public class UpdateCheckService : IUpdateCheckService, IDisposable
                 !Version.TryParse(_currentVersion, out var current))
                 return null;
 
-            return remote > current ? new UpdateInfo(tag, url) : null;
+            return remote > current ? new Models.UpdateInfo(tag, url) : null;
         }
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or JsonException or OperationCanceledException or ObjectDisposedException)
         {

--- a/QuickMail/Services/UpdateCheckService.cs
+++ b/QuickMail/Services/UpdateCheckService.cs
@@ -30,6 +30,14 @@ public class UpdateCheckService : IUpdateCheckService, IDisposable
     private readonly string? _feedOverride;
     private bool _disposed;
 
+    // Installed-path (Velopack) update state. Held so RestartToUpdateAsync can apply the
+    // update on demand, and so Dispose can arm apply-on-exit once the download finished.
+    private UpdateManager? _velopackManager;
+    private Velopack.UpdateInfo? _pendingUpdate;
+    private Task? _downloadTask;
+    private volatile bool _downloadCompleted;
+    private bool _restartRequested;
+
     public UpdateCheckService(string? updateFeedOverride = null)
     {
         _feedOverride = updateFeedOverride;
@@ -37,6 +45,8 @@ public class UpdateCheckService : IUpdateCheckService, IDisposable
         _http.DefaultRequestHeaders.UserAgent.Add(
             new ProductInfoHeaderValue("QuickMail", _currentVersion));
     }
+
+    public bool SelfUpdatePending => _pendingUpdate is not null;
 
     public async Task<Models.UpdateInfo?> CheckForUpdateAsync(CancellationToken cancellationToken = default)
     {
@@ -48,6 +58,31 @@ public class UpdateCheckService : IUpdateCheckService, IDisposable
             return await CheckViaVelopackAsync(mgr).ConfigureAwait(false);
 
         return await CheckViaGitHubApiAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<bool> RestartToUpdateAsync()
+    {
+        var mgr = _velopackManager;
+        var update = _pendingUpdate;
+        if (mgr is null || update is null) return false;
+        try
+        {
+            // The background download normally finished long ago; waiting covers the user
+            // racing to the Help menu on a slow connection.
+            if (_downloadTask is { } dl) await dl.ConfigureAwait(false);
+            if (!_downloadCompleted) return false;
+
+            _restartRequested = true;
+            // Preserve /debug, --profileDir, --updateFeed across the update-triggered relaunch.
+            mgr.ApplyUpdatesAndRestart(update, Environment.GetCommandLineArgs()[1..]);
+            return true; // not reached — ApplyUpdatesAndRestart exits the process
+        }
+        catch (Exception ex)
+        {
+            _restartRequested = false;
+            LogService.Log($"UpdateCheckService: restart to update failed: {ex.Message}");
+            return false;
+        }
     }
 
     private UpdateManager? CreateVelopackManager()
@@ -82,17 +117,20 @@ public class UpdateCheckService : IUpdateCheckService, IDisposable
                 return null;
 
             var version = update.TargetFullRelease.Version.ToString();
+            _velopackManager = mgr;
+            _pendingUpdate = update;
 
             // Download in the background on the service's lifetime token (not the caller's
-            // short check timeout — the package can be large). Once staged, Update.exe applies
-            // it after the app exits, so the next normal launch runs the new version. If the
-            // app exits mid-download, the next launch simply re-checks and resumes.
-            _ = Task.Run(async () =>
+            // short check timeout — the package can be large). The update is applied either
+            // when the user chooses "Restart to Update" (RestartToUpdateAsync) or, failing
+            // that, on app exit (Dispose arms Update.exe), so the next launch runs the new
+            // version. If the app exits mid-download, the next launch re-checks and resumes.
+            _downloadTask = Task.Run(async () =>
             {
                 try
                 {
                     await mgr.DownloadUpdatesAsync(update, cancelToken: _cts.Token).ConfigureAwait(false);
-                    mgr.WaitExitThenApplyUpdates(update, silent: true, restart: false);
+                    _downloadCompleted = true;
                     LogService.Log($"Update {version} downloaded; it will be applied when QuickMail exits.");
                 }
                 catch (Exception ex)
@@ -101,9 +139,8 @@ public class UpdateCheckService : IUpdateCheckService, IDisposable
                 }
             });
 
-            // Empty URL — the Help menu entry falls back to the releases page. The update
-            // itself needs no user action beyond an eventual restart.
-            return new Models.UpdateInfo(version, string.Empty);
+            // The release-tag page serves as the "what's new" link in the update dialog.
+            return new Models.UpdateInfo(version, $"{RepoUrl}/releases/tag/v{version}");
         }
         catch (Exception ex)
         {
@@ -145,6 +182,24 @@ public class UpdateCheckService : IUpdateCheckService, IDisposable
     {
         if (_disposed) return;
         _disposed = true;
+
+        // App is exiting: if a downloaded update was not applied via restart-to-update,
+        // arm Update.exe to apply it once this process ends, so the next launch runs the
+        // new version. Armed here — not right after the download — so this path and
+        // ApplyUpdatesAndRestart can never both spawn an applier.
+        if (_downloadCompleted && !_restartRequested &&
+            _velopackManager is { } mgr && _pendingUpdate is { } update)
+        {
+            try
+            {
+                mgr.WaitExitThenApplyUpdates(update, silent: true, restart: false);
+            }
+            catch (Exception ex)
+            {
+                LogService.Debug($"UpdateCheckService: arming apply-on-exit failed: {ex.Message}");
+            }
+        }
+
         _cts.Cancel();   // signal any in-flight request before releasing the handle
         _cts.Dispose();
         _http.Dispose();

--- a/QuickMail/Services/UpdateCheckService.cs
+++ b/QuickMail/Services/UpdateCheckService.cs
@@ -12,8 +12,14 @@ namespace QuickMail.Services;
 
 public class UpdateCheckService : IUpdateCheckService, IDisposable
 {
-    private const string RepoUrl = "https://github.com/kellylford/QuickMail";
+    // Single source of truth for the project location — VelopackRuntime and MainViewModel
+    // build their URLs from these rather than repeating the literal.
+    public const string RepoUrl = "https://github.com/kellylford/QuickMail";
+    public const string ReleasesPageUrl = $"{RepoUrl}/releases";
     private const string ApiUrl = "https://api.github.com/repos/kellylford/QuickMail/releases/latest";
+
+    /// <summary>The release-notes page for a specific version — the "what's new" link.</summary>
+    public static string ReleaseTagUrl(string version) => $"{ReleasesPageUrl}/tag/v{version}";
 
     // Reflection result is static for the lifetime of the app — compute once. Uses the shared
     // display version so a hotfix build (e.g. 0.7.9.1) compares at full precision and does not
@@ -56,14 +62,16 @@ public class UpdateCheckService : IUpdateCheckService, IDisposable
         // Velopack path only applies when running from a Velopack install
         // (%LocalAppData%\QuickMail\current\). The portable exe and dev builds fall through
         // to the GitHub API check below, which can only notify — not silently update.
-        var mgr = CreateVelopackManager();
+        // Manager construction probes the install layout on disk — keep it off the caller's
+        // (UI) thread; this method is invoked synchronously from window load.
+        var mgr = await Task.Run(CreateVelopackManager, cancellationToken).ConfigureAwait(false);
         if (mgr is not null)
-            return await CheckViaVelopackAsync(mgr).ConfigureAwait(false);
+            return await CheckViaVelopackAsync(mgr, cancellationToken).ConfigureAwait(false);
 
         return await CheckViaGitHubApiAsync(cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<bool> RestartToUpdateAsync()
+    public async Task<bool> RestartToUpdateAsync(CancellationToken cancellationToken = default)
     {
         var mgr = _velopackManager;
         var update = _pendingUpdate;
@@ -71,18 +79,34 @@ public class UpdateCheckService : IUpdateCheckService, IDisposable
         try
         {
             // The background download normally finished long ago; waiting covers the user
-            // racing to the Help menu on a slow connection.
-            if (_downloadTask is { } dl) await dl.ConfigureAwait(false);
-            if (!_downloadCompleted) return false;
+            // racing to the Help menu on a slow connection. The caller's token lets the
+            // update dialog retract the request (Exit/Escape) so a slow download can never
+            // trigger a surprise restart minutes after the dialog was dismissed.
+            if (_downloadTask is { } dl) await dl.WaitAsync(cancellationToken).ConfigureAwait(false);
+            if (!_downloadCompleted)
+            {
+                // The background attempt failed (e.g. transient network drop) — retry once
+                // on the user's explicit request before giving up.
+                await mgr.DownloadUpdatesAsync(update, cancelToken: cancellationToken).ConfigureAwait(false);
+                _downloadCompleted = true;
+            }
+            cancellationToken.ThrowIfCancellationRequested();
 
+            // Set before the call and deliberately never reset: if ApplyUpdatesAndRestart
+            // throws we cannot know whether its applier was already spawned, and skipping
+            // the Dispose-time arm is the safe direction (worst case the update applies on
+            // a later launch instead of two appliers racing).
             _restartRequested = true;
             // Preserve /debug, --profileDir, --updateFeed across the update-triggered relaunch.
             mgr.ApplyUpdatesAndRestart(update, Environment.GetCommandLineArgs()[1..]);
             return true; // not reached — ApplyUpdatesAndRestart exits the process
         }
+        catch (OperationCanceledException)
+        {
+            return false; // dialog dismissed — not a failure, no announcement warranted
+        }
         catch (Exception ex)
         {
-            _restartRequested = false;
             LogService.Log($"UpdateCheckService: restart to update failed: {ex.Message}");
             return false;
         }
@@ -111,16 +135,21 @@ public class UpdateCheckService : IUpdateCheckService, IDisposable
         }
     }
 
-    private async Task<Models.UpdateInfo?> CheckViaVelopackAsync(UpdateManager mgr)
+    private async Task<Models.UpdateInfo?> CheckViaVelopackAsync(UpdateManager mgr, CancellationToken cancellationToken)
     {
         try
         {
-            var update = await mgr.CheckForUpdatesAsync().ConfigureAwait(false);
+            // Velopack 1.2.0's CheckForUpdatesAsync takes no CancellationToken, so honor the
+            // caller's bound (and Dispose-time cancellation) by abandoning the wait — the
+            // underlying request is orphaned but the contract that the check is time-bounded
+            // holds, matching the GitHub API path below.
+            using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _cts.Token);
+            var update = await mgr.CheckForUpdatesAsync().WaitAsync(linked.Token).ConfigureAwait(false);
             if (update is null)
                 return null;
 
             var version = update.TargetFullRelease.Version.ToString();
-            var whatsNewUrl = $"{RepoUrl}/releases/tag/v{version}";
+            var whatsNewUrl = ReleaseTagUrl(version);
 
             // AutoUpdate off: notify-only. Report the update so the Help menu shows it, but
             // stage nothing — SelfUpdatePending stays false, so activating the Help entry
@@ -152,7 +181,7 @@ public class UpdateCheckService : IUpdateCheckService, IDisposable
                 {
                     LogService.Debug($"UpdateCheckService: background download failed: {ex.Message}");
                 }
-            });
+            }, _cts.Token);   // service lifetime, not the caller's short check timeout
 
             // The release-tag page serves as the "what's new" link in the update dialog.
             return new Models.UpdateInfo(version, whatsNewUrl);

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -5544,6 +5544,38 @@ public partial class MainViewModel : ObservableObject, IDisposable
     /// </summary>
     public event EventHandler<(string Version, string WhatsNewUrl)>? UpdateDialogRequested;
 
+    /// <summary>
+    /// Raised on the first launch after an update was applied: the View shows the
+    /// "QuickMail Update Installed" dialog. Gated by the ShowUpdateInstalledAlerts setting.
+    /// </summary>
+    public event EventHandler<(string Version, string WhatsNewUrl)>? UpdateInstalledDialogRequested;
+
+    /// <summary>
+    /// Detects that an update was applied since the previous run (recorded LastRunVersion
+    /// differs from the running version on an installed copy) and raises the
+    /// update-installed notice. Always records the running version, so the notice fires
+    /// once per update. Called once per launch by the View after the main window has loaded.
+    /// </summary>
+    public void MaybeShowUpdateInstalledNotice()
+    {
+        var cfg = _configService.Load();
+        if (cfg.LastRunVersion == CurrentVersion) return;
+
+        var previous = cfg.LastRunVersion;
+        cfg.LastRunVersion = CurrentVersion;
+        _configService.Save(cfg);
+
+        // No previous record: first run ever (or first run of a version that tracks this) —
+        // nothing was "installed" from the user's point of view.
+        if (string.IsNullOrEmpty(previous)) return;
+        // Version hops outside a Velopack install are dev/portable swaps, not updates.
+        if (!Helpers.VelopackRuntime.IsInstalled) return;
+        if (!cfg.ShowUpdateInstalledAlerts) return;
+
+        UpdateInstalledDialogRequested?.Invoke(this,
+            (CurrentVersion, $"{ReleasesPageUrl}/tag/v{CurrentVersion}"));
+    }
+
     [RelayCommand]
     private void OpenUpdatePage()
     {

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -3927,11 +3927,56 @@ public partial class MainViewModel : ObservableObject, IDisposable
     public event EventHandler? AboutRequested;
     public event EventHandler? ReportBugRequested;
 
+    // One-time first-run offer to add a desktop shortcut (installed copies only). The View
+    // shows the actual dialog and reports the answer back via ApplyDesktopShortcutChoice.
+    public event EventHandler? DesktopShortcutOfferRequested;
+
     /// <summary>
     /// Raised when a Properties dialog should be shown. The View subscribes and
     /// calls new PropertiesWindow(vm).ShowDialog().
     /// </summary>
     public event Action<PropertiesViewModel>? PropertiesRequested;
+
+    /// <summary>
+    /// Raises the desktop shortcut offer when it applies: running from a Velopack install,
+    /// never asked before, and no shortcut already present. Called once per launch by the
+    /// View after the main window has loaded.
+    /// </summary>
+    public void MaybeOfferDesktopShortcut()
+    {
+        if (!Helpers.VelopackRuntime.IsInstalled) return;
+        var cfg = _configService.Load();
+        if (cfg.DesktopShortcutPrompted) return;
+        if (Helpers.DesktopShortcut.Exists())
+        {
+            cfg.DesktopShortcutPrompted = true;
+            _configService.Save(cfg);
+            return;
+        }
+        DesktopShortcutOfferRequested?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>Records the user's answer to the desktop shortcut offer and applies it.
+    /// The offer is never repeated regardless of the answer; the choice stays editable
+    /// in Settings → General.</summary>
+    public void ApplyDesktopShortcutChoice(bool create)
+    {
+        if (create)
+        {
+            try
+            {
+                Helpers.DesktopShortcut.Create();
+                Announce("Desktop shortcut added.");
+            }
+            catch (Exception ex)
+            {
+                LogService.Debug($"Desktop shortcut: {ex.Message}");
+            }
+        }
+        var cfg = _configService.Load();
+        cfg.DesktopShortcutPrompted = true;
+        _configService.Save(cfg);
+    }
 
     private void Announce(string text, AnnouncementCategory category = AnnouncementCategory.Result)
     {

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -3963,15 +3963,21 @@ public partial class MainViewModel : ObservableObject, IDisposable
     {
         if (create)
         {
+            bool created;
             try
             {
-                Helpers.DesktopShortcut.Create();
-                Announce("Desktop shortcut added.");
+                created = Helpers.DesktopShortcut.Create();
             }
             catch (Exception ex)
             {
+                created = false;
                 LogService.Debug($"Desktop shortcut: {ex.Message}");
             }
+            // Create() can decline silently (no WScript.Shell class, unknown process path) —
+            // only report what actually happened, and point at the retry path on failure.
+            Announce(created
+                ? "Desktop shortcut added."
+                : "The desktop shortcut could not be created. You can try again from Settings, on the General page.");
         }
         var cfg = _configService.Load();
         cfg.DesktopShortcutPrompted = true;
@@ -5530,7 +5536,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
 
     // Releases landing page — used when no specific update is known so the always-present
     // "No updates available" Help entry still takes users somewhere useful.
-    private const string ReleasesPageUrl = "https://github.com/kellylford/QuickMail/releases";
+    private const string ReleasesPageUrl = UpdateCheckService.ReleasesPageUrl;
 
     // Version string of a found update (e.g. "0.8.1"); empty when up to date. Feeds the
     // update dialog for self-updating (installed) copies.
@@ -5552,12 +5558,20 @@ public partial class MainViewModel : ObservableObject, IDisposable
 
     /// <summary>
     /// Detects that an update was applied since the previous run (recorded LastRunVersion
-    /// differs from the running version on an installed copy) and raises the
-    /// update-installed notice. Always records the running version, so the notice fires
-    /// once per update. Called once per launch by the View after the main window has loaded.
+    /// differs from the running version) and raises the update-installed notice. Both the
+    /// recording and the notice are installed-copies-only: a portable or dev run on the same
+    /// profile must neither trigger a phantom notice on the next installed launch nor leave
+    /// a record that suppresses/creates one. Called once per launch by the View after the
+    /// main window has loaded; <paramref name="dialogAllowed"/> is false on the no-account
+    /// startup path, where the version is stamped but no dialog may stack on onboarding.
     /// </summary>
-    public void MaybeShowUpdateInstalledNotice()
+    public void MaybeShowUpdateInstalledNotice(bool dialogAllowed = true)
     {
+        // Version hops outside a Velopack install are dev/portable swaps, not updates —
+        // don't record them either, or an installed↔portable alternation on the shared
+        // default profile announces updates that never happened.
+        if (!Helpers.VelopackRuntime.IsInstalled) return;
+
         var cfg = _configService.Load();
         if (cfg.LastRunVersion == CurrentVersion) return;
 
@@ -5565,15 +5579,20 @@ public partial class MainViewModel : ObservableObject, IDisposable
         cfg.LastRunVersion = CurrentVersion;
         _configService.Save(cfg);
 
+        if (!dialogAllowed) return;
         // No previous record: first run ever (or first run of a version that tracks this) —
         // nothing was "installed" from the user's point of view.
         if (string.IsNullOrEmpty(previous)) return;
-        // Version hops outside a Velopack install are dev/portable swaps, not updates.
-        if (!Helpers.VelopackRuntime.IsInstalled) return;
+        // Only a forward move is an update; a downgrade (rollback install) must not be
+        // announced as one. Unparseable records fail closed (no dialog).
+        if (!Version.TryParse(previous, out var prev) ||
+            !Version.TryParse(CurrentVersion, out var current) ||
+            current <= prev)
+            return;
         if (!cfg.ShowUpdateInstalledAlerts) return;
 
         UpdateInstalledDialogRequested?.Invoke(this,
-            (CurrentVersion, $"{ReleasesPageUrl}/tag/v{CurrentVersion}"));
+            (CurrentVersion, UpdateCheckService.ReleaseTagUrl(CurrentVersion)));
     }
 
     [RelayCommand]
@@ -5596,15 +5615,18 @@ public partial class MainViewModel : ObservableObject, IDisposable
 
     /// <summary>
     /// Applies the downloaded update and restarts QuickMail. On success the process exits
-    /// inside this call. On failure the user hears why and the app keeps running (the update
-    /// still applies on a normal exit).
+    /// inside this call. On failure the user hears an accurate outcome and the app keeps
+    /// running; a cancellation (the update dialog was dismissed) is silent. The token lets
+    /// the dialog retract a restart that is waiting on a slow download.
     /// </summary>
-    public async Task RestartToUpdateAsync()
+    public async Task RestartToUpdateAsync(CancellationToken cancellationToken)
     {
         if (_updateCheckService is null) return;
-        var ok = await _updateCheckService.RestartToUpdateAsync();
-        if (!ok)
-            Announce("The update could not be applied right now. It will be installed the next time QuickMail starts.", AnnouncementCategory.Result);
+        var ok = await _updateCheckService.RestartToUpdateAsync(cancellationToken);
+        if (!ok && !cancellationToken.IsCancellationRequested)
+            // No promise of a next-start install: when the download failed, nothing is
+            // staged — the next launch re-checks and tries the download again.
+            Announce("The update could not be applied right now. QuickMail will try again the next time it starts.", AnnouncementCategory.Result);
     }
 
     // Startup check: silent when already up to date (announcing "no updates" on every launch

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -5532,16 +5532,47 @@ public partial class MainViewModel : ObservableObject, IDisposable
     // "No updates available" Help entry still takes users somewhere useful.
     private const string ReleasesPageUrl = "https://github.com/kellylford/QuickMail/releases";
 
+    // Version string of a found update (e.g. "0.8.1"); empty when up to date. Feeds the
+    // update dialog for self-updating (installed) copies.
+    private string _updateVersion = string.Empty;
+
+    /// <summary>
+    /// Raised for self-updating (installed) copies when the Help update entry is activated:
+    /// the View shows the QuickMail Update dialog (restart now / what's new / dismiss).
+    /// Portable copies never raise this — they open the release page instead, because
+    /// updating them really is a manual download.
+    /// </summary>
+    public event EventHandler<(string Version, string WhatsNewUrl)>? UpdateDialogRequested;
+
     [RelayCommand]
-#pragma warning disable CA1822 // instance required for RelayCommand integration with ObservableObject
     private void OpenUpdatePage()
-#pragma warning restore CA1822
     {
+        if (_updateCheckService?.SelfUpdatePending == true && !string.IsNullOrEmpty(_updateVersion))
+        {
+            // Installed copy: the update is already downloading/downloaded — sending the user
+            // to the release page would wrongly suggest a manual download is needed.
+            UpdateDialogRequested?.Invoke(this, (_updateVersion, UpdateReleaseUrl));
+            return;
+        }
+
         // The specific release when one was found; otherwise the general releases page.
         // UpdateReleaseUrl comes from the GitHub API response, so route it through the
         // external-URI allow-list like any other externally sourced link.
         var url = string.IsNullOrEmpty(UpdateReleaseUrl) ? ReleasesPageUrl : UpdateReleaseUrl;
         Helpers.ExternalUriPolicy.TryOpenExternal(url);
+    }
+
+    /// <summary>
+    /// Applies the downloaded update and restarts QuickMail. On success the process exits
+    /// inside this call. On failure the user hears why and the app keeps running (the update
+    /// still applies on a normal exit).
+    /// </summary>
+    public async Task RestartToUpdateAsync()
+    {
+        if (_updateCheckService is null) return;
+        var ok = await _updateCheckService.RestartToUpdateAsync();
+        if (!ok)
+            Announce("The update could not be applied right now. It will be installed the next time QuickMail starts.", AnnouncementCategory.Result);
     }
 
     // Startup check: silent when already up to date (announcing "no updates" on every launch
@@ -5557,6 +5588,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
             var info = await _updateCheckService.CheckForUpdateAsync(cts.Token);
             if (info is not null)
             {
+                _updateVersion      = info.Version;
                 UpdateAvailableText = $"Update available: v{info.Version}";
                 UpdateReleaseUrl    = info.HtmlUrl;
                 // Result, not Status: a one-time discovery outcome. Users who silence background
@@ -5565,6 +5597,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
             }
             else
             {
+                _updateVersion      = string.Empty;
                 UpdateAvailableText = NoUpdateText;
                 UpdateReleaseUrl    = string.Empty;
             }

--- a/QuickMail/ViewModels/SettingsViewModel.cs
+++ b/QuickMail/ViewModels/SettingsViewModel.cs
@@ -80,6 +80,12 @@ public partial class SettingsViewModel : ObservableObject
     private bool _desktopShortcut;
     private bool _desktopShortcutInitial;
 
+    [ObservableProperty]
+    private bool _autoUpdate;
+
+    [ObservableProperty]
+    private bool _showUpdateInstalledAlerts;
+
     // ── Composing ──────────────────────────────────────────────────────────────────
 
     [ObservableProperty]
@@ -242,6 +248,8 @@ public partial class SettingsViewModel : ObservableObject
         ConfirmEmptyTrash                = cfg.ConfirmEmptyTrash;
         DesktopShortcut                  = Helpers.DesktopShortcut.Exists();
         _desktopShortcutInitial          = DesktopShortcut;
+        AutoUpdate                       = cfg.AutoUpdate;
+        ShowUpdateInstalledAlerts        = cfg.ShowUpdateInstalledAlerts;
         AutoSaveDrafts                   = cfg.AutoSaveDrafts;
         AutoSaveIntervalSeconds          = cfg.AutoSaveIntervalSeconds;
         DefaultComposeMode = cfg.DefaultComposeMode switch
@@ -303,6 +311,8 @@ public partial class SettingsViewModel : ObservableObject
         cfg.AnnounceFormattingWhileNavigating = AnnounceFormattingWhileNavigating;
         cfg.AnnounceFlagStatus               = AnnounceFlagStatus;
         cfg.ConfirmEmptyTrash                = ConfirmEmptyTrash;
+        cfg.AutoUpdate                       = AutoUpdate;
+        cfg.ShowUpdateInstalledAlerts        = ShowUpdateInstalledAlerts;
         if (DesktopShortcut != _desktopShortcutInitial)
         {
             try

--- a/QuickMail/ViewModels/SettingsViewModel.cs
+++ b/QuickMail/ViewModels/SettingsViewModel.cs
@@ -74,6 +74,12 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty]
     private bool _confirmEmptyTrash;
 
+    // Desktop shortcut: the .lnk on the desktop is the source of truth, not config —
+    // loaded from the filesystem and applied on save only when the user changed it.
+    [ObservableProperty]
+    private bool _desktopShortcut;
+    private bool _desktopShortcutInitial;
+
     // ── Composing ──────────────────────────────────────────────────────────────────
 
     [ObservableProperty]
@@ -234,6 +240,8 @@ public partial class SettingsViewModel : ObservableObject
         AnnounceFormattingWhileNavigating = cfg.AnnounceFormattingWhileNavigating;
         AnnounceFlagStatus               = cfg.AnnounceFlagStatus;
         ConfirmEmptyTrash                = cfg.ConfirmEmptyTrash;
+        DesktopShortcut                  = Helpers.DesktopShortcut.Exists();
+        _desktopShortcutInitial          = DesktopShortcut;
         AutoSaveDrafts                   = cfg.AutoSaveDrafts;
         AutoSaveIntervalSeconds          = cfg.AutoSaveIntervalSeconds;
         DefaultComposeMode = cfg.DefaultComposeMode switch
@@ -295,6 +303,19 @@ public partial class SettingsViewModel : ObservableObject
         cfg.AnnounceFormattingWhileNavigating = AnnounceFormattingWhileNavigating;
         cfg.AnnounceFlagStatus               = AnnounceFlagStatus;
         cfg.ConfirmEmptyTrash                = ConfirmEmptyTrash;
+        if (DesktopShortcut != _desktopShortcutInitial)
+        {
+            try
+            {
+                if (DesktopShortcut) Helpers.DesktopShortcut.Create();
+                else Helpers.DesktopShortcut.Delete();
+                _desktopShortcutInitial = DesktopShortcut;
+            }
+            catch (Exception ex)
+            {
+                LogService.Debug($"Desktop shortcut: {ex.Message}");
+            }
+        }
         cfg.AutoSaveDrafts                   = AutoSaveDrafts;
         cfg.AutoSaveIntervalSeconds          = AutoSaveIntervalSeconds;
         cfg.DefaultComposeMode = DefaultComposeMode switch

--- a/QuickMail/ViewModels/SettingsViewModel.cs
+++ b/QuickMail/ViewModels/SettingsViewModel.cs
@@ -75,10 +75,10 @@ public partial class SettingsViewModel : ObservableObject
     private bool _confirmEmptyTrash;
 
     // Desktop shortcut: the .lnk on the desktop is the source of truth, not config —
-    // loaded from the filesystem and applied on save only when the user changed it.
+    // loaded from the filesystem and applied on save only when it differs from the file's
+    // current state (re-checked at save time; the file can change outside this dialog).
     [ObservableProperty]
     private bool _desktopShortcut;
-    private bool _desktopShortcutInitial;
 
     [ObservableProperty]
     private bool _autoUpdate;
@@ -247,7 +247,6 @@ public partial class SettingsViewModel : ObservableObject
         AnnounceFlagStatus               = cfg.AnnounceFlagStatus;
         ConfirmEmptyTrash                = cfg.ConfirmEmptyTrash;
         DesktopShortcut                  = Helpers.DesktopShortcut.Exists();
-        _desktopShortcutInitial          = DesktopShortcut;
         AutoUpdate                       = cfg.AutoUpdate;
         ShowUpdateInstalledAlerts        = cfg.ShowUpdateInstalledAlerts;
         AutoSaveDrafts                   = cfg.AutoSaveDrafts;
@@ -313,17 +312,26 @@ public partial class SettingsViewModel : ObservableObject
         cfg.ConfirmEmptyTrash                = ConfirmEmptyTrash;
         cfg.AutoUpdate                       = AutoUpdate;
         cfg.ShowUpdateInstalledAlerts        = ShowUpdateInstalledAlerts;
-        if (DesktopShortcut != _desktopShortcutInitial)
+        if (DesktopShortcut != Helpers.DesktopShortcut.Exists())
         {
             try
             {
-                if (DesktopShortcut) Helpers.DesktopShortcut.Create();
-                else Helpers.DesktopShortcut.Delete();
-                _desktopShortcutInitial = DesktopShortcut;
+                if (DesktopShortcut)
+                {
+                    // Create() can decline silently; reflect reality in the checkbox so the
+                    // user sees the setting did not take rather than a phantom success.
+                    if (!Helpers.DesktopShortcut.Create())
+                        DesktopShortcut = false;
+                }
+                else
+                {
+                    Helpers.DesktopShortcut.Delete();
+                }
             }
             catch (Exception ex)
             {
                 LogService.Debug($"Desktop shortcut: {ex.Message}");
+                DesktopShortcut = Helpers.DesktopShortcut.Exists();
             }
         }
         cfg.AutoSaveDrafts                   = AutoSaveDrafts;

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -292,6 +292,15 @@ public partial class MainWindow : Window
         vm.RulesManagerRequested += (_, _) => OpenRulesManager();
         vm.CreateRuleFromMessageRequested += (_, template) => OpenRulesManager(template);
         vm.TutorialRequested += (_, _) => ShowTutorial();
+        vm.DesktopShortcutOfferRequested += (_, _) =>
+        {
+            // Default is No, mirroring the old installer's unchecked desktop-icon option.
+            var choice = MessageBox.Show(this,
+                "Add a desktop shortcut for QuickMail?\n\nYou can change this anytime in Settings, on the General page.",
+                "QuickMail",
+                MessageBoxButton.YesNo, MessageBoxImage.Question, MessageBoxResult.No);
+            vm.ApplyDesktopShortcutChoice(choice == MessageBoxResult.Yes);
+        };
         vm.AboutRequested += (_, _) => ShowAboutDialog();
         vm.ReportBugRequested += (_, _) => ShowReportBugWindow();
         vm.PropertiesRequested += propertiesVm =>
@@ -960,6 +969,11 @@ public partial class MainWindow : Window
 
         // Connect accounts and sync new mail in the background; messages trickle in via FolderSynced.
         _ = _vm.StartBackgroundSyncAsync();
+
+        // One-time desktop shortcut offer for installed copies — after the window is up and
+        // the background sync has been kicked off, so the dialog neither delays startup nor
+        // strands focus (it returns to the message panel on close).
+        _vm.MaybeOfferDesktopShortcut();
     }
 
     // WM_CONTEXTMENU hook: fires synchronously before DefWindowProc so we can ensure

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -292,6 +292,14 @@ public partial class MainWindow : Window
         vm.RulesManagerRequested += (_, _) => OpenRulesManager();
         vm.CreateRuleFromMessageRequested += (_, template) => OpenRulesManager(template);
         vm.TutorialRequested += (_, _) => ShowTutorial();
+        vm.UpdateDialogRequested += (_, info) =>
+        {
+            var dialog = new UpdateDialog(info.Version, info.WhatsNewUrl, vm.RestartToUpdateAsync)
+            {
+                Owner = this,
+            };
+            dialog.ShowDialog();
+        };
         vm.DesktopShortcutOfferRequested += (_, _) =>
         {
             // Default is No, mirroring the old installer's unchecked desktop-icon option.

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -320,6 +320,8 @@ public partial class MainWindow : Window
                 "QuickMail",
                 MessageBoxButton.YesNo, MessageBoxImage.Question, MessageBoxResult.No);
             vm.ApplyDesktopShortcutChoice(choice == MessageBoxResult.Yes);
+            // Same unreliable return-to-owner focus as the update dialogs below.
+            FocusActiveMessagePanel();
         };
         vm.AboutRequested += (_, _) => ShowAboutDialog();
         vm.ReportBugRequested += (_, _) => ShowReportBugWindow();
@@ -976,6 +978,10 @@ public partial class MainWindow : Window
         var firstAccount = _vm.Accounts.FirstOrDefault();
         if (firstAccount == null)
         {
+            // Stamp the running version even on the account-less path (dialog suppressed —
+            // the Account Manager is already up) so an update applied before the first
+            // account exists still gets its one installed notice later.
+            _vm.MaybeShowUpdateInstalledNotice(dialogAllowed: false);
             OpenAccountManager();
             return;
         }
@@ -991,8 +997,8 @@ public partial class MainWindow : Window
         _ = _vm.StartBackgroundSyncAsync();
 
         // One-time desktop shortcut offer for installed copies — after the window is up and
-        // the background sync has been kicked off, so the dialog neither delays startup nor
-        // strands focus (it returns to the message panel on close).
+        // the background sync has been kicked off, so the dialog does not delay startup;
+        // the offer handler restores focus to the message panel explicitly on close.
         _vm.MaybeOfferDesktopShortcut();
 
         // "QuickMail Update Installed" notice, once per applied update. After the shortcut

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -299,6 +299,9 @@ public partial class MainWindow : Window
                 Owner = this,
             };
             dialog.ShowDialog();
+            // Only reached when the dialog was dismissed (restart exits the process).
+            // WPF's return-to-owner focus is unreliable; land in the message list explicitly.
+            FocusActiveMessagePanel();
         };
         vm.UpdateInstalledDialogRequested += (_, info) =>
         {
@@ -307,6 +310,7 @@ public partial class MainWindow : Window
                 Owner = this,
             };
             dialog.ShowDialog();
+            FocusActiveMessagePanel();
         };
         vm.DesktopShortcutOfferRequested += (_, _) =>
         {

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -300,6 +300,14 @@ public partial class MainWindow : Window
             };
             dialog.ShowDialog();
         };
+        vm.UpdateInstalledDialogRequested += (_, info) =>
+        {
+            var dialog = new UpdateInstalledDialog(info.Version, info.WhatsNewUrl)
+            {
+                Owner = this,
+            };
+            dialog.ShowDialog();
+        };
         vm.DesktopShortcutOfferRequested += (_, _) =>
         {
             // Default is No, mirroring the old installer's unchecked desktop-icon option.
@@ -982,6 +990,10 @@ public partial class MainWindow : Window
         // the background sync has been kicked off, so the dialog neither delays startup nor
         // strands focus (it returns to the message panel on close).
         _vm.MaybeOfferDesktopShortcut();
+
+        // "QuickMail Update Installed" notice, once per applied update. After the shortcut
+        // offer so a first-run-after-migration launch never stacks two dialogs.
+        _vm.MaybeShowUpdateInstalledNotice();
     }
 
     // WM_CONTEXTMENU hook: fires synchronously before DefWindowProc so we can ensure

--- a/QuickMail/Views/SettingsDialog.xaml
+++ b/QuickMail/Views/SettingsDialog.xaml
@@ -278,6 +278,23 @@
             <TabItem Header="_Advanced" AutomationProperties.Name="Advanced settings">
                 <ScrollViewer VerticalScrollBarVisibility="Auto">
                     <StackPanel Margin="10">
+                        <!-- Updates Group -->
+                        <GroupBox Header="_Updates" Padding="10" Margin="0,0,0,15"
+                                  AutomationProperties.Name="Update settings">
+                            <StackPanel>
+                                <CheckBox Content="Do_wnload and install updates automatically"
+                                          IsChecked="{Binding AutoUpdate, Mode=TwoWay}"
+                                          AutomationProperties.Name="Download and install updates automatically"/>
+                                <TextBlock Text="When off, the Help menu still reports available updates but nothing is downloaded or installed. Takes effect the next time QuickMail starts. Applies to installed copies; the portable exe never updates itself."
+                                           Foreground="{DynamicResource Theme.TextSecondary}" FontSize="{DynamicResource Theme.FontSizeSmall}" Margin="0,3,0,8" TextWrapping="Wrap"/>
+                                <CheckBox Content="Show a _message after an update has been installed"
+                                          IsChecked="{Binding ShowUpdateInstalledAlerts, Mode=TwoWay}"
+                                          AutomationProperties.Name="Show a message after an update has been installed"/>
+                                <TextBlock Text="Shows the QuickMail Update Installed dialog once, on the first start after an update."
+                                           Foreground="{DynamicResource Theme.TextSecondary}" FontSize="{DynamicResource Theme.FontSizeSmall}" Margin="0,3,0,0" TextWrapping="Wrap"/>
+                            </StackPanel>
+                        </GroupBox>
+
                         <!-- QuickMail Logging Group -->
                         <GroupBox Header="QuickMail _Logging" Padding="10" Margin="0,0,0,15"
                                   AutomationProperties.Name="QuickMail logging settings">

--- a/QuickMail/Views/SettingsDialog.xaml
+++ b/QuickMail/Views/SettingsDialog.xaml
@@ -139,6 +139,18 @@
                             </StackPanel>
                         </GroupBox>
 
+                        <!-- Desktop Shortcut Group -->
+                        <GroupBox Header="Desktop Shortc_ut" Padding="10" Margin="0,10,0,0"
+                                  AutomationProperties.Name="Desktop shortcut settings">
+                            <StackPanel>
+                                <CheckBox Content="Keep a QuickMail shortcut _on the desktop"
+                                          IsChecked="{Binding DesktopShortcut, Mode=TwoWay}"
+                                          AutomationProperties.Name="Desktop shortcut"/>
+                                <TextBlock Text="The Start Menu entry is always available; this adds or removes the desktop shortcut. Applied when settings are saved."
+                                           Foreground="{DynamicResource Theme.TextSecondary}" FontSize="{DynamicResource Theme.FontSizeSmall}" Margin="0,3,0,0" TextWrapping="Wrap"/>
+                            </StackPanel>
+                        </GroupBox>
+
                         <!-- Composing Group -->
                         <GroupBox Header="Com_posing" Padding="10" Margin="0,10,0,0"
                                   AutomationProperties.Name="Composing settings">

--- a/QuickMail/Views/UpdateDialog.xaml
+++ b/QuickMail/Views/UpdateDialog.xaml
@@ -1,0 +1,48 @@
+<Window x:Class="QuickMail.Views.UpdateDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="QuickMail Update"
+        Height="200" Width="440"
+        MinHeight="180" MinWidth="360"
+        ResizeMode="NoResize"
+        WindowStartupLocation="CenterOwner"
+        ShowInTaskbar="False"
+        Background="{DynamicResource Theme.WindowBackground}"
+        Foreground="{DynamicResource Theme.TextPrimary}"
+        FontFamily="{DynamicResource Theme.FontFamily}"
+        FontSize="{DynamicResource Theme.FontSizeBase}">
+
+    <DockPanel Margin="20">
+
+        <StackPanel DockPanel.Dock="Bottom"
+                    Orientation="Horizontal"
+                    HorizontalAlignment="Right"
+                    Margin="0,16,0,0">
+            <Button x:Name="RestartButton"
+                    Content="_Restart to Update"
+                    IsDefault="True"
+                    MinWidth="120"
+                    Click="RestartButton_Click"
+                    AutomationProperties.Name="Restart to update"/>
+            <Button Content="E_xit"
+                    IsCancel="True"
+                    MinWidth="75"
+                    Margin="8,0,0,0"
+                    AutomationProperties.Name="Exit"/>
+        </StackPanel>
+
+        <StackPanel>
+            <TextBlock x:Name="MessageText"
+                       TextWrapping="Wrap"
+                       Margin="0,0,0,12"/>
+            <TextBlock>
+                <Hyperlink x:Name="WhatsNewLink"
+                           RequestNavigate="WhatsNewLink_RequestNavigate"
+                           AutomationProperties.Name="See what's new">
+                    See what's new
+                </Hyperlink>
+            </TextBlock>
+        </StackPanel>
+
+    </DockPanel>
+</Window>

--- a/QuickMail/Views/UpdateDialog.xaml.cs
+++ b/QuickMail/Views/UpdateDialog.xaml.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Navigation;
+
+namespace QuickMail.Views;
+
+/// <summary>
+/// Shown for self-updating (installed) copies when the Help update entry is activated.
+/// Tells the user the update installs itself on relaunch and offers to restart now.
+/// Escape / Exit dismiss the dialog; the update still applies on the next normal exit.
+/// </summary>
+public partial class UpdateDialog : Window
+{
+    private readonly Func<Task> _restartToUpdate;
+
+    public UpdateDialog(string version, string whatsNewUrl, Func<Task> restartToUpdate)
+    {
+        _restartToUpdate = restartToUpdate;
+        InitializeComponent();
+        MessageText.Text =
+            $"Version {version} of QuickMail is available and will be installed automatically " +
+            "the next time QuickMail starts.";
+        WhatsNewLink.NavigateUri = new Uri(whatsNewUrl);
+        Loaded += (_, _) => RestartButton.Focus();
+    }
+
+    private async void RestartButton_Click(object sender, RoutedEventArgs e)
+    {
+        // On success this call never returns — the app exits and relaunches updated.
+        // On failure the VM announces the outcome; close so the user is not left staring
+        // at a dialog whose primary action just declined to act.
+        RestartButton.IsEnabled = false;
+        await _restartToUpdate();
+        Close();
+    }
+
+    private void WhatsNewLink_RequestNavigate(object sender, RequestNavigateEventArgs e)
+    {
+        // All ShellExecute launches go through the allow-list. See ExternalUriPolicy.
+        Helpers.ExternalUriPolicy.TryOpenExternal(e.Uri.AbsoluteUri);
+        e.Handled = true;
+    }
+}

--- a/QuickMail/Views/UpdateDialog.xaml.cs
+++ b/QuickMail/Views/UpdateDialog.xaml.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Navigation;
@@ -9,12 +10,17 @@ namespace QuickMail.Views;
 /// Shown for self-updating (installed) copies when the Help update entry is activated.
 /// Tells the user the update installs itself on relaunch and offers to restart now.
 /// Escape / Exit dismiss the dialog; the update still applies on the next normal exit.
+/// Dismissal also cancels a pending restart, so a restart requested while the download
+/// is still in flight can never fire after the user has moved on.
 /// </summary>
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1001",
+    Justification = "_restartCts is cancelled and disposed in the Closed handler; WPF never calls Dispose on Window instances, so implementing IDisposable here would be dead code.")]
 public partial class UpdateDialog : Window
 {
-    private readonly Func<Task> _restartToUpdate;
+    private readonly Func<CancellationToken, Task> _restartToUpdate;
+    private readonly CancellationTokenSource _restartCts = new();
 
-    public UpdateDialog(string version, string whatsNewUrl, Func<Task> restartToUpdate)
+    public UpdateDialog(string version, string whatsNewUrl, Func<CancellationToken, Task> restartToUpdate)
     {
         _restartToUpdate = restartToUpdate;
         InitializeComponent();
@@ -23,16 +29,19 @@ public partial class UpdateDialog : Window
             "the next time QuickMail starts.";
         WhatsNewLink.NavigateUri = new Uri(whatsNewUrl);
         Loaded += (_, _) => RestartButton.Focus();
+        Closed += (_, _) => { _restartCts.Cancel(); _restartCts.Dispose(); };
     }
 
     private async void RestartButton_Click(object sender, RoutedEventArgs e)
     {
         // On success this call never returns — the app exits and relaunches updated.
         // On failure the VM announces the outcome; close so the user is not left staring
-        // at a dialog whose primary action just declined to act.
+        // at a dialog whose primary action just declined to act. If the user closes the
+        // dialog while this is waiting on the download, Closed cancels the token and the
+        // restart is retracted silently.
         RestartButton.IsEnabled = false;
-        await _restartToUpdate();
-        Close();
+        await _restartToUpdate(_restartCts.Token);
+        if (IsVisible) Close();   // the user may have closed the dialog during the wait
     }
 
     private void WhatsNewLink_RequestNavigate(object sender, RequestNavigateEventArgs e)

--- a/QuickMail/Views/UpdateInstalledDialog.xaml
+++ b/QuickMail/Views/UpdateInstalledDialog.xaml
@@ -1,0 +1,40 @@
+<Window x:Class="QuickMail.Views.UpdateInstalledDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="QuickMail Update Installed"
+        Height="180" Width="420"
+        MinHeight="160" MinWidth="340"
+        ResizeMode="NoResize"
+        WindowStartupLocation="CenterOwner"
+        ShowInTaskbar="False"
+        Background="{DynamicResource Theme.WindowBackground}"
+        Foreground="{DynamicResource Theme.TextPrimary}"
+        FontFamily="{DynamicResource Theme.FontFamily}"
+        FontSize="{DynamicResource Theme.FontSizeBase}">
+
+    <DockPanel Margin="20">
+
+        <Button x:Name="ExitButton"
+                DockPanel.Dock="Bottom"
+                Content="E_xit"
+                IsCancel="True"
+                MinWidth="75"
+                HorizontalAlignment="Right"
+                Margin="0,16,0,0"
+                AutomationProperties.Name="Exit"/>
+
+        <StackPanel>
+            <TextBlock x:Name="MessageText"
+                       TextWrapping="Wrap"
+                       Margin="0,0,0,12"/>
+            <TextBlock>
+                <Hyperlink x:Name="WhatsNewLink"
+                           RequestNavigate="WhatsNewLink_RequestNavigate"
+                           AutomationProperties.Name="See what's new">
+                    See what's new
+                </Hyperlink>
+            </TextBlock>
+        </StackPanel>
+
+    </DockPanel>
+</Window>

--- a/QuickMail/Views/UpdateInstalledDialog.xaml.cs
+++ b/QuickMail/Views/UpdateInstalledDialog.xaml.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Windows;
+using System.Windows.Navigation;
+
+namespace QuickMail.Views;
+
+/// <summary>
+/// Shown once on the first launch after an update was applied (installed copies, gated by
+/// the ShowUpdateInstalledAlerts setting). Escape / Exit dismiss it.
+/// </summary>
+public partial class UpdateInstalledDialog : Window
+{
+    public UpdateInstalledDialog(string version, string whatsNewUrl)
+    {
+        InitializeComponent();
+        MessageText.Text = $"QuickMail was updated to version {version}.";
+        WhatsNewLink.NavigateUri = new Uri(whatsNewUrl);
+        Loaded += (_, _) => ExitButton.Focus();
+    }
+
+    private void WhatsNewLink_RequestNavigate(object sender, RequestNavigateEventArgs e)
+    {
+        // All ShellExecute launches go through the allow-list. See ExternalUriPolicy.
+        Helpers.ExternalUriPolicy.TryOpenExternal(e.Uri.AbsoluteUri);
+        e.Handled = true;
+    }
+}

--- a/build.bat
+++ b/build.bat
@@ -53,12 +53,27 @@ echo Packing Velopack release v%VERSION%...
 :: --packVersion must be SemVer (3-part, or a prerelease tag like 0.8.1-1 for a hotfix);
 :: a 4-part version is rejected by vpk. --shortcuts StartMenuRoot matches the old Inno
 :: behavior (Start Menu always, no desktop shortcut by default).
+:: --msi builds the wizard installer (welcome, license acceptance, conclusion) that is the
+:: user-facing download; the one-click Setup.exe is also produced but not shipped.
+:: --instLocation PerUser keeps the install in %LocalAppData% so background updates never
+:: need elevation.
 :: Note: local packs are full-only. CI runs `vpk download github` first so packs there
 :: also produce a delta package against the previous release.
+:: vpk requires the license file to have a .txt/.md/.rtf extension; the repo's LICENSE
+:: has none, so copy it to a gitignored .txt alongside the other installer content.
+:: --framework webview2 restores the old installer's WebView2 install-on-demand.
+copy /y LICENSE installer\velopack\license.txt >nul
 vpk pack --packId QuickMail --packVersion %VERSION% --packDir publish ^
   --mainExe QuickMail.exe --packTitle QuickMail --packAuthors "Kelly Ford" ^
-  --shortcuts StartMenuRoot --outputDir installer\Output\Releases
-if errorlevel 1 (
+  --shortcuts StartMenuRoot --outputDir installer\Output\Releases ^
+  --framework webview2 ^
+  --msi --instLocation PerUser ^
+  --instWelcome installer\velopack\welcome.txt ^
+  --instLicense installer\velopack\license.txt ^
+  --instConclusion installer\velopack\conclusion.txt
+:: vpk exits with -1 on fatal errors; `if errorlevel 1` is false for negative codes,
+:: so compare against 0 explicitly.
+if %errorlevel% neq 0 (
     echo INSTALLER FAILED: vpk pack errors.
     exit /b 1
 )

--- a/build.bat
+++ b/build.bat
@@ -36,22 +36,34 @@ if errorlevel 1 (
     exit /b 1
 )
 echo.
-echo Locating Inno Setup 6 compiler...
-set "ISCC="
-if exist "%ProgramFiles(x86)%\Inno Setup 6\ISCC.exe" set "ISCC=%ProgramFiles(x86)%\Inno Setup 6\ISCC.exe"
-if not defined ISCC if exist "%ProgramFiles%\Inno Setup 6\ISCC.exe" set "ISCC=%ProgramFiles%\Inno Setup 6\ISCC.exe"
-if not defined ISCC (
-    echo INSTALLER FAILED: Inno Setup 6 not found. Install it from https://jrsoftware.org/isdl.php
+echo Locating vpk (Velopack CLI)...
+where vpk >nul 2>nul
+if errorlevel 1 (
+    echo INSTALLER FAILED: vpk not found. Install it with: dotnet tool install -g vpk
     exit /b 1
 )
-echo Compiling installer with "%ISCC%"...
-"%ISCC%" installer\quickmail.iss
+echo Reading version from QuickMail\QuickMail.csproj...
+set "VERSION="
+for /f "usebackq delims=" %%v in (`powershell -NoProfile -Command "(Select-Xml -Path QuickMail\QuickMail.csproj -XPath '/Project/PropertyGroup/Version').Node.InnerText"`) do set "VERSION=%%v"
+if not defined VERSION (
+    echo INSTALLER FAILED: could not read ^<Version^> from QuickMail\QuickMail.csproj.
+    exit /b 1
+)
+echo Packing Velopack release v%VERSION%...
+:: --packVersion must be SemVer (3-part, or a prerelease tag like 0.8.1-1 for a hotfix);
+:: a 4-part version is rejected by vpk. --shortcuts StartMenuRoot matches the old Inno
+:: behavior (Start Menu always, no desktop shortcut by default).
+:: Note: local packs are full-only. CI runs `vpk download github` first so packs there
+:: also produce a delta package against the previous release.
+vpk pack --packId QuickMail --packVersion %VERSION% --packDir publish ^
+  --mainExe QuickMail.exe --packTitle QuickMail --packAuthors "Kelly Ford" ^
+  --shortcuts StartMenuRoot --outputDir installer\Output\Releases
 if errorlevel 1 (
-    echo INSTALLER FAILED: Inno Setup compilation errors.
+    echo INSTALLER FAILED: vpk pack errors.
     exit /b 1
 )
 echo.
-echo Output: installer\Output\quickmail-v^<version^>-setup.exe
+echo Output: installer\Output\Releases\QuickMail-win-Setup.exe (plus update packages)
 goto end
 
 :clean

--- a/docs/INSTALLER.md
+++ b/docs/INSTALLER.md
@@ -58,6 +58,37 @@ On a `v*` tag, `.github/workflows/quickmail.yml`:
    `.nupkg` packages, and the feed metadata files. The in-app updater reads these from the
    latest GitHub release.
 
+## Testing updates locally (no GitHub release needed)
+
+The `--updateFeed <path>` startup flag points the update check at a local folder of
+`vpk pack` output instead of GitHub Releases, so the complete cycle — check, background
+download, apply on relaunch, delta packaging — can be verified offline:
+
+1. `build.bat installer` — packs the current csproj version (say `0.8.1`) into
+   `installer\Output\Releases\`.
+2. Run `installer\Output\Releases\QuickMail-win-Setup.exe`. The app installs to
+   `%LocalAppData%\QuickMail` and launches.
+3. Bump `<Version>` in `QuickMail/QuickMail.csproj` (say `0.8.2`) and run
+   `build.bat installer` again **without deleting the Releases folder** — because the
+   previous full package is still there, this also exercises delta generation
+   (`QuickMail-0.8.2-delta.nupkg` appears).
+4. Launch the **installed** copy with the feed override:
+   `%LocalAppData%\QuickMail\current\QuickMail.exe --updateFeed <repo>\installer\Output\Releases`
+   The startup check finds 0.8.2, announces it, and downloads it in the background
+   (`quickmail.log` records "Update 0.8.2 downloaded; it will be applied when QuickMail
+   exits").
+5. Exit QuickMail. `Update.exe` applies the staged update.
+6. Relaunch (Start Menu or the same command). Help menu now reads "running version 0.8.2".
+
+Add `--profileDir <scratch>` to any of these launches to keep test runs away from real
+data. Uninstalling via Settings → Apps removes `%LocalAppData%\QuickMail` and shortcuts;
+revert the csproj version bump afterwards.
+
+The flag only overrides *where packages come from*; everything else (Velopack's installed
+detection, staging, `Update.exe` apply) runs exactly the production code path. What it
+cannot test: the GitHub Releases fetch itself (`GithubSource`) and the CI packing steps —
+those are exercised by the first real tagged release.
+
 ## Migrating from the Inno Setup installer
 
 Users on an Inno Setup install (v0.8.0 and earlier) need a one-time manual reinstall to get

--- a/docs/INSTALLER.md
+++ b/docs/INSTALLER.md
@@ -1,14 +1,72 @@
-# Installer
+# Installer & Automatic Updates
 
-`installer/quickmail.iss` is an Inno Setup 6 script that packages the **self-contained single-file** `publish/QuickMail.exe` into a Windows installer. `build.bat installer` runs `dotnet publish` then `ISCC.exe`, emitting `installer/Output/quickmail-v<version>-setup.exe` (gitignored).
+QuickMail is packaged with [Velopack](https://velopack.io/). `build.bat installer` runs
+`dotnet publish` then `vpk pack`, emitting `installer/Output/Releases/` (gitignored)
+containing:
 
-Key facts:
+- `QuickMail-win-Setup.exe` — the user-facing installer
+- `QuickMail-<version>-full.nupkg` — the full update package consumed by the in-app updater
+- `QuickMail-<version>-delta.nupkg` — binary delta from the previous release (generated only
+  when the previous release's packages are present; CI fetches them with `vpk download github`
+  before packing, local builds produce full packages only)
+- `RELEASES`, `releases.win.json`, `assets.win.json` — release feed metadata read by the updater
+- `QuickMail-win-Portable.zip` — **not shipped**; the raw single-file `publish/QuickMail.exe`
+  remains the portable download
 
-- **Only `QuickMail.exe` is shipped.** Because the build is self-contained (the .NET 8 runtime is bundled in the exe), there is **no .NET runtime dependency**. The `.pdb` and `Microsoft.Web.WebView2.*.xml` files that also appear in `publish/` are intentionally excluded.
-- **The single external prerequisite is the WebView2 Runtime**, installed on demand via `Dependency_AddWebView2` from the bundled `installer/CodeDependencies.iss` (the standard DomGries dependency helper, vendored verbatim — leave it unmodified).
-- **Version is read from the exe** at compile time via `GetVersionNumbersString`, so it always matches `FileVersion` in the csproj — never hardcode it in the `.iss`.
-- **Per-user install by default** (`PrivilegesRequired=lowest` + `PrivilegesRequiredOverridesAllowed=dialog`); the user may opt into an all-users install, which elevates.
-- **No app mutex exists**, so `CloseApplications=yes` uses the Restart Manager to detect a running copy during an upgrade.
-- Uninstall offers to delete user data under `%APPDATA%\QuickMail`; Credential Manager entries are left untouched.
-- English-only UI strings live in `installer/Languages/Custom.en.isl` (define only messages not already in Inno's `Default.isl`).
-- The installer is a downstream packaging artifact — it does **not** alter the GitHub Actions release, which still ships the bare self-contained `QuickMail.exe`.
+The `vpk` CLI is a .NET global tool: `dotnet tool install -g vpk`.
+
+## Key facts
+
+- **Per-user install only.** Velopack installs to `%LocalAppData%\QuickMail\current\`, no
+  elevation prompt. There is no all-users install path.
+- **Automatic updates.** The startup update check (`UpdateCheckService`) uses Velopack's
+  `UpdateManager` with a GitHub Releases source when running from an installed copy. A found
+  update is downloaded silently in the background and applied by `Update.exe` after the app
+  exits, so the next launch runs the new version. The portable exe falls back to the original
+  GitHub API check, which can only notify.
+- **Version string must be SemVer.** `vpk pack --packVersion` rejects 4-part versions. The
+  release tag is the source of truth in CI (stripped of the leading `v`) and must match the
+  csproj `<Version>` — the workflow fails the release if they differ. A hotfix should use a
+  SemVer2 prerelease tag (e.g. `0.8.1-1`), not a 4th segment.
+- **Entry point requirement.** `vpk pack` verifies via IL inspection that `Main` calls
+  `VelopackApp.Build().Run()`. That is why `App.xaml` compiles as `Page` and `App.xaml.cs`
+  declares an explicit `Main` (see the csproj `StartupObject`). Removing or reordering that
+  call breaks packaging.
+- **Shortcuts:** Start Menu only (`--shortcuts StartMenuRoot`), matching the previous
+  installer's default of no desktop shortcut.
+- **No WebView2 prerequisite check.** The old Inno Setup installer installed the WebView2
+  Runtime on demand; Velopack has no equivalent hook. WebView2 ships with Windows 11 and
+  current Windows 10. If this becomes a support issue, add a startup check with a download
+  link.
+- **User data is never touched.** The app installs to `%LocalAppData%\QuickMail`; user data
+  lives in `%APPDATA%\QuickMail` and Windows Credential Manager. Install, update, and
+  uninstall never touch either.
+- **Code signing** is not wired up yet. `vpk pack` supports Azure Trusted Signing via
+  `--azureTrustedSignFile` when that work completes.
+
+## Release flow (CI)
+
+On a `v*` tag, `.github/workflows/quickmail.yml`:
+
+1. Verifies the tag version matches the csproj `<Version>`.
+2. `dotnet publish` (unchanged single-file self-contained build).
+3. `vpk download github` — fetches the previous release's packages so a delta can be built.
+   Allowed to fail (the first Velopack release has no prior packages).
+4. `vpk pack` — builds setup exe, full/delta packages, and feed metadata; then deletes the
+   downloaded previous-version `.nupkg` so only current-version assets upload.
+5. `softprops/action-gh-release` uploads the portable `QuickMail.exe`, the setup exe, the
+   `.nupkg` packages, and the feed metadata files. The in-app updater reads these from the
+   latest GitHub release.
+
+## Migrating from the Inno Setup installer
+
+Users on an Inno Setup install (v0.8.0 and earlier) need a one-time manual reinstall to get
+onto the auto-update track:
+
+1. Uninstall QuickMail via Settings → Apps, **declining** the offer to delete user data.
+2. Download and run `QuickMail-win-Setup.exe` from the releases page.
+3. Launch QuickMail — accounts, settings, and mail are exactly as they were.
+
+The retired Inno Setup script (`installer/quickmail.iss`, `installer/CodeDependencies.iss`,
+`installer/Languages/Custom.en.isl`) is kept in the repo for reference until the first
+Velopack release has shipped successfully.

--- a/docs/INSTALLER.md
+++ b/docs/INSTALLER.md
@@ -4,7 +4,11 @@ QuickMail is packaged with [Velopack](https://velopack.io/). `build.bat installe
 `dotnet publish` then `vpk pack`, emitting `installer/Output/Releases/` (gitignored)
 containing:
 
-- `QuickMail-win-Setup.exe` — the user-facing installer
+- `QuickMail-win.msi` — **the user-facing installer**: a standard Windows Installer wizard
+  (WiX 5) with welcome, license acceptance, and conclusion pages fed from
+  `installer/velopack/*.txt` and the repo `LICENSE`
+- `QuickMail-win-Setup.exe` — Velopack's one-click installer (no wizard, no license page);
+  produced by `vpk pack` but **not shipped** — the MSI is the installer users download
 - `QuickMail-<version>-full.nupkg` — the full update package consumed by the in-app updater
 - `QuickMail-<version>-delta.nupkg` — binary delta from the previous release (generated only
   when the previous release's packages are present; CI fetches them with `vpk download github`
@@ -17,13 +21,32 @@ The `vpk` CLI is a .NET global tool: `dotnet tool install -g vpk`.
 
 ## Key facts
 
-- **Per-user install only.** Velopack installs to `%LocalAppData%\QuickMail\current\`, no
-  elevation prompt. There is no all-users install path.
+- **Per-user install only (deliberate).** The MSI is packed with `--instLocation PerUser`:
+  installs to `%LocalAppData%\QuickMail\current\`, no elevation prompt. Velopack supports
+  `--instLocation Either` (user chooses Program Files), but background updates from a
+  non-elevated process into Program Files are unverified — offering that choice could break
+  the silent-update guarantee, so it stays off until proven.
 - **Automatic updates.** The startup update check (`UpdateCheckService`) uses Velopack's
   `UpdateManager` with a GitHub Releases source when running from an installed copy. A found
   update is downloaded silently in the background and applied by `Update.exe` after the app
-  exits, so the next launch runs the new version. The portable exe falls back to the original
+  exits, so the next launch runs the new version. Updates work identically whether the MSI
+  or Setup.exe performed the original install. The portable exe falls back to the original
   GitHub API check, which can only notify.
+- **Desktop shortcut is the app's job, not the installer's.** `--shortcuts StartMenuRoot`
+  creates only the Start Menu entry. On first launch of an installed copy, QuickMail offers
+  to add a desktop shortcut (accessible in-app dialog, default No, asked once — recorded as
+  `DesktopShortcutPrompted` in config.ini); the choice stays editable in Settings → General.
+  The shortcut targets `%LocalAppData%\QuickMail\current\QuickMail.exe`, which is stable
+  across updates. See `Helpers/DesktopShortcut.cs`.
+- **Uninstall offers to remove user data.** Velopack's `OnBeforeUninstallFastCallback` (wired
+  in `App.xaml.cs Main`) launches a detached PowerShell prompt — detached because Update.exe
+  kills hook processes after 30 seconds, far too short to leave a question pending. Default
+  answer keeps everything; an explicit Yes deletes `%APPDATA%\QuickMail` **and** QuickMail
+  entries in Windows Credential Manager (passwords `QuickMail:<id>`, tokens `QuickMail.*`).
+  Custom `--profileDir` locations are never touched. Data survival on uninstall-without-Yes
+  matches the old Inno behavior.
+- **WebView2 install-on-demand** is preserved via `--framework webview2` — setup installs the
+  WebView2 Runtime when missing, same as the old Inno `Dependency_AddWebView2`.
 - **Version string must be SemVer.** `vpk pack --packVersion` rejects 4-part versions. The
   release tag is the source of truth in CI (stripped of the leading `v`) and must match the
   csproj `<Version>` — the workflow fails the release if they differ. A hotfix should use a
@@ -32,15 +55,6 @@ The `vpk` CLI is a .NET global tool: `dotnet tool install -g vpk`.
   `VelopackApp.Build().Run()`. That is why `App.xaml` compiles as `Page` and `App.xaml.cs`
   declares an explicit `Main` (see the csproj `StartupObject`). Removing or reordering that
   call breaks packaging.
-- **Shortcuts:** Start Menu only (`--shortcuts StartMenuRoot`), matching the previous
-  installer's default of no desktop shortcut.
-- **No WebView2 prerequisite check.** The old Inno Setup installer installed the WebView2
-  Runtime on demand; Velopack has no equivalent hook. WebView2 ships with Windows 11 and
-  current Windows 10. If this becomes a support issue, add a startup check with a download
-  link.
-- **User data is never touched.** The app installs to `%LocalAppData%\QuickMail`; user data
-  lives in `%APPDATA%\QuickMail` and Windows Credential Manager. Install, update, and
-  uninstall never touch either.
 - **Code signing** is not wired up yet. `vpk pack` supports Azure Trusted Signing via
   `--azureTrustedSignFile` when that work completes.
 
@@ -54,7 +68,7 @@ On a `v*` tag, `.github/workflows/quickmail.yml`:
    Allowed to fail (the first Velopack release has no prior packages).
 4. `vpk pack` — builds setup exe, full/delta packages, and feed metadata; then deletes the
    downloaded previous-version `.nupkg` so only current-version assets upload.
-5. `softprops/action-gh-release` uploads the portable `QuickMail.exe`, the setup exe, the
+5. `softprops/action-gh-release` uploads the portable `QuickMail.exe`, the MSI installer, the
    `.nupkg` packages, and the feed metadata files. The in-app updater reads these from the
    latest GitHub release.
 
@@ -66,8 +80,9 @@ download, apply on relaunch, delta packaging — can be verified offline:
 
 1. `build.bat installer` — packs the current csproj version (say `0.8.1`) into
    `installer\Output\Releases\`.
-2. Run `installer\Output\Releases\QuickMail-win-Setup.exe`. The app installs to
-   `%LocalAppData%\QuickMail` and launches.
+2. Run `installer\Output\Releases\QuickMail-win.msi`. Walk the wizard (welcome, license,
+   conclusion); the app installs to `%LocalAppData%\QuickMail`. First launch offers the
+   desktop shortcut.
 3. Bump `<Version>` in `QuickMail/QuickMail.csproj` (say `0.8.2`) and run
    `build.bat installer` again **without deleting the Releases folder** — because the
    previous full package is still there, this also exercises delta generation
@@ -95,7 +110,7 @@ Users on an Inno Setup install (v0.8.0 and earlier) need a one-time manual reins
 onto the auto-update track:
 
 1. Uninstall QuickMail via Settings → Apps, **declining** the offer to delete user data.
-2. Download and run `QuickMail-win-Setup.exe` from the releases page.
+2. Download and run `QuickMail-win.msi` from the releases page.
 3. Launch QuickMail — accounts, settings, and mail are exactly as they were.
 
 The retired Inno Setup script (`installer/quickmail.iss`, `installer/CodeDependencies.iss`,

--- a/docs/INSTALLER.md
+++ b/docs/INSTALLER.md
@@ -44,7 +44,10 @@ The `vpk` CLI is a .NET global tool: `dotnet tool install -g vpk`.
   answer keeps everything; an explicit Yes deletes `%APPDATA%\QuickMail` **and** QuickMail
   entries in Windows Credential Manager (passwords `QuickMail:<id>`, tokens `QuickMail.*`).
   Custom `--profileDir` locations are never touched. Data survival on uninstall-without-Yes
-  matches the old Inno behavior.
+  matches the old Inno behavior. The prompt is **best-effort**: on script-restricted machines
+  (AppLocker, Constrained Language Mode) it may never appear, in which case data is simply
+  kept — the safe default. The hook and the prompt script log to
+  `%TEMP%\quickmail-uninstall.log` for diagnosis.
 - **WebView2 install-on-demand** is preserved via `--framework webview2` — setup installs the
   WebView2 Runtime when missing, same as the old Inno `Dependency_AddWebView2`.
 - **Version string must be SemVer.** `vpk pack --packVersion` rejects 4-part versions. The

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -7,6 +7,7 @@ QuickMail is a keyboard and screen reader friendly email program for Windows. Al
 ## Contents
 
 - [System Requirements](#system-requirements)
+- [Installing QuickMail](#installing-quickmail)
 - [Adding Accounts](#adding-accounts)
 - [Main Window](#main-window)
 - [Reading Mail](#reading-mail)
@@ -28,8 +29,24 @@ QuickMail is a keyboard and screen reader friendly email program for Windows. Al
 ## System Requirements
 
 - Windows 10 (1703 or later) or Windows 11
-- Microsoft Edge WebView2 Runtime (included with Windows 11 and current Windows 10; available from Microsoft if missing)
+- Microsoft Edge WebView2 Runtime (the installer adds this automatically when missing; included with Windows 11 and current Windows 10)
 - An IMAP/SMTP email account (Gmail, Outlook.com, Microsoft 365, or any standard IMAP provider)
+
+---
+
+## Installing QuickMail
+
+Download **QuickMail-win.msi** from the releases page and run it. A standard setup wizard walks through a welcome page, the license agreement, and installation. QuickMail installs for the current user only — no administrator permission is needed — and adds a Start Menu entry.
+
+The first time an installed QuickMail starts, it asks whether to add a desktop shortcut. Either answer is remembered, and you can change it anytime in **Settings → General** under **Desktop Shortcut**.
+
+Once installed, QuickMail keeps itself up to date automatically: new versions download quietly in the background and are applied the next time you exit and reopen the app. See [Checking for Updates](#checking-for-updates).
+
+**Portable option:** `QuickMail.exe` on the same releases page is a single-file version that runs from anywhere with no installation. It does not update itself; the Help menu tells you when a new version is available to download.
+
+### Uninstalling
+
+Remove QuickMail from **Settings → Apps** as usual. After the app is removed, QuickMail asks whether to also delete your data — accounts, settings, contacts, rules, templates, saved views, cached mail, and saved passwords. Choose **No** (the default) to keep everything, so reinstalling later picks up exactly where you left off; choose **Yes** to remove it all.
 
 ---
 

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -147,11 +147,11 @@ Open **Settings → Keyboard** to reassign any shortcut to a different key. Type
 
 ### Checking for Updates
 
-QuickMail checks for a newer release in the background each time it starts. The top entry of the **Help** menu always shows the result: **"No updates available — running version X.Y.Z"** when you are current, or **"Update available: vX.Y.Z"** when a newer release exists. Activating the entry opens the QuickMail releases site in your browser. If an update is found, a spoken announcement follows a few seconds after launch; the background check itself is silent when you are already up to date.
+QuickMail checks for a newer release in the background each time it starts. The top entry of the **Help** menu always shows the result: **"No updates available — running version X.Y.Z"** when you are current, or **"Update available: vX.Y.Z"** when a newer release exists. If an update is found, a spoken announcement follows a few seconds after launch; the background check itself is silent when you are already up to date.
 
-**Installed copies update themselves.** If you installed QuickMail with the setup program, a found update is also downloaded quietly in the background and installed automatically the next time you exit and reopen QuickMail — no download page, no installer to run, no security warnings. Your accounts, settings, and mail are untouched by an update.
+**Installed copies update themselves.** If you installed QuickMail with the setup program, a found update is downloaded quietly in the background and installed automatically the next time you exit and reopen QuickMail — no download page, no installer to run, no security warnings. Activating the Help menu update entry opens a **QuickMail Update** dialog that says the new version will be installed on relaunch, with three choices: **Restart to Update** applies it immediately and reopens QuickMail; **See what's new** opens that version's release notes in your browser; **Exit** (or Escape) dismisses the dialog — the update still installs the next time you start QuickMail. Your accounts, settings, and mail are untouched by an update.
 
-**The portable exe does not update itself.** If you run the standalone `QuickMail.exe`, the Help menu entry still tells you when a new version exists, and updating remains a manual download of the new exe from the releases page.
+**The portable exe does not update itself.** If you run the standalone `QuickMail.exe`, the Help menu entry still tells you when a new version exists; activating it opens the releases page, and updating remains a manual download of the new exe.
 
 The **Help** menu also has a **Keyboard Tutorial** entry, a short interactive walkthrough of core navigation (F6 pane cycling, Ctrl+1/2/3, the command palette, and Escape) for anyone new to the app.
 

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -7,7 +7,7 @@ QuickMail is a keyboard and screen reader friendly email program for Windows. Al
 ## Contents
 
 - [System Requirements](#system-requirements)
-- [Installing QuickMail](#installing-quickmail)
+- [Installing and Updating QuickMail](#installing-and-updating-quickmail)
 - [Adding Accounts](#adding-accounts)
 - [Main Window](#main-window)
 - [Reading Mail](#reading-mail)
@@ -34,15 +34,52 @@ QuickMail is a keyboard and screen reader friendly email program for Windows. Al
 
 ---
 
-## Installing QuickMail
+## Installing and Updating QuickMail
 
-Download **QuickMail-win.msi** from the releases page and run it. A standard setup wizard walks through a welcome page, the license agreement, and installation. QuickMail installs for the current user only — no administrator permission is needed — and adds a Start Menu entry.
+QuickMail installs with a standard setup wizard and then keeps itself up to date. The guiding principle is that **you are in control**: the defaults are designed to keep you current with no effort, you are told when a new version has been installed, and every part of the automatic behavior can be turned off — QuickMail never stops you from updating manually instead.
 
-The first time an installed QuickMail starts, it asks whether to add a desktop shortcut. Either answer is remembered, and you can change it anytime in **Settings → General** under **Desktop Shortcut**.
+### Installing for the first time
 
-Once installed, QuickMail keeps itself up to date automatically: new versions download quietly in the background and are applied the next time you exit and reopen the app. See [Checking for Updates](#checking-for-updates).
+1. Download **QuickMail-win.msi** from the [releases page](https://github.com/kellylford/QuickMail/releases) and run it.
+2. The setup wizard walks through a welcome page, the license agreement, and installation. QuickMail installs for the current user only — no administrator permission is needed. If the WebView2 component QuickMail uses to display mail is missing from your PC, setup adds it automatically.
+3. A Start Menu entry is created. The first time QuickMail starts, it asks whether to also add a desktop shortcut — either answer is remembered, and you can change your mind anytime in **Settings → General** under **Desktop Shortcut**.
 
-**Portable option:** `QuickMail.exe` on the same releases page is a single-file version that runs from anywhere with no installation. It does not update itself; the Help menu tells you when a new version is available to download.
+### If you already have QuickMail installed
+
+Versions before 0.8.1 used a different installer, so moving onto the self-updating track takes one manual step:
+
+1. Uninstall your current QuickMail from **Settings → Apps**. When the uninstaller offers to delete your data, choose **No**.
+2. Download and run **QuickMail-win.msi** as described above.
+3. Start QuickMail. All of your accounts, settings, contacts, rules, templates, saved views, and cached mail are exactly as you left them — your data lives in a separate location the installer never touches, and passwords stay safely in Windows Credential Manager.
+
+This is a one-time step. From then on, updates arrive on their own.
+
+### How updating works
+
+Each time QuickMail starts, it quietly checks for a newer release in the background. The top entry of the **Help** menu always shows the result — **"No updates available — running version X.Y.Z"** or **"Update available: vX.Y.Z"** — so you can confirm where you stand at any moment.
+
+When an update is found, QuickMail announces it once, downloads it quietly in the background, and installs it automatically the next time you exit and reopen the app. There is no download page, no installer to run, and no security warning — and nothing interrupts what you are doing.
+
+If you would rather not wait for your next restart, activate the Help menu update entry. The **QuickMail Update** dialog offers three choices:
+
+- **Restart to Update** — applies the update immediately and reopens QuickMail.
+- **See what's new** — opens that version's release notes in your browser.
+- **Exit** (or Escape) — closes the dialog; the update still installs on your next normal restart.
+
+So you always know when a version change has happened, the first start after an update shows a **QuickMail Update Installed** dialog confirming the new version, with the same **See what's new** link. Press **Exit** or Escape to dismiss it; it appears only once per update.
+
+An update never touches your mail, accounts, or settings.
+
+### Staying in control
+
+Two settings in **Settings → Advanced**, under **Updates**, put the whole mechanism under your control:
+
+- **Download and install updates automatically** — on by default. Turn it off and QuickMail returns to notification-only behavior: the Help menu still tells you when a new version exists and takes you to the download page, but nothing is downloaded or installed unless you do it yourself. The change takes effect the next time QuickMail starts, and you can turn it back on whenever you like.
+- **Show a message after an update has been installed** — on by default. Turn it off to skip the QuickMail Update Installed dialog; the Help menu entry still reflects your current version.
+
+### The portable version
+
+`QuickMail.exe` on the same releases page is a single-file version that runs from anywhere with no installation — nothing is written to Program Files or the registry, and it never updates itself. The Help menu tells you when a new version is available; updating is a manual download of the new exe, replacing the old one. Your data is shared with an installed copy, so you can move between the two freely.
 
 ### Uninstalling
 
@@ -149,11 +186,7 @@ Open **Settings → Keyboard** to reassign any shortcut to a different key. Type
 
 QuickMail checks for a newer release in the background each time it starts. The top entry of the **Help** menu always shows the result: **"No updates available — running version X.Y.Z"** when you are current, or **"Update available: vX.Y.Z"** when a newer release exists. If an update is found, a spoken announcement follows a few seconds after launch; the background check itself is silent when you are already up to date.
 
-**Installed copies update themselves.** If you installed QuickMail with the setup program, a found update is downloaded quietly in the background and installed automatically the next time you exit and reopen QuickMail — no download page, no installer to run, no security warnings. Activating the Help menu update entry opens a **QuickMail Update** dialog that says the new version will be installed on relaunch, with three choices: **Restart to Update** applies it immediately and reopens QuickMail; **See what's new** opens that version's release notes in your browser; **Exit** (or Escape) dismisses the dialog — the update still installs the next time you start QuickMail. Your accounts, settings, and mail are untouched by an update.
-
-After an update has been applied, the first launch of the new version shows a **QuickMail Update Installed** dialog confirming the version, with the same **See what's new** link and an **Exit** button (Escape also closes it).
-
-Two settings in **Settings → Advanced**, under **Updates**, control this behavior. **Download and install updates automatically** (on by default) — turn it off to go back to notification-only: the Help menu still reports new versions and takes you to the download page, but nothing installs itself; the change takes effect the next time QuickMail starts. **Show a message after an update has been installed** (on by default) — turn it off to skip the QuickMail Update Installed dialog.
+Installed copies download and install updates automatically, and both that behavior and its notifications are configurable — see [Installing and Updating QuickMail](#installing-and-updating-quickmail) for the full walkthrough.
 
 **The portable exe does not update itself.** If you run the standalone `QuickMail.exe`, the Help menu entry still tells you when a new version exists; activating it opens the releases page, and updating remains a manual download of the new exe.
 

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -151,6 +151,10 @@ QuickMail checks for a newer release in the background each time it starts. The 
 
 **Installed copies update themselves.** If you installed QuickMail with the setup program, a found update is downloaded quietly in the background and installed automatically the next time you exit and reopen QuickMail — no download page, no installer to run, no security warnings. Activating the Help menu update entry opens a **QuickMail Update** dialog that says the new version will be installed on relaunch, with three choices: **Restart to Update** applies it immediately and reopens QuickMail; **See what's new** opens that version's release notes in your browser; **Exit** (or Escape) dismisses the dialog — the update still installs the next time you start QuickMail. Your accounts, settings, and mail are untouched by an update.
 
+After an update has been applied, the first launch of the new version shows a **QuickMail Update Installed** dialog confirming the version, with the same **See what's new** link and an **Exit** button (Escape also closes it).
+
+Two settings in **Settings → Advanced**, under **Updates**, control this behavior. **Download and install updates automatically** (on by default) — turn it off to go back to notification-only: the Help menu still reports new versions and takes you to the download page, but nothing installs itself; the change takes effect the next time QuickMail starts. **Show a message after an update has been installed** (on by default) — turn it off to skip the QuickMail Update Installed dialog.
+
 **The portable exe does not update itself.** If you run the standalone `QuickMail.exe`, the Help menu entry still tells you when a new version exists; activating it opens the releases page, and updating remains a manual download of the new exe.
 
 The **Help** menu also has a **Keyboard Tutorial** entry, a short interactive walkthrough of core navigation (F6 pane cycling, Ctrl+1/2/3, the command palette, and Escape) for anyone new to the app.

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -28,7 +28,7 @@ QuickMail is a keyboard and screen reader friendly email program for Windows. Al
 ## System Requirements
 
 - Windows 10 (1703 or later) or Windows 11
-- Microsoft Edge WebView2 Runtime (the installer checks for this automatically)
+- Microsoft Edge WebView2 Runtime (included with Windows 11 and current Windows 10; available from Microsoft if missing)
 - An IMAP/SMTP email account (Gmail, Outlook.com, Microsoft 365, or any standard IMAP provider)
 
 ---
@@ -130,7 +130,11 @@ Open **Settings → Keyboard** to reassign any shortcut to a different key. Type
 
 ### Checking for Updates
 
-QuickMail checks for a newer release in the background each time it starts. The top entry of the **Help** menu always shows the result: **"No updates available — running version X.Y.Z"** when you are current, or **"Update available: vX.Y.Z"** when a newer release exists. Activating the entry opens the matching page on the QuickMail releases site in your browser, so it is always useful — even when there is nothing new. If an update is found, a spoken announcement follows a few seconds after launch; the background check itself is silent when you are already up to date.
+QuickMail checks for a newer release in the background each time it starts. The top entry of the **Help** menu always shows the result: **"No updates available — running version X.Y.Z"** when you are current, or **"Update available: vX.Y.Z"** when a newer release exists. Activating the entry opens the QuickMail releases site in your browser. If an update is found, a spoken announcement follows a few seconds after launch; the background check itself is silent when you are already up to date.
+
+**Installed copies update themselves.** If you installed QuickMail with the setup program, a found update is also downloaded quietly in the background and installed automatically the next time you exit and reopen QuickMail — no download page, no installer to run, no security warnings. Your accounts, settings, and mail are untouched by an update.
+
+**The portable exe does not update itself.** If you run the standalone `QuickMail.exe`, the Help menu entry still tells you when a new version exists, and updating remains a manual download of the new exe from the releases page.
 
 The **Help** menu also has a **Keyboard Tutorial** entry, a short interactive walkthrough of core navigation (F6 pane cycling, Ctrl+1/2/3, the command palette, and Escape) for anyone new to the app.
 

--- a/docs/planning/velopack-auto-update-plan.md
+++ b/docs/planning/velopack-auto-update-plan.md
@@ -2,12 +2,16 @@
 
 ## Status
 
-Spike validated, ready for implementation. Tracked in [#156](https://github.com/kellylford/QuickMail/issues/156). Supersedes [squirrel-auto-update-plan.md](squirrel-auto-update-plan.md) (on hold).
+**Implemented** (July 2026). Tracked in [#156](https://github.com/kellylford/QuickMail/issues/156). Supersedes [squirrel-auto-update-plan.md](squirrel-auto-update-plan.md).
 
-A hands-on spike on `worktree-velopack-auto-update` confirmed the two blockers that stalled the
-Clowd.Squirrel attempt are gone with Velopack, and packaging works end to end against QuickMail's
-actual self-contained single-file build. The spike branch is not merged — implementation continues
-from there once this plan is reviewed.
+The original spike branch (`worktree-velopack-auto-update`) was deleted before its code was
+merged, so Phases 1–4 were re-implemented from this document. Everything the spike validated
+reproduced cleanly: `vpk pack` (Velopack 1.2.0) succeeds against the real single-file publish
+output and verifies the entry point via IL inspection, and the full test suite passes with the
+in-app changes. See `docs/INSTALLER.md` for the as-built packaging and release flow. Items
+still pending live verification are the install/update-cycle checks in the Verification
+Checklist below (fresh install, migration from Inno Setup, update apply-on-relaunch,
+`--profileDir` across an update, delta generation on the second release).
 
 ## TL;DR
 

--- a/docs/release-notes-v0.8.1.md
+++ b/docs/release-notes-v0.8.1.md
@@ -5,7 +5,12 @@
 Starting with this release, QuickMail keeps itself up to date. When a newer version is
 available, the installed app downloads it quietly in the background and installs it the next
 time you exit and reopen QuickMail — no download page, no installer to run, no security
-warnings. The Help menu continues to show whether you are current.
+warnings. The Help menu continues to show whether you are current, offers a **Restart to
+Update** option when a new version is waiting, and the first start after an update confirms
+what was installed. You stay in control throughout: automatic updating and its notifications
+can each be turned off in **Settings → Advanced**, with manual updating always available. See
+the [Installing and Updating section of the User Guide](https://kellylford.github.io/QuickMail/installing-and-updating-quickmail.html)
+for the full walkthrough.
 
 ### One-time step for existing installed users
 

--- a/docs/release-notes-v0.8.1.md
+++ b/docs/release-notes-v0.8.1.md
@@ -14,7 +14,8 @@ manual reinstall:
 
 1. Uninstall your current QuickMail from **Settings → Apps**. When the uninstaller offers to
    delete user data, **choose No**.
-2. Download and run **QuickMail-win-Setup.exe** from this release page.
+2. Download and run **QuickMail-win.msi** from this release page. A standard setup wizard
+   walks through the license and installation.
 3. Start QuickMail. All your accounts, settings, contacts, rules, templates, saved views, and
    cached mail are exactly as you left them.
 
@@ -26,7 +27,10 @@ Notes on the new install:
 
 - QuickMail now installs per-user (no administrator prompt). The previous option to install
   for all users is gone.
-- A Start Menu entry is created; no desktop shortcut is added.
+- A Start Menu entry is created. The first time QuickMail starts, it asks whether to add a
+  desktop shortcut; the choice can be changed anytime in Settings → General.
+- Uninstalling now asks whether to also remove your data — and unlike before, choosing Yes
+  also clears QuickMail's saved passwords from Windows Credential Manager.
 
 ### Portable exe users
 

--- a/docs/release-notes-v0.8.1.md
+++ b/docs/release-notes-v0.8.1.md
@@ -1,0 +1,38 @@
+# QuickMail v0.8.1
+
+## Automatic updates
+
+Starting with this release, QuickMail keeps itself up to date. When a newer version is
+available, the installed app downloads it quietly in the background and installs it the next
+time you exit and reopen QuickMail — no download page, no installer to run, no security
+warnings. The Help menu continues to show whether you are current.
+
+### One-time step for existing installed users
+
+This release uses a new installer, so getting onto the automatic-update track requires one
+manual reinstall:
+
+1. Uninstall your current QuickMail from **Settings → Apps**. When the uninstaller offers to
+   delete user data, **choose No**.
+2. Download and run **QuickMail-win-Setup.exe** from this release page.
+3. Start QuickMail. All your accounts, settings, contacts, rules, templates, saved views, and
+   cached mail are exactly as you left them.
+
+Your data is safe throughout: settings and mail live in a separate location the installer
+never touches, and passwords stay in Windows Credential Manager. After this one reinstall,
+all future updates are automatic.
+
+Notes on the new install:
+
+- QuickMail now installs per-user (no administrator prompt). The previous option to install
+  for all users is gone.
+- A Start Menu entry is created; no desktop shortcut is added.
+
+### Portable exe users
+
+Nothing changes. `QuickMail.exe` remains a single-file download that you update manually;
+the Help menu still tells you when a new version is available.
+
+## Other changes
+
+<!-- Fill in remaining changes for this release before tagging. -->

--- a/installer/velopack/conclusion.txt
+++ b/installer/velopack/conclusion.txt
@@ -1,0 +1,7 @@
+QuickMail has been installed.
+
+You can start QuickMail from the Start Menu. The first time it runs, QuickMail offers to add a desktop shortcut; you can change that choice anytime in Settings.
+
+On first launch, open Settings, then Accounts, to add your email account. Press F1 inside the app to open the user guide.
+
+QuickMail will keep itself up to date automatically from now on.

--- a/installer/velopack/welcome.txt
+++ b/installer/velopack/welcome.txt
@@ -1,0 +1,5 @@
+Welcome to QuickMail Setup.
+
+QuickMail is a keyboard-first, accessible desktop email client for Windows. This wizard installs QuickMail for the current user; no administrator permission is needed.
+
+Once installed, QuickMail keeps itself up to date: new versions download in the background and are applied automatically the next time you start the app.


### PR DESCRIPTION
Closes #156.

Implements automatic updates via [Velopack](https://velopack.io/), replacing the Inno Setup installer, per `docs/planning/velopack-auto-update-plan.md` (the original spike branch was deleted before merging; re-implemented from the plan).

## What ships

- **MSI wizard installer** (`QuickMail-win.msi`, WiX 5 via `vpk --msi`): welcome, license acceptance, and conclusion pages; per-user install to `%LocalAppData%\QuickMail`, no elevation; WebView2 installed on demand (`--framework webview2`). Velopack's one-click `Setup.exe` is intentionally not shipped.
- **Silent background updates** for installed copies: the startup check uses Velopack's `UpdateManager` against GitHub Releases, downloads in the background, and applies on exit (or immediately via the dialog below). The portable exe keeps the notification-only GitHub API check.
- **QuickMail Update dialog** (Help menu, installed copies): "Version X is available and will be installed on relaunch" — Restart to Update / See what's new / Exit (Escape).
- **QuickMail Update Installed dialog** on the first launch after an update, driven by a `LastRunVersion` record in config.
- **Advanced → Updates settings**: turn off automatic updating (notification-only mode) and/or the update-installed notice.
- **Desktop shortcut**: installer creates the Start Menu entry only; first launch offers a desktop shortcut (asked once), editable later in Settings → General.
- **Uninstall data prompt**: `OnBeforeUninstallFastCallback` spawns a detached prompt (hooks are killed after 30s) offering to delete `%APPDATA%\QuickMail` and QuickMail Credential Manager entries; default keeps everything.
- **Release workflow**: tag-must-match-csproj guard, `vpk download github` for delta packages, `vpk pack`, and asset upload alongside the unchanged portable exe.
- **`--updateFeed <path>` flag** for offline update-cycle testing against local `vpk pack` output (procedure in `docs/INSTALLER.md`).

## Verified

- Full local update cycles across 0.8.1 → 0.8.6 test packs: announcement, background download (delta packages confirmed), dialog restart path, apply-on-exit path, update-installed notice, auto-update opt-out, focus restoration.
- MSI wizard install/upgrade/uninstall exercised live, including screen reader walkthrough.
- Full test suite passes; smoke test passes; `vpk pack` validated against the real single-file publish output.

## Notes

- Existing installed users need a one-time reinstall (decline data deletion) — migration notes drafted in `docs/release-notes-v0.8.1.md`; rename to match the actual next release tag and bump the csproj `<Version>` before tagging.
- Per-machine install is deliberately unsupported (elevated installs would break non-elevated background updates); documented in `docs/INSTALLER.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
