### PR TITLE
Fix stack-overflow crash when pasting comma text into an address field

### DIFF
--- a/QuickMail.Tests/TokenizedAddressBoxPasteTests.cs
+++ b/QuickMail.Tests/TokenizedAddressBoxPasteTests.cs
@@ -1,0 +1,94 @@
+// Regression tests for the address-field paste crash.
+//
+// Pasting text that contains a comma or semicolon auto-commits the input into
+// chips. When the pasted text parsed to no routable address but still held a
+// delimiter (e.g. a bare "Last, First" name), CommitCurrentInput wrote the raw
+// text — comma and all — back into the TextBox. That assignment re-raised
+// TextChanged, which auto-committed again, wrote it back again, and recursed
+// without bound until the stack overflowed and the process crashed. The crash
+// surfaced inside the screen reader's in-process accessibility event-cache
+// module (its hook rides every UIA event on the stack), but the runaway
+// recursion was ours.
+//
+// A real StackOverflowException cannot be caught in .NET — it tears down the
+// test host. So the strongest signal here is simply that these tests RUN TO
+// COMPLETION: if the re-entrancy guard regressed, the paste below would crash
+// the entire test run rather than fail an assertion.
+
+using System.Linq;
+using System.Windows;
+using System.Windows.Threading;
+using QuickMail.Controls;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+[Collection("WpfTests")]
+public class TokenizedAddressBoxPasteTests
+{
+    [StaFact]
+    public void Paste_CommaNameWithoutAddress_DoesNotRecurse()
+    {
+        EnsureApplication();
+        var box = new TokenizedAddressBox();
+
+        // Simulate pasting a bare "Last, First" name (contains a comma, no '@').
+        // Before the fix this recursed until the stack overflowed.
+        box.InputBox.Text = "Ford, Kelly";
+        DoEvents();
+
+        // No routable address, so no chip is created and the unrecognised text is
+        // handed back to the input box for the user to correct.
+        Assert.Empty(box.GetChips());
+        Assert.Equal("Ford, Kelly", box.InputBox.Text);
+    }
+
+    [StaFact]
+    public void Paste_SingleCommaSeparator_DoesNotRecurse()
+    {
+        EnsureApplication();
+        var box = new TokenizedAddressBox();
+
+        box.InputBox.Text = "a,b";
+        DoEvents();
+
+        Assert.Empty(box.GetChips());
+        Assert.Equal("a,b", box.InputBox.Text);
+    }
+
+    [StaFact]
+    public void Paste_CommaSeparatedValidAddresses_StillCommitsChips()
+    {
+        // Guards against the fix over-reaching: legitimate comma-delimited
+        // addresses must still auto-commit into chips.
+        EnsureApplication();
+        var box = new TokenizedAddressBox();
+
+        box.InputBox.Text = "alice@example.com, bob@example.com";
+        DoEvents();
+
+        var chips = box.GetChips();
+        Assert.Equal(2, chips.Count);
+        Assert.Contains(chips, c => c.EmailAddress == "alice@example.com");
+        Assert.Contains(chips, c => c.EmailAddress == "bob@example.com");
+        Assert.Equal(string.Empty, box.InputBox.Text);
+    }
+
+    private static void EnsureApplication()
+    {
+        lock (typeof(Application))
+        {
+            if (Application.Current == null)
+                new Application { ShutdownMode = ShutdownMode.OnExplicitShutdown };
+        }
+    }
+
+    private static void DoEvents()
+    {
+        var frame = new DispatcherFrame();
+        Dispatcher.CurrentDispatcher.BeginInvoke(
+            DispatcherPriority.Background,
+            new System.Action(() => frame.Continue = false));
+        Dispatcher.PushFrame(frame);
+    }
+}

--- a/QuickMail/Controls/TokenizedAddressBox.xaml.cs
+++ b/QuickMail/Controls/TokenizedAddressBox.xaml.cs
@@ -23,6 +23,16 @@ public partial class TokenizedAddressBox : UserControl
     // own value and destroy the chips.
     private string _lastSerializedText = string.Empty;
 
+    // Guards CommitCurrentInput against re-entrancy. Assignments to InputBox.Text
+    // inside the commit raise TextChanged synchronously, and that handler auto-commits
+    // whenever the text still contains a comma or semicolon. Without this guard, text
+    // that parses to no routable address but keeps a delimiter (e.g. a pasted bare
+    // "Last, First" name) gets written back to the box, re-triggers the commit, and
+    // recurses without bound — overflowing the stack and crashing the process. The
+    // crash surfaced in the screen reader's in-process event-cache module because its
+    // hook rides every UIA event on the stack, but the runaway recursion is ours.
+    private bool _isCommitting;
+
     /// <summary>
     /// When true the LostKeyboardFocus handler will not auto-commit the input.
     /// Set by ComposeWindow while focus is in the autocomplete popup (which lives
@@ -193,39 +203,51 @@ public partial class TokenizedAddressBox : UserControl
 
     private void CommitCurrentInput()
     {
-        var raw = InputBox.Text.Trim().TrimEnd(',', ';').Trim();
-        if (string.IsNullOrEmpty(raw)) { InputBox.Text = string.Empty; return; }
-
-        // Clear first so UpdateAddressText called from AddChip excludes this raw text
-        InputBox.Text = string.Empty;
-
-        if (InternetAddressList.TryParse(raw, out var list))
+        // Re-entrancy guard: the InputBox.Text assignments below fire TextChanged
+        // synchronously, and that handler calls back here on comma/semicolon. If a
+        // re-entrant call slips through it would recurse without bound (see _isCommitting).
+        if (_isCommitting) return;
+        _isCommitting = true;
+        try
         {
-            bool added = false;
-            foreach (var addr in list.OfType<MailboxAddress>())
+            var raw = InputBox.Text.Trim().TrimEnd(',', ';').Trim();
+            if (string.IsNullOrEmpty(raw)) { InputBox.Text = string.Empty; return; }
+
+            // Clear first so UpdateAddressText called from AddChip excludes this raw text
+            InputBox.Text = string.Empty;
+
+            if (InternetAddressList.TryParse(raw, out var list))
             {
-                if (string.IsNullOrWhiteSpace(addr.Address)) continue;
-                if (!addr.Address.Contains('@')) continue;
-                AddChip(new AddressChipModel { DisplayName = addr.Name ?? string.Empty, EmailAddress = addr.Address });
-                added = true;
+                bool added = false;
+                foreach (var addr in list.OfType<MailboxAddress>())
+                {
+                    if (string.IsNullOrWhiteSpace(addr.Address)) continue;
+                    if (!addr.Address.Contains('@')) continue;
+                    AddChip(new AddressChipModel { DisplayName = addr.Name ?? string.Empty, EmailAddress = addr.Address });
+                    added = true;
+                }
+                if (!added)
+                {
+                    // MimeKit parsed it but produced no usable address — treat as bare email
+                    if (raw.Contains('@'))
+                        AddChip(new AddressChipModel { EmailAddress = raw });
+                    else
+                        InputBox.Text = raw; // return unrecognised text to the input box
+                }
             }
-            if (!added)
+            else if (raw.Contains('@'))
             {
-                // MimeKit parsed it but produced no usable address — treat as bare email
-                if (raw.Contains('@'))
-                    AddChip(new AddressChipModel { EmailAddress = raw });
-                else
-                    InputBox.Text = raw; // return unrecognised text to the input box
+                AddChip(new AddressChipModel { EmailAddress = raw });
+            }
+            else
+            {
+                // Not recognisable — return to the input box so the user can fix it
+                InputBox.Text = raw;
             }
         }
-        else if (raw.Contains('@'))
+        finally
         {
-            AddChip(new AddressChipModel { EmailAddress = raw });
-        }
-        else
-        {
-            // Not recognisable — return to the input box so the user can fix it
-            InputBox.Text = raw;
+            _isCommitting = false;
         }
     }
 


### PR DESCRIPTION
## Root cause

`TokenizedAddressBox` auto-commits the inner `TextBox` into address chips whenever its text contains a comma or semicolon: the `TextChanged` handler calls `CommitPendingInput()` -> `CommitCurrentInput()`.

`CommitCurrentInput()` writes text back into `InputBox.Text` on the paths where the input is not a routable address (e.g. a pasted bare `Last, First` name, or a minimal `a,b`). Because that string still contains the delimiter, the assignment re-raised `TextChanged` synchronously, which auto-committed again and wrote it back again — unbounded recursion until the stack overflowed and the process crashed.

The crash report named a screen reader's in-process accessibility event-cache module as the fault module (its hook rides every UIA event on the stack), but the runaway recursion was QuickMail's own.

## Fix

Add a re-entrancy guard field `_isCommitting` and wrap the body of `CommitCurrentInput()` in `try { _isCommitting = true; ... } finally { _isCommitting = false; }`, returning early when already committing. A programmatic write-back to `InputBox.Text` can no longer re-trigger a commit, so the recursion is broken at the first re-entrant call. The `finally` guarantees the guard resets on every exit path (including the early return for empty input), and the guard cannot swallow a legitimate commit: valid comma-separated addresses clear the input and add chips, leaving no delimiter behind to re-commit.

## Tests

Adds `QuickMail.Tests/TokenizedAddressBoxPasteTests.cs` with 3 STA regression tests:
- `Paste_CommaNameWithoutAddress_DoesNotRecurse` — bare `Ford, Kelly`
- `Paste_SingleCommaSeparator_DoesNotRecurse` — minimal `a,b`
- `Paste_CommaSeparatedValidAddresses_StillCommitsChips` — proves the guard does not block normal auto-commit

A real `StackOverflowException` cannot be caught in .NET, so the strongest signal is that these tests run to completion instead of tearing down the test host.

## Verification

Independent review confirmed the guard resets on all exit paths and does not interfere with the `LostKeyboardFocus`/`SuppressLostFocusCommit`, Tab/Return/comma key, or autocomplete `InputTextChanged` paths. Full suite: 1088 passed. The single failing test (`SelectorItemAccessibilityTests.ThemeComboBox_ItemPeerNames_AreCleanDisplayNames`) is a pre-existing, order-dependent WPF/UIA realization flake (issue #211) — it fails identically with the new tests excluded and passes in isolation, so it is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)