### PR TITLE
Fix the focus-navigation test flake: serialize WPF/STA tests (#211)

### DIFF
--- a/QuickMail.Tests/PropertiesViewModelTests.cs
+++ b/QuickMail.Tests/PropertiesViewModelTests.cs
@@ -9,6 +9,9 @@ using Xunit;
 
 namespace QuickMail.Tests;
 
+// WpfTests collection: these STA tests touch WPF/clipboard state; serialize them with the
+// other WPF/STA tests so no two STA window-owning threads run at once (issue #211).
+[Collection("WpfTests")]
 public class PropertiesViewModelTests
 {
     private static PropertiesViewModel Make(

--- a/QuickMail.Tests/ReportBugViewModelTests.cs
+++ b/QuickMail.Tests/ReportBugViewModelTests.cs
@@ -25,6 +25,9 @@ sealed class FakeBugReportService : IBugReportService
     public string BuildReportText(BugReportModel report) => $"BODY:{report.WhatHappened}";
 }
 
+// WpfTests collection: serialize with the other WPF/STA tests so no two STA window-owning
+// threads run concurrently (issue #211).
+[Collection("WpfTests")]
 public class ReportBugViewModelTests
 {
     private static ReportBugViewModel Make(out FakeBugReportService service)

--- a/QuickMail.Tests/SelectorItemAccessibilityTests.cs
+++ b/QuickMail.Tests/SelectorItemAccessibilityTests.cs
@@ -19,6 +19,12 @@ namespace QuickMail.Tests;
 /// exactly that record bug; these tests lock the fix and cover every item type the app
 /// binds into a Selector so a new one can't silently reintroduce it.
 /// </summary>
+// Part of the WpfTests collection so it never runs concurrently with another WPF/STA test.
+// This class creates and Show()s a real Window on its own STA thread; running it in parallel
+// with the other STA tests means two STA threads can own live WPF windows at once, which is
+// the concurrency that produces the intermittent HwndSubclass teardown crash and focus-
+// navigation flakes (issue #211).
+[Collection("WpfTests")]
 public class SelectorItemAccessibilityTests
 {
     // End-to-end: the actual reported control. Reads the real UIA item peer names a


### PR DESCRIPTION
Closes the root cause behind the flaky CI failures that blocked the v0.8.1 release.

## Root cause

WPF tests are serialized via `[Collection("WpfTests")]`, but **three `[StaFact]` classes were missing it** and ran in parallel: `SelectorItemAccessibilityTests` (runs in CI; does `new Window{…}.Show()` on its own STA thread), plus `PropertiesViewModelTests` and `ReportBugViewModelTests` (CI-excluded, flake locally). So two STA threads could own live WPF windows simultaneously — the shared root of **both** observed flakes:

- **Host crash:** an orphaned window HWND from one STA thread catches a broadcast message after its thread ends → `HwndSubclass.SubclassWndProc` → `Thread.get_CurrentThread()` `NullReferenceException` → xUnit "catastrophic failure", non-zero exit with `failed=0`.
- **Focus flake:** `GrabAddressesDialogTests.Tab_FromAddressList_MovesToAddToGroupCheckbox` navigation racing another thread's WPF state.

## Evidence

`GrabAddressesDialogTests` ran **20/20 clean in isolation** but flaked **~1/8 in the full suite** — it only breaks when another STA test runs concurrently. Diagnosis in #211.

## Fix

Add `[Collection("WpfTests")]` to the three orphan classes so no two WPF-window tests ever run at once.

## Verification

- Full suite (CI filter) **12/12 clean** with the fix (was ~1/8 before).
- Isolated `GrabAddressesDialogTests` 20/20 clean.

The CI trx-tolerance guard from the previous change stays in place as belt-and-suspenders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)