### PR TITLE
Server contact sync & prior recipients (#256)

### DIFF
--- a/QuickMail.Tests/ContactServiceSyncTests.cs
+++ b/QuickMail.Tests/ContactServiceSyncTests.cs
@@ -1,0 +1,204 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using QuickMail.Models;
+using QuickMail.Services;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// Tests for the server-contact-sync side of ContactService (issue #256): the wholesale
+/// replace/remove merge and the read-time dedup-by-email. The invariant that matters most is that
+/// a sync never touches local contacts or another account's synced contacts.
+/// </summary>
+public class ContactServiceSyncTests
+{
+    private static (ContactService service, string dir) MakeService()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), $"QM-ContactSyncTests-{Guid.NewGuid():N}");
+        return (new ContactService(new ProfileContext(dir)), dir);
+    }
+
+    private static void Cleanup(string dir)
+    {
+        try { if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true); } catch { }
+    }
+
+    private static ContactModel Synced(string sourceId, string name, string email, bool prior = false) => new()
+    {
+        SourceId         = sourceId,
+        DisplayName      = name,
+        EmailAddress     = email,
+        IsPriorRecipient = prior,
+    };
+
+    [Fact]
+    public async Task Replace_PreservesLocalContacts()
+    {
+        var (svc, dir) = MakeService();
+        var acct = Guid.NewGuid();
+        try
+        {
+            await svc.UpsertContactAsync(new ContactModel { DisplayName = "Local Person", EmailAddress = "local@x.test" });
+
+            await svc.ReplaceSyncedContactsAsync(acct, ContactSource.Microsoft,
+                [Synced("m1", "Server Person", "server@x.test")]);
+
+            var all = await svc.LoadAllContactsAsync();
+            Assert.Contains(all, c => c.EmailAddress == "local@x.test" && c.IsLocal);
+            Assert.Contains(all, c => c.EmailAddress == "server@x.test" && c.Source == ContactSource.Microsoft);
+        }
+        finally { Cleanup(dir); }
+    }
+
+    [Fact]
+    public async Task Replace_RemovesStaleServerRows_ButKeepsUpdatedOnesWithSameId()
+    {
+        var (svc, dir) = MakeService();
+        var acct = Guid.NewGuid();
+        try
+        {
+            await svc.ReplaceSyncedContactsAsync(acct, ContactSource.Microsoft,
+                [Synced("m1", "First", "one@x.test"), Synced("m2", "Second", "two@x.test")]);
+            var firstPass = await svc.LoadAllContactsAsync();
+            var m1Id = firstPass.Single(c => c.SourceId == "m1").Id;
+
+            // Second sync: m1 renamed, m2 gone, m3 new.
+            await svc.ReplaceSyncedContactsAsync(acct, ContactSource.Microsoft,
+                [Synced("m1", "First Renamed", "one@x.test"), Synced("m3", "Third", "three@x.test")]);
+
+            var all = await svc.LoadAllContactsAsync();
+            Assert.DoesNotContain(all, c => c.SourceId == "m2");                       // stale removed
+            Assert.Contains(all, c => c.SourceId == "m3");                             // new added
+            var m1 = all.Single(c => c.SourceId == "m1");
+            Assert.Equal("First Renamed", m1.DisplayName);                             // updated in place
+            Assert.Equal(m1Id, m1.Id);                                                // stable id preserved
+        }
+        finally { Cleanup(dir); }
+    }
+
+    [Fact]
+    public async Task Replace_IgnoresOtherAccountsAndSources()
+    {
+        var (svc, dir) = MakeService();
+        var acctA = Guid.NewGuid();
+        var acctB = Guid.NewGuid();
+        try
+        {
+            await svc.ReplaceSyncedContactsAsync(acctA, ContactSource.Microsoft, [Synced("a1", "A One", "a1@x.test")]);
+            await svc.ReplaceSyncedContactsAsync(acctB, ContactSource.Google,    [Synced("b1", "B One", "b1@x.test")]);
+
+            // Re-sync account A with an empty set — B's Google rows must survive.
+            await svc.ReplaceSyncedContactsAsync(acctA, ContactSource.Microsoft, []);
+
+            var all = await svc.LoadAllContactsAsync();
+            Assert.DoesNotContain(all, c => c.SourceId == "a1");
+            Assert.Contains(all, c => c.SourceId == "b1" && c.Source == ContactSource.Google);
+        }
+        finally { Cleanup(dir); }
+    }
+
+    [Fact]
+    public async Task Replace_SkipsRowsWithNoEmailOrNoSourceId()
+    {
+        var (svc, dir) = MakeService();
+        var acct = Guid.NewGuid();
+        try
+        {
+            await svc.ReplaceSyncedContactsAsync(acct, ContactSource.Microsoft,
+            [
+                Synced("m1", "Good", "good@x.test"),
+                Synced("", "No Id", "noid@x.test"),
+                Synced("m2", "No Email", ""),
+            ]);
+            var all = await svc.LoadAllContactsAsync();
+            Assert.Single(all);
+            Assert.Equal("m1", all[0].SourceId);
+        }
+        finally { Cleanup(dir); }
+    }
+
+    [Fact]
+    public async Task RemoveSynced_DropsOnlyThatAccountsRows()
+    {
+        var (svc, dir) = MakeService();
+        var acct = Guid.NewGuid();
+        try
+        {
+            await svc.UpsertContactAsync(new ContactModel { DisplayName = "Keep Me", EmailAddress = "keep@x.test" });
+            await svc.ReplaceSyncedContactsAsync(acct, ContactSource.Microsoft, [Synced("m1", "Gone", "gone@x.test")]);
+
+            await svc.RemoveSyncedContactsAsync(acct);
+
+            var all = await svc.LoadAllContactsAsync();
+            Assert.Single(all);
+            Assert.Equal("keep@x.test", all[0].EmailAddress);
+        }
+        finally { Cleanup(dir); }
+    }
+
+    [Fact]
+    public async Task Search_DedupsByEmail_PreferringLocalThenSavedThenPrior()
+    {
+        var (svc, dir) = MakeService();
+        var acct = Guid.NewGuid();
+        try
+        {
+            // Same address from three origins.
+            await svc.UpsertContactAsync(new ContactModel { DisplayName = "Local Name", EmailAddress = "dup@x.test" });
+            await svc.ReplaceSyncedContactsAsync(acct, ContactSource.Microsoft,
+            [
+                Synced("m1", "Saved Name", "dup@x.test"),
+                Synced("p1", "Prior Name", "dup@x.test", prior: true),
+            ]);
+
+            var results = await svc.SearchContactsAsync("dup");
+            Assert.Single(results);
+            Assert.Equal("Local Name", results[0].DisplayName); // local wins
+        }
+        finally { Cleanup(dir); }
+    }
+
+    [Fact]
+    public async Task Search_DedupIsCaseInsensitiveOnEmail()
+    {
+        var (svc, dir) = MakeService();
+        var acct = Guid.NewGuid();
+        try
+        {
+            await svc.ReplaceSyncedContactsAsync(acct, ContactSource.Microsoft,
+            [
+                Synced("m1", "Saved", "Person@X.Test"),
+                Synced("p1", "Prior", "person@x.test", prior: true),
+            ]);
+            var results = await svc.SearchContactsAsync("person");
+            Assert.Single(results);
+            Assert.Equal("Saved", results[0].DisplayName); // saved outranks prior recipient
+        }
+        finally { Cleanup(dir); }
+    }
+
+    [Fact]
+    public async Task OldContactsJson_WithoutProvenanceFields_LoadsAsLocal()
+    {
+        var (svc, dir) = MakeService();
+        try
+        {
+            Directory.CreateDirectory(dir);
+            // Legacy shape: only the four original fields, no Source/SourceId/OwnerAccountId.
+            var legacy = "[{\"Id\":1,\"DisplayName\":\"Legacy\",\"EmailAddress\":\"legacy@x.test\",\"LastUsedTicks\":0}]";
+            await File.WriteAllTextAsync(Path.Combine(dir, "contacts.json"), legacy);
+
+            var all = await svc.LoadAllContactsAsync();
+            Assert.Single(all);
+            Assert.True(all[0].IsLocal);
+            Assert.Equal(ContactSource.Local, all[0].Source);
+            Assert.Null(all[0].OwnerAccountId);
+        }
+        finally { Cleanup(dir); }
+    }
+}

--- a/QuickMail.Tests/ContactSourceMappingTests.cs
+++ b/QuickMail.Tests/ContactSourceMappingTests.cs
@@ -68,6 +68,34 @@ public class ContactSourceMappingTests
         Assert.Equal(ContactSource.Microsoft, source.Source);
     }
 
+    // OAuth stub whose INTERACTIVE token path throws — proving contact sync only ever uses the
+    // silent path (fix for review finding #1: no interactive sign-in inside the modal address book).
+    private sealed class SilentOnlyOAuth : IOAuthService
+    {
+        public Task<string> GetAccessTokenAsync(AccountModel account, CancellationToken ct = default) => Task.FromResult(string.Empty);
+        public Task<string> GetAccessTokenAsync(AccountModel account, string[] scopes, CancellationToken ct = default)
+            => throw new InvalidOperationException("interactive path must not be used by contact sync");
+        public Task<string> GetAccessTokenSilentAsync(AccountModel account, string[] scopes, CancellationToken ct = default) => Task.FromResult("silent-token");
+        public Task EnsureSilentTokenAsync(AccountModel account, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<OAuthResult> SignInInteractiveAsync(AccountModel account, CancellationToken ct = default) => Task.FromResult(new OAuthResult(string.Empty, string.Empty));
+        public Task RequestContactsConsentAsync(AccountModel account, CancellationToken ct = default) => Task.CompletedTask;
+        public Task SignOutAsync(AccountModel account) => Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task Graph_UsesSilentTokenPath_NotInteractive()
+    {
+        var handler = new CannedHandler(
+            ("/me/contacts", """{"value":[{"id":"c1","displayName":"Alice","emailAddresses":[{"address":"alice@x.test"}]}]}"""),
+            ("/me/people", """{"value":[]}"""));
+        var source = new GraphContactSource(new GraphClient(new SilentOnlyOAuth(), new HttpClient(handler)));
+
+        // Would throw if the source used the interactive GetAccessTokenAsync(scopes) overload.
+        var result = await source.FetchAsync(MsAccount);
+
+        Assert.Single(result, c => c.EmailAddress == "alice@x.test");
+    }
+
     [Fact]
     public async Task Graph_SavedContactWinsOverSamePriorRecipient()
     {

--- a/QuickMail.Tests/ContactSourceMappingTests.cs
+++ b/QuickMail.Tests/ContactSourceMappingTests.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using QuickMail.Models;
+using QuickMail.Services;
+using QuickMail.Services.Graph;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// Verifies the provider DTO → <see cref="ContactModel"/> mapping for both contact sources
+/// (issue #256), using a canned <see cref="HttpMessageHandler"/> so no network is touched. The
+/// stub OAuth services supply an empty bearer token.
+/// </summary>
+public class ContactSourceMappingTests
+{
+    // Returns a fixed JSON body for the first URL substring that matches; 404 otherwise.
+    private sealed class CannedHandler : HttpMessageHandler
+    {
+        private readonly (string UrlContains, string Json)[] _routes;
+        public CannedHandler(params (string, string)[] routes) => _routes = routes;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            var url = request.RequestUri!.ToString();
+            foreach (var (contains, json) in _routes)
+                if (url.Contains(contains, StringComparison.OrdinalIgnoreCase))
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json"),
+                    });
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+        }
+    }
+
+    private static readonly AccountModel MsAccount =
+        new() { Username = "u@x.test", AuthType = AuthType.OAuth2Microsoft };
+    private static readonly AccountModel GoogleAccount =
+        new() { Username = "u@gmail.test", AuthType = AuthType.OAuth2Google };
+
+    [Fact]
+    public async Task Graph_MapsSavedContactsAndPriorRecipients()
+    {
+        var handler = new CannedHandler(
+            ("/me/contacts", """
+                {"value":[{"id":"c1","displayName":"Alice","emailAddresses":[{"name":"Alice","address":"alice@x.test"}]}]}
+                """),
+            ("/me/people", """
+                {"value":[{"id":"p1","displayName":"","scoredEmailAddresses":[{"address":"bob@x.test","relevanceScore":1.0}]}]}
+                """));
+        var source = new GraphContactSource(new GraphClient(new StubOAuthService(), new HttpClient(handler)));
+
+        var result = await source.FetchAsync(MsAccount);
+
+        var alice = result.Single(c => c.EmailAddress == "alice@x.test");
+        Assert.Equal("c1", alice.SourceId);
+        Assert.Equal("Alice", alice.DisplayName);
+        Assert.False(alice.IsPriorRecipient);
+
+        var bob = result.Single(c => c.EmailAddress == "bob@x.test");
+        Assert.True(bob.IsPriorRecipient);
+        Assert.Equal(string.Empty, bob.DisplayName); // person with no display name
+        Assert.Equal(ContactSource.Microsoft, source.Source);
+    }
+
+    [Fact]
+    public async Task Graph_SavedContactWinsOverSamePriorRecipient()
+    {
+        var handler = new CannedHandler(
+            ("/me/contacts", """
+                {"value":[{"id":"c1","displayName":"Dup","emailAddresses":[{"address":"dup@x.test"}]}]}
+                """),
+            ("/me/people", """
+                {"value":[{"id":"p1","displayName":"Dup Person","scoredEmailAddresses":[{"address":"dup@x.test"}]}]}
+                """));
+        var source = new GraphContactSource(new GraphClient(new StubOAuthService(), new HttpClient(handler)));
+
+        var result = await source.FetchAsync(MsAccount);
+
+        Assert.Single(result, c => c.EmailAddress == "dup@x.test");
+        Assert.False(result.Single(c => c.EmailAddress == "dup@x.test").IsPriorRecipient);
+    }
+
+    [Fact]
+    public async Task Google_MapsConnectionsAndOtherContacts()
+    {
+        var handler = new CannedHandler(
+            ("connections", """
+                {"connections":[{"resourceName":"people/c1","names":[{"displayName":"Gina"}],"emailAddresses":[{"value":"gina@x.test"}]}]}
+                """),
+            ("otherContacts", """
+                {"otherContacts":[{"resourceName":"otherContacts/c9","emailAddresses":[{"value":"otto@x.test"}]}]}
+                """));
+        var source = new GoogleContactSource(new GooglePeopleClient(new StubGoogleOAuthService(), new HttpClient(handler)));
+
+        var result = await source.FetchAsync(GoogleAccount);
+
+        var gina = result.Single(c => c.EmailAddress == "gina@x.test");
+        Assert.Equal("people/c1", gina.SourceId);
+        Assert.Equal("Gina", gina.DisplayName);
+        Assert.False(gina.IsPriorRecipient);
+
+        var otto = result.Single(c => c.EmailAddress == "otto@x.test");
+        Assert.Equal("otherContacts/c9", otto.SourceId);
+        Assert.True(otto.IsPriorRecipient);              // other contacts are prior recipients
+        Assert.Equal(string.Empty, otto.DisplayName);
+        Assert.Equal(ContactSource.Google, source.Source);
+    }
+
+    [Fact]
+    public async Task Google_SkipsPersonWithNoEmail()
+    {
+        var handler = new CannedHandler(
+            ("connections", """
+                {"connections":[{"resourceName":"people/c1","names":[{"displayName":"NoEmail"}]}]}
+                """),
+            ("otherContacts", """{"otherContacts":[]}"""));
+        var source = new GoogleContactSource(new GooglePeopleClient(new StubGoogleOAuthService(), new HttpClient(handler)));
+
+        var result = await source.FetchAsync(GoogleAccount);
+
+        Assert.Empty(result);
+    }
+}

--- a/QuickMail.Tests/ContactSyncScopeAndViewModelTests.cs
+++ b/QuickMail.Tests/ContactSyncScopeAndViewModelTests.cs
@@ -55,6 +55,7 @@ public class AddressBookViewModelSyncTests
         public bool CanSync(AccountModel account) => true;
         public Task<ContactSyncResult> SyncAccountAsync(AccountModel account, CancellationToken ct = default) => Task.FromResult(ContactSyncResult.None);
         public Task<ContactSyncResult> SyncAllAsync(CancellationToken ct = default) { SyncAllCount++; return Task.FromResult(new ContactSyncResult(1, 3, null)); }
+        public Task<ContactSyncResult> SyncAllDueAsync(TimeSpan minInterval, CancellationToken ct = default) => SyncAllAsync(ct);
         public Task RemoveAccountContactsAsync(Guid accountId, CancellationToken ct = default) => Task.CompletedTask;
     }
 

--- a/QuickMail.Tests/ContactSyncScopeAndViewModelTests.cs
+++ b/QuickMail.Tests/ContactSyncScopeAndViewModelTests.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using QuickMail.Models;
+using QuickMail.Services;
+using QuickMail.ViewModels;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// Guards the OAuth scope sets: contact scopes must be their own set, never folded into the default
+/// mail scopes (which would force every existing user to re-consent on next connect — spec §13.1).
+/// </summary>
+public class OAuthContactScopeTests
+{
+    [Fact]
+    public void GraphContactScopes_AreTheTwoReadOnlyContactScopes()
+    {
+        Assert.Contains("https://graph.microsoft.com/Contacts.Read", OAuthService.GraphContactScopes);
+        Assert.Contains("https://graph.microsoft.com/People.Read", OAuthService.GraphContactScopes);
+    }
+
+    [Fact]
+    public void DefaultMailScopes_DoNotContainContactScopes()
+    {
+        foreach (var scope in OAuthService.ImapSmtpScopes.Concat(OAuthService.GraphMailScopes).Concat(OAuthService.GraphMailScopesPersonal))
+        {
+            Assert.DoesNotContain("Contacts.Read", scope);
+            Assert.DoesNotContain("People.Read", scope);
+        }
+    }
+
+    [Fact]
+    public void ContactScopes_AreNotRequestedByDefaultScopeSelection()
+    {
+        // A Graph account's default (mail) scopes must not include the contact scopes.
+        var graphAccount = new AccountModel { BackendKind = BackendKind.MicrosoftGraph, AuthType = AuthType.OAuth2Microsoft };
+        var defaults = OAuthService.DefaultScopesFor(graphAccount);
+        Assert.DoesNotContain(defaults, s => s.Contains("Contacts.Read") || s.Contains("People.Read"));
+    }
+}
+
+/// <summary>
+/// AddressBookViewModel behaviour for synced contacts (issue #256): synced rows are read-only, and
+/// the Sync Contacts Now command delegates to the sync service.
+/// </summary>
+public class AddressBookViewModelSyncTests
+{
+    private sealed class RecordingSyncService : IContactSyncService
+    {
+        public int SyncAllCount;
+        public bool CanSync(AccountModel account) => true;
+        public Task<ContactSyncResult> SyncAccountAsync(AccountModel account, CancellationToken ct = default) => Task.FromResult(ContactSyncResult.None);
+        public Task<ContactSyncResult> SyncAllAsync(CancellationToken ct = default) { SyncAllCount++; return Task.FromResult(new ContactSyncResult(1, 3, null)); }
+        public Task RemoveAccountContactsAsync(Guid accountId, CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    private static ContactModel Local()  => new() { Id = 1, DisplayName = "Local",  EmailAddress = "l@x.test", Source = ContactSource.Local };
+    private static ContactModel Synced() => new() { Id = 2, DisplayName = "Synced", EmailAddress = "s@x.test", Source = ContactSource.Microsoft, SourceId = "m1" };
+
+    [Fact]
+    public void LocalContact_IsEditableAndDeletable()
+    {
+        var vm = new AddressBookViewModel(new StubContactService()) { SelectedContact = Local() };
+        Assert.True(vm.CanEditContact);
+        Assert.True(vm.CanDeleteContact);
+    }
+
+    [Fact]
+    public void SyncedContact_IsNotEditableOrDeletable()
+    {
+        var vm = new AddressBookViewModel(new StubContactService()) { SelectedContact = Synced() };
+        Assert.False(vm.CanEditContact);
+        Assert.False(vm.CanDeleteContact);
+    }
+
+    [Fact]
+    public void CanSyncContacts_ReflectsWhetherSyncServiceIsWired()
+    {
+        Assert.False(new AddressBookViewModel(new StubContactService()).CanSyncContacts);
+        Assert.True(new AddressBookViewModel(new StubContactService(), new RecordingSyncService()).CanSyncContacts);
+    }
+
+    [Fact]
+    public async Task SyncContactsNowCommand_InvokesSyncService()
+    {
+        var recorder = new RecordingSyncService();
+        var vm = new AddressBookViewModel(new StubContactService(), recorder);
+        await vm.SyncContactsNowCommand.ExecuteAsync(null);
+        Assert.Equal(1, recorder.SyncAllCount);
+    }
+}

--- a/QuickMail.Tests/ContactSyncServiceTests.cs
+++ b/QuickMail.Tests/ContactSyncServiceTests.cs
@@ -112,6 +112,23 @@ public class ContactSyncServiceTests
     }
 
     [Fact]
+    public async Task SyncAccount_SignInRequired_ReturnsFriendlyMessage()
+    {
+        var (contacts, dir) = MakeContacts();
+        try
+        {
+            var ms = new FakeSource { Source = ContactSource.Microsoft, OnFetch = _ => throw new InteractiveSignInRequiredException("grant lapsed") };
+            var sut = new ContactSyncService(new FakeAccountService(), contacts, ms, new FakeSource { Source = ContactSource.Google });
+
+            var result = await sut.SyncAccountAsync(new AccountModel { AuthType = AuthType.OAuth2Microsoft, AccountName = "Work" });
+
+            Assert.Equal(0, result.AccountsSynced);
+            Assert.Contains("sign-in needed", result.Error);
+        }
+        finally { Cleanup(dir); }
+    }
+
+    [Fact]
     public async Task SyncAll_OnlySyncsEnabledAndSupportedAccounts()
     {
         var (contacts, dir) = MakeContacts();
@@ -135,6 +152,48 @@ public class ContactSyncServiceTests
             Assert.Equal(1, result.AccountsSynced);
             Assert.Equal(1, ms.FetchCount);
             Assert.Equal(0, google.FetchCount);
+        }
+        finally { Cleanup(dir); }
+    }
+
+    [Fact]
+    public async Task SyncAllDue_ThrottlesRepeatCallsWithinInterval()
+    {
+        var (contacts, dir) = MakeContacts();
+        try
+        {
+            var ms = new FakeSource { Source = ContactSource.Microsoft, OnFetch = _ => [Server("m1", "a@x.test")] };
+            var accts = new FakeAccountService
+            {
+                Accounts = [new AccountModel { AuthType = AuthType.OAuth2Microsoft, SyncContacts = true }],
+            };
+            var sut = new ContactSyncService(accts, contacts, ms, new FakeSource { Source = ContactSource.Google });
+
+            await sut.SyncAllDueAsync(TimeSpan.FromHours(12));
+            await sut.SyncAllDueAsync(TimeSpan.FromHours(12)); // within window → skipped
+
+            Assert.Equal(1, ms.FetchCount);
+        }
+        finally { Cleanup(dir); }
+    }
+
+    [Fact]
+    public async Task SyncAllDue_ZeroInterval_AlwaysRuns()
+    {
+        var (contacts, dir) = MakeContacts();
+        try
+        {
+            var ms = new FakeSource { Source = ContactSource.Microsoft, OnFetch = _ => [Server("m1", "a@x.test")] };
+            var accts = new FakeAccountService
+            {
+                Accounts = [new AccountModel { AuthType = AuthType.OAuth2Microsoft, SyncContacts = true }],
+            };
+            var sut = new ContactSyncService(accts, contacts, ms, new FakeSource { Source = ContactSource.Google });
+
+            await sut.SyncAllDueAsync(TimeSpan.Zero);
+            await sut.SyncAllDueAsync(TimeSpan.Zero);
+
+            Assert.Equal(2, ms.FetchCount);
         }
         finally { Cleanup(dir); }
     }

--- a/QuickMail.Tests/ContactSyncServiceTests.cs
+++ b/QuickMail.Tests/ContactSyncServiceTests.cs
@@ -1,0 +1,159 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using QuickMail.Models;
+using QuickMail.Services;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// Tests ContactSyncService orchestration (issue #256): source selection by auth type, the
+/// enabled/supported filter in SyncAllAsync, and best-effort failure isolation.
+/// </summary>
+public class ContactSyncServiceTests
+{
+    private sealed class FakeSource : IProviderContactSource
+    {
+        public ContactSource Source { get; init; }
+        public Func<AccountModel, IReadOnlyList<ContactModel>> OnFetch = _ => Array.Empty<ContactModel>();
+        public int FetchCount;
+
+        public Task<IReadOnlyList<ContactModel>> FetchAsync(AccountModel account, CancellationToken ct = default)
+        {
+            FetchCount++;
+            return Task.FromResult(OnFetch(account));
+        }
+    }
+
+    private sealed class FakeAccountService : IAccountService
+    {
+        public List<AccountModel> Accounts = [];
+        public List<AccountModel> LoadAccounts() => Accounts;
+        public void SaveAccounts(List<AccountModel> accounts) => Accounts = accounts;
+        public void SetDefaultAccount(Guid accountId) { }
+    }
+
+    private static (ContactService svc, string dir) MakeContacts()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), $"QM-ContactSyncSvc-{Guid.NewGuid():N}");
+        return (new ContactService(new ProfileContext(dir)), dir);
+    }
+
+    private static void Cleanup(string dir)
+    {
+        try { if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true); } catch { }
+    }
+
+    private static ContactModel Server(string id, string email) =>
+        new() { SourceId = id, DisplayName = id, EmailAddress = email };
+
+    [Fact]
+    public async Task SyncAccount_Microsoft_ReplacesContactsAndReportsCount()
+    {
+        var (contacts, dir) = MakeContacts();
+        try
+        {
+            var ms = new FakeSource { Source = ContactSource.Microsoft, OnFetch = _ => [Server("m1", "a@x.test"), Server("m2", "b@x.test")] };
+            var google = new FakeSource { Source = ContactSource.Google };
+            var sut = new ContactSyncService(new FakeAccountService(), contacts, ms, google);
+            var account = new AccountModel { AuthType = AuthType.OAuth2Microsoft };
+
+            var result = await sut.SyncAccountAsync(account);
+
+            Assert.Equal(1, result.AccountsSynced);
+            Assert.Equal(2, result.ContactsFetched);
+            Assert.Null(result.Error);
+            Assert.Equal(1, ms.FetchCount);
+            Assert.Equal(2, (await contacts.LoadAllContactsAsync()).Count);
+        }
+        finally { Cleanup(dir); }
+    }
+
+    [Fact]
+    public async Task SyncAccount_PasswordAccount_IsNoOp()
+    {
+        var (contacts, dir) = MakeContacts();
+        try
+        {
+            var ms = new FakeSource { Source = ContactSource.Microsoft };
+            var google = new FakeSource { Source = ContactSource.Google };
+            var sut = new ContactSyncService(new FakeAccountService(), contacts, ms, google);
+
+            var result = await sut.SyncAccountAsync(new AccountModel { AuthType = AuthType.Password });
+
+            Assert.Equal(0, result.AccountsSynced);
+            Assert.Equal(0, ms.FetchCount);
+            Assert.Equal(0, google.FetchCount);
+            Assert.False(sut.CanSync(new AccountModel { AuthType = AuthType.Password }));
+        }
+        finally { Cleanup(dir); }
+    }
+
+    [Fact]
+    public async Task SyncAccount_SourceThrows_ReturnsErrorAndDoesNotThrow()
+    {
+        var (contacts, dir) = MakeContacts();
+        try
+        {
+            var ms = new FakeSource { Source = ContactSource.Microsoft, OnFetch = _ => throw new InvalidOperationException("boom") };
+            var google = new FakeSource { Source = ContactSource.Google };
+            var sut = new ContactSyncService(new FakeAccountService(), contacts, ms, google);
+
+            var result = await sut.SyncAccountAsync(new AccountModel { AuthType = AuthType.OAuth2Microsoft });
+
+            Assert.Equal(0, result.AccountsSynced);
+            Assert.Contains("boom", result.Error);
+        }
+        finally { Cleanup(dir); }
+    }
+
+    [Fact]
+    public async Task SyncAll_OnlySyncsEnabledAndSupportedAccounts()
+    {
+        var (contacts, dir) = MakeContacts();
+        try
+        {
+            var ms = new FakeSource { Source = ContactSource.Microsoft, OnFetch = _ => [Server("m1", "a@x.test")] };
+            var google = new FakeSource { Source = ContactSource.Google, OnFetch = _ => [Server("g1", "g@x.test")] };
+            var accts = new FakeAccountService
+            {
+                Accounts =
+                [
+                    new AccountModel { AuthType = AuthType.OAuth2Microsoft, SyncContacts = true  }, // sync
+                    new AccountModel { AuthType = AuthType.OAuth2Google,    SyncContacts = false }, // skip: disabled
+                    new AccountModel { AuthType = AuthType.Password,        SyncContacts = true  }, // skip: unsupported
+                ],
+            };
+            var sut = new ContactSyncService(accts, contacts, ms, google);
+
+            var result = await sut.SyncAllAsync();
+
+            Assert.Equal(1, result.AccountsSynced);
+            Assert.Equal(1, ms.FetchCount);
+            Assert.Equal(0, google.FetchCount);
+        }
+        finally { Cleanup(dir); }
+    }
+
+    [Fact]
+    public async Task RemoveAccountContacts_PurgesThatAccount()
+    {
+        var (contacts, dir) = MakeContacts();
+        try
+        {
+            var acct = Guid.NewGuid();
+            await contacts.ReplaceSyncedContactsAsync(acct, ContactSource.Microsoft, [Server("m1", "a@x.test")]);
+            var sut = new ContactSyncService(new FakeAccountService(), contacts,
+                new FakeSource { Source = ContactSource.Microsoft }, new FakeSource { Source = ContactSource.Google });
+
+            await sut.RemoveAccountContactsAsync(acct);
+
+            Assert.Empty(await contacts.LoadAllContactsAsync());
+        }
+        finally { Cleanup(dir); }
+    }
+}

--- a/QuickMail.Tests/StubServices.cs
+++ b/QuickMail.Tests/StubServices.cs
@@ -85,6 +85,7 @@ sealed class StubGoogleOAuthService : IGoogleOAuthService
 {
     public Task<string> GetAccessTokenAsync(string username, CancellationToken ct = default) => Task.FromResult(string.Empty);
     public Task<OAuthResult> SignInInteractiveAsync(string loginHint, CancellationToken ct = default) => Task.FromResult(new OAuthResult(string.Empty, loginHint));
+    public Task<OAuthResult> AuthorizeContactsAsync(string loginHint, CancellationToken ct = default) => Task.FromResult(new OAuthResult(string.Empty, loginHint));
     public Task SignOutAsync(string username) => Task.CompletedTask;
 }
 
@@ -94,6 +95,7 @@ sealed class StubOAuthService : IOAuthService
     public Task<string> GetAccessTokenAsync(AccountModel account, string[] scopes, CancellationToken ct = default) => Task.FromResult(string.Empty);
     public Task EnsureSilentTokenAsync(AccountModel account, CancellationToken ct = default) => Task.CompletedTask;
     public Task<OAuthResult> SignInInteractiveAsync(AccountModel account, CancellationToken ct = default) => Task.FromResult(new OAuthResult(string.Empty, string.Empty));
+    public Task RequestContactsConsentAsync(AccountModel account, CancellationToken ct = default) => Task.CompletedTask;
     public Task SignOutAsync(AccountModel account) => Task.CompletedTask;
 }
 
@@ -137,6 +139,8 @@ sealed class StubContactService : IContactService
     public Task<List<ContactModel>> LoadAllContactsAsync() => Task.FromResult(new List<ContactModel>());
     public Task DeleteContactAsync(int id) => Task.CompletedTask;
     public Task<bool> UpdateContactAsync(int id, string displayName, string emailAddress) => Task.FromResult(true);
+    public Task ReplaceSyncedContactsAsync(Guid accountId, ContactSource source, IReadOnlyList<ContactModel> serverContacts) => Task.CompletedTask;
+    public Task RemoveSyncedContactsAsync(Guid accountId) => Task.CompletedTask;
 
     // Groups — no-op stubs. Tests that need real group behaviour construct
     // a real ContactService pointed at a temp directory.
@@ -150,6 +154,14 @@ sealed class StubContactService : IContactService
     public Task TouchGroupAsync(int groupId) => Task.CompletedTask;
     public Task<List<GroupModel>> SearchGroupsAsync(string prefix, CancellationToken ct = default)
         => Task.FromResult(new List<GroupModel>());
+}
+
+sealed class StubContactSyncService : IContactSyncService
+{
+    public bool CanSync(AccountModel account) => false;
+    public Task<ContactSyncResult> SyncAccountAsync(AccountModel account, CancellationToken ct = default) => Task.FromResult(ContactSyncResult.None);
+    public Task<ContactSyncResult> SyncAllAsync(CancellationToken ct = default) => Task.FromResult(ContactSyncResult.None);
+    public Task RemoveAccountContactsAsync(Guid accountId, CancellationToken ct = default) => Task.CompletedTask;
 }
 
 sealed class StubViewService : IViewService

--- a/QuickMail.Tests/StubServices.cs
+++ b/QuickMail.Tests/StubServices.cs
@@ -93,6 +93,7 @@ sealed class StubOAuthService : IOAuthService
 {
     public Task<string> GetAccessTokenAsync(AccountModel account, CancellationToken ct = default) => Task.FromResult(string.Empty);
     public Task<string> GetAccessTokenAsync(AccountModel account, string[] scopes, CancellationToken ct = default) => Task.FromResult(string.Empty);
+    public Task<string> GetAccessTokenSilentAsync(AccountModel account, string[] scopes, CancellationToken ct = default) => Task.FromResult(string.Empty);
     public Task EnsureSilentTokenAsync(AccountModel account, CancellationToken ct = default) => Task.CompletedTask;
     public Task<OAuthResult> SignInInteractiveAsync(AccountModel account, CancellationToken ct = default) => Task.FromResult(new OAuthResult(string.Empty, string.Empty));
     public Task RequestContactsConsentAsync(AccountModel account, CancellationToken ct = default) => Task.CompletedTask;
@@ -161,6 +162,7 @@ sealed class StubContactSyncService : IContactSyncService
     public bool CanSync(AccountModel account) => false;
     public Task<ContactSyncResult> SyncAccountAsync(AccountModel account, CancellationToken ct = default) => Task.FromResult(ContactSyncResult.None);
     public Task<ContactSyncResult> SyncAllAsync(CancellationToken ct = default) => Task.FromResult(ContactSyncResult.None);
+    public Task<ContactSyncResult> SyncAllDueAsync(TimeSpan minInterval, CancellationToken ct = default) => Task.FromResult(ContactSyncResult.None);
     public Task RemoveAccountContactsAsync(Guid accountId, CancellationToken ct = default) => Task.CompletedTask;
 }
 

--- a/QuickMail/App.xaml.cs
+++ b/QuickMail/App.xaml.cs
@@ -14,6 +14,7 @@ public partial class App : Application
     // Held so OnExit can dispose them.
     private GraphSendMailService? _graphSendMail;
     private ContactService? _contactService;
+    private GooglePeopleClient? _googlePeopleClient;
     private TemplateService? _templateService;
     private ChangeNotifierRouter? _changeNotifier;
     private GraphChangeNotifier? _graphNotifier;
@@ -227,6 +228,13 @@ public partial class App : Application
             var ruleService = new RuleService(mailRouter, localStore, profile.ProfileDir);
             var syncService = new SyncService(mailRouter, localStore, configService, ruleService);
 
+            // Contact sync (issue #256): Graph source reuses the Graph backend's client; Google source
+            // gets its own People API client (owns an HttpClient → disposed in OnExit).
+            var graphContactSource  = new GraphContactSource(graphBackend.Client);
+            _googlePeopleClient     = new GooglePeopleClient(googleOAuth);
+            var googleContactSource = new GoogleContactSource(_googlePeopleClient);
+            var contactSyncService  = new ContactSyncService(accountService, contactService, graphContactSource, googleContactSource);
+
             var startupCfg = configService.Load();
             Views.AccessibilityHelper.Configure(startupCfg);
             LogService.Format  = startupCfg.LogFormat;
@@ -259,11 +267,11 @@ public partial class App : Application
             var mainVm = new MainViewModel(
                 mailRouter, accountService, credentialService, localStore, oauthService, syncService, configService, commandRegistry, viewService, ruleService, smtpService,
                 onlineMode: onlineMode, flagService: flagService, calendarService: calendarService, changeNotifier: _changeNotifier, updateCheckService: _updateCheckService,
-                themeService: themeService, notificationService: _notificationService);
+                themeService: themeService, notificationService: _notificationService, contactSyncService: contactSyncService);
             mainVm.RegisterAccountBackend = a => mailRouter.RegisterAccount(a.Id, BackendFor(a));
             mainVm.LoadAccountList(accounts);
 
-            var mainWindow = new MainWindow(mainVm, smtpService, accountService, credentialService, mailRouter, oauthService, commandRegistry, contactService, configService, localStore, viewService, ruleService, templateService, featureGate, flagService, customDictionary, themeService, _bugReportService, _notificationService);
+            var mainWindow = new MainWindow(mainVm, smtpService, accountService, credentialService, mailRouter, oauthService, commandRegistry, contactService, configService, localStore, viewService, ruleService, templateService, featureGate, flagService, customDictionary, themeService, _bugReportService, _notificationService, contactSyncService);
 
             // Clicking a new-mail toast brings QuickMail to the foreground and opens the referenced
             // message. OnActivated may fire on a background thread, so marshal to the UI thread first.
@@ -295,6 +303,7 @@ public partial class App : Application
         _imapBackend?.Dispose();    // closes connection pools (StopWatchers already ran, and is idempotent)
         _graphBackend?.Dispose();   // releases GraphClient/HttpClient; after the notifiers, which poll through its client
         _graphSendMail?.Dispose();
+        _googlePeopleClient?.Dispose();
         _contactService?.Dispose();
         _templateService?.Dispose();
         _updateCheckService?.Dispose();

--- a/QuickMail/Models/AccountModel.cs
+++ b/QuickMail/Models/AccountModel.cs
@@ -44,6 +44,14 @@ public partial class AccountModel : ObservableObject
     public bool IsDefault { get; set; } = false;
 
     /// <summary>
+    /// When true, QuickMail pulls this account's contacts and prior recipients from the mail
+    /// provider into the local address book (issue #256). Off by default; only meaningful for
+    /// OAuth accounts (Microsoft or Google), which are the only backends exposing a contact API.
+    /// Enabling it triggers a one-time consent for read-only contact scopes.
+    /// </summary>
+    public bool SyncContacts { get; set; } = false;
+
+    /// <summary>
     /// Plain-text signature appended to new messages and replies/forwards.
     /// Empty string means no signature. Stored in accounts.json.
     /// </summary>

--- a/QuickMail/Models/ContactModel.cs
+++ b/QuickMail/Models/ContactModel.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text.Json.Serialization;
 
 namespace QuickMail.Models;
@@ -8,6 +9,42 @@ public class ContactModel
     public string DisplayName   { get; set; } = string.Empty;
     public string EmailAddress  { get; set; } = string.Empty;
     public long   LastUsedTicks { get; set; }
+
+    // ── Provenance (issue #256 — server contact sync) ────────────────────────
+    // All four default to a plain local contact so existing contacts.json files
+    // (written before these fields existed) deserialize unchanged: System.Text.Json
+    // fills absent properties with their defaults, i.e. Source = Local, no owner.
+
+    /// <summary>
+    /// Where this contact came from. <see cref="ContactSource.Local"/> for user-created
+    /// contacts (the default); a provider value for synced entries.
+    /// </summary>
+    public ContactSource Source { get; set; } = ContactSource.Local;
+
+    /// <summary>
+    /// Provider-side identifier (Graph contact/person id, Google People <c>resourceName</c>).
+    /// Null for local contacts. Used to update a synced contact in place across re-syncs
+    /// rather than duplicating it, and to diff the server set against the local cache.
+    /// </summary>
+    public string? SourceId { get; set; }
+
+    /// <summary>
+    /// The account this contact was synced from. Null for local contacts. A sync only ever
+    /// replaces rows matching its own <c>(OwnerAccountId, Source)</c> slice, so local contacts
+    /// and other accounts' synced contacts are never disturbed.
+    /// </summary>
+    public Guid? OwnerAccountId { get; set; }
+
+    /// <summary>
+    /// True when this entry came from a "people you've emailed" source (Graph <c>/me/people</c>,
+    /// Google other-contacts) rather than a saved address-book contact. Prior recipients rank
+    /// below saved contacts in autocomplete dedup.
+    /// </summary>
+    public bool IsPriorRecipient { get; set; }
+
+    /// <summary>True for user-owned contacts; false for anything synced from a server.</summary>
+    [JsonIgnore]
+    public bool IsLocal => Source == ContactSource.Local;
 
     [JsonIgnore]
     public string Display => string.IsNullOrWhiteSpace(DisplayName)

--- a/QuickMail/Models/ContactSource.cs
+++ b/QuickMail/Models/ContactSource.cs
@@ -1,0 +1,20 @@
+namespace QuickMail.Models;
+
+/// <summary>
+/// Where a <see cref="ContactModel"/> came from. <see cref="Local"/> contacts are created
+/// by the user (Add, Grab Addresses, compose upsert) and are never touched by a server sync.
+/// The other values mark contacts pulled from a mail provider by the contact-sync feature
+/// (issue #256); those are read-only in the address book and are replaced wholesale on each
+/// re-sync of their owning account.
+/// </summary>
+public enum ContactSource
+{
+    /// <summary>User-owned contact stored only in QuickMail. The default for every existing entry.</summary>
+    Local = 0,
+
+    /// <summary>Synced from a Microsoft account via Graph (<c>/me/contacts</c> and <c>/me/people</c>).</summary>
+    Microsoft = 1,
+
+    /// <summary>Synced from a Google account via the People API (connections and other contacts).</summary>
+    Google = 2,
+}

--- a/QuickMail/Services/ContactService.cs
+++ b/QuickMail/Services/ContactService.cs
@@ -65,14 +65,16 @@ public class ContactService : IContactService, IDisposable
         await _loadLock.WaitAsync(ct);
         try
         {
-            return string.IsNullOrEmpty(q)
-                ? _contactsCache.OrderByDescending(c => c.LastUsedTicks).ToList()
+            // Dedup by email so a person present as both a local contact and a synced
+            // contact/prior-recipient (issue #256) shows once in autocomplete.
+            var source = string.IsNullOrEmpty(q)
+                ? _contactsCache.AsEnumerable()
                 : _contactsCache.Where(c =>
                     c.DisplayName.Contains(q, StringComparison.OrdinalIgnoreCase) ||
-                    c.EmailAddress.Contains(q, StringComparison.OrdinalIgnoreCase))
-                  .OrderByDescending(c => c.LastUsedTicks)
-                  .Take(10)
-                  .ToList();
+                    c.EmailAddress.Contains(q, StringComparison.OrdinalIgnoreCase));
+
+            var deduped = DedupByEmail(source).OrderByDescending(c => c.LastUsedTicks);
+            return string.IsNullOrEmpty(q) ? deduped.ToList() : deduped.Take(10).ToList();
         }
         finally
         {
@@ -86,13 +88,30 @@ public class ContactService : IContactService, IDisposable
         await _loadLock.WaitAsync();
         try
         {
-            return _contactsCache.OrderBy(c => c.DisplayName).ThenBy(c => c.EmailAddress).ToList();
+            return DedupByEmail(_contactsCache)
+                .OrderBy(c => c.DisplayName).ThenBy(c => c.EmailAddress).ToList();
         }
         finally
         {
             _loadLock.Release();
         }
     }
+
+    /// <summary>
+    /// Collapses contacts that share an email address (case-insensitive) to a single row,
+    /// preferring — in order — a local contact, then a saved server contact, then a prior
+    /// recipient. Among equal-rank duplicates the most-recently-used wins. The winner is the
+    /// original cache object (never mutated), so callers see one row per person without the
+    /// cache being altered.
+    /// </summary>
+    private static IEnumerable<ContactModel> DedupByEmail(IEnumerable<ContactModel> contacts)
+        => contacts
+            .GroupBy(c => c.EmailAddress.Trim(), StringComparer.OrdinalIgnoreCase)
+            .Select(g => g.OrderBy(SourceRank).ThenByDescending(c => c.LastUsedTicks).First());
+
+    // Local user contacts outrank saved server contacts, which outrank prior recipients.
+    private static int SourceRank(ContactModel c)
+        => c.Source == ContactSource.Local ? 0 : (c.IsPriorRecipient ? 2 : 1);
 
     public async Task DeleteContactAsync(int id)
     {
@@ -139,6 +158,79 @@ public class ContactService : IContactService, IDisposable
             contact.LastUsedTicks = DateTimeOffset.UtcNow.UtcTicks;
             await SaveContactsAsyncLocked();
             return true;
+        }
+        finally
+        {
+            _loadLock.Release();
+        }
+    }
+
+    // ── Server contact sync (issue #256) ─────────────────────────────────────
+
+    public async Task ReplaceSyncedContactsAsync(Guid accountId, ContactSource source, IReadOnlyList<ContactModel> serverContacts)
+    {
+        await EnsureLoadedAsync();
+        await _loadLock.WaitAsync();
+        try
+        {
+            // Existing synced rows for exactly this (account, source), keyed by provider id so a
+            // contact edited server-side updates in place and keeps its local Id (and any group
+            // membership) rather than being deleted and re-added.
+            var existingBySourceId = _contactsCache
+                .Where(c => c.OwnerAccountId == accountId && c.Source == source && c.SourceId != null)
+                .ToDictionary(c => c.SourceId!, StringComparer.Ordinal);
+
+            var seenSourceIds = new HashSet<string>(StringComparer.Ordinal);
+            // Compute the next id once; recomputing Max() per new row would be O(n²).
+            var nextId = _contactsCache.Count > 0 ? _contactsCache.Max(c => c.Id) + 1 : 1;
+
+            foreach (var sc in serverContacts)
+            {
+                // Skip malformed provider rows: a contact with no id can't be diffed on the next
+                // sync, and one with no email is useless for addressing.
+                if (string.IsNullOrEmpty(sc.SourceId) || string.IsNullOrWhiteSpace(sc.EmailAddress))
+                    continue;
+
+                seenSourceIds.Add(sc.SourceId);
+                if (existingBySourceId.TryGetValue(sc.SourceId, out var existing))
+                {
+                    existing.DisplayName      = sc.DisplayName;
+                    existing.EmailAddress     = sc.EmailAddress;
+                    existing.LastUsedTicks    = sc.LastUsedTicks;
+                    existing.IsPriorRecipient = sc.IsPriorRecipient;
+                }
+                else
+                {
+                    sc.Id             = nextId++;
+                    sc.Source         = source;
+                    sc.OwnerAccountId = accountId;
+                    _contactsCache.Add(sc);
+                }
+            }
+
+            // Drop synced rows for this (account, source) the server no longer returns — this is how
+            // a contact deleted on the server disappears from QuickMail on the next sync.
+            _contactsCache.RemoveAll(c =>
+                c.OwnerAccountId == accountId && c.Source == source &&
+                (c.SourceId is null || !seenSourceIds.Contains(c.SourceId)));
+
+            await SaveContactsAsyncLocked();
+        }
+        finally
+        {
+            _loadLock.Release();
+        }
+    }
+
+    public async Task RemoveSyncedContactsAsync(Guid accountId)
+    {
+        await EnsureLoadedAsync();
+        await _loadLock.WaitAsync();
+        try
+        {
+            var removed = _contactsCache.RemoveAll(c => c.OwnerAccountId == accountId);
+            if (removed > 0)
+                await SaveContactsAsyncLocked();
         }
         finally
         {

--- a/QuickMail/Services/ContactSyncService.cs
+++ b/QuickMail/Services/ContactSyncService.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using QuickMail.Models;
+
+namespace QuickMail.Services;
+
+/// <inheritdoc cref="IContactSyncService"/>
+public sealed class ContactSyncService : IContactSyncService
+{
+    private readonly IAccountService _accounts;
+    private readonly IContactService _contacts;
+    private readonly IProviderContactSource _microsoftSource;
+    private readonly IProviderContactSource _googleSource;
+
+    public ContactSyncService(
+        IAccountService accounts,
+        IContactService contacts,
+        IProviderContactSource microsoftSource,
+        IProviderContactSource googleSource)
+    {
+        _accounts        = accounts;
+        _contacts        = contacts;
+        _microsoftSource = microsoftSource;
+        _googleSource    = googleSource;
+    }
+
+    public bool CanSync(AccountModel account) => SourceFor(account) is not null;
+
+    private IProviderContactSource? SourceFor(AccountModel account) => account.AuthType switch
+    {
+        // Keyed by auth type, not backend: a Gmail account is IMAP + Google OAuth (not the Graph
+        // backend), and an Outlook.com account can be IMAP + Microsoft OAuth. The contact API follows
+        // the identity provider, so a valid OAuth token is what makes contact sync possible.
+        AuthType.OAuth2Microsoft => _microsoftSource,
+        AuthType.OAuth2Google    => _googleSource,
+        _                        => null,
+    };
+
+    public async Task<ContactSyncResult> SyncAccountAsync(AccountModel account, CancellationToken ct = default)
+    {
+        var source = SourceFor(account);
+        if (source is null) return ContactSyncResult.None;
+
+        try
+        {
+            var fetched = await source.FetchAsync(account, ct);
+            await _contacts.ReplaceSyncedContactsAsync(account.Id, source.Source, fetched);
+            LogService.Log($"ContactSync: {account.AccountLabel} — {fetched.Count} contact(s) synced.");
+            return new ContactSyncResult(1, fetched.Count, null);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // Best-effort: log and report, never throw. A contact-sync failure must not break the
+            // mail-sync caller (spec §5.1, §13.1).
+            LogService.Log($"ContactSync failed for {account.AccountLabel}", ex);
+            return new ContactSyncResult(0, 0, ex.Message);
+        }
+    }
+
+    public async Task<ContactSyncResult> SyncAllAsync(CancellationToken ct = default)
+    {
+        int accountsSynced = 0, contactsFetched = 0;
+        string? error = null;
+
+        foreach (var account in _accounts.LoadAccounts())
+        {
+            if (!account.SyncContacts || !CanSync(account)) continue;
+            ct.ThrowIfCancellationRequested();
+
+            var result = await SyncAccountAsync(account, ct);
+            accountsSynced  += result.AccountsSynced;
+            contactsFetched += result.ContactsFetched;
+            if (result.Error is not null) error = result.Error; // last error wins; each is logged
+        }
+
+        return new ContactSyncResult(accountsSynced, contactsFetched, error);
+    }
+
+    public Task RemoveAccountContactsAsync(Guid accountId, CancellationToken ct = default)
+        => _contacts.RemoveSyncedContactsAsync(accountId);
+}

--- a/QuickMail/Services/ContactSyncService.cs
+++ b/QuickMail/Services/ContactSyncService.cs
@@ -13,6 +13,11 @@ public sealed class ContactSyncService : IContactSyncService
     private readonly IProviderContactSource _microsoftSource;
     private readonly IProviderContactSource _googleSource;
 
+    // Process-lifetime throttle for the automatic background trigger. UtcNow is only read here (not in
+    // a resumable/replayable context), so it's safe.
+    private readonly object _throttleLock = new();
+    private DateTimeOffset _lastAutoSyncUtc = DateTimeOffset.MinValue;
+
     public ContactSyncService(
         IAccountService accounts,
         IContactService contacts,
@@ -53,6 +58,14 @@ public sealed class ContactSyncService : IContactSyncService
         {
             throw;
         }
+        catch (InteractiveSignInRequiredException ex)
+        {
+            // The read-only contact grant has lapsed. We never open an interactive window from sync
+            // (it could deadlock the modal address book), so tell the user how to restore it.
+            LogService.Log($"ContactSync: sign-in required for {account.AccountLabel} — {ex.Message}");
+            return new ContactSyncResult(0, 0,
+                $"sign-in needed — turn contact sync off and on again for {account.AccountLabel} in account settings.");
+        }
         catch (Exception ex)
         {
             // Best-effort: log and report, never throw. A contact-sync failure must not break the
@@ -79,6 +92,20 @@ public sealed class ContactSyncService : IContactSyncService
         }
 
         return new ContactSyncResult(accountsSynced, contactsFetched, error);
+    }
+
+    public Task<ContactSyncResult> SyncAllDueAsync(TimeSpan minInterval, CancellationToken ct = default)
+    {
+        lock (_throttleLock)
+        {
+            if (DateTimeOffset.UtcNow - _lastAutoSyncUtc < minInterval)
+                return Task.FromResult(ContactSyncResult.None);
+            // Stamp on attempt (not on success): a transient failure shouldn't cause a full re-fetch
+            // on the next reconnect/activation within the window. The manual command and the next
+            // launch both provide a way to retry sooner.
+            _lastAutoSyncUtc = DateTimeOffset.UtcNow;
+        }
+        return SyncAllAsync(ct);
     }
 
     public Task RemoveAccountContactsAsync(Guid accountId, CancellationToken ct = default)

--- a/QuickMail/Services/Contacts/GoogleContactSource.cs
+++ b/QuickMail/Services/Contacts/GoogleContactSource.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using QuickMail.Models;
+
+namespace QuickMail.Services;
+
+/// <summary>
+/// Pulls contacts from a Google account via the People API (issue #256): saved connections and
+/// "other contacts" (prior recipients). Read-only; relies on the account having consented to the
+/// People read scopes (see <see cref="IGoogleOAuthService.AuthorizeContactsAsync"/>). If it hasn't,
+/// the People API returns 403 and this surfaces as a sync error.
+/// </summary>
+public sealed class GoogleContactSource : IProviderContactSource
+{
+    // Matches the Graph source's cap so both providers behave the same (spec §13.1).
+    private const int MaxPriorRecipients = 1000;
+
+    private readonly GooglePeopleClient _people;
+
+    public GoogleContactSource(GooglePeopleClient people) => _people = people;
+
+    public ContactSource Source => ContactSource.Google;
+
+    public async Task<IReadOnlyList<ContactModel>> FetchAsync(AccountModel account, CancellationToken ct = default)
+    {
+        var results = new List<ContactModel>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        // ── Saved contacts (connections) ────────────────────────────────────
+        var connections = await _people.GetConnectionsAsync(account.Username, ct);
+        foreach (var p in connections)
+        {
+            var c = Map(p, isPriorRecipient: false);
+            if (c is null || !seen.Add(c.EmailAddress)) continue;
+            results.Add(c);
+        }
+
+        // ── Prior recipients (other contacts) ───────────────────────────────
+        var others = await _people.GetOtherContactsAsync(account.Username, ct);
+        int priorAdded = 0;
+        bool capped = false;
+        foreach (var p in others)
+        {
+            var c = Map(p, isPriorRecipient: true);
+            if (c is null || !seen.Add(c.EmailAddress)) continue;
+            if (priorAdded >= MaxPriorRecipients) { capped = true; break; }
+            results.Add(c);
+            priorAdded++;
+        }
+
+        if (capped)
+            LogService.Log($"GoogleContactSource: capped prior recipients at {MaxPriorRecipients} for {account.AccountLabel}.");
+
+        return results;
+    }
+
+    /// <summary>Maps a People API person to a contact, or null if it has no usable email / id.</summary>
+    private static ContactModel? Map(GooglePerson p, bool isPriorRecipient)
+    {
+        var email = p.EmailAddresses?
+            .Select(e => e.Value?.Trim())
+            .FirstOrDefault(v => !string.IsNullOrWhiteSpace(v));
+        if (string.IsNullOrWhiteSpace(email) || string.IsNullOrEmpty(p.ResourceName))
+            return null;
+
+        var name = p.Names?
+            .Select(n => n.DisplayName?.Trim())
+            .FirstOrDefault(n => !string.IsNullOrWhiteSpace(n)) ?? string.Empty;
+
+        return new ContactModel
+        {
+            SourceId         = p.ResourceName,
+            DisplayName      = name,
+            EmailAddress     = email,
+            IsPriorRecipient = isPriorRecipient,
+        };
+    }
+}

--- a/QuickMail/Services/Contacts/GraphContactSource.cs
+++ b/QuickMail/Services/Contacts/GraphContactSource.cs
@@ -34,9 +34,12 @@ public sealed class GraphContactSource : IProviderContactSource
         var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         // ── Saved contacts ──────────────────────────────────────────────────
+        // silentOnly: sync must never launch an interactive sign-in — the address book runs modal,
+        // where an embedded WebView2 could deadlock the UI thread. Consent is obtained up front when
+        // the user enables sync; if the grant later lapses, this throws and sync reports an error.
         var contacts = await _graph.GetAllPagesAsync<GraphContact>(
             account, "/me/contacts?$select=id,displayName,emailAddresses&$top=100",
-            OAuthService.GraphContactScopes, ct);
+            OAuthService.GraphContactScopes, silentOnly: true, ct);
 
         foreach (var c in contacts)
         {
@@ -55,7 +58,7 @@ public sealed class GraphContactSource : IProviderContactSource
         // ── Prior recipients (people the user has corresponded with) ─────────
         var people = await _graph.GetAllPagesAsync<GraphPerson>(
             account, "/me/people?$select=id,displayName,scoredEmailAddresses&$top=100",
-            OAuthService.GraphContactScopes, ct);
+            OAuthService.GraphContactScopes, silentOnly: true, ct);
 
         int priorAdded = 0;
         bool capped = false;

--- a/QuickMail/Services/Contacts/GraphContactSource.cs
+++ b/QuickMail/Services/Contacts/GraphContactSource.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using QuickMail.Models;
+using QuickMail.Services.Graph;
+
+namespace QuickMail.Services;
+
+/// <summary>
+/// Pulls contacts from a Microsoft account via Graph: <c>/me/contacts</c> (saved contacts) and
+/// <c>/me/people</c> (relevance-ranked prior recipients). Read-only; uses the explicit
+/// <see cref="OAuthService.GraphContactScopes"/> so it works for personal and work/school accounts
+/// alike (issue #256).
+/// </summary>
+public sealed class GraphContactSource : IProviderContactSource
+{
+    // Prior recipients can be numerous. Cap what we import so contacts.json stays small and the
+    // address book / autocomplete stay responsive (spec §13.1). Saved contacts are never capped.
+    private const int MaxPriorRecipients = 1000;
+
+    private readonly GraphClient _graph;
+
+    public GraphContactSource(GraphClient graph) => _graph = graph;
+
+    public ContactSource Source => ContactSource.Microsoft;
+
+    public async Task<IReadOnlyList<ContactModel>> FetchAsync(AccountModel account, CancellationToken ct = default)
+    {
+        var results = new List<ContactModel>();
+        // De-dup emails within the provider result: a saved contact wins over the same address
+        // appearing again as a prior recipient.
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        // ── Saved contacts ──────────────────────────────────────────────────
+        var contacts = await _graph.GetAllPagesAsync<GraphContact>(
+            account, "/me/contacts?$select=id,displayName,emailAddresses&$top=100",
+            OAuthService.GraphContactScopes, ct);
+
+        foreach (var c in contacts)
+        {
+            var email = FirstEmail(c.EmailAddresses?.Select(e => e.Address));
+            if (email is null || string.IsNullOrEmpty(c.Id)) continue;
+            if (!seen.Add(email)) continue;
+            results.Add(new ContactModel
+            {
+                SourceId         = c.Id,
+                DisplayName      = c.DisplayName?.Trim() ?? string.Empty,
+                EmailAddress     = email,
+                IsPriorRecipient = false,
+            });
+        }
+
+        // ── Prior recipients (people the user has corresponded with) ─────────
+        var people = await _graph.GetAllPagesAsync<GraphPerson>(
+            account, "/me/people?$select=id,displayName,scoredEmailAddresses&$top=100",
+            OAuthService.GraphContactScopes, ct);
+
+        int priorAdded = 0;
+        bool capped = false;
+        foreach (var p in people)
+        {
+            var email = FirstEmail(p.ScoredEmailAddresses?.Select(e => e.Address));
+            if (email is null) continue;
+            if (!seen.Add(email)) continue;
+            if (priorAdded >= MaxPriorRecipients) { capped = true; break; }
+            results.Add(new ContactModel
+            {
+                // People ids can be absent; the email is a stable per-account key in that case.
+                SourceId         = string.IsNullOrEmpty(p.Id) ? email : p.Id,
+                DisplayName      = p.DisplayName?.Trim() ?? string.Empty,
+                EmailAddress     = email,
+                IsPriorRecipient = true,
+            });
+            priorAdded++;
+        }
+
+        if (capped)
+            LogService.Log($"GraphContactSource: capped prior recipients at {MaxPriorRecipients} for {account.AccountLabel}.");
+
+        return results;
+    }
+
+    private static string? FirstEmail(IEnumerable<string?>? addresses)
+    {
+        var a = addresses?.FirstOrDefault(x => !string.IsNullOrWhiteSpace(x))?.Trim();
+        return string.IsNullOrEmpty(a) ? null : a;
+    }
+}

--- a/QuickMail/Services/Contacts/IProviderContactSource.cs
+++ b/QuickMail/Services/Contacts/IProviderContactSource.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using QuickMail.Models;
+
+namespace QuickMail.Services;
+
+/// <summary>
+/// Fetches an account's contacts and prior recipients from its mail provider, normalized to
+/// <see cref="ContactModel"/> (issue #256). Each provider (Microsoft Graph, Google People) has one
+/// implementation. The returned models carry <see cref="ContactModel.SourceId"/>,
+/// <see cref="ContactModel.EmailAddress"/>, <see cref="ContactModel.DisplayName"/> and
+/// <see cref="ContactModel.IsPriorRecipient"/>; <c>Source</c>/<c>OwnerAccountId</c>/<c>Id</c> are
+/// assigned by <see cref="IContactService.ReplaceSyncedContactsAsync"/> during the merge.
+/// </summary>
+public interface IProviderContactSource
+{
+    /// <summary>Which <see cref="ContactSource"/> this source produces.</summary>
+    ContactSource Source { get; }
+
+    /// <summary>
+    /// Fetches saved contacts and prior recipients for the account. Emails are de-duplicated within
+    /// the provider result (a saved contact takes precedence over the same address as a prior
+    /// recipient). Throws on transport/auth failure so the caller can surface a sync error.
+    /// </summary>
+    Task<IReadOnlyList<ContactModel>> FetchAsync(AccountModel account, CancellationToken ct = default);
+}

--- a/QuickMail/Services/Google/GooglePeopleClient.cs
+++ b/QuickMail/Services/Google/GooglePeopleClient.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace QuickMail.Services;
+
+/// <summary>
+/// Minimal client for the Google People API (issue #256), mirroring <c>GraphClient</c>'s shape: a
+/// raw <see cref="HttpClient"/> that attaches the bearer token per request and follows
+/// <c>nextPageToken</c> until the collection is exhausted. Only the two read endpoints contact sync
+/// needs are exposed: saved connections and "other contacts" (prior recipients). A raw HttpClient
+/// keeps the published binary small, matching the Graph backend's approach.
+/// </summary>
+public sealed class GooglePeopleClient : IDisposable
+{
+    private const string BaseUrl = "https://people.googleapis.com/v1";
+    private static readonly JsonSerializerOptions JsonOpts = new() { PropertyNameCaseInsensitive = true };
+
+    private readonly IGoogleOAuthService _oauth;
+    private readonly HttpClient _http;
+    private readonly bool _ownsHttp;
+
+    public GooglePeopleClient(IGoogleOAuthService oauth, HttpClient? http = null)
+    {
+        _oauth    = oauth;
+        _http     = http ?? new HttpClient();
+        _ownsHttp = http is null;
+    }
+
+    /// <summary>Saved contacts (<c>people/me/connections</c>).</summary>
+    public Task<List<GooglePerson>> GetConnectionsAsync(string username, CancellationToken ct = default)
+        => PageAsync(username, "people/me/connections?personFields=names,emailAddresses&pageSize=1000",
+                     other: false, ct);
+
+    /// <summary>"Other contacts" — people emailed but not saved, i.e. prior recipients.</summary>
+    public Task<List<GooglePerson>> GetOtherContactsAsync(string username, CancellationToken ct = default)
+        => PageAsync(username, "otherContacts?readMask=names,emailAddresses&pageSize=1000",
+                     other: true, ct);
+
+    private async Task<List<GooglePerson>> PageAsync(string username, string path, bool other, CancellationToken ct)
+    {
+        var all = new List<GooglePerson>();
+        string? pageToken = null;
+        do
+        {
+            var token = await _oauth.GetAccessTokenAsync(username, ct);
+            var url = $"{BaseUrl}/{path}" +
+                      (string.IsNullOrEmpty(pageToken) ? string.Empty : $"&pageToken={Uri.EscapeDataString(pageToken)}");
+
+            using var req = new HttpRequestMessage(HttpMethod.Get, url);
+            req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+            using var resp = await _http.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, ct);
+            if (!resp.IsSuccessStatusCode)
+            {
+                var body = await resp.Content.ReadAsStringAsync(ct);
+                throw new HttpRequestException(
+                    $"People API request failed ({(int)resp.StatusCode} {resp.StatusCode}): {Truncate(body, 500)}");
+            }
+
+            var page  = await resp.Content.ReadFromJsonAsync<GooglePeopleResponse>(JsonOpts, ct);
+            var items = other ? page?.OtherContacts : page?.Connections;
+            if (items != null) all.AddRange(items);
+            pageToken = page?.NextPageToken;
+        }
+        while (!string.IsNullOrEmpty(pageToken));
+
+        return all;
+    }
+
+    private static string Truncate(string s, int max) => s.Length <= max ? s : s[..max];
+
+    public void Dispose()
+    {
+        if (_ownsHttp) _http.Dispose();
+    }
+}
+
+// ── People API DTOs ──────────────────────────────────────────────────────────
+
+public sealed class GooglePerson
+{
+    [JsonPropertyName("resourceName")]  public string? ResourceName  { get; set; }
+    [JsonPropertyName("names")]         public List<GoogleName>?  Names          { get; set; }
+    [JsonPropertyName("emailAddresses")] public List<GoogleEmail>? EmailAddresses { get; set; }
+}
+
+public sealed class GoogleName
+{
+    [JsonPropertyName("displayName")] public string? DisplayName { get; set; }
+}
+
+public sealed class GoogleEmail
+{
+    [JsonPropertyName("value")] public string? Value { get; set; }
+}
+
+internal sealed class GooglePeopleResponse
+{
+    [JsonPropertyName("connections")]   public List<GooglePerson>? Connections   { get; set; }
+    [JsonPropertyName("otherContacts")] public List<GooglePerson>? OtherContacts { get; set; }
+    [JsonPropertyName("nextPageToken")] public string? NextPageToken { get; set; }
+}

--- a/QuickMail/Services/GoogleOAuthService.cs
+++ b/QuickMail/Services/GoogleOAuthService.cs
@@ -20,6 +20,19 @@ public partial class GoogleOAuthService : IGoogleOAuthService
     // Gmail IMAP/SMTP access + openid/email so we can confirm the signed-in address from the id_token.
     private static readonly string[] Scopes = ["https://mail.google.com/", "openid", "email"];
 
+    // Read-only People API scopes for contact sync (issue #256): contacts.readonly → saved
+    // connections; contacts.other.readonly → "other contacts" (people emailed but not saved =
+    // prior recipients). These are Google "sensitive" scopes and require app verification.
+    // Requested only when the user opts a Google account into contact sync, combined with the
+    // mail scopes so the single stored refresh token continues to cover mail as well.
+    private static readonly string[] ContactsScopes =
+    [
+        "https://www.googleapis.com/auth/contacts.readonly",
+        "https://www.googleapis.com/auth/contacts.other.readonly",
+    ];
+
+    private static string[] MailAndContactsScopes => [.. Scopes, .. ContactsScopes];
+
     private static string TokenKey(string username)
         => $"QuickMail:GoogleToken:{username.ToLowerInvariant()}";
 
@@ -35,7 +48,7 @@ public partial class GoogleOAuthService : IGoogleOAuthService
         _credentialService = credentialService;
     }
 
-    private static GoogleAuthorizationCodeFlow CreateFlow(IDataStore? dataStore = null)
+    private static GoogleAuthorizationCodeFlow CreateFlow(string[] scopes, IDataStore? dataStore = null)
     {
         return new GoogleAuthorizationCodeFlow(new GoogleAuthorizationCodeFlow.Initializer
         {
@@ -44,7 +57,7 @@ public partial class GoogleOAuthService : IGoogleOAuthService
                 ClientId     = ClientId,
                 ClientSecret = ClientSecret,
             },
-            Scopes    = Scopes,
+            Scopes    = scopes,
             DataStore = dataStore ?? new NoOpDataStore(),
         });
     }
@@ -59,7 +72,7 @@ public partial class GoogleOAuthService : IGoogleOAuthService
             if (string.IsNullOrEmpty(refreshToken))
                 throw new InvalidOperationException($"No Google credentials stored for {username}. Sign in first.");
 
-            credential = new UserCredential(CreateFlow(new NoOpDataStore()), username, new TokenResponse
+            credential = new UserCredential(CreateFlow(Scopes, new NoOpDataStore()), username, new TokenResponse
             {
                 RefreshToken = refreshToken,
             });
@@ -70,10 +83,16 @@ public partial class GoogleOAuthService : IGoogleOAuthService
         return await credential.GetAccessTokenForRequestAsync(cancellationToken: ct);
     }
 
-    public async Task<OAuthResult> SignInInteractiveAsync(string loginHint, CancellationToken ct = default)
+    public Task<OAuthResult> SignInInteractiveAsync(string loginHint, CancellationToken ct = default)
+        => AuthorizeInteractiveAsync(loginHint, Scopes, ct);
+
+    public Task<OAuthResult> AuthorizeContactsAsync(string loginHint, CancellationToken ct = default)
+        => AuthorizeInteractiveAsync(loginHint, MailAndContactsScopes, ct);
+
+    private async Task<OAuthResult> AuthorizeInteractiveAsync(string loginHint, string[] scopes, CancellationToken ct)
     {
         // NoOpDataStore: we handle persistence ourselves via CredentialService / WCM.
-        var flow     = CreateFlow(new NoOpDataStore());
+        var flow     = CreateFlow(scopes, new NoOpDataStore());
         var receiver = new LocalServerCodeReceiver();
         var app      = new AuthorizationCodeInstalledApp(flow, receiver);
 
@@ -92,7 +111,7 @@ public partial class GoogleOAuthService : IGoogleOAuthService
 
         _cache[email.ToLowerInvariant()] = credential;
 
-        LogService.Log($"GoogleOAuthService: interactive sign-in complete for {email}");
+        LogService.Log($"GoogleOAuthService: interactive sign-in complete for {email} ({scopes.Length} scopes)");
         var accessToken = await credential.GetAccessTokenForRequestAsync(cancellationToken: ct);
         return new OAuthResult(accessToken, email);
     }

--- a/QuickMail/Services/Graph/GraphClient.cs
+++ b/QuickMail/Services/Graph/GraphClient.cs
@@ -54,13 +54,22 @@ public sealed class GraphClient : IDisposable
     /// <c>People.Read</c> rather than the account's default mail scopes. A null <paramref name="scopes"/>
     /// uses the account's default scopes (identical to the two-argument overload).
     /// </summary>
-    public async Task<List<T>> GetAllPagesAsync<T>(AccountModel account, string path, string[]? scopes, CancellationToken ct = default)
+    public Task<List<T>> GetAllPagesAsync<T>(AccountModel account, string path, string[]? scopes, CancellationToken ct = default)
+        => GetAllPagesAsync<T>(account, path, scopes, silentOnly: false, ct);
+
+    /// <summary>
+    /// As the scope-aware overload, but when <paramref name="silentOnly"/> is true the bearer token
+    /// is acquired without any interactive fallback (issue #256): contact sync can run inside the
+    /// modal address book, where launching an embedded WebView2 sign-in could deadlock the UI thread.
+    /// A missing/expired grant surfaces as <see cref="InteractiveSignInRequiredException"/>.
+    /// </summary>
+    public async Task<List<T>> GetAllPagesAsync<T>(AccountModel account, string path, string[]? scopes, bool silentOnly, CancellationToken ct = default)
     {
         var all = new List<T>();
         string? next = path;
         while (!string.IsNullOrEmpty(next))
         {
-            using var resp = await SendAsync(account, HttpMethod.Get, next, null, scopes, ct);
+            using var resp = await SendAsync(account, HttpMethod.Get, next, null, scopes, silentOnly, ct);
             await EnsureSuccessAsync(resp, ct);
             var page = await resp.Content.ReadFromJsonAsync<GraphCollection<T>>(JsonOpts, ct);
             if (page?.Value != null) all.AddRange(page.Value);
@@ -135,10 +144,10 @@ public sealed class GraphClient : IDisposable
 
     private Task<HttpResponseMessage> SendAsync(
         AccountModel account, HttpMethod method, string pathOrUrl, Func<HttpContent>? contentFactory, CancellationToken ct)
-        => SendAsync(account, method, pathOrUrl, contentFactory, null, ct);
+        => SendAsync(account, method, pathOrUrl, contentFactory, null, silentOnly: false, ct);
 
     private async Task<HttpResponseMessage> SendAsync(
-        AccountModel account, HttpMethod method, string pathOrUrl, Func<HttpContent>? contentFactory, string[]? scopes, CancellationToken ct)
+        AccountModel account, HttpMethod method, string pathOrUrl, Func<HttpContent>? contentFactory, string[]? scopes, bool silentOnly, CancellationToken ct)
     {
         var url = pathOrUrl.StartsWith("http", StringComparison.OrdinalIgnoreCase) ? pathOrUrl : BaseUrl + pathOrUrl;
 
@@ -147,10 +156,13 @@ public sealed class GraphClient : IDisposable
         {
             // Default (scopes == null): per-account default scopes (DefaultScopesFor) — `.default` for
             // work/school, explicit Mail.ReadWrite/etc. for personal Microsoft accounts (#217). An
-            // explicit scope set is passed only by contact sync (Graph Contacts.Read/People.Read).
+            // explicit scope set is passed only by contact sync (Graph Contacts.Read/People.Read),
+            // which also asks for silent-only acquisition so it never opens an interactive window.
             var token = scopes is null
                 ? await _oauth.GetAccessTokenAsync(account, ct)
-                : await _oauth.GetAccessTokenAsync(account, scopes, ct);
+                : silentOnly
+                    ? await _oauth.GetAccessTokenSilentAsync(account, scopes, ct)
+                    : await _oauth.GetAccessTokenAsync(account, scopes, ct);
             using var req = new HttpRequestMessage(method, url);
             req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
             if (contentFactory != null)

--- a/QuickMail/Services/Graph/GraphClient.cs
+++ b/QuickMail/Services/Graph/GraphClient.cs
@@ -45,13 +45,22 @@ public sealed class GraphClient : IDisposable
     }
 
     /// <summary>GET a collection, following <c>@odata.nextLink</c> until exhausted.</summary>
-    public async Task<List<T>> GetAllPagesAsync<T>(AccountModel account, string path, CancellationToken ct = default)
+    public Task<List<T>> GetAllPagesAsync<T>(AccountModel account, string path, CancellationToken ct = default)
+        => GetAllPagesAsync<T>(account, path, null, ct);
+
+    /// <summary>
+    /// GET a collection with an explicit token scope set, following <c>@odata.nextLink</c> until
+    /// exhausted. Used by contact sync (issue #256) to request Graph <c>Contacts.Read</c>/
+    /// <c>People.Read</c> rather than the account's default mail scopes. A null <paramref name="scopes"/>
+    /// uses the account's default scopes (identical to the two-argument overload).
+    /// </summary>
+    public async Task<List<T>> GetAllPagesAsync<T>(AccountModel account, string path, string[]? scopes, CancellationToken ct = default)
     {
         var all = new List<T>();
         string? next = path;
         while (!string.IsNullOrEmpty(next))
         {
-            using var resp = await SendAsync(account, HttpMethod.Get, next, null, ct);
+            using var resp = await SendAsync(account, HttpMethod.Get, next, null, scopes, ct);
             await EnsureSuccessAsync(resp, ct);
             var page = await resp.Content.ReadFromJsonAsync<GraphCollection<T>>(JsonOpts, ct);
             if (page?.Value != null) all.AddRange(page.Value);
@@ -124,18 +133,24 @@ public sealed class GraphClient : IDisposable
         return await resp.Content.ReadAsByteArrayAsync(ct);
     }
 
-    private async Task<HttpResponseMessage> SendAsync(
+    private Task<HttpResponseMessage> SendAsync(
         AccountModel account, HttpMethod method, string pathOrUrl, Func<HttpContent>? contentFactory, CancellationToken ct)
+        => SendAsync(account, method, pathOrUrl, contentFactory, null, ct);
+
+    private async Task<HttpResponseMessage> SendAsync(
+        AccountModel account, HttpMethod method, string pathOrUrl, Func<HttpContent>? contentFactory, string[]? scopes, CancellationToken ct)
     {
         var url = pathOrUrl.StartsWith("http", StringComparison.OrdinalIgnoreCase) ? pathOrUrl : BaseUrl + pathOrUrl;
 
         // Up to 3 attempts to ride out HTTP 429 throttling.
         for (int attempt = 0; ; attempt++)
         {
-            // Use the per-account default scopes (DefaultScopesFor): `.default` for work/school,
-            // explicit Mail.ReadWrite/etc. for personal Microsoft accounts (#217). Passing the static
-            // GraphMailScopes here would force `.default` on personal accounts, which is read-only.
-            var token = await _oauth.GetAccessTokenAsync(account, ct);
+            // Default (scopes == null): per-account default scopes (DefaultScopesFor) — `.default` for
+            // work/school, explicit Mail.ReadWrite/etc. for personal Microsoft accounts (#217). An
+            // explicit scope set is passed only by contact sync (Graph Contacts.Read/People.Read).
+            var token = scopes is null
+                ? await _oauth.GetAccessTokenAsync(account, ct)
+                : await _oauth.GetAccessTokenAsync(account, scopes, ct);
             using var req = new HttpRequestMessage(method, url);
             req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
             if (contentFactory != null)

--- a/QuickMail/Services/Graph/GraphDtos.cs
+++ b/QuickMail/Services/Graph/GraphDtos.cs
@@ -94,3 +94,27 @@ internal sealed class GraphFollowUpFlag
     /// <summary>Values: "notFlagged" | "flagged" | "complete".</summary>
     [JsonPropertyName("flagStatus")] public string FlagStatus { get; set; } = "notFlagged";
 }
+
+// ── Contact sync (issue #256) ────────────────────────────────────────────────
+
+/// <summary>A saved contact from <c>/me/contacts</c>.</summary>
+internal sealed class GraphContact
+{
+    [JsonPropertyName("id")] public string Id { get; set; } = string.Empty;
+    [JsonPropertyName("displayName")] public string? DisplayName { get; set; }
+    [JsonPropertyName("emailAddresses")] public List<GraphEmailAddress>? EmailAddresses { get; set; }
+}
+
+/// <summary>A relevance-ranked person from <c>/me/people</c> (prior recipients).</summary>
+internal sealed class GraphPerson
+{
+    [JsonPropertyName("id")] public string? Id { get; set; }
+    [JsonPropertyName("displayName")] public string? DisplayName { get; set; }
+    [JsonPropertyName("scoredEmailAddresses")] public List<GraphScoredEmailAddress>? ScoredEmailAddresses { get; set; }
+}
+
+internal sealed class GraphScoredEmailAddress
+{
+    [JsonPropertyName("address")] public string? Address { get; set; }
+    [JsonPropertyName("relevanceScore")] public double RelevanceScore { get; set; }
+}

--- a/QuickMail/Services/IContactService.cs
+++ b/QuickMail/Services/IContactService.cs
@@ -20,6 +20,26 @@ public interface IContactService
     /// </summary>
     Task<bool> UpdateContactAsync(int id, string displayName, string emailAddress);
 
+    // ── Server contact sync (issue #256) ─────────────────────────────────────
+
+    /// <summary>
+    /// Replaces the set of contacts synced from a given account+source with a fresh
+    /// server snapshot. Rows are matched by <see cref="ContactModel.SourceId"/> so a
+    /// contact updated on the server keeps its local <see cref="ContactModel.Id"/>
+    /// (preserving any group membership); rows no longer present on the server are
+    /// removed. Purely local contacts and contacts owned by other accounts or other
+    /// sources are never touched. This is the one-way (server → local) merge; QuickMail
+    /// never writes back.
+    /// </summary>
+    Task ReplaceSyncedContactsAsync(Guid accountId, ContactSource source, IReadOnlyList<ContactModel> serverContacts);
+
+    /// <summary>
+    /// Removes every contact synced from the given account (all sources), leaving local
+    /// contacts and other accounts' synced contacts intact. Called when the user disables
+    /// contact sync for an account or deletes the account.
+    /// </summary>
+    Task RemoveSyncedContactsAsync(Guid accountId);
+
     // ── Groups ───────────────────────────────────────────────────────────────
     // All group operations share the same _loadLock as contact operations so
     // the picker dialog can interleave reads and writes safely (see CLAUDE.md

--- a/QuickMail/Services/IContactSyncService.cs
+++ b/QuickMail/Services/IContactSyncService.cs
@@ -34,6 +34,14 @@ public interface IContactSyncService
     /// <summary>Syncs every account with <see cref="AccountModel.SyncContacts"/> enabled and a contact source.</summary>
     Task<ContactSyncResult> SyncAllAsync(CancellationToken ct = default);
 
+    /// <summary>
+    /// Like <see cref="SyncAllAsync"/> but throttled: does nothing if a sync ran less than
+    /// <paramref name="minInterval"/> ago. Used by the automatic background trigger, which fires on
+    /// every startup/reconnect/account-activation — without this it would re-fetch every account's
+    /// full contact list each time. The manual "Sync Contacts Now" path bypasses this and always runs.
+    /// </summary>
+    Task<ContactSyncResult> SyncAllDueAsync(TimeSpan minInterval, CancellationToken ct = default);
+
     /// <summary>Removes an account's synced contacts (on disable or account deletion).</summary>
     Task RemoveAccountContactsAsync(Guid accountId, CancellationToken ct = default);
 }

--- a/QuickMail/Services/IContactSyncService.cs
+++ b/QuickMail/Services/IContactSyncService.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using QuickMail.Models;
+
+namespace QuickMail.Services;
+
+/// <summary>
+/// Outcome of a contact sync. <see cref="Error"/> is non-null when at least one account failed;
+/// individual failures are also logged. One-way only — QuickMail never writes contacts back.
+/// </summary>
+public record ContactSyncResult(int AccountsSynced, int ContactsFetched, string? Error)
+{
+    public static ContactSyncResult None => new(0, 0, null);
+}
+
+/// <summary>
+/// Orchestrates one-way (server → local) contact sync for the address book (issue #256). Picks a
+/// provider source per account by <see cref="AccountModel.AuthType"/>, fetches contacts + prior
+/// recipients, and hands them to <see cref="IContactService.ReplaceSyncedContactsAsync"/>. Best-effort:
+/// a provider/auth failure is caught and reported, never thrown to a mail-sync caller.
+/// </summary>
+public interface IContactSyncService
+{
+    /// <summary>True if the account's auth type exposes a contact API (Microsoft or Google OAuth).</summary>
+    bool CanSync(AccountModel account);
+
+    /// <summary>
+    /// Syncs one account regardless of its <see cref="AccountModel.SyncContacts"/> flag (used right
+    /// after the user opts in). No-op for accounts without a contact source.
+    /// </summary>
+    Task<ContactSyncResult> SyncAccountAsync(AccountModel account, CancellationToken ct = default);
+
+    /// <summary>Syncs every account with <see cref="AccountModel.SyncContacts"/> enabled and a contact source.</summary>
+    Task<ContactSyncResult> SyncAllAsync(CancellationToken ct = default);
+
+    /// <summary>Removes an account's synced contacts (on disable or account deletion).</summary>
+    Task RemoveAccountContactsAsync(Guid accountId, CancellationToken ct = default);
+}

--- a/QuickMail/Services/IGoogleOAuthService.cs
+++ b/QuickMail/Services/IGoogleOAuthService.cs
@@ -18,5 +18,13 @@ public interface IGoogleOAuthService
     /// </summary>
     Task<OAuthResult> SignInInteractiveAsync(string loginHint, CancellationToken ct = default);
 
+    /// <summary>
+    /// Re-runs interactive sign-in requesting the mail scopes plus the read-only People API scopes
+    /// (contacts + other contacts) needed for contact sync (issue #256). Overwrites the stored
+    /// refresh token with one granted the wider scope set, so later <see cref="GetAccessTokenAsync"/>
+    /// tokens can call the People API. Used when the user opts a Google account into contact sync.
+    /// </summary>
+    Task<OAuthResult> AuthorizeContactsAsync(string loginHint, CancellationToken ct = default);
+
     Task SignOutAsync(string username);
 }

--- a/QuickMail/Services/IOAuthService.cs
+++ b/QuickMail/Services/IOAuthService.cs
@@ -27,6 +27,15 @@ public interface IOAuthService
     Task<string> GetAccessTokenAsync(AccountModel account, string[] scopes, CancellationToken ct = default);
 
     /// <summary>
+    /// Returns an access token for the given scope set using ONLY the silent (cached / refresh-token)
+    /// path — never opens an interactive sign-in window. Throws
+    /// <see cref="InteractiveSignInRequiredException"/> if a token can't be obtained silently. Used by
+    /// contact sync (issue #256) so a fetch can never launch an embedded WebView2 inside a modal
+    /// window's message loop (the address book runs modal), which risks a UI-thread deadlock.
+    /// </summary>
+    Task<string> GetAccessTokenSilentAsync(AccountModel account, string[] scopes, CancellationToken ct = default);
+
+    /// <summary>
     /// Verifies a token can be obtained <b>silently</b> (from the cache / refresh token) for this
     /// account, without opening an interactive sign-in window. Throws
     /// <see cref="InteractiveSignInRequiredException"/> if the user would have to sign in

--- a/QuickMail/Services/IOAuthService.cs
+++ b/QuickMail/Services/IOAuthService.cs
@@ -41,5 +41,13 @@ public interface IOAuthService
     /// </summary>
     Task<OAuthResult> SignInInteractiveAsync(AccountModel account, CancellationToken ct = default);
 
+    /// <summary>
+    /// Ensures the account has consented to the read-only contact scopes needed for contact sync
+    /// (issue #256): Graph <c>Contacts.Read</c>/<c>People.Read</c> for Microsoft accounts, the
+    /// People API read scopes for Google. Silent when consent was already granted; otherwise opens
+    /// an interactive sign-in. Throws if the user declines. Call from a foreground user action only.
+    /// </summary>
+    Task RequestContactsConsentAsync(AccountModel account, CancellationToken ct = default);
+
     Task SignOutAsync(AccountModel account);
 }

--- a/QuickMail/Services/OAuthRouter.cs
+++ b/QuickMail/Services/OAuthRouter.cs
@@ -54,6 +54,16 @@ public class OAuthRouter : IOAuthService
             : _microsoft.SignInInteractiveAsync(account, ct);
     }
 
+    public Task RequestContactsConsentAsync(AccountModel account, CancellationToken ct = default)
+    {
+        // Google's contact scopes are requested via a fresh interactive sign-in that widens the
+        // stored refresh token's grant; Microsoft's are requested by acquiring a token for the
+        // Graph contact scopes (silent if already consented, interactive otherwise).
+        return account.AuthType == AuthType.OAuth2Google
+            ? _google.AuthorizeContactsAsync(account.Username, ct)
+            : _microsoft.RequestContactsConsentAsync(account, ct);
+    }
+
     public Task SignOutAsync(AccountModel account)
     {
         return account.AuthType == AuthType.OAuth2Google

--- a/QuickMail/Services/OAuthRouter.cs
+++ b/QuickMail/Services/OAuthRouter.cs
@@ -35,6 +35,16 @@ public class OAuthRouter : IOAuthService
             : _microsoft.GetAccessTokenAsync(account, scopes, ct);
     }
 
+    public Task<string> GetAccessTokenSilentAsync(AccountModel account, string[] scopes, CancellationToken ct = default)
+    {
+        // Google's GetAccessTokenAsync is already silent-only — it refreshes the stored token or
+        // throws, and never opens a browser — so it doubles as the silent path here. Microsoft gets
+        // the real silent-only acquisition (no interactive fallback).
+        return account.AuthType == AuthType.OAuth2Google
+            ? _google.GetAccessTokenAsync(account.Username, ct)
+            : _microsoft.GetAccessTokenSilentAsync(account, scopes, ct);
+    }
+
     public Task EnsureSilentTokenAsync(AccountModel account, CancellationToken ct = default)
     {
         // Google is KNOWINGLY UNPROTECTED here: its token flow uses the system browser (not the

--- a/QuickMail/Services/OAuthService.cs
+++ b/QuickMail/Services/OAuthService.cs
@@ -54,6 +54,17 @@ public class OAuthService : IOAuthService
         "https://graph.microsoft.com/User.Read",
     ];
 
+    // Read-only contact scopes for contact sync (issue #256). Explicit scopes (not `.default`) so
+    // they work for BOTH personal and work/school Microsoft accounts — the same reasoning as the
+    // personal-mail scopes above. Requested only when the user opts an account into contact sync.
+    // Contacts.Read → /me/contacts (saved contacts); People.Read → /me/people (relevance-ranked
+    // people the user has corresponded with, i.e. prior recipients).
+    public static readonly string[] GraphContactScopes =
+    [
+        "https://graph.microsoft.com/Contacts.Read",
+        "https://graph.microsoft.com/People.Read",
+    ];
+
     // Authoritative "is this a personal Microsoft account" signal: every consumer account lives in the
     // well-known MSA "consumers" tenant. Detected from the MSAL account at sign-in and persisted on
     // AccountModel (#233), so it's correct even for personal accounts on custom/vanity domains.
@@ -226,6 +237,16 @@ public class OAuthService : IOAuthService
         LogService.Log($"OAuthService: interactive sign-in complete for {result.Account.Username} " +
                        $"(personal Microsoft account: {isPersonal}).");
         return new OAuthResult(result.AccessToken, result.Account.Username, isPersonal);
+    }
+
+    public async Task RequestContactsConsentAsync(AccountModel account, CancellationToken ct = default)
+    {
+        // Acquiring a token for the contact scopes is what drives consent: silent if the user has
+        // already granted them (cached refresh token covers them), interactive otherwise. The token
+        // itself is discarded here — GraphContactSource acquires its own when it fetches — but the
+        // grant now lives in the MSAL cache, so later silent acquisition (including background sync)
+        // succeeds without another prompt.
+        await GetAccessTokenAsync(account, GraphContactScopes, ct);
     }
 
     public async Task SignOutAsync(AccountModel account)

--- a/QuickMail/Services/OAuthService.cs
+++ b/QuickMail/Services/OAuthService.cs
@@ -186,6 +186,29 @@ public class OAuthService : IOAuthService
         return result.AccessToken;
     }
 
+    public async Task<string> GetAccessTokenSilentAsync(AccountModel account, string[] scopes, CancellationToken ct = default)
+    {
+        await EnsureTokenCacheAsync();
+        var msalAccounts = await _msal.GetAccountsAsync();
+        var msalAccount  = msalAccounts.FirstOrDefault(a =>
+            string.Equals(a.Username, account.Username, StringComparison.OrdinalIgnoreCase));
+
+        if (msalAccount is null)
+            throw new InteractiveSignInRequiredException($"No cached sign-in for {account.Username}.");
+
+        try
+        {
+            var silent = await _msal.AcquireTokenSilent(scopes, msalAccount).ExecuteAsync(ct);
+            return silent.AccessToken;
+        }
+        catch (MsalUiRequiredException ex)
+        {
+            // Deliberately do NOT fall back to interactive — the caller (contact sync) may be running
+            // inside a modal message loop where an embedded WebView2 sign-in can deadlock the UI thread.
+            throw new InteractiveSignInRequiredException($"Silent token unavailable for {account.Username}.", ex);
+        }
+    }
+
     public async Task EnsureSilentTokenAsync(AccountModel account, CancellationToken ct = default)
     {
         await EnsureTokenCacheAsync();

--- a/QuickMail/ViewModels/AccountManagerViewModel.cs
+++ b/QuickMail/ViewModels/AccountManagerViewModel.cs
@@ -89,6 +89,52 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
         StatusText = string.Empty;
     }
 
+    /// <summary>
+    /// Applies a contact-sync toggle immediately (issue #256) — there is no Save step for it.
+    /// Enabling requests read-only contact consent, persists the flag, and pulls an initial snapshot;
+    /// disabling purges the account's synced contacts. On failure the checkbox is reverted. Called
+    /// from the checkbox's Click handler (Click fires only on real user interaction, never on the
+    /// programmatic assignment in <see cref="OnSelectedAccountChanged"/>). Returns without side
+    /// effects if there is no selected account. <paramref name="enabled"/> is the new checkbox state.
+    /// </summary>
+    public async Task SetContactSyncAsync(bool enabled)
+    {
+        if (SelectedAccount is not { } account) return;
+
+        try
+        {
+            if (enabled)
+            {
+                if (!CanSyncContacts) return; // box is hidden for these accounts; defensive
+                account.SyncContacts = true;
+                StatusText = "Requesting permission to read your contacts…";
+                await _oauth.RequestContactsConsentAsync(account);
+                _accountService.SaveAccounts([.. Accounts]);
+                // Pull an initial snapshot so contacts appear without waiting for the next launch.
+                _contactSync?.SyncAccountAsync(account).LogFaults("contact sync after enable");
+                StatusText = "Contact sync enabled — new contact data will be available in QuickMail.";
+            }
+            else
+            {
+                account.SyncContacts = false;
+                _accountService.SaveAccounts([.. Accounts]);
+                if (_contactSync != null)
+                    await _contactSync.RemoveAccountContactsAsync(account.Id);
+                StatusText = "Contact sync disabled.";
+            }
+        }
+        catch (Exception ex)
+        {
+            // Consent declined or failed — revert the checkbox and leave sync off so we don't retry
+            // against a missing grant.
+            account.SyncContacts = false;
+            SyncContacts = false;
+            _accountService.SaveAccounts([.. Accounts]);
+            StatusText = $"Contact sync not enabled: {ex.Message}";
+            LogService.Log($"AccountManager: contact-sync enable failed for {account.AccountLabel} — {ex.Message}");
+        }
+    }
+
     public AddAccountViewModel CreateAddAccountViewModel() => new(_featureGate, MailService, OAuthService);
 
     public void CommitNewAccount(AccountModel account, string password)
@@ -102,11 +148,10 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
     }
 
     [RelayCommand]
-    private async Task SaveAccountAsync()
+    private void SaveAccount()
     {
         if (SelectedAccount == null) return;
         var account = SelectedAccount;
-        var wasSyncingContacts = account.SyncContacts;
 
         account.AccountName = AccountName;
         account.DisplayName = DisplayName;
@@ -125,25 +170,14 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
         account.SmtpUseSsl = SmtpUseSsl;
         account.SmtpAcceptInvalidCert = SmtpAcceptInvalidCert;
         account.Signature = Signature;
-        // Never enable sync for a backend without a contact API, even if the checkbox state is stale.
-        account.SyncContacts = SyncContacts && CanSyncContacts;
+        // SyncContacts is NOT touched here — the checkbox applies itself immediately via
+        // OnSyncContactsChanged (consent + persist), so Save never enables/disables it.
 
         if (AuthType == AuthType.Password && !string.IsNullOrEmpty(Password))
             _credentials.SavePassword(account.Id, Password);
 
-        // Contact-sync transitions (issue #256): enabling asks for read-only contact consent and
-        // pulls an initial snapshot; disabling purges the account's synced contacts. Both are
-        // best-effort and never block the account save.
-        StatusText = "Account saved.";
-        if (account.SyncContacts && !wasSyncingContacts)
-            await EnableContactSyncAsync(account);
-        else if (!account.SyncContacts && wasSyncingContacts && _contactSync != null)
-        {
-            await _contactSync.RemoveAccountContactsAsync(account.Id);
-            StatusText = "Account saved. Contact sync disabled.";
-        }
-
         _accountService.SaveAccounts([.. Accounts]);
+        StatusText = "Account saved.";
 
         // Force list item refresh
         var idx = Accounts.IndexOf(account);
@@ -152,26 +186,6 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
             Accounts.RemoveAt(idx);
             Accounts.Insert(idx, account);
             SelectedAccount = Accounts[idx];
-        }
-    }
-
-    private async Task EnableContactSyncAsync(AccountModel account)
-    {
-        try
-        {
-            StatusText = "Requesting permission to read your contacts…";
-            await _oauth.RequestContactsConsentAsync(account);
-            // Pull an initial snapshot so contacts appear without waiting for the next launch.
-            _contactSync?.SyncAccountAsync(account).LogFaults("contact sync after enable");
-            StatusText = "Account saved. Contact sync enabled — new contact data will be available in QuickMail.";
-        }
-        catch (Exception ex)
-        {
-            // Consent declined or failed — leave sync off so we don't retry against a missing grant.
-            account.SyncContacts = false;
-            SyncContacts = false;
-            StatusText = $"Account saved. Contact sync not enabled: {ex.Message}";
-            LogService.Log($"AccountManager: contact-sync consent failed for {account.AccountLabel} — {ex.Message}");
         }
     }
 

--- a/QuickMail/ViewModels/AccountManagerViewModel.cs
+++ b/QuickMail/ViewModels/AccountManagerViewModel.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using QuickMail.Helpers;
 using QuickMail.Models;
 using QuickMail.Services;
 
@@ -17,15 +18,29 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
     private readonly IConfigService _configService;
     private readonly IOAuthService _oauth;
     private readonly IFeatureGate _featureGate;
+    private readonly IContactSyncService? _contactSync;
 
     [ObservableProperty]
     private ObservableCollection<AccountModel> _accounts = [];
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(IsEditing))]
+    [NotifyPropertyChangedFor(nameof(CanSyncContacts))]
     private AccountModel? _selectedAccount;
 
     public bool IsEditing => SelectedAccount != null;
+
+    /// <summary>
+    /// Contact sync (issue #256) is offered only for OAuth accounts — the only backends that expose
+    /// a contact API. Password/IMAP accounts show no checkbox at all (spec §6 Path F).
+    /// </summary>
+    public bool CanSyncContacts =>
+        _contactSync != null &&
+        SelectedAccount is { AuthType: AuthType.OAuth2Microsoft or AuthType.OAuth2Google };
+
+    /// <summary>Bound to the "Sync contacts from this account" checkbox; mirrors the selected account.</summary>
+    [ObservableProperty]
+    private bool _syncContacts;
 
     public override bool ShowGoogleAuthOption => _featureGate.IsEnabled(FeatureFlag.GoogleAuth);
 
@@ -36,7 +51,8 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
         IOAuthService oauth,
         ILocalStoreService localStore,
         IConfigService configService,
-        IFeatureGate featureGate)
+        IFeatureGate featureGate,
+        IContactSyncService? contactSync = null)
         : base(imap, oauth)
     {
         _accountService = accountService;
@@ -45,6 +61,7 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
         _localStore     = localStore;
         _configService  = configService;
         _featureGate    = featureGate;
+        _contactSync    = contactSync;
         Accounts = new ObservableCollection<AccountModel>(accountService.LoadAccounts());
     }
 
@@ -68,6 +85,7 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
         SmtpUseSsl = value.SmtpUseSsl;
         SmtpAcceptInvalidCert = value.SmtpAcceptInvalidCert;
         Signature = value.Signature;
+        SyncContacts = value.SyncContacts;
         StatusText = string.Empty;
     }
 
@@ -84,41 +102,76 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
     }
 
     [RelayCommand]
-    private void SaveAccount()
+    private async Task SaveAccountAsync()
     {
         if (SelectedAccount == null) return;
+        var account = SelectedAccount;
+        var wasSyncingContacts = account.SyncContacts;
 
-        SelectedAccount.AccountName = AccountName;
-        SelectedAccount.DisplayName = DisplayName;
-        SelectedAccount.Username = Username;
+        account.AccountName = AccountName;
+        account.DisplayName = DisplayName;
+        account.Username = Username;
         // Backfill the personal-account flag when this edit re-authed (SignInMicrosoftAsync set it);
         // leave it untouched otherwise so a plain field edit doesn't wipe a prior detection (#233).
         if (IsPersonalMicrosoftAccount.HasValue)
-            SelectedAccount.IsPersonalMicrosoftAccount = IsPersonalMicrosoftAccount;
-        SelectedAccount.AuthType = AuthType;
-        SelectedAccount.ImapHost = ImapHost;
-        SelectedAccount.ImapPort = ImapPort;
-        SelectedAccount.ImapUseSsl = ImapUseSsl;
-        SelectedAccount.ImapAcceptInvalidCert = ImapAcceptInvalidCert;
-        SelectedAccount.SmtpHost = SmtpHost;
-        SelectedAccount.SmtpPort = SmtpPort;
-        SelectedAccount.SmtpUseSsl = SmtpUseSsl;
-        SelectedAccount.SmtpAcceptInvalidCert = SmtpAcceptInvalidCert;
-        SelectedAccount.Signature = Signature;
+            account.IsPersonalMicrosoftAccount = IsPersonalMicrosoftAccount;
+        account.AuthType = AuthType;
+        account.ImapHost = ImapHost;
+        account.ImapPort = ImapPort;
+        account.ImapUseSsl = ImapUseSsl;
+        account.ImapAcceptInvalidCert = ImapAcceptInvalidCert;
+        account.SmtpHost = SmtpHost;
+        account.SmtpPort = SmtpPort;
+        account.SmtpUseSsl = SmtpUseSsl;
+        account.SmtpAcceptInvalidCert = SmtpAcceptInvalidCert;
+        account.Signature = Signature;
+        // Never enable sync for a backend without a contact API, even if the checkbox state is stale.
+        account.SyncContacts = SyncContacts && CanSyncContacts;
 
         if (AuthType == AuthType.Password && !string.IsNullOrEmpty(Password))
-            _credentials.SavePassword(SelectedAccount.Id, Password);
+            _credentials.SavePassword(account.Id, Password);
+
+        // Contact-sync transitions (issue #256): enabling asks for read-only contact consent and
+        // pulls an initial snapshot; disabling purges the account's synced contacts. Both are
+        // best-effort and never block the account save.
+        StatusText = "Account saved.";
+        if (account.SyncContacts && !wasSyncingContacts)
+            await EnableContactSyncAsync(account);
+        else if (!account.SyncContacts && wasSyncingContacts && _contactSync != null)
+        {
+            await _contactSync.RemoveAccountContactsAsync(account.Id);
+            StatusText = "Account saved. Contact sync disabled.";
+        }
 
         _accountService.SaveAccounts([.. Accounts]);
-        StatusText = "Account saved.";
 
         // Force list item refresh
-        var idx = Accounts.IndexOf(SelectedAccount);
+        var idx = Accounts.IndexOf(account);
         if (idx >= 0)
         {
             Accounts.RemoveAt(idx);
-            Accounts.Insert(idx, SelectedAccount);
+            Accounts.Insert(idx, account);
             SelectedAccount = Accounts[idx];
+        }
+    }
+
+    private async Task EnableContactSyncAsync(AccountModel account)
+    {
+        try
+        {
+            StatusText = "Requesting permission to read your contacts…";
+            await _oauth.RequestContactsConsentAsync(account);
+            // Pull an initial snapshot so contacts appear without waiting for the next launch.
+            _contactSync?.SyncAccountAsync(account).LogFaults("contact sync after enable");
+            StatusText = "Account saved. Contact sync enabled — new contact data will be available in QuickMail.";
+        }
+        catch (Exception ex)
+        {
+            // Consent declined or failed — leave sync off so we don't retry against a missing grant.
+            account.SyncContacts = false;
+            SyncContacts = false;
+            StatusText = $"Account saved. Contact sync not enabled: {ex.Message}";
+            LogService.Log($"AccountManager: contact-sync consent failed for {account.AccountLabel} — {ex.Message}");
         }
     }
 
@@ -146,6 +199,13 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
         {
             try   { await _oauth.SignOutAsync(account); }
             catch (Exception ex) { LogService.Log($"AccountManager.DeleteAccount: failed OAuth sign-out — {ex.Message}"); }
+        }
+
+        // Purge this account's synced contacts (issue #256) so they don't linger after deletion.
+        if (_contactSync != null)
+        {
+            try   { await _contactSync.RemoveAccountContactsAsync(account.Id); }
+            catch (Exception ex) { LogService.Log($"AccountManager.DeleteAccount: failed to remove synced contacts — {ex.Message}"); }
         }
 
         StatusText = "Account deleted.";

--- a/QuickMail/ViewModels/AddressBookViewModel.cs
+++ b/QuickMail/ViewModels/AddressBookViewModel.cs
@@ -143,13 +143,6 @@ public partial class AddressBookViewModel : ObservableObject
             EditEmail    = value?.EmailAddress ?? string.Empty;
             ContactError = string.Empty;
         }
-
-        // Let a screen reader user know why Edit/Delete are unavailable on a synced contact.
-        if (value is { IsLocal: false })
-        {
-            var provider = value.Source == ContactSource.Google ? "Google" : "Outlook";
-            Announce($"Synced contact, read-only. Edit it in {provider}.", AnnouncementCategory.Hint);
-        }
     }
 
     // ── Group editing ────────────────────────────────────────────────────────

--- a/QuickMail/ViewModels/AddressBookViewModel.cs
+++ b/QuickMail/ViewModels/AddressBookViewModel.cs
@@ -19,6 +19,7 @@ namespace QuickMail.ViewModels;
 public partial class AddressBookViewModel : ObservableObject
 {
     private readonly IContactService _contactService;
+    private readonly IContactSyncService? _contactSync;
     private List<ContactModel> _allContacts = [];
 
     private Action<ContactModel>? _toInsertAction;
@@ -56,13 +57,17 @@ public partial class AddressBookViewModel : ObservableObject
         OnPropertyChanged(nameof(HasInsertActions));
     }
 
-    public AddressBookViewModel(IContactService contactService)
+    public AddressBookViewModel(IContactService contactService, IContactSyncService? contactSync = null)
     {
         _contactService = contactService;
+        _contactSync    = contactSync;
         // Exposed so dialogs (e.g. GroupManagerWindow) opened from this address book
         // can re-use the same IContactService instance.
         ContactService = contactService;
     }
+
+    /// <summary>True when contact sync is wired up, enabling the "Sync Contacts Now" affordance.</summary>
+    public bool CanSyncContacts => _contactSync != null;
 
     /// <summary>
     /// The IContactService the VM was constructed with. Exposed so dialogs opened
@@ -122,8 +127,10 @@ public partial class AddressBookViewModel : ObservableObject
     private int _editingContactId;
 
     public bool IsContactReadOnly => !IsEditingContact;
-    public bool CanEditContact    => HasSelectedContact && !IsEditingContact;
-    public bool CanDeleteContact  => HasSelectedContact && !IsEditingContact;
+    // Synced contacts (issue #256) are read-only: they're owned by the server, so Edit/Delete are
+    // disabled for them. A local contact with the same address can still be added and edited.
+    public bool CanEditContact    => HasSelectedContact && !IsEditingContact && SelectedContact!.IsLocal;
+    public bool CanDeleteContact  => HasSelectedContact && !IsEditingContact && SelectedContact!.IsLocal;
 
     [ObservableProperty]
     private string _contactError = string.Empty;
@@ -135,6 +142,13 @@ public partial class AddressBookViewModel : ObservableObject
             EditName     = value?.DisplayName  ?? string.Empty;
             EditEmail    = value?.EmailAddress ?? string.Empty;
             ContactError = string.Empty;
+        }
+
+        // Let a screen reader user know why Edit/Delete are unavailable on a synced contact.
+        if (value is { IsLocal: false })
+        {
+            var provider = value.Source == ContactSource.Google ? "Google" : "Outlook";
+            Announce($"Synced contact, read-only. Edit it in {provider}.", AnnouncementCategory.Hint);
         }
     }
 
@@ -158,6 +172,21 @@ public partial class AddressBookViewModel : ObservableObject
         ApplyFilter(SearchText);
         await ReloadGroupsAsync();
         RebuildSelectedGroupMembers();
+    }
+
+    [RelayCommand]
+    private async Task SyncContactsNowAsync()
+    {
+        if (_contactSync is null) return;
+        Announce("Syncing contacts…", AnnouncementCategory.Status);
+        var result = await _contactSync.SyncAllAsync();
+        await LoadAsync();
+        var message = result.Error is not null
+            ? $"Contact sync failed: {result.Error}"
+            : result.AccountsSynced == 0
+                ? "No accounts are set up to sync contacts."
+                : $"Contacts synced, {result.ContactsFetched} total.";
+        Announce(message, AnnouncementCategory.Result);
     }
 
     [RelayCommand]

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -26,6 +26,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
     private readonly ILocalStoreService _localStore;
     private readonly IOAuthService _oauthService;
     private readonly ISyncService _syncService;
+    private readonly IContactSyncService? _contactSync;
     private readonly IConfigService _configService;
     private readonly IViewService _viewService;
     private readonly ICommandRegistry _commandRegistry;
@@ -806,7 +807,8 @@ public partial class MainViewModel : ObservableObject, IDisposable
         IUpdateCheckService? updateCheckService = null,
         IUiDispatcher? uiDispatcher = null,
         IThemeService? themeService = null,
-        INotificationService? notificationService = null)
+        INotificationService? notificationService = null,
+        IContactSyncService? contactSyncService = null)
     {
         _imap            = imap;
         _ui              = uiDispatcher ?? new WpfUiDispatcher();
@@ -826,6 +828,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
         _updateCheckService   = updateCheckService;
         _themeService         = themeService;
         _notifications        = notificationService;
+        _contactSync          = contactSyncService;
         OnlineMode            = onlineMode;
 
         var cfg = _configService.Load();
@@ -1577,6 +1580,13 @@ public partial class MainViewModel : ObservableObject, IDisposable
         // Signal that the startup connect finished so a notification click that cold-started the app
         // (its account wasn't connected yet when the toast was activated) can now open its message.
         StartupConnectCompleted?.Invoke();
+
+        // Contact sync (issue #256): best-effort, fire-and-forget, after mail accounts have connected
+        // so their OAuth tokens are warm — contact-scope acquisition is then silent (no sign-in popup).
+        // Runs before the early-return paths below so it happens in every mode. Silent by design: it
+        // refreshes the address book in the background; the manual "Sync Contacts Now" command is the
+        // one that announces. A failure here is logged and never affects mail sync.
+        _contactSync?.SyncAllAsync(ct).LogFaults("startup contact sync");
 
         // Nothing connected — skip the heavy full sync. Watchers/labels are already handled above, and
         // WireUpWatchers will start the watcher once an account connects later.

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -1583,10 +1583,12 @@ public partial class MainViewModel : ObservableObject, IDisposable
 
         // Contact sync (issue #256): best-effort, fire-and-forget, after mail accounts have connected
         // so their OAuth tokens are warm — contact-scope acquisition is then silent (no sign-in popup).
-        // Runs before the early-return paths below so it happens in every mode. Silent by design: it
-        // refreshes the address book in the background; the manual "Sync Contacts Now" command is the
-        // one that announces. A failure here is logged and never affects mail sync.
-        _contactSync?.SyncAllAsync(ct).LogFaults("startup contact sync");
+        // Runs before the early-return paths below so it happens in every mode. Throttled (12h): this
+        // method also runs on manual account activation and runtime add, so an unthrottled call would
+        // re-fetch every account's full contact list each time. Silent by design; the manual "Sync
+        // Contacts Now" command is the one that announces and bypasses the throttle. A failure here is
+        // logged and never affects mail sync.
+        _contactSync?.SyncAllDueAsync(TimeSpan.FromHours(12), ct).LogFaults("startup contact sync");
 
         // Nothing connected — skip the heavy full sync. Watchers/labels are already handled above, and
         // WireUpWatchers will start the watcher once an account connects later.

--- a/QuickMail/Views/AccountManagerDialog.xaml
+++ b/QuickMail/Views/AccountManagerDialog.xaml
@@ -228,6 +228,18 @@
                          VerticalScrollBarVisibility="Auto"
                          TabIndex="11"/>
 
+                <!-- Contact sync (issue #256) — shown only for OAuth accounts, the only backends
+                     with a contact API. Password/IMAP accounts see nothing here. -->
+                <StackPanel Visibility="{Binding CanSyncContacts, Converter={StaticResource BoolToVisibility}}">
+                    <Separator Margin="0,12,0,6"/>
+                    <TextBlock Text="Contacts" FontWeight="SemiBold" Margin="0,0,0,6"/>
+                    <CheckBox Content="Sync _contacts from this account"
+                              IsChecked="{Binding SyncContacts}"
+                              AutomationProperties.Name="Sync contacts from this account"
+                              AutomationProperties.HelpText="Pulls this account's contacts and the people you've emailed into the address book. Enabling asks for a one-time read-only permission."
+                              Margin="0,0,0,4" TabIndex="12"/>
+                </StackPanel>
+
             </StackPanel>
         </ScrollViewer>
 

--- a/QuickMail/Views/AccountManagerDialog.xaml
+++ b/QuickMail/Views/AccountManagerDialog.xaml
@@ -235,6 +235,7 @@
                     <TextBlock Text="Contacts" FontWeight="SemiBold" Margin="0,0,0,6"/>
                     <CheckBox Content="Sync _contacts from this account"
                               IsChecked="{Binding SyncContacts}"
+                              Click="SyncContactsCheckBox_Click"
                               AutomationProperties.Name="Sync contacts from this account"
                               AutomationProperties.HelpText="Pulls this account's contacts and the people you've emailed into the address book. Enabling asks for a one-time read-only permission."
                               Margin="0,0,0,4" TabIndex="12"/>

--- a/QuickMail/Views/AccountManagerDialog.xaml.cs
+++ b/QuickMail/Views/AccountManagerDialog.xaml.cs
@@ -68,4 +68,15 @@ public partial class AccountManagerDialog : Window
         DialogResult = true;
         Close();
     }
+
+    // The "Sync contacts" checkbox applies immediately (issue #256): checking it prompts for consent
+    // and pulls contacts; unchecking purges them. Click fires only on real user interaction, so
+    // switching accounts (which sets IsChecked programmatically) does not trigger this. async void is
+    // the sanctioned pattern for a fire-and-forget UI reaction in a View; the VM method handles its
+    // own errors.
+    private async void SyncContactsCheckBox_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is CheckBox { IsChecked: { } isChecked })
+            await _vm.SetContactSyncAsync(isChecked);
+    }
 }

--- a/QuickMail/Views/AddressBookWindow.xaml
+++ b/QuickMail/Views/AddressBookWindow.xaml
@@ -133,10 +133,15 @@
                                     AutomationProperties.Name="Delete selected contact"
                                     IsEnabled="{Binding CanDeleteContact}"
                                     MinWidth="60" Margin="0,0,4,0" TabIndex="9"/>
+                            <Button Content="Sync _Now"
+                                    Command="{Binding SyncContactsNowCommand}"
+                                    AutomationProperties.Name="Sync contacts now"
+                                    Visibility="{Binding CanSyncContacts, Converter={StaticResource BoolToVis}}"
+                                    MinWidth="60" Margin="0,0,4,0" TabIndex="10"/>
                             <Border Margin="0,0,4,0"/>
                             <Button Content="Close"
                                     AutomationProperties.Name="Close address book"
-                                    MinWidth="60" TabIndex="10"
+                                    MinWidth="60" TabIndex="11"
                                     Click="Close_Click"/>
                         </StackPanel>
 

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -165,6 +165,7 @@ public partial class MainWindow : Window
     private static readonly TimeSpan WebViewNavigationTimeout = TimeSpan.FromSeconds(4);
 
     private readonly IContactService _contactService;
+    private readonly IContactSyncService? _contactSyncService;
     private readonly IConfigService _configService;
     private readonly ILocalStoreService _localStore;
     private readonly IViewService _viewService;
@@ -225,7 +226,8 @@ public partial class MainWindow : Window
         ICustomDictionaryService? customDictionary = null,
         IThemeService? themeService = null,
         IBugReportService? bugReportService = null,
-        INotificationService? notificationService = null)
+        INotificationService? notificationService = null,
+        IContactSyncService? contactSyncService = null)
     {
         _vm = vm;
         _notificationService = notificationService;
@@ -236,6 +238,7 @@ public partial class MainWindow : Window
         _oauth = oauth;
         _registry = registry;
         _contactService = contactService;
+        _contactSyncService = contactSyncService;
         _configService = configService;
         _localStore = localStore;
         _viewService = viewService;
@@ -941,6 +944,11 @@ public partial class MainWindow : Window
             id: "contacts.openAddressBook", category: "Contacts", title: "Address Book",
             execute: OpenAddressBook,
             defaultKey: Key.B, defaultModifiers: ModifierKeys.Control | ModifierKeys.Shift));
+
+        _registry.Register(new CommandDefinition(
+            id: "contacts.syncNow", category: "Contacts", title: "Sync Contacts Now",
+            execute: SyncContactsNow,
+            isAvailable: () => _contactSyncService != null));
 
         _registry.Register(new CommandDefinition(
             id: "settings.toggleCustomAnnouncements", category: "Settings", title: "Toggle Custom Announcements",
@@ -4066,7 +4074,7 @@ public partial class MainWindow : Window
 
     private void OpenAccountManager()
     {
-        var accountVm = new AccountManagerViewModel(_accountService, _credentials, _imap, _oauth, _localStore, _configService, _featureGate);
+        var accountVm = new AccountManagerViewModel(_accountService, _credentials, _imap, _oauth, _localStore, _configService, _featureGate, _contactSyncService);
         var dialog = new AccountManagerDialog(accountVm) { Owner = this };
         if (dialog.ShowDialog() == true)
             _vm.RefreshAccountList();
@@ -4074,7 +4082,7 @@ public partial class MainWindow : Window
 
     private void OpenAccountManagerForAccount(AccountModel account)
     {
-        var accountVm = new AccountManagerViewModel(_accountService, _credentials, _imap, _oauth, _localStore, _configService, _featureGate);
+        var accountVm = new AccountManagerViewModel(_accountService, _credentials, _imap, _oauth, _localStore, _configService, _featureGate, _contactSyncService);
         var dialog    = new AccountManagerDialog(accountVm) { Owner = this };
         // Pre-select the account in the manager
         accountVm.SelectedAccount = accountVm.Accounts.FirstOrDefault(a => a.Id == account.Id);
@@ -4618,9 +4626,32 @@ public partial class MainWindow : Window
     private void MenuAddressBook_Click(object sender, RoutedEventArgs e)
         => OpenAddressBook();
 
+    // Fire-and-forget contact sync from the command palette / Sync Contacts Now (issue #256).
+    // Announcements respect the user's Status/Result announcement settings.
+    private async void SyncContactsNow()
+    {
+        if (_contactSyncService is null) return;
+        AccessibilityHelper.Announce(this, "Syncing contacts…", category: AnnouncementCategory.Status);
+        try
+        {
+            var result = await _contactSyncService.SyncAllAsync();
+            var message = result.Error is not null
+                ? $"Contact sync failed: {result.Error}"
+                : result.AccountsSynced == 0
+                    ? "No accounts are set up to sync contacts."
+                    : $"Contacts synced, {result.ContactsFetched} total.";
+            AccessibilityHelper.Announce(this, message, category: AnnouncementCategory.Result);
+        }
+        catch (Exception ex)
+        {
+            LogService.Log("SyncContactsNow", ex);
+            AccessibilityHelper.Announce(this, $"Contact sync failed: {ex.Message}", category: AnnouncementCategory.Result);
+        }
+    }
+
     private void OpenAddressBook()
     {
-        var vm = new AddressBookViewModel(_contactService);
+        var vm = new AddressBookViewModel(_contactService, _contactSyncService);
 
         // When the address book is opened standalone (not from a compose window) the
         // insert actions open a new compose window on demand.  All calls from a single

--- a/docs/planning/contact-sync-server-issue-256-pm-dev-spec.md
+++ b/docs/planning/contact-sync-server-issue-256-pm-dev-spec.md
@@ -1,0 +1,448 @@
+# Server Contact Sync & Prior Recipients — PM + Dev Spec (Issue #256)
+
+> **Status:** Draft for Kelly's review (Session 1).
+> **Issue:** [#256 — Add support for syncing contacts from the server to the address book and sending emails to prior recipients](https://github.com/kellylford/QuickMail/issues/256)
+> **Scope note:** This spec is about pulling contacts **from the mail provider** (Gmail, Outlook/M365) into QuickMail. The **local address book already exists** — this feature feeds it from the server; it does not build it from scratch.
+
+---
+
+## Section 1: Executive Summary
+
+QuickMail already has a working local address book (`ContactService`, `contacts.json`, the Address Book window, groups, and Grab Addresses) and compose autocomplete already reads from it. What it **cannot** do today is learn about the people you already know from your mail provider: your Gmail/Outlook contacts and the people you've previously emailed never appear until you manually add them. This spec adds **one-way sync (server → local)** for Microsoft Graph and Google accounts, plus surfacing of **prior recipients** (Graph `/me/people`, Google "other contacts"). Synced people flow into the existing Address Book and the existing To/Cc autocomplete with **zero new UI in compose** — the plumbing already reads through `IContactService`. Writing changes **back** to the server and iCloud/CardDAV support are explicitly deferred to v2 (§4.2, §13.2) — this recommendation is the main thing to confirm before implementation.
+
+---
+
+## Section 2: User Problem & Opportunity
+
+### 2.1 Current state (verified against code)
+
+| Surface | Today | Pain | Who feels it |
+|---|---|---|---|
+| Address Book (`AddressBookWindow`, `ContactService`) | Contacts exist only if the user typed them in, ran Grab Addresses, or picked them in compose (`UpsertContactAsync` call sites) | The user's real contact list — hundreds of people already in Gmail/Outlook — is invisible | Every user with an existing provider account |
+| Compose To/Cc autocomplete (`ComposeWindow.xaml.cs:277` — `SearchContactsAsync` + `SearchGroupsAsync`) | Already works, but **only** over locally-known contacts/groups | You can't autocomplete someone you emailed last week unless QuickMail happened to capture them | Everyone composing mail |
+| Prior recipients | No concept exists. Graph `/me/people` and Google `otherContacts` are never queried | The single most useful autocomplete source (people you've corresponded with) is absent | Everyone composing mail |
+| Cross-device consistency | `contacts.json` is local to the profile | A contact added on another device/mail app never appears here | Multi-device users |
+
+**Verified facts used below:**
+- `IContactService` / `ContactService` back a flat `contacts.json`; the in-memory `_contactsCache` is what both the Address Book and compose autocomplete read (`ContactService.cs:60` `SearchContactsAsync`).
+- `ContactModel` is `{ Id, DisplayName, EmailAddress, LastUsedTicks }` — **single email per contact**, no source/provenance field (`Models/ContactModel.cs`).
+- Microsoft Graph infrastructure exists: `GraphClient` with `GetAllPagesAsync` + `@odata.nextLink` paging and per-account token acquisition (`Services/Graph/GraphClient.cs`).
+- Google OAuth infrastructure exists: `IGoogleOAuthService.GetAccessTokenAsync(username)` (`Services/IGoogleOAuthService.cs`). There is **no** Google People API client yet.
+- OAuth scopes are declared centrally in `OAuthService` (`ImapSmtpScopes`, `GraphMailScopes`, `GraphMailScopesPersonal`, `DefaultScopesFor`). Adding contact scopes means users **re-consent** (§13.1).
+- `SyncService` already runs account sync and raises progress events (`Services/SyncService.cs`) — the natural hook for periodic contact sync.
+- iCloud and plain IMAP/SMTP accounts (`BackendKind.ImapSmtp` with `AuthType.Password`) have **no** contact API; iCloud contacts are CardDAV, for which there is no infrastructure.
+
+### 2.2 Target personas
+
+1. **Returning Gmail power user** — has 400 contacts in Google. Wants them all searchable in QuickMail's To field on day one without re-typing. Uses the feature passively: sync runs, names autocomplete.
+2. **Outlook/M365 professional** — relies on prior recipients ("I emailed Dana last month, just start typing Dana"). Wants `/me/people` relevance ranking, not just saved contacts.
+3. **Screen reader user (Kelly's baseline)** — needs the autocomplete to announce when suggestions appear and how many, and needs a clear, non-chatty sync status. The autocomplete already announces (`ComposeWindow.xaml.cs:294`); this feature must not degrade that.
+4. **Privacy-conscious user** — wants sync **off by default** or at least clearly controllable, and does not want prior-recipient harvesting they didn't ask for.
+5. **Multi-account user** — has both a Gmail and an Outlook account. Wants both contact sets, deduplicated, without the same person appearing three times in autocomplete.
+
+### 2.3 Why now
+
+- The provider auth stacks (Graph client, Google OAuth) are already in place — this is the first feature that reuses them for *non-mail* data, which validates the investment.
+- The local address book and compose autocomplete just matured (groups, edit-mode redesign in `address-book-contacts-pm-dev-spec.md`). Sync is the missing input side.
+- Autocomplete already reads through `IContactService`, so server contacts light up existing surfaces with no compose-side work.
+
+---
+
+## Section 3: Design Principles
+
+1. **Feed the existing store; don't fork it.** Synced contacts land in the same `IContactService` the Address Book and autocomplete already read. No parallel "server contacts" panel in v1.
+2. **Read-only in v1. The server is the source of truth for synced entries; the user's local additions are never overwritten and never (yet) pushed up.** This eliminates the entire class of two-way-sync conflict/delete-propagation bugs for the first release.
+3. **Never clobber user edits or lose local-only contacts.** A re-sync replaces the *server-owned* set for an account; purely-local contacts are untouched.
+4. **Off by default, per-account, and visible.** No contact scope is requested and no data is pulled until the user opts in. Opting in triggers a clearly-explained re-consent.
+5. **Announcements respect the existing category system.** Sync progress is `Status`; sync results are `Result`; no forced announcements. The autocomplete's existing "N results" announcement is the model.
+6. **Degrade silently for accounts that can't sync.** IMAP/password and iCloud accounts simply don't offer the toggle — no errors, no empty panels.
+
+---
+
+## Section 4: Feature Scope & Acceptance Criteria
+
+### 4.1 In scope (v1)
+
+| Feature | Setting / Shortcut | Default | Notes |
+|---|---|---|---|
+| One-way contact sync (server → local) | Per-account `SyncContacts` bool | **Off** | Enabling triggers scope re-consent |
+| Microsoft Graph source | — | — | `/me/contacts` (saved) + `/me/people` (prior recipients / relevance) |
+| Google source | — | — | People API `people/me/connections` (saved) + `otherContacts` (prior recipients) |
+| Contacts appear in Address Book | (existing window) | — | Synced entries listed alongside local; marked read-only for edit (§5.1) |
+| Contacts appear in compose autocomplete | (existing) | — | Free — `SearchContactsAsync` already backs it |
+| Manual "Sync Contacts Now" | `CommandRegistry` id `contacts.syncNow`, category **Contacts**, no default key | — | In Command Palette + Address Book |
+| Automatic sync | on connect + every N hours via `SyncService` | 12h | Cheap; contacts change rarely |
+| Dedup across sources | — | — | By email (case-insensitive); one autocomplete row per address |
+| Sync status announcement | `AnnouncementCategory.Status` | respects `AnnounceStatus` | e.g. "Contacts synced, 412 total" |
+
+### 4.2 Explicitly out of scope (v1) — **deferred to v2**
+
+- **Write-back (create/edit/delete → server).** The issue explicitly asks for this. Recommendation: defer. Rationale in §13.2. In v1, the user can still create/edit **local** contacts exactly as today; those simply stay local.
+- **iCloud / CardDAV / generic IMAP contact sync.** No infrastructure exists; CardDAV + app-specific-password handling is a separate, large effort.
+- **Rich contact fields** — phone numbers, multiple email addresses per person, photos, org/title. `ContactModel` is single-email; expanding it is its own spec.
+- **Contact groups/labels from the server** (Google labels, Outlook categories). Local groups are unaffected; server groups are not imported.
+- **Conflict resolution UI** — not needed while sync is one-way.
+- **Selective/partial sync** (choose which folders/labels). All contacts + all prior recipients, or nothing.
+
+If Kelly wants write-back in v1, that changes the data-model, conflict, and delete-propagation design substantially — flag it now (§13.2), not during implementation.
+
+### 4.3 Acceptance criteria
+
+- A Gmail user who enables sync sees their Google contacts and recently-emailed people in the To autocomplete within one sync cycle, deduplicated.
+- A Graph user likewise, sourced from `/me/contacts` + `/me/people`.
+- Local-only contacts and Grab Addresses entries are never deleted or renamed by a sync.
+- Disabling sync for an account removes that account's server-owned contacts on the next sync/toggle, leaving local contacts intact.
+- Screen reader announces suggestion count in compose (unchanged behavior) and a concise sync status when `AnnounceStatus` is on.
+- IMAP/password accounts show no sync toggle and are unaffected.
+
+---
+
+## Section 5: Architecture & Technical Decisions
+
+### 5.1 Key architectural decisions
+
+**Decision 1 — Store synced contacts in the existing `contacts.json`, discriminated by provenance fields on `ContactModel`.**
+
+Add to `ContactModel`:
+```csharp
+public ContactSource Source   { get; set; } = ContactSource.Local; // Local | MicrosoftGraph | Google
+public string? SourceId       { get; set; }   // provider resource id (Graph id / People resourceName)
+public Guid?   OwnerAccountId { get; set; }   // which account synced it; null for Local
+public bool    IsPriorRecipient { get; set; } // from /me/people or otherContacts, not a saved contact
+```
+- **Alternatives:** (a) separate `synced-contacts-<accountId>.json` files merged at read time; (b) SQLite table. 
+- **Rationale:** The single-file approach means the Address Book and autocomplete get server contacts with **zero query changes** — they already read `_contactsCache`. `Source`/`OwnerAccountId` let a sync replace exactly the `(account, source)` slice while leaving `Local` rows alone. `SourceId` is what future write-back needs and what makes re-sync an update-in-place rather than a duplicate. Separate files (a) would require merge logic in every reader; SQLite (b) is over-engineering for a few thousand rows and diverges from the established JSON pattern.
+- **Trade-off:** `contacts.json` grows (hundreds–low thousands of rows). Acceptable; it's loaded once into memory. `LocalStoreService` (SQLite) is **not** involved, so `--online` mode is unaffected (§5.2).
+
+**Decision 2 — Read-only-for-edit on synced rows in the Address Book.**
+
+A synced contact (`Source != Local`) is shown but its Add/Edit/Delete affordances behave as: Edit is disabled (or, later, "copy to local"), Delete removes it from the local cache only until the next sync re-adds it. Simplest v1: **synced rows are read-only**; the Edit button is disabled and Delete is hidden for them. This keeps the one-way contract honest and avoids the "I deleted it and it came back" confusion — surfaced instead by disabling the action.
+
+**Decision 3 — New `IContactSyncService`, not more methods on `IContactService`.**
+
+`IContactService` owns local persistence and search; provider I/O is a different concern (HTTP, OAuth, paging, provider DTOs). Add:
+```csharp
+public interface IContactSyncService
+{
+    Task<ContactSyncResult> SyncAccountAsync(AccountModel account, CancellationToken ct = default);
+    Task<ContactSyncResult> SyncAllAsync(CancellationToken ct = default);
+    Task RemoveAccountContactsAsync(Guid accountId, CancellationToken ct = default); // on disable / account removal
+}
+public record ContactSyncResult(int Fetched, int Added, int Updated, int Removed, string? Error);
+```
+Implementations: `GraphContactSource` and `GoogleContactSource` (both implement a small internal `IProviderContactSource` returning a normalized `List<ContactModel>` with `Source`/`SourceId` set). `ContactSyncService` diffs the provider set against `_contactsCache` for that `(account, source)` and calls new bulk methods on `IContactService`:
+```csharp
+// IContactService additions:
+Task ReplaceSyncedContactsAsync(Guid accountId, ContactSource source, IReadOnlyList<ContactModel> serverContacts);
+Task RemoveSyncedContactsAsync(Guid accountId); // all sources for the account
+```
+`ReplaceSyncedContactsAsync` does the merge under `_loadLock`: upsert-by-`SourceId`, delete server rows for that `(account, source)` no longer present, **never touch `Source == Local` rows or rows owned by other accounts.**
+
+**Decision 4 — Wire sync into `SyncService`'s existing cadence, gated by config.**
+
+`SyncService` already loops accounts on connect and periodically. Add a contact-sync pass that, for each account with `SyncContacts == true`, calls `IContactSyncService.SyncAccountAsync`. Manual `contacts.syncNow` calls `SyncAllAsync` directly. Contact sync runs **after** mail sync and is best-effort — a contact-sync failure never blocks mail (separate try/catch scope, per the standard fetch pattern in `docs/ARCHITECTURE.md`).
+
+**Decision 5 — OAuth scopes: incremental, opt-in, per provider.**
+
+- **Graph:** add `Contacts.Read` and `People.Read` (read-only). Requested only when the user enables sync, via the existing `GetAccessTokenAsync(account, scopes, ct)` overload (`IOAuthService`). Personal vs work/school scope selection follows the existing `DefaultScopesFor` pattern.
+- **Google:** add `https://www.googleapis.com/auth/contacts.readonly` and `https://www.googleapis.com/auth/contacts.other.readonly`. **These are Google "sensitive" scopes** — see §13.1 for the verification/consent-screen implication. `IGoogleOAuthService` currently returns a token for the mail scopes only; it needs an overload to request the contacts scopes (or the contacts scopes added to the consent set, triggering re-consent).
+
+**Decision 6 — Dedup at read time in `SearchContactsAsync` / `LoadAllContactsAsync`, by email.**
+
+When the same email exists from multiple sources (Local + Graph + Google), collapse to one row for autocomplete/list, preferring: `Local` (user-curated name) > saved server contact > prior recipient. `LastUsedTicks` is taken as the max across duplicates so relevance ordering is preserved. This keeps one person = one row in the To field.
+
+### 5.2 Runtime mode compatibility
+
+| Mode | LocalStoreService used? | This feature calls `LocalStore…`? | Effect |
+|---|---|---|---|
+| Normal | ✓ | **No** — contacts live in `contacts.json` via `ContactService` | Works |
+| `--online` | ✗ (SQLite mail cache off) | **No** | Works — contact sync is independent of the mail SQLite cache |
+| `--profileDir <path>` | n/a | reads/writes `contacts.json` in that profile | Works (alternate path) |
+
+Contact sync touches only `ContactService` (JSON) and provider HTTP. It is safe in every mode.
+
+### 5.3 Code reuse and duplication risks
+
+- **Paging & token handling:** `GraphClient.GetAllPagesAsync` already handles `@odata.nextLink` + token refresh + retry. `GraphContactSource` must reuse it, not re-implement HTTP. Google has no equivalent client yet — build a minimal `GooglePeopleClient` (paged GET with `pageToken`) mirroring `GraphClient`'s shape so both sources feel the same.
+- **DTO mapping:** Graph contact/person → `ContactModel` and Google Person → `ContactModel` are the two normalization points. Keep them in the respective `*ContactSource` classes; do not scatter provider field knowledge into `ContactSyncService`.
+- **Announcement text:** reuse the existing `Status`/`Result` announcement pattern from `ComposeWindow`/sync; don't invent a new mechanism.
+
+### 5.4 Shared component audit (mandatory)
+
+| Component | File | Other consumers | Change needed | Risk / mitigation |
+|---|---|---|---|---|
+| `ContactModel` | `Models/ContactModel.cs` | `ContactService`, `AddressBookViewModel`, `ComposeWindow` autocomplete, `GrabAddressesDialog`, tests | Add `Source`, `SourceId`, `OwnerAccountId`, `IsPriorRecipient` (all defaulted) | New fields default to `Local`/null → existing local flows unchanged. `[JsonIgnore] Display` untouched. Verify `contacts.json` round-trips old files (missing fields deserialize to defaults). |
+| `IContactService` / `ContactService` | `Services/IContactService.cs`, `ContactService.cs` | Address Book VM, compose autocomplete, Grab Addresses | Add `ReplaceSyncedContactsAsync`, `RemoveSyncedContactsAsync`; make `SearchContactsAsync`/`LoadAllContactsAsync` dedup by email | Existing `Upsert/Update/Delete/Search` signatures unchanged. Dedup must not drop local-only rows. Covered by new + existing `ContactService` tests. |
+| `AddressBookViewModel` | `ViewModels/AddressBookViewModel.cs` | Address Book window only | Disable Edit/Delete for `Source != Local`; add "Sync Contacts Now" command | Local add/edit flow (per `address-book-contacts-pm-dev-spec.md`) must still pass its tests. |
+| `SyncService` | `Services/SyncService.cs` | `MainViewModel` background sync | Add best-effort contact-sync pass gated by config | Contact-sync failure must not affect mail sync — separate catch scope. Verify mail sync unaffected when contact sync throws. |
+| `OAuthService` | `Services/OAuthService.cs` | mail connect (IMAP/Graph) | Add `Contacts.Read`/`People.Read` to a new scope constant; request only on opt-in | Must **not** add contact scopes to the default mail scope set, or every existing user re-consents on next connect. New scope set requested lazily. |
+| `IGoogleOAuthService` / `GoogleOAuthService` | `Services/IGoogleOAuthService.cs`, `GoogleOAuthService.cs` | Gmail mail connect | Add overload / scope set for contacts scopes | Same lazy-consent rule. Google sensitive-scope verification risk (§13.1). |
+| `AccountModel` | `Models/AccountModel.cs` | accounts.json, account editor | Add `bool SyncContacts` (persisted, default false) | New defaulted field → old accounts.json round-trips. |
+| `StubServices.cs` | `QuickMail.Tests/StubServices.cs` | all VM/service tests | Add `StubContactSyncService` + new `IContactService` method stubs | Tests won't compile without stubs; add no-op implementations. |
+| `App.xaml.cs` DI root | `App.xaml.cs` | startup wiring | Register `IContactSyncService` + provider sources; dispose in `OnExit` if `IDisposable` | Follow existing manual-DI ordering (after `ContactService`, needs `IOAuthService`/`IGoogleOAuthService`/`GraphClient`). |
+
+If any component here has no other consumers it's noted as "only" above; every modified shared type is listed.
+
+---
+
+## Section 6: Keyboard Walkthrough (Mandatory)
+
+### Path A: Enable sync for a Google account (opt-in + first sync)
+
+1. User opens the account editor for their Gmail account, Tabs to the new **"Sync contacts from this account"** checkbox. **Expected:** screen reader announces "Sync contacts from this account, checkbox, not checked."
+2. User presses Space to check it. **Expected:** checkbox announces "checked." A `Hint` announcement fires once: "Enabling this will ask Google for permission to read your contacts." (respects `AnnounceHints`).
+3. User activates **Save**. **Expected:** a browser sign-in/consent window opens (existing Google OAuth flow) requesting the contacts scopes. Focus is in the browser per existing OAuth behavior.
+4. User consents; the browser closes. **Expected:** focus returns to the account editor / account list per existing OAuth return behavior. If `AnnounceStatus` on: "Syncing contacts…" then "Contacts synced, 412 total" (`Status`).
+5. **Edge — user cancels consent:** **Expected:** checkbox reverts to unchecked, `Result` announcement "Contact sync not enabled," no contacts pulled.
+
+### Path B: Manual sync now
+
+1. In the Address Book (Ctrl+Shift+B) or Command Palette (Ctrl+Shift+P), user activates **"Sync Contacts Now."** **Expected:** `Status` announcement "Syncing contacts…".
+2. On completion. **Expected:** `Result` announcement "Contacts synced, 412 total" (or "Contact sync failed: <reason>" on error). Focus unchanged.
+
+### Path C: Autocomplete a prior recipient in compose (the payoff path)
+
+1. User opens compose, focus in To field, types "dan". **Expected:** existing autocomplete behavior — suggestion list appears including synced saved contacts **and** prior recipients; screen reader announces the count exactly as today (`ComposeWindow.xaml.cs:294`, `Result`).
+2. User presses Down arrow. **Expected:** moves through suggestions; each announces "DisplayName, email" via existing item automation names. A prior-recipient-only entry (no saved name) announces its email.
+3. User presses Enter. **Expected:** the address is inserted into the To field (existing behavior). No duplicate entry for the same person appears (dedup).
+
+### Path D: Browse synced contacts in the Address Book
+
+1. User opens Address Book, arrows to a synced contact. **Expected:** announced as "DisplayName <email>" like any contact.
+2. User presses F2 / activates **Edit**. **Expected:** Edit is **disabled** for synced contacts; a `Hint` fires once on focus: "Synced contact — edit it in Google/Outlook." (respects `AnnounceHints`). No edit fields become active.
+3. User presses **Delete** on a synced contact. **Expected:** Delete is unavailable for synced rows (button disabled / key ignored); optional `Hint`: "Synced contacts are managed on the server."
+
+### Path E: Disable sync
+
+1. User unchecks the account's "Sync contacts" box, Saves. **Expected:** `Result` announcement "Contact sync disabled." That account's server-owned contacts are removed from the Address Book on save; **local contacts remain.**
+
+### Path F: IMAP/password account (no sync available)
+
+1. User opens the account editor for a plain IMAP account. **Expected:** the "Sync contacts" checkbox is **absent** (not merely disabled) — no contact API exists for this backend. No announcement, no error.
+
+---
+
+## Section 7: Accessibility Checklist (Mandatory)
+
+- **AutomationProperties.Name** — new controls: account-editor checkbox `"Sync contacts from this account"`; Address Book command surfaces reuse existing button/menu naming. No role names, no shortcuts baked in.
+- **AnnouncementCategory:**
+  - "Syncing contacts…" → **Status** (background progress; respects `AnnounceStatus`).
+  - "Contacts synced, N total" / "Contact sync failed: …" → **Result** (action outcome; respects `AnnounceResults`).
+  - "Enabling this will ask <provider> for permission…" and "Synced contact — edit it in <provider>" → **Hint** (respects `AnnounceHints`, fired on focus/toggle, not baked into names).
+  - Compose suggestion count → **unchanged** (existing `Result` announcement).
+- **Screen reader browse mode / WebView2** — none introduced. The consent browser is the existing OAuth window.
+- **Focus restoration** — no new dialogs; consent uses the existing OAuth flow's focus return. The account editor's Save/focus behavior is unchanged.
+- **F6 ring** — **no new panes.** Synced contacts live in the existing Address Book list and compose autocomplete, both already in their windows' focus models.
+- **Checkbox / radio groups** — one new standalone checkbox in the account editor; not a radio group.
+- **Color-only information** — synced-vs-local status must not be color-only. Convey "synced" via the disabled Edit/Delete affordance + the on-focus `Hint`, not a color swatch. (If a visual marker is added later, pair it with text.)
+
+**Summary:** One new checkbox, one new command, four new announcements across three categories, no new panes, no new WebView2 surfaces, no F6 changes.
+
+---
+
+## Section 8: Acceptance Walkthrough (Mandatory — run in Session 3)
+
+### Scenario 1: Google happy path
+**Setup:** App running, a Gmail account configured, sync currently off, some local-only contacts present.
+1. Enable "Sync contacts" on the Gmail account, Save, consent in browser. **Verify:** `Status` "Syncing contacts…" then `Result` "Contacts synced, N total"; N ≈ Google contact count.
+2. Open Address Book. **Verify:** Google contacts appear alongside the pre-existing local contacts; local contacts still present and unchanged.
+3. Open compose, type a prefix matching a **prior recipient** you never saved. **Verify:** it appears in suggestions; count announced; Enter inserts it.
+4. **Edge — offline:** disconnect network, run "Sync Contacts Now." **Verify:** `Result` "Contact sync failed: …"; no crash; existing contacts intact.
+
+### Scenario 2: Graph happy path
+**Setup:** M365/Outlook account (`BackendKind.MicrosoftGraph`), sync off.
+1. Enable sync, Save, consent. **Verify:** contacts from `/me/contacts` appear; prior recipients from `/me/people` autocomplete in compose.
+
+### Scenario 3: Dedup across two accounts
+**Setup:** Both a Gmail and an Outlook account, both synced, a person present in both.
+1. Type that person's prefix in compose. **Verify:** exactly **one** suggestion for that email, not two.
+2. Open Address Book. **Verify:** one row for that email (or clearly a single entry), local name preferred if one exists.
+
+### Scenario 4: No-regression — local contact flows (shared component: `ContactService`, `AddressBookViewModel`)
+**Setup:** Sync on for one account.
+1. Add a new **local** contact via the Address Book (existing flow). **Verify:** it saves, appears, autocompletes.
+2. Run "Sync Contacts Now." **Verify:** the local contact is **still there**, unchanged, after sync.
+3. Edit and delete the local contact. **Verify:** existing edit/delete behavior unchanged; announcements per `address-book-contacts-pm-dev-spec.md`.
+
+### Scenario 5: Synced rows are read-only (shared component: `AddressBookViewModel`)
+1. Select a synced contact, press F2. **Verify:** Edit does not open; `Hint` fires (if `AnnounceHints` on). 
+2. Press Delete on a synced contact. **Verify:** not deletable via the row; local contacts still deletable.
+
+### Scenario 6: Disable sync
+1. Uncheck sync for an account, Save. **Verify:** `Result` "Contact sync disabled"; that account's server contacts gone from Address Book on next load; local contacts remain.
+
+### Scenario 7: IMAP account (shared component: account editor)
+1. Open a plain IMAP/password account's editor. **Verify:** no "Sync contacts" checkbox present; no error.
+
+### Scenario 8: `--online` mode
+1. Launch with `--online`, run "Sync Contacts Now." **Verify:** works identically (contact sync is independent of the mail SQLite cache).
+
+### Scenario 9: Screen reader pass
+1. Tab through the account editor. **Verify:** checkbox name "Sync contacts from this account," state announced.
+2. In compose, verify suggestion count still announced (no regression).
+3. Toggle `AnnounceStatus` off, run a sync. **Verify:** no "Syncing…" chatter; `Result` still respects `AnnounceResults` setting.
+
+Mark each pass/fail; any fail documented before Session 4.
+
+---
+
+## Section 9: Success Metrics
+
+- **Behavioral:** A synced Gmail/Outlook user gets ≥95% of their provider contacts + prior recipients autocompleting in To/Cc within one sync cycle.
+- **No data loss:** Zero local-only contacts removed or renamed by any sync (automated test + Scenario 4).
+- **Dedup:** One autocomplete row per email across all sources (Scenario 3).
+- **Keyboard-centric:** Enable, sync-now, autocomplete, and browse are all fully keyboard-operable.
+- **Accessibility:** Sync status obeys `AnnounceStatus`/`AnnounceResults`; compose count announcement unchanged; synced-vs-local distinguishable without color.
+- **No mail regression:** Contact-sync failure never blocks or slows mail sync (separate catch scope).
+- **Online mode:** identical behavior under `--online`.
+
+---
+
+## Section 10: Implementation Phases
+
+### Phase 1 — Data model & store merge (no provider I/O)
+**Goal:** `ContactModel` carries provenance; `ContactService` can bulk-replace a `(account, source)` slice and dedup on read; nothing hits the network.
+**Deliverables:** `ContactSource` enum; `ContactModel` fields; `IContactService.ReplaceSyncedContactsAsync`/`RemoveSyncedContactsAsync`; dedup in `SearchContactsAsync`/`LoadAllContactsAsync`; `AccountModel.SyncContacts`; `StubServices` updates.
+**Tests:** replace-preserves-local; replace-removes-stale-server-rows; dedup-by-email-prefers-local; old-`contacts.json`-round-trips.
+**Risk:** dedup accidentally dropping local rows → covered by explicit test. **Duration:** 3–4h.
+
+### Phase 2 — Graph contact source
+**Goal:** `GraphContactSource` pulls `/me/contacts` + `/me/people`, normalized to `ContactModel`, via `GraphClient`. Read-only scope requested lazily.
+**Deliverables:** `IProviderContactSource`, `GraphContactSource`, Graph contact/person DTOs, `Contacts.Read`/`People.Read` scope constant + lazy request path in `OAuthService`.
+**Tests:** DTO→`ContactModel` mapping (saved contact, person-only/no-name); paging; scope selection personal vs work.
+**Risk:** scope creep into default mail scopes → test asserts default mail connect scopes unchanged. **Duration:** 4–6h.
+
+### Phase 3 — Google contact source
+**Goal:** `GooglePeopleClient` + `GoogleContactSource` pull `connections` + `otherContacts`.
+**Deliverables:** minimal paged People API client, `GoogleContactSource`, contacts scopes + lazy request in `GoogleOAuthService`.
+**Tests:** mapping, paging (`pageToken`), otherContacts→`IsPriorRecipient=true`.
+**Risk:** Google sensitive-scope consent/verification (§13.1) — dev/test uses the app's own account; document the verification requirement. **Duration:** 4–6h.
+
+### Phase 4 — Orchestration, config, and cadence
+**Goal:** `ContactSyncService` diffs & applies; `SyncService` runs it best-effort; manual `contacts.syncNow` command; account-editor checkbox; disable/removal cleanup.
+**Deliverables:** `IContactSyncService`/`ContactSyncService`, DI wiring, `SyncService` hook (separate catch scope), `CommandRegistry` `contacts.syncNow`, account-editor XAML checkbox, `RemoveAccountContactsAsync` on disable/account delete.
+**Tests:** diff add/update/remove counts; failure isolation from mail sync; toggle-off removes server rows.
+**Risk:** contact-sync exception bubbling into mail sync → explicit isolation test. **Duration:** 4–6h.
+
+### Phase 5 — Address Book read-only affordance & announcements
+**Goal:** synced rows read-only in the Address Book with on-focus `Hint`; sync status/result announcements wired through `AccessibilityHelper.Announce` with correct categories.
+**Deliverables:** `AddressBookViewModel` `CanEdit/CanDelete` account for `Source`; hint + status + result announcements.
+**Tests:** VM `CanEditContact` false for synced rows; announcement category correctness (where testable).
+**Risk:** none major. **Duration:** 2–3h.
+
+Each phase is independently committable and reviewable.
+
+---
+
+## Section 11: Files to Create / Modify
+
+### Create
+| File | Purpose |
+|---|---|
+| `Models/ContactSource.cs` | enum `Local / MicrosoftGraph / Google` |
+| `Services/IContactSyncService.cs` | sync orchestration interface + `ContactSyncResult` |
+| `Services/ContactSyncService.cs` | diff & apply, cadence entry points |
+| `Services/Contacts/IProviderContactSource.cs` | per-provider fetch abstraction |
+| `Services/Contacts/GraphContactSource.cs` | `/me/contacts` + `/me/people` → `ContactModel` |
+| `Services/Contacts/GoogleContactSource.cs` | People `connections` + `otherContacts` → `ContactModel` |
+| `Services/Google/GooglePeopleClient.cs` | minimal paged People API client |
+| `QuickMail.Tests/ContactSyncServiceTests.cs` | diff/merge/failure-isolation |
+| `QuickMail.Tests/ContactSourceMappingTests.cs` | provider DTO → `ContactModel` |
+
+### Modify
+| File | Changes |
+|---|---|
+| `Models/ContactModel.cs` | add `Source`, `SourceId`, `OwnerAccountId`, `IsPriorRecipient` |
+| `Models/AccountModel.cs` | add `bool SyncContacts` (default false) |
+| `Services/IContactService.cs` / `ContactService.cs` | add bulk replace/remove; dedup on read |
+| `Services/OAuthService.cs` | add contact/people read scope set + lazy request |
+| `Services/IGoogleOAuthService.cs` / `GoogleOAuthService.cs` | add contacts-scope token path |
+| `Services/SyncService.cs` | best-effort contact-sync pass (separate catch) |
+| `ViewModels/AddressBookViewModel.cs` | `contacts.syncNow`; read-only for synced rows |
+| account editor XAML/VM | "Sync contacts" checkbox (Graph/Google backends only) |
+| `App.xaml.cs` | register `IContactSyncService` + sources; dispose |
+| `QuickMail.Tests/StubServices.cs` | `StubContactSyncService` + new `IContactService` methods |
+
+---
+
+## Section 12: Tests to Add
+
+| Test Class | Methods | Coverage |
+|---|---|---|
+| `ContactServiceSyncTests` | ReplacePreservesLocal; ReplaceRemovesStaleServerRows; ReplaceIgnoresOtherAccounts; DedupPrefersLocal; DedupMaxLastUsed; OldJsonRoundTrips | store merge + dedup |
+| `ContactSourceMappingTests` | GraphContact→Model; GraphPersonNoName→Model; GooglePerson→Model; OtherContact→PriorRecipientFlag | provider normalization |
+| `ContactSyncServiceTests` | DiffCountsAddUpdateRemove; FailureDoesNotThrowToCaller; DisableRemovesAccountRows | orchestration |
+| `OAuthScopeTests` | DefaultMailConnectScopesUnchanged; ContactScopesRequestedOnlyOnOptIn | scope-creep guard |
+| `AddressBookViewModelSyncTests` | SyncedRowNotEditable; SyncedRowNotDeletable; SyncNowCommandInvokesService | VM affordances |
+
+Every new public method gets a test; scope-creep guard test is the highest-value safety net.
+
+---
+
+## Section 13: Known Risks & Open Questions
+
+### 13.1 Risks
+
+| Risk | Prob. | Impact | Mitigation |
+|---|---|---|---|
+| Adding contact scopes to the **default** mail scope set forces every existing user to re-consent on next connect | Med | Major | New scope constant requested **only** on opt-in; `OAuthScopeTests.DefaultMailConnectScopesUnchanged` gate. |
+| Google `contacts.readonly` / `contacts.other.readonly` are **sensitive scopes** → Google OAuth app needs verification; unverified apps hit the "unverified app" screen and a 100-user cap | Med | Major | Document as a release gate; dev/test with the app owner's own account; may require Google verification submission before GA. **Kelly decision needed (§13.2).** |
+| Re-sync creates duplicates instead of updating | Med | Major | Update-by-`SourceId`, not by email; `ReplaceSyncedContactsAsync` test. |
+| A sync deletes local-only contacts | Low | Blocker | Merge only ever touches rows with matching `(OwnerAccountId, Source)`; `ReplacePreservesLocal` test + Scenario 4. |
+| Contact-sync failure blocks mail sync | Low | Major | Separate try/catch scope in `SyncService`; `FailureDoesNotThrowToCaller` test. |
+| `contacts.json` bloat / load time with thousands of prior recipients | Low | Minor | Cap prior recipients (e.g. top ~1000 by relevance) if needed; log the cap per CLAUDE.md "no silent caps." |
+| Synced-vs-local conveyed by color only | Low | Major | Non-color affordance (disabled Edit + on-focus Hint), per §7. |
+
+### 13.2 Open questions — **need a decision before Session 2**
+
+1. **Write-back in v1 or v2?** The issue asks for create/edit-syncs-to-server. This spec recommends **v2** (one-way read in v1) to avoid two-way conflict, delete-propagation, and etag-collision complexity on the first release. In v1 users still create/edit *local* contacts. **Confirm: read-only v1 acceptable?**
+KF: Yes, no syncing now back to the server, maybe never. The one thing the user can do is resync from the server and we should be able to edit previously synced from that system. For example the user updates an email address or deletes one on the synced account. we need to be able to adapt to that. Realtime syncing isn't critical unless it can easily be done at the same time we are checking mail or something.
+
+
+2. **Sync default: off (recommended) or on?** Recommend **off** for privacy + to avoid surprise re-consent. **Confirm.**
+KF: Off for sure and a notification when turned on that new data will be available in Quickmail.
+
+3. **Google verification:** Are we prepared to submit the QuickMail Google OAuth app for sensitive-scope verification, or restrict Google contact sync to a smaller/test audience initially? (Graph has no equivalent gate.)
+KF: I'd think this is the same limitation we have today? Maybe we need to request more permisisons but yes we are prepared to deal with the goolg eissues.
+
+
+4. **Synced-contact editing model:** v1 recommends **read-only synced rows** (edit in provider). Alternative: "copy to local and edit," which creates a local override. Recommend read-only for v1. **Confirm.**
+KF: Yes
+
+
+
+5. **Prior-recipient volume cap:** cap at ~1000 by relevance, or pull all? Recommend a logged cap. **Confirm the number.**
+You can try 1000 but we'll have to see how the performance is. Also, we already have grab addresses from an open message as one mitigation today.
+Every question has a recommended default above; the spec is implementable on those defaults if Kelly approves them.
+
+---
+
+## Section 14: Appendix — Command / Setting Reference
+
+| Item | Type | Default | Notes |
+|---|---|---|---|
+| `contacts.syncNow` | CommandRegistry command, category **Contacts** | no default key | Palette + Address Book |
+| `AccountModel.SyncContacts` | per-account setting | **false** | Persisted in accounts.json |
+| Auto-sync interval | internal | 12h + on connect | Via `SyncService` |
+| Graph scopes | OAuth | `Contacts.Read`, `People.Read` | Requested on opt-in only |
+| Google scopes | OAuth | `contacts.readonly`, `contacts.other.readonly` | Sensitive — verification (§13.1) |
+
+---
+
+## Section 15: Implementation Guidance for AI (Session 2)
+
+### 15.1 Adjustments you're expected to make
+- The exact Graph `/me/people` query params (relevance ordering, `$top`, filtering personal-vs-org) are left to you — reuse `GraphClient.GetAllPagesAsync` and pick sensible defaults; log any cap.
+- Whether `GooglePeopleClient` shares a base with `GraphClient` or stays standalone is your call — match `GraphClient`'s method shape for consistency.
+- The dedup tie-break beyond "local > saved > prior recipient" (e.g. which provider wins between two saved contacts) is your judgment; keep it deterministic and covered by a test.
+
+### 15.2 When to ask for clarification
+- The five open questions in §13.2 are **normative gates.** Do not implement write-back, flip the default to on, or change the read-only synced-row model without an explicit answer.
+- If Google sensitive-scope verification blocks even test sign-in, stop and report — don't work around it by weakening scopes to something that can't read prior recipients.
+- If you discover `contacts.json` merge can't cleanly preserve local rows under the existing `_loadLock` model, stop and raise it — data loss here is a blocker, not an implementation detail.
+
+### 15.3 Highest-risk acceptance steps (from §8)
+- Scenario 4 (local contacts survive a sync) — the data-loss guard.
+- Scenario 3 (dedup across two accounts) — the one-person-one-row guarantee.
+- Scenario 1 step 4 (offline sync fails gracefully) and the mail-sync isolation.
+Focus verification effort there.


### PR DESCRIPTION
Implements **issue #256** — sync contacts and prior recipients from the mail provider into the address book, so people you already know autocomplete in the To field.

Approved spec: `docs/planning/contact-sync-server-issue-256-pm-dev-spec.md` (Kelly's `KF:` answers to all five gating questions are recorded in §13.2).

## What this does (V1)
- **One-way sync (server → local)** for Microsoft (Graph `/me/contacts` + `/me/people`) and Google (People `connections` + `otherContacts`) accounts. Synced people appear in the existing Address Book and the existing compose autocomplete with **no compose-side changes** — both already read through `IContactService`.
- **Off by default**, per-account **"Sync contacts from this account"** toggle in the account editor (OAuth accounts only; password/IMAP accounts see nothing). Enabling requests **read-only** contact scopes (one-time consent), announces that new data will be available, and pulls an initial snapshot. Disabling purges that account's synced contacts.
- **Prior recipients** (people you've emailed) come from `/me/people` / `otherContacts`, capped at 1000 per source (logged when capped).
- **Dedup by email** across local + synced sources — one row per person (local name preferred, then saved contact, then prior recipient).
- **Synced rows are read-only** in the Address Book (Edit/Delete disabled, on-focus hint); a local contact with the same address is still fully editable.
- **"Sync Contacts Now"** command (Contacts category, Command Palette) + an address-book button. Best-effort **silent sync at startup** after mail accounts connect (tokens already warm → no sign-in popup).

## Re-sync semantics (per Kelly's answer #1)
Re-sync **adapts to server-side edits/deletes**: contacts update in place by provider id (keeping their local id), and rows deleted on the server disappear locally on the next sync. Never writes back; never touches local contacts or other accounts' synced rows.

## Explicitly deferred to v2
Write-back, iCloud/CardDAV, and a periodic (12h) timer — startup + manual covers the "at mail-check time" cadence Kelly asked for. Google sensitive-scope verification is a release gate (Kelly confirmed prepared to handle).

## Key changes
- `ContactModel`: `Source` / `SourceId` / `OwnerAccountId` / `IsPriorRecipient` (back-compatible — old `contacts.json` loads as `Local`).
- `IContactService.ReplaceSyncedContactsAsync` / `RemoveSyncedContactsAsync` + read-time dedup.
- `IContactSyncService` / `ContactSyncService`; `GraphContactSource`, `GoogleContactSource` + `GooglePeopleClient`; scope-aware `GraphClient` overload.
- `RequestContactsConsentAsync` across `IOAuthService`/router/MS, `AuthorizeContactsAsync` on Google.
- `AccountModel.SyncContacts`; account-editor checkbox; VM wiring; DI in `App.xaml.cs`.

## Testing
- **24 new tests** (store merge/dedup, provider mapping via canned HTTP, orchestration/failure-isolation, scope-creep guard, VM read-only + command).
- **Full suite green: 1205 passed, 0 failed.**
- Not yet exercised live — awaiting Kelly's manual acceptance walkthrough (spec §8), especially the real OAuth consent + fetch against live Gmail/Outlook accounts, which automated tests can't cover.

Closes #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)