### PR TITLE
Delete from the message context menu now acts on the whole selection (#221)

### DIFF
--- a/QuickMail/Views/MainWindow.xaml
+++ b/QuickMail/Views/MainWindow.xaml
@@ -198,7 +198,7 @@
             <Separator/>
             <MenuItem Header="_Delete"
                       AutomationProperties.Name="Delete"
-                      Command="{Binding DeleteMessageCommand}"/>
+                      Click="MessageContextMenu_Delete_Click"/>
             <Separator/>
             <MenuItem Header="Flag_s"
                       Tag="FlagsSubmenu"

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -4602,6 +4602,29 @@ public partial class MainWindow : Window
     private async void MessageContextMenu_CopyToFolder_Click(object sender, RoutedEventArgs e)
         => await CopyMessageToFolderAsync();
 
+    // Context-menu Delete must act on the whole selection, exactly like the Delete key and the
+    // Move/Copy context-menu items. Binding to the VM's DeleteMessageCommand deleted only
+    // SelectedMessage (a single item), which is why Ctrl+A then context-menu Delete removed just
+    // the focused message. GetSelectedMessages() returns every selected row in the flat list, or
+    // the single message node in a grouped tree.
+    private async void MessageContextMenu_Delete_Click(object sender, RoutedEventArgs e)
+    {
+        var messages = GetSelectedMessages();
+        if (messages.Count == 0) return;
+
+        await _vm.DeleteMessagesAsync(messages);
+
+        // Land focus the same way the Move context-menu handler does.
+        if (_vm.IsConversationsView)
+            LandOnConversationAfterRebuild(0);
+        else if (_vm.IsFromView)
+            LandOnSenderGroupAfterRebuild(0);
+        else if (_vm.IsToView)
+            LandOnToGroupAfterRebuild(0);
+        else
+            FocusMessageListFirstItem();
+    }
+
     // ── Conversation context menu handlers ───────────────────────────────────
 
     private async void ConversationContextMenu_MoveToFolder_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
## Summary

Fixes #221 — "Select all does not work on messages." After Ctrl+A in the flat message list (which announces e.g. "500 messages selected"), invoking **Delete** from the context menu deleted only the single focused message, not the whole selection.

## Root cause

The context menu's Delete item was bound to `Command="{Binding DeleteMessageCommand}"`, and that VM command deletes only `SelectedMessage` (one item). The Delete *key* handler and the Move/Copy context-menu items already act on the full `MessageList.SelectedItems` set — Delete was the odd one out.

## Fix

- `MainWindow.xaml` — the Delete `MenuItem` now uses `Click="MessageContextMenu_Delete_Click"` instead of the single-item command binding.
- `MainWindow.xaml.cs` — new `MessageContextMenu_Delete_Click` handler pulls the whole selection via the existing `GetSelectedMessages()` helper, deletes it through `DeleteMessagesAsync`, and lands focus the same way the Move context-menu handler does (first item in the flat list; `LandOn*` in grouped views).

This reuses the same selection and focus-landing plumbing that Delete-key and Move/Copy already rely on, so the context menu is now consistent. Reply/Reply All/Forward remain single-message (correct); Move/Copy already worked on the selection.

As a side benefit, grouped-view context-menu Delete now lands focus correctly — the old command path never made the `LandOn*` calls, so focus could previously be stranded there.

## Verification

- `dotnet build QuickMail.sln` — 0 errors.
- Independent code review: no Critical/High/Medium findings; all four `MessageContextMenu` entry points (flat list + Conversations/From/To message nodes) verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
