### PR TITLE
Add Windows notifications + run-in-background (closes #240)

### DIFF
--- a/QuickMail.Tests/ConfigServiceSaveTests.cs
+++ b/QuickMail.Tests/ConfigServiceSaveTests.cs
@@ -49,20 +49,20 @@ public class ConfigServiceSaveTests
     }
 
     [Fact]
-    public void NotifyOnNewMail_DefaultsOn_AndRoundTrips()
+    public void NotifyOnNewMail_DefaultsOff_AndRoundTrips()
     {
         var profile = MakeTempProfile();
         var service = new ConfigService(profile);
 
-        // Default is on when the key is absent from a fresh config.
-        Assert.True(service.Load().NotifyOnNewMail);
+        // Default is off (opt-in) when the key is absent from a fresh config.
+        Assert.False(service.Load().NotifyOnNewMail);
 
         var config = service.Load();
-        config.NotifyOnNewMail = false;
+        config.NotifyOnNewMail = true;
         service.Save(config);
 
         var reloaded = new ConfigService(profile).Load();
-        Assert.False(reloaded.NotifyOnNewMail);
+        Assert.True(reloaded.NotifyOnNewMail);
     }
 
     [Fact]

--- a/QuickMail.Tests/ConfigServiceSaveTests.cs
+++ b/QuickMail.Tests/ConfigServiceSaveTests.cs
@@ -49,6 +49,23 @@ public class ConfigServiceSaveTests
     }
 
     [Fact]
+    public void NotifyOnNewMail_DefaultsOn_AndRoundTrips()
+    {
+        var profile = MakeTempProfile();
+        var service = new ConfigService(profile);
+
+        // Default is on when the key is absent from a fresh config.
+        Assert.True(service.Load().NotifyOnNewMail);
+
+        var config = service.Load();
+        config.NotifyOnNewMail = false;
+        service.Save(config);
+
+        var reloaded = new ConfigService(profile).Load();
+        Assert.False(reloaded.NotifyOnNewMail);
+    }
+
+    [Fact]
     public void Save_LeavesNoTempFileBehind()
     {
         var profile = MakeTempProfile();

--- a/QuickMail.Tests/ConfigServiceSaveTests.cs
+++ b/QuickMail.Tests/ConfigServiceSaveTests.cs
@@ -66,6 +66,25 @@ public class ConfigServiceSaveTests
     }
 
     [Fact]
+    public void CloseToTray_DefaultsOff_AndRoundTrips()
+    {
+        var profile = MakeTempProfile();
+        var service = new ConfigService(profile);
+
+        Assert.False(service.Load().CloseToTray);       // default off
+        Assert.False(service.Load().TrayHintShown);     // default off
+
+        var config = service.Load();
+        config.CloseToTray = true;
+        config.TrayHintShown = true;
+        service.Save(config);
+
+        var reloaded = new ConfigService(profile).Load();
+        Assert.True(reloaded.CloseToTray);
+        Assert.True(reloaded.TrayHintShown);
+    }
+
+    [Fact]
     public void Save_LeavesNoTempFileBehind()
     {
         var profile = MakeTempProfile();

--- a/QuickMail.Tests/MainViewModelFlagTests.cs
+++ b/QuickMail.Tests/MainViewModelFlagTests.cs
@@ -97,8 +97,8 @@ public class MainViewModelFlagTests
 #pragma warning restore CS0067
         public void Fire(IReadOnlyList<MailMessageSummary> messages) => FolderSynced?.Invoke(messages);
         public Task SyncAllAccountsAsync(IEnumerable<AccountModel> accounts, IReadOnlyDictionary<Guid, List<MailFolderModel>> cachedFolders, CancellationToken ct) => Task.CompletedTask;
-        public Task SyncOneFolderAsync(AccountModel account, MailFolderModel folder, CancellationToken ct) => Task.CompletedTask;
-        public Task SyncOneFolderOnlineAsync(AccountModel account, MailFolderModel folder, CancellationToken ct) => Task.CompletedTask;
+        public Task<IReadOnlyList<MailMessageSummary>> SyncOneFolderAsync(AccountModel account, MailFolderModel folder, CancellationToken ct) => Task.FromResult<IReadOnlyList<MailMessageSummary>>(Array.Empty<MailMessageSummary>());
+        public Task<IReadOnlyList<MailMessageSummary>> SyncOneFolderOnlineAsync(AccountModel account, MailFolderModel folder, CancellationToken ct) => Task.FromResult<IReadOnlyList<MailMessageSummary>>(Array.Empty<MailMessageSummary>());
         public DateTimeOffset? LastSyncedUtc(Guid accountId) => null;
     }
 

--- a/QuickMail.Tests/NewMailFilterTests.cs
+++ b/QuickMail.Tests/NewMailFilterTests.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using QuickMail.Helpers;
+using QuickMail.Models;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// Covers <see cref="NewMailFilter"/> — the "genuinely new" rules that gate new-mail toasts:
+/// unread only, arrived at/after the session threshold, and de-duplicated across repeated fires.
+/// </summary>
+public class NewMailFilterTests
+{
+    private static readonly Guid Acct = Guid.NewGuid();
+    private static readonly DateTimeOffset Threshold = new(2026, 7, 11, 12, 0, 0, TimeSpan.Zero);
+
+    private static MailMessageSummary Msg(string id, DateTimeOffset date, bool read = false) => new()
+    {
+        MessageId = id,
+        AccountId = Acct,
+        From = "Jane <jane@example.com>",
+        Subject = "Hello",
+        Date = date,
+        IsRead = read,
+    };
+
+    [Fact]
+    public void FreshUnreadMessage_IsSelected()
+    {
+        var seen = new HashSet<string>();
+        var result = NewMailFilter.SelectNew(
+            new[] { Msg("1", Threshold.AddMinutes(5)) }, Threshold, seen);
+
+        Assert.Single(result);
+        Assert.Equal("1", result[0].MessageId);
+    }
+
+    [Fact]
+    public void MessageBeforeThreshold_IsExcluded()
+    {
+        var seen = new HashSet<string>();
+        var result = NewMailFilter.SelectNew(
+            new[] { Msg("1", Threshold.AddMinutes(-1)) }, Threshold, seen);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void MessageAtThreshold_IsIncluded()
+    {
+        var seen = new HashSet<string>();
+        var result = NewMailFilter.SelectNew(
+            new[] { Msg("1", Threshold) }, Threshold, seen);
+
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public void ReadMessage_IsExcluded()
+    {
+        var seen = new HashSet<string>();
+        var result = NewMailFilter.SelectNew(
+            new[] { Msg("1", Threshold.AddMinutes(5), read: true) }, Threshold, seen);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void RepeatedFire_NotifiesOnlyOnce()
+    {
+        var seen = new HashSet<string>();
+        var m = Msg("1", Threshold.AddMinutes(5));
+
+        var first  = NewMailFilter.SelectNew(new[] { m }, Threshold, seen);
+        var second = NewMailFilter.SelectNew(new[] { m }, Threshold, seen);
+
+        Assert.Single(first);
+        Assert.Empty(second); // key already recorded — no duplicate toast
+    }
+
+    [Fact]
+    public void MixedBatch_SelectsOnlyTheGenuinelyNew()
+    {
+        var seen = new HashSet<string>();
+        var batch = new[]
+        {
+            Msg("old",   Threshold.AddMinutes(-10)),           // before launch
+            Msg("read",  Threshold.AddMinutes(5), read: true), // already read
+            Msg("new1",  Threshold.AddMinutes(5)),             // genuinely new
+            Msg("new2",  Threshold.AddMinutes(6)),             // genuinely new
+        };
+
+        var result = NewMailFilter.SelectNew(batch, Threshold, seen);
+
+        Assert.Equal(new[] { "new1", "new2" }, result.Select(m => m.MessageId).ToArray());
+    }
+}

--- a/QuickMail.Tests/QuickMail.Tests.csproj
+++ b/QuickMail.Tests/QuickMail.Tests.csproj
@@ -1,7 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <!-- Must match (or exceed) the main project's Windows-10 TFM: a project can only reference
+         another whose platform version is <= its own. -->
+    <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
     <UseWPF>true</UseWPF>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/QuickMail.Tests/SelectorItemAccessibilityTests.cs
+++ b/QuickMail.Tests/SelectorItemAccessibilityTests.cs
@@ -1,8 +1,10 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
 using System.Windows.Automation.Peers;
 using System.Windows.Controls;
+using System.Windows.Threading;
 using QuickMail.Models;
 using QuickMail.ViewModels;
 using Xunit;
@@ -52,12 +54,31 @@ public class SelectorItemAccessibilityTests
         {
             combo.IsDropDownOpen = true;
             combo.UpdateLayout();
+            DrainDispatcher(); // let item containers / peers realize before reading names
+
+            // GetChildren() also surfaces the ComboBox's editable/selection chrome peers (e.g. a
+            // TextBoxAutomationPeer with no name), and whether those are realized is load-dependent —
+            // in isolation only the item peers appear, but under CPU pressure from the parallel suite
+            // an empty-named TextBox peer is realized at index 0 too. Filter to the item peers (the
+            // elements a screen reader announces when navigating the list) so the assertion is stable
+            // and still catches a leaked type-name / record-dump ToString on any item.
             var names = (UIElementAutomationPeer.CreatePeerForElement(combo).GetChildren() ?? new List<AutomationPeer>())
+                .OfType<ListBoxItemAutomationPeer>()
                 .Select(p => p.GetName())
                 .ToList();
             Assert.Equal(new[] { "System", "Parchment", "Parchment Dark" }, names);
         }
         finally { window.Close(); }
+    }
+
+    // Pumps the STA dispatcher until all queued work down to SystemIdle priority (layout,
+    // container generation, peer realization) has run.
+    private static void DrainDispatcher()
+    {
+        var frame = new DispatcherFrame();
+        Dispatcher.CurrentDispatcher.BeginInvoke(
+            DispatcherPriority.SystemIdle, new Action(() => frame.Continue = false));
+        Dispatcher.PushFrame(frame);
     }
 
     // Cheap, fast guard on the item types themselves: their ToString() must be display

--- a/QuickMail.Tests/SessionFeaturesTests.cs
+++ b/QuickMail.Tests/SessionFeaturesTests.cs
@@ -265,16 +265,16 @@ public class IdleNewMailTests
             IReadOnlyDictionary<Guid, List<MailFolderModel>> cachedFolders, CancellationToken ct)
             => Task.CompletedTask;
 
-        public Task SyncOneFolderAsync(AccountModel account, MailFolderModel folder, CancellationToken ct)
+        public Task<IReadOnlyList<MailMessageSummary>> SyncOneFolderAsync(AccountModel account, MailFolderModel folder, CancellationToken ct)
         {
             SyncOneFolderCalled.TrySetResult((account, folder));
-            return Task.CompletedTask;
+            return Task.FromResult<IReadOnlyList<MailMessageSummary>>(Array.Empty<MailMessageSummary>());
         }
 
-        public Task SyncOneFolderOnlineAsync(AccountModel account, MailFolderModel folder, CancellationToken ct)
+        public Task<IReadOnlyList<MailMessageSummary>> SyncOneFolderOnlineAsync(AccountModel account, MailFolderModel folder, CancellationToken ct)
         {
             SyncOneFolderOnlineCalled.TrySetResult((account, folder));
-            return Task.CompletedTask;
+            return Task.FromResult<IReadOnlyList<MailMessageSummary>>(Array.Empty<MailMessageSummary>());
         }
 
         public DateTimeOffset? LastSyncedUtc(Guid accountId) => null;

--- a/QuickMail.Tests/SettingsViewModelTests.cs
+++ b/QuickMail.Tests/SettingsViewModelTests.cs
@@ -54,14 +54,14 @@ public class SettingsViewModelTests
         var configService = new StubConfigService();
         var registry = new StubCommandRegistry();
 
-        // Default is on.
+        // Default is off (opt-in).
         var vm = new SettingsViewModel(configService, registry);
-        Assert.True(vm.NotifyOnNewMail);
+        Assert.False(vm.NotifyOnNewMail);
 
-        vm.NotifyOnNewMail = false;
+        vm.NotifyOnNewMail = true;
         vm.SaveCommand.Execute(null);
 
-        Assert.False(configService.Load().NotifyOnNewMail);
+        Assert.True(configService.Load().NotifyOnNewMail);
     }
 
     [Fact]

--- a/QuickMail.Tests/SettingsViewModelTests.cs
+++ b/QuickMail.Tests/SettingsViewModelTests.cs
@@ -49,6 +49,22 @@ public class SettingsViewModelTests
     }
 
     [Fact]
+    public void NotifyOnNewMail_LoadsAndSaves()
+    {
+        var configService = new StubConfigService();
+        var registry = new StubCommandRegistry();
+
+        // Default is on.
+        var vm = new SettingsViewModel(configService, registry);
+        Assert.True(vm.NotifyOnNewMail);
+
+        vm.NotifyOnNewMail = false;
+        vm.SaveCommand.Execute(null);
+
+        Assert.False(configService.Load().NotifyOnNewMail);
+    }
+
+    [Fact]
     public void SaveWithHotkeys_PersistsHotkeysInConfig()
     {
         var configService = new StubConfigService();

--- a/QuickMail.Tests/SettingsViewModelTests.cs
+++ b/QuickMail.Tests/SettingsViewModelTests.cs
@@ -65,6 +65,21 @@ public class SettingsViewModelTests
     }
 
     [Fact]
+    public void CloseToTray_LoadsAndSaves()
+    {
+        var configService = new StubConfigService();
+        var registry = new StubCommandRegistry();
+
+        var vm = new SettingsViewModel(configService, registry);
+        Assert.False(vm.CloseToTray); // default off
+
+        vm.CloseToTray = true;
+        vm.SaveCommand.Execute(null);
+
+        Assert.True(configService.Load().CloseToTray);
+    }
+
+    [Fact]
     public void SaveWithHotkeys_PersistsHotkeysInConfig()
     {
         var configService = new StubConfigService();

--- a/QuickMail.Tests/StubServices.cs
+++ b/QuickMail.Tests/StubServices.cs
@@ -188,8 +188,8 @@ sealed class StubSyncService : ISyncService
     public event Action<int, int>? SyncProgressChanged;
 #pragma warning restore CS0067
     public Task SyncAllAccountsAsync(IEnumerable<AccountModel> accounts, IReadOnlyDictionary<Guid, List<MailFolderModel>> cachedFolders, CancellationToken ct) => Task.CompletedTask;
-    public Task SyncOneFolderAsync(AccountModel account, MailFolderModel folder, CancellationToken ct) => Task.CompletedTask;
-    public Task SyncOneFolderOnlineAsync(AccountModel account, MailFolderModel folder, CancellationToken ct) => Task.CompletedTask;
+    public Task<IReadOnlyList<MailMessageSummary>> SyncOneFolderAsync(AccountModel account, MailFolderModel folder, CancellationToken ct) => Task.FromResult<IReadOnlyList<MailMessageSummary>>(Array.Empty<MailMessageSummary>());
+    public Task<IReadOnlyList<MailMessageSummary>> SyncOneFolderOnlineAsync(AccountModel account, MailFolderModel folder, CancellationToken ct) => Task.FromResult<IReadOnlyList<MailMessageSummary>>(Array.Empty<MailMessageSummary>());
     public DateTimeOffset? LastSyncedUtc(Guid accountId) => null;
 }
 

--- a/QuickMail.Tests/WindowsToastNotificationServiceTests.cs
+++ b/QuickMail.Tests/WindowsToastNotificationServiceTests.cs
@@ -1,0 +1,41 @@
+using System;
+using QuickMail.Models;
+using QuickMail.Services;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// Smoke coverage for <see cref="WindowsToastNotificationService"/>. A headless test can't assert
+/// that a toast actually renders, so these verify the guard rails: construction and the empty-set
+/// path never throw, and <see cref="INotificationService.IsSupported"/> is queryable. The tests
+/// deliberately do not fire a real toast so the suite stays free of on-screen side effects.
+/// </summary>
+public class WindowsToastNotificationServiceTests
+{
+    [Fact]
+    public void Construction_AndIsSupported_DoNotThrow()
+    {
+        using var svc = new WindowsToastNotificationService();
+        _ = svc.IsSupported; // returns a bool without throwing
+    }
+
+    [Fact]
+    public void ShowNewMail_WithEmptySet_IsANoOp()
+    {
+        using var svc = new WindowsToastNotificationService();
+        svc.ShowNewMail("Account", Guid.NewGuid(), Array.Empty<MailMessageSummary>());
+        // No exception = pass. An empty set must never attempt to build or show a toast.
+    }
+
+    [Theory]
+    [InlineData("Jane Smith <jane@example.com>", "Jane Smith")]   // name + address → name only
+    [InlineData("\"Smith, Jane\" <jane@example.com>", "Smith, Jane")] // quoted name preserved
+    [InlineData("<jane@example.com>", "jane@example.com")]         // no display name → bare address
+    [InlineData("jane@example.com", "jane@example.com")]           // bare address
+    [InlineData("", "")]                                          // empty stays empty
+    public void SenderDisplayName_StripsAddress(string from, string expected)
+    {
+        Assert.Equal(expected, WindowsToastNotificationService.SenderDisplayName(from));
+    }
+}

--- a/QuickMail.Tests/WindowsToastNotificationServiceTests.cs
+++ b/QuickMail.Tests/WindowsToastNotificationServiceTests.cs
@@ -1,4 +1,5 @@
 using System;
+using Microsoft.Toolkit.Uwp.Notifications;
 using QuickMail.Models;
 using QuickMail.Services;
 using Xunit;
@@ -26,6 +27,80 @@ public class WindowsToastNotificationServiceTests
         using var svc = new WindowsToastNotificationService();
         svc.ShowNewMail("Account", Guid.NewGuid(), Array.Empty<MailMessageSummary>());
         // No exception = pass. An empty set must never attempt to build or show a toast.
+    }
+
+    [Fact]
+    public void ParseActivation_ExtractsAccountFolderAndMessage()
+    {
+        var accountId = Guid.NewGuid();
+        var arg = new ToastArguments()
+            .Add("action", "openMail")
+            .Add("accountId", accountId.ToString())
+            .Add("folder", "INBOX")
+            .Add("messageId", "42")
+            .ToString();
+
+        var act = WindowsToastNotificationService.ParseActivation(arg);
+
+        Assert.NotNull(act);
+        Assert.Equal(accountId, act!.AccountId);
+        Assert.Equal("INBOX", act.Folder);
+        Assert.Equal("42", act.MessageId);
+    }
+
+    [Fact]
+    public void ParseActivation_MultiMessageToast_HasNoMessageId()
+    {
+        var accountId = Guid.NewGuid();
+        var arg = new ToastArguments()
+            .Add("action", "openMail")
+            .Add("accountId", accountId.ToString())
+            .Add("folder", "INBOX")
+            .ToString();
+
+        var act = WindowsToastNotificationService.ParseActivation(arg);
+
+        Assert.NotNull(act);
+        Assert.Equal(accountId, act!.AccountId);
+        Assert.Null(act.MessageId); // no single target -> handler just foregrounds
+    }
+
+    [Fact]
+    public void ParseActivation_InfoToast_ReturnsNull()
+    {
+        var arg = new ToastArguments().Add("action", "info").ToString();
+        Assert.Null(WindowsToastNotificationService.ParseActivation(arg));
+    }
+
+    [Fact]
+    public void DispatchActivation_BuffersUntilFirstSubscriber_ThenReplays()
+    {
+        using var svc = new WindowsToastNotificationService();
+        var act = new NotificationActivation(Guid.NewGuid(), "INBOX", "7");
+
+        // Arrives before anyone subscribes (cold start) — must not be dropped.
+        svc.DispatchActivation(act);
+
+        NotificationActivation? received = null;
+        svc.Activated += a => received = a; // first subscriber gets the buffered activation
+
+        Assert.Same(act, received);
+    }
+
+    [Fact]
+    public void DispatchActivation_WithSubscriber_DeliversImmediately_AndOnce()
+    {
+        using var svc = new WindowsToastNotificationService();
+        var count = 0;
+        svc.Activated += _ => count++;
+
+        svc.DispatchActivation(new NotificationActivation(Guid.NewGuid(), "INBOX", "1"));
+        Assert.Equal(1, count);
+
+        // A late second subscriber must NOT receive the already-delivered activation.
+        NotificationActivation? late = null;
+        svc.Activated += a => late = a;
+        Assert.Null(late);
     }
 
     [Theory]

--- a/QuickMail/App.xaml.cs
+++ b/QuickMail/App.xaml.cs
@@ -245,12 +245,12 @@ public partial class App : Application
             mainVm.RegisterAccountBackend = a => mailRouter.RegisterAccount(a.Id, BackendFor(a));
             mainVm.LoadAccountList(accounts);
 
-            var mainWindow = new MainWindow(mainVm, smtpService, accountService, credentialService, mailRouter, oauthService, commandRegistry, contactService, configService, localStore, viewService, ruleService, templateService, featureGate, flagService, customDictionary, themeService, _bugReportService);
+            var mainWindow = new MainWindow(mainVm, smtpService, accountService, credentialService, mailRouter, oauthService, commandRegistry, contactService, configService, localStore, viewService, ruleService, templateService, featureGate, flagService, customDictionary, themeService, _bugReportService, _notificationService);
 
-            // Clicking a new-mail toast brings QuickMail to the foreground. OnActivated may fire on
-            // a background thread, so marshal to the UI thread before touching the window.
-            _notificationService.Activated += () =>
-                mainWindow.Dispatcher.BeginInvoke(() => mainWindow.RestoreAndActivate());
+            // Clicking a new-mail toast brings QuickMail to the foreground and opens the referenced
+            // message. OnActivated may fire on a background thread, so marshal to the UI thread first.
+            _notificationService.Activated += act =>
+                mainWindow.Dispatcher.BeginInvoke(() => mainWindow.HandleNotificationActivation(act));
 
             mainWindow.Show();
         }

--- a/QuickMail/App.xaml.cs
+++ b/QuickMail/App.xaml.cs
@@ -22,6 +22,7 @@ public partial class App : Application
     private UpdateCheckService? _updateCheckService;
     private ThemeService? _themeService;
     private BugReportService? _bugReportService;
+    private WindowsToastNotificationService? _notificationService;
 
     // Explicit entry point (App.xaml compiles as Page; see csproj StartupObject). Velopack must
     // run before any WPF initialization: on install/update/uninstall its hooks handle the event
@@ -236,14 +237,21 @@ public partial class App : Application
 
             _updateCheckService = new UpdateCheckService(configService, ParseUpdateFeed(e.Args));
             _bugReportService   = new BugReportService(credentialService);
+            _notificationService = new WindowsToastNotificationService();
             var mainVm = new MainViewModel(
                 mailRouter, accountService, credentialService, localStore, oauthService, syncService, configService, commandRegistry, viewService, ruleService, smtpService,
                 onlineMode: onlineMode, flagService: flagService, calendarService: calendarService, changeNotifier: _changeNotifier, updateCheckService: _updateCheckService,
-                themeService: themeService);
+                themeService: themeService, notificationService: _notificationService);
             mainVm.RegisterAccountBackend = a => mailRouter.RegisterAccount(a.Id, BackendFor(a));
             mainVm.LoadAccountList(accounts);
 
             var mainWindow = new MainWindow(mainVm, smtpService, accountService, credentialService, mailRouter, oauthService, commandRegistry, contactService, configService, localStore, viewService, ruleService, templateService, featureGate, flagService, customDictionary, themeService, _bugReportService);
+
+            // Clicking a new-mail toast brings QuickMail to the foreground. OnActivated may fire on
+            // a background thread, so marshal to the UI thread before touching the window.
+            _notificationService.Activated += () =>
+                mainWindow.Dispatcher.BeginInvoke(() => mainWindow.RestoreAndActivate());
+
             mainWindow.Show();
         }
         catch (Exception ex)
@@ -268,6 +276,7 @@ public partial class App : Application
         _updateCheckService?.Dispose();
         _bugReportService?.Dispose();
         _themeService?.Dispose();   // unsubscribes SystemParameters/SystemEvents static events
+        _notificationService?.Dispose(); // unhooks the toast-activation static event
         base.OnExit(e);
     }
 

--- a/QuickMail/Helpers/NewMailFilter.cs
+++ b/QuickMail/Helpers/NewMailFilter.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using QuickMail.Models;
+
+namespace QuickMail.Helpers;
+
+/// <summary>
+/// Pure logic for deciding which just-synced inbox messages are "genuinely new" and should
+/// raise a new-mail notification. Kept separate from <c>MainViewModel</c> so the rules are
+/// unit-testable without a live VM. See docs/planning/notifications-pm-dev-spec.md.
+/// </summary>
+internal static class NewMailFilter
+{
+    // Separator that cannot appear in a Guid string or an IMAP message id, so the composite
+    // key is unambiguous.
+    private const string Sep = "|";
+
+    /// <summary>Per-session identity for a message across repeated IDLE fires.</summary>
+    public static string Key(MailMessageSummary m) => m.AccountId + Sep + m.MessageId;
+
+    /// <summary>
+    /// Returns the genuinely-new messages from <paramref name="incoming"/>: unread, dated at or
+    /// after <paramref name="thresholdUtc"/> (so the startup backlog is excluded), and whose key
+    /// is not already in <paramref name="alreadyNotified"/>. Survivors' keys are added to
+    /// <paramref name="alreadyNotified"/> so a later call for the same message returns nothing.
+    /// </summary>
+    public static List<MailMessageSummary> SelectNew(
+        IEnumerable<MailMessageSummary> incoming,
+        DateTimeOffset thresholdUtc,
+        ISet<string> alreadyNotified)
+    {
+        var result = new List<MailMessageSummary>();
+        foreach (var m in incoming)
+        {
+            if (m.IsRead) continue;
+            if (m.Date < thresholdUtc) continue;
+            if (!alreadyNotified.Add(Key(m))) continue;
+            result.Add(m);
+        }
+        return result;
+    }
+}

--- a/QuickMail/Models/ConfigModel.cs
+++ b/QuickMail/Models/ConfigModel.cs
@@ -147,6 +147,11 @@ public class ConfigModel
     /// <summary>Show a confirmation dialog before emptying trash. Default on.</summary>
     public bool ConfirmEmptyTrash { get; set; } = true;
 
+    // ── Notifications ─────────────────────────────────────────────────────────────
+
+    /// <summary>Show a Windows toast notification when new mail arrives in an inbox. Default on.</summary>
+    public bool NotifyOnNewMail { get; set; } = true;
+
     /// <summary>Whether the user has completed the first-run keyboard tutorial.</summary>
     public bool TutorialCompleted { get; set; } = false;
 

--- a/QuickMail/Models/ConfigModel.cs
+++ b/QuickMail/Models/ConfigModel.cs
@@ -152,6 +152,17 @@ public class ConfigModel
     /// <summary>Show a Windows toast notification when new mail arrives in an inbox. Default on.</summary>
     public bool NotifyOnNewMail { get; set; } = true;
 
+    /// <summary>
+    /// When closing the main window, hide QuickMail to the notification area (system tray) instead
+    /// of exiting, so new-mail watchers keep running and notifications keep arriving. Default off
+    /// (existing behaviour: closing the window exits the app).
+    /// </summary>
+    public bool CloseToTray { get; set; } = false;
+
+    /// <summary>Whether the one-time "still running in the notification area" hint has been shown.
+    /// Maintained automatically the first time the window hides to the tray.</summary>
+    public bool TrayHintShown { get; set; } = false;
+
     /// <summary>Whether the user has completed the first-run keyboard tutorial.</summary>
     public bool TutorialCompleted { get; set; } = false;
 

--- a/QuickMail/Models/ConfigModel.cs
+++ b/QuickMail/Models/ConfigModel.cs
@@ -149,8 +149,9 @@ public class ConfigModel
 
     // ── Notifications ─────────────────────────────────────────────────────────────
 
-    /// <summary>Show a Windows toast notification when new mail arrives in an inbox. Default on.</summary>
-    public bool NotifyOnNewMail { get; set; } = true;
+    /// <summary>Show a Windows toast notification when new mail arrives in an inbox. Default off —
+    /// the user opts in from Settings.</summary>
+    public bool NotifyOnNewMail { get; set; } = false;
 
     /// <summary>
     /// When closing the main window, hide QuickMail to the notification area (system tray) instead

--- a/QuickMail/QuickMail.csproj
+++ b/QuickMail/QuickMail.csproj
@@ -2,7 +2,10 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <!-- Windows-10 TFM (1809 / 17763) is required so Microsoft.Toolkit.Uwp.Notifications can
+         call the Windows.UI.Notifications WinRT `.Show()` API for new-mail toasts. Plain
+         net8.0-windows (= windows7.0) does not expose it. See docs/planning/notifications-pm-dev-spec.md. -->
+    <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
@@ -49,6 +52,9 @@
     <PackageReference Include="Microsoft.Identity.Client" Version="4.85.2" />
     <PackageReference Include="Microsoft.Identity.Client.Desktop" Version="4.85.2" />
     <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.85.2" />
+    <!-- Windows toast (app) notifications for unpackaged Win32 apps: ToastNotificationManagerCompat
+         auto-registers the AppUserModelID + COM activator, no MSIX manifest required. -->
+    <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
     <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.4022.49" />
     <PackageReference Include="Roslynator.Analyzers" Version="4.15.0">
       <PrivateAssets>all</PrivateAssets>

--- a/QuickMail/QuickMail.csproj
+++ b/QuickMail/QuickMail.csproj
@@ -9,6 +9,12 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
+    <!-- WinForms is enabled ONLY for the system-tray NotifyIcon (Views/TrayIconManager). WPF has no
+         native tray icon. WinForms types are always fully qualified; the implicit global usings for
+         System.Windows.Forms / System.Drawing are removed below so they never collide with the WPF
+         System.Windows(.Media) types this codebase uses unqualified (Point, Size, Color, Brush,
+         Application, MessageBox, ...). -->
+    <UseWindowsForms>true</UseWindowsForms>
     <Version>0.8.2</Version>
     <AssemblyVersion>0.8.2</AssemblyVersion>
     <FileVersion>0.8.2</FileVersion>
@@ -40,6 +46,13 @@
   <ItemGroup>
     <!-- Built-in themes ship inside the assembly; ThemeStore parses them with the same loader as user theme files. -->
     <EmbeddedResource Include="Themes\BuiltIn\*.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Keep WinForms/Drawing OUT of the implicit global usings (see UseWindowsForms note above) so
+         their type names never collide with the WPF types used unqualified across the codebase. -->
+    <Using Remove="System.Windows.Forms" />
+    <Using Remove="System.Drawing" />
   </ItemGroup>
 
   <ItemGroup>

--- a/QuickMail/Services/ConfigService.cs
+++ b/QuickMail/Services/ConfigService.cs
@@ -248,6 +248,7 @@ public class ConfigService : IConfigService
                         break;
                     case "announceformattingwhilenavigating": config.AnnounceFormattingWhileNavigating = ParseBool(value); break;
                     case "confirmemptytrash":    config.ConfirmEmptyTrash    = ParseBool(value); break;
+                    case "notifyonnewmail":      config.NotifyOnNewMail      = ParseBool(value); break;
                     case "logformat":
                         config.LogFormat = string.Equals(value, "timefirst", StringComparison.OrdinalIgnoreCase) ? "timeFirst" : "actionFirst";
                         break;
@@ -464,6 +465,11 @@ public class ConfigService : IConfigService
         sb.AppendLine($"ConfirmEmptyTrash = {(config.ConfirmEmptyTrash ? "on" : "off")}");
         sb.AppendLine("# Show a confirmation dialog before permanently deleting all messages in trash.");
         sb.AppendLine("# Values: on, off.");
+        sb.AppendLine();
+
+        sb.AppendLine($"NotifyOnNewMail = {(config.NotifyOnNewMail ? "on" : "off")}");
+        sb.AppendLine("# Show a Windows notification when new mail arrives in an inbox.");
+        sb.AppendLine("# Notifications appear while QuickMail is running. Values: on, off.");
         sb.AppendLine();
 
         sb.AppendLine($"LogFormat = {config.LogFormat}");

--- a/QuickMail/Services/ConfigService.cs
+++ b/QuickMail/Services/ConfigService.cs
@@ -249,6 +249,8 @@ public class ConfigService : IConfigService
                     case "announceformattingwhilenavigating": config.AnnounceFormattingWhileNavigating = ParseBool(value); break;
                     case "confirmemptytrash":    config.ConfirmEmptyTrash    = ParseBool(value); break;
                     case "notifyonnewmail":      config.NotifyOnNewMail      = ParseBool(value); break;
+                    case "closetotray":          config.CloseToTray          = ParseBool(value); break;
+                    case "trayhintshown":        config.TrayHintShown        = ParseBool(value); break;
                     case "logformat":
                         config.LogFormat = string.Equals(value, "timefirst", StringComparison.OrdinalIgnoreCase) ? "timeFirst" : "actionFirst";
                         break;
@@ -470,6 +472,17 @@ public class ConfigService : IConfigService
         sb.AppendLine($"NotifyOnNewMail = {(config.NotifyOnNewMail ? "on" : "off")}");
         sb.AppendLine("# Show a Windows notification when new mail arrives in an inbox.");
         sb.AppendLine("# Notifications appear while QuickMail is running. Values: on, off.");
+        sb.AppendLine();
+
+        sb.AppendLine($"CloseToTray = {(config.CloseToTray ? "on" : "off")}");
+        sb.AppendLine("# When you close the main window, keep QuickMail running in the notification");
+        sb.AppendLine("# area (system tray) instead of exiting, so new-mail notifications keep arriving.");
+        sb.AppendLine("# Restore it from the tray icon or a notification. Values: on, off.");
+        sb.AppendLine();
+
+        sb.AppendLine($"TrayHintShown = {(config.TrayHintShown ? "on" : "off")}");
+        sb.AppendLine("# Whether the one-time 'still running in the notification area' hint has been");
+        sb.AppendLine("# shown. Maintained automatically. Values: on, off.");
         sb.AppendLine();
 
         sb.AppendLine($"LogFormat = {config.LogFormat}");

--- a/QuickMail/Services/INotificationService.cs
+++ b/QuickMail/Services/INotificationService.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using QuickMail.Models;
+
+namespace QuickMail.Services;
+
+/// <summary>
+/// Shows Windows toast (app) notifications. The single implementation
+/// (<see cref="WindowsToastNotificationService"/>) wraps the Windows Community Toolkit
+/// notification platform; a null service (tests, unsupported OS) means notifications are
+/// simply not shown. See docs/planning/notifications-pm-dev-spec.md.
+/// </summary>
+public interface INotificationService
+{
+    /// <summary>
+    /// False on a down-level OS or if the notification platform rejected registration.
+    /// Callers must no-op when false.
+    /// </summary>
+    bool IsSupported { get; }
+
+    /// <summary>
+    /// Show a new-mail toast for one account. <paramref name="newMessages"/> is the
+    /// genuinely-new set — already de-duplicated and gated by the caller. Best-effort:
+    /// never throws.
+    /// </summary>
+    void ShowNewMail(string accountLabel, Guid accountId, IReadOnlyList<MailMessageSummary> newMessages);
+
+    /// <summary>
+    /// Raised when the user activates (clicks) a toast. May fire off the UI thread — the
+    /// handler must marshal to the UI thread before touching any window.
+    /// </summary>
+    event Action? Activated;
+}

--- a/QuickMail/Services/INotificationService.cs
+++ b/QuickMail/Services/INotificationService.cs
@@ -5,6 +5,12 @@ using QuickMail.Models;
 namespace QuickMail.Services;
 
 /// <summary>
+/// Identifies what a clicked toast should open. <see cref="MessageId"/> is null for the
+/// "N new messages" toast (no single target — the handler just surfaces the account's inbox).
+/// </summary>
+public sealed record NotificationActivation(Guid AccountId, string? Folder, string? MessageId);
+
+/// <summary>
 /// Shows Windows toast (app) notifications. The single implementation
 /// (<see cref="WindowsToastNotificationService"/>) wraps the Windows Community Toolkit
 /// notification platform; a null service (tests, unsupported OS) means notifications are
@@ -26,8 +32,14 @@ public interface INotificationService
     void ShowNewMail(string accountLabel, Guid accountId, IReadOnlyList<MailMessageSummary> newMessages);
 
     /// <summary>
-    /// Raised when the user activates (clicks) a toast. May fire off the UI thread — the
-    /// handler must marshal to the UI thread before touching any window.
+    /// Show a one-off informational toast (e.g. the "still running in the notification area"
+    /// hint). Best-effort: never throws.
     /// </summary>
-    event Action? Activated;
+    void ShowInfo(string title, string message);
+
+    /// <summary>
+    /// Raised when the user activates (clicks) a toast, carrying the message to open. May fire
+    /// off the UI thread — the handler must marshal to the UI thread before touching any window.
+    /// </summary>
+    event Action<NotificationActivation>? Activated;
 }

--- a/QuickMail/Services/ISyncService.cs
+++ b/QuickMail/Services/ISyncService.cs
@@ -39,15 +39,17 @@ public interface ISyncService
 
     /// <summary>
     /// Syncs a single folder for one account. Used by the IDLE watcher for targeted
-    /// inbox sync without a full account-wide sweep.
+    /// inbox sync without a full account-wide sweep. Returns the messages fetched this pass
+    /// (empty when none) so the caller can decide which are genuinely new for notification.
     /// </summary>
-    Task SyncOneFolderAsync(AccountModel account, MailFolderModel folder, CancellationToken ct);
+    Task<IReadOnlyList<MailMessageSummary>> SyncOneFolderAsync(AccountModel account, MailFolderModel folder, CancellationToken ct);
 
     /// <summary>
     /// Online-mode variant: fetches the most recent messages directly from IMAP without
     /// touching the local store, then fires <see cref="FolderSynced"/> so the UI updates.
+    /// Returns the messages fetched this pass (empty when none).
     /// </summary>
-    Task SyncOneFolderOnlineAsync(AccountModel account, MailFolderModel folder, CancellationToken ct);
+    Task<IReadOnlyList<MailMessageSummary>> SyncOneFolderOnlineAsync(AccountModel account, MailFolderModel folder, CancellationToken ct);
 
     /// <summary>
     /// Returns the UTC time of the last completed sync for the given account,

--- a/QuickMail/Services/SyncService.cs
+++ b/QuickMail/Services/SyncService.cs
@@ -137,7 +137,7 @@ public class SyncService : ISyncService
         }
     }
 
-    public async Task SyncOneFolderAsync(AccountModel account, MailFolderModel folder, CancellationToken ct)
+    public async Task<IReadOnlyList<MailMessageSummary>> SyncOneFolderAsync(AccountModel account, MailFolderModel folder, CancellationToken ct)
     {
         // IDLE-triggered sync in non-online (SQLite cache) mode.
         //
@@ -159,9 +159,10 @@ public class SyncService : ISyncService
             await _store.UpsertSummariesAsync(incoming);
             await Application.Current.Dispatcher.InvokeAsync(() => FolderSynced?.Invoke(incoming));
         }
+        return incoming;
     }
 
-    public async Task SyncOneFolderOnlineAsync(AccountModel account, MailFolderModel folder, CancellationToken ct)
+    public async Task<IReadOnlyList<MailMessageSummary>> SyncOneFolderOnlineAsync(AccountModel account, MailFolderModel folder, CancellationToken ct)
     {
         // Fetch the last 50 messages. OnFolderSynced deduplicates by UID so already-visible
         // messages are harmlessly skipped; only truly new arrivals are inserted.
@@ -172,6 +173,7 @@ public class SyncService : ISyncService
         {
             await Application.Current.Dispatcher.InvokeAsync(() => FolderSynced?.Invoke(incoming));
         }
+        return incoming;
     }
 
     private async Task<List<MailMessageSummary>> SyncFolderAsync(AccountModel account, MailFolderModel folder, CancellationToken ct)

--- a/QuickMail/Services/WindowsToastNotificationService.cs
+++ b/QuickMail/Services/WindowsToastNotificationService.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Toolkit.Uwp.Notifications;
+using QuickMail.Models;
+
+namespace QuickMail.Services;
+
+/// <summary>
+/// Windows Community Toolkit implementation of <see cref="INotificationService"/> for an
+/// unpackaged (non-MSIX) Win32 app. <see cref="ToastNotificationManagerCompat"/> auto-registers
+/// the AppUserModelID and a COM activator in the registry on first use — no appxmanifest and (on
+/// Windows 10 1709+) no Start Menu shortcut required. The app name and icon shown on the toast
+/// come from Velopack's Start Menu shortcut, which the compat layer latches onto; a dev run with
+/// no shortcut still works but may show a generic label.
+///
+/// Every platform call is guarded: any failure degrades to a logged no-op, never a crash.
+/// See docs/planning/notifications-pm-dev-spec.md.
+/// </summary>
+public sealed class WindowsToastNotificationService : INotificationService, IDisposable
+{
+    private const string NewMailGroup = "newmail";
+
+    private readonly bool _osSupported;
+    private bool _activationHooked;
+
+    public event Action? Activated;
+
+    public WindowsToastNotificationService()
+    {
+        _osSupported = OperatingSystem.IsWindowsVersionAtLeast(10, 0, 17763);
+        if (!_osSupported) return;
+
+        try
+        {
+            ToastNotificationManagerCompat.OnActivated += OnToastActivated;
+            _activationHooked = true;
+        }
+        catch (Exception ex)
+        {
+            // Registration/hook failed — treat notifications as unsupported for this session.
+            _osSupported = false;
+            LogService.Log("WindowsToastNotificationService: activation hook failed", ex);
+        }
+    }
+
+    public bool IsSupported => _osSupported;
+
+    public void ShowNewMail(string accountLabel, Guid accountId, IReadOnlyList<MailMessageSummary> newMessages)
+    {
+        if (!_osSupported || newMessages is null || newMessages.Count == 0) return;
+
+        try
+        {
+            var builder = new ToastContentBuilder()
+                .AddArgument("action", "openMail")
+                .AddArgument("accountId", accountId.ToString());
+
+            if (newMessages.Count == 1)
+            {
+                var m = newMessages[0];
+                var display = SenderDisplayName(m.From);
+                var sender  = string.IsNullOrWhiteSpace(display) ? accountLabel : display;
+                var subject = string.IsNullOrWhiteSpace(m.Subject) ? "(no subject)" : m.Subject;
+                builder.AddArgument("messageId", m.MessageId)
+                       .AddText(sender)
+                       .AddText(subject);
+                if (!string.IsNullOrWhiteSpace(m.Preview))
+                    builder.AddText(m.Preview);
+            }
+            else
+            {
+                builder.AddText($"{newMessages.Count} new messages")
+                       .AddText(accountLabel);
+            }
+
+            // Tag/group per account so repeated arrivals for one account collapse rather than
+            // stack endlessly in the notification center.
+            builder.Show(toast =>
+            {
+                toast.Tag   = Sanitize(accountId.ToString());
+                toast.Group = NewMailGroup;
+            });
+        }
+        catch (Exception ex)
+        {
+            LogService.Log("WindowsToastNotificationService: ShowNewMail failed", ex);
+        }
+    }
+
+    private void OnToastActivated(ToastNotificationActivatedEventArgsCompat e)
+    {
+        // Fires on a background thread. Just surface the event; the subscriber marshals to the UI
+        // thread. Phase 1 ignores the arguments (click = bring the app forward); accountId/messageId
+        // are carried for a future "open the clicked message" enhancement.
+        try { Activated?.Invoke(); }
+        catch (Exception ex) { LogService.Log("WindowsToastNotificationService: activation handler threw", ex); }
+    }
+
+    // Toast tags/groups are limited to 64 chars and a restricted character set; a Guid string is
+    // safe, but sanitize defensively so an unexpected value can never throw inside Show().
+    private static string Sanitize(string s) => s.Length <= 64 ? s : s[..64];
+
+    // Reduce the From header to a display name so the toast (and the screen reader reading it)
+    // says "Jane Smith", not "Jane Smith jane@example.com". Falls back to the bare address, then
+    // to the raw header, so a toast never ends up with an empty sender.
+    internal static string SenderDisplayName(string from)
+    {
+        if (string.IsNullOrWhiteSpace(from)) return string.Empty;
+        try
+        {
+            if (MimeKit.MailboxAddress.TryParse(from, out var mb))
+                return string.IsNullOrWhiteSpace(mb.Name) ? mb.Address : mb.Name;
+        }
+        catch { /* malformed header — fall back to the raw string */ }
+        return from;
+    }
+
+    public void Dispose()
+    {
+        if (_activationHooked)
+        {
+            try { ToastNotificationManagerCompat.OnActivated -= OnToastActivated; }
+            catch { /* best effort */ }
+            _activationHooked = false;
+        }
+    }
+}

--- a/QuickMail/Services/WindowsToastNotificationService.cs
+++ b/QuickMail/Services/WindowsToastNotificationService.cs
@@ -23,7 +23,31 @@ public sealed class WindowsToastNotificationService : INotificationService, IDis
     private readonly bool _osSupported;
     private bool _activationHooked;
 
-    public event Action? Activated;
+    // Activation can arrive on a cold start (a toast clicked while the app was closed relaunches it)
+    // before App has subscribed. Buffer the most recent one and flush it to the first subscriber so
+    // the click is never dropped in the startup window. Guarded because OnActivated fires on a
+    // background thread while the subscribe happens on the UI thread.
+    private readonly object _activationLock = new();
+    private Action<NotificationActivation>? _activated;
+    private NotificationActivation? _bufferedActivation;
+
+    public event Action<NotificationActivation>? Activated
+    {
+        add
+        {
+            NotificationActivation? replay = null;
+            lock (_activationLock)
+            {
+                _activated += value;
+                if (_bufferedActivation != null) { replay = _bufferedActivation; _bufferedActivation = null; }
+            }
+            if (replay != null) value?.Invoke(replay);
+        }
+        remove
+        {
+            lock (_activationLock) { _activated -= value; }
+        }
+    }
 
     public WindowsToastNotificationService()
     {
@@ -51,9 +75,12 @@ public sealed class WindowsToastNotificationService : INotificationService, IDis
 
         try
         {
+            // Carry the inbox folder so a click can open the exact message without re-resolving it.
+            var folder = newMessages[0].FolderName ?? string.Empty;
             var builder = new ToastContentBuilder()
                 .AddArgument("action", "openMail")
-                .AddArgument("accountId", accountId.ToString());
+                .AddArgument("accountId", accountId.ToString())
+                .AddArgument("folder", folder);
 
             if (newMessages.Count == 1)
             {
@@ -87,13 +114,65 @@ public sealed class WindowsToastNotificationService : INotificationService, IDis
         }
     }
 
+    public void ShowInfo(string title, string message)
+    {
+        if (!_osSupported) return;
+        try
+        {
+            new ToastContentBuilder()
+                .AddArgument("action", "info")
+                .AddText(title)
+                .AddText(message)
+                .Show();
+        }
+        catch (Exception ex)
+        {
+            LogService.Log("WindowsToastNotificationService: ShowInfo failed", ex);
+        }
+    }
+
     private void OnToastActivated(ToastNotificationActivatedEventArgsCompat e)
     {
-        // Fires on a background thread. Just surface the event; the subscriber marshals to the UI
-        // thread. Phase 1 ignores the arguments (click = bring the app forward); accountId/messageId
-        // are carried for a future "open the clicked message" enhancement.
-        try { Activated?.Invoke(); }
+        // Fires on a background thread. Parse the toast arguments into a NotificationActivation and
+        // surface it; the subscriber marshals to the UI thread. A missing/unparseable accountId
+        // yields Guid.Empty, which the handler treats as "just bring the app forward".
+        try
+        {
+            var act = ParseActivation(e.Argument);
+            if (act != null) DispatchActivation(act);
+        }
         catch (Exception ex) { LogService.Log("WindowsToastNotificationService: activation handler threw", ex); }
+    }
+
+    // Raises Activated, or buffers when no subscriber has attached yet (cold start still wiring up)
+    // so the click is delivered to the first subscriber instead of being dropped.
+    internal void DispatchActivation(NotificationActivation act)
+    {
+        Action<NotificationActivation>? handler;
+        lock (_activationLock)
+        {
+            handler = _activated;
+            if (handler == null) { _bufferedActivation = act; return; }
+        }
+        handler.Invoke(act);
+    }
+
+    /// <summary>
+    /// Parses a toast's argument string into a <see cref="NotificationActivation"/>, or null when it
+    /// is the "still running" info toast (which has no target and must not open a message). A missing
+    /// or unparseable accountId yields <see cref="Guid.Empty"/>, which the handler treats as
+    /// "just bring the app forward".
+    /// </summary>
+    internal static NotificationActivation? ParseActivation(string argument)
+    {
+        var args = ToastArguments.Parse(argument);
+
+        if (args.TryGetValue("action", out var action) && action == "info") return null;
+
+        Guid.TryParse(args.Get("accountId"), out var accountId);
+        var folder    = args.Contains("folder") ? args.Get("folder") : null;
+        var messageId = args.Contains("messageId") ? args.Get("messageId") : null;
+        return new NotificationActivation(accountId, folder, messageId);
     }
 
     // Toast tags/groups are limited to 64 chars and a restricted character set; a Guid string is

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -34,6 +34,14 @@ public partial class MainViewModel : ObservableObject, IDisposable
     private readonly IFlagService? _flagService;
     private readonly ICalendarService? _calendarService;
     private readonly IUpdateCheckService? _updateCheckService;
+    // Windows toast notifications for new mail. Null in tests and when the OS/platform is
+    // unsupported. Calling into it is an OS side-effect a service owns, not a View-layer type,
+    // so it does not violate the no-UI-types-in-ViewModels rule.
+    private readonly INotificationService? _notifications;
+    // New-mail notification state (UI-thread-owned): threshold excludes the startup backlog;
+    // the key set de-dupes across repeated IDLE fires within the session.
+    private readonly DateTimeOffset _notifyThresholdUtc = DateTimeOffset.UtcNow;
+    private readonly HashSet<string> _notifiedMessageKeys = new();
     // Exposes hex strings only, so consuming it here does not violate the
     // no-UI-types-in-ViewModels rule. Null in tests that don't exercise theming.
     private readonly IThemeService? _themeService;
@@ -789,7 +797,8 @@ public partial class MainViewModel : ObservableObject, IDisposable
         IChangeNotifier? changeNotifier = null,
         IUpdateCheckService? updateCheckService = null,
         IUiDispatcher? uiDispatcher = null,
-        IThemeService? themeService = null)
+        IThemeService? themeService = null,
+        INotificationService? notificationService = null)
     {
         _imap            = imap;
         _ui              = uiDispatcher ?? new WpfUiDispatcher();
@@ -808,6 +817,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
         _calendarService      = calendarService;
         _updateCheckService   = updateCheckService;
         _themeService         = themeService;
+        _notifications        = notificationService;
         OnlineMode            = onlineMode;
 
         var cfg = _configService.Load();
@@ -1935,10 +1945,13 @@ public partial class MainViewModel : ObservableObject, IDisposable
         {
             try
             {
-                if (OnlineMode)
-                    await _syncService.SyncOneFolderOnlineAsync(account, inbox, CancellationToken.None);
-                else
-                    await _syncService.SyncOneFolderAsync(account, inbox, CancellationToken.None);
+                var incoming = OnlineMode
+                    ? await _syncService.SyncOneFolderOnlineAsync(account, inbox, CancellationToken.None)
+                    : await _syncService.SyncOneFolderAsync(account, inbox, CancellationToken.None);
+
+                // Notify on the UI thread so the de-dupe set stays single-thread-owned.
+                if (incoming.Count > 0)
+                    _ui.Post(() => MaybeNotifyNewMail(account, incoming));
             }
             catch (Exception ex)
             {
@@ -1946,6 +1959,25 @@ public partial class MainViewModel : ObservableObject, IDisposable
             }
         });
     });
+
+    // Shows a Windows toast for genuinely-new inbox mail. Runs on the UI thread (the caller posts
+    // it there) so _notifiedMessageKeys is single-thread-owned. Setting is re-read live so a
+    // Settings change takes effect without a restart.
+    private void MaybeNotifyNewMail(AccountModel account, IReadOnlyList<MailMessageSummary> incoming)
+    {
+        if (_notifications is not { IsSupported: true }) return;
+        if (!_configService.Load().NotifyOnNewMail) return;
+
+        // Bound session memory: the set only holds keys of messages we've already notified for, but
+        // an always-on session could grow it without limit. Clearing risks at most a re-notify for a
+        // message still inside the last-50 IDLE fetch window whose Date is after launch — negligible.
+        if (_notifiedMessageKeys.Count > 10_000) _notifiedMessageKeys.Clear();
+
+        var fresh = Helpers.NewMailFilter.SelectNew(incoming, _notifyThresholdUtc, _notifiedMessageKeys);
+        if (fresh.Count == 0) return;
+
+        _notifications.ShowNewMail(account.AccountLabel, account.Id, fresh);
+    }
 
     private void OnMessagesRemoved(IReadOnlyList<MailMessageSummary> removed)
     {

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -1564,6 +1564,10 @@ public partial class MainViewModel : ObservableObject, IDisposable
         // account that connects OUTSIDE this startup pipeline still gets polled for new mail.
         WireUpWatchers();
 
+        // Signal that the startup connect finished so a notification click that cold-started the app
+        // (its account wasn't connected yet when the toast was activated) can now open its message.
+        StartupConnectCompleted?.Invoke();
+
         // Nothing connected — skip the heavy full sync. Watchers/labels are already handled above, and
         // WireUpWatchers will start the watcher once an account connects later.
         if (_cachedFolders.Count == 0) return;
@@ -4695,10 +4699,21 @@ public partial class MainViewModel : ObservableObject, IDisposable
     [RelayCommand]
     private void ManageAccounts() => ManageAccountsRequested?.Invoke();
 
-#pragma warning disable CA1822 // [RelayCommand] target must be an instance method for the MVVM Toolkit source generator
+    /// <summary>Raised when the user chooses Exit. The View performs the actual shutdown so it can
+    /// first flag the close as an explicit exit (bypassing close-to-tray). Keeping the shutdown in
+    /// the View also honours the MVVM rule that VMs do not touch <c>Application</c>.</summary>
+    public event Action? ExitRequested;
+
+    /// <summary>Raised on the UI thread once the startup connect pass has completed. Lets a deferred
+    /// notification activation (cold start) open its message once the account is reachable.</summary>
+    public event Action? StartupConnectCompleted;
+
+    /// <summary>True when the account's folders are cached, i.e. it is connected and a message detail
+    /// fetch by id can succeed. Used to decide whether to open a toast's message now or defer it.</summary>
+    public bool IsAccountReady(Guid accountId) => _cachedFolders.ContainsKey(accountId);
+
     [RelayCommand]
-    private void Exit() => Application.Current.Shutdown();
-#pragma warning restore CA1822
+    private void Exit() => ExitRequested?.Invoke();
 
     // ── Account context menu commands ─────────────────────────────────────────
 

--- a/QuickMail/ViewModels/SettingsViewModel.cs
+++ b/QuickMail/ViewModels/SettingsViewModel.cs
@@ -77,6 +77,9 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty]
     private bool _notifyOnNewMail;
 
+    [ObservableProperty]
+    private bool _closeToTray;
+
     // Desktop shortcut: the .lnk on the desktop is the source of truth, not config —
     // loaded from the filesystem and applied on save only when it differs from the file's
     // current state (re-checked at save time; the file can change outside this dialog).
@@ -250,6 +253,7 @@ public partial class SettingsViewModel : ObservableObject
         AnnounceFlagStatus               = cfg.AnnounceFlagStatus;
         ConfirmEmptyTrash                = cfg.ConfirmEmptyTrash;
         NotifyOnNewMail                  = cfg.NotifyOnNewMail;
+        CloseToTray                      = cfg.CloseToTray;
         DesktopShortcut                  = Helpers.DesktopShortcut.Exists();
         AutoUpdate                       = cfg.AutoUpdate;
         ShowUpdateInstalledAlerts        = cfg.ShowUpdateInstalledAlerts;
@@ -315,6 +319,7 @@ public partial class SettingsViewModel : ObservableObject
         cfg.AnnounceFlagStatus               = AnnounceFlagStatus;
         cfg.ConfirmEmptyTrash                = ConfirmEmptyTrash;
         cfg.NotifyOnNewMail                  = NotifyOnNewMail;
+        cfg.CloseToTray                      = CloseToTray;
         cfg.AutoUpdate                       = AutoUpdate;
         cfg.ShowUpdateInstalledAlerts        = ShowUpdateInstalledAlerts;
         if (DesktopShortcut != Helpers.DesktopShortcut.Exists())

--- a/QuickMail/ViewModels/SettingsViewModel.cs
+++ b/QuickMail/ViewModels/SettingsViewModel.cs
@@ -74,6 +74,9 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty]
     private bool _confirmEmptyTrash;
 
+    [ObservableProperty]
+    private bool _notifyOnNewMail;
+
     // Desktop shortcut: the .lnk on the desktop is the source of truth, not config —
     // loaded from the filesystem and applied on save only when it differs from the file's
     // current state (re-checked at save time; the file can change outside this dialog).
@@ -246,6 +249,7 @@ public partial class SettingsViewModel : ObservableObject
         AnnounceFormattingWhileNavigating = cfg.AnnounceFormattingWhileNavigating;
         AnnounceFlagStatus               = cfg.AnnounceFlagStatus;
         ConfirmEmptyTrash                = cfg.ConfirmEmptyTrash;
+        NotifyOnNewMail                  = cfg.NotifyOnNewMail;
         DesktopShortcut                  = Helpers.DesktopShortcut.Exists();
         AutoUpdate                       = cfg.AutoUpdate;
         ShowUpdateInstalledAlerts        = cfg.ShowUpdateInstalledAlerts;
@@ -310,6 +314,7 @@ public partial class SettingsViewModel : ObservableObject
         cfg.AnnounceFormattingWhileNavigating = AnnounceFormattingWhileNavigating;
         cfg.AnnounceFlagStatus               = AnnounceFlagStatus;
         cfg.ConfirmEmptyTrash                = ConfirmEmptyTrash;
+        cfg.NotifyOnNewMail                  = NotifyOnNewMail;
         cfg.AutoUpdate                       = AutoUpdate;
         cfg.ShowUpdateInstalledAlerts        = ShowUpdateInstalledAlerts;
         if (DesktopShortcut != Helpers.DesktopShortcut.Exists())

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -562,6 +562,35 @@ public partial class MainWindow : Window
             TryHandleMessageTreeTypeAhead);
     }
 
+    /// <summary>
+    /// Restores the window from minimized and brings it to the foreground. Called when the user
+    /// clicks a new-mail toast. WPF's <see cref="Window.Activate"/> alone does not reliably steal
+    /// foreground from another app, so the window handle is pushed forward via Win32 as well.
+    /// </summary>
+    public void RestoreAndActivate()
+    {
+        try
+        {
+            if (!IsVisible) Show();
+            if (WindowState == WindowState.Minimized) WindowState = WindowState.Normal;
+            Activate();
+
+            var hwnd = new WindowInteropHelper(this).Handle;
+            if (hwnd != IntPtr.Zero) NativeForeground.SetForegroundWindow(hwnd);
+        }
+        catch (Exception ex)
+        {
+            LogService.Debug($"RestoreAndActivate: {ex.Message}");
+        }
+    }
+
+    private static class NativeForeground
+    {
+        [System.Runtime.InteropServices.DllImport("user32.dll")]
+        [return: System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.Bool)]
+        public static extern bool SetForegroundWindow(IntPtr hWnd);
+    }
+
     protected override void OnClosed(EventArgs e)
     {
         foreach (var w in _openComposeWindows.ToList())

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -174,6 +174,17 @@ public partial class MainWindow : Window
     private readonly ICustomDictionaryService? _customDictionary;
     private readonly IThemeService? _themeService;
     private readonly IBugReportService? _bugReportService;
+    private readonly INotificationService? _notificationService;
+
+    // ── Close-to-tray / run-in-background ──────────────────────────────────────
+    // Created lazily the first time the window hides to the tray; disposed in OnClosed.
+    private TrayIconManager? _trayIcon;
+    // Set when the user explicitly exits (File > Exit or the tray Exit item) so OnClosing does not
+    // divert the close into hide-to-tray.
+    private bool _explicitExit;
+    // A notification click whose target account was not connected yet (cold start); replayed once
+    // StartupConnectCompleted fires. Null when nothing is pending.
+    private Services.NotificationActivation? _pendingActivation;
 
     // Last High Contrast state announced, so an HC transition is announced once
     // with the HC wording and everything else as "Theme changed to …".
@@ -213,9 +224,11 @@ public partial class MainWindow : Window
         IFlagService? flagService = null,
         ICustomDictionaryService? customDictionary = null,
         IThemeService? themeService = null,
-        IBugReportService? bugReportService = null)
+        IBugReportService? bugReportService = null,
+        INotificationService? notificationService = null)
     {
         _vm = vm;
+        _notificationService = notificationService;
         _smtp = smtp;
         _accountService = accountService;
         _credentials = credentials;
@@ -247,6 +260,17 @@ public partial class MainWindow : Window
             vm.ThemeManagerRequested += (_, _) => OpenThemeManager();
         }
 
+        vm.ExitRequested += RequestExit;
+        vm.StartupConnectCompleted += () => Dispatcher.BeginInvoke(TryProcessPendingActivation);
+        // Windows logoff/shutdown must exit for real, not hide to tray (otherwise Windows shows the
+        // "app is preventing sign-out" screen and force-kills us, leaking the tray icon). Subscribe
+        // only when this ctor runs on the Application's own thread — SessionEnding's add accessor is
+        // thread-affine and throws otherwise (tests construct MainWindow off the shared Application's
+        // thread). CheckAccess() is itself safe to call cross-thread; in production the window is
+        // always created on the UI thread, so this is true.
+        var app = Application.Current;
+        if (app != null && app.CheckAccess())
+            app.SessionEnding += (_, _) => _explicitExit = true;
         vm.ComposeRequested += OpenComposeWindow;
         vm.SelectAttachmentsForForwardRequested += ShowForwardAttachmentDialogAsync;
         vm.ManageAccountsRequested += OpenAccountManager;
@@ -591,10 +615,136 @@ public partial class MainWindow : Window
         public static extern bool SetForegroundWindow(IntPtr hWnd);
     }
 
+    // ── Close-to-tray / run-in-background ──────────────────────────────────────
+
+    protected override void OnClosing(System.ComponentModel.CancelEventArgs e)
+    {
+        // When close-to-tray is enabled, a normal window close hides to the notification area
+        // instead of exiting so the new-mail watchers keep running. An explicit exit (File > Exit
+        // or the tray Exit item) sets _explicitExit and falls through to a real close.
+        var cfg = _configService.Load();
+        if (cfg.CloseToTray && !_explicitExit)
+        {
+            e.Cancel = true;
+            HideToTray(cfg);
+            return;
+        }
+        base.OnClosing(e);
+    }
+
+    private void HideToTray(Models.ConfigModel cfg)
+    {
+        _trayIcon ??= new TrayIconManager(onOpen: RestoreFromTray, onExit: RequestExit);
+        _trayIcon.Show();
+        Hide();
+
+        // One-time hint so the app doesn't silently vanish. Delivered as a toast (announced natively
+        // by screen readers), not baked into any control.
+        if (!cfg.TrayHintShown)
+        {
+            _notificationService?.ShowInfo(
+                "QuickMail is still running",
+                "QuickMail is in the notification area. Open it from the tray icon or a new-mail " +
+                "notification, or right-click the tray icon and choose Exit to quit.");
+            cfg.TrayHintShown = true;
+            _configService.Save(cfg);
+        }
+    }
+
+    // Invoked from the tray icon (double-click or the Open item), which fires on the UI thread.
+    private void RestoreFromTray()
+    {
+        RestoreAndActivate();
+        _trayIcon?.Hide(); // tray icon is only shown while the window is hidden
+    }
+
+    // Invoked from File > Exit (vm.ExitRequested) and the tray Exit item. Flags an explicit exit so
+    // OnClosing performs a real close, then shuts the app down.
+    private void RequestExit()
+    {
+        _explicitExit = true;
+        Application.Current.Shutdown();
+    }
+
+    /// <summary>
+    /// Handles a clicked new-mail toast: brings the window forward, then opens the message it
+    /// referenced (deferring until the account is connected if the click cold-started the app).
+    /// Called on the UI thread by App from <see cref="INotificationService.Activated"/>.
+    /// </summary>
+    public void HandleNotificationActivation(Services.NotificationActivation act)
+    {
+        RestoreFromTray();
+        _pendingActivation = act;
+        TryProcessPendingActivation();
+    }
+
+    private void TryProcessPendingActivation()
+    {
+        var act = _pendingActivation;
+        if (act is null) return;
+
+        // No single target (the "N new messages" toast) or malformed args: the window is already
+        // foregrounded, nothing more to open.
+        if (string.IsNullOrEmpty(act.MessageId) || string.IsNullOrEmpty(act.Folder) || act.AccountId == Guid.Empty)
+        {
+            _pendingActivation = null;
+            return;
+        }
+
+        // Cold start: the account isn't connected yet, so a detail fetch would fail. Keep it pending;
+        // StartupConnectCompleted re-runs this once the account is reachable.
+        if (!_vm.IsAccountReady(act.AccountId)) return;
+
+        _pendingActivation = null;
+        _ = OpenMessageByIdentityAsync(act.AccountId, act.Folder, act.MessageId);
+    }
+
+    /// <summary>
+    /// Opens a message identified by (account, folder, id) in the user's configured MessageOpenMode.
+    /// Mirrors <see cref="OpenMessageFromListAsync"/>'s mode routing but without its drafts check —
+    /// a notification always targets an inbox message. <see cref="MainViewModel.SelectMessageAsync"/>
+    /// fetches the detail by id (cache or IMAP), so the message need not be in the loaded list.
+    /// </summary>
+    private async Task OpenMessageByIdentityAsync(Guid accountId, string folder, string messageId)
+    {
+        // Prefer the real row from the loaded list when it's there: opening it then propagates
+        // read-state to the visible row (clears the unread styling) and gives Window-mode Prev/Next
+        // the correct surrounding list. Fall back to a stub when the message isn't currently loaded
+        // (a different folder is selected); SelectMessageAsync still fetches its detail by id.
+        var summary = _vm.Messages.FirstOrDefault(m =>
+                          m.AccountId == accountId &&
+                          string.Equals(m.FolderName, folder, StringComparison.OrdinalIgnoreCase) &&
+                          m.MessageId == messageId)
+                      ?? new MailMessageSummary
+                      {
+                          AccountId  = accountId,
+                          FolderName = folder,
+                          MessageId  = messageId,
+                      };
+
+        switch (_vm.MessageOpenMode)
+        {
+            case MessageOpenMode.Tab:
+                _vm.OpenMessageTab(summary);
+                break;
+
+            case MessageOpenMode.Window:
+                OpenMessageInNewWindow(summary);
+                break;
+
+            default: // ReadingPane
+                await _vm.SelectMessageCommand.ExecuteAsync(summary);
+                if (_vm.IsMessageOpen && _vm.MessageDetail != null)
+                    await ShowMessageBodyAsync(_vm.MessageDetail);
+                break;
+        }
+    }
+
     protected override void OnClosed(EventArgs e)
     {
         foreach (var w in _openComposeWindows.ToList())
             w.Close();
+        _trayIcon?.Dispose(); // remove the tray icon so it doesn't linger after exit
         // Cancels all in-flight VM operations (sync, prefetch, loads) and releases
         // their CTS handles. OnClosed, not OnClosing — the close cannot be cancelled here.
         _vm.Dispose();

--- a/QuickMail/Views/SettingsDialog.xaml
+++ b/QuickMail/Views/SettingsDialog.xaml
@@ -147,6 +147,12 @@
                                           IsChecked="{Binding NotifyOnNewMail, Mode=TwoWay}"
                                           AutomationProperties.Name="Show a notification when new mail arrives"/>
                                 <TextBlock Text="Windows shows a notification when new mail arrives in an inbox while QuickMail is running."
+                                           Foreground="{DynamicResource Theme.TextSecondary}" FontSize="{DynamicResource Theme.FontSizeSmall}" Margin="0,3,0,8" TextWrapping="Wrap"/>
+
+                                <CheckBox Content="_Keep running in the notification area when I close the window"
+                                          IsChecked="{Binding CloseToTray, Mode=TwoWay}"
+                                          AutomationProperties.Name="Keep running in the notification area when I close the window"/>
+                                <TextBlock Text="Closing the window hides QuickMail to the notification area (system tray) instead of exiting, so notifications keep arriving. Restore it from the tray icon or a notification; use File then Exit, or the tray icon's Exit, to quit."
                                            Foreground="{DynamicResource Theme.TextSecondary}" FontSize="{DynamicResource Theme.FontSizeSmall}" Margin="0,3,0,0" TextWrapping="Wrap"/>
                             </StackPanel>
                         </GroupBox>

--- a/QuickMail/Views/SettingsDialog.xaml
+++ b/QuickMail/Views/SettingsDialog.xaml
@@ -139,6 +139,18 @@
                             </StackPanel>
                         </GroupBox>
 
+                        <!-- Notifications Group -->
+                        <GroupBox Header="_Notifications" Padding="10" Margin="0,10,0,0"
+                                  AutomationProperties.Name="Notification settings">
+                            <StackPanel>
+                                <CheckBox Content="Show a _notification when new mail arrives"
+                                          IsChecked="{Binding NotifyOnNewMail, Mode=TwoWay}"
+                                          AutomationProperties.Name="Show a notification when new mail arrives"/>
+                                <TextBlock Text="Windows shows a notification when new mail arrives in an inbox while QuickMail is running."
+                                           Foreground="{DynamicResource Theme.TextSecondary}" FontSize="{DynamicResource Theme.FontSizeSmall}" Margin="0,3,0,0" TextWrapping="Wrap"/>
+                            </StackPanel>
+                        </GroupBox>
+
                         <!-- Desktop Shortcut Group -->
                         <GroupBox Header="Desktop Shortc_ut" Padding="10" Margin="0,10,0,0"
                                   AutomationProperties.Name="Desktop shortcut settings">

--- a/QuickMail/Views/TrayIconManager.cs
+++ b/QuickMail/Views/TrayIconManager.cs
@@ -1,0 +1,66 @@
+using System;
+using QuickMail.Services;
+
+namespace QuickMail.Views;
+
+/// <summary>
+/// Owns the system-tray <c>NotifyIcon</c> used by close-to-tray mode. WPF has no native tray icon,
+/// so this is the one place WinForms is used (its types are always fully qualified — see the
+/// UseWindowsForms note in QuickMail.csproj). Purely UI plumbing (a View-layer concern): it exposes
+/// Show/Hide and raises the supplied callbacks for the Open and Exit menu actions. The callbacks
+/// fire on the UI thread (the NotifyIcon is created on it).
+/// </summary>
+internal sealed class TrayIconManager : IDisposable
+{
+    private readonly System.Windows.Forms.NotifyIcon _icon;
+
+    public TrayIconManager(Action onOpen, Action onExit)
+    {
+        _icon = new System.Windows.Forms.NotifyIcon
+        {
+            Text    = "QuickMail",
+            Icon    = LoadAppIcon(),
+            Visible = false,
+        };
+        // Double-clicking the icon is the conventional "restore" gesture.
+        _icon.DoubleClick += (_, _) => onOpen();
+
+        var menu     = new System.Windows.Forms.ContextMenuStrip();
+        var openItem = new System.Windows.Forms.ToolStripMenuItem("&Open QuickMail");
+        openItem.Click += (_, _) => onOpen();
+        var exitItem = new System.Windows.Forms.ToolStripMenuItem("E&xit QuickMail");
+        exitItem.Click += (_, _) => onExit();
+        menu.Items.Add(openItem);
+        menu.Items.Add(exitItem);
+        _icon.ContextMenuStrip = menu;
+    }
+
+    public void Show() => _icon.Visible = true;
+    public void Hide() => _icon.Visible = false;
+
+    // The app ships no dedicated .ico, so use the executable's own icon; fall back to the generic
+    // application icon if it can't be read. Picks up a real app icon automatically once one is set.
+    private static System.Drawing.Icon LoadAppIcon()
+    {
+        try
+        {
+            var exe = Environment.ProcessPath;
+            if (!string.IsNullOrEmpty(exe))
+            {
+                var ico = System.Drawing.Icon.ExtractAssociatedIcon(exe);
+                if (ico != null) return ico;
+            }
+        }
+        catch (Exception ex)
+        {
+            LogService.Debug($"TrayIconManager: could not load app icon: {ex.Message}");
+        }
+        return System.Drawing.SystemIcons.Application;
+    }
+
+    public void Dispose()
+    {
+        _icon.Visible = false; // remove from the tray immediately
+        _icon.Dispose();
+    }
+}

--- a/docs/planning/notifications-pm-dev-spec.md
+++ b/docs/planning/notifications-pm-dev-spec.md
@@ -1,0 +1,258 @@
+# New-Mail Notifications — PM/Dev Spec
+
+Issue: [#240 — Add notification support](https://github.com/kellylford/QuickMail/issues/240)
+
+## Summary
+
+Surface a **Windows toast (app) notification** when new mail arrives, using the
+platform's own notification system so it is announced by screen readers, appears in the
+Windows notification center, and honours the OS's Focus Assist / Do Not Disturb and
+per-app notification settings.
+
+The important realisation from reading the code: **QuickMail already detects new mail**.
+The change-notifier infrastructure (`IChangeNotifier`) runs an IMAP IDLE connection per
+account (`ImapMailService`) and a Microsoft Graph `/messages/delta` poll
+(`GraphChangeNotifier`), aggregated by `ChangeNotifierRouter`. When new mail lands in an
+inbox it raises `InboxNewMailDetected(accountId)`, which `MainViewModel.OnInboxNewMailDetected`
+already handles by running a targeted inbox sync. So this feature does **not** add polling —
+it hangs a toast off the signal that already exists.
+
+Because the notification uses the Windows notification platform, the "accessibility
+infrastructure comes from Microsoft" (the issue author's phrasing): screen readers announce
+toasts natively, and the user can review/replay them from the notification center
+(Win+A) or navigate to the newest with Win+Shift+V. We add **no** custom
+`AccessibilityHelper.Announce` for new mail — the toast is the mechanism, and layering an
+in-app announcement on top would double-speak.
+
+## Phasing
+
+Issue #240 asks for three things: (1) toast on new mail, (2) minimize-to-tray on close, and
+(3) periodic background sync. Item (3) already exists (IDLE / delta poll). This spec is
+delivered in two phases:
+
+- **Phase 1 (this PR): Windows toast notifications for new mail.** Works whenever QuickMail
+  is running (foreground, background, or minimized to the taskbar) — already the common case
+  for an email client.
+- **Phase 2 (deferred, spec'd below): Run in background / close to tray.** Lets QuickMail keep
+  running (and keep delivering notifications) after the window is closed. Larger surface —
+  adds a tray icon, a new interaction model, and its own accessibility requirements — so it
+  is intentionally split out.
+
+---
+
+# Phase 1 — Toast notifications (implemented)
+
+## Doing it "properly": the Microsoft rules for an unpackaged Win32 app
+
+QuickMail is an **unpackaged** (non-MSIX) self-contained WPF app installed by Velopack. The
+Microsoft-sanctioned path for such apps is the **Windows Community Toolkit** notifications
+library (`Microsoft.Toolkit.Uwp.Notifications`), which provides `ToastNotificationManagerCompat`
+and `ToastContentBuilder`. For unpackaged apps this library:
+
+- **Auto-registers the AppUserModelID (AUMID) and a COM activator** in the registry on first
+  use. No `Package.appxmanifest`, and (on Windows 10 1709+) **no Start Menu shortcut is
+  required** — the manifest/shortcut steps in Microsoft's docs are the MSIX-only path.
+- **Handles activation** (the user clicking the toast) via the
+  `ToastNotificationManagerCompat.OnActivated` static event. Activation may arrive on a
+  background thread and must be marshalled to the UI thread before touching any window.
+- Requires the project to target a **Windows-10 TFM** (`net8.0-windowsX.0.17763.0` or higher)
+  so the underlying `Windows.UI.Notifications` WinRT `.Show()` API is available. QuickMail
+  currently targets `net8.0-windows` (= `net8.0-windows7.0`), so the TFM is bumped (below).
+
+### Build changes required
+
+- `QuickMail.csproj`: `TargetFramework` `net8.0-windows` → `net8.0-windows10.0.17763.0`; add
+  `PackageReference Microsoft.Toolkit.Uwp.Notifications 7.1.3`.
+- `QuickMail.Tests.csproj`: `TargetFramework` bumped to match (a project can only reference a
+  project whose platform version is ≤ its own).
+
+`SupportedOSPlatformVersion` becomes 10.0.17763 (Windows 10 1809, Oct 2018). This is the
+effective floor for the toast APIs and is a reasonable minimum for a 2026 desktop app.
+
+## Design
+
+### New service: `INotificationService` / `WindowsToastNotificationService`
+
+`Services/INotificationService.cs`:
+
+```csharp
+public interface INotificationService
+{
+    /// <summary>False on down-level OS or if the platform rejected registration; callers no-op.</summary>
+    bool IsSupported { get; }
+
+    /// <summary>Show a new-mail toast for one account. `newMessages` is the genuinely-new set
+    /// (already de-duplicated and gated by the caller). Best-effort; never throws.</summary>
+    void ShowNewMail(string accountLabel, Guid accountId, IReadOnlyList<MailMessageSummary> newMessages);
+
+    /// <summary>Raised (possibly off the UI thread) when the user activates a toast.</summary>
+    event Action? Activated;
+}
+```
+
+`Services/WindowsToastNotificationService.cs` (View/OS-layer service; a service may make OS
+calls — the MVVM "no System.Windows in a VM" rule applies to ViewModels, not services):
+
+- `IsSupported` = `OperatingSystem.IsWindowsVersionAtLeast(10, 0, 17763)` AND registration did
+  not throw. The whole thing is wrapped so any failure degrades to a silent no-op (logged),
+  never a crash.
+- Constructor subscribes `ToastNotificationManagerCompat.OnActivated`; the handler raises
+  `Activated`. Toast arguments carry `accountId`/`messageId` for future use (Phase 1 only needs
+  "bring the app forward").
+- `ShowNewMail`:
+  - **1 new message:** title = sender display name, body = subject (first non-empty of subject /
+    "(no subject)"), optional preview attribution line.
+  - **N new messages:** title = "{N} new messages", body = account label.
+  - Toasts are tagged/grouped per account (`tag = accountId`, `group = "newmail"`) so repeated
+    arrivals for one account collapse rather than stack endlessly.
+- App identity (name "QuickMail" + icon) comes from Velopack's Start Menu shortcut, which the
+  compat layer latches onto during auto-registration. In a dev run (F5, no shortcut) toasts
+  still work but may show a generic app label — expected, not a bug.
+
+### Deciding what is "genuinely new" (no flooding, no duplicates)
+
+The trigger is `OnInboxNewMailDetected(accountId)`, which fires **only** from the change
+notifier on a real new-mail event — never during the initial bulk sync. But it carries no
+message details, so the targeted inbox sync it already runs is extended to **return** the
+fetched summaries:
+
+- `ISyncService.SyncOneFolderAsync` / `SyncOneFolderOnlineAsync` change from `Task` to
+  `Task<IReadOnlyList<MailMessageSummary>>`, returning the `incoming` list they already
+  compute (empty when nothing was fetched). `FolderSynced` still fires exactly as before.
+
+`MainViewModel` then filters `incoming` down to the genuinely-new set on the **UI thread**
+(so the dedupe set is single-thread-owned):
+
+- **Unread only** (`!IsRead`) — a message already read on another device is not new to the user.
+- **Arrived this session** (`Date >= _notifyThresholdUtc`, captured at VM construction) — the
+  targeted sync fetches the last 50 messages, so the pre-existing backlog is excluded.
+- **Not already notified** — a per-key `HashSet<string>` (`accountId + \0 + MessageId`) prevents
+  re-notifying the same message when IDLE fires repeatedly within a session.
+
+If any survive, `INotificationService.ShowNewMail` is called. The threshold + unread + dedupe
+combination means: no toast for startup backlog, no toast for mail read elsewhere, and no
+duplicate toast on repeated IDLE fires.
+
+### Activation
+
+`WindowsToastNotificationService.Activated` → `App` marshals to the UI thread and calls a new
+`MainWindow.RestoreAndActivate()` (restore if minimized, `Show()`, `Activate()`, foreground via
+`SetForegroundWindow`). Phase 1 click behaviour = **bring QuickMail to the foreground**.
+Opening the specific clicked message is deferred (see Out of scope) — the accountId/messageId
+are already in the toast args for when we add it.
+
+### Configuration
+
+New `ConfigModel.NotifyOnNewMail` (bool, **default on**). Consistent with the app's other
+opt-out defaults (AutoUpdate on, announcements on) and with the issue's intent. Parsed/written
+by `ConfigService` in the `[global]` section as `NotifyOnNewMail = on|off`, read live via
+`_configService.Load()` on each detection so a Settings change takes effect without restart.
+
+Settings UI: a new **Notifications** GroupBox on the **General** tab with one checkbox,
+"Show a _notification when new mail arrives", bound to `SettingsViewModel.NotifyOnNewMail`.
+
+## Keyboard walkthrough
+
+New mail arrives (screen reader running), `NotifyOnNewMail` on:
+
+1. QuickMail is running (foreground, background, or minimized). New mail lands in an inbox.
+2. The change notifier raises `InboxNewMailDetected`; the targeted sync fetches it; the message
+   is genuinely new (unread, after launch, not seen before).
+3. A Windows toast appears. The screen reader announces it natively, e.g.
+   "QuickMail. Jane Smith. Subject: Lunch Thursday?" (content order is the platform's).
+4. The user presses **Win+Shift+V** to move focus to the most recent notification (standard
+   Windows shortcut; not an app shortcut). The screen reader reads the toast.
+5. The user presses **Enter** to activate it → QuickMail restores and comes to the foreground;
+   focus lands in the main window. (Or **Delete**/dismiss to clear it, standard toast behaviour.)
+6. If the user does nothing, the toast auto-dismisses to the notification center (Win+A), where
+   it can be reviewed later — all standard OS behaviour QuickMail does not implement.
+
+With `NotifyOnNewMail` off (Settings → General → Notifications, unchecked): step 3 never
+happens; nothing else changes.
+
+## Infrastructure changes
+
+- **F6 ring:** unchanged. No new pane; the toast is an OS surface, not an in-app control.
+- **CommandRegistry:** no new command. (Toggling notifications is a Settings checkbox, not a
+  hotkey action — consistent with the other announcement/appearance settings.)
+- **`AutomationProperties.Name` added/changed:** one — the new checkbox "Show a notification
+  when new mail arrives" (short label; no role words, no instructions).
+- **`AccessibilityHelper.Announce` calls added:** **none.** The toast is delivered by the
+  Windows notification platform, which screen readers announce natively. Deliberately not
+  layering an in-app announcement (would double-speak).
+- **VM state properties:** none of the existing state flags (e.g. `IsMessageOpen`) change. New
+  private VM state only: `_notifyThresholdUtc`, `_notifiedMessageKeys`, and the injected
+  `INotificationService? _notifications`.
+- **Selector-bound item types:** none added (no new ComboBox/ListView item types), so no
+  `SelectorItemAccessibilityTests` change.
+- **DI / lifecycle:** `WindowsToastNotificationService` constructed in `App.OnStartup`, passed to
+  `MainViewModel` (new optional ctor param `INotificationService? notificationService = null`,
+  so existing tests/construction are unaffected), `Activated` wired to `MainWindow.RestoreAndActivate`.
+- **Interface change:** `ISyncService.SyncOneFolderAsync` / `SyncOneFolderOnlineAsync` return
+  `Task<IReadOnlyList<MailMessageSummary>>`. The `SyncService` implementation and the test stub
+  are updated; all existing callers ignore the return value, so behaviour is unchanged.
+
+## Tests
+
+- `WindowsToastNotificationService`: `IsSupported` reflects OS version; `ShowNewMail` is a no-op
+  (no throw) when unsupported. (Cannot assert a real toast renders in a headless test.)
+- New-mail filter logic (extracted to a testable pure helper or exercised via a stub
+  `INotificationService`): asserts startup backlog (Date < threshold) does not notify; already-
+  read messages do not notify; a repeated IDLE fire for the same message notifies once; a fresh
+  unread message notifies with the expected count.
+- `ConfigService`: round-trips `NotifyOnNewMail` (on/off, default on when absent).
+- `SettingsViewModel`: loads and saves `NotifyOnNewMail`.
+
+## Out of scope (Phase 1)
+
+- **Opening the clicked message.** Click brings the app to the foreground; it does not navigate
+  to the specific message (that requires locating the message across folders/accounts and is
+  deferred; the args are already carried for a follow-up).
+- **Backdated delivery.** A message whose `Date` header predates app launch but is delivered
+  after launch will not toast (excluded by the `Date >= threshold` gate). `MailMessageSummary`
+  exposes only `Date` (sent), not the IMAP INTERNALDATE (received); using received date is a
+  possible future refinement. Real-time arrivals — the overwhelming majority — are unaffected.
+- **Per-account notification toggles**, custom sounds, notification actions (Archive/Mark read
+  from the toast), and per-message-count batching windows.
+- **Notifications for non-inbox folders.** Only inbox new mail notifies, matching the existing
+  `InboxNewMailDetected` scope.
+- **Mail rules are not pre-applied before notifying.** The targeted IDLE/delta sync
+  (`SyncOneFolderAsync`/`SyncOneFolderOnlineAsync`) does not run the rule engine (only the full
+  `SyncFolderAsync` does), so a message that a rule will subsequently move or delete can still
+  raise a new-mail toast. Pre-existing behaviour of the targeted-sync path; acceptable for Phase 1.
+  A future refinement could suppress toasts for rule-matched senders.
+- **Everything in Phase 2** (below).
+
+---
+
+# Phase 2 — Run in background / close to tray (deferred)
+
+Not implemented in this PR. Captured so the design is on record.
+
+Goal: when enabled, closing the main window hides it to the system tray instead of exiting, so
+IDLE/delta watchers keep running and toasts keep arriving; the app is restored from the tray or
+a toast; an explicit Exit truly quits.
+
+Sketch:
+
+- Add `<UseWindowsForms>true</UseWindowsForms>` and a `System.Windows.Forms.NotifyIcon` managed
+  by a small View-layer `TrayIconManager` owned by `MainWindow` (or `App`). Icon = app icon,
+  tooltip "QuickMail", context menu **Open QuickMail** / **Exit**.
+- New `ConfigModel.CloseToTray` (bool, **default off** — preserves today's exit-on-close
+  behaviour for existing users). Settings → General → Notifications: "When I close the window,
+  keep QuickMail running in the notification area".
+- `MainWindow.OnClosing`: if `CloseToTray` and this is not an explicit exit, cancel the close and
+  `Hide()`. An explicit-exit flag (set by the tray **Exit** item and a File → Exit menu item)
+  bypasses the cancel and calls `Application.Current.Shutdown()`.
+- Tray restore reuses `RestoreAndActivate()` (added in Phase 1).
+
+Phase 2 accessibility requirements (must be in its own spec before coding):
+
+- The tray icon and its context menu must be keyboard reachable (Win+B → arrows → Menu/Enter is
+  the OS path) and each menu item needs a clear accessible name.
+- A keyboard-only way to exit must always exist independent of the mouse (File → Exit).
+- First time the window hides to tray, a one-time toast/hint ("QuickMail is still running in the
+  notification area") so the app doesn't silently vanish — delivered as a toast (native SR
+  announcement), not baked into any control name.
+- Decide `ShutdownMode` implications (WPF `OnLastWindowClose` vs `OnExplicitShutdown`) so hiding
+  the last window doesn't terminate the process.

--- a/docs/planning/notifications-pm-dev-spec.md
+++ b/docs/planning/notifications-pm-dev-spec.md
@@ -28,15 +28,12 @@ in-app announcement on top would double-speak.
 
 Issue #240 asks for three things: (1) toast on new mail, (2) minimize-to-tray on close, and
 (3) periodic background sync. Item (3) already exists (IDLE / delta poll). This spec is
-delivered in two phases:
+delivered in two phases, **both implemented in this PR**:
 
-- **Phase 1 (this PR): Windows toast notifications for new mail.** Works whenever QuickMail
-  is running (foreground, background, or minimized to the taskbar) — already the common case
-  for an email client.
-- **Phase 2 (deferred, spec'd below): Run in background / close to tray.** Lets QuickMail keep
-  running (and keep delivering notifications) after the window is closed. Larger surface —
-  adds a tray icon, a new interaction model, and its own accessibility requirements — so it
-  is intentionally split out.
+- **Phase 1: Windows toast notifications for new mail** — plus clicking a toast opens the
+  referenced message. Works whenever QuickMail is running (foreground, background, minimized).
+- **Phase 2: Run in background / close to tray.** Lets QuickMail keep running (and keep
+  delivering notifications) after the window is closed, restoring from the tray or a toast.
 
 ---
 
@@ -133,13 +130,30 @@ If any survive, `INotificationService.ShowNewMail` is called. The threshold + un
 combination means: no toast for startup backlog, no toast for mail read elsewhere, and no
 duplicate toast on repeated IDLE fires.
 
-### Activation
+### Activation — bring forward + open the clicked message
 
-`WindowsToastNotificationService.Activated` → `App` marshals to the UI thread and calls a new
-`MainWindow.RestoreAndActivate()` (restore if minimized, `Show()`, `Activate()`, foreground via
-`SetForegroundWindow`). Phase 1 click behaviour = **bring QuickMail to the foreground**.
-Opening the specific clicked message is deferred (see Out of scope) — the accountId/messageId
-are already in the toast args for when we add it.
+The toast carries `accountId`, `folder` (the inbox FullName), and — for a single-message toast —
+`messageId` in its arguments. `WindowsToastNotificationService.OnActivated` parses them (extracted
+to the testable `ParseActivation`) into a `NotificationActivation(accountId, folder, messageId?)`
+and raises `Activated`. `App` marshals to the UI thread and calls
+`MainWindow.HandleNotificationActivation(act)`, which:
+
+1. Restores + foregrounds the window (`RestoreAndActivate`: `Show()`, un-minimize, `Activate()`,
+   Win32 `SetForegroundWindow`) and hides the tray icon.
+2. Opens the referenced message via `OpenMessageByIdentityAsync(accountId, folder, messageId)` —
+   which mirrors the existing `OpenMessageFromListAsync` mode routing (ReadingPane / Tab / Window)
+   minus its drafts check. `SelectMessageAsync` fetches the detail by id (cache or IMAP), so the
+   message need not be in the currently-loaded list.
+
+The multi-message ("N new messages") toast has no `messageId`, so its click only brings the app
+forward.
+
+**Cold start.** Because Phase 2 keeps the app running, most activations are warm. But a toast can
+outlive the app in the Action Center; clicking it then **relaunches** QuickMail via the
+auto-registered COM activator, and `OnActivated` fires before accounts connect. `HandleNotificationActivation`
+stashes the activation and re-tries it when `MainViewModel.StartupConnectCompleted` fires (after
+the startup connect populates the account's folders — `IsAccountReady`), so the message opens once
+the account is reachable. If the account never connects, the app is simply left foregrounded.
 
 ### Configuration
 
@@ -162,8 +176,9 @@ New mail arrives (screen reader running), `NotifyOnNewMail` on:
    "QuickMail. Jane Smith. Subject: Lunch Thursday?" (content order is the platform's).
 4. The user presses **Win+Shift+V** to move focus to the most recent notification (standard
    Windows shortcut; not an app shortcut). The screen reader reads the toast.
-5. The user presses **Enter** to activate it → QuickMail restores and comes to the foreground;
-   focus lands in the main window. (Or **Delete**/dismiss to clear it, standard toast behaviour.)
+5. The user presses **Enter** to activate it → QuickMail restores and comes to the foreground and
+   **opens that message** in the user's configured mode (reading pane / tab / window). (Or
+   **Delete**/dismiss to clear it, standard toast behaviour.)
 6. If the user does nothing, the toast auto-dismisses to the notification center (Win+A), where
    it can be reviewed later — all standard OS behaviour QuickMail does not implement.
 
@@ -182,12 +197,15 @@ happens; nothing else changes.
   layering an in-app announcement (would double-speak).
 - **VM state properties:** none of the existing state flags (e.g. `IsMessageOpen`) change. New
   private VM state only: `_notifyThresholdUtc`, `_notifiedMessageKeys`, and the injected
-  `INotificationService? _notifications`.
+  `INotificationService? _notifications`. New VM public surface: `event ExitRequested` (Exit now
+  raises this instead of calling `Application.Current.Shutdown()` — the View shuts down, which also
+  removes a pre-existing MVVM violation), `event StartupConnectCompleted`, `bool IsAccountReady(id)`.
 - **Selector-bound item types:** none added (no new ComboBox/ListView item types), so no
   `SelectorItemAccessibilityTests` change.
 - **DI / lifecycle:** `WindowsToastNotificationService` constructed in `App.OnStartup`, passed to
-  `MainViewModel` (new optional ctor param `INotificationService? notificationService = null`,
-  so existing tests/construction are unaffected), `Activated` wired to `MainWindow.RestoreAndActivate`.
+  both `MainViewModel` and `MainWindow` (new optional ctor params, so existing tests/construction
+  are unaffected). `Activated` (now `Action<NotificationActivation>`) is wired to
+  `MainWindow.HandleNotificationActivation`; the service is disposed in `App.OnExit`.
 - **Interface change:** `ISyncService.SyncOneFolderAsync` / `SyncOneFolderOnlineAsync` return
   `Task<IReadOnlyList<MailMessageSummary>>`. The `SyncService` implementation and the test stub
   are updated; all existing callers ignore the return value, so behaviour is unchanged.
@@ -200,14 +218,14 @@ happens; nothing else changes.
   `INotificationService`): asserts startup backlog (Date < threshold) does not notify; already-
   read messages do not notify; a repeated IDLE fire for the same message notifies once; a fresh
   unread message notifies with the expected count.
-- `ConfigService`: round-trips `NotifyOnNewMail` (on/off, default on when absent).
-- `SettingsViewModel`: loads and saves `NotifyOnNewMail`.
+- `WindowsToastNotificationService.ParseActivation`: extracts accountId/folder/messageId from a
+  toast argument string; the multi-message toast has no messageId; the info toast returns null.
+- `WindowsToastNotificationService.SenderDisplayName`: strips the address, keeps the display name.
+- `ConfigService`: round-trips `NotifyOnNewMail`, `CloseToTray`, `TrayHintShown` (defaults on/off/off).
+- `SettingsViewModel`: loads and saves `NotifyOnNewMail` and `CloseToTray`.
 
 ## Out of scope (Phase 1)
 
-- **Opening the clicked message.** Click brings the app to the foreground; it does not navigate
-  to the specific message (that requires locating the message across folders/accounts and is
-  deferred; the args are already carried for a follow-up).
 - **Backdated delivery.** A message whose `Date` header predates app launch but is delivered
   after launch will not toast (excluded by the `Date >= threshold` gate). `MailMessageSummary`
   exposes only `Date` (sent), not the IMAP INTERNALDATE (received); using received date is a
@@ -225,34 +243,77 @@ happens; nothing else changes.
 
 ---
 
-# Phase 2 — Run in background / close to tray (deferred)
+# Phase 2 — Run in background / close to tray (implemented)
 
-Not implemented in this PR. Captured so the design is on record.
+When `CloseToTray` is on, closing the main window hides it to the notification area instead of
+exiting, so the IDLE/delta watchers keep running and toasts keep arriving. The window is restored
+from the tray icon or a notification; an explicit Exit truly quits.
 
-Goal: when enabled, closing the main window hides it to the system tray instead of exiting, so
-IDLE/delta watchers keep running and toasts keep arriving; the app is restored from the tray or
-a toast; an explicit Exit truly quits.
+## Design
 
-Sketch:
+- **Tray icon.** WPF has no native tray icon, so `<UseWindowsForms>true</UseWindowsForms>` is
+  enabled *only* for a `System.Windows.Forms.NotifyIcon`, wrapped by a small View-layer
+  `Views/TrayIconManager`. WinForms types are always fully qualified and its implicit global usings
+  (`System.Windows.Forms`, `System.Drawing`) are removed in the csproj so they can't collide with
+  the WPF `System.Windows(.Media)` type names used unqualified across the codebase. Icon = the
+  executable's own icon (`Icon.ExtractAssociatedIcon`, falling back to `SystemIcons.Application` —
+  the app ships no dedicated `.ico`); tooltip "QuickMail"; context menu **Open QuickMail** / **Exit
+  QuickMail**; double-click restores. The icon is created lazily on first hide and is visible only
+  while the window is hidden.
+- **Config.** `ConfigModel.CloseToTray` (bool, **default off** — preserves today's exit-on-close
+  behaviour for existing users) and `ConfigModel.TrayHintShown` (bool, internal one-time-hint
+  state). Both in `[global]`; parsed/written by `ConfigService`. Settings → General → Notifications
+  gains a checkbox "Keep running in the notification area when I close the window", bound to
+  `SettingsViewModel.CloseToTray`.
+- **Close handling.** `MainWindow.OnClosing`: if `CloseToTray` and not an explicit exit, cancel the
+  close, show the tray icon, and `Hide()`. Because the window is *hidden* (never closed) the process
+  stays alive under WPF's default `ShutdownMode=OnLastWindowClose` — no `ShutdownMode` change is
+  needed. An explicit exit sets `_explicitExit` first so `OnClosing` performs a real close.
+- **Exit paths.** `MainViewModel.Exit` now raises `ExitRequested` (instead of calling
+  `Application.Current.Shutdown()` — removing an MVVM violation); `MainWindow` handles it and the
+  tray **Exit** item via `RequestExit()`, which sets `_explicitExit` and calls
+  `Application.Current.Shutdown()`. `MainWindow.OnClosed` disposes the tray icon so it never lingers.
+- **One-time hint.** The first time the window hides to the tray, `INotificationService.ShowInfo`
+  shows a "QuickMail is still running in the notification area…" toast (announced natively by
+  screen readers, not baked into any control), then `TrayHintShown` is set so it never repeats.
+  Its click is ignored (`action=info` toast has no target).
 
-- Add `<UseWindowsForms>true</UseWindowsForms>` and a `System.Windows.Forms.NotifyIcon` managed
-  by a small View-layer `TrayIconManager` owned by `MainWindow` (or `App`). Icon = app icon,
-  tooltip "QuickMail", context menu **Open QuickMail** / **Exit**.
-- New `ConfigModel.CloseToTray` (bool, **default off** — preserves today's exit-on-close
-  behaviour for existing users). Settings → General → Notifications: "When I close the window,
-  keep QuickMail running in the notification area".
-- `MainWindow.OnClosing`: if `CloseToTray` and this is not an explicit exit, cancel the close and
-  `Hide()`. An explicit-exit flag (set by the tray **Exit** item and a File → Exit menu item)
-  bypasses the cancel and calls `Application.Current.Shutdown()`.
-- Tray restore reuses `RestoreAndActivate()` (added in Phase 1).
+## Keyboard walkthrough
 
-Phase 2 accessibility requirements (must be in its own spec before coding):
+Close-to-tray on, screen reader running:
 
-- The tray icon and its context menu must be keyboard reachable (Win+B → arrows → Menu/Enter is
-  the OS path) and each menu item needs a clear accessible name.
-- A keyboard-only way to exit must always exist independent of the mouse (File → Exit).
-- First time the window hides to tray, a one-time toast/hint ("QuickMail is still running in the
-  notification area") so the app doesn't silently vanish — delivered as a toast (native SR
-  announcement), not baked into any control name.
-- Decide `ShutdownMode` implications (WPF `OnLastWindowClose` vs `OnExplicitShutdown`) so hiding
-  the last window doesn't terminate the process.
+1. User presses **Alt+F4** (or File → Exit is *not* used). The window vanishes; a toast announces
+   "QuickMail is still running in the notification area…" (first time only). Focus returns to the
+   desktop/previous app — QuickMail is no longer in the Alt+Tab list.
+2. New mail arrives → a toast appears exactly as in Phase 1. **Enter** on it restores QuickMail to
+   the foreground and opens the message.
+3. To restore manually: **Win+B** moves focus to the notification area; the user arrows to the
+   QuickMail icon (announced "QuickMail"), presses **Enter** (or the **Menu** key → "Open
+   QuickMail") → the window returns to the foreground.
+4. To quit: from the tray icon, **Menu** key → arrow to "Exit QuickMail" → **Enter**; or, when the
+   window is open, **Alt** → File → **Exit** (`ExitCommand`). Either performs a real shutdown.
+
+With `CloseToTray` off (default): closing the window exits the app exactly as before; the tray icon
+is never created.
+
+## Infrastructure changes
+
+- **F6 ring:** unchanged (the tray icon is an OS surface, not an in-app pane).
+- **CommandRegistry:** no new command. Exit keeps its existing `ExitCommand`; close-to-tray is a
+  Settings checkbox, not a hotkey.
+- **`AutomationProperties.Name`:** one new checkbox, "Keep running in the notification area when I
+  close the window" (short label). Tray menu item labels ("Open QuickMail", "Exit QuickMail") are
+  WinForms `ToolStripMenuItem` text, exposed to UIA by WinForms.
+- **`AccessibilityHelper.Announce`:** none. The one-time hint is a native toast (`ShowInfo`).
+- **Build:** `UseWindowsForms=true`; implicit `System.Windows.Forms` / `System.Drawing` usings
+  removed. `MainWindow` gains an `INotificationService?` ctor param (for the hint).
+- **Lifecycle:** `TrayIconManager` (owns the `NotifyIcon`) is created lazily and disposed in
+  `MainWindow.OnClosed`.
+
+## Out of scope (Phase 2)
+
+- **Minimize-to-tray** (only *close* hides to tray; the minimize button still minimizes to the
+  taskbar).
+- **Persistent tray icon** while the window is open (the icon appears only while hidden).
+- **Launch-on-startup / start-hidden** and any autostart registration.
+- **Unread-count badge / dynamic tray tooltip** (tooltip is the static "QuickMail").

--- a/docs/planning/notifications-pm-dev-spec.md
+++ b/docs/planning/notifications-pm-dev-spec.md
@@ -157,10 +157,11 @@ the account is reachable. If the account never connects, the app is simply left 
 
 ### Configuration
 
-New `ConfigModel.NotifyOnNewMail` (bool, **default on**). Consistent with the app's other
-opt-out defaults (AutoUpdate on, announcements on) and with the issue's intent. Parsed/written
-by `ConfigService` in the `[global]` section as `NotifyOnNewMail = on|off`, read live via
-`_configService.Load()` on each detection so a Settings change takes effect without restart.
+New `ConfigModel.NotifyOnNewMail` (bool, **default off — opt-in**). Notifications and
+run-in-background are both off by default so nothing about the app's behaviour changes until the
+user enables them in Settings. Parsed/written by `ConfigService` in the `[global]` section as
+`NotifyOnNewMail = on|off`, read live via `_configService.Load()` on each detection so a Settings
+change takes effect without restart.
 
 Settings UI: a new **Notifications** GroupBox on the **General** tab with one checkbox,
 "Show a _notification when new mail arrives", bound to `SettingsViewModel.NotifyOnNewMail`.
@@ -221,7 +222,7 @@ happens; nothing else changes.
 - `WindowsToastNotificationService.ParseActivation`: extracts accountId/folder/messageId from a
   toast argument string; the multi-message toast has no messageId; the info toast returns null.
 - `WindowsToastNotificationService.SenderDisplayName`: strips the address, keeps the display name.
-- `ConfigService`: round-trips `NotifyOnNewMail`, `CloseToTray`, `TrayHintShown` (defaults on/off/off).
+- `ConfigService`: round-trips `NotifyOnNewMail`, `CloseToTray`, `TrayHintShown` (all default off).
 - `SettingsViewModel`: loads and saves `NotifyOnNewMail` and `CloseToTray`.
 
 ## Out of scope (Phase 1)


### PR DESCRIPTION
Implements issue #240 (Windows notifications + run-in-background). Both features are **off by default** and opt-in from **Settings → General → Notifications**.

## What's included
- **New-mail toasts** — proper Windows app notifications for an unpackaged Win32 app via `Microsoft.Toolkit.Uwp.Notifications` / `ToastNotificationManagerCompat` (auto-registers AUMID + COM activator; no MSIX manifest). Hung off the existing `IChangeNotifier` new-mail signal (IMAP IDLE / Graph delta). Screen-reader-announced natively; sender display name + subject; de-duped and gated so no startup flood.
- **Click a toast → opens that message** in the user's configured mode (reading pane / tab / window), bringing the window forward. Cold-start clicks defer until the account connects, then open.
- **Run in background / close to tray** — `CloseToTray` (default off): closing the window hides QuickMail to the notification area (WinForms `NotifyIcon`, `Views/TrayIconManager`) so watchers keep running; restore from the tray icon or a toast; File→Exit / tray Exit quits; Windows logoff exits cleanly. One-time "still running…" hint toast.
- **Settings** — two opt-in checkboxes; `MainViewModel.Exit` refactored to raise an event (removes an MVVM violation).

## Build
- TFM bumped `net8.0-windows` → `net8.0-windows10.0.17763.0` (required for the WinRT toast API); `UseWindowsForms=true` for the tray icon only (implicit WinForms/Drawing usings removed to avoid collisions).

## Verification
- Debug + single-file publish build clean; **1170 tests pass**; runtime-smoke-tested (startup, close-to-tray keeps the process alive).
- Two independent code reviews; all findings addressed.
- Spec: `docs/planning/notifications-pm-dev-spec.md`.

Closes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)