### PR TITLE
Background-sync reliability: stale-connection retry (#268), read-state reconcile (#269), notify logging (#270)

### DIFF
--- a/QuickMail/Services/ImapMailService.cs
+++ b/QuickMail/Services/ImapMailService.cs
@@ -1046,6 +1046,27 @@ public class ImapMailService : IMailService, IChangeNotifier
         catch { return false; }
     }
 
+    // Actively verifies a pooled connection is alive by issuing a NOOP. IsConnected only reflects the
+    // last known socket state, so a connection the server silently dropped during a long idle passes
+    // IsClientUsable but fails on the next real command. A NOOP forces that failure here, letting the
+    // pool discard the dead client and reconnect instead of surfacing "An existing connection was
+    // forcibly closed by the remote host" to the caller (#268). Cancellation propagates; any other
+    // failure means the connection is dead.
+    private static async Task<bool> IsConnectionAliveAsync(ImapClient client, CancellationToken ct)
+    {
+        try
+        {
+            await client.NoOpAsync(ct);
+            return true;
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex)
+        {
+            LogService.Debug($"IMAP pool: stale connection discarded after NOOP probe — {ex.GetType().Name}: {ex.Message}");
+            return false;
+        }
+    }
+
     private static void DisposeClient(ImapClient client)
     {
         try { client.Dispose(); } catch { /* best effort */ }
@@ -1092,7 +1113,17 @@ public class ImapMailService : IMailService, IChangeNotifier
         private readonly object _gate = new();
         private readonly Stack<ImapClient> _idle = new();
         private readonly HashSet<ImapClient> _all = new();
+        // When each idle client was returned to the pool. A client that has been sitting idle longer
+        // than StaleProbeThreshold is liveness-probed (NOOP) before reuse — see RentAsync (#268).
+        private readonly Dictionary<ImapClient, DateTimeOffset> _returnedUtc = new();
         private bool _disposed;
+
+        // A pooled connection idle longer than this is NOOP-probed before reuse. IsConnected is a
+        // cached flag; a server that silently drops the socket during a long idle still reports
+        // connected until the next I/O, so without a probe the caller gets "An existing connection
+        // was forcibly closed by the remote host." Hot reuse (under the threshold) skips the probe to
+        // avoid an extra round-trip on every rent.
+        private static readonly TimeSpan StaleProbeThreshold = TimeSpan.FromSeconds(30);
 
         public AccountConnectionPool(
             ImapMailService owner, AccountModel account, string? password, int maxConnections)
@@ -1153,8 +1184,8 @@ public class ImapMailService : IMailService, IChangeNotifier
             {
                 while (client == null)
                 {
-                    AccountModel account;
-                    string? password;
+                    ImapClient? reuse = null;
+                    var reuseIsStale = false;
 
                     lock (_gate)
                     {
@@ -1165,17 +1196,40 @@ public class ImapMailService : IMailService, IChangeNotifier
                             var candidate = _idle.Pop();
                             if (IsClientUsable(candidate))
                             {
-                                client = candidate;
+                                reuse = candidate;
+                                reuseIsStale = !_returnedUtc.TryGetValue(candidate, out var returned)
+                                    || DateTimeOffset.UtcNow - returned > StaleProbeThreshold;
+                                _returnedUtc.Remove(candidate);
                                 break;
                             }
 
                             _all.Remove(candidate);
+                            _returnedUtc.Remove(candidate);
                             DisposeClient(candidate);
                         }
+                    }
 
-                        if (client != null)
+                    if (reuse != null)
+                    {
+                        // A client idle beyond the threshold may have been silently dropped by the
+                        // server; probe it with a NOOP before handing it out so we reconnect here
+                        // instead of throwing in the caller (#268). Hot reuse skips the probe.
+                        if (!reuseIsStale || await IsConnectionAliveAsync(reuse, ct))
+                        {
+                            client = reuse;
                             break;
+                        }
 
+                        lock (_gate) { _all.Remove(reuse); }
+                        DisposeClient(reuse);
+                        continue; // dead connection — try the next idle client or create a fresh one
+                    }
+
+                    AccountModel account;
+                    string? password;
+                    lock (_gate)
+                    {
+                        ObjectDisposedException.ThrowIf(_disposed, this);
                         account = CloneAccount(Account);
                         password = Password;
                     }
@@ -1214,11 +1268,13 @@ public class ImapMailService : IMailService, IChangeNotifier
                 if (!_disposed && IsClientUsable(client))
                 {
                     _idle.Push(client);
+                    _returnedUtc[client] = DateTimeOffset.UtcNow;
                     keep = true;
                 }
                 else
                 {
                     _all.Remove(client);
+                    _returnedUtc.Remove(client);
                 }
             }
 
@@ -1240,6 +1296,7 @@ public class ImapMailService : IMailService, IChangeNotifier
                 clients = _all.ToList();
                 _idle.Clear();
                 _all.Clear();
+                _returnedUtc.Clear();
             }
 
             foreach (var client in clients)
@@ -1256,6 +1313,7 @@ public class ImapMailService : IMailService, IChangeNotifier
                 clients = _all.ToList();
                 _idle.Clear();
                 _all.Clear();
+                _returnedUtc.Clear();
             }
 
             foreach (var client in clients)

--- a/QuickMail/Services/ImapMailService.cs
+++ b/QuickMail/Services/ImapMailService.cs
@@ -1214,7 +1214,22 @@ public class ImapMailService : IMailService, IChangeNotifier
                         // A client idle beyond the threshold may have been silently dropped by the
                         // server; probe it with a NOOP before handing it out so we reconnect here
                         // instead of throwing in the caller (#268). Hot reuse skips the probe.
-                        if (!reuseIsStale || await IsConnectionAliveAsync(reuse, ct))
+                        bool alive;
+                        try
+                        {
+                            alive = !reuseIsStale || await IsConnectionAliveAsync(reuse, ct);
+                        }
+                        catch
+                        {
+                            // Probe cancelled (or threw) after we popped `reuse` from _idle. `client` is
+                            // still null, so the outer catch won't clean it up — discard it here so the
+                            // connection isn't orphaned in _all for the rest of the session.
+                            lock (_gate) { _all.Remove(reuse); }
+                            DisposeClient(reuse);
+                            throw;
+                        }
+
+                        if (alive)
                         {
                             client = reuse;
                             break;

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -1909,6 +1909,10 @@ public partial class MainViewModel : ObservableObject, IDisposable
         // Collect truly new messages; add them to _rawMessages immediately so the
         // search pool stays in sync with what the list will eventually show.
         var toInsert = new List<MailMessageSummary>();
+        // Existing messages whose read-state was reconciled from the server (#269). Their filter
+        // membership may have changed (e.g. now-read messages must leave the Unread view), so their
+        // presence in the visible list is reconciled after the loop.
+        var readReconciled = new List<MailMessageSummary>();
         foreach (var msg in relevant.OrderByDescending(m => m.Date))
         {
             // Reconcile server-flagged state for new incoming messages: a message with
@@ -1929,7 +1933,10 @@ public partial class MainViewModel : ObservableObject, IDisposable
                     // refreshes the row; folder unread counts reconcile via the debounced,
                     // STATUS-authoritative refresh already scheduled on the sync path.
                     if (existing.IsRead != msg.IsRead)
+                    {
                         existing.IsRead = msg.IsRead;
+                        readReconciled.Add(existing); // its filter membership may have changed
+                    }
 
                     // Flag clear (§9.3): server now reports not-flagged but we still show a flag —
                     // another client cleared it, so clear our local flag to match.
@@ -1961,6 +1968,20 @@ public partial class MainViewModel : ObservableObject, IDisposable
         {
             foreach (var msg in toInsert)
                 InsertMessageSorted(msg);
+
+            // #269: reconcile the visible list for messages whose read-state changed externally. A
+            // now-read message must leave the Unread view; a now-unread one must (re)appear if it
+            // matches. Done inside the batch so it costs one Reset, not one event per change.
+            foreach (var m in readReconciled)
+            {
+                var shouldShow = MatchesFilter(m) && MatchesDayLimit(m)
+                    && (string.IsNullOrWhiteSpace(SearchText) || MatchesSearch(m));
+                var isShown = Messages.Contains(m);
+                if (shouldShow && !isShown)
+                    InsertMessageSorted(m);
+                else if (!shouldShow && isShown)
+                    Messages.Remove(m);
+            }
         }
         // If WPF cleared SelectedMessage during the Reset but the message is still in
         // the list, restore it so the reading pane header and command guards stay correct.

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -1921,14 +1921,20 @@ public partial class MainViewModel : ObservableObject, IDisposable
             var key = keyOf(msg);
             if (!seen.Add(key))
             {
-                // Existing message: reconcile external flag change (§9.3).
-                // If the server now reports not-flagged but the in-memory message still has
-                // a flag set, another client cleared it — clear our local flag to match.
-                if (!msg.IsServerFlagged &&
-                    rawByKey.TryGetValue(key, out var existing) &&
-                    existing.FlagId != null)
+                // Existing message: reconcile external state changes made by another client.
+                if (rawByKey.TryGetValue(key, out var existing))
                 {
-                    existing.FlagId = null;
+                    // Read/unread (#269): a message read (or marked unread) elsewhere — e.g. Gmail
+                    // web — must not keep showing the stale state here. IsRead is observable, so this
+                    // refreshes the row; folder unread counts reconcile via the debounced,
+                    // STATUS-authoritative refresh already scheduled on the sync path.
+                    if (existing.IsRead != msg.IsRead)
+                        existing.IsRead = msg.IsRead;
+
+                    // Flag clear (§9.3): server now reports not-flagged but we still show a flag —
+                    // another client cleared it, so clear our local flag to match.
+                    if (!msg.IsServerFlagged && existing.FlagId != null)
+                        existing.FlagId = null;
                 }
                 continue;
             }
@@ -2028,6 +2034,17 @@ public partial class MainViewModel : ObservableObject, IDisposable
         if (_notifiedMessageKeys.Count > 10_000) _notifiedMessageKeys.Clear();
 
         var fresh = Helpers.NewMailFilter.SelectNew(incoming, _notifyThresholdUtc, _notifiedMessageKeys);
+
+        // #270 instrumentation: the user reports an inflated count that re-notifies every ~30 min
+        // (the IDLE reconnect cadence). Log enough to tell whether the SAME message re-notifies each
+        // cycle (dedup key not matching / session reset) or a genuinely new one arrives. UIDs are the
+        // dedup key input, so logging them pins which mechanism is at play. Debug-only (Advanced log).
+        LogService.Debug(
+            $"NewMail notify [{account.AccountLabel}]: incoming={incoming.Count} " +
+            $"unread={incoming.Count(m => !m.IsRead)} fresh={fresh.Count} " +
+            $"notifiedSetSize={_notifiedMessageKeys.Count} threshold={_notifyThresholdUtc:o} " +
+            $"freshUids=[{string.Join(",", fresh.Select(m => m.MessageId))}]");
+
         if (fresh.Count == 0) return;
 
         _notifications.ShowNewMail(account.AccountLabel, account.Id, fresh);


### PR DESCRIPTION
Splits three reliability fixes out of #240 (reported by @diamondStar35). Each is small and independently reviewable.

## #268 — "An existing connection was forcibly closed" when opening a message after long idle

The pool judged a reused client alive with only `IsConnected && IsAuthenticated`, which are cached flags — a server that silently dropped the socket during a long idle still reports connected until the next I/O, so the stale client got handed out and the fetch threw.

Fix: a pooled client idle longer than 30s is NOOP-probed before reuse; if the probe fails, the dead client is discarded and the pool reconnects. Hot reuse (under the threshold) skips the probe, so there's no extra round-trip on the common path.

## #269 — Messages stay unread after being read in another client

`OnFolderSynced` reconciled the server `\Flagged` state for already-cached messages but never reconciled `\Seen`. Now the cached copy's `IsRead` is updated to match the server on sync (both directions). `IsRead` is observable, so the row refreshes; folder unread counts converge via the debounced STATUS-authoritative refresh already scheduled on the sync path.

Note: the *trigger* half of #269 (IMAP IDLE only fires on new arrivals, not flag changes) is addressed by the fallback-poll work in #267.

## #270 — Inflated / repeating new-mail notification

Instrumentation only — no behavior change. `MaybeNotifyNewMail` now logs (debug/Advanced only) the incoming count, unread count, surviving "fresh" count, dedup-set size, threshold, and the fresh UIDs, so the user's log will reveal whether the same message re-notifies each IDLE cycle (dedup key mismatch / session reset) or a genuinely new message arrives.

## Testing

- `dotnet build` clean (0 warnings, 0 errors).
- `dotnet test` — 1227 passed. The one failure (`PropertiesViewModelTests.CopyAll`) is a pre-existing clipboard `OpenClipboard Failed` environmental flake, unrelated to these changes.
- Not yet exercised live against a real server (stale-connection path in particular benefits from a manual soak test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
