### PR TITLE
Use explicit Graph scopes for personal Microsoft accounts so they can write/delete mail (#217)

### DIFF
--- a/QuickMail.Tests/OAuthServiceScopeSelectionTests.cs
+++ b/QuickMail.Tests/OAuthServiceScopeSelectionTests.cs
@@ -1,0 +1,38 @@
+using QuickMail.Models;
+using QuickMail.Services;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// Locks the per-account scope selection (#217/#218): personal Microsoft accounts must get the
+/// explicit Graph scopes (so they can write/delete), work/school Graph accounts use `.default`, and
+/// IMAP always uses the IMAP scopes. Guards against a future refactor silently reverting the routing.
+/// </summary>
+public class OAuthServiceScopeSelectionTests
+{
+    [Theory]
+    [InlineData("me@outlook.com")]
+    [InlineData("me@hotmail.com")]
+    [InlineData("ME@Live.com")] // case-insensitive
+    public void PersonalGraphAccount_UsesExplicitScopes(string username)
+    {
+        var account = new AccountModel { BackendKind = BackendKind.MicrosoftGraph, Username = username };
+        Assert.Same(OAuthService.GraphMailScopesPersonal, OAuthService.DefaultScopesFor(account));
+    }
+
+    [Fact]
+    public void WorkSchoolGraphAccount_UsesDefaultScope()
+    {
+        var account = new AccountModel { BackendKind = BackendKind.MicrosoftGraph, Username = "user@contoso.com" };
+        Assert.Same(OAuthService.GraphMailScopes, OAuthService.DefaultScopesFor(account));
+    }
+
+    [Fact]
+    public void ImapAccount_UsesImapScopes_EvenOnAPersonalDomain()
+    {
+        // The personal-domain check applies only to the Graph backend; IMAP always gets IMAP scopes.
+        var account = new AccountModel { BackendKind = BackendKind.ImapSmtp, Username = "me@outlook.com" };
+        Assert.Same(OAuthService.ImapSmtpScopes, OAuthService.DefaultScopesFor(account));
+    }
+}

--- a/QuickMail/QuickMail.csproj
+++ b/QuickMail/QuickMail.csproj
@@ -57,4 +57,10 @@
     <PackageReference Include="Velopack" Version="1.2.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Expose internals to the test assembly so pure helpers (e.g. OAuthService.DefaultScopesFor)
+         can be unit-tested without widening the public API. -->
+    <InternalsVisibleTo Include="QuickMail.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/QuickMail/Services/Graph/GraphClient.cs
+++ b/QuickMail/Services/Graph/GraphClient.cs
@@ -132,7 +132,10 @@ public sealed class GraphClient : IDisposable
         // Up to 3 attempts to ride out HTTP 429 throttling.
         for (int attempt = 0; ; attempt++)
         {
-            var token = await _oauth.GetAccessTokenAsync(account, OAuthService.GraphMailScopes, ct);
+            // Use the per-account default scopes (DefaultScopesFor): `.default` for work/school,
+            // explicit Mail.ReadWrite/etc. for personal Microsoft accounts (#217). Passing the static
+            // GraphMailScopes here would force `.default` on personal accounts, which is read-only.
+            var token = await _oauth.GetAccessTokenAsync(account, ct);
             using var req = new HttpRequestMessage(method, url);
             req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
             if (contentFactory != null)

--- a/QuickMail/Services/OAuthService.cs
+++ b/QuickMail/Services/OAuthService.cs
@@ -68,7 +68,7 @@ public class OAuthService : IOAuthService
         return PersonalMicrosoftDomains.Contains(username[(at + 1)..].Trim().ToLowerInvariant());
     }
 
-    private static string[] DefaultScopesFor(AccountModel account)
+    internal static string[] DefaultScopesFor(AccountModel account)
     {
         if (account.BackendKind != BackendKind.MicrosoftGraph)
             return ImapSmtpScopes;

--- a/QuickMail/Services/OAuthService.cs
+++ b/QuickMail/Services/OAuthService.cs
@@ -30,13 +30,51 @@ public class OAuthService : IOAuthService
         "https://outlook.office.com/.default",
     ];
 
+    // Work/school (AAD) Graph accounts: `.default` requests exactly the app-registration's declared
+    // permissions, which matches what admin consent grants (fixes the consent loop, #208).
     public static readonly string[] GraphMailScopes =
     [
         "https://graph.microsoft.com/.default",
     ];
 
+    // Personal Microsoft accounts (Outlook.com/Hotmail/Live): `.default` under-delivers for MSA,
+    // because personal accounts have no admin-consent model — `.default` returns only the permissions
+    // the user already consented to, which came back read-only (delete/move → 403 ErrorAccessDenied,
+    // #217). Request the explicit delegated mail scopes so the user is prompted to consent to read AND
+    // write. Org-only permissions (User.ReadBasic.All directory search, MailboxSettings.ReadWrite
+    // server rules) don't apply to personal accounts and are omitted.
+    public static readonly string[] GraphMailScopesPersonal =
+    [
+        "https://graph.microsoft.com/Mail.ReadWrite",
+        "https://graph.microsoft.com/Mail.Send",
+        "https://graph.microsoft.com/User.Read",
+    ];
+
+    // Well-known consumer domains, used only for the FIRST sign-in (before a token exists). Once an
+    // account has signed in, the authoritative signal is the MSAL account's tenant id
+    // (9188040d-6c67-4c5b-b112-36a304b66dad = the MSA "consumers" tenant) — a production version
+    // should prefer that. This heuristic covers the common personal-account domains.
+    private static readonly string[] PersonalMicrosoftDomains =
+    {
+        "outlook.com", "hotmail.com", "live.com", "msn.com", "passport.com", "windowslive.com",
+        "hotmail.co.uk", "live.co.uk", "outlook.jp", "outlook.de", "outlook.fr",
+    };
+
+    private static bool IsPersonalMicrosoftAccount(string? username)
+    {
+        if (string.IsNullOrWhiteSpace(username)) return false;
+        var at = username.LastIndexOf('@');
+        if (at < 0 || at == username.Length - 1) return false;
+        return PersonalMicrosoftDomains.Contains(username[(at + 1)..].Trim().ToLowerInvariant());
+    }
+
     private static string[] DefaultScopesFor(AccountModel account)
-        => account.BackendKind == BackendKind.MicrosoftGraph ? GraphMailScopes : ImapSmtpScopes;
+    {
+        if (account.BackendKind != BackendKind.MicrosoftGraph)
+            return ImapSmtpScopes;
+        // Personal accounts need explicit scopes to obtain write access; work/school uses `.default`.
+        return IsPersonalMicrosoftAccount(account.Username) ? GraphMailScopesPersonal : GraphMailScopes;
+    }
 
     private readonly string _cacheDir;
     private const string CacheFileName = "msal.cache";


### PR DESCRIPTION
Fixes #217.

## Problem
Under `.default` (#208), **personal Microsoft accounts (Outlook.com/Hotmail/Live) could read but not delete/move/flag mail** — writes failed with `403 ErrorAccessDenied`. `.default` is honored through the admin-consent model, which only exists for work/school (AAD) tenants; a personal account's `.default` token came back **read-only**. Work/school accounts were unaffected.

## Fix
Per-account-type scope selection in `OAuthService.DefaultScopesFor`:
- **Work/school (AAD):** keep `.default` (preserves the #208 admin-consent loop fix).
- **Personal Microsoft (MSA):** request explicit `Mail.ReadWrite` / `Mail.Send` / `User.Read`, so the user is prompted to consent to **write**.

Personal accounts are detected by email domain (see caveat below). Also routed `GraphClient`'s token requests through the per-account selection (`GetAccessTokenAsync(account, ct)`) instead of the hardcoded `.default` array — otherwise the per-account scopes never reached the actual Graph calls.

## Live validation (real Outlook.com account)
1. Before: delete on the Outlook.com account → `403 ErrorAccessDenied`, message reappears.
2. After: re-consented the account (consent screen now offered **read/write**), it connected, and delete succeeded — `"1 message deleted."`, no 403. Work account (AAD) delete continued to work throughout, still on `.default`.

## Caveats / follow-ups (not blocking the fix)
- **Detection heuristic:** personal accounts are currently detected by email domain — a prototype-grade heuristic. A production version should key off the **MSAL account's tenant id** (`9188040d-6c67-4c5b-b112-36a304b66dad` = the MSA "consumers" tenant) once the account has signed in. Flagging for your call on how robust you want this before merge.
- **`Mail.Send` not granted for MSA:** the consent granted read/write but **not** send, even though `Mail.Send` was requested. Sending *from* a personal account may still fail; delete/move/flag (the reported bug) does not depend on it. Needs a separate look at why `Mail.Send` doesn't grant for personal accounts.
- **Mid-session re-consent needs a restart:** switching an already-added account to the new scopes leaves it "connected for polling but not for folder ops" until an app restart (nothing re-registers it in `GraphMailService` after the new consent). Separate UX gap I can fix so a restart isn't required.

## Testing
`dotnet test -c Release` — build clean; Graph/OAuth/account suites green. No test pins scope strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
