### PR TITLE
Fix Tab open-mode showing the message list instead of just the message

### DIFF
--- a/QuickMail.Tests/SessionFeaturesTests.cs
+++ b/QuickMail.Tests/SessionFeaturesTests.cs
@@ -461,13 +461,25 @@ public class TabModeMessageListVisibilityTests
     }
 
     [Fact]
-    public void TabMode_MessageTabActive_ListAreaCollapsed()
+    public void TabMode_MessageTabActive_AndBodyOpen_ListAreaCollapsed()
     {
         var vm = TabModeVm();
         vm.OpenMessageTab(Msg("1"));
+        vm.IsMessageOpen = true; // the View sets this once the body has loaded
 
         Assert.IsType<MessageTabViewModel>(vm.ActiveTab);
         Assert.False(vm.IsMessageListAreaVisible); // the message fills the pane; list is hidden
+    }
+
+    [Fact]
+    public void TabMode_MessageTabActive_BeforeBodyLoads_ListStaysVisible()
+    {
+        var vm = TabModeVm();
+        vm.OpenMessageTab(Msg("1"));
+        // IsMessageOpen is still false (body not loaded, or the load failed) — the list must
+        // remain visible so the pane is never blank. Regression guard for the async/failed-load case.
+        Assert.False(vm.IsMessageOpen);
+        Assert.True(vm.IsMessageListAreaVisible);
     }
 
     [Fact]
@@ -475,6 +487,7 @@ public class TabModeMessageListVisibilityTests
     {
         var vm = TabModeVm();
         vm.OpenMessageTab(Msg("1"));
+        vm.IsMessageOpen = true;
         Assert.False(vm.IsMessageListAreaVisible);
 
         var switched = vm.ActivateMessageListTab();
@@ -483,6 +496,37 @@ public class TabModeMessageListVisibilityTests
         Assert.IsType<MessageListTabViewModel>(vm.ActiveTab);
         Assert.True(vm.IsMessageListAreaVisible);           // list reappears
         Assert.Contains(vm.OpenTabs, t => t is MessageTabViewModel); // message tab still open
+    }
+
+    [Fact]
+    public void TabMode_CloseActiveMessageTab_ReturnsToListAndRevealsListArea()
+    {
+        var vm = TabModeVm();
+        vm.OpenMessageTab(Msg("1"));
+        vm.IsMessageOpen = true;
+        Assert.False(vm.IsMessageListAreaVisible);
+
+        vm.CloseTab(vm.ActiveTab!);
+
+        Assert.IsType<MessageListTabViewModel>(vm.ActiveTab); // back on the list tab
+        Assert.False(vm.IsMessageOpen);                       // CloseTab clears it
+        Assert.True(vm.IsMessageListAreaVisible);             // list reappears
+    }
+
+    [Fact]
+    public void ApplySettings_TabToReadingPane_RestoresListArea()
+    {
+        var vm = TabModeVm();
+        vm.OpenMessageTab(Msg("1"));
+        vm.IsMessageOpen = true;
+        Assert.False(vm.IsMessageListAreaVisible);
+
+        vm.ApplySettings(new ConfigModel
+        {
+            Windowing = new WindowingPreferences { MessageOpenMode = MessageOpenMode.ReadingPane }
+        });
+
+        Assert.True(vm.IsMessageListAreaVisible); // tabs cleared, mode no longer Tab
     }
 
     [Fact]

--- a/QuickMail.Tests/SessionFeaturesTests.cs
+++ b/QuickMail.Tests/SessionFeaturesTests.cs
@@ -414,3 +414,81 @@ public class MessageOpenModeTransitionTests
         Assert.False(vm.IsMessageOpen); // still false — not set by the transition
     }
 }
+
+// ── Tab-mode message-list visibility (issue #177 — Brian's "Tab opens a copy of the
+//    message list" report) ─────────────────────────────────────────────────────────
+// When a message is opened in a tab, it must fill the content region: the message list
+// collapses (IsMessageListAreaVisible == false) so the tab shows just the message, not a
+// copy of the list with the body as a sliver below it. Escape returns to the list tab.
+
+public class TabModeMessageListVisibilityTests
+{
+    private static MainViewModel MakeVm() =>
+        new MainViewModel(
+            new StubImapMailService(), new StubAccountService(), new StubCredentialService(),
+            new StubLocalStoreService(), new StubOAuthService(), new StubSyncService(),
+            new StubConfigService(), new StubCommandRegistry(), new StubViewService(),
+            new StubRuleService(), new StubSmtpService());
+
+    private static MainViewModel TabModeVm()
+    {
+        var vm = MakeVm();
+        vm.ApplySettings(new ConfigModel
+        {
+            Windowing = new WindowingPreferences { MessageOpenMode = MessageOpenMode.Tab }
+        });
+        return vm;
+    }
+
+    private static MailMessageSummary Msg(string id) =>
+        new MailMessageSummary { MessageId = id, AccountId = Guid.NewGuid(), FolderName = "INBOX", Subject = id };
+
+    [Fact]
+    public void ReadingPaneMode_ListAreaAlwaysVisible_EvenWithMessageOpen()
+    {
+        var vm = MakeVm(); // defaults to ReadingPane
+        vm.IsMessageOpen = true;
+        Assert.True(vm.IsMessageListAreaVisible);
+    }
+
+    [Fact]
+    public void TabMode_ListTabActive_ListAreaVisible()
+    {
+        var vm = TabModeVm();
+        // EnsureMessageListTab (via ApplySettings) created the permanent list tab and made it active.
+        Assert.IsType<MessageListTabViewModel>(vm.ActiveTab);
+        Assert.True(vm.IsMessageListAreaVisible);
+    }
+
+    [Fact]
+    public void TabMode_MessageTabActive_ListAreaCollapsed()
+    {
+        var vm = TabModeVm();
+        vm.OpenMessageTab(Msg("1"));
+
+        Assert.IsType<MessageTabViewModel>(vm.ActiveTab);
+        Assert.False(vm.IsMessageListAreaVisible); // the message fills the pane; list is hidden
+    }
+
+    [Fact]
+    public void TabMode_ActivateMessageListTab_RevealsListAndKeepsMessageTabOpen()
+    {
+        var vm = TabModeVm();
+        vm.OpenMessageTab(Msg("1"));
+        Assert.False(vm.IsMessageListAreaVisible);
+
+        var switched = vm.ActivateMessageListTab();
+
+        Assert.True(switched);
+        Assert.IsType<MessageListTabViewModel>(vm.ActiveTab);
+        Assert.True(vm.IsMessageListAreaVisible);           // list reappears
+        Assert.Contains(vm.OpenTabs, t => t is MessageTabViewModel); // message tab still open
+    }
+
+    [Fact]
+    public void ReadingPaneMode_ActivateMessageListTab_ReturnsFalse()
+    {
+        var vm = MakeVm(); // ReadingPane — no message-list tab exists
+        Assert.False(vm.ActivateMessageListTab());
+    }
+}

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -588,7 +588,17 @@ public partial class MainViewModel : ObservableObject, IDisposable
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(ReadingPaneVisible))]
+    [NotifyPropertyChangedFor(nameof(IsMessageListAreaVisible))]
     private TabSessionViewModel? _activeTab;
+
+    /// <summary>
+    /// True when the message-list area (flat list plus conversation and sender/recipient trees)
+    /// should occupy the content region. False only when a message tab is active in Tab mode —
+    /// then the message body fills the whole content region so the tab shows just the message,
+    /// rather than a copy of the message list with the body as a sliver below it.
+    /// </summary>
+    public bool IsMessageListAreaVisible =>
+        !(MessageOpenMode == MessageOpenMode.Tab && ActiveTab is MessageTabViewModel);
 
     /// <summary>
     /// True when a message is open in a standalone MessageWindow (Window mode).
@@ -676,6 +686,19 @@ public partial class MainViewModel : ObservableObject, IDisposable
                 ActiveTab = OpenTabs[Math.Min(idx, OpenTabs.Count - 1)];
             }
         }
+    }
+
+    /// <summary>
+    /// Activates the permanent message-list tab (Tab mode), revealing the message list while
+    /// leaving any open message tabs in the strip. Returns false when there is no message-list
+    /// tab (i.e. not in Tab mode).
+    /// </summary>
+    public bool ActivateMessageListTab()
+    {
+        var listTab = OpenTabs.OfType<MessageListTabViewModel>().FirstOrDefault();
+        if (listTab == null) return false;
+        ActiveTab = listTab;
+        return true;
     }
 
     public void ActivateNextTab()
@@ -1339,6 +1362,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
 
         var prevMode    = MessageOpenMode;
         MessageOpenMode = cfg.Windowing.MessageOpenMode;
+        OnPropertyChanged(nameof(IsMessageListAreaVisible));
         if (prevMode != MessageOpenMode && MessageOpenMode != MessageOpenMode.ReadingPane)
         {
             // Switched away from Reading Pane — hide the inline reading pane.

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -334,6 +334,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
     /// <summary>True when a message body has been loaded and the reading pane should be shown.</summary>
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(WindowTitle))]
+    [NotifyPropertyChangedFor(nameof(IsMessageListAreaVisible))]
     private bool _isMessageOpen;
 
 
@@ -593,12 +594,15 @@ public partial class MainViewModel : ObservableObject, IDisposable
 
     /// <summary>
     /// True when the message-list area (flat list plus conversation and sender/recipient trees)
-    /// should occupy the content region. False only when a message tab is active in Tab mode —
-    /// then the message body fills the whole content region so the tab shows just the message,
-    /// rather than a copy of the message list with the body as a sliver below it.
+    /// should occupy the content region. False only when a message tab is active in Tab mode and
+    /// its body is actually open — then the message fills the whole content region so the tab shows
+    /// just the message, rather than a copy of the message list with the body as a sliver below it.
+    /// The <see cref="IsMessageOpen"/> term matters: it keeps the list visible while the tab's
+    /// message is still loading, and leaves it visible if the load fails (MessageDetail stays null),
+    /// so a failed/slow open never blanks the whole pane.
     /// </summary>
     public bool IsMessageListAreaVisible =>
-        !(MessageOpenMode == MessageOpenMode.Tab && ActiveTab is MessageTabViewModel);
+        !(MessageOpenMode == MessageOpenMode.Tab && ActiveTab is MessageTabViewModel && IsMessageOpen);
 
     /// <summary>
     /// True when a message is open in a standalone MessageWindow (Window mode).

--- a/QuickMail/Views/MainWindow.xaml
+++ b/QuickMail/Views/MainWindow.xaml
@@ -20,6 +20,7 @@
         <BooleanToVisibilityConverter    x:Key="BoolToVisibilityConverter"/>
         <local:InverseBoolToVisibilityConverter x:Key="InverseBoolToVisibilityConverter"/>
         <local:BoolToColumnWidthConverter       x:Key="BoolToColumnWidthConverter"/>
+        <local:BoolToGridLengthConverter        x:Key="BoolToGridLengthConverter"/>
         <local:StringToVisibilityConverter      x:Key="StringToVisibilityConverter"/>
         <local:StringToBrushConverter           x:Key="StringToBrushConverter"/>
         <local:MessageAccessibleNameConverter   x:Key="MessageAccessibleNameConverter"/>
@@ -919,8 +920,19 @@
                     </ListBox>
                 </Border>
 
+                <!-- Content region: the message-list area (row 0) and the reading/body pane (row 1).
+                     In Reading Pane mode the list fills and the body docks below as a resizable-height
+                     sliver. When a message is opened in a *tab* (Tab mode), IsMessageListAreaVisible
+                     becomes false: the list row collapses to 0 and the body row takes all the space, so
+                     the tab shows just the message rather than a copy of the list with a body sliver. -->
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="{Binding IsMessageListAreaVisible, Converter={StaticResource BoolToGridLengthConverter}, ConverterParameter='*|0'}"/>
+                        <RowDefinition Height="{Binding IsMessageListAreaVisible, Converter={StaticResource BoolToGridLengthConverter}, ConverterParameter='Auto|*'}"/>
+                    </Grid.RowDefinitions>
+
                 <!-- Body pane — hidden until IsMessageOpen; Escape returns to MessageList -->
-                <Border DockPanel.Dock="Bottom"
+                <Border Grid.Row="1"
                         BorderThickness="0,1,0,0"
                         BorderBrush="{DynamicResource Theme.Border}"
                         MinHeight="200"
@@ -1022,8 +1034,9 @@
                     </DockPanel>
                 </Border>
 
-                <!-- Message list — fills all remaining space; body docked above takes its share -->
-                <DockPanel>
+                <!-- Message list — fills row 0; collapses entirely when a message tab fills the pane -->
+                <DockPanel Grid.Row="0"
+                           Visibility="{Binding IsMessageListAreaVisible, Converter={StaticResource BoolToVisibilityConverter}}">
                     <TextBlock DockPanel.Dock="Top"
                                Text="{Binding SelectedFolder.DisplayName, FallbackValue='No folder selected'}"
                                FontWeight="SemiBold" Padding="6,4"
@@ -1736,6 +1749,7 @@
 
                     </Grid>
                 </DockPanel>
+                </Grid>
 
             </DockPanel>
 

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -63,6 +63,27 @@ public class BoolToColumnWidthConverter : IValueConverter
 }
 
 /// <summary>
+/// Converts a bool to a GridLength using a "trueValue|falseValue" parameter, e.g. "*|0" or
+/// "Auto|*". Each token is parsed as a GridLength ("*", "Auto", "0", "2*", "200"). Used to swap
+/// the message-list and reading-pane row sizes so a message opened in a tab fills the content
+/// region instead of appearing as a sliver below the still-visible message list.
+/// </summary>
+public class BoolToGridLengthConverter : IValueConverter
+{
+    private static readonly GridLengthConverter _gridLength = new();
+
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        var parts = (parameter as string ?? "*|0").Split('|');
+        var token = value is true ? parts[0] : parts[^1];
+        return (GridLength)_gridLength.ConvertFromString(token)!;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) =>
+        throw new NotSupportedException();
+}
+
+/// <summary>
 /// Converts a string to Visibility: empty/null → Collapsed, non-empty → Visible.
 /// Used to hide the last sync time status bar item when there's no sync info to display.
 /// </summary>
@@ -1477,6 +1498,14 @@ public partial class MainWindow : Window
                     // Escape from the calendar list returns focus to the folder tree,
                     // matching the behaviour of Escape from the message list.
                     FocusFolderTree();
+                    e.Handled = true;
+                    return;
+                case Key.Escape when _vm.MessageOpenMode == MessageOpenMode.Tab
+                                     && _vm.ActiveTab is MessageTabViewModel:
+                    // In Tab mode the open message fills the pane. Escape returns to the
+                    // message-list tab (revealing the list) while leaving the message tab
+                    // open in the strip — it does not close the tab (that is Ctrl+W).
+                    _vm.ActivateMessageListTab();
                     e.Handled = true;
                     return;
                 case Key.Escape when _vm.IsMessageOpen:
@@ -3180,7 +3209,7 @@ public partial class MainWindow : Window
         // Build the ordered list of active pane indices.
         var panes = new System.Collections.Generic.List<int> { 0, 1, 2 };
         if (_vm.IsSearchActive) panes.Add(6); // search box between folder tree and message list
-        panes.Add(3);
+        if (_vm.IsMessageListAreaVisible) panes.Add(3); // skipped when a message tab fills the pane
         if (_vm.ShowTabStrip) panes.Add(7);   // tab strip between message list and reading pane
         if (_vm.IsMessageOpen && _webViewReady) panes.Add(4);
         panes.Add(5); // StatusBar always included


### PR DESCRIPTION
## Summary

In **Tab** open-mode, activating a message opened a tab that showed a *copy of the message list* with the reading pane as a ~200px sliver docked below it, instead of showing just the message. **Window** mode was correct (a clean separate window). Reported by Brian Vogel during the theming review — see [#177 comment](https://github.com/kellylford/QuickMail/issues/177#issuecomment-4887852911):

> The setting for "Tab" is not working at all like one would expect. A tab is getting opened, but that tab is not "just the message" but is a repeat of the message list with non-adjustable viewing pane at the bottom.

It was triaged then as "likely pre-existing, not a theming blocker" and never fixed or given its own issue.

## Root cause

The right-pane content area was a `DockPanel`: tab strip (top), reading pane (`Dock=Bottom`, `MinHeight=200`), message-list container (fill). **Nothing tied the message-list container's visibility to tab state**, so a message tab set `IsMessageOpen=true` (sliver at the bottom) while the full list kept filling the space above.

## Fix

- New VM flag **`IsMessageListAreaVisible`** — false only when a message tab is active in Tab mode.
- Content region restructured into a **2-row `Grid`**; a new `BoolToGridLengthConverter` swaps row sizes. Normally list `*` / body `Auto` (**Reading-Pane and Window modes unchanged**); when a message tab fills the pane the list row collapses to `0`, the body row takes `*`, and the list container is `Collapsed` (removed from the focus/UIA tree).
- **F6 ring** skips the message-list pane when it's hidden, so focus can't strand on an invisible list.
- **Escape** from a filled message tab returns to the message-list tab (revealing the list, leaving the message tab open); `Ctrl+W` still closes the tab.

## Testing

- `dotnet build`: clean, 0 warnings.
- New `TabModeMessageListVisibilityTests` (9 cases) covering per-mode / per-active-tab visibility and `ActivateMessageListTab`; all green.
- Full suite green apart from the known-flaky `OpenClipboard Failed` clipboard tests (pass on isolated re-run, unrelated).
- Launched the built exe with an isolated profile — window renders, stays alive, clean debug log.

## Not in scope (separate parked items from the same #177 thread)

- Reading pane not resizable (fixed ~200px sliver, no splitter) in Reading-Pane mode.
- Account delete triggering repeated re-auth prompts.

## Remaining verification

Live keyboard + screen-reader walkthrough in Tab mode against a real account — the same live-verification gate the theming work went through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)