### PR TITLE
Detect personal Microsoft accounts by MSAL tenant id, not email domain (#233)

### DIFF
--- a/QuickMail.Tests/OAuthServiceScopeSelectionTests.cs
+++ b/QuickMail.Tests/OAuthServiceScopeSelectionTests.cs
@@ -35,4 +35,31 @@ public class OAuthServiceScopeSelectionTests
         var account = new AccountModel { BackendKind = BackendKind.ImapSmtp, Username = "me@outlook.com" };
         Assert.Same(OAuthService.ImapSmtpScopes, OAuthService.DefaultScopesFor(account));
     }
+
+    [Fact]
+    public void CustomDomainPersonalAccount_StoredTenantFlagOverridesDomainGuess() // #233
+    {
+        // A personal Microsoft account on a custom/vanity domain: the email-domain guess would say
+        // "work" and break write, but the persisted tenant-derived flag makes it use explicit scopes.
+        var account = new AccountModel
+        {
+            BackendKind = BackendKind.MicrosoftGraph,
+            Username = "me@myvanitydomain.com",
+            IsPersonalMicrosoftAccount = true,
+        };
+        Assert.Same(OAuthService.GraphMailScopesPersonal, OAuthService.DefaultScopesFor(account));
+    }
+
+    [Fact]
+    public void WorkAccountOnPersonalLookingDomain_StoredFlagFalseUsesDefault()
+    {
+        // Flag explicitly false wins over a personal-looking domain → work/school (`.default`).
+        var account = new AccountModel
+        {
+            BackendKind = BackendKind.MicrosoftGraph,
+            Username = "user@outlook.com",
+            IsPersonalMicrosoftAccount = false,
+        };
+        Assert.Same(OAuthService.GraphMailScopes, OAuthService.DefaultScopesFor(account));
+    }
 }

--- a/QuickMail/Models/AccountModel.cs
+++ b/QuickMail/Models/AccountModel.cs
@@ -17,6 +17,14 @@ public partial class AccountModel : ObservableObject
     /// <summary>Which protocol stack this account uses. Fixed at account creation.</summary>
     public BackendKind BackendKind { get; set; } = BackendKind.ImapSmtp;
 
+    /// <summary>
+    /// True if this is a personal Microsoft account (its MSAL tenant is the consumers tenant), null if
+    /// not yet detected. Set from the token at Microsoft sign-in and used to pick explicit Graph scopes
+    /// for consumer accounts — which is correct even on custom domains, where the email-domain guess
+    /// fails (#233). Null falls back to that domain guess.
+    /// </summary>
+    public bool? IsPersonalMicrosoftAccount { get; set; }
+
     /// <summary>Optional Azure AD tenant ID for Graph accounts. Null = "common" authority.</summary>
     public string? TenantId { get; set; }
 

--- a/QuickMail/Services/IOAuthService.cs
+++ b/QuickMail/Services/IOAuthService.cs
@@ -4,7 +4,13 @@ using QuickMail.Models;
 
 namespace QuickMail.Services;
 
-public record OAuthResult(string AccessToken, string Username);
+/// <param name="IsPersonalMicrosoftAccount">
+/// True when the signed-in account is a personal Microsoft account (its MSAL tenant is the well-known
+/// consumers tenant) — determined authoritatively from the token rather than the email domain. Drives
+/// the per-account scope selection for consumer accounts (#217/#233). Microsoft sign-in only; Google
+/// leaves it false.
+/// </param>
+public record OAuthResult(string AccessToken, string Username, bool IsPersonalMicrosoftAccount = false);
 
 public interface IOAuthService
 {

--- a/QuickMail/Services/OAuthService.cs
+++ b/QuickMail/Services/OAuthService.cs
@@ -50,17 +50,22 @@ public class OAuthService : IOAuthService
         "https://graph.microsoft.com/User.Read",
     ];
 
-    // Well-known consumer domains, used only for the FIRST sign-in (before a token exists). Once an
-    // account has signed in, the authoritative signal is the MSAL account's tenant id
-    // (9188040d-6c67-4c5b-b112-36a304b66dad = the MSA "consumers" tenant) — a production version
-    // should prefer that. This heuristic covers the common personal-account domains.
+    // Authoritative "is this a personal Microsoft account" signal: every consumer account lives in the
+    // well-known MSA "consumers" tenant. Detected from the MSAL account at sign-in and persisted on
+    // AccountModel (#233), so it's correct even for personal accounts on custom/vanity domains.
+    internal const string MsaConsumersTenantId = "9188040d-6c67-4c5b-b112-36a304b66dad";
+
+    // FALLBACK only — the email-domain guess used before a token exists (very first sign-in) and for
+    // accounts added before tenant detection shipped. Covers the common personal-account domains; a
+    // personal account on a custom domain is missed here, which is exactly why the tenant id above is
+    // the authoritative source once available.
     private static readonly string[] PersonalMicrosoftDomains =
     {
         "outlook.com", "hotmail.com", "live.com", "msn.com", "passport.com", "windowslive.com",
         "hotmail.co.uk", "live.co.uk", "outlook.jp", "outlook.de", "outlook.fr",
     };
 
-    private static bool IsPersonalMicrosoftAccount(string? username)
+    private static bool IsPersonalMicrosoftDomain(string? username)
     {
         if (string.IsNullOrWhiteSpace(username)) return false;
         var at = username.LastIndexOf('@');
@@ -73,7 +78,10 @@ public class OAuthService : IOAuthService
         if (account.BackendKind != BackendKind.MicrosoftGraph)
             return ImapSmtpScopes;
         // Personal accounts need explicit scopes to obtain write access; work/school uses `.default`.
-        return IsPersonalMicrosoftAccount(account.Username) ? GraphMailScopesPersonal : GraphMailScopes;
+        // Prefer the persisted, tenant-derived flag; fall back to the email-domain guess only when the
+        // account hasn't been detected yet (first sign-in, or added before detection shipped).
+        var isPersonal = account.IsPersonalMicrosoftAccount ?? IsPersonalMicrosoftDomain(account.Username);
+        return isPersonal ? GraphMailScopesPersonal : GraphMailScopes;
     }
 
     private readonly string _cacheDir;
@@ -204,8 +212,14 @@ public class OAuthService : IOAuthService
             builder = builder.WithLoginHint(account.Username);
 
         var result = await builder.ExecuteAsync(ct);
-        LogService.Log($"OAuthService: interactive sign-in complete for {result.Account.Username}");
-        return new OAuthResult(result.AccessToken, result.Account.Username);
+        // Authoritative personal-vs-work detection from the token: personal Microsoft accounts sign in
+        // under the well-known MSA consumers tenant. The caller persists this on the account so scope
+        // selection is correct even for consumer accounts on custom domains (#233).
+        var isPersonal = string.Equals(result.Account?.HomeAccountId?.TenantId, MsaConsumersTenantId,
+            StringComparison.OrdinalIgnoreCase);
+        LogService.Log($"OAuthService: interactive sign-in complete for {result.Account.Username} " +
+                       $"(personal Microsoft account: {isPersonal}).");
+        return new OAuthResult(result.AccessToken, result.Account.Username, isPersonal);
     }
 
     public async Task SignOutAsync(AccountModel account)

--- a/QuickMail/ViewModels/AccountEditorViewModel.cs
+++ b/QuickMail/ViewModels/AccountEditorViewModel.cs
@@ -97,6 +97,13 @@ public abstract partial class AccountEditorViewModel : ObservableObject
 
     partial void OnAuthTypeChanged(AuthType value) => OnAuthTypeChangedInternal(value);
 
+    /// <summary>
+    /// Detected from the token at Microsoft sign-in (null until signed in). Carried to
+    /// <see cref="AccountModel.IsPersonalMicrosoftAccount"/> by the derived VM's ToAccountModel so
+    /// scope selection is correct even for personal accounts on custom domains (#233).
+    /// </summary>
+    public bool? IsPersonalMicrosoftAccount { get; private set; }
+
     [RelayCommand]
     private async Task SignInMicrosoftAsync()
     {
@@ -108,6 +115,7 @@ public abstract partial class AccountEditorViewModel : ObservableObject
             var tempAccount = new AccountModel { Username = Username, AuthType = AuthType.OAuth2Microsoft, BackendKind = BackendKind };
             var result = await OAuthService.SignInInteractiveAsync(tempAccount, cts.Token);
             Username = result.Username;
+            IsPersonalMicrosoftAccount = result.IsPersonalMicrosoftAccount;
             StatusText = $"Signed in as {result.Username}";
         }
         catch (Exception ex)

--- a/QuickMail/ViewModels/AccountManagerViewModel.cs
+++ b/QuickMail/ViewModels/AccountManagerViewModel.cs
@@ -91,6 +91,10 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
         SelectedAccount.AccountName = AccountName;
         SelectedAccount.DisplayName = DisplayName;
         SelectedAccount.Username = Username;
+        // Backfill the personal-account flag when this edit re-authed (SignInMicrosoftAsync set it);
+        // leave it untouched otherwise so a plain field edit doesn't wipe a prior detection (#233).
+        if (IsPersonalMicrosoftAccount.HasValue)
+            SelectedAccount.IsPersonalMicrosoftAccount = IsPersonalMicrosoftAccount;
         SelectedAccount.AuthType = AuthType;
         SelectedAccount.ImapHost = ImapHost;
         SelectedAccount.ImapPort = ImapPort;

--- a/QuickMail/ViewModels/AddAccountViewModel.cs
+++ b/QuickMail/ViewModels/AddAccountViewModel.cs
@@ -120,6 +120,7 @@ public partial class AddAccountViewModel : AccountEditorViewModel
         Username = Username,
         AuthType = AuthType,
         BackendKind = BackendKind,
+        IsPersonalMicrosoftAccount = IsPersonalMicrosoftAccount,
         ImapHost = ImapHost,
         ImapPort = ImapPort,
         ImapUseSsl = ImapUseSsl,


### PR DESCRIPTION
Fixes #233. **Stacked on #218** — it refines #218's `DefaultScopesFor`; base it there and it retargets to `main` once #218 lands.

## Problem
#218 identifies a personal (MSA) account by **email domain** to decide it needs explicit write scopes. But a personal Microsoft account can use *any* address ("add an existing email"), so a consumer account on a custom domain is misclassified as work → falls back to `.default` → delete/move breaks again (the 403), silently and for only some users.

## Fix
Detect **authoritatively from the token**: every personal Microsoft account signs in under the well-known MSA consumers tenant `9188040d-6c67-4c5b-b112-36a304b66dad`.

- `SignInInteractiveAsync` reads `result.Account.HomeAccountId.TenantId` and returns `IsPersonalMicrosoftAccount` on `OAuthResult`.
- The editor VMs persist it on **`AccountModel.IsPersonalMicrosoftAccount`** (`bool?`) — the add flow via `ToAccountModel`, and a re-auth of an existing account backfills it on save.
- `DefaultScopesFor` prefers the **persisted flag**, falling back to the email-domain guess only when an account hasn't been detected yet (first sign-in / added before this shipped). So a custom-domain personal account gets explicit scopes once signed in, and the decision survives restarts.

## Testing
`OAuthServiceScopeSelectionTests` adds two cases: a **custom-domain** account with the stored flag → explicit scopes (would've broken under the domain guess), and a personal-looking domain with the flag explicitly `false` → `.default`. `dotnet test -c Release`: build clean, 1092/1093 (the one miss is the known clipboard `COMException` flake, unrelated).

Retires the before-GA caveat from #218's review.
