### PR TITLE
Fix: OAuth/Graph accounts wrongly report "No password stored" on reconnect

### DIFF
--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -2675,8 +2675,11 @@ public partial class MainViewModel : ObservableObject, IDisposable
         IsBusy = true;
         try
         {
-            var password = _credentials.GetPassword(account.Id);
-            if (string.IsNullOrEmpty(password))
+            // Only Password accounts need a stored secret. OAuth/Graph accounts authenticate via
+            // the token cache (no password by design), so don't gate them on GetPassword — doing so
+            // reported "No password stored" and never attempted the OAuth reconnect.
+            var password = account.AuthType == AuthType.Password ? _credentials.GetPassword(account.Id) : null;
+            if (account.AuthType == AuthType.Password && string.IsNullOrEmpty(password))
             {
                 StatusText = $"No password stored for {account.AccountLabel}.";
                 return;


### PR DESCRIPTION
## Bug
Activating a **disconnected OAuth or Graph account** (Enter on the account row) reported **"No password stored for &lt;account&gt;"** and never attempted to reconnect.

`MainViewModel.SelectAccountAsync` fetched a stored password and bailed when it was empty, **without checking `AuthType`**:

```csharp
var password = _credentials.GetPassword(account.Id);
if (string.IsNullOrEmpty(password)) { StatusText = $"No password stored…"; return; }
```

OAuth2Microsoft / OAuth2Google / Graph accounts have **no** stored password by design (they authenticate via the MSAL token cache), so this path always short-circuited them before the OAuth token flow could run.

## Fix
Gate the password lookup **and** the empty-password error on `AuthType.Password`; pass `null` for OAuth/Graph so `ConnectAsync` runs the token flow. This mirrors the guard already present in `ComposeViewModel` (`&& account.AuthType == AuthType.Password`).

## Testing
- `dotnet test -c Release` — build clean; account/MainViewModel suites green (95 passed).
- Found while testing a Graph (Microsoft 365) account: reconnecting from the disconnected state reported "No password stored" instead of prompting an OAuth sign-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
