### PR TITLE
Address #234 review: null-safety + document the personal-account migration gap

### DIFF
--- a/QuickMail.Tests/OAuthServiceScopeSelectionTests.cs
+++ b/QuickMail.Tests/OAuthServiceScopeSelectionTests.cs
@@ -62,4 +62,21 @@ public class OAuthServiceScopeSelectionTests
         };
         Assert.Same(OAuthService.GraphMailScopes, OAuthService.DefaultScopesFor(account));
     }
+
+    [Fact]
+    public void CustomDomainPersonalAccount_NotYetDetected_FallsBackToDefault_KnownMigrationGap()
+    {
+        // DELIBERATE, documented fallback (#234 review, concern 1): a personal account on a custom
+        // domain that hasn't been detected yet (added before tenant detection shipped, never re-authed)
+        // has a null flag → the email-domain guess says "work" → `.default`. Auto-heal is deferred; new
+        // accounts are detected at sign-in, so this only affects pre-detection accounts (near-zero while
+        // the Graph backend is feature-gated). Locked as a test so it reads as intended, not an oversight.
+        var account = new AccountModel
+        {
+            BackendKind = BackendKind.MicrosoftGraph,
+            Username = "me@myvanitydomain.com",
+            IsPersonalMicrosoftAccount = null,
+        };
+        Assert.Same(OAuthService.GraphMailScopes, OAuthService.DefaultScopesFor(account));
+    }
 }

--- a/QuickMail/Services/OAuthService.cs
+++ b/QuickMail/Services/OAuthService.cs
@@ -214,8 +214,10 @@ public class OAuthService : IOAuthService
         var result = await builder.ExecuteAsync(ct);
         // Authoritative personal-vs-work detection from the token: personal Microsoft accounts sign in
         // under the well-known MSA consumers tenant. The caller persists this on the account so scope
-        // selection is correct even for consumer accounts on custom domains (#233).
-        var isPersonal = string.Equals(result.Account?.HomeAccountId?.TenantId, MsaConsumersTenantId,
+        // selection is correct even for consumer accounts on custom domains (#233). Account is non-null
+        // after a successful interactive ExecuteAsync (same assumption as the Username deref below);
+        // HomeAccountId keeps its ?. defensively — a null tenant just resolves to "not personal".
+        var isPersonal = string.Equals(result.Account.HomeAccountId?.TenantId, MsaConsumersTenantId,
             StringComparison.OrdinalIgnoreCase);
         LogService.Log($"OAuthService: interactive sign-in complete for {result.Account.Username} " +
                        $"(personal Microsoft account: {isPersonal}).");


### PR DESCRIPTION
Follow-ups to your post-merge review on #234.

- **Concern 2 (null-safety) — fixed.** Dropped the misleading `result.Account?.` in `SignInInteractiveAsync`; `Account` is non-null after a successful interactive `ExecuteAsync` (same assumption the `Username` deref already makes), so the `?.` implied a null case the code doesn't handle. `HomeAccountId` keeps its `?.` defensively — a null tenant just resolves to "not personal."
- **Concern 3 (test) — added.** A case locking the *deliberate* pre-detection fallback: custom-domain personal account with a null flag → `.default`. Reads as intentional migration behavior, not an oversight.
- **Concern 1 (auto-heal) — deferred, documented.** New accounts are detected at sign-in, so every personal account added going forward is classified correctly regardless of domain. The gap only affects accounts added **before** detection shipped and never re-authed — near-zero while the Graph backend is feature-gated (the affected population is essentially the maintainer's own test accounts, already flagged). Revisit before GA if it becomes relevant.

`dotnet test -c Release`: build clean, scope-selection suite 8/8.
