### PR TITLE
Fix folder creation discoverability (#250), orphaned message windows (#252), flag hotkey focus (#255); document toast trade-off (#253)

### DIFF
--- a/QuickMail/Services/SingleInstanceService.cs
+++ b/QuickMail/Services/SingleInstanceService.cs
@@ -60,6 +60,17 @@ public sealed class SingleInstanceService : IDisposable
             executeOnlyOnce: false);
     }
 
+    // Design note (issue #253): the activation signal is a bare auto-reset event that carries no
+    // payload — it tells the running instance "come to the foreground", nothing more. A second
+    // launch that arrives with toast-activation arguments (open a specific message) therefore
+    // brings the window forward but drops the account/folder/message deep-link. This is a
+    // deliberately accepted trade-off, not a bug: the case only occurs when the running instance's
+    // in-process toast COM registration has failed AND a stale toast survives to COM-launch a
+    // second exe — otherwise activation is delivered in-process and never reaches this path.
+    // Forwarding the payload would require real inter-process data transfer (e.g. a named pipe
+    // carrying the command line) on the single-instance/startup path, which this app has a history
+    // of hangs and zombie processes on; the low likelihood does not justify that added surface.
+    // If this is ever revisited, this method (and ActivateEventName) is the seam to extend.
     private static void SignalExistingInstance(string key)
     {
         try

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -4988,6 +4988,59 @@ public partial class MainViewModel : ObservableObject, IDisposable
         finally { IsBusy = false; }
     }
 
+    // Set by CreateFolderReturningFoldersAsync (the folder-picker path) because that runs while the
+    // modal picker's message loop is active — rebuilding the main-window folder tree then is the
+    // documented re-entrancy crash (see CLAUDE.md "re-query the folder tree ... while the dialog's
+    // loop is still active"). The rebuild is deferred to CommitPendingFolderTreeRebuild(), called
+    // once the picker has closed.
+    private bool _folderTreeRebuildPending;
+
+    /// <summary>
+    /// Creates a folder for the folder picker (move/copy-message flow) and returns the owning
+    /// account's refreshed folder list so the picker — which holds a filtered copy of
+    /// <see cref="CachedFolders"/> — can rebuild its own tree in place and select the new folder.
+    /// Refreshes only the cache (not the main-window folder tree); that rebuild is deferred to
+    /// <see cref="CommitPendingFolderTreeRebuild"/> because this runs inside the picker's modal
+    /// loop. Returns null on failure.
+    /// </summary>
+    public async Task<IReadOnlyList<MailFolderModel>?> CreateFolderReturningFoldersAsync(
+        Guid accountId, string? parentFolderName, string name)
+    {
+        StatusText = $"Creating folder '{name}'…";
+        IsBusy     = true;
+        try
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            await _imap.CreateFolderAsync(accountId, parentFolderName, name, cts.Token);
+            var folderList = await _imap.GetFoldersAsync(accountId, cts.Token);
+            _cachedFolders[accountId] = folderList;
+            var account = Accounts.FirstOrDefault(a => a.Id == accountId);
+            if (account != null) ApplyAccountStatus(account, folderList);
+            _folderTreeRebuildPending = true;
+            StatusText = $"Folder '{name}' created.";
+            return folderList;
+        }
+        catch (Exception ex)
+        {
+            StatusText = $"Failed to create folder: {ex.Message}";
+            LogService.Log("CreateFolder", ex);
+            return null;
+        }
+        finally { IsBusy = false; }
+    }
+
+    /// <summary>
+    /// Rebuilds the main-window folder tree from cache if a folder was created via the picker while
+    /// a modal was open. Safe to call unconditionally; a no-op when nothing is pending. Callers must
+    /// invoke this only after the modal picker has closed (its message loop is dead).
+    /// </summary>
+    public void CommitPendingFolderTreeRebuild()
+    {
+        if (!_folderTreeRebuildPending) return;
+        _folderTreeRebuildPending = false;
+        RebuildFolderListFromCache();
+    }
+
     /// <summary>Moves a folder to a new parent (IMAP RENAME) and refreshes the tree.</summary>
     public async Task MoveFolderToAsync(FolderTreeNode node, MailFolderModel destination)
     {
@@ -5093,6 +5146,10 @@ public partial class MainViewModel : ObservableObject, IDisposable
     {
         if (messages.Count == 0) return;
 
+        // If the destination was just created inside the (now-closed) folder picker, bring the main
+        // folder tree up to date — deferred out of the picker's modal loop for re-entrancy safety.
+        CommitPendingFolderTreeRebuild();
+
         var label  = messages.Count == 1 ? "message" : $"{messages.Count} messages";
         StatusText = $"Moving {label}…";
         IsBusy     = true;
@@ -5142,6 +5199,10 @@ public partial class MainViewModel : ObservableObject, IDisposable
     public async Task CopySelectedMessagesToFolderAsync(IReadOnlyList<MailMessageSummary> messages, MailFolderModel destination)
     {
         if (messages.Count == 0) return;
+
+        // If the destination was just created inside the (now-closed) folder picker, bring the main
+        // folder tree up to date — deferred out of the picker's modal loop for re-entrancy safety.
+        CommitPendingFolderTreeRebuild();
 
         var label  = messages.Count == 1 ? "message" : $"{messages.Count} messages";
         StatusText = $"Copying {label}…";

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -5146,10 +5146,6 @@ public partial class MainViewModel : ObservableObject, IDisposable
     {
         if (messages.Count == 0) return;
 
-        // If the destination was just created inside the (now-closed) folder picker, bring the main
-        // folder tree up to date — deferred out of the picker's modal loop for re-entrancy safety.
-        CommitPendingFolderTreeRebuild();
-
         var label  = messages.Count == 1 ? "message" : $"{messages.Count} messages";
         StatusText = $"Moving {label}…";
         IsBusy     = true;
@@ -5199,10 +5195,6 @@ public partial class MainViewModel : ObservableObject, IDisposable
     public async Task CopySelectedMessagesToFolderAsync(IReadOnlyList<MailMessageSummary> messages, MailFolderModel destination)
     {
         if (messages.Count == 0) return;
-
-        // If the destination was just created inside the (now-closed) folder picker, bring the main
-        // folder tree up to date — deferred out of the picker's modal loop for re-entrancy safety.
-        CommitPendingFolderTreeRebuild();
 
         var label  = messages.Count == 1 ? "message" : $"{messages.Count} messages";
         StatusText = $"Copying {label}…";

--- a/QuickMail/Views/FolderPickerWindow.xaml
+++ b/QuickMail/Views/FolderPickerWindow.xaml
@@ -23,9 +23,13 @@
                  AutomationProperties.Name="Folder search"/>
 
         <DockPanel DockPanel.Dock="Bottom" Margin="0,8,0,0">
+            <!-- No access-key underscore on the content: WPF activates a bare mnemonic letter
+                 without Alt when focus isn't in a text field, so "_New Folder" fired on plain "n"
+                 in the folder tree and stole the tree's type-ahead. Alt+N is wired explicitly in
+                 code-behind instead; the accessible name still reads "New Folder". -->
             <Button x:Name="NewFolderButton"
                     DockPanel.Dock="Left"
-                    Content="_New Folder…"
+                    Content="New Folder…"
                     MinWidth="90"
                     Visibility="Collapsed"
                     Click="NewFolderButton_Click"
@@ -93,6 +97,7 @@
                   AutomationProperties.Name="Folders"
                   BorderThickness="1"
                   KeyboardNavigation.TabNavigation="Once"
+                  TextSearch.TextPath="Label"
                   PreviewKeyDown="FolderTreeView_PreviewKeyDown"
                   MouseDoubleClick="FolderTreeView_MouseDoubleClick">
             <TreeView.Resources>

--- a/QuickMail/Views/FolderPickerWindow.xaml
+++ b/QuickMail/Views/FolderPickerWindow.xaml
@@ -22,20 +22,28 @@
                  PreviewKeyDown="SearchBox_PreviewKeyDown"
                  AutomationProperties.Name="Folder search"/>
 
-        <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal"
-                    HorizontalAlignment="Right" Margin="0,8,0,0">
-            <Button x:Name="OpenButton"
-                    Content="_Open"
-                    IsDefault="True"
-                    MinWidth="75"
-                    Margin="0,0,6,0"
-                    Click="OpenButton_Click"
-                    AutomationProperties.Name="Open selected folder"/>
-            <Button Content="_Cancel"
-                    IsCancel="True"
-                    MinWidth="75"
-                    AutomationProperties.Name="Cancel"/>
-        </StackPanel>
+        <DockPanel DockPanel.Dock="Bottom" Margin="0,8,0,0">
+            <Button x:Name="NewFolderButton"
+                    DockPanel.Dock="Left"
+                    Content="_New Folder…"
+                    MinWidth="90"
+                    Visibility="Collapsed"
+                    Click="NewFolderButton_Click"
+                    AutomationProperties.Name="New Folder"/>
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                <Button x:Name="OpenButton"
+                        Content="_Open"
+                        IsDefault="True"
+                        MinWidth="75"
+                        Margin="0,0,6,0"
+                        Click="OpenButton_Click"
+                        AutomationProperties.Name="Open selected folder"/>
+                <Button Content="_Cancel"
+                        IsCancel="True"
+                        MinWidth="75"
+                        AutomationProperties.Name="Cancel"/>
+            </StackPanel>
+        </DockPanel>
 
         <ListBox x:Name="FolderListBox"
                  AutomationProperties.Name="Folders"

--- a/QuickMail/Views/FolderPickerWindow.xaml.cs
+++ b/QuickMail/Views/FolderPickerWindow.xaml.cs
@@ -57,6 +57,10 @@ public partial class FolderPickerWindow : Window
         InitializeComponent();
         Title = title;
 
+        // Alt+N → New Folder (see FolderPicker_PreviewKeyDown). Window-level so it fires from the
+        // tree, the buttons, or anywhere else in the picker.
+        PreviewKeyDown += FolderPicker_PreviewKeyDown;
+
         // The New Folder button is only meaningful when the caller supplied a way to create one.
         // Scoped to the tree view (the move/copy-message picker); the flat list has no in-place
         // repopulation path wired, so it never offers creation.
@@ -300,6 +304,22 @@ public partial class FolderPickerWindow : Window
         {
             e.Handled = true;
             Commit();
+        }
+    }
+
+    // Alt+N opens New Folder. Wired explicitly (rather than a button mnemonic) so a bare "n" in the
+    // folder tree stays available for type-ahead instead of triggering the button (see the XAML note
+    // on NewFolderButton). Handled window-wide so it works whatever picker control has focus.
+    private void FolderPicker_PreviewKeyDown(object sender, KeyEventArgs e)
+    {
+        // With Alt held, the character arrives as a System key; the real key is in SystemKey.
+        var key = e.Key == Key.System ? e.SystemKey : e.Key;
+        if (key == Key.N
+            && (Keyboard.Modifiers & ModifierKeys.Alt) == ModifierKeys.Alt
+            && NewFolderButton.Visibility == Visibility.Visible)
+        {
+            e.Handled = true;
+            NewFolderButton_Click(NewFolderButton, new RoutedEventArgs());
         }
     }
 

--- a/QuickMail/Views/FolderPickerWindow.xaml.cs
+++ b/QuickMail/Views/FolderPickerWindow.xaml.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
@@ -26,6 +27,16 @@ public partial class FolderPickerWindow : Window
     private readonly MailFolderModel? _initialFolder;
     private readonly bool _useTreeView;
 
+    // When non-null, a "New Folder" button is shown and this callback creates the folder,
+    // refreshes the owning account, and returns that account's refreshed folder list so the
+    // picker can rebuild in place and select the new folder (issue #250, move/copy-message flow).
+    private readonly Func<Guid, string?, string, Task<IReadOnlyList<MailFolderModel>?>>? _folderCreator;
+
+    // Retained for the tree view so it can be rebuilt after a folder is created. Not needed by the
+    // flat list, which reuses its own ObservableCollection (_items) directly.
+    private List<AccountModel>? _treeAccounts;
+    private Dictionary<Guid, List<MailFolderModel>>? _treeFolders;
+
     public MailFolderModel? SelectedFolder { get; private set; }
     public AccountModel? SelectedAccount { get; private set; }
 
@@ -36,13 +47,22 @@ public partial class FolderPickerWindow : Window
         string title = "Go to Folder",
         MailFolderModel? initialFolder = null,
         IReadOnlyDictionary<Guid, MailFolderModel>? accountMailFolders = null,
-        bool useTreeView = false)
+        bool useTreeView = false,
+        Func<Guid, string?, string, Task<IReadOnlyList<MailFolderModel>?>>? folderCreator = null)
     {
         _initialFolder = initialFolder;
         _useTreeView = useTreeView;
+        _folderCreator = folderCreator;
 
         InitializeComponent();
         Title = title;
+
+        // The New Folder button is only meaningful when the caller supplied a way to create one.
+        // Scoped to the tree view (the move/copy-message picker); the flat list has no in-place
+        // repopulation path wired, so it never offers creation.
+        NewFolderButton.Visibility = folderCreator != null && useTreeView
+            ? Visibility.Visible
+            : Visibility.Collapsed;
 
         if (_useTreeView)
         {
@@ -113,23 +133,35 @@ public partial class FolderPickerWindow : Window
         FolderListBox.Visibility = Visibility.Collapsed;
         FolderTreeView.Visibility = Visibility.Visible;
 
-        var roots = new List<FolderTreeNode>();
-        var accountList = accounts.ToList();
+        // Retain a private, mutable copy so RebuildTreeView can regenerate the tree after a folder
+        // is created without depending on the caller's snapshot (which may be a filtered copy).
+        _treeAccounts = accounts.ToList();
+        _treeFolders  = _treeAccounts
+            .Where(a => cachedFolders.ContainsKey(a.Id))
+            .ToDictionary(a => a.Id, a => cachedFolders[a.Id].ToList());
 
-        foreach (var account in accountList)
+        RebuildTreeView();
+
+        Loaded += (_, _) => Dispatcher.InvokeAsync(
+            () => FolderTreeView.Focus(), DispatcherPriority.Input);
+    }
+
+    private void RebuildTreeView()
+    {
+        if (_treeAccounts == null || _treeFolders == null) return;
+
+        var roots = new List<FolderTreeNode>();
+        foreach (var account in _treeAccounts)
         {
-            if (!cachedFolders.TryGetValue(account.Id, out var folders) || folders.Count == 0)
+            if (!_treeFolders.TryGetValue(account.Id, out var folders) || folders.Count == 0)
                 continue;
 
-            var nodes = FolderTreeBuilder.Build(folders, accountList.Count > 1 ? account : null);
+            var nodes = FolderTreeBuilder.Build(folders, _treeAccounts.Count > 1 ? account : null);
             ExpandAll(nodes);
             roots.AddRange(nodes);
         }
 
         FolderTreeView.ItemsSource = roots;
-
-        Loaded += (_, _) => Dispatcher.InvokeAsync(
-            () => FolderTreeView.Focus(), DispatcherPriority.Input);
     }
 
     private static void ExpandAll(IEnumerable<FolderTreeNode> nodes)
@@ -274,6 +306,145 @@ public partial class FolderPickerWindow : Window
     private void FolderTreeView_MouseDoubleClick(object sender, MouseButtonEventArgs e) => Commit();
 
     private void OpenButton_Click(object sender, RoutedEventArgs e) => Commit();
+
+    // Create a folder from within the picker (move/copy-message flow, tree view only). The parent
+    // is the currently selected folder, or the account root when a header / nothing is selected.
+    // After creation the tree is rebuilt from the refreshed folder list and the new folder selected
+    // so the user can immediately Open it as the move/copy destination.
+    private async void NewFolderButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (_folderCreator == null || !_useTreeView || _treeFolders == null) return;
+        if (!TryResolveTreeCreateTarget(out var accountId, out var parentFullName, out var parentLabel))
+            return;
+
+        var dlg = new NewFolderDialog { Owner = this, ParentFolderName = parentLabel };
+        if (dlg.ShowDialog() != true) return;
+
+        var name = dlg.FolderName;
+        var updated = await _folderCreator(accountId, parentFullName, name);
+        if (updated == null) return; // failure is surfaced by the caller (main-window status text)
+
+        _treeFolders[accountId] = updated.ToList();
+        RebuildTreeView();
+
+        // Container generation for the freshly-assigned ItemsSource completes on a later dispatcher
+        // pass; select the new node once it exists so focus lands on it for the screen reader.
+        // Fire-and-forget: the selection is a UI side effect with nothing to await on.
+        _ = Dispatcher.InvokeAsync(
+            () => SelectCreatedTreeNode(accountId, parentFullName, name),
+            DispatcherPriority.Input);
+    }
+
+    private bool TryResolveTreeCreateTarget(out Guid accountId, out string? parentFullName, out string parentLabel)
+    {
+        accountId = Guid.Empty;
+        parentFullName = null;
+        parentLabel = string.Empty;
+
+        var node = FolderTreeView.SelectedItem as FolderTreeNode;
+
+        // A real folder is selected → create a subfolder beneath it.
+        if (node is { IsHeader: false, Folder: { } folder })
+        {
+            accountId = folder.AccountId;
+            parentFullName = folder.FullName;
+            parentLabel = folder.DisplayName;
+            return true;
+        }
+
+        // A header (account) node is selected → create at that account's root.
+        if (node is { IsHeader: true } && _treeAccounts != null)
+        {
+            var acct = _treeAccounts.FirstOrDefault(a => a.AccountLabel == node.Label);
+            if (acct != null)
+            {
+                accountId = acct.Id;
+                parentLabel = acct.AccountLabel;
+                return true;
+            }
+        }
+
+        // Nothing (usable) selected → fall back to the sole account's root. The move/copy-message
+        // picker is scoped to the accounts owning the messages, so this is unambiguous when there
+        // is only one. With several accounts and no folder selected we can't guess a destination.
+        if (_treeFolders != null && _treeFolders.Count == 1 && _treeAccounts != null)
+        {
+            var acct = _treeAccounts.FirstOrDefault(a => _treeFolders.ContainsKey(a.Id));
+            if (acct != null)
+            {
+                accountId = acct.Id;
+                parentLabel = acct.AccountLabel;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private void SelectCreatedTreeNode(Guid accountId, string? parentFullName, string name)
+    {
+        if (FolderTreeView.ItemsSource is not IEnumerable<FolderTreeNode> roots) return;
+
+        // Siblings of the new folder: the parent's children, the account header's children, or the
+        // top level (single-account tree).
+        IEnumerable<FolderTreeNode> siblings;
+        if (parentFullName != null)
+        {
+            var parent = FindNodeByFolder(roots, accountId, parentFullName);
+            siblings = parent?.Children ?? roots;
+        }
+        else
+        {
+            var header = roots.FirstOrDefault(n => n.IsHeader &&
+                n.Children.Any(c => c.Folder?.AccountId == accountId));
+            siblings = header?.Children ?? roots;
+        }
+
+        var created = siblings.FirstOrDefault(n =>
+            !n.IsHeader && n.Folder?.AccountId == accountId &&
+            string.Equals(n.Folder?.DisplayName, name, StringComparison.OrdinalIgnoreCase));
+
+        var container = created != null ? ContainerFromNode(FolderTreeView, created) : null;
+        if (container != null)
+        {
+            container.IsSelected = true;
+            container.BringIntoView();
+            container.Focus();
+        }
+        else
+        {
+            FolderTreeView.Focus();
+        }
+    }
+
+    private static FolderTreeNode? FindNodeByFolder(
+        IEnumerable<FolderTreeNode> nodes, Guid accountId, string fullName)
+    {
+        foreach (var node in nodes)
+        {
+            if (!node.IsHeader && node.Folder?.AccountId == accountId &&
+                string.Equals(node.Folder?.FullName, fullName, StringComparison.Ordinal))
+                return node;
+
+            var found = FindNodeByFolder(node.Children, accountId, fullName);
+            if (found != null) return found;
+        }
+        return null;
+    }
+
+    private static TreeViewItem? ContainerFromNode(ItemsControl parent, FolderTreeNode target)
+    {
+        for (int i = 0; i < parent.Items.Count; i++)
+        {
+            if (parent.ItemContainerGenerator.ContainerFromIndex(i) is not TreeViewItem tvi)
+                continue;
+            if (ReferenceEquals(parent.Items[i], target))
+                return tvi;
+            var found = ContainerFromNode(tvi, target);
+            if (found != null) return found;
+        }
+        return null;
+    }
 
     private void SelectFirstVisibleItem()
     {

--- a/QuickMail/Views/MainWindow.xaml
+++ b/QuickMail/Views/MainWindow.xaml
@@ -332,6 +332,13 @@
                 </MenuItem>
             </MenuItem>
 
+            <!-- Folder -->
+            <MenuItem Header="Fol_der">
+                <MenuItem Header="_New Folder…"
+                          Click="MenuNewFolder_Click"
+                          AutomationProperties.Name="New Folder"/>
+            </MenuItem>
+
             <!-- View -->
             <MenuItem Header="_View">
                 <MenuItem Header="_Refresh"

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -3897,7 +3897,9 @@ public partial class MainWindow : Window
 
         var targetIdx = _vm.SenderGroups.IndexOf(group);
         var picker = BuildMessageFolderPicker(group.Messages, "Move to Folder");
-        if (picker.ShowDialog() != true || picker.SelectedFolder == null) return;
+        var pickerOpened = picker.ShowDialog();
+        _vm.CommitPendingFolderTreeRebuild(); // apply a folder created inside the picker, even on cancel (no-op otherwise)
+        if (pickerOpened != true || picker.SelectedFolder == null) return;
 
         await _vm.MoveSelectedMessagesToFolderAsync(group.Messages, picker.SelectedFolder);
         LandOnSenderGroupAfterRebuild(targetIdx);
@@ -3909,7 +3911,9 @@ public partial class MainWindow : Window
         if (_vm.CachedFolders.Count == 0) return;
 
         var picker = BuildMessageFolderPicker(group.Messages, "Copy to Folder");
-        if (picker.ShowDialog() != true || picker.SelectedFolder == null) return;
+        var pickerOpened = picker.ShowDialog();
+        _vm.CommitPendingFolderTreeRebuild(); // apply a folder created inside the picker, even on cancel (no-op otherwise)
+        if (pickerOpened != true || picker.SelectedFolder == null) return;
 
         await _vm.CopySelectedMessagesToFolderAsync(group.Messages, picker.SelectedFolder);
     }
@@ -4038,7 +4042,9 @@ public partial class MainWindow : Window
 
         var targetIdx = _vm.ToGroups.IndexOf(group);
         var picker = BuildMessageFolderPicker(group.Messages, "Move to Folder");
-        if (picker.ShowDialog() != true || picker.SelectedFolder == null) return;
+        var pickerOpened = picker.ShowDialog();
+        _vm.CommitPendingFolderTreeRebuild(); // apply a folder created inside the picker, even on cancel (no-op otherwise)
+        if (pickerOpened != true || picker.SelectedFolder == null) return;
 
         await _vm.MoveSelectedMessagesToFolderAsync(group.Messages, picker.SelectedFolder);
         LandOnToGroupAfterRebuild(targetIdx);
@@ -4050,7 +4056,9 @@ public partial class MainWindow : Window
         if (_vm.CachedFolders.Count == 0) return;
 
         var picker = BuildMessageFolderPicker(group.Messages, "Copy to Folder");
-        if (picker.ShowDialog() != true || picker.SelectedFolder == null) return;
+        var pickerOpened = picker.ShowDialog();
+        _vm.CommitPendingFolderTreeRebuild(); // apply a folder created inside the picker, even on cancel (no-op otherwise)
+        if (pickerOpened != true || picker.SelectedFolder == null) return;
 
         await _vm.CopySelectedMessagesToFolderAsync(group.Messages, picker.SelectedFolder);
     }
@@ -4559,7 +4567,9 @@ public partial class MainWindow : Window
 
         if (_vm.CachedFolders.Count == 0) return;
         var picker = new FolderPickerWindow(_vm.Accounts, _vm.CachedFolders, title: "Move Folder To") { Owner = this };
-        if (picker.ShowDialog() != true || picker.SelectedFolder == null) return;
+        var pickerOpened = picker.ShowDialog();
+        _vm.CommitPendingFolderTreeRebuild(); // apply a folder created inside the picker, even on cancel (no-op otherwise)
+        if (pickerOpened != true || picker.SelectedFolder == null) return;
 
         await _vm.MoveFolderToAsync(node, picker.SelectedFolder);
     }
@@ -4571,7 +4581,9 @@ public partial class MainWindow : Window
 
         if (_vm.CachedFolders.Count == 0) return;
         var picker = new FolderPickerWindow(_vm.Accounts, _vm.CachedFolders, title: "Copy Folder To") { Owner = this };
-        if (picker.ShowDialog() != true || picker.SelectedFolder == null) return;
+        var pickerOpened = picker.ShowDialog();
+        _vm.CommitPendingFolderTreeRebuild(); // apply a folder created inside the picker, even on cancel (no-op otherwise)
+        if (pickerOpened != true || picker.SelectedFolder == null) return;
 
         await _vm.CopyFolderToAsync(node, picker.SelectedFolder);
     }
@@ -4798,7 +4810,9 @@ public partial class MainWindow : Window
         if (messages.Count == 0 || _vm.CachedFolders.Count == 0) return;
 
         var picker = BuildMessageFolderPicker(messages, "Move to Folder");
-        if (picker.ShowDialog() != true || picker.SelectedFolder == null) return;
+        var pickerOpened = picker.ShowDialog();
+        _vm.CommitPendingFolderTreeRebuild(); // apply a folder created inside the picker, even on cancel (no-op otherwise)
+        if (pickerOpened != true || picker.SelectedFolder == null) return;
 
         await _vm.MoveSelectedMessagesToFolderAsync(messages, picker.SelectedFolder);
 
@@ -4816,7 +4830,9 @@ public partial class MainWindow : Window
         if (messages.Count == 0 || _vm.CachedFolders.Count == 0) return;
 
         var picker = BuildMessageFolderPicker(messages, "Copy to Folder");
-        if (picker.ShowDialog() != true || picker.SelectedFolder == null) return;
+        var pickerOpened = picker.ShowDialog();
+        _vm.CommitPendingFolderTreeRebuild(); // apply a folder created inside the picker, even on cancel (no-op otherwise)
+        if (pickerOpened != true || picker.SelectedFolder == null) return;
 
         await _vm.CopySelectedMessagesToFolderAsync(messages, picker.SelectedFolder);
     }
@@ -4827,7 +4843,9 @@ public partial class MainWindow : Window
         if (messages.Count == 0 || _vm.CachedFolders.Count == 0) return;
 
         var picker = BuildMessageFolderPicker(messages, "Move to Folder");
-        if (picker.ShowDialog() != true || picker.SelectedFolder == null) return;
+        var pickerOpened = picker.ShowDialog();
+        _vm.CommitPendingFolderTreeRebuild(); // apply a folder created inside the picker, even on cancel (no-op otherwise)
+        if (pickerOpened != true || picker.SelectedFolder == null) return;
 
         await _vm.MoveSelectedMessagesToFolderAsync(messages, picker.SelectedFolder);
 
@@ -4846,8 +4864,10 @@ public partial class MainWindow : Window
         var messages = GetSelectedMessages();
         if (messages.Count == 0 || _vm.CachedFolders.Count == 0) return;
 
-        var picker = new FolderPickerWindow(_vm.Accounts, _vm.CachedFolders, title: "Copy to Folder", useTreeView: true) { Owner = this };
-        if (picker.ShowDialog() != true || picker.SelectedFolder == null) return;
+        var picker = BuildMessageFolderPicker(messages, "Copy to Folder");
+        var pickerOpened = picker.ShowDialog();
+        _vm.CommitPendingFolderTreeRebuild(); // apply a folder created inside the picker, even on cancel (no-op otherwise)
+        if (pickerOpened != true || picker.SelectedFolder == null) return;
 
         await _vm.CopySelectedMessagesToFolderAsync(messages, picker.SelectedFolder);
     }
@@ -4889,8 +4909,10 @@ public partial class MainWindow : Window
         if (_vm.CachedFolders.Count == 0) return;
 
         var targetIdx = _vm.Conversations.IndexOf(group);
-        var picker = new FolderPickerWindow(_vm.Accounts, _vm.CachedFolders, title: "Move Conversation to Folder", useTreeView: true) { Owner = this };
-        if (picker.ShowDialog() != true || picker.SelectedFolder == null) return;
+        var picker = BuildMessageFolderPicker(group.Messages, "Move Conversation to Folder");
+        var pickerOpened = picker.ShowDialog();
+        _vm.CommitPendingFolderTreeRebuild(); // apply a folder created inside the picker, even on cancel (no-op otherwise)
+        if (pickerOpened != true || picker.SelectedFolder == null) return;
 
         await _vm.MoveSelectedMessagesToFolderAsync(group.Messages, picker.SelectedFolder);
         LandOnConversationAfterRebuild(targetIdx);
@@ -4901,8 +4923,10 @@ public partial class MainWindow : Window
         if (ConversationTree.SelectedItem is not ConversationGroup group || group.Messages.Count == 0) return;
         if (_vm.CachedFolders.Count == 0) return;
 
-        var picker = new FolderPickerWindow(_vm.Accounts, _vm.CachedFolders, title: "Copy Conversation to Folder", useTreeView: true) { Owner = this };
-        if (picker.ShowDialog() != true || picker.SelectedFolder == null) return;
+        var picker = BuildMessageFolderPicker(group.Messages, "Copy Conversation to Folder");
+        var pickerOpened = picker.ShowDialog();
+        _vm.CommitPendingFolderTreeRebuild(); // apply a folder created inside the picker, even on cancel (no-op otherwise)
+        if (pickerOpened != true || picker.SelectedFolder == null) return;
 
         await _vm.CopySelectedMessagesToFolderAsync(group.Messages, picker.SelectedFolder);
     }

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -1233,9 +1233,68 @@ public partial class MainWindow : Window
                            $"AttachListFocusWithin={ReadingPaneAttachmentList.IsKeyboardFocusWithin}, " +
                            $"AttachListFocused={ReferenceEquals(focused, ReadingPaneAttachmentList)}");
             if (focused == null)
+            {
                 FocusPanelSynchronously();
+
+                // On the very first Shift+F10 after launch, WebView2 still holds Win32 focus, so the
+                // .Focus() above only takes effect on a later dispatcher tick — too late for THIS
+                // message. WPF then has no focused element to route ContextMenuOpening from, falls
+                // through to DefWindowProc, and the Win32 system menu (Move/Size/Close) appears
+                // instead of our menu (issue #148, recurring). Swallow the message so that system
+                // menu can't show, and open the active panel's context menu once focus has settled.
+                // This branch is a no-op whenever .Focus() did establish focus synchronously, so it
+                // only ever affects the otherwise-broken first press.
+                if (Keyboard.FocusedElement == null)
+                {
+                    handled = true;
+                    Dispatcher.BeginInvoke(OpenActivePanelContextMenu, DispatcherPriority.Input);
+                }
+            }
         }
         return IntPtr.Zero;
+    }
+
+    // Opens the context menu for whichever message panel is active, placed on that panel. Used only
+    // as the deferred recovery when the first post-launch Shift+F10 arrived with no WPF focus (see
+    // OnWmContextMenu). By the time this runs, Win32 focus has settled onto the main window, so the
+    // panel's own selection-based menu resolves correctly.
+    private void OpenActivePanelContextMenu()
+    {
+        FocusPanelSynchronously();
+
+        ContextMenu? menu = null;
+        FrameworkElement? target = null;
+
+        if (_vm.IsConversationsView && ConversationTree.Items.Count > 0)
+        {
+            target = ConversationTree;
+            menu = ConversationTree.SelectedItem is ConversationGroup
+                ? (ContextMenu)FindResource("ConversationGroupContextMenu")
+                : (ContextMenu)FindResource("MessageContextMenu");
+        }
+        else if (_vm.IsFromView && SenderGroupTree.Items.Count > 0)
+        {
+            target = SenderGroupTree;
+            menu = SenderGroupTree.SelectedItem is SenderGroup
+                ? (ContextMenu)FindResource("SenderGroupContextMenu")
+                : (ContextMenu)FindResource("MessageContextMenu");
+        }
+        else if (_vm.IsToView && ToGroupTree.Items.Count > 0)
+        {
+            target = ToGroupTree;
+            menu = ToGroupTree.SelectedItem is SenderGroup
+                ? (ContextMenu)FindResource("ToGroupContextMenu")
+                : (ContextMenu)FindResource("MessageContextMenu");
+        }
+        else if (_vm.IsMessagesView && MessageList.Items.Count > 0)
+        {
+            target = MessageList;
+            menu = (ContextMenu)FindResource("MessageContextMenu");
+        }
+
+        if (menu == null || target == null) return;
+        menu.PlacementTarget = target;
+        menu.IsOpen = true;
     }
 
     // Synchronous panel focus — no Dispatcher.InvokeAsync — used from the Win32 hook
@@ -1328,7 +1387,13 @@ public partial class MainWindow : Window
             if (ReadingPaneAttachmentList.IsKeyboardFocusWithin)
                 return;
 
-            if (!IsMessageListFocused() && !IsGroupTreeFocused())
+            // Only supply a focus target when WPF has NONE (e.g. WebView2 stole Win32 focus at
+            // startup, leaving FocusedElement null). If focus is already in a real panel — the
+            // folder tree, the account list, a message panel — leave it so that panel's own
+            // context menu opens. Redirecting on any non-message focus wrongly replaced the folder
+            // tree's FolderContextMenu with the message menu (#255 follow-up: Shift+F10 on the
+            // folder list showed Reply/Reply All instead of New/Move/Delete Folder).
+            if (focused == null)
             {
                 if (_vm.IsConversationsView)      ConversationTree.Focus();
                 else if (_vm.IsFromView)           SenderGroupTree.Focus();

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -201,6 +201,11 @@ public partial class MainWindow : Window
     // closes. Independent (unowned) windows are not auto-closed by WPF on owner close.
     private readonly List<ComposeWindow> _openComposeWindows = new();
 
+    // Tracks open standalone message windows (MessageOpenMode = Window) for the same reason as
+    // compose windows: they are unowned, so WPF does not close them when the main window closes,
+    // and a surviving one keeps the process (and single-instance mutex) alive — see OnClosed (#252).
+    private readonly List<MessageWindow> _openMessageWindows = new();
+
     // ── Grouped-message tree controllers ──────────────────────────────────────
     private GroupedMessageTreeController? _convTreeController;
     private GroupedMessageTreeController? _senderTreeController;
@@ -745,6 +750,12 @@ public partial class MainWindow : Window
     {
         foreach (var w in _openComposeWindows.ToList())
             w.Close();
+        // Standalone message windows (MessageOpenMode = Window) are unowned, so WPF keeps the
+        // process alive after the main window closes if any remain open — a zombie that still
+        // holds the per-profile single-instance mutex and blocks relaunch (issue #252). Close
+        // them explicitly on a real main-window close, the same way compose windows are handled.
+        foreach (var w in _openMessageWindows.ToList())
+            w.Close();
         _trayIcon?.Dispose(); // remove the tray icon so it doesn't linger after exit
         // Cancels all in-flight VM operations (sync, prefetch, loads) and releases
         // their CTS handles. OnClosed, not OnClosing — the close cannot be cancelled here.
@@ -974,11 +985,18 @@ public partial class MainWindow : Window
             defaultKey: Key.A, defaultModifiers: ModifierKeys.Control,
             isAvailable: IsMessageListFocused));
 
+        // Bare K only flags when the message area (flat list or a group tree) actually has
+        // keyboard focus. Without the focus gate, K fired on the selected message even while
+        // focus was in the folder tree — hijacking the tree's type-ahead (issue #255). Leaving
+        // the command unavailable keeps e.Handled false, so the focused control's own type-ahead
+        // (jump to a folder starting with "k") takes the key. Mirrors the calendar plain-key
+        // gestures above, which scope to CalendarList focus for the same reason.
         _registry.Register(new CommandDefinition(
             id: "mail.toggleFlag", category: "Mail", title: "Toggle Flag",
             execute: async () => await ToggleFlagCommandAsync(),
             defaultKey: Key.K, defaultModifiers: ModifierKeys.None,
-            isAvailable: () => _vm.HasSelectedMessage || IsGroupRowSelected()));
+            isAvailable: () => IsMessageAreaFocused()
+                && (_vm.HasSelectedMessage || IsGroupRowSelected())));
 
         _registry.Register(new CommandDefinition(
             id: "mail.pickFlag", category: "Mail", title: "Pick Flag…",
@@ -1005,6 +1023,16 @@ public partial class MainWindow : Window
                 && !(IsMessageListFocused() && MessageList.SelectedItems.Count > 1)
                 && !IsGroupTreeFocused()
                 && !FolderList.IsKeyboardFocusWithin)); // folder.delete owns Delete in the folder tree
+
+        // New Folder — creates a folder under the folder-tree selection (or the selected account's
+        // root when nothing folder-specific is selected). Registered so it appears in the Command
+        // Palette and keyboard customizations; before this the only entry point was the folder
+        // context menu, leaving folder creation undiscoverable (issue #250). No default key —
+        // users can bind one via keyboard customizations.
+        _registry.Register(new CommandDefinition(
+            id: "folder.new", category: "Mail", title: "New Folder…",
+            execute: () => _ = NewFolderFromSelectionAsync(),
+            isAvailable: () => _vm.Accounts.Count > 0));
 
         // Delete on a real folder in the folder tree deletes that folder (shares the Delete gesture
         // with mail.delete; the registry prefers whichever command is available for the focus).
@@ -2144,6 +2172,11 @@ public partial class MainWindow : Window
                 || IsDescendantOf(ConversationTree, dep);
         return false;
     }
+
+    // True when keyboard focus is inside the message area — the flat message list or any of the
+    // grouped trees. Plain-key mail gestures (e.g. K to flag) gate on this so they don't fire
+    // while focus is elsewhere (folder tree, account list) and steal that control's type-ahead.
+    private bool IsMessageAreaFocused() => IsMessageListFocused() || IsGroupTreeFocused();
 
     private bool IsGroupRowSelected()
     {
@@ -4236,6 +4269,7 @@ public partial class MainWindow : Window
         // WebView2 even after the user alt-tabs back to the main window. As an independent
         // window, the AT cleanly exits browse mode when focus leaves the message window.
         var win = new MessageWindow(winVm, _imap, _localStore, _webViewEnvironment, _themeService, _configService);
+        _openMessageWindows.Add(win);
 
         // Wire mail action delegates so the window has full message operations.
         // Each delegate syncs MainViewModel selection to the window's current message
@@ -4307,8 +4341,8 @@ public partial class MainWindow : Window
         };
         win.Closed += (_, _) =>
         {
-            _vm.IsMessageOpenInWindow =
-                Application.Current.Windows.OfType<MessageWindow>().Any();
+            _openMessageWindows.Remove(win);
+            _vm.IsMessageOpenInWindow = _openMessageWindows.Count > 0;
 
             // Restore focus to the originating message list item (issue 46).
             Dispatcher.InvokeAsync(() =>
@@ -4320,7 +4354,7 @@ public partial class MainWindow : Window
         };
 
         // Offset from previous windows so they don't stack exactly.
-        var offset = Application.Current.Windows.OfType<MessageWindow>().Count() * 24;
+        var offset = _openMessageWindows.Count * 24;
         win.Left = Left + 60 + offset;
         win.Top  = Top  + 40 + offset;
 
@@ -4489,21 +4523,29 @@ public partial class MainWindow : Window
     }
 
     private async void FolderContextMenu_NewFolder_Click(object sender, RoutedEventArgs e)
-    {
-        var node = GetContextMenuFolderNode(sender);
-        if (node == null) return;
+        => await CreateFolderUnderNodeAsync(GetContextMenuFolderNode(sender));
 
-        // Determine the parent: if it's a header node (account), create at root; otherwise under the selected folder
-        var parentFolder = node.IsHeader ? null : node.Folder;
+    // Entry point for the New Folder command (menu / Command Palette / customizable hotkey).
+    // Uses the folder tree's current selection so the same "create under here" behaviour as the
+    // context menu is reachable without a mouse — the context menu was the only path before, which
+    // left folder creation undiscoverable for keyboard and screen-reader users (issue #250).
+    private async Task NewFolderFromSelectionAsync()
+        => await CreateFolderUnderNodeAsync(FolderList.SelectedItem as FolderTreeNode);
+
+    private async Task CreateFolderUnderNodeAsync(FolderTreeNode? node)
+    {
+        // Determine the parent: a header node (account) creates at root; a folder node creates
+        // beneath it. With no folder-tree selection, fall back to the selected account's root.
+        var parentFolder = node is { IsHeader: false } ? node.Folder : null;
         var accountId    = parentFolder?.AccountId
-                          ?? _vm.Accounts.FirstOrDefault(a => a.AccountLabel == node.Label)?.Id
+                          ?? (node != null ? _vm.Accounts.FirstOrDefault(a => a.AccountLabel == node.Label)?.Id : null)
                           ?? _vm.SelectedAccount?.Id;
         if (accountId == null || accountId == Guid.Empty) return;
 
         var dlg = new NewFolderDialog
         {
             Owner = this,
-            ParentFolderName = parentFolder?.DisplayName ?? node.Label
+            ParentFolderName = parentFolder?.DisplayName ?? node?.Label ?? string.Empty
         };
         if (dlg.ShowDialog() != true) return;
 
@@ -4649,6 +4691,9 @@ public partial class MainWindow : Window
     }
 
     private void MenuPlainText_Click(object sender, RoutedEventArgs e) => TogglePlainTextView();
+
+    private async void MenuNewFolder_Click(object sender, RoutedEventArgs e)
+        => await NewFolderFromSelectionAsync();
 
     private void MenuSettings_Click(object sender, RoutedEventArgs e)
     {

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -5023,7 +5023,10 @@ public partial class MainWindow : Window
         var folders  = _vm.CachedFolders
                           .Where(kv => ids.Contains(kv.Key))
                           .ToDictionary(kv => kv.Key, kv => kv.Value);
-        return new FolderPickerWindow(accounts, folders, title: title, useTreeView: true) { Owner = this };
+        return new FolderPickerWindow(accounts, folders, title: title, useTreeView: true,
+            folderCreator: (accountId, parentFullName, name) =>
+                _vm.CreateFolderReturningFoldersAsync(accountId, parentFullName, name))
+            { Owner = this };
     }
 
     private void RebuildViewsMenu()


### PR DESCRIPTION
Fixes four reported issues around folder creation, orphaned message windows, single-instance toast activation, and the flag hotkey. Three are code fixes; #253 is a documented "working as designed" decision.

## #250 — No ability to create new folders

Folder creation already existed (`NewFolderDialog` + `CreateFolderAndRefreshAsync`), but the **only** entry point was the folder-tree context menu. For a keyboard/screen-reader user that path is effectively undiscoverable, and there is no create option at all in the move/copy-mail flow.

**Fix:** registered a `folder.new` command so folder creation now appears in the **Command Palette** and **keyboard customizations** (bindable to any key), and added a **Folder ▸ New Folder…** menu item. The context-menu handler and the new entry points share one `CreateFolderUnderNodeAsync` helper — a folder-tree node creates a subfolder beneath it, a header (account) node or an empty selection creates at the account root.

The move/copy-message folder picker now also has a **New Folder** button. Creating from there makes the folder under the selected node (or the account root), refreshes the picker's tree in place, and selects the new folder so you can immediately Open it as the move/copy destination. Re-entrancy safety: the create path only refreshes the folder *cache* while the picker's modal loop is live and defers the main-window folder-tree rebuild until after the picker closes (via `CommitPendingFolderTreeRebuild`, run from the move/copy VM methods) — rebuilding the main tree inside the modal loop is the documented "re-query the folder tree while the dialog's loop is active" crash. The button is shown only in the tree-view picker (the move/copy-message flow), which is the only path wired for in-place repopulation.

## #252 — Orphaned message windows keep a zombie process alive

`MainWindow.OnClosed` closed compose windows but not standalone `MessageWindow` instances (MessageOpenMode = Window). A surviving message window kept the process — and the per-profile single-instance mutex — alive, so relaunch silently did nothing until the process was killed.

**Fix:** message windows are now tracked in an `_openMessageWindows` list (mirroring `_openComposeWindows`) and closed in `OnClosed`. As a bonus this replaces two `Application.Current.Windows.OfType<MessageWindow>()` scans with the tracked list.

## #253 — Toast activation payload dropped (documented as designed)

Per decision, taking option 1 from the issue. The single-instance activation signal is a bare event that only says "come to the foreground" — a second launch carrying toast deep-link args brings the window forward but drops the "open this specific message" payload. This only occurs in a corner case (running instance's toast COM registration failed **and** a stale toast survives), and forwarding the payload would mean adding real IPC (named pipe) on the startup path this app has had hang/zombie history with. Documented the trade-off in `SingleInstanceService.SignalExistingInstance` and marked the seam for any future revisit. **This issue can be closed as working-as-designed.**

## #255 — Flag hotkey fires when focus isn't in the message list

Bare **K** (`mail.toggleFlag`) was available whenever a message was selected, regardless of focus. Pressing K in the folder tree flagged the background-selected message instead of doing type-ahead to a folder starting with "k".

**Fix:** gated the command on a new `IsMessageAreaFocused()` (message list or a group tree). When focus is elsewhere the command is unavailable, `e.Handled` stays false, and the focused control's own type-ahead handles the key. This mirrors the existing calendar plain-key gestures that scope to `CalendarList` focus for exactly this reason. (Ctrl+Shift+K "Pick Flag…" is a chord that doesn't collide with type-ahead, so it's left as-is.)

## Tests

- `dotnet test` — 1180/1181 pass. The one failure is `PropertiesViewModelTests.CopyRow_PutsLabelColonValueOnClipboard` failing with `OpenClipboard Failed (CLIPBRD_E_CANT_OPEN)` — a pre-existing environmental clipboard-contention flake (passes in isolation), unrelated to this change.
- No unit test was added for the #250 command registration: the commands register in `OnLoaded` (only fires when the window is shown), and the existing tests construct-and-close without showing, so there's no non-flaky seam to assert it. Covered by the manual steps below instead.

## Manual testing needed (keyboard + screen reader)

1. **#250 New Folder — Command Palette:** Ctrl+Shift+P → "New Folder" → run. Confirm the dialog opens, and creating a folder while a folder is selected in the tree nests it correctly; with an account header selected it creates at the root.
2. **#250 New Folder — menu:** Alt to the menu bar → **Folder ▸ New Folder…**. Confirm it works and is announced sensibly.
3. **#250 New Folder — in the picker (move/copy messages):** select one or more messages → Move to Folder (or Copy to Folder). In the picker, Tab to (or activate) **New Folder**, create a folder under the selected destination. Confirm the picker's tree updates, the new folder is selected, and pressing Open/Enter moves/copies the messages into it. Afterward confirm the new folder also appears in the main folder tree. Try it with a folder selected (nested) and with nothing/the account selected (root).
4. **#250 keyboard binding (optional):** assign a hotkey to "New Folder" in keyboard customizations and confirm it triggers.
4. **#252 zombie process:** Settings → CloseToTray **off**, MessageOpenMode = **Window**. Open a message in its own window, then close the main window. Confirm the process fully exits (no lingering QuickMail), and relaunch starts normally.
5. **#255 flag hotkey:** move focus to the folder list, press **K**. Confirm it does type-ahead to a folder starting with "k" and does **not** flag a message. Then focus the message list, press K, and confirm it still toggles the flag; in a grouped view (Conversations/By Sender/By Recipient) confirm K on a group row still flags the group.
