### PR TITLE
Start watchers + refresh status when an account connects after startup (#214)

### DIFF
--- a/QuickMail.Tests/WatcherStartGateTests.cs
+++ b/QuickMail.Tests/WatcherStartGateTests.cs
@@ -1,0 +1,49 @@
+using System;
+using QuickMail.ViewModels;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// Locks the anti-thrash contract behind WireUpWatchers (#215): watchers restart only when the
+/// connected-account set actually changes, and state advances only after they're marked started.
+/// </summary>
+public class WatcherStartGateTests
+{
+    [Fact]
+    public void RestartsOnlyWhenTheConnectedSetChanges()
+    {
+        var gate = new WatcherStartGate();
+        var a = Guid.NewGuid();
+        var b = Guid.NewGuid();
+
+        Assert.True(gate.HasChanged([a]));       // first time → start
+        gate.MarkStarted([a]);
+        Assert.False(gate.HasChanged([a]));      // same set → no restart (anti-thrash)
+        Assert.True(gate.HasChanged([a, b]));    // set grew → restart
+        gate.MarkStarted([a, b]);
+        Assert.False(gate.HasChanged([a, b]));   // same again → no restart
+        Assert.True(gate.HasChanged([a]));       // set shrank → restart
+    }
+
+    [Fact]
+    public void SetComparisonIsOrderInsensitive()
+    {
+        var gate = new WatcherStartGate();
+        var a = Guid.NewGuid();
+        var b = Guid.NewGuid();
+        gate.MarkStarted([a, b]);
+        Assert.False(gate.HasChanged([b, a])); // same members, different order → no restart
+    }
+
+    [Fact]
+    public void ChangeIsReportedAgainUntilMarkStarted()
+    {
+        // If a change couldn't be acted on (e.g. no active background-sync token so watchers didn't
+        // start and MarkStarted wasn't called), the same change must still be reported next time.
+        var gate = new WatcherStartGate();
+        var a = Guid.NewGuid();
+        Assert.True(gate.HasChanged([a]));
+        Assert.True(gate.HasChanged([a])); // still changed — not swallowed
+    }
+}

--- a/QuickMail/QuickMail.csproj
+++ b/QuickMail/QuickMail.csproj
@@ -57,4 +57,10 @@
     <PackageReference Include="Velopack" Version="1.2.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Expose internals to the test assembly so small pure helpers (e.g. WatcherStartGate) can be
+         unit-tested without widening the public API. -->
+    <InternalsVisibleTo Include="QuickMail.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -1528,31 +1528,18 @@ public partial class MainViewModel : ObservableObject, IDisposable
         ReplaceCts(ref _bgSyncCts, out var ct);
 
         await ConnectAllAccountsAsync();
+
+        // Start the change-notifier watchers (Graph delta poll / IMAP IDLE) and the reachability
+        // handler for whatever connected, and refresh the status labels. Runs even when nothing
+        // connected yet; it is also invoked from the manual-activation and runtime-add paths, so an
+        // account that connects OUTSIDE this startup pipeline still gets polled for new mail.
+        WireUpWatchers();
+
+        // Nothing connected — skip the heavy full sync. Watchers/labels are already handled above, and
+        // WireUpWatchers will start the watcher once an account connects later.
         if (_cachedFolders.Count == 0) return;
 
         var accountList = Accounts.ToList();
-        _changeNotifier?.StartWatchers(accountList, ct);
-
-        // Subscribe to account reachability changes (watcher connection lost/restored).
-        // No announcement — this is internal bookkeeping. Stored in a field and unsubscribed first so
-        // repeated StartBackgroundSyncAsync calls don't stack handlers (each capturing a stale list).
-        // The event fires on the ThreadPool, so marshal the UI-touching work onto the UI thread.
-        if (_changeNotifier != null)
-        {
-            if (_onReachabilityChanged != null)
-                _changeNotifier.AccountReachabilityChanged -= _onReachabilityChanged;
-
-            _onReachabilityChanged = (accountId, isReachable) => _ui.Post(() =>
-            {
-                var account = accountList.FirstOrDefault(a => a.Id == accountId);
-                if (account != null)
-                {
-                    var folders = isReachable && _cachedFolders.TryGetValue(accountId, out var f) ? f : null;
-                    ApplyAccountStatus(account, folders);
-                }
-            });
-            _changeNotifier.AccountReachabilityChanged += _onReachabilityChanged;
-        }
 
         // Subscribe to sync progress updates.
         // Announce every 10 folders to avoid excessive screen reader chatter.
@@ -1648,6 +1635,60 @@ public partial class MainViewModel : ObservableObject, IDisposable
             progressCts.Cancel();
             try { await progressTask.ConfigureAwait(false); } catch { }
         }
+    }
+
+    // Accounts whose change-notifier watchers are currently running, so WireUpWatchers only restarts
+    // them when the connected set actually changes (StartWatchers is a full stop-and-restart).
+    private HashSet<Guid> _watchedAccountIds = new();
+
+    /// <summary>
+    /// Ensures the change-notifier watchers (Graph delta poll / IMAP IDLE) are running for every
+    /// currently-connected account, the reachability handler is subscribed against the live account
+    /// list, and the connection/last-sync labels reflect reality. Idempotent and cheap — safe to call
+    /// after the startup connect, a manual sign-in/activation (<see cref="SelectAccountAsync"/>), or a
+    /// runtime account add (<see cref="RefreshAccountList"/>). Without this, an account that connects
+    /// outside the startup pipeline is never polled for new mail and the status bar stays stuck at
+    /// "Offline / Never synced".
+    /// </summary>
+    private void WireUpWatchers()
+    {
+        var connected    = Accounts.Where(a => _cachedFolders.ContainsKey(a.Id)).ToList();
+        var connectedIds = connected.Select(a => a.Id).ToHashSet();
+
+        // Only (re)start watchers when the connected set changed — StartWatchers stops and restarts
+        // every watcher, so calling it on each activation would thrash the poll loops for no reason.
+        if (_changeNotifier != null
+            && _bgSyncCts is { IsCancellationRequested: false }
+            && !connectedIds.SetEquals(_watchedAccountIds))
+        {
+            _changeNotifier.StartWatchers(connected, _bgSyncCts.Token);
+            _watchedAccountIds = connectedIds;
+
+            // (Re)subscribe the reachability handler. It resolves from the LIVE Accounts collection
+            // (not a snapshot), so it never goes stale (issue #126). Unsubscribe first so repeated
+            // calls don't stack handlers; it fires on the ThreadPool, so marshal UI work onto the UI thread.
+            if (_onReachabilityChanged != null)
+                _changeNotifier.AccountReachabilityChanged -= _onReachabilityChanged;
+            _onReachabilityChanged = (accountId, isReachable) => _ui.Post(() =>
+            {
+                var account = Accounts.FirstOrDefault(a => a.Id == accountId);
+                if (account != null)
+                {
+                    var folders = isReachable && _cachedFolders.TryGetValue(accountId, out var f) ? f : null;
+                    ApplyAccountStatus(account, folders);
+                }
+            });
+            _changeNotifier.AccountReachabilityChanged += _onReachabilityChanged;
+        }
+
+        ConnectionStatusText = _cachedFolders.Count > 0
+            ? $"{_cachedFolders.Count} account{(_cachedFolders.Count == 1 ? "" : "s")} connected"
+            : "Offline";
+
+        // Don't leave the label stuck at its pre-sync defaults once an account is actually connected;
+        // the sync/poll paths (OnFolderSynced, StartBackgroundSyncAsync) keep it current from here.
+        if (_cachedFolders.Count > 0 && LastSyncText is "Never synced" or "In progress")
+            LastSyncText = $"Synced {DateTime.Now:t}";
     }
 
     private async Task AnnounceLoadingProgressAsync(CancellationToken ct)
@@ -2713,6 +2754,9 @@ public partial class MainViewModel : ObservableObject, IDisposable
             _cachedFolders[account.Id] = folderList;
             ApplyAccountStatus(account, folderList);
             RebuildFolderListFromCache();
+            // Start this account's new-mail watcher and refresh the status labels — a manual
+            // sign-in/activation previously connected the account but never began polling it.
+            WireUpWatchers();
             StatusText = $"Connected to {account.AccountLabel}. Press Enter on a folder to load messages.";
         }
         catch (OperationCanceledException)
@@ -5253,26 +5297,6 @@ public partial class MainViewModel : ObservableObject, IDisposable
     {
         LoadAccountList();
 
-        // After LoadAccountList creates a new Accounts collection, update the reachability handler so
-        // it resolves accounts from the fresh list rather than the stale one (fixes issue #126).
-        if (_changeNotifier != null)
-        {
-            if (_onReachabilityChanged != null)
-                _changeNotifier.AccountReachabilityChanged -= _onReachabilityChanged;
-
-            var accountList = Accounts.ToList();
-            _onReachabilityChanged = (accountId, isReachable) => _ui.Post(() =>
-            {
-                var account = accountList.FirstOrDefault(a => a.Id == accountId);
-                if (account != null)
-                {
-                    var folders = isReachable && _cachedFolders.TryGetValue(accountId, out var f) ? f : null;
-                    ApplyAccountStatus(account, folders);
-                }
-            });
-            _changeNotifier.AccountReachabilityChanged += _onReachabilityChanged;
-        }
-
         // Reconnect any accounts that aren't already connected (e.g. newly added OAuth2 accounts).
         // _cachedFolders is UI-thread-owned: snapshot the connected set here (still on the UI
         // thread) and marshal every write back through _ui so the background loop never
@@ -5294,6 +5318,12 @@ public partial class MainViewModel : ObservableObject, IDisposable
                     }
                 });
             }
+
+            // Start the delta-poll/IDLE watcher for any newly-connected account and refresh the status
+            // labels — previously a runtime-added account connected but was never polled for new mail.
+            // WireUpWatchers also (re)subscribes the reachability handler against the fresh, live
+            // account list, which is what the old inline block here did for issue #126.
+            _ui.Invoke(WireUpWatchers);
         });
     }
 

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -1637,9 +1637,10 @@ public partial class MainViewModel : ObservableObject, IDisposable
         }
     }
 
-    // Accounts whose change-notifier watchers are currently running, so WireUpWatchers only restarts
-    // them when the connected set actually changes (StartWatchers is a full stop-and-restart).
-    private HashSet<Guid> _watchedAccountIds = new();
+    // Tracks the connected-account set the watchers were last started for, so WireUpWatchers only
+    // restarts them when the set actually changes (StartWatchers is a full stop-and-restart). Extracted
+    // into a small gate so the anti-thrash contract is unit-testable (WatcherStartGateTests).
+    private readonly WatcherStartGate _watcherGate = new();
 
     /// <summary>
     /// Ensures the change-notifier watchers (Graph delta poll / IMAP IDLE) are running for every
@@ -1657,7 +1658,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
 
         // Only (re)start watchers when the connected set changed — StartWatchers stops and restarts
         // every watcher, so calling it on each activation would thrash the poll loops for no reason.
-        if (_changeNotifier != null && !connectedIds.SetEquals(_watchedAccountIds))
+        if (_changeNotifier != null && _watcherGate.HasChanged(connectedIds))
         {
             // Watchers run under the background-sync lifetime. In the normal launch order
             // StartBackgroundSyncAsync runs first and creates _bgSyncCts; guard against a null/cancelled
@@ -1674,7 +1675,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
             else
             {
                 _changeNotifier.StartWatchers(connected, _bgSyncCts.Token);
-                _watchedAccountIds = connectedIds;
+                _watcherGate.MarkStarted(connectedIds); // advance state only when watchers actually start
 
                 // (Re)subscribe the reachability handler. It resolves from the LIVE Accounts collection
                 // (not a snapshot), so it never goes stale (issue #126). Unsubscribe first so repeated

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -1657,28 +1657,41 @@ public partial class MainViewModel : ObservableObject, IDisposable
 
         // Only (re)start watchers when the connected set changed — StartWatchers stops and restarts
         // every watcher, so calling it on each activation would thrash the poll loops for no reason.
-        if (_changeNotifier != null
-            && _bgSyncCts is { IsCancellationRequested: false }
-            && !connectedIds.SetEquals(_watchedAccountIds))
+        if (_changeNotifier != null && !connectedIds.SetEquals(_watchedAccountIds))
         {
-            _changeNotifier.StartWatchers(connected, _bgSyncCts.Token);
-            _watchedAccountIds = connectedIds;
-
-            // (Re)subscribe the reachability handler. It resolves from the LIVE Accounts collection
-            // (not a snapshot), so it never goes stale (issue #126). Unsubscribe first so repeated
-            // calls don't stack handlers; it fires on the ThreadPool, so marshal UI work onto the UI thread.
-            if (_onReachabilityChanged != null)
-                _changeNotifier.AccountReachabilityChanged -= _onReachabilityChanged;
-            _onReachabilityChanged = (accountId, isReachable) => _ui.Post(() =>
+            // Watchers run under the background-sync lifetime. In the normal launch order
+            // StartBackgroundSyncAsync runs first and creates _bgSyncCts; guard against a null/cancelled
+            // token so we never start watchers against a dead one. Log rather than skip silently — a
+            // silent skip would leave a connected account unpolled with no trace (#215 review). This is
+            // reachable only if a connect path (SelectAccountAsync / RefreshAccountList) somehow runs
+            // before the first StartBackgroundSyncAsync, which the normal startup sequence prevents.
+            if (_bgSyncCts is not { IsCancellationRequested: false })
             {
-                var account = Accounts.FirstOrDefault(a => a.Id == accountId);
-                if (account != null)
+                LogService.Log("WireUpWatchers: connected set changed but the background-sync token is not " +
+                               "active; watchers not started (only expected if a connect path runs before " +
+                               "StartBackgroundSyncAsync).");
+            }
+            else
+            {
+                _changeNotifier.StartWatchers(connected, _bgSyncCts.Token);
+                _watchedAccountIds = connectedIds;
+
+                // (Re)subscribe the reachability handler. It resolves from the LIVE Accounts collection
+                // (not a snapshot), so it never goes stale (issue #126). Unsubscribe first so repeated
+                // calls don't stack handlers; it fires on the ThreadPool, so marshal UI work onto the UI thread.
+                if (_onReachabilityChanged != null)
+                    _changeNotifier.AccountReachabilityChanged -= _onReachabilityChanged;
+                _onReachabilityChanged = (accountId, isReachable) => _ui.Post(() =>
                 {
-                    var folders = isReachable && _cachedFolders.TryGetValue(accountId, out var f) ? f : null;
-                    ApplyAccountStatus(account, folders);
-                }
-            });
-            _changeNotifier.AccountReachabilityChanged += _onReachabilityChanged;
+                    var account = Accounts.FirstOrDefault(a => a.Id == accountId);
+                    if (account != null)
+                    {
+                        var folders = isReachable && _cachedFolders.TryGetValue(accountId, out var f) ? f : null;
+                        ApplyAccountStatus(account, folders);
+                    }
+                });
+                _changeNotifier.AccountReachabilityChanged += _onReachabilityChanged;
+            }
         }
 
         ConnectionStatusText = _cachedFolders.Count > 0

--- a/QuickMail/ViewModels/WatcherStartGate.cs
+++ b/QuickMail/ViewModels/WatcherStartGate.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+
+namespace QuickMail.ViewModels;
+
+/// <summary>
+/// Tracks which connected-account set the change-notifier watchers were last started for, so callers
+/// only restart them when the set actually changes. <c>StartWatchers</c> is a full stop/restart, so
+/// restarting on every account activation would thrash the poll loops. State advances only via
+/// <see cref="MarkStarted"/> — which the caller invokes after watchers actually (re)start — so a
+/// change that couldn't be acted on (e.g. no active background-sync token) is reported again next time.
+/// Small and testable (WatcherStartGateTests).
+/// </summary>
+internal sealed class WatcherStartGate
+{
+    private HashSet<Guid> _started = new();
+
+    /// <summary>True if <paramref name="connectedIds"/> differs from the set watchers were last started for.</summary>
+    public bool HasChanged(IReadOnlyCollection<Guid> connectedIds) => !_started.SetEquals(connectedIds);
+
+    /// <summary>Records that watchers are now running for exactly <paramref name="connectedIds"/>.</summary>
+    public void MarkStarted(IReadOnlyCollection<Guid> connectedIds) => _started = new HashSet<Guid>(connectedIds);
+}


### PR DESCRIPTION
Fixes #214.

## Problem
The change-notifier watchers (Graph delta poll / IMAP IDLE) and the connection/last-sync status labels are established **only** by `StartBackgroundSyncAsync`, which runs **once at startup** and **early-returns `if (_cachedFolders.Count == 0)`** right after the startup connect. So:

- If the account(s) present at startup don't connect (e.g. one needing interactive sign-in — which #207 correctly leaves disconnected), the whole pipeline is skipped: **no watchers, no poll, labels stuck** at "Offline / Never synced".
- Accounts that connect **later** — `SelectAccountAsync` (manual activation) and `RefreshAccountList` (runtime add) — populate `_cachedFolders` and load mail, but **never call `StartWatchers`** and never refresh the labels. So a late-connected account is **never polled for new mail**.

Confirmed live: a session that started with its only account failing to connect showed **zero** overnight log activity (a running 60s poll logs a token acquisition every minute); mail that arrived overnight was picked up only on manual navigation, not by a poll.

## Fix
New idempotent `WireUpWatchers()`:
- starts watchers for **every currently-connected account** (`StartWatchers` is a full stop-and-restart, so it only restarts when the connected set actually changes — no thrashing on every activation);
- (re)subscribes the reachability handler against the **live** `Accounts` collection (also removes two duplicated copies of that block, and keeps the issue #126 freshness guarantee by resolving from the live list);
- refreshes `ConnectionStatusText`, and unsticks `LastSyncText` from its pre-sync default once an account is connected.

Called from all three connect paths — startup (`StartBackgroundSyncAsync`, no longer gated behind the empty-connect early-return), `SelectAccountAsync`, and `RefreshAccountList`.

## Testing
- `dotnet test -c Release` — build clean; MainViewModel + related suites green (the intermittent full-run miss is the known clipboard/`LogService` environmental flake, green in isolation).
- Manual verification pending on a real multi-account profile: add/activate an account after startup and confirm (a) the 60s poll starts (new mail appears without navigating) and (b) the status bar flips to "N connected / Synced …".

Relates to #207 (which exposed this by correctly leaving sign-in-required accounts disconnected at startup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
