### PR TITLE
Reconnect accounts by backend state after a mid-session re-consent (#219)

### DIFF
--- a/QuickMail.Tests/ComposeViewModelAutoSaveTests.cs
+++ b/QuickMail.Tests/ComposeViewModelAutoSaveTests.cs
@@ -159,6 +159,7 @@ sealed class RecordingMailService : IMailService
     }
 
     public Task ConnectAsync(AccountModel account, string? password = null, CancellationToken ct = default) => Task.CompletedTask;
+    public bool IsConnected(Guid accountId) => true;
     public Task DisconnectAsync(Guid accountId, CancellationToken ct = default) => Task.CompletedTask;
     public Task<List<MailFolderModel>> GetFoldersAsync(Guid accountId, CancellationToken ct = default) => Task.FromResult(new List<MailFolderModel>());
     public Task<List<MailMessageSummary>> GetMessageSummariesAsync(Guid accountId, string folderName, int maxMessages, CancellationToken ct = default) => Task.FromResult(new List<MailMessageSummary>());

--- a/QuickMail.Tests/GraphBackendGateTests.cs
+++ b/QuickMail.Tests/GraphBackendGateTests.cs
@@ -84,6 +84,7 @@ public class MailServiceRouterTests
 
         // Remaining members are unused by these tests.
         public Task ConnectAsync(AccountModel account, string? password = null, CancellationToken ct = default) => Task.CompletedTask;
+        public bool IsConnected(Guid accountId) => true;
         public Task DisconnectAsync(Guid accountId, CancellationToken ct = default) => Task.CompletedTask;
         public Task<List<MailMessageSummary>> GetMessageSummariesAsync(Guid accountId, string folderName, int maxMessages, CancellationToken ct = default) => Task.FromResult(new List<MailMessageSummary>());
         public Task<List<MailMessageSummary>> GetMessagesSinceDateAsync(Guid accountId, string folderName, DateTime since, CancellationToken ct = default) => Task.FromResult(new List<MailMessageSummary>());

--- a/QuickMail.Tests/ReconnectConditionTests.cs
+++ b/QuickMail.Tests/ReconnectConditionTests.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Linq;
+using QuickMail.Models;
+using QuickMail.ViewModels;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// Locks the #219 reconnect condition (`MainViewModel.AccountsNeedingConnect`): an account is
+/// reconnected when the backend has dropped it — even though the VM's `_cachedFolders` still has it —
+/// which is exactly the mid-session re-consent case. Also covers the newly-added (not-cached) case
+/// and the already-healthy (skip) case.
+/// </summary>
+public class ReconnectConditionTests
+{
+    private static AccountModel Acct(Guid id) => new() { Id = id };
+
+    [Fact]
+    public void BackendDropped_ButStillCached_IsReconnected() // the #219 case
+    {
+        var id = Guid.NewGuid();
+        var result = MainViewModel.AccountsNeedingConnect(
+            [Acct(id)],
+            isBackendConnected: _ => false, // backend dropped it (re-consent left it unregistered)
+            hasCachedFolders: _ => true);   // but the VM still shows its folders
+        Assert.Contains(result, a => a.Id == id);
+    }
+
+    [Fact]
+    public void ConnectedAndCached_IsSkipped()
+    {
+        var id = Guid.NewGuid();
+        var result = MainViewModel.AccountsNeedingConnect([Acct(id)], _ => true, _ => true);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void NotCached_IsReconnected() // newly added account
+    {
+        var id = Guid.NewGuid();
+        var result = MainViewModel.AccountsNeedingConnect([Acct(id)], _ => true, _ => false);
+        Assert.Contains(result, a => a.Id == id);
+    }
+}

--- a/QuickMail.Tests/SavedViewsTests.cs
+++ b/QuickMail.Tests/SavedViewsTests.cs
@@ -780,6 +780,7 @@ public class SavedViewsMainViewModelTests
         private readonly List<MailMessageSummary> _messages;
         public DatedMailService(IEnumerable<MailMessageSummary> messages) => _messages = new(messages);
         public Task ConnectAsync(AccountModel account, string? password = null, CancellationToken ct = default) => Task.CompletedTask;
+        public bool IsConnected(Guid accountId) => true;
         public Task DisconnectAsync(Guid accountId, CancellationToken ct = default) => Task.CompletedTask;
         public Task<List<MailFolderModel>> GetFoldersAsync(Guid accountId, CancellationToken ct = default) => Task.FromResult(new List<MailFolderModel>());
         public Task<List<MailMessageSummary>> GetMessageSummariesAsync(Guid accountId, string folderName, int maxMessages, CancellationToken ct = default) => Task.FromResult(new List<MailMessageSummary>(_messages));

--- a/QuickMail.Tests/SessionFeaturesTests.cs
+++ b/QuickMail.Tests/SessionFeaturesTests.cs
@@ -214,6 +214,7 @@ public class IdleNewMailTests
             });
 
         public Task ConnectAsync(AccountModel account, string? password = null, CancellationToken ct = default) => Task.CompletedTask;
+        public bool IsConnected(Guid accountId) => true;
         public Task DisconnectAsync(Guid accountId, CancellationToken ct = default) => Task.CompletedTask;
         public Task<List<MailMessageSummary>> GetMessageSummariesAsync(Guid accountId, string folderName, int maxMessages, CancellationToken ct = default) => Task.FromResult(new List<MailMessageSummary>());
         public Task<List<MailMessageSummary>> GetMessagesSinceDateAsync(Guid accountId, string folderName, DateTime since, CancellationToken ct = default) => Task.FromResult(new List<MailMessageSummary>());

--- a/QuickMail.Tests/StubServices.cs
+++ b/QuickMail.Tests/StubServices.cs
@@ -15,6 +15,7 @@ namespace QuickMail.Tests;
 sealed class StubImapMailService : IMailService
 {
     public Task ConnectAsync(AccountModel account, string? password = null, CancellationToken ct = default) => Task.CompletedTask;
+    public bool IsConnected(Guid accountId) => true;
     public Task DisconnectAsync(Guid accountId, CancellationToken ct = default) => Task.CompletedTask;
     public Task<List<MailFolderModel>> GetFoldersAsync(Guid accountId, CancellationToken ct = default) => Task.FromResult(new List<MailFolderModel>());
     public Task<List<MailMessageSummary>> GetMessageSummariesAsync(Guid accountId, string folderName, int maxMessages, CancellationToken ct = default) => Task.FromResult(new List<MailMessageSummary>());

--- a/QuickMail/QuickMail.csproj
+++ b/QuickMail/QuickMail.csproj
@@ -57,4 +57,10 @@
     <PackageReference Include="Velopack" Version="1.2.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Expose internals to the test assembly so pure helpers (e.g. the reconnect condition
+         MainViewModel.AccountsNeedingConnect) can be unit-tested without widening the public API. -->
+    <InternalsVisibleTo Include="QuickMail.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/QuickMail/Services/GraphMailService.cs
+++ b/QuickMail/Services/GraphMailService.cs
@@ -72,6 +72,8 @@ public class GraphMailService : IMailService
         LogService.Log($"GraphMailService: connected for {account.AccountLabel} ({account.Username}).");
     }
 
+    public bool IsConnected(Guid accountId) => _accounts.ContainsKey(accountId);
+
     /// <summary>
     /// Resolves the stable IDs of the well-known folders (Inbox, Sent, Drafts, Deleted, Junk) by
     /// their Graph well-known names, so detection survives localized display names and user renames.

--- a/QuickMail/Services/IMailService.cs
+++ b/QuickMail/Services/IMailService.cs
@@ -12,8 +12,8 @@ public interface IMailService : IDisposable
     Task DisconnectAsync(Guid accountId, CancellationToken ct = default);
 
     /// <summary>
-    /// True if the account currently has a live backend registration (Graph: a resolved account +
-    /// well-known-folder map; IMAP: a connection pool). Used to decide whether an account needs a
+    /// True if the account currently has a live backend registration (Graph: the resolved-account
+    /// registration; IMAP: a connection pool). Used to decide whether an account needs a
     /// fresh <see cref="ConnectAsync"/> — e.g. after a mid-session re-consent that changed its
     /// token/scopes (#219), so an account that's stale in the VM but unregistered in the backend is
     /// reconnected without requiring an app restart.

--- a/QuickMail/Services/IMailService.cs
+++ b/QuickMail/Services/IMailService.cs
@@ -10,6 +10,15 @@ public interface IMailService : IDisposable
 {
     Task ConnectAsync(AccountModel account, string? password = null, CancellationToken ct = default);
     Task DisconnectAsync(Guid accountId, CancellationToken ct = default);
+
+    /// <summary>
+    /// True if the account currently has a live backend registration (Graph: a resolved account +
+    /// well-known-folder map; IMAP: a connection pool). Used to decide whether an account needs a
+    /// fresh <see cref="ConnectAsync"/> — e.g. after a mid-session re-consent that changed its
+    /// token/scopes (#219), so an account that's stale in the VM but unregistered in the backend is
+    /// reconnected without requiring an app restart.
+    /// </summary>
+    bool IsConnected(Guid accountId);
     Task<List<MailFolderModel>> GetFoldersAsync(Guid accountId, CancellationToken ct = default);
     Task<List<MailMessageSummary>> GetMessageSummariesAsync(
         Guid accountId, string folderName, int maxMessages, CancellationToken ct = default);

--- a/QuickMail/Services/ImapMailService.cs
+++ b/QuickMail/Services/ImapMailService.cs
@@ -96,6 +96,8 @@ public class ImapMailService : IMailService, IChangeNotifier
         }
     }
 
+    public bool IsConnected(Guid accountId) => _pools.ContainsKey(accountId);
+
     public async Task DisconnectAsync(Guid accountId, CancellationToken ct = default)
     {
         if (_idleCts.TryRemove(accountId, out var watcherCts))

--- a/QuickMail/Services/MailServiceRouter.cs
+++ b/QuickMail/Services/MailServiceRouter.cs
@@ -54,6 +54,8 @@ public class MailServiceRouter : IMailService
     public Task DisconnectAsync(Guid accountId, CancellationToken ct = default)
         => For(accountId).DisconnectAsync(accountId, ct);
 
+    public bool IsConnected(Guid accountId) => For(accountId).IsConnected(accountId);
+
     public Task<List<MailFolderModel>> GetFoldersAsync(Guid accountId, CancellationToken ct = default)
         => For(accountId).GetFoldersAsync(accountId, ct);
 

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -5293,6 +5293,18 @@ public partial class MainViewModel : ObservableObject, IDisposable
         Process.Start(new ProcessStartInfo(tempPath) { UseShellExecute = true });
     }
 
+    /// <summary>
+    /// The accounts that need a (re)connect: those the backend doesn't have registered, OR whose
+    /// folders aren't cached in the VM. Checking the backend (not just cached folders) is what
+    /// re-registers an account dropped by a mid-session re-consent without an app restart (#219).
+    /// Pure/static so the reconnect condition is unit-testable independent of the async connect loop.
+    /// </summary>
+    internal static List<AccountModel> AccountsNeedingConnect(
+        IEnumerable<AccountModel> accounts,
+        Func<Guid, bool> isBackendConnected,
+        Func<Guid, bool> hasCachedFolders)
+        => accounts.Where(a => !isBackendConnected(a.Id) || !hasCachedFolders(a.Id)).ToList();
+
     public void RefreshAccountList()
     {
         LoadAccountList();
@@ -5304,9 +5316,8 @@ public partial class MainViewModel : ObservableObject, IDisposable
         // it, so folder ops fail "…is not connected" until an app restart (#219). Reconnecting it
         // here fixes that without a restart. _cachedFolders is UI-thread-owned: read it on the UI
         // thread and marshal every write back through _ui so the background loop never touches it.
-        var accountsToConnect = Accounts
-            .Where(a => !_imap.IsConnected(a.Id) || !_cachedFolders.ContainsKey(a.Id))
-            .ToList();
+        var accountsToConnect = AccountsNeedingConnect(
+            Accounts, _imap.IsConnected, id => _cachedFolders.ContainsKey(id));
         _ = Task.Run(async () =>
         {
             foreach (var account in accountsToConnect)

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -5297,12 +5297,16 @@ public partial class MainViewModel : ObservableObject, IDisposable
     {
         LoadAccountList();
 
-        // Reconnect any accounts that aren't already connected (e.g. newly added OAuth2 accounts).
-        // _cachedFolders is UI-thread-owned: snapshot the connected set here (still on the UI
-        // thread) and marshal every write back through _ui so the background loop never
-        // touches the dictionary directly.
-        var alreadyConnected = new HashSet<Guid>(_cachedFolders.Keys);
-        var accountsToConnect = Accounts.Where(a => !alreadyConnected.Contains(a.Id)).ToList();
+        // Reconnect any account that isn't truly connected in its backend, OR whose folders aren't
+        // cached in the VM (e.g. a newly added account). Checking the backend (_imap.IsConnected) —
+        // not just _cachedFolders — is what catches an account that was re-consented / re-authed
+        // mid-session: its VM state can look present while GraphMailService/ImapMailService dropped
+        // it, so folder ops fail "…is not connected" until an app restart (#219). Reconnecting it
+        // here fixes that without a restart. _cachedFolders is UI-thread-owned: read it on the UI
+        // thread and marshal every write back through _ui so the background loop never touches it.
+        var accountsToConnect = Accounts
+            .Where(a => !_imap.IsConnected(a.Id) || !_cachedFolders.ContainsKey(a.Id))
+            .ToList();
         _ = Task.Run(async () =>
         {
             foreach (var account in accountsToConnect)


### PR DESCRIPTION
Fixes #219. **Stacked on #215** (`fix/late-connect-sync-and-watchers`) — it builds on that PR's `RefreshAccountList`/`WireUpWatchers` form; base it there for now and it retargets to `main` once #215 lands.

## Problem
Re-consenting / re-authing an account mid-session (e.g. granting a broader scope set) left it **"connected for polling but not for folder ops"** until an app restart. `RefreshAccountList` decided what to reconnect from **`_cachedFolders.Keys`**, which doesn't reflect the actual backend registration. An account that `GraphMailService`/`ImapMailService` had dropped (or never registered) — but whose VM state still looked present — was skipped, so folder ops failed with `InvalidOperationException: Graph account <id> is not connected` until a restart cleared the stale state.

## Fix
- Add **`IMailService.IsConnected(Guid accountId)`** — Graph: `_accounts.ContainsKey`; IMAP: `_pools.ContainsKey`; `MailServiceRouter` delegates to the account's backend.
- `RefreshAccountList` now reconnects an account when it's **not backend-connected OR has no cached folders**, instead of trusting `_cachedFolders` alone. That re-registers a re-authed account in its backend without a restart, and `WireUpWatchers` (#215) then refreshes its poll + status.

## Testing
- `dotnet test -c Release` — build clean; 1085/1086 (the one miss is the known clipboard `COMException` environmental flake, unrelated; passes in isolation). No behavior change for already-connected accounts (both conditions false → skipped as before).
- Live validation still to do: re-consent an account mid-session and confirm it reconnects (folders + delete work) **without** a restart. I'll run that on a combined build with #218 so the personal account is exercisable.

Surfaced while validating #217/#218.
