### PR TITLE
Fix #225: mark messages read on the server when opened from cache

### DIFF
--- a/QuickMail.Tests/MarkReadOnOpenTests.cs
+++ b/QuickMail.Tests/MarkReadOnOpenTests.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using QuickMail.Models;
+using QuickMail.Services;
+using QuickMail.ViewModels;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// Regression tests for issue #225: opening a message must set the \Seen flag on the
+/// server, even when the body is served from the local cache (a prefetched message is
+/// cached without \Seen, so relying on the GetMessageDetailAsync fetch side effect leaves
+/// it unread in other clients).
+/// </summary>
+public class MarkReadOnOpenTests
+{
+    private static (MainViewModel vm, RecordingImapService imap) MakeVm(
+        ILocalStoreService store, Guid accountId)
+    {
+        var imap = new RecordingImapService();
+        var vm = new MainViewModel(
+            imap, new StubAccountService(), new StubCredentialService(),
+            store, new StubOAuthService(), new StubSyncService(), new StubConfigService(),
+            new StubCommandRegistry(), new StubViewService(), new StubRuleService(), new StubSmtpService());
+        // SelectMessageAsync bails unless the message's account is selectable.
+        vm.SelectedAccount = new AccountModel { Id = accountId, Username = "test@example.com" };
+        return (vm, imap);
+    }
+
+    private static MailMessageSummary UnreadMsg(Guid accountId) => new()
+    {
+        MessageId  = "42",
+        AccountId  = accountId,
+        FolderName = "INBOX",
+        IsRead     = false,
+    };
+
+    [Fact]
+    public async Task OpeningCachedUnreadMessage_MarksReadOnServer()
+    {
+        // Cache HIT: LoadDetailAsync returns a detail, so the IMAP body fetch (which would
+        // otherwise set \Seen as a side effect) never runs. This is the prefetched-message case.
+        var accountId = Guid.NewGuid();
+        var (vm, imap) = MakeVm(new CacheHitStore(), accountId);
+        var msg = UnreadMsg(accountId);
+
+        await vm.SelectMessageCommand.ExecuteAsync(msg);
+
+        Assert.Contains((accountId, "INBOX", "42"), imap.MarkReadCalls);
+        Assert.True(msg.IsRead);
+    }
+
+    [Fact]
+    public async Task OpeningAlreadyReadMessage_DoesNotMarkReadAgain()
+    {
+        var accountId = Guid.NewGuid();
+        var (vm, imap) = MakeVm(new CacheHitStore(), accountId);
+        var msg = UnreadMsg(accountId);
+        msg.IsRead = true; // already read → no server call needed
+
+        await vm.SelectMessageCommand.ExecuteAsync(msg);
+
+        Assert.Empty(imap.MarkReadCalls);
+    }
+
+    /// <summary>Records mark-read calls; every other member is a no-op stub.</summary>
+    private sealed class RecordingImapService : IMailService
+    {
+        public List<(Guid AccountId, string FolderName, string MessageId)> MarkReadCalls { get; } = [];
+
+        public Task MarkReadAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default)
+        {
+            MarkReadCalls.Add((accountId, folderName, messageId));
+            return Task.CompletedTask;
+        }
+
+        public Task ConnectAsync(AccountModel account, string? password = null, CancellationToken ct = default) => Task.CompletedTask;
+        public bool IsConnected(Guid accountId) => true;
+        public Task DisconnectAsync(Guid accountId, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<List<MailFolderModel>> GetFoldersAsync(Guid accountId, CancellationToken ct = default) => Task.FromResult(new List<MailFolderModel>());
+        public Task<List<MailMessageSummary>> GetMessageSummariesAsync(Guid accountId, string folderName, int maxMessages, CancellationToken ct = default) => Task.FromResult(new List<MailMessageSummary>());
+        public Task<List<MailMessageSummary>> GetMessagesSinceDateAsync(Guid accountId, string folderName, DateTime since, CancellationToken ct = default) => Task.FromResult(new List<MailMessageSummary>());
+        public Task<List<MailMessageSummary>> GetMessagesSinceAsync(Guid accountId, string folderName, string sinceMessageId, int initialCount, CancellationToken ct = default) => Task.FromResult(new List<MailMessageSummary>());
+        public Task<MailMessageDetail> GetMessageDetailAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default) => Task.FromResult(new MailMessageDetail());
+        public Task<MailMessageDetail> PrefetchMessageDetailAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default) => Task.FromResult(new MailMessageDetail());
+        public Task MarkReadBatchAsync(Guid accountId, string folderName, IList<string> messageIds, CancellationToken ct = default) => Task.CompletedTask;
+        public Task SetMessageFlaggedAsync(Guid accountId, string folderName, string messageId, bool flagged, CancellationToken ct = default) => Task.CompletedTask;
+        public Task MoveToTrashAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default) => Task.CompletedTask;
+        public Task MoveToTrashBatchAsync(Guid accountId, string folderName, IList<string> messageIds, CancellationToken ct = default) => Task.CompletedTask;
+        public Task PermanentlyDeleteBatchAsync(Guid accountId, string folderName, IList<string> messageIds, CancellationToken ct = default) => Task.CompletedTask;
+        public Task NoOpAsync(Guid accountId, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<int> CountTrashMessagesAsync(Guid accountId, CancellationToken ct = default) => Task.FromResult(0);
+        public Task<int> EmptyTrashAsync(Guid accountId, CancellationToken ct = default) => Task.FromResult(0);
+        public Task<IList<string>> GetFolderMessageIdsAsync(Guid accountId, string folderName, CancellationToken ct = default) => Task.FromResult<IList<string>>(Array.Empty<string>());
+        public Task<IReadOnlyDictionary<string, string>> FetchPreviewsAsync(Guid accountId, string folderName, IList<string> messageIds, int maxLines, CancellationToken ct = default) => Task.FromResult<IReadOnlyDictionary<string, string>>(new Dictionary<string, string>());
+        public Task<int> PollAsync(Guid accountId, string folderName, CancellationToken ct = default) => Task.FromResult(0);
+        public Task<(int Total, int Unread)> GetInboxStatusAsync(Guid accountId, CancellationToken ct = default) => Task.FromResult((0, 0));
+        public Task<string?> FindDraftsFolderNameAsync(Guid accountId, CancellationToken ct = default) => Task.FromResult<string?>(null);
+        public Task<string> AppendDraftAsync(Guid accountId, ComposeModel draft, string? replaceMessageId, CancellationToken ct = default) => Task.FromResult("0");
+        public Task AppendToSentAsync(Guid accountId, ComposeModel sent, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<byte[]> DownloadAttachmentAsync(Guid accountId, string folderName, string messageId, string partSpecifier, CancellationToken ct = default) => Task.FromResult(Array.Empty<byte>());
+        public Task CopyMessagesAsync(Guid accountId, string folderName, IList<string> messageIds, string destinationFolder, CancellationToken ct = default) => Task.CompletedTask;
+        public Task MoveMessagesAsync(Guid accountId, string folderName, IList<string> messageIds, string destinationFolder, CancellationToken ct = default) => Task.CompletedTask;
+        public Task CreateFolderAsync(Guid accountId, string? parentFolderName, string name, CancellationToken ct = default) => Task.CompletedTask;
+        public Task DeleteFolderAsync(Guid accountId, string folderName, CancellationToken ct = default) => Task.CompletedTask;
+        public Task RenameFolderAsync(Guid accountId, string folderName, string newName, string? newParentFolderName, CancellationToken ct = default) => Task.CompletedTask;
+        public Task CopyFolderAsync(Guid accountId, string folderName, string? destinationParentName, CancellationToken ct = default) => Task.CompletedTask;
+        public void Dispose() { }
+    }
+
+    /// <summary>Local store whose LoadDetailAsync always returns a detail — the cache-hit path.</summary>
+    private sealed class CacheHitStore : ILocalStoreService
+    {
+        public Task<MailMessageDetail?> LoadDetailAsync(Guid accountId, string folderName, string messageId)
+            => Task.FromResult<MailMessageDetail?>(new MailMessageDetail
+            {
+                MessageId  = messageId,
+                AccountId  = accountId,
+                FolderName = folderName,
+            });
+
+        public void Initialize() { }
+        public Task UpsertSummariesAsync(IEnumerable<MailMessageSummary> summaries) => Task.CompletedTask;
+        public Task<List<MailMessageSummary>> LoadAllSummariesAsync() => Task.FromResult(new List<MailMessageSummary>());
+        public Task<List<MailMessageSummary>> LoadAllSummariesAsync(Guid accountId) => Task.FromResult(new List<MailMessageSummary>());
+        public Task<List<MailMessageSummary>> LoadFolderSummariesAsync(Guid accountId, string folderName, int? limit = null) => Task.FromResult(new List<MailMessageSummary>());
+        public Task DeleteSummariesAsync(Guid accountId, string folderName, IEnumerable<string> messageIds) => Task.CompletedTask;
+        public Task DeleteAccountDataAsync(Guid accountId) => Task.CompletedTask;
+        public Task UpdateIsReadAsync(Guid accountId, string folderName, string messageId, bool isRead) => Task.CompletedTask;
+        public Task UpdateIsReadBatchAsync(IEnumerable<(Guid AccountId, string FolderName, string MessageId)> items, bool isRead) => Task.CompletedTask;
+        public Task UpdatePreviewAsync(Guid accountId, string folderName, string messageId, string preview) => Task.CompletedTask;
+        public Task UpdatePreviewsBatchAsync(Guid accountId, string folderName, IEnumerable<(string MessageId, string Preview)> updates) => Task.CompletedTask;
+        public Task<bool> HasSummariesMissingRecipientsAsync() => Task.FromResult(false);
+        public Task UpsertDetailAsync(MailMessageDetail detail) => Task.CompletedTask;
+        public Task<string> GetMaxMessageKeyAsync(Guid accountId, string folderName) => Task.FromResult("0");
+        public Task<HashSet<string>> GetAllMessageIdsAsync(Guid accountId, string folderName) => Task.FromResult(new HashSet<string>());
+        public Task<int> CountSummariesAsync(Guid accountId) => Task.FromResult(0);
+        public Task<DateTimeOffset?> GetOldestMessageDateAsync(Guid accountId) => Task.FromResult<DateTimeOffset?>(null);
+        public Task UpdateFlagIdAsync(Guid accountId, string folderName, string messageId, string? flagId) => Task.CompletedTask;
+        public Task UpdateFlagIdBatchAsync(IEnumerable<(Guid AccountId, string FolderName, string MessageId)> items, string? flagId) => Task.CompletedTask;
+        public Task UpsertCalendarEventAsync(CalendarEvent evt) => Task.CompletedTask;
+        public Task<List<CalendarEvent>> LoadCalendarEventsAsync() => Task.FromResult(new List<CalendarEvent>());
+        public Task UpdateCalendarResponseStatusAsync(string uid, Guid accountId, CalendarResponseStatus status) => Task.CompletedTask;
+        public Task DeleteCalendarEventAsync(string uid, Guid accountId) => Task.CompletedTask;
+        public Task<List<(Guid AccountId, string FolderName, string MessageId, string IcsText)>> LoadAllCalendarIcsAsync()
+            => Task.FromResult(new List<(Guid, string, string, string)>());
+        public Task ClearOrphanedCalendarSourceLinksAsync() => Task.CompletedTask;
+        public Task<string?> GetDeltaTokenAsync(Guid accountId, string folderId) => Task.FromResult<string?>(null);
+        public Task SetDeltaTokenAsync(Guid accountId, string folderId, string deltaToken) => Task.CompletedTask;
+    }
+}

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -3095,7 +3095,20 @@ public partial class MainViewModel : ObservableObject, IDisposable
             // folder unread counts on this path too — otherwise they stay stale until the next
             // manual refresh (issue #227 follow-up).
             if (wasUnread)
+            {
                 ScheduleFolderCountRefresh(summary.AccountId);
+
+                // Mark read on the server explicitly rather than relying on the body fetch's
+                // \Seen side effect. In cached mode the detail is usually served from the local
+                // store — prefetched messages are cached without \Seen (PrefetchMessageDetailAsync
+                // uses markRead: false) — so GetMessageDetailAsync, the only thing that flags the
+                // server, never runs and the message stays unread in other clients (issue #225).
+                // AddFlags(\Seen) is idempotent, so re-flagging on the cache-miss path is harmless.
+                // Online mode already flagged it during the GetMessageDetailAsync fetch above.
+                if (!OnlineMode)
+                    _imap.MarkReadAsync(summary.AccountId, summary.FolderName, summary.MessageId)
+                        .LogFaults("mark read on open");
+            }
             if (!OnlineMode)
             {
                 _localStore.UpdateIsReadAsync(summary.AccountId, summary.FolderName, summary.MessageId, true)

--- a/QuickMail/Views/MessageWindow.xaml.cs
+++ b/QuickMail/Views/MessageWindow.xaml.cs
@@ -230,6 +230,15 @@ public partial class MessageWindow : Window
 
             _vm.MessageDetail = detail;
             await ShowMessageBodyAsync(detail);
+
+            // Opening a message in a standalone window must mark it read on the server, same as
+            // the reading pane and tabs do. Loading here is cache-first, so relying on the body
+            // fetch's \Seen side effect would leave prefetched (cache-hit) messages unread in
+            // other clients (issue #225). MarkReadAction routes through MainViewModel, which
+            // updates the summary, the local store, and the server, and is a no-op when already
+            // read. Runs after the body is shown so a load failure never marks an unread message.
+            if (summary.IsRead == false)
+                _vm.MarkReadCommand.Execute(null);
         }
         catch (OperationCanceledException) { /* window closed mid-load — normal */ }
         catch (Exception ex)

--- a/QuickMail/Views/MessageWindow.xaml.cs
+++ b/QuickMail/Views/MessageWindow.xaml.cs
@@ -234,9 +234,10 @@ public partial class MessageWindow : Window
             // Opening a message in a standalone window must mark it read on the server, same as
             // the reading pane and tabs do. Loading here is cache-first, so relying on the body
             // fetch's \Seen side effect would leave prefetched (cache-hit) messages unread in
-            // other clients (issue #225). MarkReadAction routes through MainViewModel, which
-            // updates the summary, the local store, and the server, and is a no-op when already
-            // read. Runs after the body is shown so a load failure never marks an unread message.
+            // other clients (issue #225). MarkReadCommand invokes MarkReadAction, which MainWindow
+            // wires to MainViewModel.MarkMessagesReadAsync — that updates the summary, the local
+            // store, and the server, and is a no-op when already read. Runs after the body is
+            // shown so a load failure never marks an unread message.
             if (summary.IsRead == false)
                 _vm.MarkReadCommand.Execute(null);
         }


### PR DESCRIPTION
## Root cause

In cached (default, non-online) mode, opening a message serves its detail from the local SQLite store on a cache hit. The IMAP server `\Seen` flag was only being set as a *side effect* of `ImapMailService.GetMessageDetailAsync`, which runs only on a cache **miss**. Prefetched messages are cached by `PrefetchMessageDetailAsync` with `markRead: false`, so on open they were served straight from cache — `GetMessageDetailAsync` never ran, and the server was never flagged. Result: messages showed as read in QuickMail but stayed unread in other clients (Outlook, Apple Mail).

## The fix

Mark read on the server **explicitly** at open time rather than depending on the fetch side effect, across all three open modes:

1. **Reading pane and tab modes** — `MainViewModel.SelectMessageAsync`: when opening an unread message in cached mode, explicitly call `_imap.MarkReadAsync(...)` (fire-and-forget with `.LogFaults`). Guarded by `if (!OnlineMode)` so the online path is unaffected — online already flags the server during the `GetMessageDetailAsync` fetch, so there is no double-flag. `AddFlags(\Seen)` is idempotent, so re-flagging on the cache-miss path is harmless.
2. **Standalone window mode** — `MessageWindow.LoadSelectedMessageAsync`: after the body loads, auto-marks read via `_vm.MarkReadCommand.Execute(null)`. This routes through `MessageWindowViewModel.MarkReadAction` → `MainViewModel.MarkMessagesReadAsync`, which updates the summary, the local store, and the server (`MarkReadBatchAsync`). It runs *after* the body is shown so a load failure never marks an unread message, and is guarded by `if (summary.IsRead == false)`. `MarkMessagesReadAsync` additionally filters to `!m.IsRead`, so the call is a no-op when already read.

## Test coverage

New `QuickMail.Tests/MarkReadOnOpenTests.cs`:
- `OpeningCachedUnreadMessage_MarksReadOnServer` — cache-hit path (`LoadDetailAsync` returns a detail, so the IMAP body fetch never runs) still records a `MarkReadAsync` server call and flips the summary to read.
- `OpeningAlreadyReadMessage_DoesNotMarkReadAgain` — an already-read message makes no server call.

## Verification

- `dotnet build QuickMail/QuickMail.csproj -c Release` — 0 errors.
- `dotnet test --filter "FullyQualifiedName~MarkReadOnOpenTests"` — 2 passed.

Note: the full parallel test run has a known pre-existing flake, `SelectorItemAccessibilityTests.ThemeComboBox_ItemPeerNames_AreCleanDisplayNames`, which is unrelated to this change and also fails on clean `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)