### PR TITLE
Request per-resource `.default` OAuth scope instead of explicit permission lists

### DIFF
--- a/QuickMail/Services/OAuthService.cs
+++ b/QuickMail/Services/OAuthService.cs
@@ -15,29 +15,24 @@ public class OAuthService : IOAuthService
     private const string ClientId  = "bcdc84f1-d37c-4581-b14a-a01f7b3a1312";
     private const string Authority = "https://login.microsoftonline.com/common";
 
-    // Delegated scopes per backend. An account's BackendKind selects which set is requested.
+    // Per-resource `.default` scope. `.default` requests EXACTLY the delegated permissions declared
+    // on the app registration (docs/ENTRA-APP-REGISTRATION.md §3) — so the requested set always
+    // matches what admin consent grants, eliminating the requested-vs-declared mismatch that produced
+    // the "admin granted consent but the user is still prompted" loop. Design & rationale:
+    // docs/planning/oauth-default-scope-pm-dev-spec.md. Notes:
+    //  - `.default` is per-resource and cannot be combined with other scopes, hence one array each.
+    //  - MSAL adds openid/profile/offline_access automatically for the public-client desktop flow,
+    //    so refresh tokens still issue (verified live: silent re-acquisition works with `.default`).
+    //  - A new permission (e.g. MailboxSettings.ReadWrite for server rules) is now added by DECLARING
+    //    it on the app registration + re-granting consent — not by editing this list.
     public static readonly string[] ImapSmtpScopes =
     [
-        "https://outlook.office.com/IMAP.AccessAsUser.All",
-        "https://outlook.office.com/SMTP.Send",
-        "offline_access",
+        "https://outlook.office.com/.default",
     ];
 
     public static readonly string[] GraphMailScopes =
     [
-        "https://graph.microsoft.com/Mail.ReadWrite",
-        "https://graph.microsoft.com/Mail.Send",
-        // MailboxSettings.ReadWrite grants read AND write access to server-side Inbox rules
-        // (the Graph messageRule API: /me/mailFolders/inbox/messageRules). It is requested up
-        // front -- while the Graph backend is still behind its feature gate and no production
-        // account has consented yet -- so the permission set captured at the very first sign-in
-        // already includes it. That way users will NOT face a second consent prompt when the
-        // server-side rules manager ships. ReadWrite supersedes the read-only MailboxSettings.Read
-        // we previously requested. Rationale and feature design: docs/planning/server-rules-pm-dev-spec.md.
-        "https://graph.microsoft.com/MailboxSettings.ReadWrite",
-        "https://graph.microsoft.com/User.Read",
-        "https://graph.microsoft.com/User.ReadBasic.All",
-        "offline_access",
+        "https://graph.microsoft.com/.default",
     ];
 
     private static string[] DefaultScopesFor(AccountModel account)


### PR DESCRIPTION
Implements the design in **#204** (`docs/planning/oauth-default-scope-pm-dev-spec.md`).

## Change
`OAuthService.GraphMailScopes` → `https://graph.microsoft.com/.default`, `ImapSmtpScopes` → `https://outlook.office.com/.default`. That's the whole code change — every token path already flows through these two arrays (`GraphClient` passes `GraphMailScopes`; IMAP uses the default → `ImapSmtpScopes`).

## Why
`.default` requests **exactly the delegated permissions declared on the app registration**, so "what the app asks for" and "what admin consent grants" are the same set by construction. That removes the requested-vs-declared mismatch behind the **"admin granted consent but the user is still prompted"** loop — which happens whenever the code requests a scope that isn't declared on the registration (most recently `MailboxSettings.ReadWrite`).

## Live verification
Tested on a real admin-consent tenant (`infinitewr`) where admin consent had already been granted but the explicit-scope build **looped forever** (because it requested the undeclared `MailboxSettings.ReadWrite`). With `.default`:
- `OAuthService: silent token acquired for <intended user>` — **silent**, correct identity, **no re-prompt**.
- The mailbox opened and messages loaded. No `MailboxNotEnabledForRESTAPI`.
- Silent re-acquisition confirms MSAL still issues refresh tokens with `.default` alone (resolves the spec's `offline_access` open question).

## Consequence to note
Adding a new permission is now a **registration action** (declare + re-grant consent), not a code edit. In particular, **`MailboxSettings.ReadWrite` must be declared on the app registration** before the server-rules feature can use it — `.default` will only request it once it's declared. Ordinary mail works without it (as verified above).

## Testing
- `dotnet test -c Release` — build clean; 1085/1086, the one miss being an unrelated environmental flake (`LogServiceTests` shared-state / clipboard `COMException`), both green in isolation. No test pins scope strings.

Depends conceptually on #204 (the spec). Can merge after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
