### PR TITLE
Add fallback mail-sync poll with configurable interval (#267)

### DIFF
--- a/QuickMail.Tests/ConfigServiceSaveTests.cs
+++ b/QuickMail.Tests/ConfigServiceSaveTests.cs
@@ -85,6 +85,41 @@ public class ConfigServiceSaveTests
     }
 
     [Fact]
+    public void MailSyncPollMinutes_DefaultsTo5_AndRoundTrips()
+    {
+        var profile = MakeTempProfile();
+        var service = new ConfigService(profile);
+
+        // Default is 5 minutes (fallback poll on) for a fresh config.
+        Assert.Equal(5, service.Load().MailSyncPollMinutes);
+
+        var config = service.Load();
+        config.MailSyncPollMinutes = 15;
+        service.Save(config);
+
+        var reloaded = new ConfigService(profile).Load();
+        Assert.Equal(15, reloaded.MailSyncPollMinutes);
+    }
+
+    [Theory]
+    [InlineData(0, 0)]     // 0 disables the fallback poll and is preserved
+    [InlineData(-3, 0)]    // any non-positive value normalizes to 0 (disabled)
+    [InlineData(1, 1)]     // lower bound
+    [InlineData(200, 120)] // clamped to the 120-minute ceiling
+    public void MailSyncPollMinutes_IsClampedOnLoad(int written, int expected)
+    {
+        var profile = MakeTempProfile();
+        var service = new ConfigService(profile);
+
+        var config = service.Load();
+        config.MailSyncPollMinutes = written;
+        service.Save(config);
+
+        var reloaded = new ConfigService(profile).Load();
+        Assert.Equal(expected, reloaded.MailSyncPollMinutes);
+    }
+
+    [Fact]
     public void SaveThenLoad_RoundTripsReadAsPlainText()
     {
         // Issue #34: the sticky plain-text preference must survive a real INI write→read

--- a/QuickMail/Models/ConfigModel.cs
+++ b/QuickMail/Models/ConfigModel.cs
@@ -55,6 +55,14 @@ public class ConfigModel
     /// </summary>
     public int GraphPollSeconds { get; set; } = 60;
 
+    /// <summary>
+    /// Fallback mail-sync interval in minutes. Primary new-mail detection is IMAP IDLE (server push);
+    /// this periodic inbox sync is a safety net for when a server never pushes, the held IDLE
+    /// connection dies quietly, or read/flag state changed in another client (which IDLE never
+    /// reports). Default 5. Set to 0 to disable and rely on IDLE alone. Clamped to 0 or 1–120.
+    /// </summary>
+    public int MailSyncPollMinutes { get; set; } = 5;
+
     // ── Appearance ────────────────────────────────────────────────────────────────
 
     /// <summary>

--- a/QuickMail/Services/ConfigService.cs
+++ b/QuickMail/Services/ConfigService.cs
@@ -224,6 +224,11 @@ public class ConfigService : IConfigService
                     case "graphpollseconds":
                         if (int.TryParse(value, out var gps)) config.GraphPollSeconds = Math.Clamp(gps, 30, 600);
                         break;
+                    case "mailsyncpollminutes":
+                        // 0 disables the fallback poll; any other value is clamped to 1–120.
+                        if (int.TryParse(value, out var msp))
+                            config.MailSyncPollMinutes = msp <= 0 ? 0 : Math.Clamp(msp, 1, 120);
+                        break;
                     case "appearancethemeid":
                         if (!string.IsNullOrWhiteSpace(value)) config.AppearanceThemeId = value;
                         break;
@@ -393,6 +398,13 @@ public class ConfigService : IConfigService
         sb.AppendLine($"GraphPollSeconds = {Math.Clamp(config.GraphPollSeconds, 30, 600)}");
         sb.AppendLine("# Poll interval (seconds) for the Microsoft Graph new-mail watcher.");
         sb.AppendLine("# Default is 60. Values: 30-600. IMAP accounts use IDLE and ignore this.");
+        sb.AppendLine();
+
+        sb.AppendLine($"MailSyncPollMinutes = {(config.MailSyncPollMinutes <= 0 ? 0 : Math.Clamp(config.MailSyncPollMinutes, 1, 120))}");
+        sb.AppendLine("# Fallback mail-sync interval (minutes) behind IMAP IDLE.");
+        sb.AppendLine("# Periodically re-syncs inboxes so new mail still arrives if the server never");
+        sb.AppendLine("# pushes or the IDLE connection dies, and read/flag changes from other clients");
+        sb.AppendLine("# reconcile. Default 5. Set to 0 to disable and rely on IDLE alone. Values: 0 or 1-120.");
         sb.AppendLine();
 
         sb.AppendLine($"AppearanceThemeId = {config.AppearanceThemeId}");

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -1706,6 +1706,10 @@ public partial class MainViewModel : ObservableObject, IDisposable
             // Start periodic NOOP heartbeat (10-minute interval) to keep connections alive
             // and detect mid-session drops on non-INBOX folders.
             _ = StartPeriodicNoOpAsync(accountList, ct);
+
+            // Start the fallback mail-sync loop (issue #267) — a safety net behind IMAP IDLE that
+            // periodically re-syncs inboxes on a user-configurable interval.
+            _ = StartFallbackSyncAsync(ct);
         }
         catch (OperationCanceledException) { /* sync cancelled — normal */ }
         catch (Exception ex)
@@ -1823,6 +1827,59 @@ public partial class MainViewModel : ObservableObject, IDisposable
                     try { await _imap.NoOpAsync(account.Id, ct); }
                     catch (OperationCanceledException) { throw; }
                     catch (Exception ex) { LogService.Log($"NOOP for {account.AccountLabel}", ex); }
+                }
+            }
+        }
+        catch (OperationCanceledException) { }
+    }
+
+    // Fallback mail sync behind IMAP IDLE (issue #267). IDLE is the primary new-mail signal, but if a
+    // server never pushes, the held IDLE connection dies quietly, or a message's read/flag state
+    // changes in another client (which IDLE never reports), nothing updates until the user acts. This
+    // loop periodically re-syncs each IMAP account's inbox as the safety net. The interval is
+    // user-configurable (config.MailSyncPollMinutes); 0 disables it. Re-reads the setting each cycle
+    // so a Settings change takes effect without a restart. Non-online only — online mode has no local
+    // store to sync into and StartBackgroundSyncAsync returns before this is reached.
+    private async Task StartFallbackSyncAsync(CancellationToken ct)
+    {
+        try
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                var minutes = _configService.Load().MailSyncPollMinutes;
+
+                // Disabled: re-check the setting every 5 minutes so re-enabling it doesn't need a restart.
+                var delay = minutes <= 0 ? TimeSpan.FromMinutes(5) : TimeSpan.FromMinutes(minutes);
+                await Task.Delay(delay, ct);
+                if (ct.IsCancellationRequested) break;
+                if (_configService.Load().MailSyncPollMinutes <= 0) continue; // still disabled after the wait
+
+                foreach (var account in Accounts.ToList())
+                {
+                    if (ct.IsCancellationRequested) break;
+                    if (account.BackendKind != BackendKind.ImapSmtp) continue; // Graph has its own delta poll
+                    if (!_cachedFolders.TryGetValue(account.Id, out var folders)) continue;
+
+                    var inbox = folders.FirstOrDefault(f =>
+                        f.Kind == Models.SpecialFolderKind.Inbox ||
+                        string.Equals(f.FullName, "INBOX", StringComparison.OrdinalIgnoreCase));
+                    if (inbox is null) continue;
+
+                    try
+                    {
+                        var incoming = await _syncService.SyncOneFolderAsync(account, inbox, ct);
+                        LogService.Debug($"Fallback sync [{account.AccountLabel}] inbox: {incoming.Count} fetched.");
+
+                        // Notify for genuinely-new arrivals the same way the IDLE path does; the
+                        // de-dupe set (single-thread-owned) prevents re-notifying mail IDLE already flagged.
+                        if (incoming.Count > 0)
+                            _ui.Post(() => MaybeNotifyNewMail(account, incoming));
+
+                        // New/updated mail changes server unread counts; refresh (debounced, STATUS-authoritative).
+                        ScheduleFolderCountRefresh(account.Id);
+                    }
+                    catch (OperationCanceledException) { throw; }
+                    catch (Exception ex) { LogService.Log($"Fallback sync {account.AccountLabel}", ex); }
                 }
             }
         }

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -1837,9 +1837,16 @@ public partial class MainViewModel : ObservableObject, IDisposable
     // server never pushes, the held IDLE connection dies quietly, or a message's read/flag state
     // changes in another client (which IDLE never reports), nothing updates until the user acts. This
     // loop periodically re-syncs each IMAP account's inbox as the safety net. The interval is
-    // user-configurable (config.MailSyncPollMinutes); 0 disables it. Re-reads the setting each cycle
-    // so a Settings change takes effect without a restart. Non-online only — online mode has no local
-    // store to sync into and StartBackgroundSyncAsync returns before this is reached.
+    // user-configurable (config.MailSyncPollMinutes); 0 disables it. Re-reads the setting at the top of
+    // each cycle so a Settings change applies without a restart — note the change takes effect after the
+    // current wait elapses (up to one interval of lag; Off→enabled is bounded at ≤5 min). Non-online
+    // only — online mode has no local store to sync into and StartBackgroundSyncAsync returns first.
+    //
+    // Threading: the loop body runs on a threadpool thread (ConfigureAwait(false) on the delay), so the
+    // fetch + SQLite upsert never touch the UI thread. Accounts/_cachedFolders are UI-thread-owned, so
+    // the work list is snapshotted via _ui.Invoke, and the UI-owned follow-ups (notify, count refresh)
+    // are marshalled back via _ui.Post. This mirrors OnInboxNewMailDetected but makes the thread
+    // ownership explicit rather than relying on an ambient sync context.
     private async Task StartFallbackSyncAsync(CancellationToken ct)
     {
         try
@@ -1850,33 +1857,47 @@ public partial class MainViewModel : ObservableObject, IDisposable
 
                 // Disabled: re-check the setting every 5 minutes so re-enabling it doesn't need a restart.
                 var delay = minutes <= 0 ? TimeSpan.FromMinutes(5) : TimeSpan.FromMinutes(minutes);
-                await Task.Delay(delay, ct);
+                await Task.Delay(delay, ct).ConfigureAwait(false);
                 if (ct.IsCancellationRequested) break;
                 if (_configService.Load().MailSyncPollMinutes <= 0) continue; // still disabled after the wait
 
-                foreach (var account in Accounts.ToList())
+                // Snapshot the IMAP inboxes to sync on the UI thread (Accounts/_cachedFolders are
+                // UI-thread-owned). Graph accounts are skipped — they have their own delta poll.
+                var jobs = new List<(AccountModel Account, MailFolderModel Inbox)>();
+                _ui.Invoke(() =>
+                {
+                    foreach (var account in Accounts)
+                    {
+                        if (account.BackendKind != BackendKind.ImapSmtp) continue;
+                        if (!_cachedFolders.TryGetValue(account.Id, out var folders)) continue;
+
+                        var inbox = folders.FirstOrDefault(f =>
+                            f.Kind == Models.SpecialFolderKind.Inbox ||
+                            string.Equals(f.FullName, "INBOX", StringComparison.OrdinalIgnoreCase));
+                        if (inbox != null) jobs.Add((account, inbox));
+                    }
+                });
+
+                foreach (var (account, inbox) in jobs)
                 {
                     if (ct.IsCancellationRequested) break;
-                    if (account.BackendKind != BackendKind.ImapSmtp) continue; // Graph has its own delta poll
-                    if (!_cachedFolders.TryGetValue(account.Id, out var folders)) continue;
-
-                    var inbox = folders.FirstOrDefault(f =>
-                        f.Kind == Models.SpecialFolderKind.Inbox ||
-                        string.Equals(f.FullName, "INBOX", StringComparison.OrdinalIgnoreCase));
-                    if (inbox is null) continue;
-
                     try
                     {
-                        var incoming = await _syncService.SyncOneFolderAsync(account, inbox, ct);
+                        // Fetch + SQLite upsert run off the UI thread; SyncOneFolderAsync marshals its
+                        // FolderSynced event to the UI thread internally.
+                        var incoming = await _syncService.SyncOneFolderAsync(account, inbox, ct)
+                            .ConfigureAwait(false);
                         LogService.Debug($"Fallback sync [{account.AccountLabel}] inbox: {incoming.Count} fetched.");
 
-                        // Notify for genuinely-new arrivals the same way the IDLE path does; the
-                        // de-dupe set (single-thread-owned) prevents re-notifying mail IDLE already flagged.
-                        if (incoming.Count > 0)
-                            _ui.Post(() => MaybeNotifyNewMail(account, incoming));
-
-                        // New/updated mail changes server unread counts; refresh (debounced, STATUS-authoritative).
-                        ScheduleFolderCountRefresh(account.Id);
+                        // Marshal the UI-owned follow-ups back to the UI thread: notify for genuinely-new
+                        // arrivals (the single-thread-owned de-dupe set prevents re-notifying mail IDLE
+                        // already flagged) and refresh unread counts (debounced, STATUS-authoritative).
+                        _ui.Post(() =>
+                        {
+                            if (incoming.Count > 0)
+                                MaybeNotifyNewMail(account, incoming);
+                            ScheduleFolderCountRefresh(account.Id);
+                        });
                     }
                     catch (OperationCanceledException) { throw; }
                     catch (Exception ex) { LogService.Log($"Fallback sync {account.AccountLabel}", ex); }

--- a/QuickMail/ViewModels/SettingsViewModel.cs
+++ b/QuickMail/ViewModels/SettingsViewModel.cs
@@ -33,6 +33,9 @@ public partial class SettingsViewModel : ObservableObject
     private int _initialSyncCount;
 
     [ObservableProperty]
+    private int _mailSyncPollMinutes;
+
+    [ObservableProperty]
     private bool _customAnnouncements;
 
     [ObservableProperty]
@@ -249,6 +252,7 @@ public partial class SettingsViewModel : ObservableObject
         ViewMode = cfg.ViewMode;
         SyncDays = cfg.SyncDays;
         InitialSyncCount = cfg.InitialSyncCount;
+        MailSyncPollMinutes = cfg.MailSyncPollMinutes;
         CustomAnnouncements = cfg.CustomAnnouncements;
         AnnounceHints       = cfg.AnnounceHints;
         AnnounceStatus      = cfg.AnnounceStatus;
@@ -317,6 +321,7 @@ public partial class SettingsViewModel : ObservableObject
         cfg.ViewMode = ViewMode;
         cfg.SyncDays = SyncDays;
         cfg.InitialSyncCount = InitialSyncCount;
+        cfg.MailSyncPollMinutes = MailSyncPollMinutes;
         cfg.CustomAnnouncements = CustomAnnouncements;
         cfg.AnnounceHints       = AnnounceHints;
         cfg.AnnounceStatus      = AnnounceStatus;

--- a/QuickMail/Views/SettingsDialog.xaml
+++ b/QuickMail/Views/SettingsDialog.xaml
@@ -130,6 +130,28 @@
                                         <ComboBoxItem Tag="0" Content="All messages"/>
                                     </ComboBox>
                                 </StackPanel>
+
+                                <!-- Fallback sync interval -->
+                                <StackPanel Margin="0,8,0,0">
+                                    <Label x:Name="MailPollLabel"
+                                           Content="Check for new mail _every:"
+                                           Target="{Binding ElementName=MailPollCombo}"
+                                           FontWeight="SemiBold"/>
+                                    <ComboBox x:Name="MailPollCombo"
+                                              SelectedValue="{Binding MailSyncPollMinutes, Mode=TwoWay}"
+                                              SelectedValuePath="Tag"
+                                              AutomationProperties.LabeledBy="{Binding ElementName=MailPollLabel}">
+                                        <ComboBoxItem Tag="0" Content="Off (server push only)"/>
+                                        <ComboBoxItem Tag="1" Content="1 minute"/>
+                                        <ComboBoxItem Tag="5" Content="5 minutes"/>
+                                        <ComboBoxItem Tag="15" Content="15 minutes"/>
+                                        <ComboBoxItem Tag="30" Content="30 minutes"/>
+                                        <ComboBoxItem Tag="60" Content="60 minutes"/>
+                                    </ComboBox>
+                                    <TextBlock Text="A safety net behind instant server push: re-checks your inbox on this schedule so new mail still arrives, and read messages sync, if push is interrupted."
+                                               Foreground="{DynamicResource Theme.TextSecondary}" FontSize="{DynamicResource Theme.FontSizeSmall}"
+                                               TextWrapping="Wrap" Margin="0,3,0,0"/>
+                                </StackPanel>
                             </StackPanel>
                         </GroupBox>
 


### PR DESCRIPTION
Closes part of #240; addresses #267 (reported by @diamondStar35).

## Problem

Background new-mail detection relies entirely on IMAP IDLE (server push). There is no periodic poll, so if a server never pushes or the held IDLE connection dies quietly, nothing pulls new mail until the user manually opens a folder. The user reported "sync almost does not work at all" and asked for a configurable interval.

## Change

A fallback mail-sync loop behind IDLE, with a user-configurable interval.

- **Setting**: `MailSyncPollMinutes` in `ConfigModel` — default **5**, `0` disables (rely on IDLE alone), clamped to `1–120`. Parsed and written by `ConfigService` (with a documented comment block in the ini).
- **UI**: a new combo under Settings → Sync, "Check for new mail every" (Off / 1 / 5 / 15 / 30 / 60 minutes), accessibly labelled via `AutomationProperties.LabeledBy` like the sibling Sync combos, with a short explanatory caption.
- **Loop**: `StartFallbackSyncAsync` in `MainViewModel`, started next to the existing NOOP heartbeat (non-online mode only). It re-reads the interval each cycle so a Settings change applies without a restart, then syncs each IMAP account's inbox via `SyncOneFolderAsync`, notifies genuinely-new arrivals through the shared de-dupe path (`MaybeNotifyNewMail`), and schedules the debounced STATUS-authoritative unread-count refresh.

Graph accounts are skipped (they have their own delta poll). Online mode returns before the loop starts (no local store to sync into).

## Scope / notes

- **First cut** per discussion — inbox-only fallback (the highest-value path for the reported symptoms). A full all-folders periodic sync is a possible follow-up.
- Composes with #269 (read-state reconcile on sync): this PR provides the *trigger*; #269 provides the inbox read/unread reconciliation. Both are needed for "read in Gmail clears here on the next poll."
- Mnemonic for the new combo is Alt+E; no obvious collision in the dialog.

## Testing

- `dotnet build` clean (0 warnings, 0 errors).
- New tests: default value, save/load round-trip, and clamp/normalize cases (`0`, negative→`0`, lower bound, `>120`→`120`).
- Focused run of ConfigService / SettingsViewModel / XamlParse / ViewModelConstruction suites: 66 passed. XamlParse covers the Settings dialog loading with the new control.
- Not yet exercised live (the timing behavior benefits from a manual soak with IDLE disabled/interrupted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
