### PR TITLE
Fix personal Microsoft sign-in on the IMAP path: explicit scopes, not `.default` (#239)

### DIFF
--- a/QuickMail.Tests/OAuthServiceScopeSelectionTests.cs
+++ b/QuickMail.Tests/OAuthServiceScopeSelectionTests.cs
@@ -62,4 +62,25 @@ public class OAuthServiceScopeSelectionTests
         };
         Assert.Same(OAuthService.GraphMailScopes, OAuthService.DefaultScopesFor(account));
     }
+
+    [Fact]
+    public void ImapScopes_AreExplicit_NotDefault() // #239
+    {
+        // `.default` on the IMAP resource is invalid for personal Microsoft accounts and blocked
+        // sign-in entirely (#239). The IMAP/SMTP path must request explicit scopes, which work for
+        // personal and work accounts alike (the IMAP path doesn't consult the personal/work flag).
+        Assert.Contains("https://outlook.office.com/IMAP.AccessAsUser.All", OAuthService.ImapSmtpScopes);
+        Assert.Contains("https://outlook.office.com/SMTP.Send", OAuthService.ImapSmtpScopes);
+        Assert.DoesNotContain("https://outlook.office.com/.default", OAuthService.ImapSmtpScopes);
+    }
+
+    [Theory]
+    [InlineData("me@outlook.com")]  // personal domain
+    [InlineData("me@outlook.cl")]   // custom-domain personal (the exact #239 reporter case)
+    [InlineData("user@contoso.com")] // work
+    public void ImapAccount_AlwaysGetsExplicitImapScopes_RegardlessOfType(string username)
+    {
+        var account = new AccountModel { BackendKind = BackendKind.ImapSmtp, Username = username };
+        Assert.Same(OAuthService.ImapSmtpScopes, OAuthService.DefaultScopesFor(account));
+    }
 }

--- a/QuickMail/Services/OAuthService.cs
+++ b/QuickMail/Services/OAuthService.cs
@@ -15,23 +15,27 @@ public class OAuthService : IOAuthService
     private const string ClientId  = "bcdc84f1-d37c-4581-b14a-a01f7b3a1312";
     private const string Authority = "https://login.microsoftonline.com/common";
 
-    // Per-resource `.default` scope. `.default` requests EXACTLY the delegated permissions declared
-    // on the app registration (docs/ENTRA-APP-REGISTRATION.md §3) — so the requested set always
-    // matches what admin consent grants, eliminating the requested-vs-declared mismatch that produced
-    // the "admin granted consent but the user is still prompted" loop. Design & rationale:
-    // docs/planning/oauth-default-scope-pm-dev-spec.md. Notes:
-    //  - `.default` is per-resource and cannot be combined with other scopes, hence one array each.
-    //  - MSAL adds openid/profile/offline_access automatically for the public-client desktop flow,
-    //    so refresh tokens still issue (verified live: silent re-acquisition works with `.default`).
-    //  - A new permission (e.g. MailboxSettings.ReadWrite for server rules) is now added by DECLARING
-    //    it on the app registration + re-granting consent — not by editing this list.
+    // IMAP/SMTP-over-OAuth (Exchange Online / Outlook.com). Uses EXPLICIT scopes, NOT `.default`:
+    // `.default` on `outlook.office.com` is invalid for personal Microsoft accounts — the resource
+    // isn't in the app's Required Resource Access for consumer sign-in and there's no admin-consent
+    // model — which broke personal-account sign-in on the IMAP path entirely (#239, sign-in error
+    // "scope … is not valid … refers to a resource which is not listed"). Explicit
+    // IMAP.AccessAsUser.All + SMTP.Send work for BOTH personal and work accounts, and the `.default`
+    // loop-avoidance benefit (#208) never applied here anyway: the IMAP resource only ever needs these
+    // two declared scopes, so there is no requested-vs-declared mismatch. MSAL adds
+    // openid/profile/offline_access automatically for the public-client flow, so refresh tokens issue.
     public static readonly string[] ImapSmtpScopes =
     [
-        "https://outlook.office.com/.default",
+        "https://outlook.office.com/IMAP.AccessAsUser.All",
+        "https://outlook.office.com/SMTP.Send",
     ];
 
-    // Work/school (AAD) Graph accounts: `.default` requests exactly the app-registration's declared
-    // permissions, which matches what admin consent grants (fixes the consent loop, #208).
+    // Work/school (AAD) Graph accounts: `.default` requests EXACTLY the app-registration's declared
+    // permissions, matching what admin consent grants — this is what fixed the requested-vs-declared
+    // mismatch that produced the "admin granted consent but the user is still prompted" loop (#208).
+    // `.default` is per-resource and cannot be combined with other scopes. Rationale:
+    // docs/planning/oauth-default-scope-pm-dev-spec.md. (Personal Graph accounts use
+    // GraphMailScopesPersonal below — `.default` under-delivers write for them, #217.)
     public static readonly string[] GraphMailScopes =
     [
         "https://graph.microsoft.com/.default",

--- a/docs/ENTRA-APP-REGISTRATION.md
+++ b/docs/ENTRA-APP-REGISTRATION.md
@@ -49,12 +49,16 @@ above; the embedded view intercepts that navigation internally (no loopback list
 
 ## 3. API permissions (delegated, Microsoft Graph + Exchange Online)
 
-QuickMail requests the **per-resource `.default` scope** at sign-in — `https://graph.microsoft.com/.default`
-for Graph accounts and `https://outlook.office.com/.default` for IMAP/SMTP-over-OAuth. `.default`
-asks for **exactly the delegated permissions declared here** — nothing more, no runtime incremental
-consent. **This list is therefore the complete definition of what QuickMail can request.** A
-permission missing here can never be acquired at runtime, no matter what the code does. See
+Only the **Graph** backend uses the per-resource **`.default` scope** at sign-in
+(`https://graph.microsoft.com/.default`), which asks for **exactly the delegated Graph permissions
+declared here** — nothing more, no runtime incremental consent. See
 `docs/planning/oauth-default-scope-pm-dev-spec.md`.
+
+The **IMAP/SMTP-over-OAuth** path requests **explicit** scopes (`IMAP.AccessAsUser.All` + `SMTP.Send`),
+**not** `.default` — `.default` on `outlook.office.com` is invalid for personal Microsoft accounts and
+broke consumer sign-in on the IMAP path entirely (#239). Explicit scopes work for personal and work
+accounts alike, and `.default` bought the IMAP path nothing (its resource only needs those two
+declared scopes). Both must still be declared here.
 
 > **Exception — personal Microsoft accounts (Outlook.com/MSA).** `.default` is honored only through
 > the AAD admin-consent model, which consumer accounts don't have, so their `.default` token comes

--- a/docs/planning/oauth-default-scope-pm-dev-spec.md
+++ b/docs/planning/oauth-default-scope-pm-dev-spec.md
@@ -20,6 +20,14 @@ the request to the **per-resource `.default` scope**:
 resource** — no more, no less. The app registration (`docs/ENTRA-APP-REGISTRATION.md` §3) becomes
 the single source of truth for the permission set.
 
+> **Correction (post-ship, #239):** `.default` was over-applied to the **IMAP/SMTP** path. It is
+> invalid for personal Microsoft accounts on `outlook.office.com` (no admin-consent model → the
+> resource isn't in Required Resource Access for consumer sign-in), which broke consumer sign-in on
+> the IMAP path entirely. The IMAP/SMTP path now requests **explicit** scopes
+> (`IMAP.AccessAsUser.All` + `SMTP.Send`), which work for personal and work accounts alike; `.default`
+> bought it nothing (no undeclared-scope loop there). Everything below about `.default` applies to the
+> **Graph** path only.
+
 This is a **pure `.default`** decision: there is no runtime incremental/step-up consent for any
 Graph permission, including the server-rules write scope.
 


### PR DESCRIPTION
Fixes #239.

## Problem
The `.default` migration was **over-applied to the IMAP/SMTP path.** `.default` on `outlook.office.com` is **invalid for personal Microsoft accounts** — the resource isn't in the app's Required Resource Access for consumer sign-in, and there's no admin-consent model — so personal-account sign-in via IMAP fails outright:

> Sign-in failed: The provided value for the input parameter 'scope' is not valid. The scope 'https://outlook.office.com/.default …' is not valid - it refers to a resource which is not listed in the client's Required Resource Access…

Because the Graph backend is **feature-gated**, IMAP OAuth is the **only** way to add a Microsoft account on shipped builds — so this broke consumer sign-in for *every* personal Microsoft account, not an edge case. The #217/#218/#234 personal-account fix only covered the **Graph** path.

(The reporter's `outlook.cl` domain is a good clue, but the IMAP path never even consults the personal/work distinction — a plain `outlook.com` personal account hits the same wall.)

## Fix
`ImapSmtpScopes` now requests **explicit** `IMAP.AccessAsUser.All` + `SMTP.Send` instead of `outlook.office.com/.default`:
- Explicit scopes work for **both** personal and work accounts — that's what shipped before the `.default` migration and it worked for everyone.
- `.default` bought the IMAP path **nothing**: the loop it solved (#208) was a *Graph* problem (the undeclared `MailboxSettings.ReadWrite`); the IMAP resource only ever needs those two declared scopes → no requested-vs-declared mismatch.
- It needs **no** personal/work detection at sign-in, which the domain heuristic couldn't do for `outlook.cl` anyway (and detection runs only *after* a successful sign-in — the very thing failing here).

## Testing
`OAuthServiceScopeSelectionTests` locks it: IMAP scopes are explicit (not `.default`), and IMAP accounts get them regardless of type (incl. the `outlook.cl` case). Build clean; scope-selection suite green. ENTRA doc §3 + the `.default` spec corrected to note IMAP uses explicit scopes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
