### PR TITLE
Single instance per profile: relaunch restores the running app (#240)

### DIFF
--- a/QuickMail.Tests/SingleInstanceServiceTests.cs
+++ b/QuickMail.Tests/SingleInstanceServiceTests.cs
@@ -1,0 +1,106 @@
+using System.IO;
+using QuickMail.Services;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+public class SingleInstanceServiceTests
+{
+    // Each test that touches real kernel objects uses a unique profile path so tests never
+    // collide with each other or with a QuickMail instance running on the machine.
+    private static string[] UniqueProfileArgs() =>
+        ProfileArgs(Path.Combine(Path.GetTempPath(), "qm-si-test-" + Guid.NewGuid().ToString("N")));
+
+    private static string[] ProfileArgs(string dir) => new[] { "--profileDir", dir };
+
+    [Fact]
+    public void ProfileKey_IsStableAcrossCaseAndTrailingSeparator()
+    {
+        var baseKey = SingleInstanceService.ProfileKey(ProfileArgs(@"C:\Data\QuickMailProfile"));
+
+        Assert.Equal(baseKey, SingleInstanceService.ProfileKey(ProfileArgs(@"c:\data\quickmailprofile")));
+        Assert.Equal(baseKey, SingleInstanceService.ProfileKey(ProfileArgs(@"C:\Data\QuickMailProfile\")));
+        Assert.Equal(baseKey, SingleInstanceService.ProfileKey(ProfileArgs(@"C:\Data\Other\..\QuickMailProfile")));
+    }
+
+    [Fact]
+    public void ProfileKey_DiffersForDifferentDirectories()
+    {
+        var a = SingleInstanceService.ProfileKey(ProfileArgs(@"C:\Data\ProfileA"));
+        var b = SingleInstanceService.ProfileKey(ProfileArgs(@"C:\Data\ProfileB"));
+        Assert.NotEqual(a, b);
+    }
+
+    [Fact]
+    public void ProfileKey_NoArgs_MatchesExplicitDefaultProfileDir()
+    {
+        var defaultDir = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "QuickMail");
+
+        Assert.Equal(
+            SingleInstanceService.ProfileKey(Array.Empty<string>()),
+            SingleInstanceService.ProfileKey(ProfileArgs(defaultDir)));
+    }
+
+    [Fact]
+    public void ProfileKey_IsFixedLengthHex()
+    {
+        var key = SingleInstanceService.ProfileKey(ProfileArgs(@"C:\Data\QuickMailProfile"));
+        Assert.Equal(32, key.Length);
+        Assert.All(key, c => Assert.True(Uri.IsHexDigit(c)));
+    }
+
+    [Fact]
+    public void SecondAcquire_ForSameProfile_FailsUntilFirstIsDisposed()
+    {
+        var args = UniqueProfileArgs();
+
+        var first = SingleInstanceService.TryAcquire(args);
+        Assert.NotNull(first);
+        try
+        {
+            Assert.Null(SingleInstanceService.TryAcquire(args));
+        }
+        finally
+        {
+            first!.Dispose();
+        }
+
+        var second = SingleInstanceService.TryAcquire(args);
+        Assert.NotNull(second);
+        second!.Dispose();
+    }
+
+    [Fact]
+    public void Acquire_ForDifferentProfiles_BothSucceed()
+    {
+        var first = SingleInstanceService.TryAcquire(UniqueProfileArgs());
+        var second = SingleInstanceService.TryAcquire(UniqueProfileArgs());
+        try
+        {
+            Assert.NotNull(first);
+            Assert.NotNull(second);
+        }
+        finally
+        {
+            first?.Dispose();
+            second?.Dispose();
+        }
+    }
+
+    [Fact]
+    public void SecondLaunch_SignalsFirstInstanceToActivate()
+    {
+        var args = UniqueProfileArgs();
+
+        using var first = SingleInstanceService.TryAcquire(args)!;
+        Assert.NotNull(first);
+
+        using var activated = new ManualResetEventSlim(false);
+        first.ListenForActivation(activated.Set);
+
+        Assert.Null(SingleInstanceService.TryAcquire(args));
+        Assert.True(activated.Wait(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken),
+            "the running instance was not signaled by the second launch");
+    }
+}

--- a/QuickMail/App.xaml.cs
+++ b/QuickMail/App.xaml.cs
@@ -24,6 +24,10 @@ public partial class App : Application
     private BugReportService? _bugReportService;
     private WindowsToastNotificationService? _notificationService;
 
+    // Owned by Main (acquired before WPF starts, disposed after Run returns); OnStartup
+    // wires its activation signal to the main window.
+    private static SingleInstanceService? _singleInstance;
+
     // Explicit entry point (App.xaml compiles as Page; see csproj StartupObject). Velopack must
     // run before any WPF initialization: on install/update/uninstall its hooks handle the event
     // and exit the process, and on a normal launch after an update it finalizes the new version.
@@ -34,9 +38,23 @@ public partial class App : Application
             .OnBeforeUninstallFastCallback(_ => LaunchUninstallDataPrompt())
             .Run();
 
-        var app = new App();
-        app.InitializeComponent();
-        app.Run();
+        // One instance per profile (issue #240): with close-to-tray the process can be running
+        // with no visible window, and relaunching from the Start menu must restore that window
+        // rather than pile up processes sharing one SQLite store. When another instance owns
+        // this profile, TryAcquire has already signaled it to come to the foreground, so this
+        // launch simply ends. --help is exempt so usage is always available.
+        if (!IsHelpRequest(args))
+        {
+            _singleInstance = SingleInstanceService.TryAcquire(args);
+            if (_singleInstance is null) return;
+        }
+
+        using (_singleInstance)
+        {
+            var app = new App();
+            app.InitializeComponent();
+            app.Run();
+        }
     }
 
     // Uninstall-time offer to remove user data, mirroring the old installer's prompt.
@@ -253,6 +271,12 @@ public partial class App : Application
                 mainWindow.Dispatcher.BeginInvoke(() => mainWindow.HandleNotificationActivation(act));
 
             mainWindow.Show();
+
+            // A second launch of the same profile signals this handle instead of starting
+            // another process; restore the window (and drop the tray icon) exactly as the
+            // tray icon's Open action would. The signal arrives on a thread-pool thread.
+            _singleInstance?.ListenForActivation(() =>
+                mainWindow.Dispatcher.BeginInvoke(() => mainWindow.RestoreFromTray()));
         }
         catch (Exception ex)
         {

--- a/QuickMail/Services/SingleInstanceService.cs
+++ b/QuickMail/Services/SingleInstanceService.cs
@@ -1,0 +1,122 @@
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+
+namespace QuickMail.Services;
+
+/// <summary>
+/// Enforces one QuickMail process per profile directory. The first instance holds a named
+/// mutex and listens on a named event; any later launch for the same profile signals that
+/// event — so the running instance can restore its window from the tray — and exits.
+/// Different --profileDir values produce different object names, so deliberate
+/// multi-profile use keeps working.
+/// </summary>
+public sealed class SingleInstanceService : IDisposable
+{
+    private readonly Mutex _mutex;
+    private readonly EventWaitHandle _activateRequested;
+    private RegisteredWaitHandle? _waitRegistration;
+    private bool _disposed;
+
+    private SingleInstanceService(Mutex mutex, EventWaitHandle activateRequested)
+    {
+        _mutex = mutex;
+        _activateRequested = activateRequested;
+    }
+
+    /// <summary>
+    /// Tries to claim single-instance ownership for the profile selected by <paramref name="args"/>.
+    /// Returns the guard on success. Returns null when another instance already owns the profile;
+    /// in that case the running instance has been signaled to bring its window to the foreground
+    /// and the caller should end the process immediately.
+    /// </summary>
+    public static SingleInstanceService? TryAcquire(string[] args)
+    {
+        var key = ProfileKey(args);
+        var mutex = new Mutex(initiallyOwned: true, $@"Local\QuickMail-{key}", out var createdNew);
+        if (!createdNew)
+        {
+            mutex.Dispose();
+            SignalExistingInstance(key);
+            return null;
+        }
+
+        var activateRequested = new EventWaitHandle(false, EventResetMode.AutoReset, ActivateEventName(key));
+        return new SingleInstanceService(mutex, activateRequested);
+    }
+
+    /// <summary>
+    /// Starts listening for activation signals from later launches. The callback fires on a
+    /// thread-pool thread; the caller is responsible for marshaling to the UI thread.
+    /// </summary>
+    public void ListenForActivation(Action onActivateRequested)
+    {
+        _waitRegistration ??= ThreadPool.RegisterWaitForSingleObject(
+            _activateRequested,
+            (_, _) => onActivateRequested(),
+            state: null,
+            Timeout.Infinite,
+            executeOnlyOnce: false);
+    }
+
+    private static void SignalExistingInstance(string key)
+    {
+        try
+        {
+            using var evt = EventWaitHandle.OpenExisting(ActivateEventName(key));
+            evt.Set();
+        }
+        catch (WaitHandleCannotBeOpenedException)
+        {
+            // The owning instance is mid-startup (mutex created, event not yet) or mid-exit.
+            // There is nothing to activate; this launch just ends.
+        }
+    }
+
+    private static string ActivateEventName(string key) => $@"Local\QuickMail-{key}-activate";
+
+    /// <summary>
+    /// Derives a fixed-length identity for the profile directory chosen by the command line,
+    /// so the kernel object names stay valid regardless of path length or characters.
+    /// Letter case and a trailing separator do not change the identity.
+    /// </summary>
+    internal static string ProfileKey(string[] args)
+    {
+        var raw = ProfileContext.ParseProfileDir(args);
+        string dir;
+        if (raw is null)
+        {
+            dir = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "QuickMail");
+        }
+        else
+        {
+            // An unparseable path still yields a stable key; startup rejects it with an
+            // error dialog before any second instance could matter.
+            try { dir = Path.GetFullPath(raw); }
+            catch (Exception) { dir = raw; }
+        }
+
+        dir = dir.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+                 .ToUpperInvariant();
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(dir));
+        return Convert.ToHexString(hash, 0, 16);
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+
+        _waitRegistration?.Unregister(null);
+        _activateRequested.Dispose();
+        try { _mutex.ReleaseMutex(); }
+        catch (ApplicationException)
+        {
+            // Not owned by this thread — closing the handle below still frees the
+            // kernel object once the process exits.
+        }
+        _mutex.Dispose();
+    }
+}

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -651,8 +651,9 @@ public partial class MainWindow : Window
         }
     }
 
-    // Invoked from the tray icon (double-click or the Open item), which fires on the UI thread.
-    private void RestoreFromTray()
+    // Invoked on the UI thread from the tray icon (activate or the Open item) and from App when
+    // a second launch of the same profile signals the running instance to come forward.
+    public void RestoreFromTray()
     {
         RestoreAndActivate();
         _trayIcon?.Hide(); // tray icon is only shown while the window is hidden


### PR DESCRIPTION
Fixes the reopened part of #240: with close-to-tray enabled, every launch from the Start menu or desktop spawned another full QuickMail process — 10 launches meant 10 processes and 10 tray icons, all sharing one SQLite store and holding duplicate IMAP connections.

## What changed

- **`SingleInstanceService`** (new): before WPF starts, `Main` claims a named mutex keyed to the profile directory (SHA-256 of the normalized path, so kernel object names stay valid for any path). If another instance already owns the profile, the new launch signals a named event and exits.
- **`App.xaml.cs`**: acquires the guard in `Main` right after the Velopack hook runs, and after `mainWindow.Show()` wires the activation signal to `RestoreFromTray()` on the UI thread — a relaunch behaves exactly like activating the tray icon's Open action. `--help` is exempt so usage stays available while an instance runs.
- **`MainWindow.RestoreFromTray`** made public so App can invoke it.
- Distinct `--profileDir` values produce distinct mutex names, so deliberate multi-profile use (isolated testing) still runs side by side.

## Testing

- 7 new tests in `SingleInstanceServiceTests` (key stability across case/trailing separator/relative segments, per-profile mutex exclusivity, activation signaling). Full suite: 1177 passed, 0 failed.
- Manual smoke: launched the built exe twice with the same `--profileDir` — second launch exited, one process remained and its window was brought forward; a different profile launched a second process as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)