### PR TITLE
Defer compose-window open off the WebView2 accelerator callback (#181)

### DIFF
--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -3820,13 +3820,33 @@ public partial class MainWindow : Window
 
     private void OpenComposeWindow(ComposeModel composeModel)
     {
-        var composeVm = new ComposeViewModel(_smtp, _accountService, _credentials, _imap, _templateService);
-        composeVm.Seed(composeModel);
-        var window = new ComposeWindow(composeVm, _contactService, _templateService, _configService, _customDictionary, _themeService);
-        composeVm.CloseRequested += window.Close;
-        _openComposeWindows.Add(window);
-        window.Closed += (_, _) => _openComposeWindows.Remove(window);
-        window.Show();
+        // Open on a fresh dispatcher turn rather than inline (issue #181).
+        //
+        // This handler can be reached synchronously from inside the reading-pane
+        // WebView2's AcceleratorKeyPressed COM callback: focus is in the WebView2
+        // and the user presses a Reply / Reply-All / Forward shortcut, which the
+        // out-of-process browser marshals back into the STA UI thread. Building and
+        // Show()-ing the compose window inline would run Window.Show()'s first layout
+        // pass — which fires cross-process UIA property-changed events to a listening
+        // screen reader — while the UI thread is still servicing that inbound WebView2
+        // COM call. Issuing an outbound cross-apartment COM call while inside an inbound
+        // one re-enters the STA in a way that never unblocks (the captured hang: pumping
+        // wait in get_HostRawElementProvider under Window.Show, rooted in
+        // CoreWebView2Controller_AcceleratorKeyPressed).
+        //
+        // InvokeAsync at Input priority lets the WebView2 callback return and the inbound
+        // COM stack unwind first, so the window opens on a clean, non-re-entrant turn.
+        // Compose windows are modeless, so the one-turn delay is imperceptible.
+        Dispatcher.InvokeAsync(() =>
+        {
+            var composeVm = new ComposeViewModel(_smtp, _accountService, _credentials, _imap, _templateService);
+            composeVm.Seed(composeModel);
+            var window = new ComposeWindow(composeVm, _contactService, _templateService, _configService, _customDictionary, _themeService);
+            composeVm.CloseRequested += window.Close;
+            _openComposeWindows.Add(window);
+            window.Closed += (_, _) => _openComposeWindows.Remove(window);
+            window.Show();
+        }, DispatcherPriority.Input);
     }
 
     private Task<IReadOnlyList<AttachmentModel>?> ShowForwardAttachmentDialogAsync(IReadOnlyList<AttachmentModel> attachments)


### PR DESCRIPTION
## Summary

Fixes a **third live-captured blocking site** of the #181 compose-open hang, and addresses the trigger all three captured sites share.

A 2026-07-09 live repro was caught spinning (~90% of one core, `Responding=True`) with two byte-identical `dotnet-stack` samples — a permanent STA wedge in a pumping COM wait under `Window.Show()`:

```
get_HostRawElementProvider              <- outbound cross-process UIA call, never returns
AutomationPeer.RaisePropertyChangedInternal / UpdateSubtree x6
ContextLayoutManager.fireAutomationEvents / UpdateLayout
HwndSource.Process_WM_SIZE
Window.Show()                           <- MainWindow.OpenComposeWindow
MainViewModel.ReplyAll()
MainWindow.OnWindowKeyDown
WebView2Base.CoreWebView2Controller_AcceleratorKeyPressed   <- inbound COM callback (ROOT)
```

## Root cause

Neither #190 (spell-check init) nor #198 (LoadInto UIA batching) covers this site — it's `Window.Show()`'s own first-layout UIA burst. The shared root, visible at the bottom of the stack: `ReplyAll` ran **nested inside the reading-pane WebView2's `AcceleratorKeyPressed` COM callback** (focus in the WebView2 + a compose shortcut). Building and showing the compose window inline issues an **outbound** cross-apartment UIA call while the STA thread is still servicing that **inbound** WebView2 COM call — re-entrant cross-apartment COM that never unblocks (widened by x64-on-ARM64 emulation). All three captured sites share this trigger, so the fix removes the nesting rather than chasing each outbound site.

## Change

`MainWindow.OpenComposeWindow` now builds + `Show()`s the compose window via `Dispatcher.InvokeAsync(…, DispatcherPriority.Input)`, so the WebView2 callback returns and the inbound COM stack unwinds before the window opens on a clean, non-re-entrant turn. `e.Handled` is still set synchronously (key routing unaffected); compose is modeless so the one-turn delay is imperceptible. Scoped to the compose-open path, where all three known sites live.

## Testing

- `build.bat release` — clean (0 warnings, 0 errors)
- `dotnet test` — 1086 passed, 0 failed
- Needs verification on the repro machine (x64-on-ARM64 + screen reader), like #190/#198.

See issue #181 for the full stack analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)