### PR TITLE
Docs: adopt per-resource `.default` OAuth scope (spec + reconcile)

### DIFF
--- a/docs/ENTRA-APP-REGISTRATION.md
+++ b/docs/ENTRA-APP-REGISTRATION.md
@@ -56,6 +56,13 @@ consent. **This list is therefore the complete definition of what QuickMail can 
 permission missing here can never be acquired at runtime, no matter what the code does. See
 `docs/planning/oauth-default-scope-pm-dev-spec.md`.
 
+> **Exception — personal Microsoft accounts (Outlook.com/MSA).** `.default` is honored only through
+> the AAD admin-consent model, which consumer accounts don't have, so their `.default` token comes
+> back read-only (delete/move → 403). Personal accounts instead request the **explicit** scopes
+> `Mail.ReadWrite` / `Mail.Send` / `User.Read` (`OAuthService.GraphMailScopesPersonal`), so the user
+> is prompted to consent to write. The Graph permissions below still need to be declared here for
+> AAD; the personal-account path just requests them explicitly rather than via `.default`. See #217.
+
 **Microsoft Graph (delegated):**
 
 | Permission | Used for |

--- a/docs/ENTRA-APP-REGISTRATION.md
+++ b/docs/ENTRA-APP-REGISTRATION.md
@@ -49,9 +49,12 @@ above; the embedded view intercepts that navigation internally (no loopback list
 
 ## 3. API permissions (delegated, Microsoft Graph + Exchange Online)
 
-Adding a scope to `OAuthService.GraphMailScopes` / `ImapSmtpScopes` in code is **not sufficient** on
-its own. For tenants that require admin consent (see §4), each delegated permission must also be
-**declared here** or admin consent cannot grant it.
+QuickMail requests the **per-resource `.default` scope** at sign-in — `https://graph.microsoft.com/.default`
+for Graph accounts and `https://outlook.office.com/.default` for IMAP/SMTP-over-OAuth. `.default`
+asks for **exactly the delegated permissions declared here** — nothing more, no runtime incremental
+consent. **This list is therefore the complete definition of what QuickMail can request.** A
+permission missing here can never be acquired at runtime, no matter what the code does. See
+`docs/planning/oauth-default-scope-pm-dev-spec.md`.
 
 **Microsoft Graph (delegated):**
 
@@ -73,9 +76,12 @@ its own. For tenants that require admin consent (see §4), each delegated permis
 Plus `offline_access` (refresh tokens) — standard OIDC scope, explicitly included in the scope
 arrays in `OAuthService.cs`; no separate portal permission entry required.
 
-> When a new scope is added to the code (e.g. `MailboxSettings.ReadWrite` was added for server-side
-> rules), it must be added to this list **and** admin consent re-granted in each admin-consent tenant.
-> Missing this is the most common cause of a "prompted but cannot consent" dead end (§5).
+> Because the app requests `.default`, adding a permission is **entirely a registration action**:
+> declare it in this list **and** re-grant admin consent in each admin-consent tenant. There is no
+> code scope list to update and no runtime consent prompt — a permission the code needs but that is
+> not declared+granted here surfaces as a feature-level `403`, not a consent dialog (§5). Declaring
+> a new scope **before** GA (while no account has consented yet) means the first consent captures it
+> and no one is ever re-prompted.
 
 ---
 
@@ -98,15 +104,26 @@ a new scope, the admin must **re-grant** consent — "already shows consented" r
 ## 5. Troubleshooting
 
 ### "Prompted for consent, but there's no way to consent" (dead-end prompt)
-The tenant disables user consent **and** the build is requesting a scope that is not in the
-admin-consented set. Almost always this means a scope was added in code but not declared in §3 and/or
-admin consent was not re-granted afterward.
-**Fix:** declare the scope (§3) → re-grant admin consent (§4). Confirm on the consent screen which
-permission lacks prior approval — that's the missing one.
+The tenant disables user consent **and** at least one **declared** permission (§3) has not been
+admin-granted for the tenant. Because QuickMail requests `.default` (the whole declared set), sign-in
+requires the full set to be consented — so any un-granted declared permission blocks sign-in, not
+just a single feature.
+**Fix:** ensure every needed permission is declared (§3) → **grant admin consent for the whole set**
+(§4). After adding a new permission, the admin must **re-grant** (an existing grant reflects the
+*old* set). With `.default` this is purely a registration/consent action — there is no code scope
+list to change.
 
-Note: builds requesting only a subset of the consented scopes (e.g. `MailboxSettings.Read` when
-`ReadWrite` is consented) sign in silently — so the same account can work on one build and dead-end
-on another purely because of which scopes that build requests.
+Note: with `.default`, "same account works on one build but dead-ends on another because of which
+scopes the build requests" **no longer happens** — every build requests the same full declared set.
+A dead-end is always a registration/consent gap (a declared scope not yet granted), never a
+per-build scope difference.
+
+### Server-rules write fails with `403` even though sign-in worked
+A residual case under `.default`: the account's cached token predates a newly-declared scope, or the
+tenant granted only part of the declared set. **Fix:** confirm `MailboxSettings.ReadWrite` is
+declared (§3) and admin-granted (§4), then **sign in again** — a fresh `.default` acquisition
+refreshes the token to include it. QuickMail surfaces this as an admin-directed message, not an
+in-app re-consent (see `docs/planning/oauth-default-scope-pm-dev-spec.md` §5).
 
 ### Sign-in lands on an unreachable `http://localhost` page, then re-prompts
 A redirect-URI misconfiguration (§2): the loopback redirect is under the wrong platform, uses a

--- a/docs/ENTRA-APP-REGISTRATION.md
+++ b/docs/ENTRA-APP-REGISTRATION.md
@@ -73,8 +73,9 @@ permission missing here can never be acquired at runtime, no matter what the cod
 | `IMAP.AccessAsUser.All` | IMAP access (XOAUTH2) |
 | `SMTP.Send` | SMTP send (XOAUTH2) |
 
-Plus `offline_access` (refresh tokens) — standard OIDC scope, explicitly included in the scope
-arrays in `OAuthService.cs`; no separate portal permission entry required.
+Plus `offline_access` (refresh tokens) — a standard OIDC scope that **MSAL adds automatically** for
+the public-client desktop flow, so refresh tokens still issue even though the code now requests only
+`.default` (verified live). It is not listed in `OAuthService.cs` and needs no separate portal entry.
 
 > Because the app requests `.default`, adding a permission is **entirely a registration action**:
 > declare it in this list **and** re-grant admin consent in each admin-consent tenant. There is no

--- a/docs/planning/graph-backend-dev-spec.md
+++ b/docs/planning/graph-backend-dev-spec.md
@@ -528,6 +528,14 @@ No code changes elsewhere in `AccountModel`. The new fields serialize/deserializ
 
 **Path:** `QuickMail/Services/OAuthService.cs`
 
+> **Superseded 2026-07-08 (scope *values* only):** the per-call overload and `DefaultScopesFor`
+> selection below are retained, but QuickMail now requests the **per-resource `.default` scope**
+> rather than an explicit list — `https://graph.microsoft.com/.default` (Graph) and
+> `https://outlook.office.com/.default` (IMAP/SMTP). The declared permission set moves to the app
+> registration (`docs/ENTRA-APP-REGISTRATION.md` §3), which becomes the source of truth. The
+> `MailboxSettings.Read` entry shown in the snippet was later superseded by `MailboxSettings.ReadWrite`
+> and is now subsumed by `.default`. Full rationale: `oauth-default-scope-pm-dev-spec.md`.
+
 Add a new overload that accepts scopes; keep existing overload for backward compatibility during refactor:
 
 ```csharp

--- a/docs/planning/graph-backend-pm-spec.md
+++ b/docs/planning/graph-backend-pm-spec.md
@@ -449,6 +449,12 @@ This diagram traces a single new message from arrival to UI render. **Both** bac
 
 ### 9.3 Authentication
 
+> **Superseded 2026-07-08 (scope values):** QuickMail now requests the per-resource `.default` scope
+> (`https://graph.microsoft.com/.default` for Graph, `https://outlook.office.com/.default` for
+> IMAP/SMTP) instead of the explicit scope lists shown below. The per-call machinery is unchanged;
+> the requested value and the source of truth (the app registration) are what changed. See
+> `oauth-default-scope-pm-dev-spec.md` and `docs/ENTRA-APP-REGISTRATION.md` §3.
+
 The MSAL infrastructure stays. `OAuthService.GetAccessTokenAsync` already handles silent-then-interactive with a DPAPI-encrypted cache.
 
 What changes: `OAuthService` accepts scopes per call instead of hardcoding the IMAP scopes. The caller passes the right scopes for the backend.
@@ -713,12 +719,19 @@ Reference for Phase 4-6 implementers. All endpoints are `https://graph.microsoft
 
 ## Appendix B: Scope comparison
 
-| Today (IMAP/OAuth) | Proposed (Graph) |
+> **Note (2026-07-08):** the table below lists the *delegated permissions* each backend uses. These
+> are now **declared on the app registration** and requested via the per-resource `.default` scope,
+> not sent as an explicit list. `MailboxSettings.Read` was later upgraded to
+> `MailboxSettings.ReadWrite` (server rules). See `oauth-default-scope-pm-dev-spec.md`.
+
+| Declared for IMAP/OAuth (Exchange Online) | Declared for Graph |
 |---|---|
 | `https://outlook.office.com/IMAP.AccessAsUser.All` | `https://graph.microsoft.com/Mail.ReadWrite` |
 | `https://outlook.office.com/SMTP.Send` | `https://graph.microsoft.com/Mail.Send` |
-| (none) | `https://graph.microsoft.com/MailboxSettings.Read` (used to discover well-known folder IDs) |
+| (none) | `https://graph.microsoft.com/MailboxSettings.ReadWrite` (folder IDs + server rules) |
+| — | `https://graph.microsoft.com/User.Read`, `User.ReadBasic.All` |
 | `offline_access` | `offline_access` |
+| requested as `outlook.office.com/.default` | requested as `graph.microsoft.com/.default` |
 
 ## Appendix C: Schema migration SQL
 

--- a/docs/planning/oauth-default-scope-pm-dev-spec.md
+++ b/docs/planning/oauth-default-scope-pm-dev-spec.md
@@ -48,16 +48,26 @@ so "what the app asks for" and "what admin consent grants" are the same set.
 
 ## 3. Decision & rationale (pure `.default`)
 
-**Decision:** request `<resource>/.default` for every OAuth backend. Do **not** keep a runtime
-incremental-consent fallback for the elevated server-rules scope.
+**Decision:** request `<resource>/.default` for **work/school (AAD)** OAuth backends — Graph and
+IMAP/SMTP. Do **not** keep a runtime incremental-consent fallback for the elevated server-rules scope.
+
+> **Exception — personal Microsoft (MSA) accounts (added after live validation, #217/#218).**
+> `.default` is honored only through the AAD admin-consent model, which consumer accounts don't have,
+> so a personal account's `.default` token comes back **read-only** — delete/move/flag fail with
+> `403 ErrorAccessDenied`. Personal Microsoft accounts therefore request the **explicit** delegated
+> scopes `Mail.ReadWrite` / `Mail.Send` / `User.Read` (`OAuthService.GraphMailScopesPersonal`), so the
+> user is prompted to consent to write. `DefaultScopesFor` selects per account type. This is the one
+> place the "pure `.default` for every backend" framing does **not** hold — everything else in this
+> section describes the AAD path.
 
 **Why pure, not a `.default`-core + step-up-rules hybrid:**
 
 - **In-app self-heal is illusory for the users who hit the wall.** In an admin-consent tenant, a
   non-admin user cannot grant a missing scope no matter how it's requested — an "in-app
   Reauthorize" just re-throws the same admin-approval wall. Since most users are **not** tenant
-  admins, the hybrid's step-up self-heal helps only the minority in user-consent-permissive tenants
-  (and personal Microsoft accounts). It is not worth the extra token-management complexity.
+  admins, the hybrid's step-up self-heal helps only the minority in user-consent-permissive tenants.
+  (Personal Microsoft accounts are handled separately — see the MSA exception above; they get
+  explicit scopes, not step-up consent.) It is not worth the extra token-management complexity.
 - **Consistent with a decision already made.** `server-rules-pm-dev-spec.md` §4 already chose to
   **capture `MailboxSettings.ReadWrite` up front, pre-GA** (fold it into every user's first
   consent) and explicitly labeled the on-`403` reauthorize path as *belt-and-suspenders* behind
@@ -72,7 +82,9 @@ incremental-consent fallback for the elevated server-rules scope.
 1. **A new permission can no longer be introduced by a code change alone.** Adding any Graph
    permission requires **declaring it on the app registration and re-granting consent** before the
    token will carry it. There is no runtime prompt to fall back on.
-2. **Consent is all-or-nothing per resource.** Requesting `graph.microsoft.com/.default` means a
+2. **Consent is all-or-nothing per resource (AAD only).** This describes the **work/school** path;
+   it does not apply to personal Microsoft accounts, which use explicit scopes (see the MSA exception
+   above). Requesting `graph.microsoft.com/.default` means an AAD
    tenant consents to the **entire declared Graph permission set** — including
    `MailboxSettings.ReadWrite` — to use the Graph backend at all. The write scope rides in the
    single sign-in consent rather than a separate later prompt; that is exactly the up-front-capture

--- a/docs/planning/oauth-default-scope-pm-dev-spec.md
+++ b/docs/planning/oauth-default-scope-pm-dev-spec.md
@@ -1,0 +1,214 @@
+# OAuth `.default` Scope Migration — PM/Dev Spec
+
+**Status:** Proposed (2026-07-08)
+**Depends on:** Graph backend (merged), embedded-WebView sign-in (merged, #139), Entra app
+registration (`docs/ENTRA-APP-REGISTRATION.md`).
+**Related:** #202 (silent identity rebind — part a merged/pending), #203 (sign-in window timeout).
+
+---
+
+## 1. Summary
+
+QuickMail currently requests an **explicit list** of delegated scopes at sign-in — a different
+list per backend (`GraphMailScopes` for Graph, `ImapSmtpScopes` for IMAP/SMTP). This spec changes
+the request to the **per-resource `.default` scope**:
+
+- Graph accounts request `https://graph.microsoft.com/.default`
+- IMAP/SMTP-over-OAuth accounts request `https://outlook.office.com/.default`
+
+`.default` asks for **exactly the delegated permissions declared on the app registration for that
+resource** — no more, no less. The app registration (`docs/ENTRA-APP-REGISTRATION.md` §3) becomes
+the single source of truth for the permission set.
+
+This is a **pure `.default`** decision: there is no runtime incremental/step-up consent for any
+Graph permission, including the server-rules write scope.
+
+---
+
+## 2. Problem being solved
+
+With explicit dynamic scopes, the set the app *requests* can drift from the set the app
+registration *declares*. In a tenant that requires **admin consent** (the common enterprise M365
+configuration, where user self-consent is disabled), that drift is fatal:
+
+1. The user signs in; the app requests a scope that isn't in the admin-consented set.
+2. The user sees a "needs admin approval" prompt **with no consent button**.
+3. An admin grants consent **via the portal** — which covers the permissions **declared on the app
+   registration**, not a dynamically-requested-but-undeclared scope.
+4. The user retries and hits the **same prompt** — the grant didn't cover the requested scope.
+
+This is the observed "admin granted consent but the user is still prompted" loop. Its root cause is
+always a mismatch between requested scopes and declared-and-granted scopes (most recently:
+`MailboxSettings.ReadWrite`, added in code for server rules, not declared on the registration).
+
+`.default` removes the mismatch **by construction**: the request set is defined by the declaration,
+so "what the app asks for" and "what admin consent grants" are the same set.
+
+---
+
+## 3. Decision & rationale (pure `.default`)
+
+**Decision:** request `<resource>/.default` for every OAuth backend. Do **not** keep a runtime
+incremental-consent fallback for the elevated server-rules scope.
+
+**Why pure, not a `.default`-core + step-up-rules hybrid:**
+
+- **In-app self-heal is illusory for the users who hit the wall.** In an admin-consent tenant, a
+  non-admin user cannot grant a missing scope no matter how it's requested — an "in-app
+  Reauthorize" just re-throws the same admin-approval wall. Since most users are **not** tenant
+  admins, the hybrid's step-up self-heal helps only the minority in user-consent-permissive tenants
+  (and personal Microsoft accounts). It is not worth the extra token-management complexity.
+- **Consistent with a decision already made.** `server-rules-pm-dev-spec.md` §4 already chose to
+  **capture `MailboxSettings.ReadWrite` up front, pre-GA** (fold it into every user's first
+  consent) and explicitly labeled the on-`403` reauthorize path as *belt-and-suspenders* behind
+  that. Pure `.default` formalizes the up-front-capture decision and drops a fallback that was both
+  secondary and non-functional for the admin-consent majority.
+- **One source of truth.** The permission set lives in exactly one place — the app registration —
+  instead of being split between code scope arrays and the portal declaration that must be kept in
+  sync by hand.
+
+**Costs we accept:**
+
+1. **A new permission can no longer be introduced by a code change alone.** Adding any Graph
+   permission requires **declaring it on the app registration and re-granting consent** before the
+   token will carry it. There is no runtime prompt to fall back on.
+2. **Consent is all-or-nothing per resource.** Requesting `graph.microsoft.com/.default` means a
+   tenant consents to the **entire declared Graph permission set** — including
+   `MailboxSettings.ReadWrite` — to use the Graph backend at all. The write scope rides in the
+   single sign-in consent rather than a separate later prompt; that is exactly the up-front-capture
+   decision from `server-rules-pm-dev-spec.md` §4, now made structural. A tenant unwilling to grant
+   the full set cannot use the Graph backend — though it can still use the **IMAP backend**, which
+   is a separate resource (`outlook.office.com`) with its own, smaller `.default` (IMAP + SMTP
+   only, no mailbox-settings write).
+
+Because the write scope is part of the sign-in consent, the elevated permission is normally gated at
+**sign-in**, not at feature use — so the "mail works but rules fail" state is a **narrow residual**,
+not the common path (see §5).
+
+---
+
+## 4. Code changes
+
+**`QuickMail/Services/OAuthService.cs`** — the per-call scope overload
+(`GetAccessTokenAsync(account, string[] scopes, ct)`) and `DefaultScopesFor(account)` **stay**.
+What changes is the *value* they resolve to:
+
+```csharp
+// Per-resource .default. Kept as named constants for readability; each is a single entry.
+public static readonly string[] GraphMailScopes   = ["https://graph.microsoft.com/.default"];
+public static readonly string[] ImapSmtpScopes    = ["https://outlook.office.com/.default"];
+
+private static string[] DefaultScopesFor(AccountModel account)
+    => account.BackendKind == BackendKind.MicrosoftGraph ? GraphMailScopes : ImapSmtpScopes;
+```
+
+Notes:
+
+- **`.default` is per-resource.** You cannot mix `.default` with other scopes in one request, and
+  you cannot combine two resources. Graph and IMAP each request their own resource's `.default`;
+  they are independent consent surfaces. This maps cleanly onto the existing per-backend selection.
+- `offline_access` is implied by the framework for public-client flows and does not need to appear
+  alongside `.default` (MSAL requests refresh tokens for the confidential/public desktop flow
+  regardless). Verify refresh-token issuance during the live test.
+- The MSAL token cache still keys tokens per requested scope-set, so a user who has both an IMAP and
+  a Graph account holds two independent cache entries (`outlook.office.com/.default` vs
+  `graph.microsoft.com/.default`) — no collision.
+- The interactive-vs-silent logic, embedded-WebView configuration, and redirect URI are unchanged.
+
+---
+
+## 5. Where consent is gated, and the `403` residual
+
+**Primary gate is at sign-in.** Because `.default` requests the full declared set, the elevated
+`MailboxSettings.ReadWrite` permission is consented (or refused) as part of the **sign-in** consent,
+not lazily at feature use. In an admin-consent tenant the admin grants the full declared set once
+(`docs/ENTRA-APP-REGISTRATION.md` §4); until then, **sign-in itself** is gated — the same gate as
+core mail — and shows the tenant's "needs admin approval" screen (Entra doc §5). So in steady state
+there is *no* feature-level `403`: either the account is fully consented (and rules work) or it
+can't sign in.
+
+**The `403` residual.** A `403`/insufficient-scope can still occur transiently — e.g. a scope
+declared on the registration *after* an account's token was already cached (the cached token predates
+the declaration), or a tenant that granted only part of the declared set. Handle it defensively:
+
+- The Graph service maps `403`/insufficient-scope to a typed exception
+  (`ServerRuleConsentRequiredException` for the rules path), as today.
+- The View surfaces an **actionable, admin-directed** message — never an in-app "Reauthorize" that
+  cannot succeed in an admin-consent tenant. Example: *"QuickMail can't change server rules because
+  your organization hasn't granted it permission. Ask your administrator to grant it, then sign in
+  again."* A fresh interactive `.default` sign-in **after** the grant refreshes the token to include
+  the now-granted scope — no special in-app consent flow needed.
+- Announce as a **Hint** (respects `AnnounceHints`); never a silent catch (CLAUDE.md).
+
+---
+
+## 6. Impact on existing specs
+
+- **`graph-backend-dev-spec.md` §6.8** and **`graph-backend-pm-spec.md` §9.3 / Appendix B** — the
+  per-call scope machinery they describe is retained, but the requested value changes from an
+  explicit scope *list* to `<resource>/.default`. Those sections carry a superseding pointer to this
+  doc.
+- **`server-rules-pm-dev-spec.md` §4 / Path E / §6.2 / §15** — the "graceful in-app re-consent"
+  (Path E "Reauthorize?") is replaced by the admin-directed `403` message above. The up-front
+  pre-GA capture in §4 decision (1) stands, restated as *declare on the app registration*.
+- **`docs/ENTRA-APP-REGISTRATION.md`** — the declared permission list (§3) is now the *complete
+  definition* of what the app can request; §5's "dead-end prompt" symptom shifts from a blocked
+  sign-in to a feature-level `403`.
+
+---
+
+## 7. Keyboard walkthrough
+
+Ordinary sign-in is **UI-unchanged** — the user still chooses the backend, enters their address,
+and signs in through the embedded window. (In an admin-consent tenant, sign-in is gated on the admin
+having consented to the full declared set — that "needs admin approval" screen is the tenant's, not
+QuickMail's, and is unchanged by this work.) The only new QuickMail-drawn path is the residual
+admin-directed `403` (§5):
+
+1. User opens **Server Rules** and Saves a create/edit. The account's admin has not granted the
+   mailbox-settings write permission.
+2. The save fails with `403`. QuickMail does **not** close the window or blank the list. It shows
+   the admin-directed message and announces (Hint): *"QuickMail can't change server rules because
+   your organization hasn't granted it permission. Ask your administrator to grant it, then sign in
+   again."*
+3. Focus stays on the editor. The user can Escape back to the list (which still displays existing
+   rules — reading works under the granted subset).
+4. After an admin grants consent tenant-wide, the user signs in again; `.default` now carries the
+   write permission and the save succeeds. Announce (Result): *"Rule created."*
+
+---
+
+## 8. Infrastructure changes
+
+- **`OAuthService.GraphMailScopes` / `ImapSmtpScopes`** — values change to per-resource `.default`;
+  the overload and `DefaultScopesFor` signatures are unchanged.
+- **No CommandRegistry, F6-ring, or `AutomationProperties.Name` changes.**
+- **`AccessibilityHelper.Announce`** — the server-rules `403` path announces a **Hint** (was a
+  Status "Reauthorized"). No new categories.
+- **App registration (Kelly, registration owner):** every delegated permission the app needs must
+  be declared for its resource (`docs/ENTRA-APP-REGISTRATION.md` §3), including
+  `MailboxSettings.ReadWrite`, **before** GA so the first consent captures the full set. Confirm no
+  tenant admin-consent policy blocks any declared scope.
+
+---
+
+## 9. Out of scope
+
+- **Runtime incremental / step-up consent** — deliberately not implemented (§3). No in-app
+  "Reauthorize" self-heal for missing Graph permissions.
+- **Programmatic admin-consent initiation from inside the app** — QuickMail directs the user to
+  their admin; it does not drive the `/adminconsent` flow itself. (A future in-band admin-consent
+  action is tracked separately under #202 part b and is not part of this change.)
+- **IMAP password accounts** — no OAuth, no consent surface; untouched.
+- **Changing the app registration's account-type or redirect configuration** — unchanged (see the
+  Entra doc §1–§2).
+
+---
+
+## 10. Open questions
+
+1. **`offline_access` with `.default`** — confirm during live test that refresh tokens are still
+   issued for the public-client desktop flow when only `<resource>/.default` is requested. If not,
+   append `offline_access` to the request array (MSAL permits `.default` + `offline_access`).
+2. **Directory search scope** (`User.ReadBasic.All`) — must be declared on the registration for
+   `.default` to include it; verify recipient-name resolution still works post-migration.

--- a/docs/planning/server-rules-pm-dev-spec.md
+++ b/docs/planning/server-rules-pm-dev-spec.md
@@ -71,16 +71,49 @@ Per Microsoft Learn (verified 2026-06):
 - **List / Get** message rules → `MailboxSettings.Read`
 - **Create / Update / Delete** message rules → `MailboxSettings.ReadWrite`
 
-**Current state:** `OAuthService.GraphMailScopes` requested `MailboxSettings.Read` before this work — **updated to `MailboxSettings.ReadWrite` by the scope-bump PR** (see §4 and §19; `QuickMail/Services/OAuthService.cs`). So **reading** server rules works with no change, and **writing** has the scope it needs once that PR merges.
+> **Updated 2026-07-08 — QuickMail now requests the per-resource `.default` scope.** Sign-in asks
+> for `https://graph.microsoft.com/.default`, i.e. **exactly the delegated permissions declared on
+> the app registration**. There is no runtime incremental/step-up consent. The permission set is
+> defined by the app registration, not by a code scope list. See
+> `oauth-default-scope-pm-dev-spec.md` for the full rationale (short version: in admin-consent
+> tenants a non-admin user can't self-heal a missing scope anyway, so an in-app "Reauthorize" flow
+> helps almost no one). The design below is restated to match.
 
-**Consequence:** Bumping the scope forces a **re-consent**. On the next interactive token acquisition, MSAL will prompt the user to grant the new permission. Existing Graph accounts will silently fail writes until they re-consent.
+**Current state:** `MailboxSettings.ReadWrite` (a superset of `MailboxSettings.Read`) is declared on
+the app registration (`docs/ENTRA-APP-REGISTRATION.md` §3). Under `.default`, once that declaration
+is in place and consent is granted, the token carries the write permission and both **reading** and
+**writing** server rules work.
+
+**Consequence:** Because `MailboxSettings.ReadWrite` is part of the declared set, `.default` requests
+it at **sign-in** — so it's consented (or refused) as part of the normal sign-in consent, not lazily
+at first write. In steady state a signed-in Graph account therefore already has the write scope and
+rules just work; a tenant that won't grant the full set gates **sign-in itself** (the same admin
+gate as core mail), not the rules feature specifically. A feature-level `403` is only a **residual**
+(a token cached before the scope was declared, or a partial tenant grant) — handled by Path E with
+an admin-directed message, never an in-app "Reauthorize." Full semantics:
+`oauth-default-scope-pm-dev-spec.md` §5.
 
 **Design decisions:**
-1. **Add `MailboxSettings.ReadWrite` to `GraphMailScopes` now, ahead of GA** (replacing `MailboxSettings.Read`, which it supersedes). **This is done — see the separate scope PR**, landed independently of the server-rules feature work.
-2. **Trigger re-consent gracefully.** When a write returns `403`/insufficient-scope, surface a clear, accessible message ("QuickMail needs additional permission to change server rules. Choose Reauthorize to grant it.") and route to the existing interactive sign-in. Never fail silently (CLAUDE.md: no silent empty state from caught exceptions). This is a **belt-and-suspenders** path: with decision (1) in place, accounts that consent after GA already have the scope and should never hit it.
-3. **Read-only fallback works without re-consent.** If an account somehow lacks the write scope, the manager still **lists** rules (read scope) and only the write actions prompt for the upgrade.
+1. **Declare `MailboxSettings.ReadWrite` on the app registration ahead of GA.** Because the Graph
+   backend is still feature-gated and no production account has consented yet, declaring the write
+   scope before the gate lifts means every user's *first* consent already includes it — no one ever
+   faces a second prompt for server rules. (This replaces the earlier "add it to the code scope
+   array" framing; under `.default` the registration is the source of truth.)
+2. **On `403`, show an actionable admin-directed message — not an in-app re-consent.** When a write
+   returns `403`/insufficient-scope, surface a clear, accessible message ("QuickMail can't change
+   server rules because your organization hasn't granted it permission. Ask your administrator to
+   grant it, then sign in again.") Never fail silently (CLAUDE.md: no silent empty state). An
+   in-app "Reauthorize" button is deliberately **not** offered: `.default` re-authorization cannot
+   grant a permission the tenant hasn't approved, and in admin-consent tenants the user isn't the
+   one who can approve it.
+3. **Read-only fallback still works.** If an account lacks the write permission, the manager still
+   **lists** rules (the granted read subset covers it) and only the write actions fail with the
+   admin-directed `403` message above.
 
-> **Decided (consent timing): capture up front, pre-GA.** Because the Graph backend is still behind a feature gate, **no production account has consented to any Graph scope yet**. Requesting `MailboxSettings.ReadWrite` *before* the gate is lifted means the permission set granted at every user's *first* sign-in already includes it — so no one ever sees a second consent prompt for the server-rules feature. This is strictly better than a lazy/on-first-write bump (which only helps once consent already exists) and is why the scope change ships separately and early, not with this feature.
+> **Decided (consent timing): capture up front, pre-GA.** With decision (1) — the write scope
+> declared on the registration before the feature gate lifts — every account's first `.default`
+> consent already carries it, so GA users never hit the `403` path at all. It exists only as a
+> safety net for a tenant whose admin somehow removed or never granted the declared scope.
 
 ---
 
@@ -122,7 +155,7 @@ All under the Inbox folder. `GraphClient` already implements every verb needed.
 - A Graph user can list, create, edit, toggle, reorder, and delete rules without leaving QuickMail, using only the keyboard.
 - A non-Graph (IMAP) account never sees the Server Rules entry point (the command's `isAvailable` returns false).
 - Every action is reachable from the window's command palette.
-- A write attempt without `MailboxSettings.ReadWrite` produces an actionable re-consent prompt, never a silent no-op.
+- A write attempt without `MailboxSettings.ReadWrite` produces an actionable, admin-directed message, never a silent no-op.
 
 ### 6.3 Common subset (editable in v1)
 
@@ -262,8 +295,8 @@ registry.Register(new CommandDefinition(
 2. **Reorder:** Move Up / Move Down change `sequence`; focus stays on the moved rule. Announce (Status): "Moved up. Now 2 of 5."
 3. **Delete:** Delete command → View shows a confirmation (modeless or a `MessageBox` from the View, never the VM). On confirm, rule removed; focus moves to the next rule (or the one above if last). Announce (Result): "Rule deleted."
 
-### Path E — re-consent
-1. User Saves a create/edit but the account lacks `MailboxSettings.ReadWrite`. Instead of failing, the View shows: "QuickMail needs permission to change server rules. Reauthorize?" On confirm, interactive sign-in runs; on success, the original action retries. Announce (Status): "Reauthorized." then (Result) "Rule created."
+### Path E — insufficient permission (admin-directed)
+1. User Saves a create/edit but the tenant hasn't granted `MailboxSettings.ReadWrite`. The save returns `403`. QuickMail does **not** blank the list or close the window; the View shows an admin-directed message and announces (Hint): "QuickMail can't change server rules because your organization hasn't granted it permission. Ask your administrator to grant it, then sign in again." Focus stays on the editor; Escape returns to the list, which still shows existing rules (reading works under the granted subset). After an admin grants the permission tenant-wide, the user signs in again and `.default` picks it up — the save then succeeds. (No in-app "Reauthorize" button: see §4.)
 
 ---
 
@@ -272,9 +305,9 @@ registry.Register(new CommandDefinition(
 - **F6 ring (within `ServerRulesWindow`):** list ⇄ account selector ⇄ summary region. (This is the window's own ring; it does not touch `MainWindow`'s `CycleFocusAsync`.)
 - **Commands added to `CommandRegistry`:** `mail.serverRules` (category Mail, no default key, `isAvailable` = has Graph account). Window-scoped actions live in the window's own palette, not the global registry.
 - **`AutomationProperties.Name` introduced:** "Server rules", "Rule name", "Conditions", "Actions", "Move to folder", "Account". (Short labels only.)
-- **`AccessibilityHelper.Announce` calls added:** open Hint; create/update/delete/toggle Results; reorder + reauthorize Status. Each gated by the matching user config (`AnnounceHints` / `AnnounceResults` / `AnnounceStatus`).
+- **`AccessibilityHelper.Announce` calls added:** open Hint; create/update/delete/toggle Results; reorder Status; the insufficient-permission `403` path is a Hint. Each gated by the matching user config (`AnnounceHints` / `AnnounceResults` / `AnnounceStatus`).
 - **VM state:** `MainViewModel` gains `OpenServerRulesCommand` + `ServerRulesRequested` event; no change to existing rule state.
-- **OAuth scope:** `GraphMailScopes` gains `MailboxSettings.ReadWrite` (supersedes `MailboxSettings.Read`).
+- **OAuth scope:** `MailboxSettings.ReadWrite` is declared on the app registration (source of truth); sign-in requests `https://graph.microsoft.com/.default`, so the token carries it once granted. See `oauth-default-scope-pm-dev-spec.md`.
 - **DI:** `IServerRuleService` / `GraphServerRuleService` constructed in `App.xaml.cs`, passed to `MainWindow` for window construction.
 
 ---
@@ -289,7 +322,7 @@ registry.Register(new CommandDefinition(
 | Rule deleted | "Rule deleted." | Result |
 | Enable/disable | "Rule disabled." | Result |
 | Reorder | "Moved up. Now 2 of 5." | Status |
-| Reauthorize done | "Reauthorized." | Status |
+| Write blocked (403) | "QuickMail can't change server rules because your organization hasn't granted it permission. Ask your administrator to grant it, then sign in again." | Hint |
 | Non-editable rule focused | "This rule can't be edited in QuickMail yet." | Hint |
 
 All via `AccessibilityHelper.Announce(text, category)` — never `RaiseNotificationEvent` directly.
@@ -301,7 +334,7 @@ All via `AccessibilityHelper.Announce(text, category)` — never `RaiseNotificat
 - **No Graph account:** entry point hidden (`isAvailable` false). If somehow reached, window shows "No Microsoft 365 account."
 - **`isReadOnly` rule:** Edit and Delete disabled; Toggle may also be disabled (read-only typically means immutable). Listed with a "read-only" marker.
 - **`hasError` rule:** listed with an "error" marker and a Hint explaining the rule is in an error state on the server; still deletable.
-- **Insufficient scope (403):** typed exception → re-consent flow (Path E). Never a silent catch.
+- **Insufficient scope (403):** typed exception → admin-directed message (Path E §4). Never a silent catch, never an in-app "Reauthorize" that can't succeed.
 - **Network/Graph failure:** surfaced as a visible status message, not a blank list (CLAUDE.md: no silent empty state).
 - **Folder IDs:** `moveToFolder`/`copyToFolder` use Graph folder IDs; the folder picker already yields these (`FullName`). Deleted-folder targets: show the raw ID with a "folder not found" note rather than crashing.
 - **`--online` mode:** unaffected — server rules never touch the local SQLite cache.
@@ -326,7 +359,7 @@ This is the single most important correctness decision; reviewers should confirm
 - **`IsFullyEditable` mapping tests:** a rule with an unsupported predicate is flagged view-only; a subset-only rule is editable.
 - **VM tests:** command availability (`isAvailable` with/without a Graph account), validation errors, confirmation/consent events raised (not `MessageBox` from the VM).
 - **XAML parse test** (`[StaFact]`) for the new windows; element-name tests use `as` + `Assert.NotNull`.
-- No live Graph in tests; a reviewer with an M365 account performs the manual keyboard walkthrough (Section 12) including a real re-consent.
+- No live Graph in tests; a reviewer with an M365 account performs the manual keyboard walkthrough (Section 12), including the admin-directed `403` path (Path E) if the write permission is ungranted.
 
 ---
 
@@ -338,7 +371,7 @@ This is the single most important correctness decision; reviewers should confirm
 - **Categories management** (`assignCategories`/`categories`) beyond display.
 - **Rules on folders other than Inbox** — the Graph API is Inbox-scoped; not expanding it.
 - **Importing/exporting rules, or syncing client rules ⇄ server rules** — explicitly not attempted.
-- **Lazy / on-first-write re-consent** — superseded. §4 adopted **up-front** consent via the scope-bump PR (captured pre-GA), so there is no re-consent migration to do and GA users won't face a re-prompt.
+- **Lazy / on-first-write re-consent, and any in-app "Reauthorize" self-heal** — superseded. §4 adopted **up-front** consent (the write scope declared on the app registration, captured pre-GA) plus per-resource `.default`, so there is no re-consent migration and no runtime consent negotiation; a missing permission is admin-directed, not self-healed. See `oauth-default-scope-pm-dev-spec.md`.
 - **Shared-mailbox rules** — deferred with the parked shared-mailbox spec (#31).
 
 ---


### PR DESCRIPTION
## What & why

Captures the decision to switch Microsoft OAuth from **explicit per-backend scope lists** to the **per-resource `.default` scope** (`graph.microsoft.com/.default`, `outlook.office.com/.default`).

`.default` requests **exactly the delegated permissions declared on the app registration** — so "what the app asks for" and "what admin consent grants" are the same set by construction. That eliminates the request-vs-declared mismatch behind the **"admin granted consent but the user is still prompted"** loop we hit in real tenants (root cause: `MailboxSettings.ReadWrite` requested in code but not declared on the registration).

**Pure `.default`** — no runtime step-up consent — because:
- In admin-consent tenants (the enterprise norm) a **non-admin can't self-heal** a missing scope regardless of mechanism, so an in-app "Reauthorize" helps almost no one.
- It's consistent with the already-made decision to capture `MailboxSettings.ReadWrite` **up front, pre-GA** (server-rules spec §4).
- The app registration becomes the **single source of truth** for the permission set.

Accepted cost, documented: consent is **all-or-nothing per resource** (a tenant grants the full declared Graph set — including mailbox-settings write — or uses the IMAP backend instead), and a new permission is now a **registration + re-consent** action, not a code change.

## Changes (docs only)
- **New** `docs/planning/oauth-default-scope-pm-dev-spec.md` — full design: rationale, `OAuthService` change, error handling (sign-in gate vs. residual `403`), keyboard walkthrough, infrastructure, out-of-scope.
- `server-rules-pm-dev-spec.md` — §4 / Path E / §6.2 / §13–15 / §18 moved from graceful in-app re-consent to an **admin-directed `403`** message (residual only; the write scope is consented at sign-in as part of the declared set).
- `graph-backend-dev-spec.md` §6.8, `graph-backend-pm-spec.md` §9.3 + Appendix B — superseding notes (scope *values* → `.default`; registration is source of truth). Per-call machinery unchanged.
- `ENTRA-APP-REGISTRATION.md` §3/§5 — declared list **is** the requested set; dead-end cause shifts to "declared-but-ungranted"; adds the residual-`403` troubleshooting entry.

## Scope / follow-ups
- **Design/spec only.** The small `OAuthService` change (request `<resource>/.default`) follows in its own PR once the design is agreed.
- **Registration action (owner):** declare the full delegated set — incl. `MailboxSettings.ReadWrite` — on the app registration before GA so the first consent captures it.
- Related: #202 (silent identity rebind / consent), #203 (sign-in window timeout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
