### PR TITLE
Local calendar authoring (combined with mail-sync fixes); v0.8.34

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -289,7 +289,7 @@ Every user-facing keyboard shortcut **must** be registered in `CommandRegistry` 
   - `Ctrl+Shift+P` — opens the Command Palette itself (cannot dispatch through the palette)
   - Navigation shortcuts `Ctrl+0–3`, `Ctrl+9`, `Ctrl+Y`, `F6` — focus-only pane jumps with no associated command title
 - **`InputGestureText` in menus** must match the registered default key, e.g. `InputGestureText="Ctrl+Shift+F"`.
-- **Category** must be one of: `View`, `Mail`, `Account`, `Contacts`, `Settings`, `Help`.
+- **Category** must be one of: `View`, `Mail`, `Account`, `Contacts`, `Calendar`, `Settings`, `Help`. (`Calendar` added 2026-07-17 per the full-calendar spec, resolved question Q4.)
 
 ### Adding a new shortcut — checklist
 

--- a/QuickMail.Tests/CalDavCalendarSyncTests.cs
+++ b/QuickMail.Tests/CalDavCalendarSyncTests.cs
@@ -1,0 +1,537 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using QuickMail.Models;
+using QuickMail.Services;
+using QuickMail.Services.Graph;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// Generic CalDAV calendar sync (read-down v1, iCloud-first) through the shared calendar sync
+/// service and the raw <see cref="CalDavCalendarClient"/>: discovery (PROPFIND principal → home
+/// → first VEVENT calendar, with a cross-host redirect that must keep Basic auth), REPORT
+/// calendar-query parsing (timed + all-day + recurring w/ EXDATE from one multistatus),
+/// replace-slice under the synthetic account id, and failure isolation. HTTP is stubbed with a
+/// queued <see cref="HttpMessageHandler"/>; persistence uses a real temp-profile
+/// LocalStoreService, mirroring GoogleCalendarSyncTests.
+/// </summary>
+public class CalDavCalendarSyncTests : IDisposable
+{
+    private const string ServerUrl = "https://caldav.icloud.com";
+    private const string Username  = "kelly@example.com";
+
+    private readonly string _tempDir;
+    private readonly LocalStoreService _store;
+    private readonly Guid _accountId = CalDavCalendarClient.AccountIdFor(ServerUrl, Username);
+
+    public CalDavCalendarSyncTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"qm-caldav-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        _store = new LocalStoreService(new ProfileContext(_tempDir));
+        _store.Initialize();
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); } catch { }
+        GC.SuppressFinalize(this);
+    }
+
+    // ── Test plumbing ────────────────────────────────────────────────────────────
+
+    private sealed record RecordedRequest(string Method, string Url, string? Depth, string? Auth, string Body);
+
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        private readonly Queue<HttpResponseMessage> _responses;
+        public List<RecordedRequest> Requests { get; } = [];
+
+        public RecordingHandler(params HttpResponseMessage[] responses)
+            => _responses = new Queue<HttpResponseMessage>(responses);
+
+        public void Enqueue(HttpResponseMessage response) => _responses.Enqueue(response);
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            Requests.Add(new RecordedRequest(
+                request.Method.Method,
+                request.RequestUri!.ToString(),
+                request.Headers.TryGetValues("Depth", out var d) ? d.First() : null,
+                request.Headers.Authorization?.ToString(),
+                request.Content == null ? string.Empty : await request.Content.ReadAsStringAsync(ct)));
+            return _responses.Count > 0 ? _responses.Dequeue() : Xml(EmptyMultistatus);
+        }
+    }
+
+    private sealed class SecretCredentialService : ICredentialService
+    {
+        private readonly Dictionary<string, string> _secrets = [];
+        public SecretCredentialService(string? key = null, string? value = null)
+        {
+            if (key != null && value != null) _secrets[key] = value;
+        }
+        public void SavePassword(Guid accountId, string password) { }
+        public string? GetPassword(Guid accountId) => null;
+        public void DeletePassword(Guid accountId) { }
+        public void SaveSecret(string key, string value) => _secrets[key] = value;
+        public string? GetSecret(string key) => _secrets.TryGetValue(key, out var v) ? v : null;
+        public void DeleteSecret(string key) => _secrets.Remove(key);
+    }
+
+    private sealed class CalDavConfigService : IConfigService
+    {
+        private ConfigModel _config;
+        public CalDavConfigService(bool configured = true)
+            => _config = configured
+                ? new ConfigModel { CalDavUrl = ServerUrl, CalDavUsername = Username, CalDavDisplayName = "iCloud" }
+                : new ConfigModel();
+        public ConfigModel Load() => _config;
+        public void Save(ConfigModel config) => _config = config;
+    }
+
+    private static HttpResponseMessage Xml(string body, HttpStatusCode code = (HttpStatusCode)207)
+        => new(code) { Content = new StringContent(body, Encoding.UTF8, "application/xml") };
+
+    private GraphCalendarSyncService Service(RecordingHandler handler,
+                                             IConfigService? config = null,
+                                             ICredentialService? credentials = null)
+        => new(new StubAccountService(), // no mail accounts — only the CalDAV source syncs
+               _store,
+               new GraphClient(new StubOAuthService(), new HttpClient(new RecordingHandler()), defaultRetryDelay: TimeSpan.Zero),
+               google: null,
+               calDav: new CalDavCalendarClient(new HttpClient(handler)),
+               config: config ?? new CalDavConfigService(),
+               credentials: credentials ?? new SecretCredentialService(CalDavCalendarClient.SecretKeyFor(Username), "app-pass"));
+
+    // ── XML fixtures ─────────────────────────────────────────────────────────────
+
+    private const string EmptyMultistatus =
+        """<?xml version="1.0"?><d:multistatus xmlns:d="DAV:"/>""";
+
+    private const string PrincipalXml =
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <d:multistatus xmlns:d="DAV:">
+          <d:response>
+            <d:href>/</d:href>
+            <d:propstat>
+              <d:prop>
+                <d:current-user-principal><d:href>/123456/principal/</d:href></d:current-user-principal>
+              </d:prop>
+              <d:status>HTTP/1.1 200 OK</d:status>
+            </d:propstat>
+          </d:response>
+        </d:multistatus>
+        """;
+
+    // iCloud reports the calendar home on the user's partition host — an ABSOLUTE href.
+    private const string HomeSetXml =
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
+          <d:response>
+            <d:href>/123456/principal/</d:href>
+            <d:propstat>
+              <d:prop>
+                <c:calendar-home-set><d:href>https://p42-caldav.icloud.com/123456/calendars/</d:href></c:calendar-home-set>
+              </d:prop>
+              <d:status>HTTP/1.1 200 OK</d:status>
+            </d:propstat>
+          </d:response>
+        </d:multistatus>
+        """;
+
+    // Home children: the home itself (plain collection), a VTODO-only Reminders list (must be
+    // skipped), then the first VEVENT-capable calendar.
+    private const string CollectionsXml =
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
+          <d:response>
+            <d:href>/123456/calendars/</d:href>
+            <d:propstat><d:prop><d:resourcetype><d:collection/></d:resourcetype></d:prop>
+            <d:status>HTTP/1.1 200 OK</d:status></d:propstat>
+          </d:response>
+          <d:response>
+            <d:href>/123456/calendars/tasks/</d:href>
+            <d:propstat><d:prop>
+              <d:resourcetype><d:collection/><c:calendar/></d:resourcetype>
+              <d:displayname>Reminders</d:displayname>
+              <c:supported-calendar-component-set><c:comp name="VTODO"/></c:supported-calendar-component-set>
+            </d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat>
+          </d:response>
+          <d:response>
+            <d:href>/123456/calendars/home/</d:href>
+            <d:propstat><d:prop>
+              <d:resourcetype><d:collection/><c:calendar/></d:resourcetype>
+              <d:displayname>Home</d:displayname>
+              <c:supported-calendar-component-set><c:comp name="VEVENT"/></c:supported-calendar-component-set>
+            </d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat>
+          </d:response>
+        </d:multistatus>
+        """;
+
+    /// <summary>Wraps ICS bodies (already XML-safe in these fixtures) in a REPORT multistatus.</summary>
+    private static string ReportXml(params string[] icsBodies)
+    {
+        var sb = new StringBuilder();
+        sb.Append("""<?xml version="1.0" encoding="UTF-8"?>""");
+        sb.Append("""<d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">""");
+        var i = 0;
+        foreach (var ics in icsBodies)
+        {
+            sb.Append($"<d:response><d:href>/123456/calendars/home/{++i}.ics</d:href>")
+              .Append("<d:propstat><d:prop><d:getetag>\"etag\"</d:getetag><c:calendar-data>")
+              .Append(ics)
+              .Append("</c:calendar-data></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response>");
+        }
+        sb.Append("</d:multistatus>");
+        return sb.ToString();
+    }
+
+    private static string TimedIcs => string.Join("\n",
+        "BEGIN:VCALENDAR",
+        "VERSION:2.0",
+        "BEGIN:VEVENT",
+        "UID:timed@icloud",
+        "SUMMARY:Dentist",
+        "LOCATION:Downtown",
+        "DESCRIPTION:Checkup",
+        "DTSTART:20260801T160000Z",
+        "DTEND:20260801T170000Z",
+        "END:VEVENT",
+        "END:VCALENDAR");
+
+    private static string AllDayIcs => string.Join("\n",
+        "BEGIN:VCALENDAR",
+        "VERSION:2.0",
+        "BEGIN:VEVENT",
+        "UID:allday@icloud",
+        "SUMMARY:Offsite",
+        "DTSTART;VALUE=DATE:20260803",
+        "DTEND;VALUE=DATE:20260805",
+        "END:VEVENT",
+        "END:VCALENDAR");
+
+    // Recurring master + an overridden instance (RECURRENCE-ID — skipped in v1) in ONE body,
+    // exactly how CalDAV servers deliver a modified series.
+    private static string RecurringIcs => string.Join("\n",
+        "BEGIN:VCALENDAR",
+        "VERSION:2.0",
+        "BEGIN:VEVENT",
+        "UID:series@icloud",
+        "SUMMARY:Weekly sync",
+        "DTSTART:20260804T090000",
+        "DTEND:20260804T093000",
+        "RRULE:FREQ=WEEKLY;BYDAY=TU",
+        "EXDATE:20260811T090000",
+        "END:VEVENT",
+        "BEGIN:VEVENT",
+        "UID:series@icloud",
+        "SUMMARY:Weekly sync (moved)",
+        "RECURRENCE-ID:20260818T090000",
+        "DTSTART:20260818T100000",
+        "END:VEVENT",
+        "END:VCALENDAR");
+
+    private static string CancelledIcs => string.Join("\n",
+        "BEGIN:VCALENDAR",
+        "VERSION:2.0",
+        "BEGIN:VEVENT",
+        "UID:gone@icloud",
+        "SUMMARY:Cancelled thing",
+        "DTSTART:20260805T090000Z",
+        "STATUS:CANCELLED",
+        "END:VEVENT",
+        "END:VCALENDAR");
+
+    private RecordingHandler FullSyncHandler(params string[] icsBodies)
+        => new(Xml(PrincipalXml), Xml(HomeSetXml), Xml(CollectionsXml), Xml(ReportXml(icsBodies)));
+
+    // ── Full pipeline: discovery + REPORT + mapping ──────────────────────────────
+
+    [Fact]
+    public async Task Sync_FullPipeline_MapsTimedAllDayAndRecurring()
+    {
+        var handler = FullSyncHandler(TimedIcs, AllDayIcs, RecurringIcs, CancelledIcs);
+
+        var result = await Service(handler).SyncAllAsync(TestContext.Current.CancellationToken);
+
+        Assert.Null(result.Error);
+        Assert.Equal(1, result.AccountsSynced);
+        Assert.Equal(3, result.EventsFetched); // cancelled skipped; override folded into master
+
+        var rows = await _store.LoadCalendarEventsAsync();
+        Assert.Equal(3, rows.Count);
+        Assert.All(rows, r =>
+        {
+            Assert.Equal(_accountId, r.AccountId); // the synthetic, deterministic source id
+            Assert.True(r.IsGraph);                // "server-synced row" → read-only in UI
+            Assert.False(r.IsUserCreated);
+            Assert.Equal(CalendarResponseStatus.Accepted, r.ResponseStatus);
+            Assert.Equal(string.Empty, r.SourceMessageId);
+        });
+
+        var timed = rows.Single(r => r.Uid == "timed@icloud");
+        Assert.Equal("Dentist", timed.Summary);
+        Assert.Equal("Downtown", timed.Location);
+        Assert.Equal("Checkup", timed.Description);
+        Assert.Equal(new DateTime(2026, 8, 1, 16, 0, 0, DateTimeKind.Utc).Ticks, timed.StartTimeTicks);
+        Assert.Equal(new DateTime(2026, 8, 1, 17, 0, 0, DateTimeKind.Utc).Ticks, timed.EndTimeTicks);
+        Assert.False(timed.IsAllDay);
+        Assert.Null(timed.RecurrenceRule);
+
+        var allDay = rows.Single(r => r.Uid == "allday@icloud");
+        Assert.True(allDay.IsAllDay);
+        // Exclusive DTEND 08-05 → last day 08-04, re-anchored like every other all-day row.
+        Assert.Equal(new DateTime(2026, 8, 3, 0, 0, 0, DateTimeKind.Local), allDay.StartTime);
+        Assert.Equal(new DateTime(2026, 8, 4, 23, 59, 59, DateTimeKind.Local), allDay.EndTime);
+
+        // Unlike Graph/Google there is no server-side expansion: the master keeps its RRULE so
+        // the local RecurrenceExpander shows occurrences, and the EXDATE hides the deleted one.
+        var series = rows.Single(r => r.Uid == "series@icloud");
+        Assert.Equal("FREQ=WEEKLY;BYDAY=TU", series.RecurrenceRule);
+        Assert.True(series.IsRecurring);
+        Assert.Equal(new DateTime(2026, 8, 11, 9, 0, 0), Assert.Single(series.GetExDates()));
+        Assert.Equal("Weekly sync", series.Summary); // the master, not the skipped override
+    }
+
+    [Fact]
+    public async Task Sync_Discovery_WalksPrincipalHomeAndCollections_WithAuthAndDepth()
+    {
+        var handler = FullSyncHandler(TimedIcs);
+
+        await Service(handler).SyncAllAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(4, handler.Requests.Count);
+        var expectedAuth = "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes($"{Username}:app-pass"));
+        Assert.All(handler.Requests, r => Assert.Equal(expectedAuth, r.Auth));
+
+        Assert.Equal(("PROPFIND", "https://caldav.icloud.com/", "0"),
+                     (handler.Requests[0].Method, handler.Requests[0].Url, handler.Requests[0].Depth));
+        Assert.Contains("current-user-principal", handler.Requests[0].Body);
+
+        Assert.Equal(("PROPFIND", "https://caldav.icloud.com/123456/principal/", "0"),
+                     (handler.Requests[1].Method, handler.Requests[1].Url, handler.Requests[1].Depth));
+        Assert.Contains("calendar-home-set", handler.Requests[1].Body);
+
+        // The home-set href was ABSOLUTE on the partition host — must be honored.
+        Assert.Equal(("PROPFIND", "https://p42-caldav.icloud.com/123456/calendars/", "1"),
+                     (handler.Requests[2].Method, handler.Requests[2].Url, handler.Requests[2].Depth));
+
+        var report = handler.Requests[3];
+        Assert.Equal("REPORT", report.Method);
+        Assert.Equal("https://p42-caldav.icloud.com/123456/calendars/home/", report.Url);
+        Assert.Equal("1", report.Depth);
+        Assert.Contains("calendar-query", report.Body);
+        Assert.Contains("""comp-filter name="VEVENT""", report.Body);
+        Assert.Contains("time-range start=", report.Body);
+    }
+
+    [Fact]
+    public async Task Sync_SecondPass_ReusesDiscoveredCalendar_AndReplacesSlice()
+    {
+        var handler = FullSyncHandler(TimedIcs, AllDayIcs);
+        var service = Service(handler);
+
+        await service.SyncAllAsync(TestContext.Current.CancellationToken);
+        Assert.Equal(2, (await _store.LoadCalendarEventsAsync()).Count);
+
+        // Second pass: the all-day event vanished on the server.
+        handler.Enqueue(Xml(ReportXml(TimedIcs)));
+        await service.SyncAllAsync(TestContext.Current.CancellationToken);
+
+        // 4 discovery+report calls, then ONE more (REPORT only — discovery cached).
+        Assert.Equal(5, handler.Requests.Count);
+        Assert.Equal("REPORT", handler.Requests[4].Method);
+        Assert.Equal("timed@icloud", Assert.Single(await _store.LoadCalendarEventsAsync()).Uid);
+    }
+
+    [Fact]
+    public async Task Sync_LeavesLocalAndInviteRows_Untouched()
+    {
+        await _store.UpsertCalendarEventAsync(new CalendarEvent
+        {
+            Uid = "local-appt", AccountId = CalendarEvent.LocalAccountId, Summary = "Mine",
+        });
+
+        var handler = FullSyncHandler(TimedIcs);
+        await Service(handler).SyncAllAsync(TestContext.Current.CancellationToken);
+
+        var rows = await _store.LoadCalendarEventsAsync();
+        Assert.Equal(2, rows.Count);
+        Assert.Contains(rows, r => r.Uid == "local-appt" && r.IsUserCreated);
+    }
+
+    // ── Failure isolation ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Sync_HttpFailure_ReportsError_AndPriorSliceSurvives()
+    {
+        await _store.ReplaceGraphCalendarEventsAsync(_accountId, [new CalendarEvent
+        {
+            Uid = "old-slice", AccountId = _accountId, Summary = "Old slice",
+        }]);
+        var handler = new RecordingHandler(
+            new HttpResponseMessage(HttpStatusCode.Unauthorized) { Content = new StringContent("bad app password") });
+
+        var result = await Service(handler).SyncAllAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(0, result.AccountsSynced);
+        Assert.NotNull(result.Error);
+        Assert.Contains("401", result.Error);
+        // Replace happens only after a full successful fetch — the previous slice survives.
+        Assert.Equal("old-slice", Assert.Single(await _store.LoadCalendarEventsAsync()).Uid);
+    }
+
+    [Fact]
+    public async Task Sync_MissingSavedPassword_ReportsError_WithoutAnyRequest()
+    {
+        var handler = FullSyncHandler(TimedIcs);
+
+        var result = await Service(handler, credentials: new SecretCredentialService())
+            .SyncAllAsync(TestContext.Current.CancellationToken);
+
+        Assert.NotNull(result.Error);
+        Assert.Contains("Settings", result.Error);
+        Assert.Empty(handler.Requests);
+        Assert.Empty(await _store.LoadCalendarEventsAsync());
+    }
+
+    [Fact]
+    public async Task Sync_NoCalDavConfigured_DoesNothing()
+    {
+        var handler = FullSyncHandler(TimedIcs);
+
+        var result = await Service(handler, config: new CalDavConfigService(configured: false))
+            .SyncAllAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(GraphCalendarSyncResult.None, result);
+        Assert.Empty(handler.Requests);
+    }
+
+    // ── Redirect handling (iCloud partition hosts) ───────────────────────────────
+
+    [Fact]
+    public async Task Discovery_FollowsCrossHostRedirect_ReattachingBasicAuth()
+    {
+        var redirect = new HttpResponseMessage(HttpStatusCode.MovedPermanently);
+        redirect.Headers.Location = new Uri("https://p42-caldav.icloud.com/");
+        var handler = new RecordingHandler(redirect, Xml(PrincipalXml), Xml(HomeSetXml), Xml(CollectionsXml));
+        using var client = new CalDavCalendarClient(new HttpClient(handler));
+
+        var info = await client.DiscoverCalendarAsync(ServerUrl, Username, "app-pass",
+                                                      TestContext.Current.CancellationToken);
+
+        // 1 redirected principal hop + re-issue, then home-set, then collections.
+        Assert.Equal(4, handler.Requests.Count);
+        Assert.Equal("https://p42-caldav.icloud.com/", handler.Requests[1].Url);
+        // .NET strips Authorization on cross-host auto-redirects; the manual re-issue must not.
+        Assert.All(handler.Requests, r => Assert.StartsWith("Basic ", r.Auth));
+        // Relative hrefs resolve against the host that ANSWERED (the redirect target).
+        Assert.Equal("https://p42-caldav.icloud.com/123456/calendars/home/", info.Url);
+        Assert.Equal("Home", info.DisplayName);
+    }
+
+    // ── Client parsing units ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void ParseInnerHref_FindsNestedHref_RegardlessOfPrefix()
+    {
+        Assert.Equal("/123456/principal/",
+            CalDavCalendarClient.ParseInnerHref(PrincipalXml, "current-user-principal"));
+        Assert.Equal("https://p42-caldav.icloud.com/123456/calendars/",
+            CalDavCalendarClient.ParseInnerHref(HomeSetXml, "calendar-home-set"));
+        Assert.Null(CalDavCalendarClient.ParseInnerHref(EmptyMultistatus, "current-user-principal"));
+    }
+
+    [Fact]
+    public void ParseFirstVEventCalendar_SkipsPlainCollectionsAndVTodoLists()
+    {
+        var (href, name) = CalDavCalendarClient.ParseFirstVEventCalendar(CollectionsXml)!.Value;
+        Assert.Equal("/123456/calendars/home/", href);
+        Assert.Equal("Home", name);
+    }
+
+    [Fact]
+    public void ParseFirstVEventCalendar_MissingComponentSet_CountsAsVEventCapable()
+    {
+        const string xml =
+            """
+            <d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
+              <d:response>
+                <d:href>/cal/</d:href>
+                <d:propstat><d:prop>
+                  <d:resourcetype><d:collection/><c:calendar/></d:resourcetype>
+                </d:prop></d:propstat>
+              </d:response>
+            </d:multistatus>
+            """;
+        var (href, name) = CalDavCalendarClient.ParseFirstVEventCalendar(xml)!.Value;
+        Assert.Equal("/cal/", href);
+        Assert.Equal("Calendar", name); // no displayname → fallback
+    }
+
+    [Fact]
+    public void ParseFirstVEventCalendar_NoCalendars_ReturnsNull()
+    {
+        Assert.Null(CalDavCalendarClient.ParseFirstVEventCalendar(EmptyMultistatus));
+    }
+
+    [Fact]
+    public void ParseCalendarData_ExtractsEveryIcsBody()
+    {
+        var bodies = CalDavCalendarClient.ParseCalendarData(ReportXml(TimedIcs, AllDayIcs));
+        Assert.Equal(2, bodies.Count);
+        Assert.Contains("UID:timed@icloud", bodies[0]);
+        Assert.Contains("UID:allday@icloud", bodies[1]);
+    }
+
+    // ── Synthetic account id ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void AccountIdFor_IsDeterministic_AndNormalized()
+    {
+        var a = CalDavCalendarClient.AccountIdFor("https://caldav.icloud.com", "kelly@example.com");
+        Assert.Equal(a, CalDavCalendarClient.AccountIdFor("https://caldav.icloud.com/", "Kelly@Example.com "));
+        Assert.NotEqual(Guid.Empty, a);
+        Assert.NotEqual(a, CalDavCalendarClient.AccountIdFor("https://caldav.icloud.com", "other@example.com"));
+        Assert.NotEqual(a, CalDavCalendarClient.AccountIdFor("https://caldav.fastmail.com", "kelly@example.com"));
+    }
+
+    // ── Mapping units ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void MapCalDavEvents_DuplicateUids_CollapseToOneRow()
+    {
+        var rows = GraphCalendarSyncService.MapCalDavEvents([TimedIcs, TimedIcs], _accountId);
+        Assert.Single(rows);
+    }
+
+    [Fact]
+    public void MapCalDavEvents_MissingUid_GetsStableSyntheticUid()
+    {
+        var ics = string.Join("\n",
+            "BEGIN:VCALENDAR",
+            "BEGIN:VEVENT",
+            "SUMMARY:No uid",
+            "DTSTART:20260801T090000Z",
+            "END:VEVENT",
+            "END:VCALENDAR");
+
+        var first  = Assert.Single(GraphCalendarSyncService.MapCalDavEvents([ics], _accountId));
+        var second = Assert.Single(GraphCalendarSyncService.MapCalDavEvents([ics], _accountId));
+
+        Assert.StartsWith("caldav-", first.Uid);
+        Assert.Equal(first.Uid, second.Uid); // stable across passes → replace-slice keeps identity
+    }
+}

--- a/QuickMail.Tests/CalendarStoreTests.cs
+++ b/QuickMail.Tests/CalendarStoreTests.cs
@@ -65,6 +65,49 @@ public class CalendarStoreTests : IDisposable
         Assert.Equal(evt.StartTimeTicks, r.StartTimeTicks);
         Assert.Equal(CalendarResponseStatus.Accepted, r.ResponseStatus);
         Assert.Equal("msg-1", r.SourceMessageId);
+        Assert.False(r.IsAllDay);
+    }
+
+    [Fact]
+    public async Task AllDayFlag_RoundTrips()
+    {
+        var evt = new CalendarEvent
+        {
+            Uid = "local-allday",
+            AccountId = CalendarEvent.LocalAccountId,
+            Summary = "Holiday",
+            StartTimeTicks = DateTime.UtcNow.Date.Ticks,
+            EndTimeTicks = DateTime.UtcNow.Date.AddDays(1).AddSeconds(-1).Ticks,
+            IsAllDay = true,
+            ResponseStatus = CalendarResponseStatus.Accepted,
+        };
+
+        await _store.UpsertCalendarEventAsync(evt);
+        var loaded = await _store.LoadCalendarEventsAsync();
+
+        Assert.Single(loaded);
+        Assert.True(loaded[0].IsAllDay);
+        Assert.True(loaded[0].IsUserCreated);
+    }
+
+    [Fact]
+    public async Task RecurrenceRule_RoundTrips()
+    {
+        var evt = new CalendarEvent
+        {
+            Uid = "local-weekly",
+            AccountId = CalendarEvent.LocalAccountId,
+            Summary = "Standup",
+            StartTimeTicks = DateTime.UtcNow.Date.AddHours(9).Ticks,
+            RecurrenceRule = "FREQ=WEEKLY;BYDAY=TU",
+            ResponseStatus = CalendarResponseStatus.Accepted,
+        };
+
+        await _store.UpsertCalendarEventAsync(evt);
+        var loaded = (await _store.LoadCalendarEventsAsync()).Single();
+
+        Assert.Equal("FREQ=WEEKLY;BYDAY=TU", loaded.RecurrenceRule);
+        Assert.True(loaded.IsRecurring);
     }
 
     [Fact]

--- a/QuickMail.Tests/CalendarViewModelTests.cs
+++ b/QuickMail.Tests/CalendarViewModelTests.cs
@@ -203,6 +203,48 @@ public class CalendarViewModelTests
     }
 
     [Fact]
+    public async Task AccountFilter_ShowsOnlyThatSource()
+    {
+        var acctA = Guid.NewGuid();
+        var local = new CalendarEvent
+        {
+            Uid = "loc-1", AccountId = CalendarEvent.LocalAccountId, Summary = "Mine",
+            StartTimeTicks = DateTime.Today.AddHours(9).ToUniversalTime().Ticks,
+            ResponseStatus = CalendarResponseStatus.Accepted,
+        };
+        var fromA = MakeEvent("a-1", DateTime.Today.AddHours(10)); fromA.AccountId = acctA;
+        var fromB = MakeEvent("b-1", DateTime.Today.AddHours(11)); // random other account
+
+        var vm = MakeVm(new List<CalendarEvent> { local, fromA, fromB });
+        await vm.LoadAsync();
+        Assert.Equal(3, vm.VisibleEvents.Count);          // null filter = all
+
+        vm.AccountFilter = acctA;                          // one account's calendar
+        Assert.Single(vm.VisibleEvents);
+        Assert.Equal("a-1", vm.VisibleEvents[0].Uid);
+
+        vm.AccountFilter = Guid.Empty;                     // local appointments only
+        Assert.Single(vm.VisibleEvents);
+        Assert.Equal("loc-1", vm.VisibleEvents[0].Uid);
+
+        vm.AccountFilter = null;                           // back to all
+        Assert.Equal(3, vm.VisibleEvents.Count);
+    }
+
+    [Fact]
+    public void CalendarFilterFor_MapsFolderNamesCorrectly()
+    {
+        var id = Guid.NewGuid();
+        Assert.Null(MainViewModel.CalendarFilterFor(MainViewModel.CalendarFolder.FullName));
+        Assert.Null(MainViewModel.CalendarFilterFor(MainViewModel.CalendarSourcePrefix + "all"));
+        Assert.Equal(Guid.Empty, MainViewModel.CalendarFilterFor(MainViewModel.CalendarSourcePrefix + "local"));
+        Assert.Equal(id, MainViewModel.CalendarFilterFor(MainViewModel.CalendarSourcePrefix + id.ToString("D")));
+        Assert.True(MainViewModel.IsCalendarFolderName(MainViewModel.CalendarSourcePrefix + "local"));
+        Assert.True(MainViewModel.IsCalendarFolderName(MainViewModel.CalendarFolder.FullName));
+        Assert.False(MainViewModel.IsCalendarFolderName("INBOX"));
+    }
+
+    [Fact]
     public async Task MonthView_Builds42Cells_WithCountsAndSelection()
     {
         var today = DateTime.Today;

--- a/QuickMail.Tests/CalendarViewModelTests.cs
+++ b/QuickMail.Tests/CalendarViewModelTests.cs
@@ -292,6 +292,92 @@ public class CalendarViewModelTests
     }
 
     [Fact]
+    public async Task ExDate_SkipsThatOccurrenceOnly()
+    {
+        var start = DateTime.Today.AddHours(9);
+        var master = MakeRecurring("x1", start, "FREQ=DAILY;COUNT=5");
+        master.AddExDate(start.AddDays(2)); // exclude the third day
+        var vm = MakeVm(new List<CalendarEvent> { master });
+        await vm.LoadAsync();
+
+        Assert.Equal(4, vm.VisibleEvents.Count);
+        Assert.DoesNotContain(vm.VisibleEvents, e => e.StartTime == start.AddDays(2));
+    }
+
+    [Fact]
+    public async Task DeleteOccurrence_ExDatesMasterAndKeepsSeries()
+    {
+        var start = DateTime.Today.AddHours(9);
+        var svc = new StubCalendarService { StoredEvents = [MakeRecurring("d1", start, "FREQ=DAILY;COUNT=4")] };
+        var vm = new CalendarViewModel(svc, onlineMode: false, showDeclinedEvents: false);
+        await vm.LoadAsync();
+        Assert.Equal(4, vm.VisibleEvents.Count);
+
+        var second = vm.VisibleEvents[1];             // tomorrow's occurrence
+        Action? deleteOne = null;
+        vm.RecurringDeleteConfirmRequested += (_, one, _) => deleteOne = one;
+        vm.DeleteEventCommand.Execute(second);
+        Assert.NotNull(deleteOne);
+        deleteOne!();
+
+        // Master survives with an EXDATE; only 3 occurrences remain.
+        Assert.Single(svc.StoredEvents);
+        Assert.Contains(svc.StoredEvents[0].GetExDates(), d => d == start.AddDays(1));
+        Assert.Equal(3, vm.VisibleEvents.Count);
+    }
+
+    [Fact]
+    public async Task EditThisEventOnly_DetachesOccurrence()
+    {
+        var start = DateTime.Today.AddHours(9);
+        var svc = new StubCalendarService { StoredEvents = [MakeRecurring("m1", start, "FREQ=DAILY;COUNT=3")] };
+        var vm = new CalendarViewModel(svc, onlineMode: false, showDeclinedEvents: false);
+        await vm.LoadAsync();
+
+        EventEditorViewModel? editor = null;
+        vm.EditorRequested += e => editor = e;
+        vm.EditEventCommand.Execute(vm.VisibleEvents[1]); // tomorrow's occurrence
+
+        Assert.NotNull(editor);
+        Assert.True(editor!.IsRecurringEdit);
+        Assert.True(editor.EditThisEventOnly);            // default scope
+        editor.Title = "Moved just this one";
+        editor.SaveCommand.Execute(null);
+
+        // Master got an EXDATE; a standalone copy exists with a new uid.
+        Assert.Equal(2, svc.StoredEvents.Count);
+        var master = svc.StoredEvents.First(e => e.Uid == "m1");
+        var detached = svc.StoredEvents.First(e => e.Uid != "m1");
+        Assert.Single(master.GetExDates());
+        Assert.Equal("Moved just this one", detached.Summary);
+        Assert.False(detached.IsRecurring);
+
+        // Still 3 visible: 2 remaining series occurrences + the detached copy.
+        Assert.Equal(3, vm.VisibleEvents.Count);
+    }
+
+    [Fact]
+    public async Task EditAllEvents_UpdatesSeriesMaster()
+    {
+        var start = DateTime.Today.AddHours(9);
+        var svc = new StubCalendarService { StoredEvents = [MakeRecurring("m2", start, "FREQ=DAILY;COUNT=3")] };
+        var vm = new CalendarViewModel(svc, onlineMode: false, showDeclinedEvents: false);
+        await vm.LoadAsync();
+
+        EventEditorViewModel? editor = null;
+        vm.EditorRequested += e => editor = e;
+        vm.EditEventCommand.Execute(vm.VisibleEvents[1]);
+
+        editor!.EditThisEventOnly = false;   // All events
+        editor.Title = "Whole series renamed";
+        editor.SaveCommand.Execute(null);
+
+        Assert.Single(svc.StoredEvents);     // still one master, no detached copy
+        Assert.Equal("Whole series renamed", svc.StoredEvents[0].Summary);
+        Assert.True(svc.StoredEvents[0].IsRecurring);
+    }
+
+    [Fact]
     public async Task RecurringWithCount_StopsAfterN()
     {
         var start = DateTime.Today.AddHours(9);

--- a/QuickMail.Tests/CalendarViewModelTests.cs
+++ b/QuickMail.Tests/CalendarViewModelTests.cs
@@ -28,10 +28,11 @@ public class CalendarViewModelTests
             SourceFolder = "INBOX",
         };
 
-    private static CalendarViewModel MakeVm(List<CalendarEvent> events, bool onlineMode = false, bool showDeclined = false)
+    private static CalendarViewModel MakeVm(List<CalendarEvent> events, bool onlineMode = false,
+                                            bool showDeclined = false, bool showFieldLabels = false)
     {
         var svc = new StubCalendarService { StoredEvents = events };
-        return new CalendarViewModel(svc, onlineMode, showDeclined);
+        return new CalendarViewModel(svc, onlineMode, showDeclined, showFieldLabels);
     }
 
     [Fact]
@@ -55,7 +56,7 @@ public class CalendarViewModelTests
     }
 
     [Fact]
-    public async Task LoadAsync_WithNoEvents_AnnouncesStatus()
+    public async Task LoadAsync_WithNoEvents_AnnouncesCreateHint()
     {
         var vm = MakeVm(new List<CalendarEvent>());
 
@@ -66,9 +67,219 @@ public class CalendarViewModelTests
         await vm.LoadAsync();
 
         Assert.Empty(vm.VisibleEvents);
-        Assert.Equal(AnnouncementCategory.Status, cat);
+        Assert.Equal(AnnouncementCategory.Hint, cat);
         Assert.Contains("No events", announced);
-        Assert.DoesNotContain("Escape", announced);
+        Assert.Contains("Press N", announced);
+    }
+
+    [Fact]
+    public async Task FieldLabels_Off_StampsDataOnlyAccessibleName()
+    {
+        var vm = MakeVm(new List<CalendarEvent> { MakeEvent("e1", DateTime.Today.AddHours(10)) },
+                        showFieldLabels: false);
+        await vm.LoadAsync();
+
+        var name = vm.VisibleEvents[0].AccessibleName;
+        Assert.Equal(vm.VisibleEvents[0].DisplayLine, name);
+        Assert.DoesNotContain("Subject ", name);
+    }
+
+    [Fact]
+    public async Task FieldLabels_On_StampsLabeledAccessibleName()
+    {
+        var vm = MakeVm(new List<CalendarEvent> { MakeEvent("e1", DateTime.Today.AddHours(10)) },
+                        showFieldLabels: true);
+        await vm.LoadAsync();
+
+        var name = vm.VisibleEvents[0].AccessibleName;
+        Assert.StartsWith("Subject ", name);
+        Assert.Contains(", when ", name);
+    }
+
+    [Fact]
+    public async Task ShowFieldLabels_ToggledLive_RestampsRows()
+    {
+        var vm = MakeVm(new List<CalendarEvent> { MakeEvent("e1", DateTime.Today.AddHours(10)) },
+                        showFieldLabels: false);
+        await vm.LoadAsync();
+        Assert.DoesNotContain("Subject ", vm.VisibleEvents[0].AccessibleName);
+
+        vm.ShowFieldLabels = true;   // e.g. from ApplySettings
+        Assert.StartsWith("Subject ", vm.VisibleEvents[0].AccessibleName);
+    }
+
+    [Fact]
+    public void NewEvent_RaisesEditorRequested_AndSavePersistsToService()
+    {
+        var svc = new StubCalendarService { StoredEvents = [] };
+        var vm = new CalendarViewModel(svc, onlineMode: false, showDeclinedEvents: false);
+
+        EventEditorViewModel? editor = null;
+        vm.EditorRequested += e => editor = e;
+
+        vm.NewEventCommand.Execute(null);
+        Assert.NotNull(editor);
+
+        editor!.Title = "Coffee";
+        editor.SaveCommand.Execute(null);
+
+        Assert.Single(svc.StoredEvents);
+        Assert.Equal("Coffee", svc.StoredEvents[0].Summary);
+        Assert.True(svc.StoredEvents[0].IsUserCreated);
+    }
+
+    [Fact]
+    public void EditEvent_OnInviteSourcedEvent_AnnouncesAndDoesNotOpenEditor()
+    {
+        var invite = MakeEvent("inv1", DateTime.Today.AddHours(9)); // has a real AccountId
+        var vm = MakeVm(new List<CalendarEvent> { invite });
+
+        var editorOpened = false;
+        string? announced = null;
+        vm.EditorRequested += _ => editorOpened = true;
+        vm.AnnouncementRequested += (t, _) => announced = t;
+
+        vm.EditEventCommand.Execute(invite);
+
+        Assert.False(editorOpened);
+        Assert.Contains("created can be edited", announced);
+    }
+
+    [Fact]
+    public async Task DayView_FiltersToReferenceDate()
+    {
+        var today = DateTime.Today;
+        var vm = MakeVm(new List<CalendarEvent>
+        {
+            MakeEvent("today-1", today.AddHours(9)),
+            MakeEvent("today-2", today.AddHours(15)),
+            MakeEvent("tomorrow", today.AddDays(1).AddHours(9)),
+        });
+        await vm.LoadAsync();
+        Assert.Equal(3, vm.VisibleEvents.Count); // Agenda shows all
+
+        vm.ShowDayCommand.Execute(null);         // Day view, reference = today
+        Assert.Equal(2, vm.VisibleEvents.Count);
+        Assert.All(vm.VisibleEvents, e => Assert.Equal(today, e.StartTime!.Value.Date));
+        Assert.Contains("Day:", vm.PeriodLabel);
+    }
+
+    [Fact]
+    public async Task DayView_NextPeriod_MovesToNextDay()
+    {
+        var today = DateTime.Today;
+        var vm = MakeVm(new List<CalendarEvent>
+        {
+            MakeEvent("today", today.AddHours(9)),
+            MakeEvent("tomorrow", today.AddDays(1).AddHours(9)),
+        });
+        await vm.LoadAsync();
+        vm.ShowDayCommand.Execute(null);
+        Assert.Single(vm.VisibleEvents);
+        Assert.Equal("today", vm.VisibleEvents[0].Uid);
+
+        vm.NextPeriodCommand.Execute(null);      // advance one day
+        Assert.Single(vm.VisibleEvents);
+        Assert.Equal("tomorrow", vm.VisibleEvents[0].Uid);
+    }
+
+    [Fact]
+    public async Task WeekView_IncludesWholeWeek_ExcludesNextWeek()
+    {
+        var today = DateTime.Today;
+        var vm = MakeVm(new List<CalendarEvent>
+        {
+            MakeEvent("in-week", today.AddHours(9)),
+            MakeEvent("plus-3", today.AddDays(3).AddHours(9)),
+            MakeEvent("plus-9", today.AddDays(9).AddHours(9)),
+        });
+        await vm.LoadAsync();
+        vm.ShowWeekCommand.Execute(null);
+
+        // The event 9 days out is definitely in a later week regardless of week-start day.
+        Assert.DoesNotContain(vm.VisibleEvents, e => e.Uid == "plus-9");
+        Assert.Contains(vm.VisibleEvents, e => e.Uid == "in-week");
+        Assert.Contains("Week of", vm.PeriodLabel);
+    }
+
+    private static CalendarEvent MakeRecurring(string uid, DateTime start, string rrule)
+        => new()
+        {
+            Uid = uid,
+            AccountId = CalendarEvent.LocalAccountId,
+            Summary = $"Recurring {uid}",
+            StartTimeTicks = start.ToUniversalTime().Ticks,
+            EndTimeTicks = start.AddMinutes(30).ToUniversalTime().Ticks,
+            RecurrenceRule = rrule,
+            ResponseStatus = CalendarResponseStatus.Accepted,
+        };
+
+    [Fact]
+    public async Task WeeklyRecurring_ExpandsAcrossWeekView()
+    {
+        // Weekly on the reference week's Monday, starting 4 weeks earlier.
+        var start = DateTime.Today.AddDays(-(int)DateTime.Today.DayOfWeek + 1).AddDays(-28).AddHours(9);
+        var vm = MakeVm(new List<CalendarEvent> { MakeRecurring("w1", start, "FREQ=WEEKLY") });
+        await vm.LoadAsync();
+
+        vm.ShowWeekCommand.Execute(null); // ReferenceDate defaults to today
+
+        // Exactly one occurrence falls in the current week (same weekday as start).
+        Assert.Single(vm.VisibleEvents);
+        Assert.True(vm.VisibleEvents[0].IsRecurring);
+        Assert.Equal(start.DayOfWeek, vm.VisibleEvents[0].StartTime!.Value.DayOfWeek);
+    }
+
+    [Fact]
+    public async Task DailyRecurring_ExpandsAcrossDayAndAgenda()
+    {
+        var start = DateTime.Today.AddDays(-3).AddHours(8);
+        var vm = MakeVm(new List<CalendarEvent> { MakeRecurring("d1", start, "FREQ=DAILY") });
+        await vm.LoadAsync();
+
+        // Day view for today → exactly one occurrence today.
+        vm.ShowDayCommand.Execute(null);
+        Assert.Single(vm.VisibleEvents);
+        Assert.Equal(DateTime.Today, vm.VisibleEvents[0].StartTime!.Value.Date);
+
+        // Agenda (all) → many occurrences across the look-ahead window.
+        vm.ShowAgendaCommand.Execute(null);
+        Assert.True(vm.VisibleEvents.Count > 10);
+    }
+
+    [Fact]
+    public async Task RecurringWithCount_StopsAfterN()
+    {
+        var start = DateTime.Today.AddHours(9);
+        var vm = MakeVm(new List<CalendarEvent> { MakeRecurring("c1", start, "FREQ=DAILY;COUNT=3") });
+        await vm.LoadAsync(); // Agenda, all
+
+        Assert.Equal(3, vm.VisibleEvents.Count);
+    }
+
+    [Fact]
+    public void DeleteEvent_LocalEvent_ConfirmsThenDeletes()
+    {
+        var local = new CalendarEvent
+        {
+            Uid = "local-1",
+            AccountId = CalendarEvent.LocalAccountId,
+            Summary = "Gym",
+            StartTimeTicks = DateTime.Today.AddHours(18).ToUniversalTime().Ticks,
+            ResponseStatus = CalendarResponseStatus.Accepted,
+        };
+        var svc = new StubCalendarService { StoredEvents = [local] };
+        var vm = new CalendarViewModel(svc, onlineMode: false, showDeclinedEvents: false);
+
+        Action? confirm = null;
+        vm.DeleteConfirmRequested += (_, cb) => confirm = cb;
+
+        vm.DeleteEventCommand.Execute(local);
+        Assert.NotNull(confirm);      // confirmation requested, not yet deleted
+        Assert.Single(svc.StoredEvents);
+
+        confirm!();                    // user confirms
+        Assert.Empty(svc.StoredEvents);
     }
 
     [Fact]

--- a/QuickMail.Tests/CalendarViewModelTests.cs
+++ b/QuickMail.Tests/CalendarViewModelTests.cs
@@ -746,6 +746,39 @@ public class CalendarViewModelTests
         return (vm, store, sync, account);
     }
 
+    [Fact]
+    public void IsCalendarPushAccount_CoversGraphAndGoogle()
+    {
+        Assert.True(MainViewModel.IsCalendarPushAccount(new AccountModel { BackendKind = BackendKind.MicrosoftGraph }));
+        Assert.True(MainViewModel.IsCalendarPushAccount(new AccountModel { AuthType = AuthType.OAuth2Google }));
+        Assert.False(MainViewModel.IsCalendarPushAccount(new AccountModel { AuthType = AuthType.Password }));
+    }
+
+    [Fact]
+    public async Task GoogleAccount_EditRoutesThroughServerPush()
+    {
+        // A Google account in the push-accounts list: routing must treat it like Microsoft.
+        var account = new AccountModel { Id = Guid.NewGuid(), AuthType = AuthType.OAuth2Google, Username = "k@gmail.com" };
+        var store = new StubCalendarService();
+        var sync = new StubGraphCalendarSyncService();
+        var vm = new CalendarViewModel(store, onlineMode: false, showDeclinedEvents: false,
+                                       showFieldLabels: false, graphSync: sync,
+                                       graphAccountsProvider: () => new[] { account });
+        var row = MakeGraphRow(account.Id, "goog-rw-1");
+        store.StoredEvents.Add(row);
+        await vm.LoadAsync();
+
+        EventEditorViewModel? editor = null;
+        vm.EditorRequested += e => editor = e;
+        vm.EditEventCommand.Execute(row);
+
+        Assert.NotNull(editor);                       // editable, not read-only
+        editor!.Title = "Moved on Google";
+        editor.SaveCommand.Execute(null);
+        Assert.Single(sync.UpdatedEvents);
+        Assert.Equal(account.Id, sync.UpdatedEvents[0].AccountId);
+    }
+
     private static CalendarEvent MakeGraphRow(Guid accountId, string uid = "srv-1") => new()
     {
         Uid = uid, AccountId = accountId, IsGraph = true, Summary = "Server event",

--- a/QuickMail.Tests/CalendarViewModelTests.cs
+++ b/QuickMail.Tests/CalendarViewModelTests.cs
@@ -202,6 +202,50 @@ public class CalendarViewModelTests
         Assert.Contains("Week of", vm.PeriodLabel);
     }
 
+    [Fact]
+    public async Task SearchText_FiltersAcrossSummaryLocationAndNotes()
+    {
+        var events = new List<CalendarEvent>
+        {
+            MakeEvent("e1", DateTime.Today.AddHours(9)),
+            MakeEvent("e2", DateTime.Today.AddHours(10)),
+            MakeEvent("e3", DateTime.Today.AddHours(11)),
+        };
+        events[0].Summary = "Dentist visit";
+        events[1].Location = "Dentist office downtown";
+        events[2].Description = "Ask the dentist about crowns";
+        events.Add(MakeEvent("e4", DateTime.Today.AddHours(12))); // no match
+
+        var vm = MakeVm(events);
+        await vm.LoadAsync();
+        Assert.Equal(4, vm.VisibleEvents.Count);
+
+        vm.SearchText = "dentist";
+        Assert.Equal(3, vm.VisibleEvents.Count);
+
+        vm.ClearSearch();
+        Assert.Equal(4, vm.VisibleEvents.Count);
+        Assert.False(vm.IsSearchActive);
+        Assert.Equal(string.Empty, vm.SearchText);
+    }
+
+    [Fact]
+    public async Task SearchText_CombinesWithDayView()
+    {
+        var today = DateTime.Today;
+        var e1 = MakeEvent("t1", today.AddHours(9));  e1.Summary = "Budget review";
+        var e2 = MakeEvent("t2", today.AddHours(10)); e2.Summary = "Lunch";
+        var e3 = MakeEvent("m1", today.AddDays(1).AddHours(9)); e3.Summary = "Budget kickoff"; // tomorrow
+
+        var vm = MakeVm(new List<CalendarEvent> { e1, e2, e3 });
+        await vm.LoadAsync();
+        vm.ShowDayCommand.Execute(null);   // today only
+        vm.SearchText = "budget";
+
+        Assert.Single(vm.VisibleEvents);   // tomorrow's budget event is outside the day window
+        Assert.Equal("t1", vm.VisibleEvents[0].Uid);
+    }
+
     private static CalendarEvent MakeRecurring(string uid, DateTime start, string rrule)
         => new()
         {

--- a/QuickMail.Tests/CalendarViewModelTests.cs
+++ b/QuickMail.Tests/CalendarViewModelTests.cs
@@ -909,7 +909,7 @@ public class CalendarViewModelTests
         Assert.Equal(CalendarEvent.LocalAccountId, saved.AccountId);
         Assert.True(saved.IsUserCreated);
         Assert.Contains(announcements, a =>
-            a.Contains("Could not save to") && a.Contains("Saved to My Appointments instead."));
+            a.Contains("Could not save to") && a.Contains("Saved to Local Calendar instead."));
     }
 
     [Fact]

--- a/QuickMail.Tests/CalendarViewModelTests.cs
+++ b/QuickMail.Tests/CalendarViewModelTests.cs
@@ -203,6 +203,59 @@ public class CalendarViewModelTests
     }
 
     [Fact]
+    public async Task MonthView_Builds42Cells_WithCountsAndSelection()
+    {
+        var today = DateTime.Today;
+        var vm = MakeVm(new List<CalendarEvent>
+        {
+            MakeEvent("m1", today.AddHours(9)),
+            MakeEvent("m2", today.AddHours(14)),
+        });
+        await vm.LoadAsync();
+
+        vm.ShowMonthCommand.Execute(null);
+
+        Assert.Equal(42, vm.MonthCells.Count);
+        Assert.NotNull(vm.SelectedMonthCell);
+        Assert.Equal(today, vm.SelectedMonthCell!.Date);
+        Assert.Equal(2, vm.SelectedMonthCell.EventCount);
+        Assert.Contains("2 events", vm.SelectedMonthCell.AccessibleName);
+        Assert.Contains("today", vm.SelectedMonthCell.AccessibleName);
+        Assert.Contains(today.ToString("MMMM yyyy"), vm.PeriodLabel);
+        // Details pane shows the selected day's events.
+        Assert.Contains("Event m1", vm.SelectedEventDetail);
+    }
+
+    [Fact]
+    public async Task MonthView_DrillIntoDay_SwitchesToDayView()
+    {
+        var today = DateTime.Today;
+        var vm = MakeVm(new List<CalendarEvent> { MakeEvent("m3", today.AddHours(9)) });
+        await vm.LoadAsync();
+        vm.ShowMonthCommand.Execute(null);
+
+        vm.DrillIntoDayCommand.Execute(null);
+
+        Assert.True(vm.IsDayView);
+        Assert.Equal(today, vm.ReferenceDate.Date);
+        Assert.Single(vm.VisibleEvents);
+    }
+
+    [Fact]
+    public async Task MonthView_NextPeriod_MovesOneMonth()
+    {
+        var vm = MakeVm(new List<CalendarEvent> { MakeEvent("m4", DateTime.Today.AddHours(9)) });
+        await vm.LoadAsync();
+        vm.ShowMonthCommand.Execute(null);
+        var before = vm.ReferenceDate;
+
+        vm.NextPeriodCommand.Execute(null);
+
+        Assert.Equal(before.AddMonths(1).Month, vm.ReferenceDate.Month);
+        Assert.Equal(42, vm.MonthCells.Count);
+    }
+
+    [Fact]
     public async Task SearchText_FiltersAcrossSummaryLocationAndNotes()
     {
         var events = new List<CalendarEvent>

--- a/QuickMail.Tests/CalendarViewModelTests.cs
+++ b/QuickMail.Tests/CalendarViewModelTests.cs
@@ -726,4 +726,82 @@ public class CalendarViewModelTests
         Assert.Equal("noon", vm.VisibleEvents[1].Uid);
         Assert.Equal("late", vm.VisibleEvents[2].Uid);
     }
+
+    // ── Save-target push (new appointments) ──────────────────────────────────────
+
+    private static (CalendarViewModel Vm, StubCalendarService Store, StubGraphCalendarSyncService Sync, AccountModel Account)
+        MakePushVm()
+    {
+        var account = new AccountModel
+        {
+            Id = Guid.NewGuid(),
+            BackendKind = BackendKind.MicrosoftGraph,
+            Username = "work@example.com",
+        };
+        var store = new StubCalendarService();
+        var sync = new StubGraphCalendarSyncService();
+        var vm = new CalendarViewModel(store, onlineMode: false, showDeclinedEvents: false,
+                                       showFieldLabels: false, graphSync: sync,
+                                       graphAccountsProvider: () => new[] { account });
+        return (vm, store, sync, account);
+    }
+
+    [Fact]
+    public async Task SaveNewEvent_AccountTarget_PushesToGraph()
+    {
+        var (vm, store, sync, account) = MakePushVm();
+        var evt = new CalendarEvent
+        {
+            Uid = "local-tmp", AccountId = account.Id, Summary = "Pushed",
+            StartTimeTicks = DateTime.UtcNow.AddHours(1).Ticks,
+        };
+
+        await vm.SaveNewEventAsync(evt);
+
+        var created = Assert.Single(sync.CreatedEvents);
+        Assert.Equal(account.Id, created.AccountId);
+        Assert.True(created.IsGraph);
+        // The push path persists via the sync service (server copy), not a local upsert.
+        Assert.DoesNotContain(store.StoredEvents, e => e.Uid == "local-tmp");
+    }
+
+    [Fact]
+    public async Task SaveNewEvent_PushFails_FallsBackToLocal_AndAnnounces()
+    {
+        var (vm, store, sync, account) = MakePushVm();
+        sync.CreateFailure = new InvalidOperationException("network down");
+        var announcements = new List<string>();
+        vm.AnnouncementRequested += (text, _) => announcements.Add(text);
+        var evt = new CalendarEvent
+        {
+            Uid = "local-fallback", AccountId = account.Id, Summary = "Keep me",
+            StartTimeTicks = DateTime.UtcNow.AddHours(1).Ticks,
+        };
+
+        await vm.SaveNewEventAsync(evt);
+
+        // Saved locally so the user's data is never lost.
+        var saved = Assert.Single(store.StoredEvents);
+        Assert.Equal("local-fallback", saved.Uid);
+        Assert.Equal(CalendarEvent.LocalAccountId, saved.AccountId);
+        Assert.True(saved.IsUserCreated);
+        Assert.Contains(announcements, a =>
+            a.Contains("Could not save to") && a.Contains("Saved to My Appointments instead."));
+    }
+
+    [Fact]
+    public async Task SaveNewEvent_LocalTarget_SavesLocallyWithoutPush()
+    {
+        var (vm, store, sync, _) = MakePushVm();
+        var evt = new CalendarEvent
+        {
+            Uid = "local-only", AccountId = CalendarEvent.LocalAccountId, Summary = "Local",
+            StartTimeTicks = DateTime.UtcNow.AddHours(1).Ticks,
+        };
+
+        await vm.SaveNewEventAsync(evt);
+
+        Assert.Empty(sync.CreatedEvents);
+        Assert.Equal("local-only", Assert.Single(store.StoredEvents).Uid);
+    }
 }

--- a/QuickMail.Tests/CalendarViewModelTests.cs
+++ b/QuickMail.Tests/CalendarViewModelTests.cs
@@ -746,6 +746,96 @@ public class CalendarViewModelTests
         return (vm, store, sync, account);
     }
 
+    private static CalendarEvent MakeGraphRow(Guid accountId, string uid = "srv-1") => new()
+    {
+        Uid = uid, AccountId = accountId, IsGraph = true, Summary = "Server event",
+        StartTimeTicks = DateTime.Today.AddHours(9).ToUniversalTime().Ticks,
+        EndTimeTicks = DateTime.Today.AddHours(10).ToUniversalTime().Ticks,
+        ResponseStatus = CalendarResponseStatus.Accepted,
+    };
+
+    [Fact]
+    public async Task EditGraphEvent_PushesUpdateToServer()
+    {
+        var (vm, store, sync, account) = MakePushVm();
+        var row = MakeGraphRow(account.Id);
+        store.StoredEvents.Add(row);
+        await vm.LoadAsync();
+
+        EventEditorViewModel? editor = null;
+        vm.EditorRequested += e => editor = e;
+        vm.EditEventCommand.Execute(row);
+
+        Assert.NotNull(editor);            // server-editable, editor opened
+        editor!.Title = "Server event (moved)";
+        editor.SaveCommand.Execute(null);
+
+        Assert.Single(sync.UpdatedEvents);
+        Assert.Equal(row.Uid, sync.UpdatedEvents[0].Uid);          // identity preserved
+        Assert.Equal(account.Id, sync.UpdatedEvents[0].AccountId);
+    }
+
+    [Fact]
+    public async Task EditGraphEvent_PushFailure_AnnouncesAndChangesNothing()
+    {
+        var (vm, store, sync, account) = MakePushVm();
+        store.StoredEvents.Add(MakeGraphRow(account.Id));
+        await vm.LoadAsync();
+        sync.WriteFailure = new InvalidOperationException("boom");
+
+        EventEditorViewModel? editor = null;
+        string? announced = null;
+        vm.EditorRequested += e => editor = e;
+        vm.AnnouncementRequested += (t, _) => announced = t;
+
+        vm.EditEventCommand.Execute(vm.VisibleEvents[0]);
+        editor!.Title = "won't stick";
+        editor.SaveCommand.Execute(null);
+
+        Assert.Contains("Could not update", announced);
+        Assert.Equal("Server event", store.StoredEvents[0].Summary); // untouched
+    }
+
+    [Fact]
+    public async Task DeleteGraphEvent_ConfirmsThenDeletesOnServer()
+    {
+        var (vm, store, sync, account) = MakePushVm();
+        var row = MakeGraphRow(account.Id);
+        store.StoredEvents.Add(row);
+        await vm.LoadAsync();
+
+        Action? confirm = null;
+        vm.DeleteConfirmRequested += (_, cb) => confirm = cb;
+        vm.DeleteEventCommand.Execute(row);
+        Assert.NotNull(confirm);
+        confirm!();
+
+        Assert.Single(sync.DeletedEvents);
+        Assert.Equal(row.Uid, sync.DeletedEvents[0].Uid);
+    }
+
+    [Fact]
+    public async Task GoogleRow_StaysReadOnly()
+    {
+        var (vm, store, _, _) = MakePushVm();
+        // A server row whose account is NOT in the Graph-accounts list (i.e. a Google account).
+        var googleRow = MakeGraphRow(Guid.NewGuid(), "goog-1");
+        store.StoredEvents.Add(googleRow);
+        await vm.LoadAsync();
+
+        var editorOpened = false;
+        string? announced = null;
+        vm.EditorRequested += _ => editorOpened = true;
+        vm.AnnouncementRequested += (t, _) => announced = t;
+
+        vm.EditEventCommand.Execute(googleRow);
+        Assert.False(editorOpened);
+        Assert.Contains("can't be edited here", announced);
+
+        vm.DeleteEventCommand.Execute(googleRow);
+        Assert.Contains("can't be deleted here", announced);
+    }
+
     [Fact]
     public async Task SaveNewEvent_AccountTarget_PushesToGraph()
     {

--- a/QuickMail.Tests/EventEditorViewModelTests.cs
+++ b/QuickMail.Tests/EventEditorViewModelTests.cs
@@ -304,7 +304,7 @@ public class EventEditorViewModelTests
 
         Assert.True(vm.ShowSaveTarget);
         Assert.Equal(2, vm.SaveTargetLabels.Count);
-        Assert.Equal("My Appointments (this computer)", vm.SaveTargetLabels[0]);
+        Assert.Equal("Local Calendar (this computer)", vm.SaveTargetLabels[0]);
         Assert.Equal("Work (Microsoft)", vm.SaveTargetLabels[1]);
         Assert.Equal(0, vm.SelectedTargetIndex);
         Assert.Equal(CalendarEvent.LocalAccountId, vm.SelectedTargetAccountId);
@@ -336,7 +336,7 @@ public class EventEditorViewModelTests
         vm.RepeatIndex = 2; // Weekly
 
         Assert.False(vm.TryBuildEvent(out _, out var error));
-        Assert.Equal("Repeating appointments can only be saved to My Appointments for now.", error);
+        Assert.Equal("Repeating appointments can only be saved to Local Calendar for now.", error);
 
         // Back on the local target the same repeat is fine.
         vm.SelectedTargetIndex = 0;

--- a/QuickMail.Tests/EventEditorViewModelTests.cs
+++ b/QuickMail.Tests/EventEditorViewModelTests.cs
@@ -288,4 +288,84 @@ public class EventEditorViewModelTests
         Assert.NotNull(announced);
         Assert.Contains("Title", announced);
     }
+
+    // ── Save-target (Calendar) picker ────────────────────────────────────────────
+
+    private static readonly Guid AccountA = Guid.NewGuid();
+
+    private static EventEditorViewModel NewEditorWithAccount() =>
+        new(new DateTime(2026, 7, 20, 9, 0, 0),
+            new[] { new CalendarSaveTarget("Work (Microsoft)", AccountA) });
+
+    [Fact]
+    public void SaveTargets_DefaultToLocal_WithAccountListed()
+    {
+        var vm = NewEditorWithAccount();
+
+        Assert.True(vm.ShowSaveTarget);
+        Assert.Equal(2, vm.SaveTargetLabels.Count);
+        Assert.Equal("My Appointments (this computer)", vm.SaveTargetLabels[0]);
+        Assert.Equal("Work (Microsoft)", vm.SaveTargetLabels[1]);
+        Assert.Equal(0, vm.SelectedTargetIndex);
+        Assert.Equal(CalendarEvent.LocalAccountId, vm.SelectedTargetAccountId);
+
+        vm.Title = "Local by default";
+        Assert.True(vm.TryBuildEvent(out var evt, out _));
+        Assert.Equal(CalendarEvent.LocalAccountId, evt.AccountId);
+    }
+
+    [Fact]
+    public void SaveTargets_AccountSelected_SetsEventAccountId()
+    {
+        var vm = NewEditorWithAccount();
+        vm.Title = "On the work calendar";
+        vm.SelectedTargetIndex = 1;
+
+        Assert.Equal(AccountA, vm.SelectedTargetAccountId);
+        Assert.True(vm.TryBuildEvent(out var evt, out _));
+        Assert.Equal(AccountA, evt.AccountId);
+        Assert.False(evt.IsUserCreated);
+    }
+
+    [Fact]
+    public void SaveTargets_RecurringToAccount_FailsValidation()
+    {
+        var vm = NewEditorWithAccount();
+        vm.Title = "Weekly on the account";
+        vm.SelectedTargetIndex = 1;
+        vm.RepeatIndex = 2; // Weekly
+
+        Assert.False(vm.TryBuildEvent(out _, out var error));
+        Assert.Equal("Repeating appointments can only be saved to My Appointments for now.", error);
+
+        // Back on the local target the same repeat is fine.
+        vm.SelectedTargetIndex = 0;
+        Assert.True(vm.TryBuildEvent(out var evt, out _));
+        Assert.Equal(CalendarEvent.LocalAccountId, evt.AccountId);
+        Assert.True(evt.IsRecurring);
+    }
+
+    [Fact]
+    public void SaveTargets_NoAccounts_PickerHidden()
+    {
+        var vm = new EventEditorViewModel(DateTime.Now);
+        Assert.False(vm.ShowSaveTarget);
+        Assert.Single(vm.SaveTargetLabels);
+    }
+
+    [Fact]
+    public void SaveTargets_EditMode_PickerHidden()
+    {
+        var vm = new EventEditorViewModel(new CalendarEvent
+        {
+            Uid = "local-x", AccountId = CalendarEvent.LocalAccountId, Summary = "Existing",
+            StartTimeTicks = DateTime.UtcNow.Ticks,
+        });
+        Assert.False(vm.ShowSaveTarget);
+
+        // Editing keeps the appointment on the local calendar (cannot move calendars in v1).
+        vm.Title = "Existing";
+        Assert.True(vm.TryBuildEvent(out var evt, out _));
+        Assert.Equal(CalendarEvent.LocalAccountId, evt.AccountId);
+    }
 }

--- a/QuickMail.Tests/EventEditorViewModelTests.cs
+++ b/QuickMail.Tests/EventEditorViewModelTests.cs
@@ -145,6 +145,7 @@ public class EventEditorViewModelTests
             Title = "Biweekly sync",
             StartDate = new DateTime(2026, 7, 14),
             StartTime = "9:00 AM",
+            EndTime = "9:30 AM",
             RepeatIndex = 2,        // Weekly
             RepeatInterval = 2,
         };
@@ -163,6 +164,7 @@ public class EventEditorViewModelTests
             Title = "MWF workout",
             StartDate = new DateTime(2026, 7, 13),
             StartTime = "6:00 AM",
+            EndTime = "7:00 AM",
             RepeatIndex = 2,          // Weekly
             RepeatOnMonday = true,
             RepeatOnWednesday = true,
@@ -181,6 +183,7 @@ public class EventEditorViewModelTests
             Title = "Simple weekly",
             StartDate = DateTime.Today,
             StartTime = "9:00 AM",
+            EndTime = "9:30 AM",
             RepeatIndex = 2,
         };
         Assert.True(vm.TryBuildEvent(out var evt, out _));
@@ -195,6 +198,7 @@ public class EventEditorViewModelTests
             Title = "Daily thing",
             StartDate = DateTime.Today,
             StartTime = "9:00 AM",
+            EndTime = "9:30 AM",
             RepeatIndex = 1,          // Daily
             RepeatOnMonday = true,    // leftover check must not leak into the rule
         };

--- a/QuickMail.Tests/EventEditorViewModelTests.cs
+++ b/QuickMail.Tests/EventEditorViewModelTests.cs
@@ -156,6 +156,73 @@ public class EventEditorViewModelTests
     }
 
     [Fact]
+    public void Repeat_WeeklyWithDayPicker_BuildsByDay()
+    {
+        var vm = new EventEditorViewModel(new DateTime(2026, 7, 13, 9, 0, 0))
+        {
+            Title = "MWF workout",
+            StartDate = new DateTime(2026, 7, 13),
+            StartTime = "6:00 AM",
+            RepeatIndex = 2,          // Weekly
+            RepeatOnMonday = true,
+            RepeatOnWednesday = true,
+            RepeatOnFriday = true,
+        };
+        Assert.True(vm.IsWeekly);
+        Assert.True(vm.TryBuildEvent(out var evt, out _));
+        Assert.Contains("BYDAY=MO,WE,FR", evt.RecurrenceRule);
+    }
+
+    [Fact]
+    public void Repeat_WeeklyNoDaysChecked_OmitsByDay()
+    {
+        var vm = new EventEditorViewModel(DateTime.Now)
+        {
+            Title = "Simple weekly",
+            StartDate = DateTime.Today,
+            StartTime = "9:00 AM",
+            RepeatIndex = 2,
+        };
+        Assert.True(vm.TryBuildEvent(out var evt, out _));
+        Assert.DoesNotContain("BYDAY", evt.RecurrenceRule); // engine falls back to start weekday
+    }
+
+    [Fact]
+    public void Repeat_DayCheckboxesIgnored_WhenNotWeekly()
+    {
+        var vm = new EventEditorViewModel(DateTime.Now)
+        {
+            Title = "Daily thing",
+            StartDate = DateTime.Today,
+            StartTime = "9:00 AM",
+            RepeatIndex = 1,          // Daily
+            RepeatOnMonday = true,    // leftover check must not leak into the rule
+        };
+        Assert.True(vm.TryBuildEvent(out var evt, out _));
+        Assert.DoesNotContain("BYDAY", evt.RecurrenceRule);
+    }
+
+    [Fact]
+    public void EditWeeklyWithByDay_PopulatesDayCheckboxes()
+    {
+        var master = new CalendarEvent
+        {
+            Uid = "local-mwf",
+            AccountId = CalendarEvent.LocalAccountId,
+            Summary = "Workout",
+            StartTimeTicks = new DateTime(2026, 7, 13, 6, 0, 0).ToUniversalTime().Ticks,
+            RecurrenceRule = "FREQ=WEEKLY;BYDAY=MO,WE,FR",
+            ResponseStatus = CalendarResponseStatus.Accepted,
+        };
+        var vm = new EventEditorViewModel(master);
+        Assert.True(vm.RepeatOnMonday);
+        Assert.True(vm.RepeatOnWednesday);
+        Assert.True(vm.RepeatOnFriday);
+        Assert.False(vm.RepeatOnTuesday);
+        Assert.False(vm.RepeatOnSunday);
+    }
+
+    [Fact]
     public void Repeat_UntilBeforeStart_FailsValidation()
     {
         var vm = new EventEditorViewModel(DateTime.Now)

--- a/QuickMail.Tests/EventEditorViewModelTests.cs
+++ b/QuickMail.Tests/EventEditorViewModelTests.cs
@@ -1,0 +1,220 @@
+using System;
+using QuickMail.Models;
+using QuickMail.ViewModels;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// Tests for <see cref="EventEditorViewModel"/> — validation and event construction.
+/// Pure VM logic, no UI.
+/// </summary>
+public class EventEditorViewModelTests
+{
+    [Fact]
+    public void NewEditor_DefaultsToLocalAccountAndHalfHourSlot()
+    {
+        var vm = new EventEditorViewModel(new DateTime(2026, 7, 16, 9, 3, 0));
+        vm.Title = "Dentist";
+
+        Assert.True(vm.TryBuildEvent(out var evt, out _));
+        Assert.Equal(CalendarEvent.LocalAccountId, evt.AccountId);
+        Assert.True(evt.IsUserCreated);
+        Assert.StartsWith("local-", evt.Uid);
+        Assert.Equal("Dentist", evt.Summary);
+        // 9:03 rounds up to 9:15; end defaults 30 min later => 30 min duration.
+        var start = new DateTime(evt.StartTimeTicks!.Value, DateTimeKind.Utc).ToLocalTime();
+        var end = new DateTime(evt.EndTimeTicks!.Value, DateTimeKind.Utc).ToLocalTime();
+        Assert.Equal(TimeSpan.FromMinutes(30), end - start);
+    }
+
+    [Fact]
+    public void MissingTitle_FailsValidation()
+    {
+        var vm = new EventEditorViewModel(DateTime.Now) { Title = "   " };
+        Assert.False(vm.TryBuildEvent(out _, out var error));
+        Assert.Contains("Title", error);
+    }
+
+    [Fact]
+    public void EndBeforeStart_FailsValidation()
+    {
+        var vm = new EventEditorViewModel(new DateTime(2026, 7, 16, 10, 0, 0))
+        {
+            Title = "Backwards",
+            StartDate = new DateTime(2026, 7, 16),
+            StartTime = "10:00 AM",
+            EndDate = new DateTime(2026, 7, 16),
+            EndTime = "9:00 AM",
+        };
+        Assert.False(vm.TryBuildEvent(out _, out var error));
+        Assert.Contains("before", error);
+    }
+
+    [Fact]
+    public void InvalidStartTime_FailsWithFriendlyMessage()
+    {
+        var vm = new EventEditorViewModel(DateTime.Now)
+        {
+            Title = "Bad time",
+            StartDate = DateTime.Today,
+            StartTime = "not a time",
+        };
+        Assert.False(vm.TryBuildEvent(out _, out var error));
+        Assert.Contains("valid time", error);
+    }
+
+    [Fact]
+    public void EditExisting_PreservesUidAndRoundTripsFields()
+    {
+        var original = new CalendarEvent
+        {
+            Uid = "local-abc",
+            AccountId = CalendarEvent.LocalAccountId,
+            Summary = "Standup",
+            Location = "Room 1",
+            Description = "Daily sync",
+            StartTimeTicks = new DateTime(2026, 7, 16, 9, 0, 0).ToUniversalTime().Ticks,
+            EndTimeTicks = new DateTime(2026, 7, 16, 9, 30, 0).ToUniversalTime().Ticks,
+            ResponseStatus = CalendarResponseStatus.Accepted,
+        };
+
+        var vm = new EventEditorViewModel(original);
+        Assert.True(vm.IsEdit);
+        Assert.Equal("Standup", vm.Title);
+        Assert.Equal("Room 1", vm.Location);
+        Assert.Equal("Daily sync", vm.Notes);
+
+        vm.Title = "Standup (edited)";
+        Assert.True(vm.TryBuildEvent(out var evt, out _));
+        Assert.Equal("local-abc", evt.Uid); // same Uid => upsert updates in place
+        Assert.Equal("Standup (edited)", evt.Summary);
+    }
+
+    [Fact]
+    public void AllDay_SpansWholeDay_AndIgnoresTimeText()
+    {
+        var vm = new EventEditorViewModel(new DateTime(2026, 7, 17, 9, 0, 0))
+        {
+            Title = "Conference",
+            IsAllDay = true,
+            StartDate = new DateTime(2026, 7, 17),
+            EndDate = new DateTime(2026, 7, 17),
+            StartTime = "garbage", // ignored when all-day
+        };
+
+        Assert.False(vm.HasTimes);
+        Assert.True(vm.TryBuildEvent(out var evt, out _));
+        Assert.True(evt.IsAllDay);
+        var start = new DateTime(evt.StartTimeTicks!.Value, DateTimeKind.Utc).ToLocalTime();
+        var end = new DateTime(evt.EndTimeTicks!.Value, DateTimeKind.Utc).ToLocalTime();
+        Assert.Equal(new DateTime(2026, 7, 17, 0, 0, 0), start);
+        Assert.Equal(start.Date, end.Date);          // single-day all-day stays within the day
+        Assert.Contains("all day", evt.DisplayLine);
+    }
+
+    [Fact]
+    public void AllDay_EndDateBeforeStart_FailsValidation()
+    {
+        var vm = new EventEditorViewModel(DateTime.Now)
+        {
+            Title = "Bad range",
+            IsAllDay = true,
+            StartDate = new DateTime(2026, 7, 17),
+            EndDate = new DateTime(2026, 7, 16),
+        };
+        Assert.False(vm.TryBuildEvent(out _, out var error));
+        Assert.Contains("before", error);
+    }
+
+    [Fact]
+    public void Repeat_None_ProducesNoRecurrence()
+    {
+        var vm = new EventEditorViewModel(DateTime.Now) { Title = "One-off", RepeatIndex = 0 };
+        Assert.False(vm.HasRepeat);
+        Assert.True(vm.TryBuildEvent(out var evt, out _));
+        Assert.Null(evt.RecurrenceRule);
+        Assert.False(evt.IsRecurring);
+    }
+
+    [Fact]
+    public void Repeat_WeeklyEveryTwo_BuildsRRule()
+    {
+        var vm = new EventEditorViewModel(new DateTime(2026, 7, 14, 9, 0, 0))
+        {
+            Title = "Biweekly sync",
+            StartDate = new DateTime(2026, 7, 14),
+            StartTime = "9:00 AM",
+            RepeatIndex = 2,        // Weekly
+            RepeatInterval = 2,
+        };
+        Assert.True(vm.HasRepeat);
+        Assert.Equal("weeks", vm.RepeatUnitLabel);
+        Assert.True(vm.TryBuildEvent(out var evt, out _));
+        Assert.Equal("FREQ=WEEKLY;INTERVAL=2", evt.RecurrenceRule);
+        Assert.True(evt.IsRecurring);
+    }
+
+    [Fact]
+    public void Repeat_UntilBeforeStart_FailsValidation()
+    {
+        var vm = new EventEditorViewModel(DateTime.Now)
+        {
+            Title = "Bad repeat",
+            StartDate = new DateTime(2026, 7, 14),
+            StartTime = "9:00 AM",
+            RepeatIndex = 1,
+            RepeatUntil = new DateTime(2026, 7, 10),
+        };
+        Assert.False(vm.TryBuildEvent(out _, out var error));
+        Assert.Contains("before the start", error);
+    }
+
+    [Fact]
+    public void EditRecurring_PopulatesRepeatFields()
+    {
+        var master = new CalendarEvent
+        {
+            Uid = "local-rec",
+            AccountId = CalendarEvent.LocalAccountId,
+            Summary = "Standup",
+            StartTimeTicks = new DateTime(2026, 7, 14, 9, 0, 0).ToUniversalTime().Ticks,
+            EndTimeTicks = new DateTime(2026, 7, 14, 9, 15, 0).ToUniversalTime().Ticks,
+            RecurrenceRule = "FREQ=MONTHLY;INTERVAL=3",
+            ResponseStatus = CalendarResponseStatus.Accepted,
+        };
+        var vm = new EventEditorViewModel(master);
+        Assert.Equal(3, vm.RepeatIndex);   // Monthly
+        Assert.Equal(3, vm.RepeatInterval);
+        Assert.True(vm.HasRepeat);
+    }
+
+    [Fact]
+    public void Save_RaisesSavedWithBuiltEvent()
+    {
+        var vm = new EventEditorViewModel(DateTime.Now) { Title = "Lunch" };
+        CalendarEvent? captured = null;
+        vm.Saved += e => captured = e;
+
+        vm.SaveCommand.Execute(null);
+
+        Assert.NotNull(captured);
+        Assert.Equal("Lunch", captured!.Summary);
+    }
+
+    [Fact]
+    public void Save_WithInvalidData_AnnouncesInsteadOfRaisingSaved()
+    {
+        var vm = new EventEditorViewModel(DateTime.Now) { Title = "" };
+        var saved = false;
+        string? announced = null;
+        vm.Saved += _ => saved = true;
+        vm.AnnouncementRequested += (t, _) => announced = t;
+
+        vm.SaveCommand.Execute(null);
+
+        Assert.False(saved);
+        Assert.NotNull(announced);
+        Assert.Contains("Title", announced);
+    }
+}

--- a/QuickMail.Tests/FlagServiceTests.cs
+++ b/QuickMail.Tests/FlagServiceTests.cs
@@ -160,6 +160,7 @@ sealed class RecordingFlagStore : ILocalStoreService
     public Task<List<(Guid AccountId, string FolderName, string MessageId, string IcsText)>> LoadAllCalendarIcsAsync()
         => Task.FromResult(new List<(Guid, string, string, string)>());
     public Task ClearOrphanedCalendarSourceLinksAsync() => Task.CompletedTask;
+    public Task ReplaceGraphCalendarEventsAsync(Guid accountId, IReadOnlyList<CalendarEvent> events) => Task.CompletedTask;
     public Task<string?> GetDeltaTokenAsync(Guid accountId, string folderId) => Task.FromResult<string?>(null);
     public Task SetDeltaTokenAsync(Guid accountId, string folderId, string deltaToken) => Task.CompletedTask;
 }

--- a/QuickMail.Tests/GoogleCalendarSyncTests.cs
+++ b/QuickMail.Tests/GoogleCalendarSyncTests.cs
@@ -1,0 +1,278 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using QuickMail.Models;
+using QuickMail.Services;
+using QuickMail.Services.Graph;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// Google calendar sync (read-down v1) through the shared calendar sync service: mapping (timed
+/// RFC3339 offsets → UTC, all-day date-only, cancelled skipped, self response status), paging via
+/// nextPageToken, replace-slice, and failure isolation. HTTP is stubbed with a queued
+/// <see cref="HttpMessageHandler"/>; persistence uses a real temp-profile LocalStoreService,
+/// mirroring GraphCalendarSyncServiceTests.
+/// </summary>
+public class GoogleCalendarSyncTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly LocalStoreService _store;
+    private readonly Guid _accountId = Guid.NewGuid();
+
+    public GoogleCalendarSyncTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"qm-gcalg-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        _store = new LocalStoreService(new ProfileContext(_tempDir));
+        _store.Initialize();
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); } catch { }
+        GC.SuppressFinalize(this);
+    }
+
+    // ── Test plumbing ────────────────────────────────────────────────────────────
+
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        private readonly Queue<HttpResponseMessage> _responses;
+        public int Calls { get; private set; }
+        public List<string> Urls { get; } = [];
+
+        public RecordingHandler(params HttpResponseMessage[] responses)
+            => _responses = new Queue<HttpResponseMessage>(responses);
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            Calls++;
+            Urls.Add(request.RequestUri!.ToString());
+            return Task.FromResult(_responses.Count > 0 ? _responses.Dequeue() : Json("""{ "items": [] }"""));
+        }
+    }
+
+    private sealed class FixedAccountService : IAccountService
+    {
+        private readonly List<AccountModel> _accounts;
+        public FixedAccountService(params AccountModel[] accounts) => _accounts = [.. accounts];
+        public List<AccountModel> LoadAccounts() => _accounts;
+        public void SaveAccounts(List<AccountModel> accounts) { }
+        public void SetDefaultAccount(Guid accountId) { }
+    }
+
+    private static HttpResponseMessage Json(string body, HttpStatusCode code = HttpStatusCode.OK)
+        => new(code) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
+
+    private AccountModel GoogleAccount() => new()
+    {
+        Id = _accountId,
+        AuthType = AuthType.OAuth2Google,
+        BackendKind = BackendKind.ImapSmtp, // Gmail mail is IMAP — the identity provider is what matters
+        Username = "kelly@gmail.com",
+    };
+
+    /// <summary>The shared sync service with only the Google client's HTTP stubbed (no Graph accounts).</summary>
+    private GraphCalendarSyncService Service(RecordingHandler handler, params AccountModel[] accounts)
+        => new(new FixedAccountService(accounts.Length > 0 ? accounts : [GoogleAccount()]),
+               _store,
+               new GraphClient(new StubOAuthService(), new HttpClient(new RecordingHandler()), defaultRetryDelay: TimeSpan.Zero),
+               new GoogleCalendarClient(new StubGoogleOAuthService(), new HttpClient(handler)));
+
+    private static string EventJson(string id, string summary,
+        string? startDateTime = null, string? endDateTime = null,
+        string? startDate = null, string? endDate = null,
+        string status = "confirmed", string? attendeesJson = null,
+        string? location = null, string? description = null)
+        => $$"""
+           {
+             "id": "{{id}}",
+             "status": "{{status}}",
+             "summary": "{{summary}}",
+             "description": "{{description ?? ""}}",
+             "location": "{{location ?? ""}}",
+             "organizer": { "email": "org@example.com", "displayName": "Org Anizer" },
+             "start": { {{(startDate != null ? $"\"date\": \"{startDate}\"" : $"\"dateTime\": \"{startDateTime}\"")}} },
+             "end": { {{(endDate != null ? $"\"date\": \"{endDate}\"" : $"\"dateTime\": \"{endDateTime}\"")}} }{{(attendeesJson is null ? "" : $", \"attendees\": {attendeesJson}")}}
+           }
+           """;
+
+    private static string Page(string? nextPageToken, params string[] events)
+        => $$"""{ "items": [{{string.Join(",", events)}}]{{(nextPageToken is null ? "" : $$""", "nextPageToken": "{{nextPageToken}}" """)}} }""";
+
+    // ── Mapping ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Sync_MapsTimedEvent_OffsetStamps_ToUtcTicks()
+    {
+        // 09:00 at -07:00 == 16:00 UTC.
+        var handler = new RecordingHandler(Json(Page(null,
+            EventJson("gid-1", "Standup",
+                      startDateTime: "2026-08-01T09:00:00-07:00", endDateTime: "2026-08-01T09:30:00-07:00",
+                      location: "Meet", description: "daily"))));
+
+        var result = await Service(handler).SyncAllAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(1, result.AccountsSynced);
+        Assert.Equal(1, result.EventsFetched);
+        Assert.Null(result.Error);
+
+        var row = Assert.Single(await _store.LoadCalendarEventsAsync());
+        Assert.Equal("gid-1", row.Uid);
+        Assert.Equal(_accountId, row.AccountId);
+        Assert.True(row.IsGraph); // is_graph = "server-synced row", Google included
+        Assert.False(row.IsUserCreated);
+        Assert.Equal("Standup", row.Summary);
+        Assert.Equal("Meet", row.Location);
+        Assert.Equal("daily", row.Description);
+        Assert.Equal("org@example.com", row.Organizer);
+        Assert.Equal("Org Anizer", row.OrganizerName);
+        Assert.Equal(new DateTime(2026, 8, 1, 16, 0, 0, DateTimeKind.Utc).Ticks, row.StartTimeTicks);
+        Assert.Equal(new DateTime(2026, 8, 1, 16, 30, 0, DateTimeKind.Utc).Ticks, row.EndTimeTicks);
+        Assert.False(row.IsAllDay);
+        Assert.Equal(string.Empty, row.SourceMessageId);
+        Assert.Null(row.RecurrenceRule);
+    }
+
+    [Fact]
+    public async Task Sync_AllDayDateOnly_AnchorsToLocalDay_EndExclusive()
+    {
+        var handler = new RecordingHandler(Json(Page(null,
+            EventJson("gid-allday", "Offsite", startDate: "2026-08-03", endDate: "2026-08-05"))));
+
+        await Service(handler).SyncAllAsync(TestContext.Current.CancellationToken);
+
+        var row = Assert.Single(await _store.LoadCalendarEventsAsync());
+        Assert.True(row.IsAllDay);
+        // Exclusive end 08-05 → last day 08-04; stored like all other all-day rows.
+        Assert.Equal(new DateTime(2026, 8, 3, 0, 0, 0, DateTimeKind.Local), row.StartTime);
+        Assert.Equal(new DateTime(2026, 8, 4, 23, 59, 59, DateTimeKind.Local), row.EndTime);
+    }
+
+    [Fact]
+    public async Task Sync_CancelledEvents_AreSkipped()
+    {
+        var handler = new RecordingHandler(Json(Page(null,
+            EventJson("gid-live", "Live", startDateTime: "2026-08-01T09:00:00Z", endDateTime: "2026-08-01T10:00:00Z"),
+            EventJson("gid-cancelled", "Gone", status: "cancelled",
+                      startDateTime: "2026-08-02T09:00:00Z", endDateTime: "2026-08-02T10:00:00Z"))));
+
+        var result = await Service(handler).SyncAllAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(1, result.EventsFetched);
+        Assert.Equal("gid-live", Assert.Single(await _store.LoadCalendarEventsAsync()).Uid);
+    }
+
+    [Theory]
+    [InlineData("""[{ "self": true, "responseStatus": "accepted" }]""",    CalendarResponseStatus.Accepted)]
+    [InlineData("""[{ "self": true, "responseStatus": "declined" }]""",    CalendarResponseStatus.Declined)]
+    [InlineData("""[{ "self": true, "responseStatus": "tentative" }]""",   CalendarResponseStatus.Tentative)]
+    [InlineData("""[{ "self": true, "responseStatus": "needsAction" }]""", CalendarResponseStatus.Pending)]
+    [InlineData("""[{ "self": false, "responseStatus": "declined" }]""",   CalendarResponseStatus.Accepted)]
+    [InlineData(null,                                                      CalendarResponseStatus.Accepted)]
+    public async Task Sync_MapsSelfAttendeeResponseStatus(string? attendeesJson, CalendarResponseStatus expected)
+    {
+        var handler = new RecordingHandler(Json(Page(null,
+            EventJson("gid-r", "R", startDateTime: "2026-08-01T09:00:00Z", endDateTime: "2026-08-01T10:00:00Z",
+                      attendeesJson: attendeesJson))));
+
+        await Service(handler).SyncAllAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(expected, Assert.Single(await _store.LoadCalendarEventsAsync()).ResponseStatus);
+    }
+
+    // ── Request shape and paging ─────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Sync_RequestsPrimaryCalendar_SingleEvents_WithWindow()
+    {
+        var handler = new RecordingHandler(Json(Page(null)));
+
+        await Service(handler).SyncAllAsync(TestContext.Current.CancellationToken);
+
+        var url = Assert.Single(handler.Urls);
+        Assert.Contains("/calendar/v3/calendars/primary/events?", url);
+        Assert.Contains("timeMin=", url);
+        Assert.Contains("timeMax=", url);
+        Assert.Contains("singleEvents=true", url);
+    }
+
+    [Fact]
+    public async Task Sync_FollowsNextPageToken()
+    {
+        var handler = new RecordingHandler(
+            Json(Page("tok-2",
+                EventJson("gid-a", "A", startDateTime: "2026-08-01T09:00:00Z", endDateTime: "2026-08-01T10:00:00Z"))),
+            Json(Page(null,
+                EventJson("gid-b", "B", startDateTime: "2026-08-02T09:00:00Z", endDateTime: "2026-08-02T10:00:00Z"))));
+
+        var result = await Service(handler).SyncAllAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, handler.Calls);
+        Assert.Contains("pageToken=tok-2", handler.Urls[1]);
+        Assert.Equal(2, result.EventsFetched);
+        Assert.Equal(new[] { "gid-a", "gid-b" },
+            (await _store.LoadCalendarEventsAsync()).Select(r => r.Uid).OrderBy(u => u).ToArray());
+    }
+
+    // ── Replace-slice and failure isolation ──────────────────────────────────────
+
+    [Fact]
+    public async Task SecondSync_RemovesEventsThatVanishedOnServer()
+    {
+        var handler = new RecordingHandler(
+            Json(Page(null,
+                EventJson("gid-keep", "Keep", startDateTime: "2026-08-01T09:00:00Z", endDateTime: "2026-08-01T10:00:00Z"),
+                EventJson("gid-drop", "Drop", startDateTime: "2026-08-02T09:00:00Z", endDateTime: "2026-08-02T10:00:00Z"))),
+            Json(Page(null,
+                EventJson("gid-keep", "Keep", startDateTime: "2026-08-01T09:00:00Z", endDateTime: "2026-08-01T10:00:00Z"))));
+
+        var service = Service(handler);
+        await service.SyncAllAsync(TestContext.Current.CancellationToken);
+        Assert.Equal(2, (await _store.LoadCalendarEventsAsync()).Count);
+
+        await service.SyncAllAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal("gid-keep", Assert.Single(await _store.LoadCalendarEventsAsync()).Uid);
+    }
+
+    [Fact]
+    public async Task Sync_HttpFailure_ReportsError_AndStoreUnchanged()
+    {
+        await _store.ReplaceGraphCalendarEventsAsync(_accountId, [new CalendarEvent
+        {
+            Uid = "gid-old", AccountId = _accountId, Summary = "Old slice",
+        }]);
+        var handler = new RecordingHandler(Json("""{ "error": "denied" }""", HttpStatusCode.Forbidden));
+
+        var result = await Service(handler).SyncAllAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(0, result.AccountsSynced);
+        Assert.NotNull(result.Error);
+        // The previous slice survives — replace happens only after a full successful fetch.
+        Assert.Equal("gid-old", Assert.Single(await _store.LoadCalendarEventsAsync()).Uid);
+    }
+
+    [Fact]
+    public async Task Sync_NonGoogleNonGraphAccounts_AreSkipped()
+    {
+        var imapPassword = new AccountModel
+        {
+            Id = Guid.NewGuid(), AuthType = AuthType.Password, BackendKind = BackendKind.ImapSmtp,
+        };
+        var handler = new RecordingHandler();
+
+        var result = await Service(handler, imapPassword).SyncAllAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(0, handler.Calls);
+        Assert.Equal(GraphCalendarSyncResult.None, result);
+    }
+}

--- a/QuickMail.Tests/GraphCalendarSyncServiceTests.cs
+++ b/QuickMail.Tests/GraphCalendarSyncServiceTests.cs
@@ -52,15 +52,19 @@ public class GraphCalendarSyncServiceTests : IDisposable
         public RecordingHandler(params HttpResponseMessage[] responses)
             => _responses = new Queue<HttpResponseMessage>(responses);
 
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        public List<string> Methods { get; } = [];
+        public List<string?> Bodies { get; } = [];
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
         {
             Calls++;
             Urls.Add(request.RequestUri!.ToString());
+            Methods.Add(request.Method.Method);
             PreferHeaders.Add(request.Headers.TryGetValues("Prefer", out var v) ? string.Join(",", v) : null);
-            var resp = _responses.Count > 0
+            Bodies.Add(request.Content is null ? null : await request.Content.ReadAsStringAsync(ct));
+            return _responses.Count > 0
                 ? _responses.Dequeue()
                 : Json("""{ "value": [] }""");
-            return Task.FromResult(resp);
         }
     }
 
@@ -382,6 +386,106 @@ public class GraphCalendarSyncServiceTests : IDisposable
         Assert.NotNull(result.Error);
         Assert.Contains("sign-in", result.Error, StringComparison.OrdinalIgnoreCase);
         Assert.Empty(await _store.LoadCalendarEventsAsync()); // nothing was deleted or inserted
+    }
+
+    // ── Create push (POST /me/events) ────────────────────────────────────────────
+
+    [Fact]
+    public async Task CreateEvent_Timed_PostsExpectedShape_AndStoresServerCopy()
+    {
+        var handler = new RecordingHandler(Json(
+            EventJson("srv-1", "Board meeting", "2026-08-01T14:00:00.0000000", "2026-08-01T15:00:00.0000000",
+                      isOrganizer: true, response: "organizer", location: "Room 9", preview: "quarterly")));
+        var service = Service(handler);
+        var evt = new CalendarEvent
+        {
+            Uid = "local-tmp", AccountId = _accountId, Summary = "Board meeting",
+            Description = "quarterly", Location = "Room 9",
+            StartTimeTicks = new DateTime(2026, 8, 1, 14, 0, 0, DateTimeKind.Utc).Ticks,
+            EndTimeTicks   = new DateTime(2026, 8, 1, 15, 0, 0, DateTimeKind.Utc).Ticks,
+        };
+
+        var created = await service.CreateEventAsync(GraphAccount(), evt, TestContext.Current.CancellationToken);
+
+        Assert.Equal("POST", Assert.Single(handler.Methods));
+        Assert.EndsWith("/me/events", handler.Urls[0]);
+        Assert.Equal("outlook.timezone=\"UTC\"", handler.PreferHeaders[0]);
+
+        using var body = System.Text.Json.JsonDocument.Parse(handler.Bodies[0]!);
+        var root = body.RootElement;
+        Assert.Equal("Board meeting", root.GetProperty("subject").GetString());
+        Assert.Equal("text", root.GetProperty("body").GetProperty("contentType").GetString());
+        Assert.Equal("quarterly", root.GetProperty("body").GetProperty("content").GetString());
+        Assert.Equal("2026-08-01T14:00:00", root.GetProperty("start").GetProperty("dateTime").GetString());
+        Assert.Equal("UTC", root.GetProperty("start").GetProperty("timeZone").GetString());
+        Assert.Equal("2026-08-01T15:00:00", root.GetProperty("end").GetProperty("dateTime").GetString());
+        Assert.Equal("Room 9", root.GetProperty("location").GetProperty("displayName").GetString());
+        Assert.False(root.GetProperty("isAllDay").GetBoolean());
+
+        // The server's copy is stored (Uid = the Graph id, is_graph set) so it shows immediately
+        // and is simply re-fetched by the next replace-slice sync.
+        Assert.Equal("srv-1", created.Uid);
+        var row = Assert.Single(await _store.LoadCalendarEventsAsync());
+        Assert.Equal("srv-1", row.Uid);
+        Assert.True(row.IsGraph);
+        Assert.Equal(CalendarResponseStatus.Accepted, row.ResponseStatus);
+    }
+
+    [Fact]
+    public async Task CreateEvent_AllDay_SendsMidnightBoundaries_EndDayAfterLastDay()
+    {
+        var handler = new RecordingHandler(Json(
+            EventJson("srv-allday", "Offsite", "2026-08-03T00:00:00.0000000", "2026-08-05T00:00:00.0000000", allDay: true)));
+        var service = Service(handler);
+        // Local all-day storage: local midnight of first day .. 23:59:59 of the last day (Aug 3-4).
+        var evt = new CalendarEvent
+        {
+            Uid = "local-tmp", AccountId = _accountId, Summary = "Offsite", IsAllDay = true,
+            StartTimeTicks = new DateTime(2026, 8, 3, 0, 0, 0, DateTimeKind.Local).ToUniversalTime().Ticks,
+            EndTimeTicks   = new DateTime(2026, 8, 4, 23, 59, 59, DateTimeKind.Local).ToUniversalTime().Ticks,
+        };
+
+        await service.CreateEventAsync(GraphAccount(), evt, TestContext.Current.CancellationToken);
+
+        using var body = System.Text.Json.JsonDocument.Parse(handler.Bodies[0]!);
+        var root = body.RootElement;
+        Assert.True(root.GetProperty("isAllDay").GetBoolean());
+        Assert.Equal("2026-08-03T00:00:00", root.GetProperty("start").GetProperty("dateTime").GetString());
+        // Graph requires an EXCLUSIVE end: the day after the last day (Aug 4 → Aug 5).
+        Assert.Equal("2026-08-05T00:00:00", root.GetProperty("end").GetProperty("dateTime").GetString());
+    }
+
+    [Fact]
+    public async Task CreateEvent_Recurring_ThrowsNotSupported()
+    {
+        var handler = new RecordingHandler();
+        var service = Service(handler);
+        var evt = new CalendarEvent
+        {
+            Uid = "local-tmp", AccountId = _accountId, Summary = "Weekly",
+            RecurrenceRule = "FREQ=WEEKLY",
+            StartTimeTicks = DateTime.UtcNow.Ticks,
+        };
+
+        await Assert.ThrowsAsync<NotSupportedException>(
+            () => service.CreateEventAsync(GraphAccount(), evt, TestContext.Current.CancellationToken));
+        Assert.Equal(0, handler.Calls); // rejected before any network traffic
+    }
+
+    [Fact]
+    public async Task CreateEvent_HttpFailure_Throws_AndStoresNothing()
+    {
+        var handler = new RecordingHandler(Json("""{ "error": "denied" }""", code: HttpStatusCode.Forbidden));
+        var service = Service(handler);
+        var evt = new CalendarEvent
+        {
+            Uid = "local-tmp", AccountId = _accountId, Summary = "Doomed",
+            StartTimeTicks = DateTime.UtcNow.Ticks,
+        };
+
+        await Assert.ThrowsAsync<HttpRequestException>(
+            () => service.CreateEventAsync(GraphAccount(), evt, TestContext.Current.CancellationToken));
+        Assert.Empty(await _store.LoadCalendarEventsAsync());
     }
 
     [Fact]

--- a/QuickMail.Tests/GraphCalendarSyncServiceTests.cs
+++ b/QuickMail.Tests/GraphCalendarSyncServiceTests.cs
@@ -207,7 +207,9 @@ public class GraphCalendarSyncServiceTests : IDisposable
         await Service(handler).SyncAllAsync(TestContext.Current.CancellationToken);
 
         Assert.Equal(1, handler.Calls);
-        Assert.Equal("outlook.timezone=\"UTC\"", handler.PreferHeaders[0]);
+        // We ask Graph for times in the machine's own Windows zone so all-day events come back
+        // as local midnights (a UTC Prefer header shifted them a day for users east of Greenwich).
+        Assert.Equal($"outlook.timezone=\"{TimeZoneInfo.Local.Id}\"", handler.PreferHeaders[0]);
         var url = handler.Urls[0];
         Assert.Contains("/me/calendarView?", url);
         Assert.Contains("startDateTime=", url);
@@ -409,7 +411,9 @@ public class GraphCalendarSyncServiceTests : IDisposable
 
         Assert.Equal("POST", Assert.Single(handler.Methods));
         Assert.EndsWith("/me/events", handler.Urls[0]);
-        Assert.Equal("outlook.timezone=\"UTC\"", handler.PreferHeaders[0]);
+        // Prefer header carries the machine's Windows zone (see Sync test); the body below still
+        // sends explicit UTC start/end, so the created event's times are unambiguous.
+        Assert.Equal($"outlook.timezone=\"{TimeZoneInfo.Local.Id}\"", handler.PreferHeaders[0]);
 
         using var body = System.Text.Json.JsonDocument.Parse(handler.Bodies[0]!);
         var root = body.RootElement;

--- a/QuickMail.Tests/GraphCalendarSyncServiceTests.cs
+++ b/QuickMail.Tests/GraphCalendarSyncServiceTests.cs
@@ -1,0 +1,404 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using QuickMail.Models;
+using QuickMail.Services;
+using QuickMail.Services.Graph;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// Graph calendar sync (read-down v1): mapping, paging, 429 retry, replace-slice semantics, and
+/// the is_graph store guards. HTTP is stubbed with a queued <see cref="HttpMessageHandler"/>
+/// (the GraphClientTests style); persistence uses a real temp-profile LocalStoreService so the
+/// replace-slice and guard SQL are exercised for real.
+/// </summary>
+public class GraphCalendarSyncServiceTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly LocalStoreService _store;
+    private readonly Guid _accountId = Guid.NewGuid();
+
+    public GraphCalendarSyncServiceTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"qm-gcal-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        _store = new LocalStoreService(new ProfileContext(_tempDir));
+        _store.Initialize();
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); } catch { }
+    }
+
+    // ── Test plumbing ────────────────────────────────────────────────────────────
+
+    /// <summary>Serves queued responses; records each request's URL and Prefer header.</summary>
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        private readonly Queue<HttpResponseMessage> _responses;
+        public int Calls { get; private set; }
+        public List<string> Urls { get; } = [];
+        public List<string?> PreferHeaders { get; } = [];
+
+        public RecordingHandler(params HttpResponseMessage[] responses)
+            => _responses = new Queue<HttpResponseMessage>(responses);
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            Calls++;
+            Urls.Add(request.RequestUri!.ToString());
+            PreferHeaders.Add(request.Headers.TryGetValues("Prefer", out var v) ? string.Join(",", v) : null);
+            var resp = _responses.Count > 0
+                ? _responses.Dequeue()
+                : Json("""{ "value": [] }""");
+            return Task.FromResult(resp);
+        }
+    }
+
+    private sealed class FixedAccountService : IAccountService
+    {
+        private readonly List<AccountModel> _accounts;
+        public FixedAccountService(params AccountModel[] accounts) => _accounts = [.. accounts];
+        public List<AccountModel> LoadAccounts() => _accounts;
+        public void SaveAccounts(List<AccountModel> accounts) { }
+        public void SetDefaultAccount(Guid accountId) { }
+    }
+
+    /// <summary>Silent token acquisition fails — the calendar grant has lapsed.</summary>
+    private sealed class SignInRequiredOAuthService : IOAuthService
+    {
+        public Task<string> GetAccessTokenAsync(AccountModel account, CancellationToken ct = default) => Task.FromResult(string.Empty);
+        public Task<string> GetAccessTokenAsync(AccountModel account, string[] scopes, CancellationToken ct = default) => Task.FromResult(string.Empty);
+        public Task<string> GetAccessTokenSilentAsync(AccountModel account, string[] scopes, CancellationToken ct = default)
+            => throw new InteractiveSignInRequiredException("consent required");
+        public Task EnsureSilentTokenAsync(AccountModel account, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<OAuthResult> SignInInteractiveAsync(AccountModel account, CancellationToken ct = default) => Task.FromResult(new OAuthResult(string.Empty, string.Empty));
+        public Task<OAuthResult> SignInInteractiveWithContactsAsync(AccountModel account, CancellationToken ct = default) => Task.FromResult(new OAuthResult(string.Empty, string.Empty));
+        public Task RequestContactsConsentAsync(AccountModel account, CancellationToken ct = default) => Task.CompletedTask;
+        public Task SignOutAsync(AccountModel account) => Task.CompletedTask;
+    }
+
+    private static HttpResponseMessage Json(string body, TimeSpan? retryAfter = null, HttpStatusCode code = HttpStatusCode.OK)
+    {
+        var r = new HttpResponseMessage(code) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
+        if (retryAfter.HasValue)
+            r.Headers.RetryAfter = new System.Net.Http.Headers.RetryConditionHeaderValue(retryAfter.Value);
+        return r;
+    }
+
+    private AccountModel GraphAccount() => new()
+    {
+        Id = _accountId,
+        BackendKind = BackendKind.MicrosoftGraph,
+        Username = "user@example.com",
+    };
+
+    private GraphCalendarSyncService Service(RecordingHandler handler, params AccountModel[] accounts)
+        => new(new FixedAccountService(accounts.Length > 0 ? accounts : [GraphAccount()]),
+               _store,
+               new GraphClient(new StubOAuthService(), new HttpClient(handler), defaultRetryDelay: TimeSpan.Zero));
+
+    private static string EventJson(string id, string subject, string startUtc, string endUtc,
+        bool allDay = false, bool isOrganizer = false, string response = "accepted",
+        string? location = null, string? preview = null)
+        => $$"""
+           {
+             "id": "{{id}}",
+             "subject": "{{subject}}",
+             "bodyPreview": "{{preview ?? ""}}",
+             "location": { "displayName": "{{location ?? ""}}" },
+             "organizer": { "emailAddress": { "name": "Alex Organizer", "address": "alex@example.com" } },
+             "start": { "dateTime": "{{startUtc}}", "timeZone": "UTC" },
+             "end": { "dateTime": "{{endUtc}}", "timeZone": "UTC" },
+             "isAllDay": {{(allDay ? "true" : "false")}},
+             "isOrganizer": {{(isOrganizer ? "true" : "false")}},
+             "responseStatus": { "response": "{{response}}" }
+           }
+           """;
+
+    private static string Page(string? nextLink, params string[] events)
+        => $$"""{ "value": [{{string.Join(",", events)}}]{{(nextLink is null ? "" : $$""", "@odata.nextLink": "{{nextLink}}" """)}} }""";
+
+    // ── Mapping ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Sync_MapsTimedEvent_StoringUtcTicksAndGraphFlag()
+    {
+        var handler = new RecordingHandler(Json(Page(null,
+            EventJson("gid-1", "Team sync", "2026-08-01T14:00:00.0000000", "2026-08-01T15:00:00.0000000",
+                      location: "Room 1", preview: "agenda"))));
+
+        var result = await Service(handler).SyncAllAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(1, result.AccountsSynced);
+        Assert.Equal(1, result.EventsFetched);
+        Assert.Null(result.Error);
+
+        var row = Assert.Single(await _store.LoadCalendarEventsAsync());
+        Assert.Equal("gid-1", row.Uid);
+        Assert.Equal(_accountId, row.AccountId);
+        Assert.True(row.IsGraph);
+        Assert.False(row.IsUserCreated); // real account id → read-only in the UI
+        Assert.Equal("Team sync", row.Summary);
+        Assert.Equal("Room 1", row.Location);
+        Assert.Equal("agenda", row.Description);
+        Assert.Equal("alex@example.com", row.Organizer);
+        Assert.Equal("Alex Organizer", row.OrganizerName);
+        Assert.Equal(new DateTime(2026, 8, 1, 14, 0, 0, DateTimeKind.Utc).Ticks, row.StartTimeTicks);
+        Assert.Equal(new DateTime(2026, 8, 1, 15, 0, 0, DateTimeKind.Utc).Ticks, row.EndTimeTicks);
+        Assert.False(row.IsAllDay);
+        Assert.Equal(CalendarResponseStatus.Accepted, row.ResponseStatus);
+        // Not an invite email, and calendarView already expanded any series server-side.
+        Assert.Equal(string.Empty, row.SourceMessageId);
+        Assert.Equal(string.Empty, row.SourceFolder);
+        Assert.Null(row.RecurrenceRule);
+        Assert.False(row.IsRecurring);
+    }
+
+    [Fact]
+    public async Task Sync_AllDayEvent_AnchorsToLocalDay()
+    {
+        // Graph all-day: midnight-to-midnight with an EXCLUSIVE end, in the preferred (UTC) zone.
+        var handler = new RecordingHandler(Json(Page(null,
+            EventJson("gid-allday", "Holiday", "2026-08-03T00:00:00.0000000", "2026-08-04T00:00:00.0000000", allDay: true))));
+
+        await Service(handler).SyncAllAsync(TestContext.Current.CancellationToken);
+
+        var row = Assert.Single(await _store.LoadCalendarEventsAsync());
+        Assert.True(row.IsAllDay);
+        // Stored like locally-authored all-day rows: local midnight .. 23:59:59 of the same day,
+        // so the event shows on August 3 in the user's zone regardless of UTC offset.
+        Assert.Equal(new DateTime(2026, 8, 3, 0, 0, 0, DateTimeKind.Local), row.StartTime);
+        Assert.Equal(new DateTime(2026, 8, 3, 23, 59, 59, DateTimeKind.Local), row.EndTime);
+    }
+
+    [Theory]
+    [InlineData("accepted",            false, CalendarResponseStatus.Accepted)]
+    [InlineData("declined",            false, CalendarResponseStatus.Declined)]
+    [InlineData("tentativelyAccepted", false, CalendarResponseStatus.Tentative)]
+    [InlineData("organizer",           true,  CalendarResponseStatus.Accepted)]
+    [InlineData("none",                true,  CalendarResponseStatus.Accepted)]
+    [InlineData("none",                false, CalendarResponseStatus.Pending)]
+    [InlineData("notResponded",        false, CalendarResponseStatus.Pending)]
+    [InlineData(null,                  false, CalendarResponseStatus.Pending)]
+    public void MapResponseStatus_CoversGraphValues(string? response, bool isOrganizer, CalendarResponseStatus expected)
+        => Assert.Equal(expected, GraphCalendarSyncService.MapResponseStatus(response, isOrganizer));
+
+    // ── Request shape ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Sync_SendsPreferUtcHeader_AndCalendarViewWindow()
+    {
+        var handler = new RecordingHandler(Json(Page(null)));
+
+        await Service(handler).SyncAllAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(1, handler.Calls);
+        Assert.Equal("outlook.timezone=\"UTC\"", handler.PreferHeaders[0]);
+        var url = handler.Urls[0];
+        Assert.Contains("/me/calendarView?", url);
+        Assert.Contains("startDateTime=", url);
+        Assert.Contains("endDateTime=", url);
+        Assert.Contains("$select=", url);
+    }
+
+    // ── Paging ───────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Sync_FollowsNextLink_AcrossPages()
+    {
+        var handler = new RecordingHandler(
+            Json(Page("https://graph.microsoft.com/v1.0/me/calendarView?page=2",
+                EventJson("gid-a", "A", "2026-08-01T09:00:00.0000000", "2026-08-01T10:00:00.0000000"),
+                EventJson("gid-b", "B", "2026-08-02T09:00:00.0000000", "2026-08-02T10:00:00.0000000"))),
+            Json(Page(null,
+                EventJson("gid-c", "C", "2026-08-03T09:00:00.0000000", "2026-08-03T10:00:00.0000000"))));
+
+        var result = await Service(handler).SyncAllAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, handler.Calls);
+        Assert.Contains("page=2", handler.Urls[1]);
+        Assert.Equal(3, result.EventsFetched);
+        var rows = await _store.LoadCalendarEventsAsync();
+        Assert.Equal(new[] { "gid-a", "gid-b", "gid-c" }, rows.Select(r => r.Uid).OrderBy(u => u).ToArray());
+    }
+
+    // ── 429 retry ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Sync_RetriesOn429_HonoringRetryAfter()
+    {
+        var handler = new RecordingHandler(
+            Json("{}", retryAfter: TimeSpan.Zero, code: (HttpStatusCode)429),
+            Json(Page(null, EventJson("gid-429", "Throttled", "2026-08-01T09:00:00.0000000", "2026-08-01T10:00:00.0000000"))));
+
+        var result = await Service(handler).SyncAllAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, handler.Calls); // one 429, one successful retry
+        Assert.Null(result.Error);
+        Assert.Equal("gid-429", Assert.Single(await _store.LoadCalendarEventsAsync()).Uid);
+    }
+
+    // ── Replace-slice ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SecondSync_RemovesEventsThatVanishedOnServer()
+    {
+        var handler = new RecordingHandler(
+            Json(Page(null,
+                EventJson("gid-keep", "Keep", "2026-08-01T09:00:00.0000000", "2026-08-01T10:00:00.0000000"),
+                EventJson("gid-drop", "Drop", "2026-08-02T09:00:00.0000000", "2026-08-02T10:00:00.0000000"))),
+            Json(Page(null,
+                EventJson("gid-keep", "Keep", "2026-08-01T09:00:00.0000000", "2026-08-01T10:00:00.0000000"))));
+
+        var service = Service(handler);
+        await service.SyncAllAsync(TestContext.Current.CancellationToken);
+        Assert.Equal(2, (await _store.LoadCalendarEventsAsync()).Count);
+
+        await service.SyncAllAsync(TestContext.Current.CancellationToken);
+
+        var rows = await _store.LoadCalendarEventsAsync();
+        Assert.Equal("gid-keep", Assert.Single(rows).Uid);
+    }
+
+    [Fact]
+    public async Task ReplaceSlice_LeavesLocalAndInviteRowsAlone()
+    {
+        // A locally-authored appointment and a harvested invite for the SAME account.
+        await _store.UpsertCalendarEventAsync(new CalendarEvent
+        {
+            Uid = "local-1", AccountId = CalendarEvent.LocalAccountId, Summary = "My appointment",
+        });
+        await _store.UpsertCalendarEventAsync(new CalendarEvent
+        {
+            Uid = "invite-1", AccountId = _accountId, Summary = "Invite",
+            SourceMessageId = "msg-1", SourceFolder = "INBOX",
+        });
+
+        var handler = new RecordingHandler(Json(Page(null,
+            EventJson("gid-1", "Graph event", "2026-08-01T09:00:00.0000000", "2026-08-01T10:00:00.0000000"))));
+        await Service(handler).SyncAllAsync(TestContext.Current.CancellationToken);
+
+        var rows = await _store.LoadCalendarEventsAsync();
+        Assert.Equal(3, rows.Count);
+        Assert.Contains(rows, r => r.Uid == "local-1" && !r.IsGraph);
+        Assert.Contains(rows, r => r.Uid == "invite-1" && !r.IsGraph && r.SourceMessageId == "msg-1");
+        Assert.Contains(rows, r => r.Uid == "gid-1" && r.IsGraph);
+    }
+
+    // ── Store guards for is_graph rows ───────────────────────────────────────────
+
+    [Fact]
+    public async Task HarvestUpsert_DoesNotOverwriteGraphRow_OnUidCollision()
+    {
+        await _store.ReplaceGraphCalendarEventsAsync(_accountId, [new CalendarEvent
+        {
+            Uid = "shared-uid", AccountId = _accountId, Summary = "Graph copy",
+            ResponseStatus = CalendarResponseStatus.Accepted,
+        }]);
+
+        // The harvest path re-upserts by (uid, account) — it must not clobber the Graph row.
+        await _store.UpsertCalendarEventAsync(new CalendarEvent
+        {
+            Uid = "shared-uid", AccountId = _accountId, Summary = "Harvested copy",
+            SourceMessageId = "msg-x", SourceFolder = "INBOX",
+        });
+
+        var row = Assert.Single(await _store.LoadCalendarEventsAsync());
+        Assert.True(row.IsGraph);
+        Assert.Equal("Graph copy", row.Summary);
+        Assert.Equal(string.Empty, row.SourceMessageId);
+    }
+
+    [Fact]
+    public async Task OrphanCleanup_SkipsGraphRows()
+    {
+        // A Graph row that (hypothetically) carries a source link must not be touched by the
+        // invite harvest's orphan cleanup — Graph rows are owned by the sync's replace-slice.
+        await _store.ReplaceGraphCalendarEventsAsync(_accountId, [new CalendarEvent
+        {
+            Uid = "gid-src", AccountId = _accountId, Summary = "Graph",
+            SourceMessageId = "not-a-real-message", SourceFolder = "INBOX",
+        }]);
+        await _store.UpsertCalendarEventAsync(new CalendarEvent
+        {
+            Uid = "invite-orphan", AccountId = _accountId, Summary = "Invite",
+            SourceMessageId = "also-gone", SourceFolder = "INBOX",
+        });
+
+        await _store.ClearOrphanedCalendarSourceLinksAsync();
+
+        var rows = await _store.LoadCalendarEventsAsync();
+        Assert.Equal("not-a-real-message", rows.Single(r => r.Uid == "gid-src").SourceMessageId);
+        Assert.Equal(string.Empty, rows.Single(r => r.Uid == "invite-orphan").SourceMessageId);
+    }
+
+    [Fact]
+    public async Task DeleteAccountData_CascadesGraphRows()
+    {
+        await _store.ReplaceGraphCalendarEventsAsync(_accountId, [new CalendarEvent
+        {
+            Uid = "gid-cascade", AccountId = _accountId, Summary = "Graph",
+        }]);
+
+        await _store.DeleteAccountDataAsync(_accountId);
+
+        Assert.Empty(await _store.LoadCalendarEventsAsync());
+    }
+
+    // ── Eligibility and failure handling ─────────────────────────────────────────
+
+    [Fact]
+    public async Task Sync_SkipsNonGraphAccounts()
+    {
+        var imapAccount = new AccountModel { Id = Guid.NewGuid(), BackendKind = BackendKind.ImapSmtp };
+        var handler = new RecordingHandler();
+
+        var result = await Service(handler, imapAccount).SyncAllAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(0, handler.Calls);
+        Assert.Equal(GraphCalendarSyncResult.None, result);
+    }
+
+    [Fact]
+    public async Task Sync_SignInRequired_ReportsErrorWithoutThrowing()
+    {
+        var handler = new RecordingHandler();
+        var graph = new GraphClient(new SignInRequiredOAuthService(), new HttpClient(handler), defaultRetryDelay: TimeSpan.Zero);
+        var service = new GraphCalendarSyncService(new FixedAccountService(GraphAccount()), _store, graph);
+
+        var result = await service.SyncAllAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(0, result.AccountsSynced);
+        Assert.NotNull(result.Error);
+        Assert.Contains("sign-in", result.Error, StringComparison.OrdinalIgnoreCase);
+        Assert.Empty(await _store.LoadCalendarEventsAsync()); // nothing was deleted or inserted
+    }
+
+    [Fact]
+    public async Task Sync_HttpFailure_ReportsErrorAndPreservesExistingRows()
+    {
+        // Seed a previous successful sync, then fail the next one — the old slice must survive
+        // (the replace happens only after a full successful fetch).
+        await _store.ReplaceGraphCalendarEventsAsync(_accountId, [new CalendarEvent
+        {
+            Uid = "gid-old", AccountId = _accountId, Summary = "Old slice",
+        }]);
+        var handler = new RecordingHandler(Json("""{ "error": "boom" }""", code: HttpStatusCode.InternalServerError));
+
+        var result = await Service(handler).SyncAllAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(0, result.AccountsSynced);
+        Assert.NotNull(result.Error);
+        Assert.Equal("gid-old", Assert.Single(await _store.LoadCalendarEventsAsync()).Uid);
+    }
+}

--- a/QuickMail.Tests/IcsModelTests.cs
+++ b/QuickMail.Tests/IcsModelTests.cs
@@ -50,6 +50,148 @@ public class IcsModelTests
         Assert.Equal(14, model.StartTime.Value.Hour); // UTC
     }
 
+    // ── Parse: TZID handling ────────────────────────────────────────────────────
+
+    private static IcsModel? ParseWithDtstart(string dtstartLine) =>
+        IcsModel.Parse(string.Join("\r\n",
+            "BEGIN:VCALENDAR",
+            "VERSION:2.0",
+            "BEGIN:VEVENT",
+            "UID:tz-test@test.com",
+            "SUMMARY:TZ Test",
+            dtstartLine,
+            "END:VEVENT",
+            "END:VCALENDAR"));
+
+    [Fact]
+    public void Parse_DtstartWithIanaTzid_ConvertsToCorrectInstant()
+    {
+        var model = ParseWithDtstart("DTSTART;TZID=America/New_York:20260115T100000");
+
+        Assert.NotNull(model?.StartTime);
+        // Expected instant computed through TimeZoneInfo so the test passes on any machine zone.
+        var eastern = TimeZoneInfo.FindSystemTimeZoneById("America/New_York");
+        var expectedUtc = TimeZoneInfo.ConvertTimeToUtc(
+            new DateTime(2026, 1, 15, 10, 0, 0, DateTimeKind.Unspecified), eastern);
+        Assert.Equal(expectedUtc, model!.StartTime!.Value.ToUniversalTime());
+    }
+
+    [Fact]
+    public void Parse_DtstartWithWindowsTzid_ConvertsToCorrectInstant()
+    {
+        var model = ParseWithDtstart("DTSTART;TZID=Eastern Standard Time:20260115T100000");
+
+        Assert.NotNull(model?.StartTime);
+        var eastern = TimeZoneInfo.FindSystemTimeZoneById("Eastern Standard Time");
+        var expectedUtc = TimeZoneInfo.ConvertTimeToUtc(
+            new DateTime(2026, 1, 15, 10, 0, 0, DateTimeKind.Unspecified), eastern);
+        Assert.Equal(expectedUtc, model!.StartTime!.Value.ToUniversalTime());
+    }
+
+    [Fact]
+    public void Parse_DtstartWithQuotedTzidAndExtraParams_StillResolves()
+    {
+        var model = ParseWithDtstart("DTSTART;VALUE=DATE-TIME;TZID=\"America/Chicago\":20260601T090000");
+
+        Assert.NotNull(model?.StartTime);
+        var central = TimeZoneInfo.FindSystemTimeZoneById("America/Chicago");
+        var expectedUtc = TimeZoneInfo.ConvertTimeToUtc(
+            new DateTime(2026, 6, 1, 9, 0, 0, DateTimeKind.Unspecified), central);
+        Assert.Equal(expectedUtc, model!.StartTime!.Value.ToUniversalTime());
+    }
+
+    [Fact]
+    public void Parse_DtstartWithUnknownTzid_FallsBackToMachineLocal()
+    {
+        var model = ParseWithDtstart("DTSTART;TZID=Not/AZone:20260115T100000");
+
+        Assert.NotNull(model?.StartTime);
+        // Historical fallback: treated as machine-local wall-clock 10:00.
+        Assert.Equal(10, model!.StartTime!.Value.Hour);
+        Assert.Equal(DateTimeKind.Local, model.StartTime.Value.Kind);
+    }
+
+    [Fact]
+    public void Parse_DtstartWithoutTzid_KeepsMachineLocalBehavior()
+    {
+        var model = ParseWithDtstart("DTSTART:20260115T100000");
+
+        Assert.NotNull(model?.StartTime);
+        Assert.Equal(10, model!.StartTime!.Value.Hour);
+    }
+
+    [Fact]
+    public void ExtractTzidParam_Variants()
+    {
+        Assert.Equal("America/Chicago", IcsModel.ExtractTzidParam("DTSTART;TZID=America/Chicago"));
+        Assert.Equal("Europe/Paris", IcsModel.ExtractTzidParam("DTSTART;VALUE=DATE-TIME;TZID=\"Europe/Paris\""));
+        Assert.Null(IcsModel.ExtractTzidParam("DTSTART"));
+        Assert.Null(IcsModel.ExtractTzidParam("DTSTART;VALUE=DATE"));
+    }
+
+    // ── ExportEvent (.ics export) ───────────────────────────────────────────────
+
+    [Fact]
+    public void ExportEvent_TimedEvent_RoundTripsThroughParse()
+    {
+        var evt = new CalendarEvent
+        {
+            Uid = "local-export1",
+            AccountId = CalendarEvent.LocalAccountId,
+            Summary = "Dentist, downtown",              // comma must survive escaping
+            Location = "12 Main St; Suite 4",           // semicolon too
+            Description = "Bring insurance card",
+            StartTimeTicks = new DateTime(2026, 7, 20, 14, 0, 0, DateTimeKind.Utc).Ticks,
+            EndTimeTicks = new DateTime(2026, 7, 20, 14, 30, 0, DateTimeKind.Utc).Ticks,
+        };
+
+        var ics = IcsModel.ExportEvent(evt);
+        Assert.Contains("METHOD:PUBLISH", ics);
+        Assert.Contains("UID:local-export1", ics);
+
+        var parsed = IcsModel.Parse(ics);
+        Assert.NotNull(parsed);
+        Assert.Equal("Dentist, downtown", parsed!.Summary);
+        Assert.Equal("12 Main St; Suite 4", parsed.Location);
+        Assert.Equal("Bring insurance card", parsed.Description);
+        Assert.Equal(evt.StartTimeTicks, parsed.StartTime!.Value.ToUniversalTime().Ticks);
+        Assert.Equal(evt.EndTimeTicks, parsed.EndTime!.Value.ToUniversalTime().Ticks);
+    }
+
+    [Fact]
+    public void ExportEvent_AllDay_UsesDateValuesWithExclusiveEnd()
+    {
+        var evt = new CalendarEvent
+        {
+            Uid = "local-allday1",
+            AccountId = CalendarEvent.LocalAccountId,
+            Summary = "Holiday",
+            IsAllDay = true,
+            StartTimeTicks = new DateTime(2026, 7, 20).ToUniversalTime().Ticks,
+            EndTimeTicks = new DateTime(2026, 7, 20, 23, 59, 59).ToUniversalTime().Ticks,
+        };
+
+        var ics = IcsModel.ExportEvent(evt);
+        Assert.Contains("DTSTART;VALUE=DATE:20260720", ics);
+        Assert.Contains("DTEND;VALUE=DATE:20260721", ics); // exclusive end = next day
+    }
+
+    [Fact]
+    public void ExportEvent_Recurring_CarriesRRule()
+    {
+        var evt = new CalendarEvent
+        {
+            Uid = "local-rec1",
+            AccountId = CalendarEvent.LocalAccountId,
+            Summary = "Standup",
+            StartTimeTicks = DateTime.UtcNow.Ticks,
+            RecurrenceRule = "FREQ=WEEKLY;BYDAY=TU",
+        };
+
+        var ics = IcsModel.ExportEvent(evt);
+        Assert.Contains("RRULE:FREQ=WEEKLY;BYDAY=TU", ics);
+    }
+
     [Fact]
     public void Parse_MinimalValidIcs_ReturnsModel()
     {

--- a/QuickMail.Tests/IcsModelTests.cs
+++ b/QuickMail.Tests/IcsModelTests.cs
@@ -611,6 +611,159 @@ public class IcsModelTests
         Assert.Equal("Standup", brief);
     }
 
+    // ── ParseAllEvents (CalDAV multi-VEVENT bodies) ─────────────────────────────
+
+    [Fact]
+    public void ParseAllEvents_MultiVEvent_ReturnsEachEvent_WithCalendarMethodApplied()
+    {
+        var ics = string.Join("\r\n",
+            "BEGIN:VCALENDAR",
+            "VERSION:2.0",
+            "METHOD:PUBLISH",
+            "BEGIN:VEVENT",
+            "UID:one@test",
+            "SUMMARY:First",
+            "DTSTART:20260801T090000Z",
+            "DTEND:20260801T100000Z",
+            "END:VEVENT",
+            "BEGIN:VEVENT",
+            "UID:two@test",
+            "SUMMARY:Second",
+            "DTSTART;VALUE=DATE:20260803",
+            "DTEND;VALUE=DATE:20260805",
+            "END:VEVENT",
+            "END:VCALENDAR");
+
+        var events = IcsModel.ParseAllEvents(ics);
+
+        Assert.Equal(2, events.Count);
+        Assert.Equal("one@test", events[0].Uid);
+        Assert.False(events[0].IsAllDay);
+        Assert.Equal("PUBLISH", events[0].Method);
+        Assert.Equal(new DateTime(2026, 8, 1, 9, 0, 0, DateTimeKind.Utc), events[0].StartTime!.Value.ToUniversalTime());
+
+        Assert.Equal("two@test", events[1].Uid);
+        Assert.True(events[1].IsAllDay);
+        Assert.Equal("PUBLISH", events[1].Method);
+        Assert.Equal(new DateTime(2026, 8, 3), events[1].StartTime!.Value.Date);
+        // DTEND stays EXCLUSIVE on the model (RFC 5545); consumers re-anchor.
+        Assert.Equal(new DateTime(2026, 8, 5), events[1].EndTime!.Value.Date);
+    }
+
+    [Fact]
+    public void ParseAllEvents_RecurringMaster_CapturesRRuleAndExDates()
+    {
+        var ics = string.Join("\r\n",
+            "BEGIN:VCALENDAR",
+            "BEGIN:VEVENT",
+            "UID:series@test",
+            "SUMMARY:Weekly sync",
+            "DTSTART:20260804T090000",   // local wall-clock, no TZID
+            "DTEND:20260804T093000",
+            "RRULE:FREQ=WEEKLY;BYDAY=TU",
+            "EXDATE:20260811T090000,20260825T090000",
+            "END:VEVENT",
+            "END:VCALENDAR");
+
+        var evt = Assert.Single(IcsModel.ParseAllEvents(ics));
+
+        Assert.Equal("FREQ=WEEKLY;BYDAY=TU", evt.RecurrenceRule);
+        Assert.Null(evt.RecurrenceId);
+        Assert.Equal(
+            new[] { new DateTime(2026, 8, 11, 9, 0, 0), new DateTime(2026, 8, 25, 9, 0, 0) },
+            evt.ExDates);
+    }
+
+    [Fact]
+    public void ParseAllEvents_UtcExDate_NormalizesToLocal()
+    {
+        var ics = string.Join("\r\n",
+            "BEGIN:VCALENDAR",
+            "BEGIN:VEVENT",
+            "UID:series-utc@test",
+            "SUMMARY:Daily",
+            "DTSTART:20260804T160000Z",
+            "RRULE:FREQ=DAILY",
+            "EXDATE:20260805T160000Z",
+            "END:VEVENT",
+            "END:VCALENDAR");
+
+        var evt = Assert.Single(IcsModel.ParseAllEvents(ics));
+
+        var expectedLocal = new DateTime(2026, 8, 5, 16, 0, 0, DateTimeKind.Utc).ToLocalTime();
+        Assert.Equal(expectedLocal, Assert.Single(evt.ExDates));
+    }
+
+    [Fact]
+    public void ParseAllEvents_OverriddenInstance_CarriesRecurrenceId()
+    {
+        var ics = string.Join("\r\n",
+            "BEGIN:VCALENDAR",
+            "BEGIN:VEVENT",
+            "UID:series@test",
+            "SUMMARY:Weekly sync",
+            "DTSTART:20260804T090000Z",
+            "RRULE:FREQ=WEEKLY",
+            "END:VEVENT",
+            "BEGIN:VEVENT",
+            "UID:series@test",
+            "SUMMARY:Weekly sync (moved)",
+            "RECURRENCE-ID:20260811T090000Z",
+            "DTSTART:20260811T100000Z",
+            "END:VEVENT",
+            "END:VCALENDAR");
+
+        var events = IcsModel.ParseAllEvents(ics);
+
+        Assert.Equal(2, events.Count);
+        Assert.Null(events[0].RecurrenceId);
+        Assert.Equal("20260811T090000Z", events[1].RecurrenceId);
+    }
+
+    [Fact]
+    public void ParseAllEvents_CapturesStatus()
+    {
+        var ics = string.Join("\r\n",
+            "BEGIN:VCALENDAR",
+            "BEGIN:VEVENT",
+            "UID:gone@test",
+            "SUMMARY:Cancelled thing",
+            "DTSTART:20260801T090000Z",
+            "STATUS:CANCELLED",
+            "END:VEVENT",
+            "END:VCALENDAR");
+
+        Assert.Equal("CANCELLED", Assert.Single(IcsModel.ParseAllEvents(ics)).Status);
+    }
+
+    [Fact]
+    public void ParseAllEvents_GarbageOrEmpty_ReturnsEmpty()
+    {
+        Assert.Empty(IcsModel.ParseAllEvents(""));
+        Assert.Empty(IcsModel.ParseAllEvents("not ics at all"));
+        Assert.Empty(IcsModel.ParseAllEvents("BEGIN:VCALENDAR\r\nEND:VCALENDAR"));
+    }
+
+    [Fact]
+    public void Parse_MultiVEventBody_ReturnsFirstEvent()
+    {
+        var ics = string.Join("\r\n",
+            "BEGIN:VCALENDAR",
+            "BEGIN:VEVENT",
+            "UID:one@test",
+            "SUMMARY:First",
+            "DTSTART:20260801T090000Z",
+            "END:VEVENT",
+            "BEGIN:VEVENT",
+            "UID:two@test",
+            "SUMMARY:Second",
+            "DTSTART:20260802T090000Z",
+            "END:VEVENT",
+            "END:VCALENDAR");
+
+        Assert.Equal("one@test", IcsModel.Parse(ics)!.Uid);
+    }
+
     // ── Helpers ─────────────────────────────────────────────────────────────────
 
     private static IcsModel CreateSampleInvite()

--- a/QuickMail.Tests/MainViewModelCalendarTests.cs
+++ b/QuickMail.Tests/MainViewModelCalendarTests.cs
@@ -52,6 +52,71 @@ public class MainViewModelCalendarTests
     }
 
     [Fact]
+    public void CheckReminders_FiresOncePerOccurrence_WithinLeadWindow()
+    {
+        var soon = DateTime.Now.AddMinutes(5);
+        var calendarService = new StubCalendarService
+        {
+            StoredEvents =
+            [
+                new CalendarEvent
+                {
+                    Uid = "rem-1", AccountId = CalendarEvent.LocalAccountId,
+                    Summary = "Standup", Location = "Zoom",
+                    StartTimeTicks = soon.ToUniversalTime().Ticks,
+                    ResponseStatus = CalendarResponseStatus.Accepted,
+                },
+                new CalendarEvent   // outside the 10-minute window: must not fire
+                {
+                    Uid = "rem-2", AccountId = CalendarEvent.LocalAccountId,
+                    Summary = "Later",
+                    StartTimeTicks = DateTime.Now.AddHours(3).ToUniversalTime().Ticks,
+                    ResponseStatus = CalendarResponseStatus.Accepted,
+                },
+            ],
+        };
+        var vm = MakeVm(calendarService);
+        vm.RemindersEnabled = true;
+        vm.ReminderLeadMinutes = 10;
+
+        var announced = new System.Collections.Generic.List<string>();
+        vm.AnnouncementRequested += (_, e) => announced.Add(e.Text);
+
+        vm.CheckReminders();
+        vm.CheckReminders();   // second pass must not re-fire
+
+        Assert.Single(announced);
+        Assert.Contains("Standup", announced[0]);
+        Assert.DoesNotContain(announced, a => a.Contains("Later"));
+    }
+
+    [Fact]
+    public void CheckReminders_Disabled_FiresNothing()
+    {
+        var calendarService = new StubCalendarService
+        {
+            StoredEvents =
+            [
+                new CalendarEvent
+                {
+                    Uid = "rem-3", AccountId = CalendarEvent.LocalAccountId,
+                    Summary = "Soon",
+                    StartTimeTicks = DateTime.Now.AddMinutes(5).ToUniversalTime().Ticks,
+                    ResponseStatus = CalendarResponseStatus.Accepted,
+                },
+            ],
+        };
+        var vm = MakeVm(calendarService);
+        vm.RemindersEnabled = false;   // default
+
+        var announced = 0;
+        vm.AnnouncementRequested += (_, _) => announced++;
+        vm.CheckReminders();
+
+        Assert.Equal(0, announced);
+    }
+
+    [Fact]
     public async Task RefreshAsync_OutsideCalendarView_DoesNotTouchCalendarService()
     {
         var calendarService = new StubCalendarService();

--- a/QuickMail.Tests/MainViewModelFlagTests.cs
+++ b/QuickMail.Tests/MainViewModelFlagTests.cs
@@ -238,6 +238,7 @@ sealed class FilterableStoreForFlags : ILocalStoreService
     public Task<List<(Guid AccountId, string FolderName, string MessageId, string IcsText)>> LoadAllCalendarIcsAsync()
         => Task.FromResult(new List<(Guid, string, string, string)>());
     public Task ClearOrphanedCalendarSourceLinksAsync() => Task.CompletedTask;
+    public Task ReplaceGraphCalendarEventsAsync(Guid accountId, IReadOnlyList<CalendarEvent> events) => Task.CompletedTask;
     public Task<string?> GetDeltaTokenAsync(Guid accountId, string folderId) => Task.FromResult<string?>(null);
     public Task SetDeltaTokenAsync(Guid accountId, string folderId, string deltaToken) => Task.CompletedTask;
 }

--- a/QuickMail.Tests/MarkReadOnOpenTests.cs
+++ b/QuickMail.Tests/MarkReadOnOpenTests.cs
@@ -148,6 +148,7 @@ public class MarkReadOnOpenTests
         public Task<List<(Guid AccountId, string FolderName, string MessageId, string IcsText)>> LoadAllCalendarIcsAsync()
             => Task.FromResult(new List<(Guid, string, string, string)>());
         public Task ClearOrphanedCalendarSourceLinksAsync() => Task.CompletedTask;
+        public Task ReplaceGraphCalendarEventsAsync(Guid accountId, IReadOnlyList<CalendarEvent> events) => Task.CompletedTask;
         public Task<string?> GetDeltaTokenAsync(Guid accountId, string folderId) => Task.FromResult<string?>(null);
         public Task SetDeltaTokenAsync(Guid accountId, string folderId, string deltaToken) => Task.CompletedTask;
     }

--- a/QuickMail.Tests/MessageFilterTests.cs
+++ b/QuickMail.Tests/MessageFilterTests.cs
@@ -52,6 +52,7 @@ public class MessageFilterTests
         public Task<List<(Guid AccountId, string FolderName, string MessageId, string IcsText)>> LoadAllCalendarIcsAsync()
             => Task.FromResult(new List<(Guid, string, string, string)>());
         public Task ClearOrphanedCalendarSourceLinksAsync() => Task.CompletedTask;
+        public Task ReplaceGraphCalendarEventsAsync(Guid accountId, IReadOnlyList<CalendarEvent> events) => Task.CompletedTask;
         public Task<string?> GetDeltaTokenAsync(Guid accountId, string folderId) => Task.FromResult<string?>(null);
         public Task SetDeltaTokenAsync(Guid accountId, string folderId, string deltaToken) => Task.CompletedTask;
     }

--- a/QuickMail.Tests/RecurrenceExpanderTests.cs
+++ b/QuickMail.Tests/RecurrenceExpanderTests.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Linq;
+using QuickMail.Helpers;
+using QuickMail.Models;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+public class RecurrenceExpanderTests
+{
+    private static readonly DateTime Mon = new(2026, 7, 13, 9, 0, 0); // a Monday at 09:00
+
+    [Fact]
+    public void Daily_EveryDay_FillsWindow()
+    {
+        var rule = new RecurrenceRule { Frequency = RecurrenceFrequency.Daily };
+        var occ = RecurrenceExpander.Expand(Mon, rule, Mon, Mon.AddDays(7));
+        Assert.Equal(7, occ.Count);
+        Assert.Equal(Mon, occ[0]);
+        Assert.All(occ, o => Assert.Equal(new TimeSpan(9, 0, 0), o.TimeOfDay)); // time preserved
+    }
+
+    [Fact]
+    public void Daily_Interval2_SkipsDays()
+    {
+        var rule = new RecurrenceRule { Frequency = RecurrenceFrequency.Daily, Interval = 2 };
+        var occ = RecurrenceExpander.Expand(Mon, rule, Mon, Mon.AddDays(7));
+        Assert.Equal(new[] { Mon, Mon.AddDays(2), Mon.AddDays(4), Mon.AddDays(6) }, occ);
+    }
+
+    [Fact]
+    public void Weekly_Default_UsesStartWeekday()
+    {
+        var rule = new RecurrenceRule { Frequency = RecurrenceFrequency.Weekly };
+        var occ = RecurrenceExpander.Expand(Mon, rule, Mon, Mon.AddDays(28));
+        Assert.Equal(4, occ.Count);
+        Assert.All(occ, o => Assert.Equal(DayOfWeek.Monday, o.DayOfWeek));
+    }
+
+    [Fact]
+    public void Weekly_ByDay_MultipleDaysPerWeek_InOrder()
+    {
+        var rule = new RecurrenceRule
+        {
+            Frequency = RecurrenceFrequency.Weekly,
+            ByDay = { DayOfWeek.Monday, DayOfWeek.Wednesday, DayOfWeek.Friday },
+        };
+        var occ = RecurrenceExpander.Expand(Mon, rule, Mon, Mon.AddDays(7));
+        Assert.Equal(3, occ.Count);
+        Assert.Equal(DayOfWeek.Monday, occ[0].DayOfWeek);
+        Assert.Equal(DayOfWeek.Wednesday, occ[1].DayOfWeek);
+        Assert.Equal(DayOfWeek.Friday, occ[2].DayOfWeek);
+        // ordering strictly increasing
+        Assert.True(occ[0] < occ[1] && occ[1] < occ[2]);
+    }
+
+    [Fact]
+    public void Count_LimitsTotalOccurrences()
+    {
+        var rule = new RecurrenceRule { Frequency = RecurrenceFrequency.Daily, Count = 3 };
+        var occ = RecurrenceExpander.Expand(Mon, rule, Mon, Mon.AddYears(1));
+        Assert.Equal(3, occ.Count);
+    }
+
+    [Fact]
+    public void Until_StopsAtDate()
+    {
+        var rule = new RecurrenceRule { Frequency = RecurrenceFrequency.Daily, Until = Mon.AddDays(2) };
+        var occ = RecurrenceExpander.Expand(Mon, rule, Mon, Mon.AddYears(1));
+        Assert.Equal(3, occ.Count); // Mon, +1, +2 inclusive
+    }
+
+    [Fact]
+    public void Window_ExcludesOccurrencesOutsideRange()
+    {
+        var rule = new RecurrenceRule { Frequency = RecurrenceFrequency.Daily };
+        // Window covers only days 3-5 from start.
+        var occ = RecurrenceExpander.Expand(Mon, rule, Mon.AddDays(3), Mon.AddDays(6));
+        Assert.Equal(new[] { Mon.AddDays(3), Mon.AddDays(4), Mon.AddDays(5) }, occ);
+    }
+
+    [Fact]
+    public void Monthly_SameDayOfMonth()
+    {
+        var start = new DateTime(2026, 1, 15, 10, 0, 0);
+        var rule = new RecurrenceRule { Frequency = RecurrenceFrequency.Monthly };
+        var occ = RecurrenceExpander.Expand(start, rule, start, start.AddMonths(3));
+        Assert.Equal(3, occ.Count);
+        Assert.All(occ, o => Assert.Equal(15, o.Day));
+    }
+
+    [Fact]
+    public void RRule_RoundTrips_WeeklyByDayWithCount()
+    {
+        var rule = new RecurrenceRule
+        {
+            Frequency = RecurrenceFrequency.Weekly,
+            Interval = 2,
+            ByDay = { DayOfWeek.Tuesday, DayOfWeek.Thursday },
+            Count = 12,
+        };
+        var text = rule.ToRRule();
+        Assert.Contains("FREQ=WEEKLY", text);
+        Assert.Contains("INTERVAL=2", text);
+        Assert.Contains("BYDAY=TU,TH", text);
+        Assert.Contains("COUNT=12", text);
+
+        var parsed = RecurrenceRule.Parse(text)!;
+        Assert.Equal(RecurrenceFrequency.Weekly, parsed.Frequency);
+        Assert.Equal(2, parsed.Interval);
+        Assert.Equal(new[] { DayOfWeek.Tuesday, DayOfWeek.Thursday }, parsed.ByDay.OrderBy(d => (int)d));
+        Assert.Equal(12, parsed.Count);
+    }
+
+    [Fact]
+    public void Parse_NullOrEmpty_ReturnsNull()
+    {
+        Assert.Null(RecurrenceRule.Parse(null));
+        Assert.Null(RecurrenceRule.Parse(""));
+        Assert.Null(RecurrenceRule.Parse("nonsense-without-freq"));
+    }
+
+    [Fact]
+    public void Parse_HandlesRRulePrefixAndUntil()
+    {
+        var parsed = RecurrenceRule.Parse("RRULE:FREQ=DAILY;UNTIL=20261231T000000Z")!;
+        Assert.Equal(RecurrenceFrequency.Daily, parsed.Frequency);
+        Assert.NotNull(parsed.Until);
+        Assert.Equal(2026, parsed.Until!.Value.Year);
+    }
+}

--- a/QuickMail.Tests/SavedViewsTests.cs
+++ b/QuickMail.Tests/SavedViewsTests.cs
@@ -845,6 +845,7 @@ public class SavedViewsMainViewModelTests
         public Task<List<(Guid AccountId, string FolderName, string MessageId, string IcsText)>> LoadAllCalendarIcsAsync()
             => Task.FromResult(new List<(Guid, string, string, string)>());
         public Task ClearOrphanedCalendarSourceLinksAsync() => Task.CompletedTask;
+        public Task ReplaceGraphCalendarEventsAsync(Guid accountId, IReadOnlyList<CalendarEvent> events) => Task.CompletedTask;
         public Task<string?> GetDeltaTokenAsync(Guid accountId, string folderId) => Task.FromResult<string?>(null);
         public Task SetDeltaTokenAsync(Guid accountId, string folderId, string deltaToken) => Task.CompletedTask;
     }

--- a/QuickMail.Tests/SelectorItemAccessibilityTests.cs
+++ b/QuickMail.Tests/SelectorItemAccessibilityTests.cs
@@ -93,6 +93,13 @@ public class SelectorItemAccessibilityTests
         Assert.Equal("Spam rule", new MailRule { Name = "Spam rule" }.ToString());
         Assert.Equal("Work", new AccountModel { AccountName = "Work" }.ToString());
 
+        // Month grid day cells (MonthGrid ListBox): spoken name = full day context.
+        var cell = new MonthCell(new System.DateTime(2026, 7, 21), displayedMonth: 7, dayEvents:
+            [new CalendarEvent { Summary = "A" }, new CalendarEvent { Summary = "B" }]);
+        Assert.Equal(cell.AccessibleName, cell.ToString());
+        Assert.Contains("Tuesday July 21", cell.ToString());
+        Assert.Contains("2 events", cell.ToString());
+
         var group = new GroupModel { Name = "Team" };
         Assert.Equal(group.Display, group.ToString());
     }

--- a/QuickMail.Tests/SessionFeaturesTests.cs
+++ b/QuickMail.Tests/SessionFeaturesTests.cs
@@ -112,6 +112,7 @@ public class PreviewSuppressionTests
         public Task<List<(Guid AccountId, string FolderName, string MessageId, string IcsText)>> LoadAllCalendarIcsAsync()
             => Task.FromResult(new List<(Guid, string, string, string)>());
         public Task ClearOrphanedCalendarSourceLinksAsync() => Task.CompletedTask;
+        public Task ReplaceGraphCalendarEventsAsync(Guid accountId, IReadOnlyList<CalendarEvent> events) => Task.CompletedTask;
         public Task<string?> GetDeltaTokenAsync(Guid accountId, string folderId) => Task.FromResult<string?>(null);
         public Task SetDeltaTokenAsync(Guid accountId, string folderId, string deltaToken) => Task.CompletedTask;
     }

--- a/QuickMail.Tests/SettingsViewModelTests.cs
+++ b/QuickMail.Tests/SettingsViewModelTests.cs
@@ -66,6 +66,138 @@ public class SettingsViewModelTests
         Assert.Equal(100, loadedConfig.InitialSyncCount);
     }
 
+    // ── CalDAV calendar source ──────────────────────────────────────────────────
+
+    private sealed class RecordingCredentialService : ICredentialService
+    {
+        public Dictionary<string, string> Secrets { get; } = [];
+        public void SavePassword(System.Guid accountId, string password) { }
+        public string? GetPassword(System.Guid accountId) => null;
+        public void DeletePassword(System.Guid accountId) { }
+        public void SaveSecret(string key, string value) => Secrets[key] = value;
+        public string? GetSecret(string key) => Secrets.TryGetValue(key, out var v) ? v : null;
+        public void DeleteSecret(string key) => Secrets.Remove(key);
+    }
+
+    private sealed class StubCalDavClient : ICalDavCalendarClient
+    {
+        public string? LastUrl, LastUser, LastPassword;
+        public bool Fail;
+        public System.Threading.Tasks.Task<CalDavCalendarInfo> DiscoverCalendarAsync(
+            string serverUrl, string username, string password, System.Threading.CancellationToken ct = default)
+        {
+            LastUrl = serverUrl; LastUser = username; LastPassword = password;
+            if (Fail) throw new System.InvalidOperationException("No event calendar was found for this account.");
+            return System.Threading.Tasks.Task.FromResult(new CalDavCalendarInfo("https://p42.example/cal/", "Home"));
+        }
+        public System.Threading.Tasks.Task<List<string>> FetchEventIcsAsync(
+            string calendarUrl, string username, string password,
+            System.DateTime startUtc, System.DateTime endUtc, System.Threading.CancellationToken ct = default)
+            => System.Threading.Tasks.Task.FromResult(new List<string>());
+    }
+
+    [Fact]
+    public void CalDav_LoadsFromConfig_AndSavePersists_UrlUsernameNameOnly()
+    {
+        var configService = new StubConfigService();
+        configService.Save(new ConfigModel
+        {
+            CalDavUrl = "https://caldav.icloud.com", CalDavUsername = "kelly@example.com", CalDavDisplayName = "Apple",
+        });
+        var creds = new RecordingCredentialService();
+        var vm = new SettingsViewModel(configService, new StubCommandRegistry(),
+                                       credentialService: creds);
+
+        Assert.Equal("https://caldav.icloud.com", vm.CalDavUrl);
+        Assert.Equal("kelly@example.com", vm.CalDavUsername);
+        Assert.Equal("Apple", vm.CalDavDisplayName);
+
+        vm.CalDavUrl = " https://caldav.fastmail.com ";
+        vm.CalDavDisplayName = "  "; // blank name falls back to the default
+        vm.SaveCommand.Execute(null);
+
+        var cfg = configService.Load();
+        Assert.Equal("https://caldav.fastmail.com", cfg.CalDavUrl);
+        Assert.Equal("kelly@example.com", cfg.CalDavUsername);
+        Assert.Equal("iCloud", cfg.CalDavDisplayName);
+        // No password typed → nothing written to the credential store (saved secret kept).
+        Assert.Empty(creds.Secrets);
+    }
+
+    [Fact]
+    public void CalDav_Save_WritesPasswordToCredentialStore_NeverConfig()
+    {
+        var configService = new StubConfigService();
+        var creds = new RecordingCredentialService();
+        var vm = new SettingsViewModel(configService, new StubCommandRegistry(),
+                                       credentialService: creds)
+        {
+            CalDavUrl = "https://caldav.icloud.com",
+            CalDavUsername = "kelly@example.com",
+            CalDavPassword = "app-specific-pass",
+        };
+
+        vm.SaveCommand.Execute(null);
+
+        Assert.Equal("app-specific-pass",
+            creds.Secrets[CalDavCalendarClient.SecretKeyFor("kelly@example.com")]);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task CalDav_Test_RunsDiscovery_WithTypedPassword()
+    {
+        var client = new StubCalDavClient();
+        var vm = new SettingsViewModel(new StubConfigService(), new StubCommandRegistry(),
+                                       credentialService: new RecordingCredentialService(),
+                                       calDavClient: client)
+        {
+            CalDavUrl = "https://caldav.icloud.com",
+            CalDavUsername = "kelly@example.com",
+            CalDavPassword = "typed-pass",
+        };
+        string? announced = null;
+        vm.CalDavTestCompleted += t => announced = t;
+
+        await vm.TestCalDavCommand.ExecuteAsync(null);
+
+        Assert.Equal("typed-pass", client.LastPassword);
+        Assert.Equal("Connected. Found calendar: Home.", vm.CalDavTestResult);
+        Assert.Equal(vm.CalDavTestResult, announced);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task CalDav_Test_FallsBackToSavedPassword_AndReportsFailure()
+    {
+        var creds = new RecordingCredentialService();
+        creds.SaveSecret(CalDavCalendarClient.SecretKeyFor("kelly@example.com"), "saved-pass");
+        var client = new StubCalDavClient { Fail = true };
+        var vm = new SettingsViewModel(new StubConfigService(), new StubCommandRegistry(),
+                                       credentialService: creds, calDavClient: client)
+        {
+            CalDavUrl = "https://caldav.icloud.com",
+            CalDavUsername = "kelly@example.com",
+        };
+
+        await vm.TestCalDavCommand.ExecuteAsync(null);
+
+        Assert.Equal("saved-pass", client.LastPassword);
+        Assert.StartsWith("Could not connect.", vm.CalDavTestResult);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task CalDav_Test_MissingFields_PromptsInsteadOfCalling()
+    {
+        var client = new StubCalDavClient();
+        var vm = new SettingsViewModel(new StubConfigService(), new StubCommandRegistry(),
+                                       credentialService: new RecordingCredentialService(),
+                                       calDavClient: client);
+
+        await vm.TestCalDavCommand.ExecuteAsync(null);
+
+        Assert.Null(client.LastUrl); // no request attempted
+        Assert.Contains("app-specific password", vm.CalDavTestResult);
+    }
+
     [Fact]
     public void NotifyOnNewMail_LoadsAndSaves()
     {

--- a/QuickMail.Tests/StubServices.cs
+++ b/QuickMail.Tests/StubServices.cs
@@ -322,10 +322,29 @@ sealed class StubGraphCalendarSyncService : IGraphCalendarSyncService
     public int SyncCallCount { get; private set; }
     public GraphCalendarSyncResult Result { get; set; } = GraphCalendarSyncResult.None;
 
+    /// <summary>When set, CreateEventAsync throws it (simulates a failed push).</summary>
+    public Exception? CreateFailure { get; set; }
+    public List<CalendarEvent> CreatedEvents { get; } = [];
+
     public Task<GraphCalendarSyncResult> SyncAllAsync(CancellationToken ct = default)
     {
         SyncCallCount++;
         return Task.FromResult(Result);
+    }
+
+    public Task<CalendarEvent> CreateEventAsync(AccountModel account, CalendarEvent evt, CancellationToken ct = default)
+    {
+        if (CreateFailure != null) throw CreateFailure;
+        // Mimic the real service: the stored copy carries the server id and the Graph flag.
+        var created = new CalendarEvent
+        {
+            Uid = "graph-" + CreatedEvents.Count, AccountId = account.Id, IsGraph = true,
+            Summary = evt.Summary, Location = evt.Location, Description = evt.Description,
+            StartTimeTicks = evt.StartTimeTicks, EndTimeTicks = evt.EndTimeTicks,
+            IsAllDay = evt.IsAllDay, ResponseStatus = CalendarResponseStatus.Accepted,
+        };
+        CreatedEvents.Add(created);
+        return Task.FromResult(created);
     }
 }
 

--- a/QuickMail.Tests/StubServices.cs
+++ b/QuickMail.Tests/StubServices.cs
@@ -308,6 +308,12 @@ sealed class StubCalendarService : ICalendarService
         if (idx >= 0) StoredEvents[idx].ResponseStatus = status;
         return Task.CompletedTask;
     }
+
+    public Task DeleteEventAsync(string uid, Guid accountId, CancellationToken ct = default)
+    {
+        StoredEvents.RemoveAll(e => e.Uid == uid && e.AccountId == accountId);
+        return Task.CompletedTask;
+    }
 }
 
 /// <summary>Runs everything inline — VM unit tests are single-threaded by design.</summary>

--- a/QuickMail.Tests/StubServices.cs
+++ b/QuickMail.Tests/StubServices.cs
@@ -346,6 +346,26 @@ sealed class StubGraphCalendarSyncService : IGraphCalendarSyncService
         CreatedEvents.Add(created);
         return Task.FromResult(created);
     }
+
+    /// <summary>When set, UpdateEventAsync/DeleteEventAsync throw it (simulates a failed push).</summary>
+    public Exception? WriteFailure { get; set; }
+    public List<CalendarEvent> UpdatedEvents { get; } = [];
+    public List<CalendarEvent> DeletedEvents { get; } = [];
+
+    public Task<CalendarEvent> UpdateEventAsync(AccountModel account, CalendarEvent evt, CancellationToken ct = default)
+    {
+        if (WriteFailure != null) throw WriteFailure;
+        evt.IsGraph = true;
+        UpdatedEvents.Add(evt);
+        return Task.FromResult(evt);
+    }
+
+    public Task DeleteEventAsync(AccountModel account, CalendarEvent evt, CancellationToken ct = default)
+    {
+        if (WriteFailure != null) throw WriteFailure;
+        DeletedEvents.Add(evt);
+        return Task.CompletedTask;
+    }
 }
 
 /// <summary>Runs everything inline — VM unit tests are single-threaded by design.</summary>

--- a/QuickMail.Tests/StubServices.cs
+++ b/QuickMail.Tests/StubServices.cs
@@ -130,6 +130,7 @@ sealed class StubLocalStoreService : ILocalStoreService
     public Task<List<(Guid AccountId, string FolderName, string MessageId, string IcsText)>> LoadAllCalendarIcsAsync()
         => Task.FromResult(new List<(Guid, string, string, string)>());
     public Task ClearOrphanedCalendarSourceLinksAsync() => Task.CompletedTask;
+    public Task ReplaceGraphCalendarEventsAsync(Guid accountId, IReadOnlyList<CalendarEvent> events) => Task.CompletedTask;
     public Task<string?> GetDeltaTokenAsync(Guid accountId, string folderId) => Task.FromResult<string?>(null);
     public Task SetDeltaTokenAsync(Guid accountId, string folderId, string deltaToken) => Task.CompletedTask;
 }
@@ -313,6 +314,18 @@ sealed class StubCalendarService : ICalendarService
     {
         StoredEvents.RemoveAll(e => e.Uid == uid && e.AccountId == accountId);
         return Task.CompletedTask;
+    }
+}
+
+sealed class StubGraphCalendarSyncService : IGraphCalendarSyncService
+{
+    public int SyncCallCount { get; private set; }
+    public GraphCalendarSyncResult Result { get; set; } = GraphCalendarSyncResult.None;
+
+    public Task<GraphCalendarSyncResult> SyncAllAsync(CancellationToken ct = default)
+    {
+        SyncCallCount++;
+        return Task.FromResult(Result);
     }
 }
 

--- a/QuickMail.Tests/UnitTest1.cs
+++ b/QuickMail.Tests/UnitTest1.cs
@@ -331,6 +331,16 @@ public class XamlParseTests
     }
 
     [StaFact]
+    public void EventEditorWindow_XamlParsesWithoutException()
+    {
+        EnsureApplication();
+        var vm = new EventEditorViewModel(new DateTime(2026, 7, 16, 9, 0, 0));
+        var window = new EventEditorWindow(vm);
+        Assert.NotNull(window);
+        window.Close();
+    }
+
+    [StaFact]
     public void GroupManagerWindow_XamlParsesWithoutException()
     {
         EnsureApplication();

--- a/QuickMail/App.xaml.cs
+++ b/QuickMail/App.xaml.cs
@@ -16,6 +16,7 @@ public partial class App : Application
     private ContactService? _contactService;
     private GooglePeopleClient? _googlePeopleClient;
     private GoogleCalendarClient? _googleCalendarClient;
+    private CalDavCalendarClient? _calDavCalendarClient;
     private TemplateService? _templateService;
     private ChangeNotifierRouter? _changeNotifier;
     private GraphChangeNotifier? _graphNotifier;
@@ -268,8 +269,13 @@ public partial class App : Application
             // disposed in OnExit, like the People client). The sync timer and its CTS live in
             // MainViewModel (disposed in MainViewModel.Dispose).
             _googleCalendarClient = new GoogleCalendarClient(googleOAuth);
+            // Generic CalDAV (iCloud-first): the source is configured in Settings (URL + username
+            // in config.ini, app-specific password in Windows Credential Manager), so the sync
+            // service reads config/credentials per pass rather than binding to an account.
+            _calDavCalendarClient = new CalDavCalendarClient();
             var graphCalendarSync = new GraphCalendarSyncService(accountService, localStore, graphBackend.Client,
-                                                                 _googleCalendarClient);
+                                                                 _googleCalendarClient,
+                                                                 _calDavCalendarClient, configService, credentialService);
 
             _updateCheckService = new UpdateCheckService(configService, ParseUpdateFeed(e.Args));
             _bugReportService   = new BugReportService(credentialService);
@@ -316,6 +322,7 @@ public partial class App : Application
         _graphSendMail?.Dispose();
         _googlePeopleClient?.Dispose();
         _googleCalendarClient?.Dispose();
+        _calDavCalendarClient?.Dispose();
         _contactService?.Dispose();
         _templateService?.Dispose();
         _updateCheckService?.Dispose();

--- a/QuickMail/App.xaml.cs
+++ b/QuickMail/App.xaml.cs
@@ -261,13 +261,19 @@ public partial class App : Application
             var calendarProvider = new LocalCacheCalendarProvider(localStore);
             var calendarService = new CalendarService(calendarProvider);
 
+            // Graph calendar sync (read-down v1): pulls each Graph account's primary calendar into
+            // the local store. Reuses the Graph backend's client (owned + disposed with the backend);
+            // the sync timer and its CTS live in MainViewModel (disposed in MainViewModel.Dispose).
+            var graphCalendarSync = new GraphCalendarSyncService(accountService, localStore, graphBackend.Client);
+
             _updateCheckService = new UpdateCheckService(configService, ParseUpdateFeed(e.Args));
             _bugReportService   = new BugReportService(credentialService);
             _notificationService = new WindowsToastNotificationService();
             var mainVm = new MainViewModel(
                 mailRouter, accountService, credentialService, localStore, oauthService, syncService, configService, commandRegistry, viewService, ruleService, smtpService,
                 onlineMode: onlineMode, flagService: flagService, calendarService: calendarService, changeNotifier: _changeNotifier, updateCheckService: _updateCheckService,
-                themeService: themeService, notificationService: _notificationService, contactSyncService: contactSyncService);
+                themeService: themeService, notificationService: _notificationService, contactSyncService: contactSyncService,
+                graphCalendarSyncService: graphCalendarSync);
             mainVm.RegisterAccountBackend = a => mailRouter.RegisterAccount(a.Id, BackendFor(a));
             mainVm.LoadAccountList(accounts);
 

--- a/QuickMail/App.xaml.cs
+++ b/QuickMail/App.xaml.cs
@@ -15,6 +15,7 @@ public partial class App : Application
     private GraphSendMailService? _graphSendMail;
     private ContactService? _contactService;
     private GooglePeopleClient? _googlePeopleClient;
+    private GoogleCalendarClient? _googleCalendarClient;
     private TemplateService? _templateService;
     private ChangeNotifierRouter? _changeNotifier;
     private GraphChangeNotifier? _graphNotifier;
@@ -261,10 +262,14 @@ public partial class App : Application
             var calendarProvider = new LocalCacheCalendarProvider(localStore);
             var calendarService = new CalendarService(calendarProvider);
 
-            // Graph calendar sync (read-down v1): pulls each Graph account's primary calendar into
-            // the local store. Reuses the Graph backend's client (owned + disposed with the backend);
-            // the sync timer and its CTS live in MainViewModel (disposed in MainViewModel.Dispose).
-            var graphCalendarSync = new GraphCalendarSyncService(accountService, localStore, graphBackend.Client);
+            // Calendar sync (read-down v1): pulls each server-backed account's primary calendar
+            // into the local store — Microsoft via the Graph backend's client (owned + disposed
+            // with the backend) and Google via its own Calendar API client (owns an HttpClient →
+            // disposed in OnExit, like the People client). The sync timer and its CTS live in
+            // MainViewModel (disposed in MainViewModel.Dispose).
+            _googleCalendarClient = new GoogleCalendarClient(googleOAuth);
+            var graphCalendarSync = new GraphCalendarSyncService(accountService, localStore, graphBackend.Client,
+                                                                 _googleCalendarClient);
 
             _updateCheckService = new UpdateCheckService(configService, ParseUpdateFeed(e.Args));
             _bugReportService   = new BugReportService(credentialService);
@@ -310,6 +315,7 @@ public partial class App : Application
         _graphBackend?.Dispose();   // releases GraphClient/HttpClient; after the notifiers, which poll through its client
         _graphSendMail?.Dispose();
         _googlePeopleClient?.Dispose();
+        _googleCalendarClient?.Dispose();
         _contactService?.Dispose();
         _templateService?.Dispose();
         _updateCheckService?.Dispose();

--- a/QuickMail/Helpers/RecurrenceExpander.cs
+++ b/QuickMail/Helpers/RecurrenceExpander.cs
@@ -43,16 +43,19 @@ public static class RecurrenceExpander
 
         if (rule.Frequency == RecurrenceFrequency.Weekly && rule.ByDay.Count > 0)
         {
-            var days = rule.ByDay.Distinct().OrderBy(d => (int)d).ToList();
+            // RFC 5545's default week start (WKST) is MONDAY. Anchoring on Sunday put Sunday
+            // occurrences of INTERVAL>1 series into the wrong alternating weeks.
+            static int MondayOffset(DayOfWeek d) => ((int)d + 6) % 7; // Mon=0 .. Sun=6
+            var days = rule.ByDay.Distinct().OrderBy(MondayOffset).ToList();
             var timeOfDay = start.TimeOfDay;
-            var weekAnchor = start.Date.AddDays(-(int)start.DayOfWeek); // Sunday of the start's week
+            var weekAnchor = start.Date.AddDays(-MondayOffset(start.DayOfWeek)); // Monday of the start's week
             var week = 0;
             while (emitted < safetyCap)
             {
                 var baseDay = weekAnchor.AddDays(7 * rule.Interval * week);
                 foreach (var d in days)
                 {
-                    var occ = baseDay.AddDays((int)d) + timeOfDay;
+                    var occ = baseDay.AddDays(MondayOffset(d)) + timeOfDay;
                     if (occ < start) continue; // days earlier in the first week than the actual start
                     yield return occ;
                     if (++emitted >= safetyCap) yield break;

--- a/QuickMail/Helpers/RecurrenceExpander.cs
+++ b/QuickMail/Helpers/RecurrenceExpander.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using QuickMail.Models;
+
+namespace QuickMail.Helpers;
+
+/// <summary>
+/// Expands a recurring event's master start + <see cref="RecurrenceRule"/> into occurrence start
+/// times. Works entirely in local wall-clock time (AddDays/AddMonths/AddYears preserve the time of
+/// day across DST — a 9:00 weekly meeting stays 9:00), and bounds work with a safety cap.
+/// </summary>
+public static class RecurrenceExpander
+{
+    // ~10 years of daily occurrences — a backstop against runaway/infinite series.
+    private const int DefaultSafetyCap = 3660;
+
+    /// <summary>
+    /// Returns occurrence start times (local) that fall within [windowStart, windowEnd), honoring
+    /// COUNT and UNTIL. Occurrences are produced in chronological order.
+    /// </summary>
+    public static List<DateTime> Expand(DateTime start, RecurrenceRule rule,
+                                        DateTime windowStart, DateTime windowEnd,
+                                        int safetyCap = DefaultSafetyCap)
+    {
+        var result = new List<DateTime>();
+        var count = 0;
+        foreach (var occ in Occurrences(start, rule, safetyCap))
+        {
+            if (rule.Count is int max && count >= max) break;
+            if (rule.Until is DateTime until && occ.Date > until.Date) break;
+            count++;
+            if (occ >= windowEnd) break;          // occurrences increase monotonically
+            if (occ >= windowStart) result.Add(occ);
+        }
+        return result;
+    }
+
+    /// <summary>Lazily yields occurrence start times from <paramref name="start"/> in order.</summary>
+    private static IEnumerable<DateTime> Occurrences(DateTime start, RecurrenceRule rule, int safetyCap)
+    {
+        var emitted = 0;
+
+        if (rule.Frequency == RecurrenceFrequency.Weekly && rule.ByDay.Count > 0)
+        {
+            var days = rule.ByDay.Distinct().OrderBy(d => (int)d).ToList();
+            var timeOfDay = start.TimeOfDay;
+            var weekAnchor = start.Date.AddDays(-(int)start.DayOfWeek); // Sunday of the start's week
+            var week = 0;
+            while (emitted < safetyCap)
+            {
+                var baseDay = weekAnchor.AddDays(7 * rule.Interval * week);
+                foreach (var d in days)
+                {
+                    var occ = baseDay.AddDays((int)d) + timeOfDay;
+                    if (occ < start) continue; // days earlier in the first week than the actual start
+                    yield return occ;
+                    if (++emitted >= safetyCap) yield break;
+                }
+                week++;
+            }
+        }
+        else
+        {
+            var cursor = start;
+            while (emitted < safetyCap)
+            {
+                yield return cursor;
+                emitted++;
+                cursor = rule.Frequency switch
+                {
+                    RecurrenceFrequency.Daily => cursor.AddDays(rule.Interval),
+                    RecurrenceFrequency.Weekly => cursor.AddDays(7 * rule.Interval),
+                    RecurrenceFrequency.Monthly => cursor.AddMonths(rule.Interval),
+                    RecurrenceFrequency.Yearly => cursor.AddYears(rule.Interval),
+                    _ => cursor.AddDays(rule.Interval),
+                };
+            }
+        }
+    }
+}

--- a/QuickMail/Models/CalendarEvent.cs
+++ b/QuickMail/Models/CalendarEvent.cs
@@ -11,11 +11,42 @@ namespace QuickMail.Models;
 /// </summary>
 public partial class CalendarEvent : ObservableObject
 {
+    /// <summary>
+    /// Sentinel account id for locally-authored events (not harvested from an email invite).
+    /// Real accounts always have a non-empty <see cref="Guid"/>, so <see cref="Guid.Empty"/> is
+    /// a safe "local calendar" marker that needs no schema change.
+    /// </summary>
+    public static readonly Guid LocalAccountId = Guid.Empty;
+
     /// <summary>ICS VEVENT UID — the stable identity of the event across updates.</summary>
     public string Uid { get; set; } = string.Empty;
 
     /// <summary>Account that received the invite. Events from all accounts merge into one calendar.</summary>
     public Guid AccountId { get; set; }
+
+    /// <summary>
+    /// True when the user created this event locally in QuickMail (vs. harvested from an email
+    /// invite). Locally-authored events are editable and deletable; invite-sourced events are not.
+    /// </summary>
+    public bool IsUserCreated => AccountId == LocalAccountId;
+
+    /// <summary>True for an all-day appointment (no meaningful start/end time of day).</summary>
+    public bool IsAllDay { get; set; }
+
+    /// <summary>
+    /// iCalendar RRULE string for a repeating appointment (e.g. "FREQ=WEEKLY;BYDAY=TU"), or null/empty
+    /// for a one-off. Parse with <see cref="Models.RecurrenceRule.Parse"/>.
+    /// </summary>
+    public string? RecurrenceRule { get; set; }
+
+    /// <summary>True when this event repeats.</summary>
+    public bool IsRecurring => !string.IsNullOrWhiteSpace(RecurrenceRule);
+
+    /// <summary>
+    /// For an expanded occurrence of a recurring series, the occurrence's own start (local); null for
+    /// a master or a one-off. Set by the ViewModel when expanding; not persisted.
+    /// </summary>
+    public DateTime? OccurrenceStart { get; set; }
 
     public string Summary { get; set; } = string.Empty;
     public string Description { get; set; } = string.Empty;
@@ -78,12 +109,22 @@ public partial class CalendarEvent : ObservableObject
                     : start.Date == now.Date.AddDays(-1) ? "yesterday"
                     : null;
                 var datePart = dayWord ?? start.ToString("ddd, MMM d");
-                sb.Append(", ").Append(datePart).Append(' ').Append(start.ToString("t"));
-                if (EndTime.HasValue && EndTime.Value.TimeOfDay != start.TimeOfDay)
-                    sb.Append(" to ").Append(EndTime.Value.ToString("t"));
+                if (IsAllDay)
+                {
+                    sb.Append(", ").Append(datePart).Append(" all day");
+                }
+                else
+                {
+                    sb.Append(", ").Append(datePart).Append(' ').Append(start.ToString("t"));
+                    if (EndTime.HasValue && EndTime.Value.TimeOfDay != start.TimeOfDay)
+                        sb.Append(" to ").Append(EndTime.Value.ToString("t"));
+                }
             }
 
-            sb.Append(", ").Append(ResponseStatus.ToString());
+            // Local appointments are the user's own; a "Pending/Accepted" RSVP word is
+            // meaningless for them, so only invite-sourced events announce a response status.
+            if (!IsUserCreated)
+                sb.Append(", ").Append(ResponseStatus.ToString());
             if (!string.IsNullOrWhiteSpace(Location))
                 sb.Append(". Location: ").Append(Location);
             if (!string.IsNullOrWhiteSpace(OrganizerName))
@@ -92,6 +133,127 @@ public partial class CalendarEvent : ObservableObject
                 sb.Append(". Organizer: ").Append(Organizer);
 
             return sb.ToString();
+        }
+    }
+
+    /// <summary>
+    /// "Fields and data" variant of <see cref="DisplayLine"/> — each value prefixed with its field
+    /// name ("Subject …, when …, status …"). Used for the row's accessible name when the
+    /// CalendarListShowFieldLabels setting is on.
+    /// </summary>
+    public string LabeledLine
+    {
+        get
+        {
+            var sb = new StringBuilder();
+            sb.Append("Subject ").Append(string.IsNullOrWhiteSpace(Summary) ? "no title" : Summary);
+            sb.Append(", when ").Append(WhenText);
+            if (!IsUserCreated)
+                sb.Append(", status ").Append(ResponseStatus.ToString());
+            if (!string.IsNullOrWhiteSpace(Location))
+                sb.Append(", location ").Append(Location);
+            var org = !string.IsNullOrWhiteSpace(OrganizerName) ? OrganizerName
+                    : !string.IsNullOrWhiteSpace(Organizer) ? Organizer : null;
+            if (!IsUserCreated && org != null)
+                sb.Append(", organizer ").Append(org);
+            return sb.ToString();
+        }
+    }
+
+    /// <summary>
+    /// The composed accessible name for the row, stamped by <see cref="ViewModels.CalendarViewModel"/>
+    /// per the CalendarListShowFieldLabels setting (labeled vs data-only). Falls back to
+    /// <see cref="DisplayLine"/> when not stamped, so the row is never announced empty.
+    /// </summary>
+    private string _accessibleName = string.Empty;
+    public string AccessibleName
+    {
+        get => string.IsNullOrEmpty(_accessibleName) ? DisplayLine : _accessibleName;
+        set => _accessibleName = value;
+    }
+
+    /// <summary>Column text for the "When" grid column — a friendly date/time range.</summary>
+    public string WhenText
+    {
+        get
+        {
+            if (!StartTime.HasValue) return "No date";
+            var start = StartTime.Value;
+            var now = DateTime.Now;
+            var dayWord = start.Date == now.Date ? "Today"
+                : start.Date == now.Date.AddDays(1) ? "Tomorrow"
+                : start.Date == now.Date.AddDays(-1) ? "Yesterday"
+                : start.ToString("ddd, MMM d");
+            if (IsAllDay)
+                return dayWord + " (all day)";
+            var sb = new StringBuilder();
+            sb.Append(dayWord).Append(' ').Append(start.ToString("t"));
+            if (EndTime.HasValue && EndTime.Value.TimeOfDay != start.TimeOfDay)
+                sb.Append('–').Append(EndTime.Value.ToString("t"));
+            return sb.ToString();
+        }
+    }
+
+    /// <summary>Column text for the "Status" grid column. Local events show "Appointment".</summary>
+    public string StatusText => IsUserCreated ? "Appointment" : ResponseStatus.ToString();
+
+    /// <summary>
+    /// Multi-line detail block shown in the master/detail Details pane, one field per line.
+    /// Read by both sighted users and, verbatim, by a screen reader on the read-only text box.
+    /// </summary>
+    public string DetailText
+    {
+        get
+        {
+            var sb = new StringBuilder();
+            sb.Append(string.IsNullOrWhiteSpace(Summary) ? "(no title)" : Summary).Append('\n');
+
+            if (StartTime.HasValue && IsAllDay)
+            {
+                sb.Append("When: ").Append(StartTime.Value.ToString("dddd, MMMM d, yyyy"))
+                  .Append(" (all day)");
+                if (EndTime.HasValue && EndTime.Value.Date > StartTime.Value.Date)
+                    sb.Append(" to ").Append(EndTime.Value.ToString("dddd, MMMM d, yyyy"));
+                sb.Append('\n');
+            }
+            else if (StartTime.HasValue)
+            {
+                sb.Append("When: ").Append(StartTime.Value.ToString("dddd, MMMM d, yyyy"))
+                  .Append(" at ").Append(StartTime.Value.ToString("t"));
+                if (EndTime.HasValue)
+                    sb.Append(" to ").Append(
+                        EndTime.Value.Date == StartTime.Value.Date
+                            ? EndTime.Value.ToString("t")
+                            : EndTime.Value.ToString("dddd, MMMM d, yyyy 'at' t"));
+                sb.Append('\n');
+            }
+            else
+            {
+                sb.Append("When: no date set\n");
+            }
+
+            if (IsRecurring)
+            {
+                var r = global::QuickMail.Models.RecurrenceRule.Parse(RecurrenceRule);
+                if (r != null) sb.Append("Repeats: ").Append(r.Describe()).Append('\n');
+            }
+
+            if (!string.IsNullOrWhiteSpace(Location))
+                sb.Append("Location: ").Append(Location).Append('\n');
+
+            if (!IsUserCreated)
+            {
+                sb.Append("Status: ").Append(ResponseStatus.ToString()).Append('\n');
+                var org = !string.IsNullOrWhiteSpace(OrganizerName) ? OrganizerName
+                        : !string.IsNullOrWhiteSpace(Organizer) ? Organizer : null;
+                if (org != null)
+                    sb.Append("Organizer: ").Append(org).Append('\n');
+            }
+
+            if (!string.IsNullOrWhiteSpace(Description))
+                sb.Append('\n').Append(Description).Append('\n');
+
+            return sb.ToString().TrimEnd('\n');
         }
     }
 }

--- a/QuickMail/Models/CalendarEvent.cs
+++ b/QuickMail/Models/CalendarEvent.cs
@@ -35,11 +35,13 @@ public partial class CalendarEvent : ObservableObject
     public bool IsAllDay { get; set; }
 
     /// <summary>
-    /// True when this row was pulled from the account's Microsoft (Graph) calendar by
-    /// <see cref="Services.GraphCalendarSyncService"/> rather than harvested from an email invite
-    /// or authored locally. Graph rows are read-only in the UI (the server is the source of truth;
-    /// v1 sync is read-down only) and are replaced wholesale on each sync, so the invite harvest
-    /// and orphan cleanup must never touch them. Persisted in the <c>is_graph</c> column.
+    /// True when this row is a SERVER-SYNCED calendar row — pulled from the account's online
+    /// calendar (Microsoft via Graph, or Google via the Calendar API) by
+    /// <see cref="Services.GraphCalendarSyncService"/> — rather than harvested from an email
+    /// invite or authored locally. The column name <c>is_graph</c> predates the Google path but
+    /// means exactly this for both providers. Server-synced rows are read-only in the UI (the
+    /// server is the source of truth; v1 sync is read-down only) and are replaced wholesale on
+    /// each sync, so the invite harvest and orphan cleanup must never touch them.
     /// </summary>
     public bool IsGraph { get; set; }
 

--- a/QuickMail/Models/CalendarEvent.cs
+++ b/QuickMail/Models/CalendarEvent.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Text;
 using CommunityToolkit.Mvvm.ComponentModel;
 
@@ -41,6 +42,34 @@ public partial class CalendarEvent : ObservableObject
 
     /// <summary>True when this event repeats.</summary>
     public bool IsRecurring => !string.IsNullOrWhiteSpace(RecurrenceRule);
+
+    /// <summary>
+    /// Excluded occurrence starts for a recurring master, serialized as comma-separated local
+    /// "yyyyMMddTHHmmss" values. Occurrences at these starts are skipped ("delete/detach just
+    /// this one"). Null/empty for one-offs and untouched series.
+    /// </summary>
+    public string? ExDates { get; set; }
+
+    /// <summary>Parses <see cref="ExDates"/> into local DateTimes (invalid entries skipped).</summary>
+    public IReadOnlyList<DateTime> GetExDates()
+    {
+        if (string.IsNullOrWhiteSpace(ExDates)) return Array.Empty<DateTime>();
+        var list = new List<DateTime>();
+        foreach (var part in ExDates.Split(',', StringSplitOptions.RemoveEmptyEntries))
+            if (DateTime.TryParseExact(part.Trim(), "yyyyMMdd'T'HHmmss",
+                    System.Globalization.CultureInfo.InvariantCulture,
+                    System.Globalization.DateTimeStyles.None, out var dt))
+                list.Add(dt);
+        return list;
+    }
+
+    /// <summary>Appends an occurrence start (local) to <see cref="ExDates"/>.</summary>
+    public void AddExDate(DateTime occurrenceStartLocal)
+    {
+        var token = occurrenceStartLocal.ToString("yyyyMMdd'T'HHmmss",
+            System.Globalization.CultureInfo.InvariantCulture);
+        ExDates = string.IsNullOrWhiteSpace(ExDates) ? token : ExDates + "," + token;
+    }
 
     /// <summary>
     /// For an expanded occurrence of a recurring series, the occurrence's own start (local); null for

--- a/QuickMail/Models/CalendarEvent.cs
+++ b/QuickMail/Models/CalendarEvent.cs
@@ -35,6 +35,15 @@ public partial class CalendarEvent : ObservableObject
     public bool IsAllDay { get; set; }
 
     /// <summary>
+    /// True when this row was pulled from the account's Microsoft (Graph) calendar by
+    /// <see cref="Services.GraphCalendarSyncService"/> rather than harvested from an email invite
+    /// or authored locally. Graph rows are read-only in the UI (the server is the source of truth;
+    /// v1 sync is read-down only) and are replaced wholesale on each sync, so the invite harvest
+    /// and orphan cleanup must never touch them. Persisted in the <c>is_graph</c> column.
+    /// </summary>
+    public bool IsGraph { get; set; }
+
+    /// <summary>
     /// iCalendar RRULE string for a repeating appointment (e.g. "FREQ=WEEKLY;BYDAY=TU"), or null/empty
     /// for a one-off. Parse with <see cref="Models.RecurrenceRule.Parse"/>.
     /// </summary>

--- a/QuickMail/Models/CalendarViewMode.cs
+++ b/QuickMail/Models/CalendarViewMode.cs
@@ -15,4 +15,7 @@ public enum CalendarViewMode
 
     /// <summary>Appointments in the week containing the reference date.</summary>
     Week,
+
+    /// <summary>A month at a glance: a 7-column day grid; Enter on a day drills into Day view.</summary>
+    Month,
 }

--- a/QuickMail/Models/CalendarViewMode.cs
+++ b/QuickMail/Models/CalendarViewMode.cs
@@ -1,0 +1,18 @@
+namespace QuickMail.Models;
+
+/// <summary>
+/// Which slice of the calendar the event list shows. All modes share the same accessible
+/// master/detail list; the mode changes which events appear and how the period is labelled.
+/// (Month grid is a separate future surface — see the full-calendar spec, M3.)
+/// </summary>
+public enum CalendarViewMode
+{
+    /// <summary>All upcoming appointments, unbounded (the original behaviour).</summary>
+    Agenda,
+
+    /// <summary>Appointments on a single reference date.</summary>
+    Day,
+
+    /// <summary>Appointments in the week containing the reference date.</summary>
+    Week,
+}

--- a/QuickMail/Models/ConfigModel.cs
+++ b/QuickMail/Models/ConfigModel.cs
@@ -128,6 +128,15 @@ public class ConfigModel
     /// </summary>
     public bool CalendarListShowFieldLabels { get; set; } = false;
 
+    /// <summary>
+    /// Fire a notification before each appointment. OFF by default (opt-in, per the
+    /// announcement-infra convention for potentially intrusive features; full-calendar spec Q6).
+    /// </summary>
+    public bool CalendarReminders { get; set; } = false;
+
+    /// <summary>Minutes before an appointment's start that the reminder fires. Default 10.</summary>
+    public int CalendarReminderMinutes { get; set; } = 10;
+
     // ── Flagging ──────────────────────────────────────────────────────────────────
 
     /// <summary>

--- a/QuickMail/Models/ConfigModel.cs
+++ b/QuickMail/Models/ConfigModel.cs
@@ -252,6 +252,26 @@ public class ConfigModel
     /// </summary>
     public string GoogleClientSecret { get; set; } = string.Empty;
 
+    // ── CalDAV calendar source ───────────────────────────────────────────────────
+
+    /// <summary>
+    /// CalDAV calendar server address (e.g. "https://caldav.icloud.com"). Set from Settings.
+    /// Empty = no CalDAV calendar source configured. Stored in the [caldav] section of
+    /// config.ini. The password is NEVER stored here — it lives in Windows Credential
+    /// Manager under <c>QuickMail/CalDAV/{username}</c> via ICredentialService.
+    /// </summary>
+    public string CalDavUrl { get; set; } = string.Empty;
+
+    /// <summary>CalDAV account username (for iCloud, the Apple ID email).</summary>
+    public string CalDavUsername { get; set; } = string.Empty;
+
+    /// <summary>Display name for the CalDAV source in the calendar folder tree.</summary>
+    public string CalDavDisplayName { get; set; } = "iCloud";
+
+    /// <summary>True when a CalDAV calendar source is configured (URL + username present).</summary>
+    public bool HasCalDavSource =>
+        !string.IsNullOrWhiteSpace(CalDavUrl) && !string.IsNullOrWhiteSpace(CalDavUsername);
+
     // ── Feature flags ─────────────────────────────────────────────────────────────
 
     /// <summary>

--- a/QuickMail/Models/ConfigModel.cs
+++ b/QuickMail/Models/ConfigModel.cs
@@ -121,6 +121,13 @@ public class ConfigModel
     /// </summary>
     public bool ContactListShowFieldLabels { get; set; } = false;
 
+    /// <summary>
+    /// When true, the calendar event list speaks field labels in each row's accessible name
+    /// ("Subject … when … status …"); when false (default) it speaks concise data only, matching
+    /// how the message and contact lists read. Mirrors <see cref="ContactListShowFieldLabels"/>.
+    /// </summary>
+    public bool CalendarListShowFieldLabels { get; set; } = false;
+
     // ── Flagging ──────────────────────────────────────────────────────────────────
 
     /// <summary>

--- a/QuickMail/Models/IcsModel.cs
+++ b/QuickMail/Models/IcsModel.cs
@@ -136,10 +136,10 @@ public class IcsModel
                         model.Location = UnescapeIcsText(value);
                         break;
                     case "DTSTART":
-                        model.StartTime = ParseIcsDateTime(value);
+                        model.StartTime = ParseIcsDateTime(value, ExtractTzidParam(prop));
                         break;
                     case "DTEND":
-                        model.EndTime = ParseIcsDateTime(value);
+                        model.EndTime = ParseIcsDateTime(value, ExtractTzidParam(prop));
                         break;
                     case "UID":
                         model.Uid = value;
@@ -194,6 +194,54 @@ public class IcsModel
         return sb.ToString();
     }
 
+    /// <summary>
+    /// Serializes a calendar event to a standalone .ics file body (METHOD:PUBLISH) suitable for
+    /// saving to disk and importing into any calendar application. All-day events use DATE values;
+    /// timed events use UTC; a recurrence rule is carried through as RRULE.
+    /// </summary>
+    public static string ExportEvent(CalendarEvent evt)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("BEGIN:VCALENDAR");
+        sb.AppendLine("VERSION:2.0");
+        sb.AppendLine("PRODID:-//QuickMail//EN");
+        sb.AppendLine("METHOD:PUBLISH");
+        sb.AppendLine("BEGIN:VEVENT");
+        sb.AppendLine($"UID:{(string.IsNullOrWhiteSpace(evt.Uid) ? Guid.NewGuid().ToString("N") : evt.Uid)}");
+        sb.AppendLine($"DTSTAMP:{DateTime.UtcNow:yyyyMMdd'T'HHmmss'Z'}");
+
+        if (evt.StartTime.HasValue)
+        {
+            if (evt.IsAllDay)
+            {
+                // All-day: DATE values; DTEND is exclusive per RFC 5545, so day after the last day.
+                var startDay = evt.StartTime.Value.Date;
+                var endDayExclusive = (evt.EndTime ?? evt.StartTime.Value).Date.AddDays(1);
+                sb.AppendLine($"DTSTART;VALUE=DATE:{startDay:yyyyMMdd}");
+                sb.AppendLine($"DTEND;VALUE=DATE:{endDayExclusive:yyyyMMdd}");
+            }
+            else
+            {
+                sb.AppendLine($"DTSTART:{evt.StartTime.Value.ToUniversalTime():yyyyMMdd'T'HHmmss'Z'}");
+                if (evt.EndTime.HasValue)
+                    sb.AppendLine($"DTEND:{evt.EndTime.Value.ToUniversalTime():yyyyMMdd'T'HHmmss'Z'}");
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(evt.RecurrenceRule))
+            sb.AppendLine($"RRULE:{evt.RecurrenceRule}");
+        if (!string.IsNullOrWhiteSpace(evt.Summary))
+            sb.AppendLine($"SUMMARY:{EscapeIcsText(evt.Summary)}");
+        if (!string.IsNullOrWhiteSpace(evt.Location))
+            sb.AppendLine($"LOCATION:{EscapeIcsText(evt.Location)}");
+        if (!string.IsNullOrWhiteSpace(evt.Description))
+            sb.AppendLine($"DESCRIPTION:{EscapeIcsText(evt.Description)}");
+
+        sb.AppendLine("END:VEVENT");
+        sb.AppendLine("END:VCALENDAR");
+        return sb.ToString();
+    }
+
     // ── Parsing helpers ────────────────────────────────────────────────────────
 
     /// <summary>ICS lines can be folded (continued on next line with a leading space/tab).</summary>
@@ -238,12 +286,13 @@ public class IcsModel
     }
 
     /// <summary>
-    /// Parses an ICS datetime value. Handles both UTC (ending in Z) and local time.
-    /// LIMITATION: TZID parameters are ignored; times without a 'Z' suffix are
-    /// treated as local machine time, which may be incorrect for attendees in
-    /// different time zones.
+    /// Parses an ICS datetime value, honoring a TZID parameter when present. A value ending in
+    /// 'Z' is UTC. A value with a resolvable <paramref name="tzid"/> is interpreted in that zone
+    /// and converted to machine-local time, so a 10:00 Eastern meeting displays correctly for a
+    /// Pacific user. A value with no TZID (or an unresolvable one) falls back to the historical
+    /// behavior: treated as machine-local time.
     /// </summary>
-    private static DateTime? ParseIcsDateTime(string value)
+    private static DateTime? ParseIcsDateTime(string value, string? tzid = null)
     {
         // Formats: 20260101T120000Z, 20260101T120000, 20260101
         value = value.Trim();
@@ -252,19 +301,60 @@ public class IcsModel
             var isUtc = value.EndsWith('Z');
             var datePart = value[..8];
             var timePart = value.Substring(9, 6);
-            if (DateTime.TryParseExact($"{datePart}{timePart}",
-                    isUtc ? "yyyyMMddHHmmss" : "yyyyMMddHHmmss",
+
+            if (isUtc)
+            {
+                if (DateTime.TryParseExact($"{datePart}{timePart}", "yyyyMMddHHmmss",
+                        System.Globalization.CultureInfo.InvariantCulture,
+                        System.Globalization.DateTimeStyles.AssumeUniversal | System.Globalization.DateTimeStyles.AdjustToUniversal,
+                        out var utc))
+                    return utc;
+                return null;
+            }
+
+            if (DateTime.TryParseExact($"{datePart}{timePart}", "yyyyMMddHHmmss",
                     System.Globalization.CultureInfo.InvariantCulture,
-                    isUtc ? System.Globalization.DateTimeStyles.AssumeUniversal | System.Globalization.DateTimeStyles.AdjustToUniversal
-                          : System.Globalization.DateTimeStyles.AssumeLocal,
-                    out var dt))
-                return dt;
+                    System.Globalization.DateTimeStyles.None,
+                    out var naive))
+            {
+                // TZID present and resolvable: the naive time is wall-clock in that zone.
+                // .NET 8 resolves both IANA ids ("America/New_York") and Windows ids
+                // ("Eastern Standard Time") on Windows 10+ via ICU.
+                if (!string.IsNullOrWhiteSpace(tzid)
+                    && TimeZoneInfo.TryFindSystemTimeZoneById(tzid, out var zone))
+                {
+                    var utcTime = TimeZoneInfo.ConvertTimeToUtc(
+                        DateTime.SpecifyKind(naive, DateTimeKind.Unspecified), zone);
+                    return utcTime.ToLocalTime();
+                }
+                // No/unknown TZID: historical behavior — assume machine-local.
+                return DateTime.SpecifyKind(naive, DateTimeKind.Local);
+            }
         }
         if (value.Length >= 8 && DateTime.TryParseExact(value[..8], "yyyyMMdd",
                 System.Globalization.CultureInfo.InvariantCulture,
                 System.Globalization.DateTimeStyles.AssumeLocal,
                 out var dateOnly))
             return dateOnly;
+        return null;
+    }
+
+    /// <summary>
+    /// Extracts the TZID parameter from a property name with parameters, e.g.
+    /// "DTSTART;TZID=America/Chicago" or "DTSTART;VALUE=DATE-TIME;TZID=\"Europe/Paris\"".
+    /// Returns null when absent. Quotes are stripped.
+    /// </summary>
+    internal static string? ExtractTzidParam(string propWithParams)
+    {
+        foreach (var part in propWithParams.Split(';'))
+        {
+            var trimmed = part.Trim();
+            if (trimmed.StartsWith("TZID=", StringComparison.OrdinalIgnoreCase))
+            {
+                var v = trimmed[5..].Trim().Trim('"');
+                return v.Length > 0 ? v : null;
+            }
+        }
         return null;
     }
 

--- a/QuickMail/Models/IcsModel.cs
+++ b/QuickMail/Models/IcsModel.cs
@@ -24,6 +24,27 @@ public class IcsModel
     public string? Sequence { get; set; }
     public string? Method { get; set; } // REQUEST, CANCEL, REPLY, etc.
 
+    /// <summary>True when DTSTART was a date-only value (VALUE=DATE) — an all-day event.
+    /// For all-day events <see cref="EndTime"/> keeps the ICS DTEND semantics: EXCLUSIVE
+    /// (midnight of the day after the last day), per RFC 5545.</summary>
+    public bool IsAllDay { get; set; }
+
+    /// <summary>Raw RRULE value for a recurring series master (e.g. "FREQ=WEEKLY;BYDAY=TU"),
+    /// or null for a one-off. Parse with <see cref="RecurrenceRule.Parse"/>.</summary>
+    public string? RecurrenceRule { get; set; }
+
+    /// <summary>Raw RECURRENCE-ID value when this VEVENT is an overridden instance of a
+    /// recurring series (not the series master). Null for masters and one-offs.</summary>
+    public string? RecurrenceId { get; set; }
+
+    /// <summary>ICS STATUS value (CONFIRMED, TENTATIVE, CANCELLED), or null when absent.</summary>
+    public string? Status { get; set; }
+
+    /// <summary>Excluded occurrence starts (EXDATE), normalized to machine-local wall-clock —
+    /// the same shape <see cref="CalendarEvent.AddExDate"/> expects. Empty for one-offs and
+    /// untouched series.</summary>
+    public List<DateTime> ExDates { get; } = [];
+
     /// <summary>
     /// Human-readable summary for screen reader announcement and display.
     /// </summary>
@@ -71,98 +92,164 @@ public class IcsModel
     }
 
     /// <summary>
-    /// Parses an ICS file from raw text content.
-    /// Returns null if the content is not a valid meeting request.
+    /// Parses an ICS file from raw text content. Multi-VEVENT calendars yield the FIRST
+    /// meaningful VEVENT (invite emails carry a single VEVENT, so this matters only for
+    /// pathological input). Returns null if the content is not a valid meeting request.
     /// </summary>
     public static IcsModel? Parse(string icsContent)
     {
-        if (string.IsNullOrWhiteSpace(icsContent)) return null;
+        var events = ParseAllEvents(icsContent);
+        return events.Count > 0 ? events[0] : null;
+    }
+
+    /// <summary>
+    /// Parses EVERY VEVENT in an ICS calendar body — the CalDAV sync path, where one
+    /// calendar-data body can carry a recurring series master plus overridden instances
+    /// (RECURRENCE-ID). Each VEVENT becomes its own model with the same per-property
+    /// handling as <see cref="Parse"/> (TZID-aware date-times, escaping, folding), plus
+    /// RRULE / EXDATE / RECURRENCE-ID / STATUS / all-day capture. The VCALENDAR-level
+    /// METHOD is applied to every event that did not carry its own. Events with neither
+    /// a start time nor a summary are dropped. Never throws; malformed input yields [].
+    /// </summary>
+    public static List<IcsModel> ParseAllEvents(string icsContent)
+    {
+        var result = new List<IcsModel>();
+        if (string.IsNullOrWhiteSpace(icsContent)) return result;
 
         try
         {
-            var model = new IcsModel();
             var lines = UnfoldLines(icsContent);
+            string? calendarMethod = null;
+            IcsModel? current = null;
 
-            bool inVevent = false;
+            void FlushCurrent()
+            {
+                // Only keep meaningful events (same criterion Parse always used).
+                if (current != null &&
+                    (current.StartTime.HasValue || !string.IsNullOrWhiteSpace(current.Summary)))
+                    result.Add(current);
+                current = null;
+            }
+
             foreach (var rawLine in lines)
             {
                 var line = rawLine.Trim();
                 if (string.IsNullOrEmpty(line)) continue;
 
-                // METHOD is at the VCALENDAR level, not inside VEVENT
-                if (!inVevent && line.StartsWith("METHOD:", StringComparison.OrdinalIgnoreCase))
-                {
-                    model.Method = line[7..];
-                    continue;
-                }
-
                 if (line.StartsWith("BEGIN:VEVENT", StringComparison.OrdinalIgnoreCase))
                 {
-                    inVevent = true;
+                    FlushCurrent(); // defensive: unterminated previous VEVENT
+                    current = new IcsModel();
                     continue;
                 }
                 if (line.StartsWith("END:VEVENT", StringComparison.OrdinalIgnoreCase))
                 {
-                    inVevent = false;
+                    FlushCurrent();
                     continue;
                 }
-                if (!inVevent) continue;
-
-                var colonIdx = line.IndexOf(':');
-                if (colonIdx < 0) continue;
-
-                var prop = line[..colonIdx];
-                var value = line[(colonIdx + 1)..];
-
-                // Handle property parameters (e.g. "DTSTART;TZID=America/Chicago:20260101T120000")
-                var semicolonIdx = prop.IndexOf(';');
-                var propName = semicolonIdx >= 0 ? prop[..semicolonIdx] : prop;
-
-                switch (propName.ToUpperInvariant())
+                if (current == null)
                 {
-                    case "ORGANIZER":
-                        model.OrganizerName = ExtractCnParam(prop);
-                        model.Organizer = ExtractMailtoValue(value);
-                        if (string.IsNullOrWhiteSpace(model.OrganizerName))
-                            model.OrganizerName = model.Organizer;
-                        break;
-                    case "SUMMARY":
-                        model.Summary = UnescapeIcsText(value);
-                        break;
-                    case "DESCRIPTION":
-                        model.Description = UnescapeIcsText(value);
-                        break;
-                    case "LOCATION":
-                        model.Location = UnescapeIcsText(value);
-                        break;
-                    case "DTSTART":
-                        model.StartTime = ParseIcsDateTime(value, ExtractTzidParam(prop));
-                        break;
-                    case "DTEND":
-                        model.EndTime = ParseIcsDateTime(value, ExtractTzidParam(prop));
-                        break;
-                    case "UID":
-                        model.Uid = value;
-                        break;
-                    case "SEQUENCE":
-                        model.Sequence = value;
-                        break;
-                    case "METHOD":
-                        model.Method = value;
-                        break;
+                    // METHOD is at the VCALENDAR level, not inside VEVENT
+                    if (line.StartsWith("METHOD:", StringComparison.OrdinalIgnoreCase))
+                        calendarMethod = line[7..];
+                    continue;
                 }
+
+                ParseVEventLine(current, line);
             }
+            FlushCurrent(); // defensive: truncated input missing END:VEVENT
 
-            // Only return if we found a meaningful event
-            if (model.StartTime.HasValue || !string.IsNullOrWhiteSpace(model.Summary))
-                return model;
+            foreach (var evt in result)
+                evt.Method ??= calendarMethod;
 
-            return null;
+            return result;
         }
         catch
         {
-            return null;
+            return [];
         }
+    }
+
+    /// <summary>Applies one unfolded content line to the VEVENT being built.</summary>
+    private static void ParseVEventLine(IcsModel model, string line)
+    {
+        var colonIdx = line.IndexOf(':');
+        if (colonIdx < 0) return;
+
+        var prop = line[..colonIdx];
+        var value = line[(colonIdx + 1)..];
+
+        // Handle property parameters (e.g. "DTSTART;TZID=America/Chicago:20260101T120000")
+        var semicolonIdx = prop.IndexOf(';');
+        var propName = semicolonIdx >= 0 ? prop[..semicolonIdx] : prop;
+
+        switch (propName.ToUpperInvariant())
+        {
+            case "ORGANIZER":
+                model.OrganizerName = ExtractCnParam(prop);
+                model.Organizer = ExtractMailtoValue(value);
+                if (string.IsNullOrWhiteSpace(model.OrganizerName))
+                    model.OrganizerName = model.Organizer;
+                break;
+            case "SUMMARY":
+                model.Summary = UnescapeIcsText(value);
+                break;
+            case "DESCRIPTION":
+                model.Description = UnescapeIcsText(value);
+                break;
+            case "LOCATION":
+                model.Location = UnescapeIcsText(value);
+                break;
+            case "DTSTART":
+                model.StartTime = ParseIcsDateTime(value, ExtractTzidParam(prop));
+                model.IsAllDay = IsDateOnly(prop, value);
+                break;
+            case "DTEND":
+                model.EndTime = ParseIcsDateTime(value, ExtractTzidParam(prop));
+                break;
+            case "UID":
+                model.Uid = value;
+                break;
+            case "SEQUENCE":
+                model.Sequence = value;
+                break;
+            case "METHOD":
+                model.Method = value;
+                break;
+            case "RRULE":
+                model.RecurrenceRule = value;
+                break;
+            case "RECURRENCE-ID":
+                model.RecurrenceId = value;
+                break;
+            case "STATUS":
+                model.Status = value.Trim();
+                break;
+            case "EXDATE":
+                // EXDATE can carry multiple comma-separated values, each honoring the
+                // property's TZID. Normalize to machine-local wall-clock, matching what
+                // CalendarEvent.AddExDate stores and RecurrenceExpander compares against.
+                var tzid = ExtractTzidParam(prop);
+                foreach (var part in value.Split(',', StringSplitOptions.RemoveEmptyEntries))
+                {
+                    var parsed = ParseIcsDateTime(part.Trim(), tzid);
+                    if (parsed.HasValue)
+                        model.ExDates.Add(parsed.Value.Kind == DateTimeKind.Utc
+                            ? parsed.Value.ToLocalTime()
+                            : parsed.Value);
+                }
+                break;
+        }
+    }
+
+    /// <summary>True when a DTSTART property is date-only: explicit VALUE=DATE parameter,
+    /// or a bare 8-digit yyyyMMdd value.</summary>
+    private static bool IsDateOnly(string propWithParams, string value)
+    {
+        foreach (var part in propWithParams.Split(';'))
+            if (string.Equals(part.Trim(), "VALUE=DATE", StringComparison.OrdinalIgnoreCase))
+                return true;
+        return value.Trim().Length == 8;
     }
 
     /// <summary>

--- a/QuickMail/Models/MonthCell.cs
+++ b/QuickMail/Models/MonthCell.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace QuickMail.Models;
+
+/// <summary>
+/// One day cell in the calendar's Month grid. Immutable snapshot built by the ViewModel:
+/// the date, that day's events, and the spoken/visual labels.
+/// </summary>
+public sealed class MonthCell
+{
+    public DateTime Date { get; }
+
+    /// <summary>True when the cell belongs to the displayed month (not a leading/trailing pad day).</summary>
+    public bool IsInMonth { get; }
+
+    public IReadOnlyList<CalendarEvent> DayEvents { get; }
+
+    public int EventCount => DayEvents.Count;
+
+    /// <summary>Visual cell text, e.g. "9" or "9 •2" when the day has 2 events.</summary>
+    public string CellText => EventCount == 0 ? Date.Day.ToString() : $"{Date.Day} •{EventCount}";
+
+    /// <summary>
+    /// Spoken name, e.g. "Tuesday June 9, 3 events" (adds "today" and the month for pad days).
+    /// </summary>
+    public string AccessibleName
+    {
+        get
+        {
+            var sb = new StringBuilder();
+            sb.Append(Date.ToString("dddd MMMM d"));
+            if (Date == DateTime.Today) sb.Append(", today");
+            sb.Append(", ").Append(EventCount == 0 ? "no events"
+                : $"{EventCount} event{(EventCount == 1 ? "" : "s")}");
+            return sb.ToString();
+        }
+    }
+
+    /// <summary>Details-pane text: the day's events, one per line.</summary>
+    public string DayDetail
+    {
+        get
+        {
+            if (EventCount == 0)
+                return Date.ToString("dddd, MMMM d, yyyy") + "\nNo events.";
+            var sb = new StringBuilder(Date.ToString("dddd, MMMM d, yyyy"));
+            foreach (var e in DayEvents.OrderBy(e => e.StartTimeTicks ?? long.MaxValue))
+                sb.Append('\n').Append(e.DisplayLine);
+            return sb.ToString();
+        }
+    }
+
+    public MonthCell(DateTime date, int displayedMonth, IReadOnlyList<CalendarEvent> dayEvents)
+    {
+        Date = date.Date;
+        IsInMonth = date.Month == displayedMonth;
+        DayEvents = dayEvents;
+    }
+
+    /// <summary>
+    /// Selector-bound items are announced via ToString (see the accessibility checklist) —
+    /// must match <see cref="AccessibleName"/>.
+    /// </summary>
+    public override string ToString() => AccessibleName;
+}

--- a/QuickMail/Models/RecurrenceRule.cs
+++ b/QuickMail/Models/RecurrenceRule.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+
+namespace QuickMail.Models;
+
+public enum RecurrenceFrequency { Daily, Weekly, Monthly, Yearly }
+
+/// <summary>
+/// A parsed subset of an iCalendar RRULE: FREQ, INTERVAL, BYDAY (weekly), and one end condition
+/// (COUNT or UNTIL). Persisted as the RRULE string in <see cref="CalendarEvent.RecurrenceRule"/>.
+/// This is intentionally a practical subset — enough for daily/weekly/monthly/yearly repeats with
+/// an optional weekly day set and an end — not full RFC 5545.
+/// </summary>
+public sealed class RecurrenceRule
+{
+    public RecurrenceFrequency Frequency { get; set; } = RecurrenceFrequency.Weekly;
+
+    /// <summary>Every N periods. 1 = every day/week/month/year.</summary>
+    public int Interval { get; set; } = 1;
+
+    /// <summary>Weekly only: the days the event repeats on. Empty = use the start date's weekday.</summary>
+    public List<DayOfWeek> ByDay { get; set; } = [];
+
+    /// <summary>Total number of occurrences (including the first). Null = no count limit.</summary>
+    public int? Count { get; set; }
+
+    /// <summary>Last date an occurrence may fall on (inclusive, local date). Null = no until limit.</summary>
+    public DateTime? Until { get; set; }
+
+    /// <summary>True when the series never ends (no COUNT, no UNTIL).</summary>
+    public bool IsInfinite => Count is null && Until is null;
+
+    private static readonly Dictionary<DayOfWeek, string> DayCodes = new()
+    {
+        [DayOfWeek.Sunday] = "SU", [DayOfWeek.Monday] = "MO", [DayOfWeek.Tuesday] = "TU",
+        [DayOfWeek.Wednesday] = "WE", [DayOfWeek.Thursday] = "TH", [DayOfWeek.Friday] = "FR",
+        [DayOfWeek.Saturday] = "SA",
+    };
+    private static readonly Dictionary<string, DayOfWeek> DayFromCode =
+        DayCodes.ToDictionary(kv => kv.Value, kv => kv.Key);
+
+    /// <summary>Serializes to an iCalendar RRULE value string (no "RRULE:" prefix).</summary>
+    public string ToRRule()
+    {
+        var sb = new StringBuilder();
+        sb.Append("FREQ=").Append(Frequency.ToString().ToUpperInvariant());
+        if (Interval > 1) sb.Append(";INTERVAL=").Append(Interval);
+        if (Frequency == RecurrenceFrequency.Weekly && ByDay.Count > 0)
+            sb.Append(";BYDAY=").Append(string.Join(",", ByDay.Distinct().OrderBy(d => (int)d).Select(d => DayCodes[d])));
+        if (Count is int c) sb.Append(";COUNT=").Append(c);
+        else if (Until is DateTime u) sb.Append(";UNTIL=").Append(u.ToUniversalTime().ToString("yyyyMMdd'T'HHmmss'Z'", CultureInfo.InvariantCulture));
+        return sb.ToString();
+    }
+
+    /// <summary>Parses an RRULE value string. Returns null if it has no recognizable FREQ.</summary>
+    public static RecurrenceRule? Parse(string? rrule)
+    {
+        if (string.IsNullOrWhiteSpace(rrule)) return null;
+        var text = rrule.Trim();
+        if (text.StartsWith("RRULE:", StringComparison.OrdinalIgnoreCase)) text = text[6..];
+
+        var parts = text.Split(';', StringSplitOptions.RemoveEmptyEntries);
+        var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var p in parts)
+        {
+            var eq = p.IndexOf('=');
+            if (eq > 0) map[p[..eq].Trim()] = p[(eq + 1)..].Trim();
+        }
+        if (!map.TryGetValue("FREQ", out var freqStr)) return null;
+
+        var rule = new RecurrenceRule();
+        rule.Frequency = freqStr.ToUpperInvariant() switch
+        {
+            "DAILY" => RecurrenceFrequency.Daily,
+            "WEEKLY" => RecurrenceFrequency.Weekly,
+            "MONTHLY" => RecurrenceFrequency.Monthly,
+            "YEARLY" => RecurrenceFrequency.Yearly,
+            _ => RecurrenceFrequency.Weekly,
+        };
+        if (map.TryGetValue("INTERVAL", out var iv) && int.TryParse(iv, out var interval) && interval > 0)
+            rule.Interval = interval;
+        if (map.TryGetValue("BYDAY", out var byday))
+            foreach (var code in byday.Split(',', StringSplitOptions.RemoveEmptyEntries))
+                if (DayFromCode.TryGetValue(code.Trim().ToUpperInvariant(), out var dow))
+                    rule.ByDay.Add(dow);
+        if (map.TryGetValue("COUNT", out var cnt) && int.TryParse(cnt, out var count) && count > 0)
+            rule.Count = count;
+        if (map.TryGetValue("UNTIL", out var until))
+        {
+            var formats = new[] { "yyyyMMdd'T'HHmmss'Z'", "yyyyMMdd'T'HHmmss", "yyyyMMdd" };
+            if (DateTime.TryParseExact(until, formats, CultureInfo.InvariantCulture,
+                    DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var u))
+                rule.Until = u.ToLocalTime();
+        }
+        return rule;
+    }
+
+    /// <summary>Short human description, e.g. "Weekly on Tuesday" or "Every 2 weeks".</summary>
+    public string Describe()
+    {
+        var unit = Frequency switch
+        {
+            RecurrenceFrequency.Daily => "day",
+            RecurrenceFrequency.Weekly => "week",
+            RecurrenceFrequency.Monthly => "month",
+            _ => "year",
+        };
+        var head = Interval == 1 ? $"{Frequency}" : $"Every {Interval} {unit}s";
+        if (Frequency == RecurrenceFrequency.Weekly && ByDay.Count > 0)
+            head += " on " + string.Join(", ", ByDay.OrderBy(d => (int)d)
+                .Select(d => CultureInfo.CurrentCulture.DateTimeFormat.GetDayName(d)));
+        if (Count is int c) head += $", {c} times";
+        else if (Until is DateTime u) head += $", until {u:MMM d, yyyy}";
+        return head;
+    }
+}

--- a/QuickMail/Models/RecurrenceRule.cs
+++ b/QuickMail/Models/RecurrenceRule.cs
@@ -90,10 +90,21 @@ public sealed class RecurrenceRule
             rule.Count = count;
         if (map.TryGetValue("UNTIL", out var until))
         {
-            var formats = new[] { "yyyyMMdd'T'HHmmss'Z'", "yyyyMMdd'T'HHmmss", "yyyyMMdd" };
-            if (DateTime.TryParseExact(until, formats, CultureInfo.InvariantCulture,
-                    DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var u))
-                rule.Until = u.ToLocalTime();
+            // Date-only UNTIL (yyyyMMdd, standard for all-day series) is a calendar date, not an
+            // instant: treating it as UTC midnight and converting to local shifted the inclusive
+            // end back a day west of Greenwich, dropping the series' final occurrence.
+            if (until.Length == 8 && DateTime.TryParseExact(until, "yyyyMMdd",
+                    CultureInfo.InvariantCulture, DateTimeStyles.None, out var dateOnly))
+            {
+                rule.Until = DateTime.SpecifyKind(dateOnly, DateTimeKind.Local);
+            }
+            else
+            {
+                var formats = new[] { "yyyyMMdd'T'HHmmss'Z'", "yyyyMMdd'T'HHmmss" };
+                if (DateTime.TryParseExact(until, formats, CultureInfo.InvariantCulture,
+                        DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var u))
+                    rule.Until = u.ToLocalTime();
+            }
         }
         return rule;
     }

--- a/QuickMail/QuickMail.csproj
+++ b/QuickMail/QuickMail.csproj
@@ -15,9 +15,9 @@
          System.Windows(.Media) types this codebase uses unqualified (Point, Size, Color, Brush,
          Application, MessageBox, ...). -->
     <UseWindowsForms>true</UseWindowsForms>
-    <Version>0.8.33</Version>
-    <AssemblyVersion>0.8.33</AssemblyVersion>
-    <FileVersion>0.8.33</FileVersion>
+    <Version>0.8.34</Version>
+    <AssemblyVersion>0.8.34</AssemblyVersion>
+    <FileVersion>0.8.34</FileVersion>
     <!-- Velopack needs a hand-written Main that runs VelopackApp.Build().Run() before WPF
          initializes (install/update/uninstall hooks run and may exit the process). App.xaml
          therefore compiles as Page (no generated Main) and the entry point is declared here. -->

--- a/QuickMail/Services/CalDav/CalDavCalendarClient.cs
+++ b/QuickMail/Services/CalDav/CalDavCalendarClient.cs
@@ -1,0 +1,290 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+
+namespace QuickMail.Services;
+
+/// <summary>One discovered CalDAV calendar collection: its absolute URL and display name.</summary>
+public sealed record CalDavCalendarInfo(string Url, string DisplayName);
+
+/// <summary>
+/// Minimal CalDAV client for generic calendar sync (read-down v1, iCloud-first). Discovery and
+/// event fetch only — see <see cref="CalDavCalendarClient"/> for the wire details.
+/// </summary>
+public interface ICalDavCalendarClient
+{
+    /// <summary>
+    /// Resolves the server's first VEVENT-capable calendar collection:
+    /// PROPFIND current-user-principal → calendar-home-set → the home's child collections.
+    /// Throws (with a presentable message) when any step fails — this doubles as the
+    /// Settings "Test" validation.
+    /// </summary>
+    Task<CalDavCalendarInfo> DiscoverCalendarAsync(string serverUrl, string username, string password,
+                                                   CancellationToken ct = default);
+
+    /// <summary>
+    /// REPORT calendar-query for VEVENTs intersecting the UTC window, returning each
+    /// response's raw calendar-data ICS body (one body per event resource; a body may hold
+    /// several VEVENTs — a recurring master plus overridden instances).
+    /// </summary>
+    Task<List<string>> FetchEventIcsAsync(string calendarUrl, string username, string password,
+                                          DateTime startUtc, DateTime endUtc, CancellationToken ct = default);
+}
+
+/// <summary>
+/// Raw-HttpClient CalDAV client (no new NuGet dependency, mirroring
+/// <see cref="GoogleCalendarClient"/>'s shape) with Basic auth per request. Built against
+/// iCloud (<c>https://caldav.icloud.com</c>) but intentionally generic — Fastmail, Nextcloud,
+/// and other RFC 4791 servers speak the same three-step discovery and calendar-query REPORT.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Redirects are followed manually.</b> iCloud's discovery entry point 301-redirects to the
+/// user's partition host (e.g. <c>p123-caldav.icloud.com</c>), and .NET strips the
+/// Authorization header on cross-host auto-redirects — which would turn every discovery into a
+/// silent 401. The own-constructed handler therefore disables auto-redirect and this class
+/// re-issues the request (same method, body, and freshly attached Basic auth) to the Location
+/// target, up to <see cref="MaxRedirects"/> hops.
+/// </para>
+/// <para>
+/// XML parsing matches by element local name (namespace-prefix agnostic) but requires the
+/// CalDAV namespace (<c>urn:ietf:params:xml:ns:caldav</c>) where it is semantically load-bearing
+/// (the <c>calendar</c> resourcetype), since <c>DAV:</c> also defines unrelated names.
+/// </para>
+/// </remarks>
+public sealed class CalDavCalendarClient : ICalDavCalendarClient, IDisposable
+{
+    private const int MaxRedirects = 5;
+    internal const string CalDavNs = "urn:ietf:params:xml:ns:caldav";
+
+    private static readonly HttpMethod PropfindMethod = new("PROPFIND");
+    private static readonly HttpMethod ReportMethod   = new("REPORT");
+
+    private readonly HttpClient _http;
+    private readonly bool _ownsHttp;
+
+    public CalDavCalendarClient(HttpClient? http = null)
+    {
+        // AllowAutoRedirect=false: redirects must be re-issued with auth re-attached (see remarks).
+        _http     = http ?? new HttpClient(new HttpClientHandler { AllowAutoRedirect = false });
+        _ownsHttp = http is null;
+    }
+
+    // ── Identity helpers ─────────────────────────────────────────────────────────
+
+    /// <summary>Windows Credential Manager key for a CalDAV source's app-specific password.</summary>
+    public static string SecretKeyFor(string username) => $"QuickMail/CalDAV/{username.Trim()}";
+
+    /// <summary>
+    /// The synthetic, stable AccountId for a CalDAV source's rows in the CalendarEvent table.
+    /// CalDAV sources are not QuickMail accounts, but every calendar row needs an account id, so
+    /// one is derived DETERMINISTICALLY from the source's identity: the first 16 bytes of
+    /// SHA-256 over <c>"caldav|{url}|{username}"</c> (both trimmed and lower-cased, trailing
+    /// slash dropped from the URL). The same Settings values always map to the same id — the
+    /// calendar-tree filter, replace-slice deletes, and previously synced rows all keep lining
+    /// up across restarts — while different sources cannot collide with each other, with real
+    /// account GUIDs (random v4), or with the local sentinel (<see cref="System.Guid.Empty"/>).
+    /// </summary>
+    public static Guid AccountIdFor(string url, string username)
+    {
+        var key = $"caldav|{url.Trim().TrimEnd('/').ToLowerInvariant()}|{username.Trim().ToLowerInvariant()}";
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(key));
+        return new Guid(hash.AsSpan(0, 16));
+    }
+
+    /// <summary>Deterministic fallback Uid for a VEVENT that (against RFC 5545) carries no UID.</summary>
+    internal static string SyntheticUid(string seed)
+    {
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(seed));
+        return "caldav-" + Convert.ToHexString(hash.AsSpan(0, 12)).ToLowerInvariant();
+    }
+
+    // ── Discovery ────────────────────────────────────────────────────────────────
+
+    private const string PrincipalBody =
+        """<?xml version="1.0" encoding="utf-8"?><d:propfind xmlns:d="DAV:"><d:prop><d:current-user-principal/></d:prop></d:propfind>""";
+
+    private const string HomeSetBody =
+        """<?xml version="1.0" encoding="utf-8"?><d:propfind xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav"><d:prop><c:calendar-home-set/></d:prop></d:propfind>""";
+
+    private const string CollectionsBody =
+        """<?xml version="1.0" encoding="utf-8"?><d:propfind xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav"><d:prop><d:resourcetype/><d:displayname/><c:supported-calendar-component-set/></d:prop></d:propfind>""";
+
+    public async Task<CalDavCalendarInfo> DiscoverCalendarAsync(string serverUrl, string username, string password,
+                                                                CancellationToken ct = default)
+    {
+        var baseUri = NormalizeUri(serverUrl);
+
+        var (principalXml, principalReqUri) =
+            await SendAsync(PropfindMethod, baseUri, PrincipalBody, depth: "0", username, password, ct);
+        var principalHref = ParseInnerHref(principalXml, "current-user-principal")
+            ?? throw new InvalidOperationException("The server did not report an account principal — check the server address.");
+
+        var (homeXml, homeReqUri) =
+            await SendAsync(PropfindMethod, new Uri(principalReqUri, principalHref), HomeSetBody, depth: "0", username, password, ct);
+        var homeHref = ParseInnerHref(homeXml, "calendar-home-set")
+            ?? throw new InvalidOperationException("The server did not report a calendar home for this account.");
+
+        var (collectionsXml, collectionsReqUri) =
+            await SendAsync(PropfindMethod, new Uri(homeReqUri, homeHref), CollectionsBody, depth: "1", username, password, ct);
+        var (calendarHref, calendarName) = ParseFirstVEventCalendar(collectionsXml)
+            ?? throw new InvalidOperationException("No event calendar was found for this account.");
+
+        return new CalDavCalendarInfo(new Uri(collectionsReqUri, calendarHref).ToString(), calendarName);
+    }
+
+    // ── Event fetch ──────────────────────────────────────────────────────────────
+
+    public async Task<List<string>> FetchEventIcsAsync(string calendarUrl, string username, string password,
+                                                       DateTime startUtc, DateTime endUtc, CancellationToken ct = default)
+    {
+        var body =
+            $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <c:calendar-query xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
+              <d:prop><d:getetag/><c:calendar-data/></d:prop>
+              <c:filter>
+                <c:comp-filter name="VCALENDAR">
+                  <c:comp-filter name="VEVENT">
+                    <c:time-range start="{Stamp(startUtc)}" end="{Stamp(endUtc)}"/>
+                  </c:comp-filter>
+                </c:comp-filter>
+              </c:filter>
+            </c:calendar-query>
+            """;
+
+        var (xml, _) = await SendAsync(ReportMethod, NormalizeUri(calendarUrl), body, depth: "1", username, password, ct);
+        return ParseCalendarData(xml);
+    }
+
+    private static string Stamp(DateTime utc)
+        => DateTime.SpecifyKind(utc, DateTimeKind.Utc)
+            .ToString("yyyyMMdd'T'HHmmss'Z'", CultureInfo.InvariantCulture);
+
+    // ── Multistatus XML parsing (internal for tests) ─────────────────────────────
+
+    /// <summary>The d:href nested inside the named property (e.g. current-user-principal,
+    /// calendar-home-set), or null. Matches by local name so any prefix works.</summary>
+    internal static string? ParseInnerHref(string xml, string propLocalName)
+    {
+        var doc = XDocument.Parse(xml);
+        var prop = doc.Descendants()
+            .FirstOrDefault(e => e.Name.LocalName.Equals(propLocalName, StringComparison.OrdinalIgnoreCase));
+        var href = prop?.Descendants().FirstOrDefault(e => e.Name.LocalName == "href")?.Value.Trim();
+        return string.IsNullOrEmpty(href) ? null : href;
+    }
+
+    /// <summary>
+    /// The first response in a Depth-1 collections multistatus whose resourcetype marks a CalDAV
+    /// calendar collection AND whose supported-calendar-component-set includes VEVENT (a missing
+    /// component set counts as supporting everything). Skips VTODO-only collections (e.g.
+    /// Reminders lists) and non-calendar children (inbox/outbox/notifications).
+    /// </summary>
+    internal static (string Href, string DisplayName)? ParseFirstVEventCalendar(string xml)
+    {
+        var doc = XDocument.Parse(xml);
+        foreach (var response in doc.Descendants().Where(e => e.Name.LocalName == "response"))
+        {
+            var href = response.Elements().FirstOrDefault(e => e.Name.LocalName == "href")?.Value.Trim();
+            if (string.IsNullOrEmpty(href)) continue;
+
+            // Must be a CalDAV calendar collection — require the caldav namespace here, since
+            // "calendar" is only meaningful as urn:ietf:params:xml:ns:caldav's resourcetype.
+            var isCalendar = response.Descendants()
+                .Where(e => e.Name.LocalName == "resourcetype")
+                .Any(rt => rt.Elements().Any(c => c.Name.LocalName == "calendar" &&
+                                                  c.Name.NamespaceName == CalDavNs));
+            if (!isCalendar) continue;
+
+            var componentSets = response.Descendants()
+                .Where(e => e.Name.LocalName == "supported-calendar-component-set")
+                .ToList();
+            var supportsVEvent = componentSets.Count == 0 || componentSets.Any(set =>
+                set.Elements().Any(c => c.Name.LocalName == "comp" &&
+                    string.Equals((string?)c.Attribute("name"), "VEVENT", StringComparison.OrdinalIgnoreCase)));
+            if (!supportsVEvent) continue;
+
+            var name = response.Descendants()
+                .FirstOrDefault(e => e.Name.LocalName == "displayname")?.Value.Trim();
+            return (href, string.IsNullOrEmpty(name) ? "Calendar" : name);
+        }
+        return null;
+    }
+
+    /// <summary>Every non-empty calendar-data ICS body in a REPORT multistatus.</summary>
+    internal static List<string> ParseCalendarData(string xml)
+    {
+        var doc = XDocument.Parse(xml);
+        return doc.Descendants()
+            .Where(e => e.Name.LocalName == "calendar-data")
+            .Select(e => e.Value)
+            .Where(v => !string.IsNullOrWhiteSpace(v))
+            .ToList();
+    }
+
+    // ── HTTP plumbing ────────────────────────────────────────────────────────────
+
+    private static Uri NormalizeUri(string url)
+    {
+        var trimmed = url.Trim();
+        if (!trimmed.Contains("://", StringComparison.Ordinal))
+            trimmed = "https://" + trimmed;
+        return new Uri(trimmed);
+    }
+
+    /// <summary>
+    /// Sends one WebDAV request with Basic auth, following redirects manually (auth re-attached
+    /// on each hop — see class remarks). Returns the response body and the FINAL request URI so
+    /// relative hrefs in the response resolve against the host that actually answered.
+    /// </summary>
+    private async Task<(string Body, Uri FinalUri)> SendAsync(HttpMethod method, Uri uri, string body,
+        string depth, string username, string password, CancellationToken ct)
+    {
+        var auth = new AuthenticationHeaderValue("Basic",
+            Convert.ToBase64String(Encoding.UTF8.GetBytes($"{username}:{password}")));
+
+        for (var hop = 0; hop <= MaxRedirects; hop++)
+        {
+            using var req = new HttpRequestMessage(method, uri);
+            req.Headers.Authorization = auth;
+            req.Headers.TryAddWithoutValidation("Depth", depth);
+            req.Content = new StringContent(body, Encoding.UTF8, "application/xml");
+
+            using var resp = await _http.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, ct);
+
+            if ((int)resp.StatusCode is 301 or 302 or 307 or 308 && resp.Headers.Location != null)
+            {
+                uri = resp.Headers.Location.IsAbsoluteUri
+                    ? resp.Headers.Location
+                    : new Uri(uri, resp.Headers.Location);
+                continue;
+            }
+
+            if (!resp.IsSuccessStatusCode) // 207 Multi-Status is a success code
+            {
+                var errBody = await resp.Content.ReadAsStringAsync(ct);
+                throw new HttpRequestException(
+                    $"CalDAV request failed ({(int)resp.StatusCode} {resp.StatusCode}): {Truncate(errBody, 300)}");
+            }
+
+            return (await resp.Content.ReadAsStringAsync(ct), uri);
+        }
+
+        throw new HttpRequestException("CalDAV request failed: too many redirects.");
+    }
+
+    private static string Truncate(string s, int max) => s.Length <= max ? s : s[..max];
+
+    public void Dispose()
+    {
+        if (_ownsHttp) _http.Dispose();
+    }
+}

--- a/QuickMail/Services/CalendarService.cs
+++ b/QuickMail/Services/CalendarService.cs
@@ -64,4 +64,13 @@ public sealed class CalendarService : ICalendarService
                 _events[idx].ResponseStatus = status;
         }
     }
+
+    public async Task DeleteEventAsync(string uid, Guid accountId, CancellationToken ct = default)
+    {
+        await _provider.DeleteEventAsync(uid, accountId, ct);
+        lock (_lock)
+        {
+            _events.RemoveAll(e => e.Uid == uid && e.AccountId == accountId);
+        }
+    }
 }

--- a/QuickMail/Services/ConfigService.cs
+++ b/QuickMail/Services/ConfigService.cs
@@ -247,6 +247,11 @@ public class ConfigService : IConfigService
                     case "announcespellingsuggestions":     config.AnnounceSpellingSuggestions     = ParseBool(value); break;
                     case "contactlistshowfieldlabels":      config.ContactListShowFieldLabels      = ParseBool(value); break;
                     case "calendarlistshowfieldlabels":     config.CalendarListShowFieldLabels     = ParseBool(value); break;
+                    case "calendarreminders":               config.CalendarReminders               = ParseBool(value); break;
+                    case "calendarreminderminutes":
+                        if (int.TryParse(value, out var remMin) && remMin >= 1 && remMin <= 1440)
+                            config.CalendarReminderMinutes = remMin;
+                        break;
                     case "spellingsuggestionsverbosity":
                         config.SpellingSuggestionsVerbosity = string.Equals(value, "justSuggestions", StringComparison.OrdinalIgnoreCase)
                             ? "justSuggestions" : "numbersWithSuggestions";
@@ -446,6 +451,15 @@ public class ConfigService : IConfigService
         sb.AppendLine($"CalendarListShowFieldLabels = {(config.CalendarListShowFieldLabels ? "on" : "off")}");
         sb.AppendLine("# Calendar: speak field labels (Subject/when/status) in each event row's");
         sb.AppendLine("# accessible name. Off (default) speaks concise data only. Values: on, off.");
+        sb.AppendLine();
+
+        sb.AppendLine($"CalendarReminders = {(config.CalendarReminders ? "on" : "off")}");
+        sb.AppendLine("# Notify before each appointment (Windows notification + announcement).");
+        sb.AppendLine("# Off by default. Values: on, off.");
+        sb.AppendLine();
+
+        sb.AppendLine($"CalendarReminderMinutes = {config.CalendarReminderMinutes}");
+        sb.AppendLine("# Minutes before the appointment start that the reminder fires (1-1440).");
         sb.AppendLine();
 
         sb.AppendLine($"AnnounceStatus = {(config.AnnounceStatus ? "on" : "off")}");

--- a/QuickMail/Services/ConfigService.cs
+++ b/QuickMail/Services/ConfigService.cs
@@ -246,6 +246,7 @@ public class ConfigService : IConfigService
                     case "announcespellingwhilenavigating": config.AnnounceSpellingWhileNavigating = ParseBool(value); break;
                     case "announcespellingsuggestions":     config.AnnounceSpellingSuggestions     = ParseBool(value); break;
                     case "contactlistshowfieldlabels":      config.ContactListShowFieldLabels      = ParseBool(value); break;
+                    case "calendarlistshowfieldlabels":     config.CalendarListShowFieldLabels     = ParseBool(value); break;
                     case "spellingsuggestionsverbosity":
                         config.SpellingSuggestionsVerbosity = string.Equals(value, "justSuggestions", StringComparison.OrdinalIgnoreCase)
                             ? "justSuggestions" : "numbersWithSuggestions";
@@ -440,6 +441,11 @@ public class ConfigService : IConfigService
         sb.AppendLine($"ContactListShowFieldLabels = {(config.ContactListShowFieldLabels ? "on" : "off")}");
         sb.AppendLine("# Address book: speak field labels (Name/email/account) in each contact row's");
         sb.AppendLine("# accessible name. Off (default) speaks concise field data only. Values: on, off.");
+        sb.AppendLine();
+
+        sb.AppendLine($"CalendarListShowFieldLabels = {(config.CalendarListShowFieldLabels ? "on" : "off")}");
+        sb.AppendLine("# Calendar: speak field labels (Subject/when/status) in each event row's");
+        sb.AppendLine("# accessible name. Off (default) speaks concise data only. Values: on, off.");
         sb.AppendLine();
 
         sb.AppendLine($"AnnounceStatus = {(config.AnnounceStatus ? "on" : "off")}");

--- a/QuickMail/Services/ConfigService.cs
+++ b/QuickMail/Services/ConfigService.cs
@@ -336,6 +336,17 @@ public class ConfigService : IConfigService
                     case "googleclientsecret": config.GoogleClientSecret = value; break;
                 }
             }
+            else if (section == "caldav")
+            {
+                switch (key)
+                {
+                    case "caldavurl":         config.CalDavUrl         = value; break;
+                    case "caldavusername":    config.CalDavUsername    = value; break;
+                    case "caldavdisplayname":
+                        if (!string.IsNullOrWhiteSpace(value)) config.CalDavDisplayName = value;
+                        break;
+                }
+            }
         }
 
         return config;
@@ -652,6 +663,22 @@ public class ConfigService : IConfigService
                 sb.AppendLine($"GoogleClientId = {config.GoogleClientId}");
             if (!string.IsNullOrEmpty(config.GoogleClientSecret))
                 sb.AppendLine($"GoogleClientSecret = {config.GoogleClientSecret}");
+            sb.AppendLine();
+        }
+
+        // ── [caldav] ───────────────────────────────────────────────────────────────
+        // Only written when a CalDAV calendar source is configured. The password is NOT
+        // here — it lives in Windows Credential Manager (QuickMail/CalDAV/{username}).
+        if (!string.IsNullOrEmpty(config.CalDavUrl) || !string.IsNullOrEmpty(config.CalDavUsername))
+        {
+            sb.AppendLine("[caldav]");
+            sb.AppendLine("# CalDAV calendar source (e.g. iCloud: https://caldav.icloud.com).");
+            sb.AppendLine("# The app-specific password is stored in Windows Credential Manager, never here.");
+            sb.AppendLine();
+            sb.AppendLine($"CalDavUrl = {config.CalDavUrl}");
+            sb.AppendLine($"CalDavUsername = {config.CalDavUsername}");
+            sb.AppendLine($"CalDavDisplayName = {config.CalDavDisplayName}");
+            sb.AppendLine("# Display name shown for this calendar in the folder tree.");
             sb.AppendLine();
         }
 

--- a/QuickMail/Services/Google/GoogleCalendarClient.cs
+++ b/QuickMail/Services/Google/GoogleCalendarClient.cs
@@ -12,18 +12,27 @@ using System.Threading.Tasks;
 namespace QuickMail.Services;
 
 /// <summary>
-/// Minimal client for the Google Calendar v3 REST API (calendar sync read-down v1), mirroring
+/// Minimal client for the Google Calendar v3 REST API, mirroring
 /// <see cref="GooglePeopleClient"/>'s shape: a raw <see cref="HttpClient"/> that attaches the
 /// bearer token per request and follows <c>nextPageToken</c> until the collection is exhausted.
-/// Only the one read endpoint v1 needs is exposed: the primary calendar's events, with
-/// <c>singleEvents=true</c> so recurring series arrive as server-expanded occurrences (each with
-/// its own id) — no local RRULE handling, matching the Graph calendarView approach. A raw
+/// Read path: the primary calendar's events, with <c>singleEvents=true</c> so recurring series
+/// arrive as server-expanded occurrences (each with its own id) — no local RRULE handling,
+/// matching the Graph calendarView approach. Write path: create/patch/delete of single events on
+/// the primary calendar (the Google counterpart of the Graph <c>/me/events</c> push). A raw
 /// HttpClient keeps the published binary small; no new NuGet dependency.
 /// </summary>
 public sealed class GoogleCalendarClient : IDisposable
 {
     private const string BaseUrl = "https://www.googleapis.com/calendar/v3";
     private static readonly JsonSerializerOptions JsonOpts = new() { PropertyNameCaseInsensitive = true };
+
+    // Write bodies omit null fields entirely: Google PATCH treats an explicit null as "clear this
+    // field", while an omitted field is left unchanged — mirroring the Graph body-builder's
+    // omit-when-blank posture.
+    private static readonly JsonSerializerOptions WriteJsonOpts = new()
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
 
     private readonly IGoogleOAuthService _oauth;
     private readonly HttpClient _http;
@@ -74,6 +83,56 @@ public sealed class GoogleCalendarClient : IDisposable
         while (!string.IsNullOrEmpty(pageToken));
 
         return all;
+    }
+
+    // ── Write path (single events on the primary calendar) ──────────────────────
+
+    /// <summary>Creates an event (<c>POST calendars/primary/events</c>) and returns the server's copy.</summary>
+    internal Task<GoogleCalendarEvent> CreateEventAsync(
+        string username, GoogleEventWriteBody body, CancellationToken ct = default)
+        => SendWriteAsync(username, HttpMethod.Post, "calendars/primary/events", body, ct);
+
+    /// <summary>Patches an event (<c>PATCH calendars/primary/events/{id}</c>) and returns the server's copy.
+    /// Omitted (null) body fields are left unchanged on the server.</summary>
+    internal Task<GoogleCalendarEvent> UpdateEventAsync(
+        string username, string eventId, GoogleEventWriteBody body, CancellationToken ct = default)
+        => SendWriteAsync(username, HttpMethod.Patch,
+                          $"calendars/primary/events/{Uri.EscapeDataString(eventId)}", body, ct);
+
+    /// <summary>Deletes an event (<c>DELETE calendars/primary/events/{id}</c>).</summary>
+    internal async Task DeleteEventAsync(string username, string eventId, CancellationToken ct = default)
+    {
+        var token = await _oauth.GetAccessTokenAsync(username, ct);
+        using var req = new HttpRequestMessage(
+            HttpMethod.Delete, $"{BaseUrl}/calendars/primary/events/{Uri.EscapeDataString(eventId)}");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        using var resp = await _http.SendAsync(req, ct);
+        if (!resp.IsSuccessStatusCode)
+        {
+            var respBody = await resp.Content.ReadAsStringAsync(ct);
+            throw new HttpRequestException(
+                $"Calendar API request failed ({(int)resp.StatusCode} {resp.StatusCode}): {Truncate(respBody, 500)}");
+        }
+    }
+
+    /// <summary>Shared POST/PATCH plumbing: bearer auth (as in the read path), JSON body, JSON response.</summary>
+    private async Task<GoogleCalendarEvent> SendWriteAsync(
+        string username, HttpMethod method, string path, GoogleEventWriteBody body, CancellationToken ct)
+    {
+        var token = await _oauth.GetAccessTokenAsync(username, ct);
+        using var req = new HttpRequestMessage(method, $"{BaseUrl}/{path}");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        req.Content = JsonContent.Create(body, options: WriteJsonOpts);
+
+        using var resp = await _http.SendAsync(req, ct);
+        var respBody = await resp.Content.ReadAsStringAsync(ct);
+        if (!resp.IsSuccessStatusCode)
+            throw new HttpRequestException(
+                $"Calendar API request failed ({(int)resp.StatusCode} {resp.StatusCode}): {Truncate(respBody, 500)}");
+
+        return JsonSerializer.Deserialize<GoogleCalendarEvent>(respBody, JsonOpts)
+            ?? throw new InvalidOperationException("Calendar API returned no event body.");
     }
 
     private static string Rfc3339(DateTime utc)
@@ -128,4 +187,19 @@ internal sealed class GoogleEventAttendee
     [JsonPropertyName("self")]           public bool Self { get; set; }
     /// <summary>"needsAction" | "declined" | "tentative" | "accepted".</summary>
     [JsonPropertyName("responseStatus")] public string? ResponseStatus { get; set; }
+}
+
+/// <summary>
+/// Request body for creating/patching an event — the Google counterpart of
+/// <c>GraphCreateEventBody</c>. Timed events carry RFC3339 UTC <c>start.dateTime</c>/<c>end.dateTime</c>
+/// stamps; all-day events carry date-only <c>start.date</c>/<c>end.date</c> with Google's EXCLUSIVE
+/// end date. Null fields are omitted from the serialized JSON (PATCH leaves them unchanged).
+/// </summary>
+internal sealed class GoogleEventWriteBody
+{
+    [JsonPropertyName("summary")]     public string? Summary { get; set; }
+    [JsonPropertyName("description")] public string? Description { get; set; }
+    [JsonPropertyName("location")]    public string? Location { get; set; }
+    [JsonPropertyName("start")]       public GoogleEventTime? Start { get; set; }
+    [JsonPropertyName("end")]         public GoogleEventTime? End { get; set; }
 }

--- a/QuickMail/Services/Google/GoogleCalendarClient.cs
+++ b/QuickMail/Services/Google/GoogleCalendarClient.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace QuickMail.Services;
+
+/// <summary>
+/// Minimal client for the Google Calendar v3 REST API (calendar sync read-down v1), mirroring
+/// <see cref="GooglePeopleClient"/>'s shape: a raw <see cref="HttpClient"/> that attaches the
+/// bearer token per request and follows <c>nextPageToken</c> until the collection is exhausted.
+/// Only the one read endpoint v1 needs is exposed: the primary calendar's events, with
+/// <c>singleEvents=true</c> so recurring series arrive as server-expanded occurrences (each with
+/// its own id) — no local RRULE handling, matching the Graph calendarView approach. A raw
+/// HttpClient keeps the published binary small; no new NuGet dependency.
+/// </summary>
+public sealed class GoogleCalendarClient : IDisposable
+{
+    private const string BaseUrl = "https://www.googleapis.com/calendar/v3";
+    private static readonly JsonSerializerOptions JsonOpts = new() { PropertyNameCaseInsensitive = true };
+
+    private readonly IGoogleOAuthService _oauth;
+    private readonly HttpClient _http;
+    private readonly bool _ownsHttp;
+
+    public GoogleCalendarClient(IGoogleOAuthService oauth, HttpClient? http = null)
+    {
+        _oauth    = oauth;
+        _http     = http ?? new HttpClient();
+        _ownsHttp = http is null;
+    }
+
+    /// <summary>
+    /// All events on the user's PRIMARY calendar within the UTC window, as server-expanded
+    /// occurrences (<c>singleEvents=true</c>), following <c>nextPageToken</c> until exhausted.
+    /// </summary>
+    internal async Task<List<GoogleCalendarEvent>> GetPrimaryEventsAsync(
+        string username, DateTime timeMinUtc, DateTime timeMaxUtc, CancellationToken ct = default)
+    {
+        var basePath = "calendars/primary/events"
+            + $"?timeMin={Uri.EscapeDataString(Rfc3339(timeMinUtc))}"
+            + $"&timeMax={Uri.EscapeDataString(Rfc3339(timeMaxUtc))}"
+            + "&singleEvents=true&maxResults=250";
+
+        var all = new List<GoogleCalendarEvent>();
+        string? pageToken = null;
+        do
+        {
+            var token = await _oauth.GetAccessTokenAsync(username, ct);
+            var url = $"{BaseUrl}/{basePath}" +
+                      (string.IsNullOrEmpty(pageToken) ? string.Empty : $"&pageToken={Uri.EscapeDataString(pageToken)}");
+
+            using var req = new HttpRequestMessage(HttpMethod.Get, url);
+            req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+            using var resp = await _http.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, ct);
+            if (!resp.IsSuccessStatusCode)
+            {
+                var body = await resp.Content.ReadAsStringAsync(ct);
+                throw new HttpRequestException(
+                    $"Calendar API request failed ({(int)resp.StatusCode} {resp.StatusCode}): {Truncate(body, 500)}");
+            }
+
+            var page = await resp.Content.ReadFromJsonAsync<GoogleCalendarEventsResponse>(JsonOpts, ct);
+            if (page?.Items != null) all.AddRange(page.Items);
+            pageToken = page?.NextPageToken;
+        }
+        while (!string.IsNullOrEmpty(pageToken));
+
+        return all;
+    }
+
+    private static string Rfc3339(DateTime utc)
+        => DateTime.SpecifyKind(utc, DateTimeKind.Utc).ToString("yyyy-MM-dd'T'HH:mm:ss'Z'", CultureInfo.InvariantCulture);
+
+    private static string Truncate(string s, int max) => s.Length <= max ? s : s[..max];
+
+    public void Dispose()
+    {
+        if (_ownsHttp) _http.Dispose();
+    }
+}
+
+// ── Calendar API DTOs ────────────────────────────────────────────────────────
+
+internal sealed class GoogleCalendarEventsResponse
+{
+    [JsonPropertyName("items")]         public List<GoogleCalendarEvent>? Items { get; set; }
+    [JsonPropertyName("nextPageToken")] public string? NextPageToken { get; set; }
+}
+
+/// <summary>One event occurrence from the Calendar API (<c>singleEvents=true</c>).</summary>
+internal sealed class GoogleCalendarEvent
+{
+    [JsonPropertyName("id")]          public string Id { get; set; } = string.Empty;
+    /// <summary>"confirmed" | "tentative" | "cancelled".</summary>
+    [JsonPropertyName("status")]      public string? Status { get; set; }
+    [JsonPropertyName("summary")]     public string? Summary { get; set; }
+    [JsonPropertyName("description")] public string? Description { get; set; }
+    [JsonPropertyName("location")]    public string? Location { get; set; }
+    [JsonPropertyName("organizer")]   public GoogleEventOrganizer? Organizer { get; set; }
+    [JsonPropertyName("start")]       public GoogleEventTime? Start { get; set; }
+    [JsonPropertyName("end")]         public GoogleEventTime? End { get; set; }
+    [JsonPropertyName("attendees")]   public List<GoogleEventAttendee>? Attendees { get; set; }
+}
+
+/// <summary>Either <c>dateTime</c> (timed, RFC3339 with offset) or <c>date</c> (all-day, "yyyy-MM-dd").</summary>
+internal sealed class GoogleEventTime
+{
+    [JsonPropertyName("dateTime")] public string? DateTime { get; set; }
+    [JsonPropertyName("date")]     public string? Date { get; set; }
+}
+
+internal sealed class GoogleEventOrganizer
+{
+    [JsonPropertyName("email")]       public string? Email { get; set; }
+    [JsonPropertyName("displayName")] public string? DisplayName { get; set; }
+}
+
+internal sealed class GoogleEventAttendee
+{
+    [JsonPropertyName("self")]           public bool Self { get; set; }
+    /// <summary>"needsAction" | "declined" | "tentative" | "accepted".</summary>
+    [JsonPropertyName("responseStatus")] public string? ResponseStatus { get; set; }
+}

--- a/QuickMail/Services/GoogleOAuthService.cs
+++ b/QuickMail/Services/GoogleOAuthService.cs
@@ -31,7 +31,22 @@ public partial class GoogleOAuthService : IGoogleOAuthService
         "https://www.googleapis.com/auth/contacts.other.readonly",
     ];
 
-    private static string[] MailAndContactsScopes => [.. Scopes, .. ContactsScopes];
+    // Google Calendar scope for calendar sync (full-calendar spec M5 read-down). Already
+    // authorized on the project's consent screen (app in Testing; see AI-HANDOFF §0). Requested
+    // on every INTERACTIVE sign-in so the next consent covers calendar too; the refresh flow in
+    // GetAccessTokenAsync deliberately keeps the mail-only scope list so tokens from refresh
+    // tokens granted BEFORE calendar consent keep working for mail unchanged — a token simply
+    // lacks calendar access (Calendar API → 403, surfaced as a logged sync error) until the
+    // user re-consents interactively.
+    private static readonly string[] CalendarScopes = ["https://www.googleapis.com/auth/calendar"];
+
+    // Every INTERACTIVE path must request the full superset it wants to keep: a successful
+    // interactive sign-in REPLACES the stored refresh token with one carrying exactly the scopes
+    // just consented, so leaving calendar out of any interactive flow would silently drop the
+    // calendar grant the next time that flow runs.
+    private static string[] MailAndCalendarScopes => [.. Scopes, .. CalendarScopes];
+
+    private static string[] MailContactsAndCalendarScopes => [.. Scopes, .. ContactsScopes, .. CalendarScopes];
 
     private static string TokenKey(string username)
         => $"QuickMail:GoogleToken:{username.ToLowerInvariant()}";
@@ -84,10 +99,10 @@ public partial class GoogleOAuthService : IGoogleOAuthService
     }
 
     public Task<OAuthResult> SignInInteractiveAsync(string loginHint, CancellationToken ct = default)
-        => AuthorizeInteractiveAsync(loginHint, Scopes, ct);
+        => AuthorizeInteractiveAsync(loginHint, MailAndCalendarScopes, ct);
 
     public Task<OAuthResult> AuthorizeContactsAsync(string loginHint, CancellationToken ct = default)
-        => AuthorizeInteractiveAsync(loginHint, MailAndContactsScopes, ct);
+        => AuthorizeInteractiveAsync(loginHint, MailContactsAndCalendarScopes, ct);
 
     private async Task<OAuthResult> AuthorizeInteractiveAsync(string loginHint, string[] scopes, CancellationToken ct)
     {

--- a/QuickMail/Services/GoogleOAuthService.cs
+++ b/QuickMail/Services/GoogleOAuthService.cs
@@ -87,7 +87,11 @@ public partial class GoogleOAuthService : IGoogleOAuthService
             if (string.IsNullOrEmpty(refreshToken))
                 throw new InvalidOperationException($"No Google credentials stored for {username}. Sign in first.");
 
-            credential = new UserCredential(CreateFlow(Scopes, new NoOpDataStore()), username, new TokenResponse
+            // Scopes: null — a refresh request must OMIT the scope parameter so Google returns a token
+            // with everything the stored refresh token was granted (mail, calendar, contacts).
+            // Passing the mail-only list here narrowed refreshed tokens and broke calendar sync
+            // after every app restart.
+            credential = new UserCredential(CreateFlow(null, new NoOpDataStore()), username, new TokenResponse
             {
                 RefreshToken = refreshToken,
             });

--- a/QuickMail/Services/Graph/GraphClient.cs
+++ b/QuickMail/Services/Graph/GraphClient.cs
@@ -158,6 +158,29 @@ public sealed class GraphClient : IDisposable
         await EnsureSuccessAsync(resp, ct);
     }
 
+    /// <summary>
+    /// PATCHes a JSON body with an explicit token scope set and deserializes the JSON response.
+    /// Used by calendar write-back to update an event (<c>PATCH /me/events/{id}</c>) under the
+    /// calendar scopes and read back the server's updated copy.
+    /// </summary>
+    public async Task<T?> PatchReadAsync<T>(AccountModel account, string path, object body,
+        string[]? scopes, bool silentOnly, IReadOnlyDictionary<string, string>? headers, CancellationToken ct = default)
+    {
+        var json = JsonSerializer.Serialize(body, JsonOpts);
+        using var resp = await SendAsync(account, HttpMethod.Patch, path,
+            () => new StringContent(json, Encoding.UTF8, "application/json"), scopes, silentOnly, headers, ct);
+        await EnsureSuccessAsync(resp, ct);
+        return await resp.Content.ReadFromJsonAsync<T>(JsonOpts, ct);
+    }
+
+    /// <summary>DELETEs a resource under an explicit token scope set (calendar write-back).</summary>
+    public async Task DeleteAsync(AccountModel account, string path,
+        string[]? scopes, bool silentOnly, CancellationToken ct = default)
+    {
+        using var resp = await SendAsync(account, HttpMethod.Delete, path, null, scopes, silentOnly, headers: null, ct);
+        await EnsureSuccessAsync(resp, ct);
+    }
+
     /// <summary>GETs a raw byte payload (attachment <c>$value</c> download).</summary>
     public async Task<byte[]> GetBytesAsync(AccountModel account, string path, CancellationToken ct = default)
     {

--- a/QuickMail/Services/Graph/GraphClient.cs
+++ b/QuickMail/Services/Graph/GraphClient.cs
@@ -120,6 +120,21 @@ public sealed class GraphClient : IDisposable
     }
 
     /// <summary>
+    /// POSTs a JSON body with an explicit token scope set (optionally silent-only, with extra
+    /// headers) and deserializes the JSON response. Used by calendar sync to create an event
+    /// (<c>POST /me/events</c>) under the calendar scopes and read back the created event.
+    /// </summary>
+    public async Task<T?> PostReadAsync<T>(AccountModel account, string path, object body,
+        string[]? scopes, bool silentOnly, IReadOnlyDictionary<string, string>? headers, CancellationToken ct = default)
+    {
+        var json = JsonSerializer.Serialize(body, JsonOpts);
+        using var resp = await SendAsync(account, HttpMethod.Post, path,
+            () => new StringContent(json, Encoding.UTF8, "application/json"), scopes, silentOnly, headers, ct);
+        await EnsureSuccessAsync(resp, ct);
+        return await resp.Content.ReadFromJsonAsync<T>(JsonOpts, ct);
+    }
+
+    /// <summary>
     /// POSTs an already-encoded raw body and deserializes the JSON response. Used to create a draft
     /// from MIME (<c>POST /me/messages</c>), where the created message's id is needed back.
     /// </summary>

--- a/QuickMail/Services/Graph/GraphClient.cs
+++ b/QuickMail/Services/Graph/GraphClient.cs
@@ -63,13 +63,22 @@ public sealed class GraphClient : IDisposable
     /// modal address book, where launching an embedded WebView2 sign-in could deadlock the UI thread.
     /// A missing/expired grant surfaces as <see cref="InteractiveSignInRequiredException"/>.
     /// </summary>
-    public async Task<List<T>> GetAllPagesAsync<T>(AccountModel account, string path, string[]? scopes, bool silentOnly, CancellationToken ct = default)
+    public Task<List<T>> GetAllPagesAsync<T>(AccountModel account, string path, string[]? scopes, bool silentOnly, CancellationToken ct = default)
+        => GetAllPagesAsync<T>(account, path, scopes, silentOnly, headers: null, ct);
+
+    /// <summary>
+    /// As the silent-aware overload, plus extra request headers applied to every page request.
+    /// Used by calendar sync to send <c>Prefer: outlook.timezone="UTC"</c> so Graph returns event
+    /// times normalized to UTC regardless of the mailbox's configured time zone.
+    /// </summary>
+    public async Task<List<T>> GetAllPagesAsync<T>(AccountModel account, string path, string[]? scopes, bool silentOnly,
+        IReadOnlyDictionary<string, string>? headers, CancellationToken ct = default)
     {
         var all = new List<T>();
         string? next = path;
         while (!string.IsNullOrEmpty(next))
         {
-            using var resp = await SendAsync(account, HttpMethod.Get, next, null, scopes, silentOnly, ct);
+            using var resp = await SendAsync(account, HttpMethod.Get, next, null, scopes, silentOnly, headers, ct);
             await EnsureSuccessAsync(resp, ct);
             var page = await resp.Content.ReadFromJsonAsync<GraphCollection<T>>(JsonOpts, ct);
             if (page?.Value != null) all.AddRange(page.Value);
@@ -144,10 +153,11 @@ public sealed class GraphClient : IDisposable
 
     private Task<HttpResponseMessage> SendAsync(
         AccountModel account, HttpMethod method, string pathOrUrl, Func<HttpContent>? contentFactory, CancellationToken ct)
-        => SendAsync(account, method, pathOrUrl, contentFactory, null, silentOnly: false, ct);
+        => SendAsync(account, method, pathOrUrl, contentFactory, null, silentOnly: false, headers: null, ct);
 
     private async Task<HttpResponseMessage> SendAsync(
-        AccountModel account, HttpMethod method, string pathOrUrl, Func<HttpContent>? contentFactory, string[]? scopes, bool silentOnly, CancellationToken ct)
+        AccountModel account, HttpMethod method, string pathOrUrl, Func<HttpContent>? contentFactory, string[]? scopes, bool silentOnly,
+        IReadOnlyDictionary<string, string>? headers, CancellationToken ct)
     {
         var url = pathOrUrl.StartsWith("http", StringComparison.OrdinalIgnoreCase) ? pathOrUrl : BaseUrl + pathOrUrl;
 
@@ -165,6 +175,9 @@ public sealed class GraphClient : IDisposable
                     : await _oauth.GetAccessTokenAsync(account, scopes, ct);
             using var req = new HttpRequestMessage(method, url);
             req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            if (headers != null)
+                foreach (var (name, value) in headers)
+                    req.Headers.TryAddWithoutValidation(name, value);
             if (contentFactory != null)
                 req.Content = contentFactory(); // fresh per attempt — content can't be resent after a 429
 

--- a/QuickMail/Services/Graph/GraphDtos.cs
+++ b/QuickMail/Services/Graph/GraphDtos.cs
@@ -118,3 +118,41 @@ internal sealed class GraphScoredEmailAddress
     [JsonPropertyName("address")] public string? Address { get; set; }
     [JsonPropertyName("relevanceScore")] public double RelevanceScore { get; set; }
 }
+
+// ── Calendar sync (full-calendar spec, M4 read-down v1) ─────────────────────
+
+/// <summary>
+/// An event occurrence from <c>/me/calendarView</c>. calendarView expands recurring series
+/// server-side, so each item is a concrete occurrence with its own id — no RRULE handling needed.
+/// </summary>
+internal sealed class GraphCalendarEvent
+{
+    [JsonPropertyName("id")] public string Id { get; set; } = string.Empty;
+    [JsonPropertyName("subject")] public string? Subject { get; set; }
+    [JsonPropertyName("bodyPreview")] public string? BodyPreview { get; set; }
+    [JsonPropertyName("location")] public GraphLocation? Location { get; set; }
+    [JsonPropertyName("organizer")] public GraphRecipient? Organizer { get; set; }
+    [JsonPropertyName("start")] public GraphDateTimeTimeZone? Start { get; set; }
+    [JsonPropertyName("end")] public GraphDateTimeTimeZone? End { get; set; }
+    [JsonPropertyName("isAllDay")] public bool IsAllDay { get; set; }
+    [JsonPropertyName("isOrganizer")] public bool IsOrganizer { get; set; }
+    [JsonPropertyName("responseStatus")] public GraphResponseStatus? ResponseStatus { get; set; }
+}
+
+/// <summary>Graph's dateTimeTimeZone shape: a wall-clock string plus the zone it is expressed in.</summary>
+internal sealed class GraphDateTimeTimeZone
+{
+    [JsonPropertyName("dateTime")] public string? DateTime { get; set; }
+    [JsonPropertyName("timeZone")] public string? TimeZone { get; set; }
+}
+
+internal sealed class GraphLocation
+{
+    [JsonPropertyName("displayName")] public string? DisplayName { get; set; }
+}
+
+internal sealed class GraphResponseStatus
+{
+    /// <summary>Values: "none" | "organizer" | "tentativelyAccepted" | "accepted" | "declined" | "notResponded".</summary>
+    [JsonPropertyName("response")] public string? Response { get; set; }
+}

--- a/QuickMail/Services/Graph/GraphDtos.cs
+++ b/QuickMail/Services/Graph/GraphDtos.cs
@@ -156,3 +156,16 @@ internal sealed class GraphResponseStatus
     /// <summary>Values: "none" | "organizer" | "tentativelyAccepted" | "accepted" | "declined" | "notResponded".</summary>
     [JsonPropertyName("response")] public string? Response { get; set; }
 }
+
+/// <summary>Request body for <c>POST /me/events</c> (create push, single events only in v1).</summary>
+internal sealed class GraphCreateEventBody
+{
+    [JsonPropertyName("subject")] public string Subject { get; set; } = string.Empty;
+    [JsonPropertyName("body"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public GraphItemBody? Body { get; set; }
+    [JsonPropertyName("start")] public GraphDateTimeTimeZone? Start { get; set; }
+    [JsonPropertyName("end")] public GraphDateTimeTimeZone? End { get; set; }
+    [JsonPropertyName("location"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public GraphLocation? Location { get; set; }
+    [JsonPropertyName("isAllDay")] public bool IsAllDay { get; set; }
+}

--- a/QuickMail/Services/GraphCalendarSyncService.cs
+++ b/QuickMail/Services/GraphCalendarSyncService.cs
@@ -30,6 +30,14 @@ namespace QuickMail.Services;
 /// row"), replace-slice per account. NOTE: the class/interface name predates the Google path;
 /// renaming to CalendarSyncService is earmarked for the M4 two-way engine.
 /// </para>
+/// <para>
+/// CalDAV path (read-down v1, iCloud-first): a single Settings-configured source (URL +
+/// username + app-specific password from Windows Credential Manager), synced via
+/// <see cref="CalDavCalendarClient"/> under a SYNTHETIC deterministic account id
+/// (<see cref="CalDavCalendarClient.AccountIdFor"/>) since a CalDAV source is not a QuickMail
+/// account. Unlike Graph/Google there is no server-side series expansion, so recurring masters
+/// keep their RRULE (+ EXDATE) and the local RecurrenceExpander produces the occurrences.
+/// </para>
 /// </remarks>
 public sealed class GraphCalendarSyncService : IGraphCalendarSyncService
 {
@@ -45,14 +53,29 @@ public sealed class GraphCalendarSyncService : IGraphCalendarSyncService
     private readonly ILocalStoreService _store;
     private readonly GraphClient _graph;
     private readonly GoogleCalendarClient? _google;
+    private readonly ICalDavCalendarClient? _calDav;
+    private readonly IConfigService? _config;
+    private readonly ICredentialService? _credentials;
+
+    // Cached CalDAV discovery result (the resolved calendar collection URL), keyed by
+    // "url|username" so a Settings change forces re-discovery; cleared on fetch failure so a
+    // stale collection URL (e.g. calendar recreated server-side) heals on the next pass.
+    private string? _calDavCalendarUrl;
+    private string? _calDavCacheKey;
 
     public GraphCalendarSyncService(IAccountService accounts, ILocalStoreService store, GraphClient graph,
-                                    GoogleCalendarClient? google = null)
+                                    GoogleCalendarClient? google = null,
+                                    ICalDavCalendarClient? calDav = null,
+                                    IConfigService? config = null,
+                                    ICredentialService? credentials = null)
     {
-        _accounts = accounts;
-        _store    = store;
-        _graph    = graph;
-        _google   = google;
+        _accounts    = accounts;
+        _store       = store;
+        _graph       = graph;
+        _google      = google;
+        _calDav      = calDav;
+        _config      = config;
+        _credentials = credentials;
     }
 
     /// <summary>Accounts on the Graph mail backend have a Microsoft calendar to pull.</summary>
@@ -104,6 +127,31 @@ public sealed class GraphCalendarSyncService : IGraphCalendarSyncService
                 // refresh token predates the calendar consent lands here as a 403 until the user
                 // re-signs-in interactively.
                 LogService.Log($"CalendarSync failed for {account.AccountLabel}", ex);
+                error = ex.Message;
+            }
+        }
+
+        // CalDAV source (iCloud/Fastmail/Nextcloud…): configured in Settings, not an account.
+        var cfg = _calDav != null && _config != null && _credentials != null ? _config.Load() : null;
+        if (cfg is { HasCalDavSource: true })
+        {
+            ct.ThrowIfCancellationRequested();
+            try
+            {
+                var count = await SyncCalDavAsync(cfg, ct);
+                accountsSynced++;
+                eventsFetched += count;
+                LogService.Log($"CalendarSync: {cfg.CalDavDisplayName} (CalDAV) — {count} event(s) synced.");
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                // Same best-effort posture as the account loop: log and report, never throw —
+                // the prior slice stays in place because replace happens only after a full fetch.
+                LogService.Log($"CalendarSync failed for {cfg.CalDavDisplayName} (CalDAV)", ex);
                 error = ex.Message;
             }
         }
@@ -239,6 +287,123 @@ public sealed class GraphCalendarSyncService : IGraphCalendarSyncService
         => DateTimeOffset.TryParse(stamp, CultureInfo.InvariantCulture, DateTimeStyles.None, out var dto)
             ? dto.UtcTicks
             : null;
+
+    // ── CalDAV (read-down v1) ────────────────────────────────────────────────────
+
+    private async Task<int> SyncCalDavAsync(ConfigModel cfg, CancellationToken ct)
+    {
+        var password = _credentials!.GetSecret(CalDavCalendarClient.SecretKeyFor(cfg.CalDavUsername));
+        if (string.IsNullOrEmpty(password))
+            throw new InvalidOperationException(
+                $"no saved calendar password for {cfg.CalDavUsername} — re-enter it in Settings.");
+
+        var cacheKey = $"{cfg.CalDavUrl}|{cfg.CalDavUsername}";
+        if (_calDavCalendarUrl == null || _calDavCacheKey != cacheKey)
+        {
+            var info = await _calDav!.DiscoverCalendarAsync(cfg.CalDavUrl, cfg.CalDavUsername, password, ct);
+            _calDavCalendarUrl = info.Url;
+            _calDavCacheKey    = cacheKey;
+        }
+
+        var nowUtc = DateTime.UtcNow;
+        List<string> icsBodies;
+        try
+        {
+            icsBodies = await _calDav!.FetchEventIcsAsync(_calDavCalendarUrl, cfg.CalDavUsername, password,
+                                                          nowUtc - WindowBack, nowUtc + WindowForward, ct);
+        }
+        catch
+        {
+            _calDavCalendarUrl = null; // stale collection URL? re-discover next pass
+            throw;
+        }
+
+        var accountId = CalDavCalendarClient.AccountIdFor(cfg.CalDavUrl, cfg.CalDavUsername);
+        var mapped = MapCalDavEvents(icsBodies, accountId);
+        await _store.ReplaceGraphCalendarEventsAsync(accountId, mapped);
+        return mapped.Count;
+    }
+
+    /// <summary>
+    /// Maps fetched calendar-data ICS bodies to local rows. Unlike Graph/Google there is NO
+    /// server-side expansion of recurring series: the master VEVENT arrives with its RRULE, which
+    /// is stored so the local <c>RecurrenceExpander</c> produces the occurrences, and EXDATE
+    /// entries land in the exdates column so deleted single occurrences stay hidden.
+    /// v1 limitations, by design: overridden instances (RECURRENCE-ID VEVENTs) are skipped — a
+    /// rescheduled occurrence shows at its original series slot; and STATUS:CANCELLED events are
+    /// dropped. Duplicate UIDs across bodies collapse to one row (last wins).
+    /// </summary>
+    internal static List<CalendarEvent> MapCalDavEvents(IEnumerable<string> icsBodies, Guid accountId)
+    {
+        var byUid = new Dictionary<string, CalendarEvent>(StringComparer.Ordinal);
+        foreach (var body in icsBodies)
+        {
+            foreach (var ics in IcsModel.ParseAllEvents(body))
+            {
+                if (string.Equals(ics.Status, "CANCELLED", StringComparison.OrdinalIgnoreCase)) continue;
+                if (!string.IsNullOrEmpty(ics.RecurrenceId)) continue;
+                var evt = MapCalDavEvent(ics, accountId);
+                byUid[evt.Uid] = evt;
+            }
+        }
+        return byUid.Values.ToList();
+    }
+
+    /// <summary>Maps one parsed VEVENT to a local row (is_graph=1 = "server-synced").</summary>
+    internal static CalendarEvent MapCalDavEvent(IcsModel ics, Guid accountId)
+    {
+        long? startTicks, endTicks;
+        if (ics.IsAllDay)
+        {
+            // ICS all-day: date values with an EXCLUSIVE DTEND. Re-anchor at LOCAL midnight /
+            // 23:59:59 of the last day, matching Graph, Google, and locally-authored all-day rows.
+            var startDay = ics.StartTime?.Date;
+            var endDay   = ics.EndTime?.Date.AddDays(-1) ?? startDay;
+            if (endDay.HasValue && startDay.HasValue && endDay.Value < startDay.Value)
+                endDay = startDay;
+            startTicks = startDay.HasValue
+                ? DateTime.SpecifyKind(startDay.Value, DateTimeKind.Local).ToUniversalTime().Ticks
+                : null;
+            endTicks = endDay.HasValue
+                ? DateTime.SpecifyKind(endDay.Value.AddDays(1).AddSeconds(-1), DateTimeKind.Local).ToUniversalTime().Ticks
+                : null;
+        }
+        else
+        {
+            // IcsModel start/end are Kind-carrying (Utc for Z stamps, Local otherwise);
+            // ToUniversalTime handles both.
+            startTicks = ics.StartTime?.ToUniversalTime().Ticks;
+            endTicks   = ics.EndTime?.ToUniversalTime().Ticks;
+        }
+
+        var uid = !string.IsNullOrWhiteSpace(ics.Uid)
+            ? ics.Uid
+            : CalDavCalendarClient.SyntheticUid($"{ics.Summary}|{startTicks}");
+
+        var evt = new CalendarEvent
+        {
+            Uid             = uid,
+            AccountId       = accountId,
+            IsGraph         = true, // "server-synced row" — read-only in UI, replace-slice owned
+            Summary         = ics.Summary?.Trim() ?? string.Empty,
+            Description     = ics.Description?.Trim() ?? string.Empty,
+            Location        = ics.Location?.Trim() ?? string.Empty,
+            Organizer       = ics.Organizer?.Trim() ?? string.Empty,
+            OrganizerName   = ics.OrganizerName?.Trim() ?? string.Empty,
+            StartTimeTicks  = startTicks,
+            EndTimeTicks    = endTicks,
+            IsAllDay        = ics.IsAllDay,
+            // The user's own calendar; CalDAV v1 does not resolve per-attendee RSVP state.
+            ResponseStatus  = CalendarResponseStatus.Accepted,
+            SourceMessageId = string.Empty, // not an invite email
+            SourceFolder    = string.Empty,
+            Sequence        = ics.Sequence,
+            RecurrenceRule  = string.IsNullOrWhiteSpace(ics.RecurrenceRule) ? null : ics.RecurrenceRule,
+        };
+        foreach (var exDate in ics.ExDates)
+            evt.AddExDate(exDate);
+        return evt;
+    }
 
     // ── Microsoft create push ────────────────────────────────────────────────────
 

--- a/QuickMail/Services/GraphCalendarSyncService.cs
+++ b/QuickMail/Services/GraphCalendarSyncService.cs
@@ -22,7 +22,7 @@ namespace QuickMail.Services;
 /// <see cref="GraphClient"/> (the same client the Graph mail backend and contact sync use).
 /// </para>
 /// <para>
-/// Google path (read-down v1): <c>GET calendars/primary/events?singleEvents=true</c> via
+/// Google path: <c>GET calendars/primary/events?singleEvents=true</c> via
 /// <see cref="GoogleCalendarClient"/> — the same server-expanded-occurrence model, keyed by
 /// <see cref="AuthType.OAuth2Google"/> (a Gmail account is IMAP + Google OAuth, so the identity
 /// provider, not the mail backend, is what makes calendar sync possible — mirrors contact sync).
@@ -405,12 +405,18 @@ public sealed class GraphCalendarSyncService : IGraphCalendarSyncService
         return evt;
     }
 
-    // ── Microsoft create push ────────────────────────────────────────────────────
+    // ── Create/edit/delete push (Microsoft + Google) ─────────────────────────────
+    // Each public method dispatches on the account: Google-signed-in accounts push to the Google
+    // Calendar API, everything else takes the Graph path. Both providers reject recurring events
+    // BEFORE any network call (v1 pushes single events only) and store the SERVER's returned copy
+    // with is_graph set, so the row shows immediately and survives the next replace-slice sync.
 
     public async Task<CalendarEvent> CreateEventAsync(AccountModel account, CalendarEvent evt, CancellationToken ct = default)
     {
         if (evt.IsRecurring)
-            throw new NotSupportedException("v1 Graph push handles single events only.");
+            throw new NotSupportedException("v1 calendar push handles single events only.");
+        if (IsGoogleEligible(account))
+            return await CreateGoogleEventAsync(account, evt, ct);
 
         var body = BuildCreateBody(evt);
 
@@ -432,7 +438,9 @@ public sealed class GraphCalendarSyncService : IGraphCalendarSyncService
     public async Task<CalendarEvent> UpdateEventAsync(AccountModel account, CalendarEvent evt, CancellationToken ct = default)
     {
         if (evt.IsRecurring)
-            throw new NotSupportedException("v1 Graph push handles single events only.");
+            throw new NotSupportedException("v1 calendar push handles single events only.");
+        if (IsGoogleEligible(account))
+            return await UpdateGoogleEventAsync(account, evt, ct);
 
         var body = BuildCreateBody(evt); // PATCH accepts the same shape; omitted fields are unchanged
         var updated = await _graph.PatchReadAsync<GraphCalendarEvent>(
@@ -448,11 +456,79 @@ public sealed class GraphCalendarSyncService : IGraphCalendarSyncService
 
     public async Task DeleteEventAsync(AccountModel account, CalendarEvent evt, CancellationToken ct = default)
     {
+        if (IsGoogleEligible(account))
+        {
+            await _google!.DeleteEventAsync(account.Username, evt.Uid, ct);
+            await _store.DeleteCalendarEventAsync(evt.Uid, account.Id);
+            LogService.Log($"CalendarSync: deleted Google event on {account.AccountLabel} ({evt.Uid}).");
+            return;
+        }
+
         await _graph.DeleteAsync(account, $"/me/events/{Uri.EscapeDataString(evt.Uid)}",
             OAuthService.GraphCalendarScopes, silentOnly: true, ct);
         await _store.DeleteCalendarEventAsync(evt.Uid, account.Id);
         LogService.Log($"GraphCalendarSync: deleted event on {account.AccountLabel} ({evt.Uid}).");
     }
+
+    // ── Google write path ────────────────────────────────────────────────────────
+
+    private async Task<CalendarEvent> CreateGoogleEventAsync(AccountModel account, CalendarEvent evt, CancellationToken ct)
+    {
+        var created = await _google!.CreateEventAsync(account.Username, BuildGoogleWriteBody(evt), ct);
+        var mapped = MapGoogleEvent(created, account.Id);
+        await _store.UpsertCalendarEventAsync(mapped);
+        LogService.Log($"CalendarSync: created Google event on {account.AccountLabel} ({mapped.Uid}).");
+        return mapped;
+    }
+
+    private async Task<CalendarEvent> UpdateGoogleEventAsync(AccountModel account, CalendarEvent evt, CancellationToken ct)
+    {
+        var updated = await _google!.UpdateEventAsync(account.Username, evt.Uid, BuildGoogleWriteBody(evt), ct);
+        var mapped = MapGoogleEvent(updated, account.Id);
+        await _store.UpsertCalendarEventAsync(mapped);
+        LogService.Log($"CalendarSync: updated Google event on {account.AccountLabel} ({mapped.Uid}).");
+        return mapped;
+    }
+
+    /// <summary>
+    /// Builds the Google create/patch body for a local event about to be pushed — the Google
+    /// counterpart of <see cref="BuildCreateBody"/>. Timed events send RFC3339 UTC stamps;
+    /// all-day events send date-only boundaries with Google's EXCLUSIVE end date (local rows
+    /// store all-day as local midnight .. 23:59:59 of the last day, so end = the day AFTER the
+    /// last day). Blank description/location are omitted, mirroring the Graph body.
+    /// </summary>
+    internal static GoogleEventWriteBody BuildGoogleWriteBody(CalendarEvent evt)
+    {
+        GoogleEventTime start, end;
+        if (evt.IsAllDay)
+        {
+            var startDay = (evt.StartTime ?? DateTime.Today).Date;
+            var lastDay  = (evt.EndTime ?? startDay).Date;
+            if (lastDay < startDay) lastDay = startDay;
+            start = new GoogleEventTime { Date = startDay.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture) };
+            end   = new GoogleEventTime { Date = lastDay.AddDays(1).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture) };
+        }
+        else
+        {
+            var startTicks = evt.StartTimeTicks ?? DateTime.UtcNow.Ticks;
+            var endTicks   = evt.EndTimeTicks ?? startTicks + TimeSpan.FromMinutes(30).Ticks;
+            start = new GoogleEventTime { DateTime = Rfc3339Utc(startTicks) };
+            end   = new GoogleEventTime { DateTime = Rfc3339Utc(endTicks) };
+        }
+
+        return new GoogleEventWriteBody
+        {
+            Summary     = evt.Summary,
+            Description = string.IsNullOrWhiteSpace(evt.Description) ? null : evt.Description,
+            Location    = string.IsNullOrWhiteSpace(evt.Location) ? null : evt.Location,
+            Start       = start,
+            End         = end,
+        };
+    }
+
+    private static string Rfc3339Utc(long utcTicks)
+        => new DateTime(utcTicks, DateTimeKind.Utc)
+            .ToString("yyyy-MM-dd'T'HH:mm:ss'Z'", CultureInfo.InvariantCulture);
 
     /// <summary>Builds the <c>POST /me/events</c> body for a local event about to be pushed.</summary>
     internal static GraphCreateEventBody BuildCreateBody(CalendarEvent evt)

--- a/QuickMail/Services/GraphCalendarSyncService.cs
+++ b/QuickMail/Services/GraphCalendarSyncService.cs
@@ -79,7 +79,8 @@ public sealed class GraphCalendarSyncService : IGraphCalendarSyncService
     }
 
     /// <summary>Accounts on the Graph mail backend have a Microsoft calendar to pull.</summary>
-    private static bool IsGraphEligible(AccountModel account) => account.BackendKind == BackendKind.MicrosoftGraph;
+    private static bool IsGraphEligible(AccountModel account) =>
+        account.BackendKind == BackendKind.MicrosoftGraph || account.AuthType == AuthType.OAuth2Microsoft;
 
     /// <summary>
     /// Google-signed-in accounts have a Google calendar to pull (keyed by auth type, not backend:

--- a/QuickMail/Services/GraphCalendarSyncService.cs
+++ b/QuickMail/Services/GraphCalendarSyncService.cs
@@ -11,13 +11,25 @@ namespace QuickMail.Services;
 
 /// <inheritdoc cref="IGraphCalendarSyncService"/>
 /// <remarks>
-/// Uses <c>GET /me/calendarView</c> over the user's PRIMARY calendar. calendarView expands
-/// recurring series server-side, so each returned item is a concrete occurrence stored as its
-/// own row (Uid = the occurrence's own Graph id) with <see cref="CalendarEvent.RecurrenceRule"/>
-/// left null — otherwise the local <c>RecurrenceExpander</c> would double-expand the series.
-/// The <c>Prefer: outlook.timezone="UTC"</c> header normalizes event times to UTC so they can be
+/// <para>
+/// Microsoft path: <c>GET /me/calendarView</c> over the user's PRIMARY calendar. calendarView
+/// expands recurring series server-side, so each returned item is a concrete occurrence stored
+/// as its own row (Uid = the occurrence's own Graph id) with
+/// <see cref="CalendarEvent.RecurrenceRule"/> left null — otherwise the local
+/// <c>RecurrenceExpander</c> would double-expand the series. The
+/// <c>Prefer: outlook.timezone="UTC"</c> header normalizes event times to UTC so they can be
 /// stored directly as UTC ticks. Paging and HTTP 429 Retry-After handling come from
 /// <see cref="GraphClient"/> (the same client the Graph mail backend and contact sync use).
+/// </para>
+/// <para>
+/// Google path (read-down v1): <c>GET calendars/primary/events?singleEvents=true</c> via
+/// <see cref="GoogleCalendarClient"/> — the same server-expanded-occurrence model, keyed by
+/// <see cref="AuthType.OAuth2Google"/> (a Gmail account is IMAP + Google OAuth, so the identity
+/// provider, not the mail backend, is what makes calendar sync possible — mirrors contact sync).
+/// Both providers store rows the same way: <c>is_graph=1</c> (meaning "server-synced calendar
+/// row"), replace-slice per account. NOTE: the class/interface name predates the Google path;
+/// renaming to CalendarSyncService is earmarked for the M4 two-way engine.
+/// </para>
 /// </remarks>
 public sealed class GraphCalendarSyncService : IGraphCalendarSyncService
 {
@@ -32,16 +44,26 @@ public sealed class GraphCalendarSyncService : IGraphCalendarSyncService
     private readonly IAccountService _accounts;
     private readonly ILocalStoreService _store;
     private readonly GraphClient _graph;
+    private readonly GoogleCalendarClient? _google;
 
-    public GraphCalendarSyncService(IAccountService accounts, ILocalStoreService store, GraphClient graph)
+    public GraphCalendarSyncService(IAccountService accounts, ILocalStoreService store, GraphClient graph,
+                                    GoogleCalendarClient? google = null)
     {
         _accounts = accounts;
         _store    = store;
         _graph    = graph;
+        _google   = google;
     }
 
-    /// <summary>Only accounts on the Graph mail backend have a Microsoft calendar to pull.</summary>
-    private static bool IsEligible(AccountModel account) => account.BackendKind == BackendKind.MicrosoftGraph;
+    /// <summary>Accounts on the Graph mail backend have a Microsoft calendar to pull.</summary>
+    private static bool IsGraphEligible(AccountModel account) => account.BackendKind == BackendKind.MicrosoftGraph;
+
+    /// <summary>
+    /// Google-signed-in accounts have a Google calendar to pull (keyed by auth type, not backend:
+    /// Gmail mail is IMAP). No-op when no Google client is wired or no such account exists.
+    /// </summary>
+    private bool IsGoogleEligible(AccountModel account)
+        => _google != null && account.AuthType == AuthType.OAuth2Google && !IsGraphEligible(account);
 
     public async Task<GraphCalendarSyncResult> SyncAllAsync(CancellationToken ct = default)
     {
@@ -50,15 +72,19 @@ public sealed class GraphCalendarSyncService : IGraphCalendarSyncService
 
         foreach (var account in _accounts.LoadAccounts())
         {
-            if (!IsEligible(account)) continue;
+            var graphEligible  = IsGraphEligible(account);
+            var googleEligible = IsGoogleEligible(account);
+            if (!graphEligible && !googleEligible) continue;
             ct.ThrowIfCancellationRequested();
 
             try
             {
-                var count = await SyncAccountAsync(account, ct);
+                var count = graphEligible
+                    ? await SyncAccountAsync(account, ct)
+                    : await SyncGoogleAccountAsync(account, ct);
                 accountsSynced++;
                 eventsFetched += count;
-                LogService.Log($"GraphCalendarSync: {account.AccountLabel} — {count} event(s) synced.");
+                LogService.Log($"CalendarSync: {account.AccountLabel} — {count} event(s) synced.");
             }
             catch (OperationCanceledException)
             {
@@ -68,14 +94,16 @@ public sealed class GraphCalendarSyncService : IGraphCalendarSyncService
             {
                 // The calendar grant hasn't been consented (or lapsed). Sync never opens an
                 // interactive sign-in window from the background — surface how to fix it instead.
-                LogService.Log($"GraphCalendarSync: sign-in required for {account.AccountLabel} — {ex.Message}");
+                LogService.Log($"CalendarSync: sign-in required for {account.AccountLabel} — {ex.Message}");
                 error = $"calendar access needs a new sign-in for {account.AccountLabel}.";
             }
             catch (Exception ex)
             {
                 // Best-effort: log and report, never throw — a calendar-sync failure must not
-                // break the mail-sync caller (mirrors ContactSyncService).
-                LogService.Log($"GraphCalendarSync failed for {account.AccountLabel}", ex);
+                // break the mail-sync caller (mirrors ContactSyncService). A Google account whose
+                // refresh token predates the calendar consent lands here as a 403 until the user
+                // re-signs-in interactively.
+                LogService.Log($"CalendarSync failed for {account.AccountLabel}", ex);
                 error = ex.Message;
             }
         }
@@ -112,6 +140,107 @@ public sealed class GraphCalendarSyncService : IGraphCalendarSyncService
         await _store.ReplaceGraphCalendarEventsAsync(account.Id, mapped);
         return mapped.Count;
     }
+
+    // ── Google (read-down v1) ────────────────────────────────────────────────────
+
+    private async Task<int> SyncGoogleAccountAsync(AccountModel account, CancellationToken ct)
+    {
+        var nowUtc = DateTime.UtcNow;
+        var items = await _google!.GetPrimaryEventsAsync(
+            account.Username, nowUtc - WindowBack, nowUtc + WindowForward, ct);
+
+        var mapped = items
+            .Where(e => !string.IsNullOrEmpty(e.Id))
+            // Cancelled occurrences can appear despite the default filters; they are deletions.
+            .Where(e => !string.Equals(e.Status, "cancelled", StringComparison.OrdinalIgnoreCase))
+            .Select(e => MapGoogleEvent(e, account.Id))
+            .ToList();
+
+        await _store.ReplaceGraphCalendarEventsAsync(account.Id, mapped);
+        return mapped.Count;
+    }
+
+    /// <summary>
+    /// Maps one Google Calendar occurrence to a local row. Stored exactly like a Graph row —
+    /// is_graph=1 here means "server-synced calendar row", regardless of which provider it came
+    /// from; the account id says whose calendar it is.
+    /// </summary>
+    internal static CalendarEvent MapGoogleEvent(GoogleCalendarEvent e, Guid accountId)
+    {
+        long? startTicks, endTicks;
+        var allDay = e.Start?.Date != null; // all-day events carry date-only start/end
+
+        if (allDay)
+        {
+            // Google all-day: date-only strings with an EXCLUSIVE end date. Re-anchor at LOCAL
+            // midnight / 23:59:59 of the last day, matching Graph and locally-authored all-day rows.
+            var startDay = ParseDateOnly(e.Start?.Date);
+            var endDay   = ParseDateOnly(e.End?.Date)?.AddDays(-1);
+            if (endDay.HasValue && startDay.HasValue && endDay.Value < startDay.Value)
+                endDay = startDay;
+            startTicks = startDay.HasValue
+                ? DateTime.SpecifyKind(startDay.Value, DateTimeKind.Local).ToUniversalTime().Ticks
+                : null;
+            endTicks = endDay.HasValue
+                ? DateTime.SpecifyKind(endDay.Value.AddDays(1).AddSeconds(-1), DateTimeKind.Local).ToUniversalTime().Ticks
+                : null;
+        }
+        else
+        {
+            startTicks = ParseRfc3339UtcTicks(e.Start?.DateTime);
+            endTicks   = ParseRfc3339UtcTicks(e.End?.DateTime);
+        }
+
+        return new CalendarEvent
+        {
+            Uid             = e.Id,
+            AccountId       = accountId,
+            IsGraph         = true, // "server-synced row" — see remark above
+            Summary         = e.Summary?.Trim() ?? string.Empty,
+            Description     = e.Description?.Trim() ?? string.Empty,
+            Location        = e.Location?.Trim() ?? string.Empty,
+            Organizer       = e.Organizer?.Email?.Trim() ?? string.Empty,
+            OrganizerName   = e.Organizer?.DisplayName?.Trim() ?? string.Empty,
+            StartTimeTicks  = startTicks,
+            EndTimeTicks    = endTicks,
+            IsAllDay        = allDay,
+            ResponseStatus  = MapGoogleResponseStatus(e),
+            SourceMessageId = string.Empty, // not an invite email
+            SourceFolder    = string.Empty,
+            RecurrenceRule  = null, // singleEvents=true already expanded any series server-side
+        };
+    }
+
+    /// <summary>
+    /// The user's own response: the attendee entry with <c>self=true</c>. Events with no
+    /// attendee list (or no self entry) are the user's own calendar entries — Accepted.
+    /// </summary>
+    internal static CalendarResponseStatus MapGoogleResponseStatus(GoogleCalendarEvent e)
+    {
+        var self = e.Attendees?.FirstOrDefault(a => a.Self);
+        return self?.ResponseStatus?.ToLowerInvariant() switch
+        {
+            "accepted"    => CalendarResponseStatus.Accepted,
+            "declined"    => CalendarResponseStatus.Declined,
+            "tentative"   => CalendarResponseStatus.Tentative,
+            "needsaction" => CalendarResponseStatus.Pending,
+            _             => CalendarResponseStatus.Accepted,
+        };
+    }
+
+    private static DateTime? ParseDateOnly(string? date)
+        => DateTime.TryParseExact(date, "yyyy-MM-dd", CultureInfo.InvariantCulture,
+                                  DateTimeStyles.None, out var d)
+            ? d.Date
+            : null;
+
+    /// <summary>Parses an RFC3339 stamp (offset-carrying) to UTC ticks.</summary>
+    private static long? ParseRfc3339UtcTicks(string? stamp)
+        => DateTimeOffset.TryParse(stamp, CultureInfo.InvariantCulture, DateTimeStyles.None, out var dto)
+            ? dto.UtcTicks
+            : null;
+
+    // ── Microsoft create push ────────────────────────────────────────────────────
 
     public async Task<CalendarEvent> CreateEventAsync(AccountModel account, CalendarEvent evt, CancellationToken ct = default)
     {

--- a/QuickMail/Services/GraphCalendarSyncService.cs
+++ b/QuickMail/Services/GraphCalendarSyncService.cs
@@ -46,8 +46,13 @@ public sealed class GraphCalendarSyncService : IGraphCalendarSyncService
     internal static readonly TimeSpan WindowBack    = TimeSpan.FromDays(30);
     internal static readonly TimeSpan WindowForward = TimeSpan.FromDays(365);
 
+    // Ask Graph for times in the machine's own zone (Windows zone id, the format Outlook uses).
+    // Timed events still convert exactly to UTC ticks via ParseGraphDateTimeUtc (which honors the
+    // returned zone). All-day events arrive as LOCAL midnights, so taking .Date yields the correct
+    // calendar day — with a UTC Prefer header an all-day event authored east of Greenwich came back
+    // as the previous day's UTC evening and displayed one day early.
     private static readonly IReadOnlyDictionary<string, string> UtcPreferHeader =
-        new Dictionary<string, string> { ["Prefer"] = "outlook.timezone=\"UTC\"" };
+        new Dictionary<string, string> { ["Prefer"] = $"outlook.timezone=\"{TimeZoneInfo.Local.Id}\"" };
 
     private readonly IAccountService _accounts;
     private readonly ILocalStoreService _store;

--- a/QuickMail/Services/GraphCalendarSyncService.cs
+++ b/QuickMail/Services/GraphCalendarSyncService.cs
@@ -113,6 +113,78 @@ public sealed class GraphCalendarSyncService : IGraphCalendarSyncService
         return mapped.Count;
     }
 
+    public async Task<CalendarEvent> CreateEventAsync(AccountModel account, CalendarEvent evt, CancellationToken ct = default)
+    {
+        if (evt.IsRecurring)
+            throw new NotSupportedException("v1 Graph push handles single events only.");
+
+        var body = BuildCreateBody(evt);
+
+        // Same auth posture as SyncAccountAsync: calendar scopes, never interactive from here.
+        // Prefer UTC so the response times come back ready to store as UTC ticks.
+        var created = await _graph.PostReadAsync<GraphCalendarEvent>(
+            account, "/me/events", body, OAuthService.GraphCalendarScopes, silentOnly: true, UtcPreferHeader, ct)
+            ?? throw new InvalidOperationException("Graph returned no event body for the created event.");
+
+        // Store the SERVER's copy (Uid = the Graph id), flagged is_graph — it shows up
+        // immediately, and because it now exists on the server it survives (is re-fetched by)
+        // the next replace-slice sync.
+        var mapped = MapEvent(created, account.Id);
+        await _store.UpsertCalendarEventAsync(mapped);
+        LogService.Log($"GraphCalendarSync: created event on {account.AccountLabel} ({mapped.Uid}).");
+        return mapped;
+    }
+
+    /// <summary>Builds the <c>POST /me/events</c> body for a local event about to be pushed.</summary>
+    internal static GraphCreateEventBody BuildCreateBody(CalendarEvent evt)
+    {
+        GraphDateTimeTimeZone start, end;
+        if (evt.IsAllDay)
+        {
+            // Graph all-day events must span midnight-to-midnight with an EXCLUSIVE end. Local
+            // all-day rows are stored as local midnight .. 23:59:59 of the last day, so send the
+            // local calendar dates as date boundaries and end = the day AFTER the last day.
+            var startDay = (evt.StartTime ?? DateTime.Today).Date;
+            var lastDay  = (evt.EndTime ?? startDay).Date;
+            if (lastDay < startDay) lastDay = startDay;
+            start = DateBoundary(startDay);
+            end   = DateBoundary(lastDay.AddDays(1));
+        }
+        else
+        {
+            start = UtcStamp(evt.StartTimeTicks ?? DateTime.UtcNow.Ticks);
+            end   = UtcStamp(evt.EndTimeTicks ?? (evt.StartTimeTicks ?? DateTime.UtcNow.Ticks) + TimeSpan.FromMinutes(30).Ticks);
+        }
+
+        return new GraphCreateEventBody
+        {
+            Subject  = evt.Summary,
+            Body     = string.IsNullOrWhiteSpace(evt.Description)
+                        ? null
+                        : new GraphItemBody { ContentType = "text", Content = evt.Description },
+            Start    = start,
+            End      = end,
+            Location = string.IsNullOrWhiteSpace(evt.Location)
+                        ? null
+                        : new GraphLocation { DisplayName = evt.Location },
+            IsAllDay = evt.IsAllDay,
+        };
+    }
+
+    private static GraphDateTimeTimeZone UtcStamp(long utcTicks) => new()
+    {
+        DateTime = new DateTime(utcTicks, DateTimeKind.Utc).ToString("yyyy-MM-dd'T'HH:mm:ss", CultureInfo.InvariantCulture),
+        TimeZone = "UTC",
+    };
+
+    /// <summary>An all-day boundary: midnight of the given calendar date (zone label UTC — all-day
+    /// events are date-anchored, so the date is what matters).</summary>
+    private static GraphDateTimeTimeZone DateBoundary(DateTime day) => new()
+    {
+        DateTime = day.ToString("yyyy-MM-dd'T'00:00:00", CultureInfo.InvariantCulture),
+        TimeZone = "UTC",
+    };
+
     /// <summary>Maps one Graph calendarView occurrence to a local <see cref="CalendarEvent"/> row.</summary>
     internal static CalendarEvent MapEvent(GraphCalendarEvent e, Guid accountId)
     {

--- a/QuickMail/Services/GraphCalendarSyncService.cs
+++ b/QuickMail/Services/GraphCalendarSyncService.cs
@@ -1,0 +1,216 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using QuickMail.Models;
+using QuickMail.Services.Graph;
+
+namespace QuickMail.Services;
+
+/// <inheritdoc cref="IGraphCalendarSyncService"/>
+/// <remarks>
+/// Uses <c>GET /me/calendarView</c> over the user's PRIMARY calendar. calendarView expands
+/// recurring series server-side, so each returned item is a concrete occurrence stored as its
+/// own row (Uid = the occurrence's own Graph id) with <see cref="CalendarEvent.RecurrenceRule"/>
+/// left null — otherwise the local <c>RecurrenceExpander</c> would double-expand the series.
+/// The <c>Prefer: outlook.timezone="UTC"</c> header normalizes event times to UTC so they can be
+/// stored directly as UTC ticks. Paging and HTTP 429 Retry-After handling come from
+/// <see cref="GraphClient"/> (the same client the Graph mail backend and contact sync use).
+/// </remarks>
+public sealed class GraphCalendarSyncService : IGraphCalendarSyncService
+{
+    // Sync window relative to now: a month of history plus a year ahead. Replace-slice per sync,
+    // so the window simply rolls forward on each pass; no delta tokens in v1.
+    internal static readonly TimeSpan WindowBack    = TimeSpan.FromDays(30);
+    internal static readonly TimeSpan WindowForward = TimeSpan.FromDays(365);
+
+    private static readonly IReadOnlyDictionary<string, string> UtcPreferHeader =
+        new Dictionary<string, string> { ["Prefer"] = "outlook.timezone=\"UTC\"" };
+
+    private readonly IAccountService _accounts;
+    private readonly ILocalStoreService _store;
+    private readonly GraphClient _graph;
+
+    public GraphCalendarSyncService(IAccountService accounts, ILocalStoreService store, GraphClient graph)
+    {
+        _accounts = accounts;
+        _store    = store;
+        _graph    = graph;
+    }
+
+    /// <summary>Only accounts on the Graph mail backend have a Microsoft calendar to pull.</summary>
+    private static bool IsEligible(AccountModel account) => account.BackendKind == BackendKind.MicrosoftGraph;
+
+    public async Task<GraphCalendarSyncResult> SyncAllAsync(CancellationToken ct = default)
+    {
+        int accountsSynced = 0, eventsFetched = 0;
+        string? error = null;
+
+        foreach (var account in _accounts.LoadAccounts())
+        {
+            if (!IsEligible(account)) continue;
+            ct.ThrowIfCancellationRequested();
+
+            try
+            {
+                var count = await SyncAccountAsync(account, ct);
+                accountsSynced++;
+                eventsFetched += count;
+                LogService.Log($"GraphCalendarSync: {account.AccountLabel} — {count} event(s) synced.");
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (InteractiveSignInRequiredException ex)
+            {
+                // The calendar grant hasn't been consented (or lapsed). Sync never opens an
+                // interactive sign-in window from the background — surface how to fix it instead.
+                LogService.Log($"GraphCalendarSync: sign-in required for {account.AccountLabel} — {ex.Message}");
+                error = $"calendar access needs a new sign-in for {account.AccountLabel}.";
+            }
+            catch (Exception ex)
+            {
+                // Best-effort: log and report, never throw — a calendar-sync failure must not
+                // break the mail-sync caller (mirrors ContactSyncService).
+                LogService.Log($"GraphCalendarSync failed for {account.AccountLabel}", ex);
+                error = ex.Message;
+            }
+        }
+
+        return accountsSynced == 0 && error is null
+            ? GraphCalendarSyncResult.None
+            : new GraphCalendarSyncResult(accountsSynced, eventsFetched, error);
+    }
+
+    private async Task<int> SyncAccountAsync(AccountModel account, CancellationToken ct)
+    {
+        var nowUtc = DateTime.UtcNow;
+        var startUtc = nowUtc - WindowBack;
+        var endUtc   = nowUtc + WindowForward;
+
+        var path = "/me/calendarView"
+            + $"?startDateTime={Uri.EscapeDataString(startUtc.ToString("yyyy-MM-dd'T'HH:mm:ss'Z'", CultureInfo.InvariantCulture))}"
+            + $"&endDateTime={Uri.EscapeDataString(endUtc.ToString("yyyy-MM-dd'T'HH:mm:ss'Z'", CultureInfo.InvariantCulture))}"
+            + "&$select=id,subject,bodyPreview,location,organizer,start,end,isAllDay,isOrganizer,responseStatus"
+            + "&$top=100";
+
+        // silentOnly: background sync must never launch an interactive sign-in (same reasoning as
+        // contact sync). Consent comes from the account's normal sign-in: work/school accounts get
+        // Calendars.ReadWrite via `.default` (declared on the app registration); personal accounts
+        // acquire the explicit GraphCalendarScopes silently once granted.
+        var items = await _graph.GetAllPagesAsync<GraphCalendarEvent>(
+            account, path, OAuthService.GraphCalendarScopes, silentOnly: true, UtcPreferHeader, ct);
+
+        var mapped = items
+            .Where(e => !string.IsNullOrEmpty(e.Id))
+            .Select(e => MapEvent(e, account.Id))
+            .ToList();
+
+        await _store.ReplaceGraphCalendarEventsAsync(account.Id, mapped);
+        return mapped.Count;
+    }
+
+    /// <summary>Maps one Graph calendarView occurrence to a local <see cref="CalendarEvent"/> row.</summary>
+    internal static CalendarEvent MapEvent(GraphCalendarEvent e, Guid accountId)
+    {
+        long? startTicks, endTicks;
+        if (e.IsAllDay)
+        {
+            // Graph all-day events span midnight-to-midnight in the returned zone with an
+            // EXCLUSIVE end. Re-anchor the dates at LOCAL midnight (and an inclusive end of
+            // 23:59:59 on the last day), matching how locally-authored all-day appointments are
+            // stored, so the row displays on the correct calendar day in the user's zone.
+            var startDay = ParseGraphDateTime(e.Start)?.Date;
+            var endDayExclusive = ParseGraphDateTime(e.End)?.Date;
+            var endDay = endDayExclusive?.AddDays(-1);
+            if (endDay.HasValue && startDay.HasValue && endDay.Value < startDay.Value)
+                endDay = startDay;
+            startTicks = startDay.HasValue
+                ? DateTime.SpecifyKind(startDay.Value, DateTimeKind.Local).ToUniversalTime().Ticks
+                : null;
+            endTicks = endDay.HasValue
+                ? DateTime.SpecifyKind(endDay.Value.AddDays(1).AddSeconds(-1), DateTimeKind.Local).ToUniversalTime().Ticks
+                : null;
+        }
+        else
+        {
+            startTicks = ToUtcTicks(e.Start);
+            endTicks   = ToUtcTicks(e.End);
+        }
+
+        return new CalendarEvent
+        {
+            Uid             = e.Id,
+            AccountId       = accountId,
+            IsGraph         = true,
+            Summary         = e.Subject?.Trim() ?? string.Empty,
+            Description     = e.BodyPreview?.Trim() ?? string.Empty,
+            Location        = e.Location?.DisplayName?.Trim() ?? string.Empty,
+            Organizer       = e.Organizer?.EmailAddress?.Address?.Trim() ?? string.Empty,
+            OrganizerName   = e.Organizer?.EmailAddress?.Name?.Trim() ?? string.Empty,
+            StartTimeTicks  = startTicks,
+            EndTimeTicks    = endTicks,
+            IsAllDay        = e.IsAllDay,
+            ResponseStatus  = MapResponseStatus(e.ResponseStatus?.Response, e.IsOrganizer),
+            // Not an invite email — there is no source message to open.
+            SourceMessageId = string.Empty,
+            SourceFolder    = string.Empty,
+            // calendarView already expanded the series server-side; leaving RecurrenceRule null
+            // prevents the local RecurrenceExpander from expanding each occurrence again.
+            RecurrenceRule  = null,
+        };
+    }
+
+    /// <summary>
+    /// Maps Graph's <c>responseStatus.response</c> to the local status. The organizer of an event
+    /// never "responds", so organizer/none map to Accepted for the user's own events; a genuine
+    /// unanswered invitation stays Pending.
+    /// </summary>
+    internal static CalendarResponseStatus MapResponseStatus(string? response, bool isOrganizer)
+        => response?.ToLowerInvariant() switch
+        {
+            "accepted"            => CalendarResponseStatus.Accepted,
+            "declined"            => CalendarResponseStatus.Declined,
+            "tentativelyaccepted" => CalendarResponseStatus.Tentative,
+            "organizer"           => CalendarResponseStatus.Accepted,
+            _                     => isOrganizer ? CalendarResponseStatus.Accepted : CalendarResponseStatus.Pending,
+        };
+
+    /// <summary>Parses a Graph dateTimeTimeZone into a UTC DateTime, honoring its zone field.</summary>
+    private static DateTime? ParseGraphDateTimeUtc(GraphDateTimeTimeZone? dtz)
+    {
+        var wall = ParseGraphDateTime(dtz);
+        if (!wall.HasValue) return null;
+
+        var zone = dtz!.TimeZone;
+        if (string.IsNullOrWhiteSpace(zone) || zone.Equals("UTC", StringComparison.OrdinalIgnoreCase))
+            return DateTime.SpecifyKind(wall.Value, DateTimeKind.Utc);
+
+        // Defensive: the Prefer header makes this UTC, but honor another zone if one comes back.
+        try
+        {
+            var tzi = TimeZoneInfo.FindSystemTimeZoneById(zone);
+            return TimeZoneInfo.ConvertTimeToUtc(DateTime.SpecifyKind(wall.Value, DateTimeKind.Unspecified), tzi);
+        }
+        catch (TimeZoneNotFoundException)
+        {
+            return DateTime.SpecifyKind(wall.Value, DateTimeKind.Utc);
+        }
+        catch (InvalidTimeZoneException)
+        {
+            return DateTime.SpecifyKind(wall.Value, DateTimeKind.Utc);
+        }
+    }
+
+    private static long? ToUtcTicks(GraphDateTimeTimeZone? dtz) => ParseGraphDateTimeUtc(dtz)?.Ticks;
+
+    /// <summary>Parses just the wall-clock value (e.g. "2026-07-16T14:00:00.0000000").</summary>
+    private static DateTime? ParseGraphDateTime(GraphDateTimeTimeZone? dtz)
+        => dtz?.DateTime != null
+           && DateTime.TryParse(dtz.DateTime, CultureInfo.InvariantCulture, DateTimeStyles.None, out var dt)
+            ? dt
+            : null;
+}

--- a/QuickMail/Services/GraphCalendarSyncService.cs
+++ b/QuickMail/Services/GraphCalendarSyncService.cs
@@ -264,6 +264,31 @@ public sealed class GraphCalendarSyncService : IGraphCalendarSyncService
         return mapped;
     }
 
+    public async Task<CalendarEvent> UpdateEventAsync(AccountModel account, CalendarEvent evt, CancellationToken ct = default)
+    {
+        if (evt.IsRecurring)
+            throw new NotSupportedException("v1 Graph push handles single events only.");
+
+        var body = BuildCreateBody(evt); // PATCH accepts the same shape; omitted fields are unchanged
+        var updated = await _graph.PatchReadAsync<GraphCalendarEvent>(
+            account, $"/me/events/{Uri.EscapeDataString(evt.Uid)}", body,
+            OAuthService.GraphCalendarScopes, silentOnly: true, UtcPreferHeader, ct)
+            ?? throw new InvalidOperationException("Graph returned no event body for the updated event.");
+
+        var mapped = MapEvent(updated, account.Id);
+        await _store.UpsertCalendarEventAsync(mapped);
+        LogService.Log($"GraphCalendarSync: updated event on {account.AccountLabel} ({mapped.Uid}).");
+        return mapped;
+    }
+
+    public async Task DeleteEventAsync(AccountModel account, CalendarEvent evt, CancellationToken ct = default)
+    {
+        await _graph.DeleteAsync(account, $"/me/events/{Uri.EscapeDataString(evt.Uid)}",
+            OAuthService.GraphCalendarScopes, silentOnly: true, ct);
+        await _store.DeleteCalendarEventAsync(evt.Uid, account.Id);
+        LogService.Log($"GraphCalendarSync: deleted event on {account.AccountLabel} ({evt.Uid}).");
+    }
+
     /// <summary>Builds the <c>POST /me/events</c> body for a local event about to be pushed.</summary>
     internal static GraphCreateEventBody BuildCreateBody(CalendarEvent evt)
     {

--- a/QuickMail/Services/ICalendarService.cs
+++ b/QuickMail/Services/ICalendarService.cs
@@ -27,4 +27,7 @@ public interface ICalendarService
 
     /// <summary>Updates the response status for an event and persists it.</summary>
     Task SetResponseStatusAsync(string uid, Guid accountId, CalendarResponseStatus status, CancellationToken ct = default);
+
+    /// <summary>Deletes an event (by Uid + AccountId) and refreshes the in-memory list.</summary>
+    Task DeleteEventAsync(string uid, Guid accountId, CancellationToken ct = default);
 }

--- a/QuickMail/Services/IGraphCalendarSyncService.cs
+++ b/QuickMail/Services/IGraphCalendarSyncService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using QuickMail.Models;
 
 namespace QuickMail.Services;
 
@@ -27,4 +28,14 @@ public interface IGraphCalendarSyncService
     /// so events deleted on the server disappear locally.
     /// </summary>
     Task<GraphCalendarSyncResult> SyncAllAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Creates a single (non-repeating) event on the account's primary Microsoft calendar
+    /// (<c>POST /me/events</c>) and upserts the server's copy into the local store with
+    /// <c>is_graph</c> set, so it appears immediately and survives the next replace-slice sync.
+    /// Unlike <see cref="SyncAllAsync"/>, this THROWS on failure — the caller decides the
+    /// fallback (e.g. save locally instead). Returns the locally-stored row (Uid = the
+    /// server-assigned event id).
+    /// </summary>
+    Task<CalendarEvent> CreateEventAsync(AccountModel account, CalendarEvent evt, CancellationToken ct = default);
 }

--- a/QuickMail/Services/IGraphCalendarSyncService.cs
+++ b/QuickMail/Services/IGraphCalendarSyncService.cs
@@ -32,18 +32,21 @@ public interface IGraphCalendarSyncService
     Task<GraphCalendarSyncResult> SyncAllAsync(CancellationToken ct = default);
 
     /// <summary>
-    /// Creates a single (non-repeating) event on the account's primary Microsoft calendar
-    /// (<c>POST /me/events</c>) and upserts the server's copy into the local store with
-    /// <c>is_graph</c> set, so it appears immediately and survives the next replace-slice sync.
+    /// Creates a single (non-repeating) event on the account's primary calendar — Microsoft
+    /// (<c>POST /me/events</c>) or Google (<c>POST calendars/primary/events</c>), dispatched on
+    /// the account — and upserts the server's copy into the local store with <c>is_graph</c> set,
+    /// so it appears immediately and survives the next replace-slice sync.
     /// Unlike <see cref="SyncAllAsync"/>, this THROWS on failure — the caller decides the
     /// fallback (e.g. save locally instead). Returns the locally-stored row (Uid = the
     /// server-assigned event id).
     /// </summary>
     Task<CalendarEvent> CreateEventAsync(AccountModel account, CalendarEvent evt, CancellationToken ct = default);
 
-    /// <summary>PATCHes an existing server event and upserts the server's returned copy locally.</summary>
+    /// <summary>PATCHes an existing server event (Microsoft or Google, dispatched on the account)
+    /// and upserts the server's returned copy locally.</summary>
     Task<CalendarEvent> UpdateEventAsync(AccountModel account, CalendarEvent evt, CancellationToken ct = default);
 
-    /// <summary>DELETEs a server event and removes the local row.</summary>
+    /// <summary>DELETEs a server event (Microsoft or Google, dispatched on the account) and
+    /// removes the local row.</summary>
     Task DeleteEventAsync(AccountModel account, CalendarEvent evt, CancellationToken ct = default);
 }

--- a/QuickMail/Services/IGraphCalendarSyncService.cs
+++ b/QuickMail/Services/IGraphCalendarSyncService.cs
@@ -16,9 +16,11 @@ public sealed record GraphCalendarSyncResult(int AccountsSynced, int EventsFetch
 }
 
 /// <summary>
-/// Pulls each Microsoft (Graph backend) account's primary calendar into the local CalendarEvent
-/// table — read-down only (full-calendar spec M4, v1). Best-effort: a failing account is logged
-/// and reported in the result, never thrown, so calendar sync can never break a mail-sync caller.
+/// Pulls each server-backed account's primary calendar into the local CalendarEvent table —
+/// read-down only: Microsoft (Graph backend) accounts via Graph calendarView, and Google-signed-in
+/// accounts via the Google Calendar REST API (the name predates the Google path; see the
+/// implementation remarks). Best-effort: a failing account is logged and reported in the result,
+/// never thrown, so calendar sync can never break a mail-sync caller.
 /// </summary>
 public interface IGraphCalendarSyncService
 {

--- a/QuickMail/Services/IGraphCalendarSyncService.cs
+++ b/QuickMail/Services/IGraphCalendarSyncService.cs
@@ -40,4 +40,10 @@ public interface IGraphCalendarSyncService
     /// server-assigned event id).
     /// </summary>
     Task<CalendarEvent> CreateEventAsync(AccountModel account, CalendarEvent evt, CancellationToken ct = default);
+
+    /// <summary>PATCHes an existing server event and upserts the server's returned copy locally.</summary>
+    Task<CalendarEvent> UpdateEventAsync(AccountModel account, CalendarEvent evt, CancellationToken ct = default);
+
+    /// <summary>DELETEs a server event and removes the local row.</summary>
+    Task DeleteEventAsync(AccountModel account, CalendarEvent evt, CancellationToken ct = default);
 }

--- a/QuickMail/Services/IGraphCalendarSyncService.cs
+++ b/QuickMail/Services/IGraphCalendarSyncService.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace QuickMail.Services;
+
+/// <summary>
+/// Outcome of a Graph calendar sync pass. <paramref name="Error"/> is a user-presentable message
+/// for the last account that failed (each failure is also logged), or null when everything
+/// succeeded. <see cref="None"/> is the "nothing eligible / nothing done" result.
+/// </summary>
+public sealed record GraphCalendarSyncResult(int AccountsSynced, int EventsFetched, string? Error)
+{
+    public static readonly GraphCalendarSyncResult None = new(0, 0, null);
+}
+
+/// <summary>
+/// Pulls each Microsoft (Graph backend) account's primary calendar into the local CalendarEvent
+/// table — read-down only (full-calendar spec M4, v1). Best-effort: a failing account is logged
+/// and reported in the result, never thrown, so calendar sync can never break a mail-sync caller.
+/// </summary>
+public interface IGraphCalendarSyncService
+{
+    /// <summary>
+    /// Syncs every eligible account's primary calendar (window: -30 days to +365 days) using
+    /// replace-slice semantics — the account's previous Graph-sourced rows are replaced wholesale,
+    /// so events deleted on the server disappear locally.
+    /// </summary>
+    Task<GraphCalendarSyncResult> SyncAllAsync(CancellationToken ct = default);
+}

--- a/QuickMail/Services/ILocalStoreService.cs
+++ b/QuickMail/Services/ILocalStoreService.cs
@@ -80,6 +80,14 @@ public interface ILocalStoreService
     Task DeleteCalendarEventAsync(string uid, Guid accountId);
 
     /// <summary>
+    /// Replaces all Graph-synced calendar rows (<c>is_graph = 1</c>) for the account with the
+    /// supplied fresh set, in one transaction. Rows are stored with <c>is_graph = 1</c> regardless
+    /// of each event's flag. Harvested-invite and locally-authored rows are untouched. Used by
+    /// <see cref="GraphCalendarSyncService"/>'s replace-slice sync (read-down v1, no delta tokens).
+    /// </summary>
+    Task ReplaceGraphCalendarEventsAsync(Guid accountId, IReadOnlyList<CalendarEvent> events);
+
+    /// <summary>
     /// Returns all non-empty calendar_ics rows from MessageDetail, for harvesting.
     /// Each item is (AccountId, FolderName, MessageId, IcsText).
     /// </summary>

--- a/QuickMail/Services/LocalCacheCalendarProvider.cs
+++ b/QuickMail/Services/LocalCacheCalendarProvider.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using QuickMail.Models;
@@ -77,6 +78,14 @@ public sealed class LocalCacheCalendarProvider : ICalendarProvider
                 SourceMessageId  = messageId,
                 SourceFolder     = folder,
                 ResponseStatus   = isCancel ? CalendarResponseStatus.Cancelled : CalendarResponseStatus.Pending,
+                // Carry the invite's all-day/recurrence data — without these, a recurring or
+                // all-day invite harvested from email showed as a single timed event at 12:00 AM.
+                IsAllDay         = model.IsAllDay,
+                RecurrenceRule   = model.RecurrenceRule,
+                ExDates          = model.ExDates.Count == 0
+                    ? null
+                    : string.Join(",", model.ExDates.Select(d =>
+                        d.ToString("yyyyMMdd'T'HHmmss", System.Globalization.CultureInfo.InvariantCulture))),
             };
             await _store.UpsertCalendarEventAsync(evt);
 

--- a/QuickMail/Services/LocalStoreService.cs
+++ b/QuickMail/Services/LocalStoreService.cs
@@ -121,6 +121,9 @@ public class LocalStoreService : ILocalStoreService
         // RRULE string for repeating appointments (null for one-offs). Idempotent ALTER.
         RunMigration(conn, "ALTER TABLE CalendarEvent ADD COLUMN recurrence_rule TEXT DEFAULT NULL;");
 
+        // Excluded occurrence starts for a recurring master ("delete just this one"). Idempotent ALTER.
+        RunMigration(conn, "ALTER TABLE CalendarEvent ADD COLUMN exdates TEXT DEFAULT NULL;");
+
         RunDataMigrations(conn);
     }
 
@@ -800,8 +803,8 @@ public class LocalStoreService : ILocalStoreService
             INSERT INTO CalendarEvent(uid, account_id, summary, description, location,
                                       organizer, organizer_name, start_time_ticks, end_time_ticks,
                                       sequence, method, source_message_id, source_folder, response_status,
-                                      is_all_day, recurrence_rule)
-            VALUES($uid, $aid, $sum, $desc, $loc, $org, $orgn, $st, $et, $seq, $meth, $smid, $sf, $rs, $allday, $rrule)
+                                      is_all_day, recurrence_rule, exdates)
+            VALUES($uid, $aid, $sum, $desc, $loc, $org, $orgn, $st, $et, $seq, $meth, $smid, $sf, $rs, $allday, $rrule, $exd)
             ON CONFLICT(uid, account_id) DO UPDATE SET
                 summary           = excluded.summary,
                 description       = excluded.description,
@@ -815,7 +818,8 @@ public class LocalStoreService : ILocalStoreService
                 source_message_id = excluded.source_message_id,
                 source_folder     = excluded.source_folder,
                 is_all_day        = excluded.is_all_day,
-                recurrence_rule   = excluded.recurrence_rule;
+                recurrence_rule   = excluded.recurrence_rule,
+                exdates           = excluded.exdates;
             """;
         cmd.Parameters.AddWithValue("$uid",  evt.Uid);
         cmd.Parameters.AddWithValue("$aid",  evt.AccountId.ToString());
@@ -833,6 +837,7 @@ public class LocalStoreService : ILocalStoreService
         cmd.Parameters.AddWithValue("$rs",   (int)evt.ResponseStatus);
         cmd.Parameters.AddWithValue("$allday", evt.IsAllDay ? 1 : 0);
         cmd.Parameters.AddWithValue("$rrule", (object?)evt.RecurrenceRule ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("$exd",  (object?)evt.ExDates ?? DBNull.Value);
         await cmd.ExecuteNonQueryAsync();
         await tx.CommitAsync();
     }
@@ -845,7 +850,7 @@ public class LocalStoreService : ILocalStoreService
         cmd.CommandText = """
             SELECT uid, account_id, summary, description, location, organizer, organizer_name,
                    start_time_ticks, end_time_ticks, sequence, method, source_message_id,
-                   source_folder, response_status, is_all_day, recurrence_rule
+                   source_folder, response_status, is_all_day, recurrence_rule, exdates
             FROM CalendarEvent
             ORDER BY start_time_ticks IS NULL, start_time_ticks ASC;
             """;
@@ -870,6 +875,7 @@ public class LocalStoreService : ILocalStoreService
                 ResponseStatus   = (CalendarResponseStatus)r.GetInt32(13),
                 IsAllDay         = !r.IsDBNull(14) && r.GetInt32(14) != 0,
                 RecurrenceRule   = r.IsDBNull(15) ? null : r.GetString(15),
+                ExDates          = r.IsDBNull(16) ? null : r.GetString(16),
             });
         }
         return list;

--- a/QuickMail/Services/LocalStoreService.cs
+++ b/QuickMail/Services/LocalStoreService.cs
@@ -124,6 +124,12 @@ public class LocalStoreService : ILocalStoreService
         // Excluded occurrence starts for a recurring master ("delete just this one"). Idempotent ALTER.
         RunMigration(conn, "ALTER TABLE CalendarEvent ADD COLUMN exdates TEXT DEFAULT NULL;");
 
+        // Marks rows pulled from a Microsoft (Graph) calendar by GraphCalendarSyncService (M4
+        // read-down v1). Graph rows are replaced wholesale per sync and must be excluded from the
+        // invite harvest and orphan cleanup; account deletion still cascades by account_id.
+        // Idempotent ALTER, mirroring is_all_day.
+        RunMigration(conn, "ALTER TABLE CalendarEvent ADD COLUMN is_graph INTEGER NOT NULL DEFAULT 0;");
+
         RunDataMigrations(conn);
     }
 
@@ -803,8 +809,8 @@ public class LocalStoreService : ILocalStoreService
             INSERT INTO CalendarEvent(uid, account_id, summary, description, location,
                                       organizer, organizer_name, start_time_ticks, end_time_ticks,
                                       sequence, method, source_message_id, source_folder, response_status,
-                                      is_all_day, recurrence_rule, exdates)
-            VALUES($uid, $aid, $sum, $desc, $loc, $org, $orgn, $st, $et, $seq, $meth, $smid, $sf, $rs, $allday, $rrule, $exd)
+                                      is_all_day, recurrence_rule, exdates, is_graph)
+            VALUES($uid, $aid, $sum, $desc, $loc, $org, $orgn, $st, $et, $seq, $meth, $smid, $sf, $rs, $allday, $rrule, $exd, $graph)
             ON CONFLICT(uid, account_id) DO UPDATE SET
                 summary           = excluded.summary,
                 description       = excluded.description,
@@ -819,8 +825,12 @@ public class LocalStoreService : ILocalStoreService
                 source_folder     = excluded.source_folder,
                 is_all_day        = excluded.is_all_day,
                 recurrence_rule   = excluded.recurrence_rule,
-                exdates           = excluded.exdates;
+                exdates           = excluded.exdates
+            WHERE CalendarEvent.is_graph = 0;
             """;
+        // The DO UPDATE ... WHERE guard: Graph-synced rows (is_graph=1) are owned by
+        // GraphCalendarSyncService's replace-slice; the invite harvest and local authoring
+        // paths that come through here must never overwrite them (e.g. on a UID collision).
         cmd.Parameters.AddWithValue("$uid",  evt.Uid);
         cmd.Parameters.AddWithValue("$aid",  evt.AccountId.ToString());
         cmd.Parameters.AddWithValue("$sum",  evt.Summary);
@@ -838,7 +848,80 @@ public class LocalStoreService : ILocalStoreService
         cmd.Parameters.AddWithValue("$allday", evt.IsAllDay ? 1 : 0);
         cmd.Parameters.AddWithValue("$rrule", (object?)evt.RecurrenceRule ?? DBNull.Value);
         cmd.Parameters.AddWithValue("$exd",  (object?)evt.ExDates ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("$graph", evt.IsGraph ? 1 : 0);
         await cmd.ExecuteNonQueryAsync();
+        await tx.CommitAsync();
+    }
+
+    public async Task ReplaceGraphCalendarEventsAsync(Guid accountId, IReadOnlyList<CalendarEvent> events)
+    {
+        // Replace-slice semantics (v1, no delta tokens): each sync deletes the account's previous
+        // Graph-sourced rows and inserts the fresh window, all in one transaction, so events that
+        // vanished on the server disappear locally. Harvested-invite and local rows (is_graph=0)
+        // are untouched.
+        await using var conn = await OpenAsync();
+        await using var tx = await conn.BeginTransactionAsync();
+
+        await using (var del = conn.CreateCommand())
+        {
+            del.CommandText = "DELETE FROM CalendarEvent WHERE account_id = $aid AND is_graph = 1;";
+            del.Parameters.AddWithValue("$aid", accountId.ToString());
+            await del.ExecuteNonQueryAsync();
+        }
+
+        await using (var ins = conn.CreateCommand())
+        {
+            // INSERT OR REPLACE: defensive against a duplicate occurrence id within one payload,
+            // and against a (astronomically unlikely) collision with a harvested invite's UID —
+            // the Graph copy wins for the (uid, account) key.
+            ins.CommandText = """
+                INSERT OR REPLACE INTO CalendarEvent(uid, account_id, summary, description, location,
+                                          organizer, organizer_name, start_time_ticks, end_time_ticks,
+                                          sequence, method, source_message_id, source_folder, response_status,
+                                          is_all_day, recurrence_rule, exdates, is_graph)
+                VALUES($uid, $aid, $sum, $desc, $loc, $org, $orgn, $st, $et, $seq, $meth, $smid, $sf, $rs, $allday, $rrule, $exd, 1);
+                """;
+            var pUid  = ins.Parameters.Add("$uid",  Microsoft.Data.Sqlite.SqliteType.Text);
+            var pAid  = ins.Parameters.Add("$aid",  Microsoft.Data.Sqlite.SqliteType.Text);
+            var pSum  = ins.Parameters.Add("$sum",  Microsoft.Data.Sqlite.SqliteType.Text);
+            var pDesc = ins.Parameters.Add("$desc", Microsoft.Data.Sqlite.SqliteType.Text);
+            var pLoc  = ins.Parameters.Add("$loc",  Microsoft.Data.Sqlite.SqliteType.Text);
+            var pOrg  = ins.Parameters.Add("$org",  Microsoft.Data.Sqlite.SqliteType.Text);
+            var pOrgn = ins.Parameters.Add("$orgn", Microsoft.Data.Sqlite.SqliteType.Text);
+            var pSt   = ins.Parameters.Add("$st",   Microsoft.Data.Sqlite.SqliteType.Integer);
+            var pEt   = ins.Parameters.Add("$et",   Microsoft.Data.Sqlite.SqliteType.Integer);
+            var pSeq  = ins.Parameters.Add("$seq",  Microsoft.Data.Sqlite.SqliteType.Text);
+            var pMeth = ins.Parameters.Add("$meth", Microsoft.Data.Sqlite.SqliteType.Text);
+            var pSmid = ins.Parameters.Add("$smid", Microsoft.Data.Sqlite.SqliteType.Text);
+            var pSf   = ins.Parameters.Add("$sf",   Microsoft.Data.Sqlite.SqliteType.Text);
+            var pRs   = ins.Parameters.Add("$rs",   Microsoft.Data.Sqlite.SqliteType.Integer);
+            var pAll  = ins.Parameters.Add("$allday", Microsoft.Data.Sqlite.SqliteType.Integer);
+            var pRr   = ins.Parameters.Add("$rrule", Microsoft.Data.Sqlite.SqliteType.Text);
+            var pExd  = ins.Parameters.Add("$exd",  Microsoft.Data.Sqlite.SqliteType.Text);
+
+            foreach (var evt in events)
+            {
+                pUid.Value  = evt.Uid;
+                pAid.Value  = accountId.ToString();
+                pSum.Value  = evt.Summary;
+                pDesc.Value = evt.Description;
+                pLoc.Value  = evt.Location;
+                pOrg.Value  = evt.Organizer;
+                pOrgn.Value = evt.OrganizerName;
+                pSt.Value   = (object?)evt.StartTimeTicks ?? DBNull.Value;
+                pEt.Value   = (object?)evt.EndTimeTicks ?? DBNull.Value;
+                pSeq.Value  = (object?)evt.Sequence ?? DBNull.Value;
+                pMeth.Value = (object?)evt.Method ?? DBNull.Value;
+                pSmid.Value = evt.SourceMessageId;
+                pSf.Value   = evt.SourceFolder;
+                pRs.Value   = (int)evt.ResponseStatus;
+                pAll.Value  = evt.IsAllDay ? 1 : 0;
+                pRr.Value   = (object?)evt.RecurrenceRule ?? DBNull.Value;
+                pExd.Value  = (object?)evt.ExDates ?? DBNull.Value;
+                await ins.ExecuteNonQueryAsync();
+            }
+        }
+
         await tx.CommitAsync();
     }
 
@@ -850,7 +933,7 @@ public class LocalStoreService : ILocalStoreService
         cmd.CommandText = """
             SELECT uid, account_id, summary, description, location, organizer, organizer_name,
                    start_time_ticks, end_time_ticks, sequence, method, source_message_id,
-                   source_folder, response_status, is_all_day, recurrence_rule, exdates
+                   source_folder, response_status, is_all_day, recurrence_rule, exdates, is_graph
             FROM CalendarEvent
             ORDER BY start_time_ticks IS NULL, start_time_ticks ASC;
             """;
@@ -876,6 +959,7 @@ public class LocalStoreService : ILocalStoreService
                 IsAllDay         = !r.IsDBNull(14) && r.GetInt32(14) != 0,
                 RecurrenceRule   = r.IsDBNull(15) ? null : r.GetString(15),
                 ExDates          = r.IsDBNull(16) ? null : r.GetString(16),
+                IsGraph          = !r.IsDBNull(17) && r.GetInt32(17) != 0,
             });
         }
         return list;
@@ -936,10 +1020,14 @@ public class LocalStoreService : ILocalStoreService
         // deletes a message) but the CalendarEvent outlives it.  After clearing,
         // OpenSourceMessage silently no-ops for these events instead of failing with
         // "Message UID N not found".
+        // is_graph = 0 guard: Graph-synced rows never reference an invite email (their source
+        // fields are already empty) and are owned by the sync's replace-slice — the invite
+        // harvest's cleanup must not touch them.
         cmd.CommandText = """
             UPDATE CalendarEvent
             SET source_message_id = '', source_folder = ''
             WHERE source_message_id != ''
+              AND is_graph = 0
               AND NOT EXISTS (
                   SELECT 1 FROM MessageDetail md
                   WHERE md.unique_id   = CalendarEvent.source_message_id

--- a/QuickMail/Services/LocalStoreService.cs
+++ b/QuickMail/Services/LocalStoreService.cs
@@ -826,11 +826,14 @@ public class LocalStoreService : ILocalStoreService
                 is_all_day        = excluded.is_all_day,
                 recurrence_rule   = excluded.recurrence_rule,
                 exdates           = excluded.exdates
-            WHERE CalendarEvent.is_graph = 0;
+            WHERE CalendarEvent.is_graph = 0 OR excluded.is_graph = 1;
             """;
-        // The DO UPDATE ... WHERE guard: Graph-synced rows (is_graph=1) are owned by
-        // GraphCalendarSyncService's replace-slice; the invite harvest and local authoring
-        // paths that come through here must never overwrite them (e.g. on a UID collision).
+        // The DO UPDATE ... WHERE guard: server-synced rows (is_graph=1) are owned by the calendar
+        // sync service; the invite harvest and local authoring paths (which write is_graph=0) must
+        // never overwrite them on a UID collision. The sync service's own write-back stores the
+        // server's returned copy WITH is_graph=1 (excluded.is_graph=1), which must update the row —
+        // without that clause a successful server edit left the local copy stale until the next
+        // replace-slice sync.
         cmd.Parameters.AddWithValue("$uid",  evt.Uid);
         cmd.Parameters.AddWithValue("$aid",  evt.AccountId.ToString());
         cmd.Parameters.AddWithValue("$sum",  evt.Summary);

--- a/QuickMail/Services/LocalStoreService.cs
+++ b/QuickMail/Services/LocalStoreService.cs
@@ -114,6 +114,13 @@ public class LocalStoreService : ILocalStoreService
             """;
         cmd.ExecuteNonQuery();
 
+        // All-day flag for locally-authored appointments. Idempotent ALTER (RunMigration ignores
+        // "duplicate column" on databases that already have it).
+        RunMigration(conn, "ALTER TABLE CalendarEvent ADD COLUMN is_all_day INTEGER NOT NULL DEFAULT 0;");
+
+        // RRULE string for repeating appointments (null for one-offs). Idempotent ALTER.
+        RunMigration(conn, "ALTER TABLE CalendarEvent ADD COLUMN recurrence_rule TEXT DEFAULT NULL;");
+
         RunDataMigrations(conn);
     }
 
@@ -792,8 +799,9 @@ public class LocalStoreService : ILocalStoreService
         cmd.CommandText = """
             INSERT INTO CalendarEvent(uid, account_id, summary, description, location,
                                       organizer, organizer_name, start_time_ticks, end_time_ticks,
-                                      sequence, method, source_message_id, source_folder, response_status)
-            VALUES($uid, $aid, $sum, $desc, $loc, $org, $orgn, $st, $et, $seq, $meth, $smid, $sf, $rs)
+                                      sequence, method, source_message_id, source_folder, response_status,
+                                      is_all_day, recurrence_rule)
+            VALUES($uid, $aid, $sum, $desc, $loc, $org, $orgn, $st, $et, $seq, $meth, $smid, $sf, $rs, $allday, $rrule)
             ON CONFLICT(uid, account_id) DO UPDATE SET
                 summary           = excluded.summary,
                 description       = excluded.description,
@@ -805,7 +813,9 @@ public class LocalStoreService : ILocalStoreService
                 sequence          = excluded.sequence,
                 method            = excluded.method,
                 source_message_id = excluded.source_message_id,
-                source_folder     = excluded.source_folder;
+                source_folder     = excluded.source_folder,
+                is_all_day        = excluded.is_all_day,
+                recurrence_rule   = excluded.recurrence_rule;
             """;
         cmd.Parameters.AddWithValue("$uid",  evt.Uid);
         cmd.Parameters.AddWithValue("$aid",  evt.AccountId.ToString());
@@ -821,6 +831,8 @@ public class LocalStoreService : ILocalStoreService
         cmd.Parameters.AddWithValue("$smid", evt.SourceMessageId);
         cmd.Parameters.AddWithValue("$sf",   evt.SourceFolder);
         cmd.Parameters.AddWithValue("$rs",   (int)evt.ResponseStatus);
+        cmd.Parameters.AddWithValue("$allday", evt.IsAllDay ? 1 : 0);
+        cmd.Parameters.AddWithValue("$rrule", (object?)evt.RecurrenceRule ?? DBNull.Value);
         await cmd.ExecuteNonQueryAsync();
         await tx.CommitAsync();
     }
@@ -833,7 +845,7 @@ public class LocalStoreService : ILocalStoreService
         cmd.CommandText = """
             SELECT uid, account_id, summary, description, location, organizer, organizer_name,
                    start_time_ticks, end_time_ticks, sequence, method, source_message_id,
-                   source_folder, response_status
+                   source_folder, response_status, is_all_day, recurrence_rule
             FROM CalendarEvent
             ORDER BY start_time_ticks IS NULL, start_time_ticks ASC;
             """;
@@ -856,6 +868,8 @@ public class LocalStoreService : ILocalStoreService
                 SourceMessageId  = r.GetString(11),
                 SourceFolder     = r.GetString(12),
                 ResponseStatus   = (CalendarResponseStatus)r.GetInt32(13),
+                IsAllDay         = !r.IsDBNull(14) && r.GetInt32(14) != 0,
+                RecurrenceRule   = r.IsDBNull(15) ? null : r.GetString(15),
             });
         }
         return list;

--- a/QuickMail/Services/OAuthService.cs
+++ b/QuickMail/Services/OAuthService.cs
@@ -65,6 +65,17 @@ public class OAuthService : IOAuthService
         "https://graph.microsoft.com/People.Read",
     ];
 
+    // Calendar read/write scope for Graph calendar sync (full-calendar spec, M4). Explicit scope so
+    // it works for BOTH personal and work/school accounts — same reasoning as GraphContactScopes.
+    // Requested only when the user adds a Microsoft calendar. NOTE: work/school accounts sign in with
+    // `.default`, so for them Calendars.ReadWrite must ALSO be declared on the app registration (see
+    // docs/ENTRA-APP-REGISTRATION.md §3); this explicit array is what personal (MSA) accounts request.
+    // Forward-declared now so M4 has the scope wired; not yet requested by any code path.
+    public static readonly string[] GraphCalendarScopes =
+    [
+        "https://graph.microsoft.com/Calendars.ReadWrite",
+    ];
+
     // Authoritative "is this a personal Microsoft account" signal: every consumer account lives in the
     // well-known MSA "consumers" tenant. Detected from the MSAL account at sign-in and persisted on
     // AccountModel (#233), so it's correct even for personal accounts on custom/vanity domains.

--- a/QuickMail/ViewModels/CalendarViewModel.cs
+++ b/QuickMail/ViewModels/CalendarViewModel.cs
@@ -126,6 +126,26 @@ public partial class CalendarViewModel : ObservableObject
     [ObservableProperty]
     private bool _isUnavailable;
 
+    /// <summary>True while the calendar search box is shown. Bound to its visibility.</summary>
+    [ObservableProperty]
+    private bool _isSearchActive;
+
+    /// <summary>
+    /// Live filter text: matches summary, location, and notes (case-insensitive).
+    /// Empty = no filtering. Reapplies the list on every change.
+    /// </summary>
+    [ObservableProperty]
+    private string _searchText = string.Empty;
+
+    partial void OnSearchTextChanged(string value) => ApplyFilters();
+
+    /// <summary>Clears and hides search, restoring the unfiltered view.</summary>
+    public void ClearSearch()
+    {
+        SearchText = string.Empty;   // triggers ApplyFilters
+        IsSearchActive = false;
+    }
+
     public CalendarViewModel(ICalendarService calendarService, bool onlineMode, bool showDeclinedEvents,
                              bool showFieldLabels = false)
     {
@@ -410,6 +430,17 @@ public partial class CalendarViewModel : ObservableObject
             {
                 result.Add(e); // Agenda, no today filter: every one-off event
             }
+        }
+
+        // Search filter — matches summary, location, or notes, case-insensitive.
+        if (!string.IsNullOrWhiteSpace(SearchText))
+        {
+            var q = SearchText.Trim();
+            result = result.Where(e =>
+                    e.Summary.Contains(q, StringComparison.OrdinalIgnoreCase)
+                    || e.Location.Contains(q, StringComparison.OrdinalIgnoreCase)
+                    || e.Description.Contains(q, StringComparison.OrdinalIgnoreCase))
+                .ToList();
         }
 
         _filteredEvents = result.OrderBy(e => e.StartTimeTicks ?? long.MaxValue).ToList();

--- a/QuickMail/ViewModels/CalendarViewModel.cs
+++ b/QuickMail/ViewModels/CalendarViewModel.cs
@@ -22,6 +22,7 @@ public partial class CalendarViewModel : ObservableObject
     private readonly ICalendarService _calendarService;
     private readonly bool _onlineMode;
     private readonly bool _showDeclinedEvents;
+    private bool _showFieldLabels;
 
     /// <summary>
     /// Raised when a screen reader announcement is needed.
@@ -37,6 +38,31 @@ public partial class CalendarViewModel : ObservableObject
     /// </summary>
     public event Action<Guid, string, string>? OpenSourceMessageRequested;
 
+    /// <summary>
+    /// Raised when the user opens the appointment editor (New or Edit). The View opens a
+    /// modeless <c>EventEditorWindow</c> for the supplied editor VM and restores focus on close.
+    /// </summary>
+    public event Action<EventEditorViewModel>? EditorRequested;
+
+    /// <summary>
+    /// Raised to confirm deleting a locally-created appointment. The View shows a confirmation
+    /// and invokes the supplied callback only if the user confirms.
+    /// </summary>
+    public event Action<CalendarEvent, Action>? DeleteConfirmRequested;
+
+    /// <summary>
+    /// Raised after a create/edit/delete has persisted and the list rebuilt, so the View can
+    /// place focus on the correct (new/neighbouring) row. Fires after the async save completes,
+    /// which the editor window's synchronous Closed handler cannot wait for.
+    /// </summary>
+    public event Action? ListFocusRequested;
+
+    /// <summary>
+    /// Raised to save an event as a .ics file. The View shows a Save dialog for the suggested
+    /// file name and writes the supplied file body.
+    /// </summary>
+    public event Action<string, string>? ExportRequested;
+
     [ObservableProperty]
     private BatchObservableCollection<CalendarEvent> _events = [];
 
@@ -47,18 +73,82 @@ public partial class CalendarViewModel : ObservableObject
     [ObservableProperty]
     private bool _isTodayFilter;
 
+    /// <summary>Which slice of the calendar the list shows (Agenda / Day / Week).</summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(PeriodLabel))]
+    [NotifyPropertyChangedFor(nameof(IsAgendaView))]
+    [NotifyPropertyChangedFor(nameof(IsDayView))]
+    [NotifyPropertyChangedFor(nameof(IsWeekView))]
+    private CalendarViewMode _viewMode = CalendarViewMode.Agenda;
+
+    /// <summary>Check-state helpers for the View Mode menu.</summary>
+    public bool IsAgendaView => ViewMode == CalendarViewMode.Agenda;
+    public bool IsDayView => ViewMode == CalendarViewMode.Day;
+    public bool IsWeekView => ViewMode == CalendarViewMode.Week;
+
+    /// <summary>The date Day/Week views are centred on. Ignored in Agenda.</summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(PeriodLabel))]
+    private DateTime _referenceDate = DateTime.Today;
+
+    /// <summary>Human-readable label for the current view + period, shown above the list.</summary>
+    public string PeriodLabel => ViewMode switch
+    {
+        CalendarViewMode.Day  => "Day: " + ReferenceDate.ToString("dddd, MMMM d, yyyy"),
+        CalendarViewMode.Week => "Week of " + WeekStart(ReferenceDate).ToString("MMMM d")
+                                 + " to " + WeekStart(ReferenceDate).AddDays(6).ToString("MMMM d"),
+        _                     => IsTodayFilter ? "Agenda: today" : "Agenda: all appointments",
+    };
+
+    private static DateTime WeekStart(DateTime date)
+    {
+        var first = System.Globalization.CultureInfo.CurrentCulture.DateTimeFormat.FirstDayOfWeek;
+        var diff = (7 + (date.DayOfWeek - first)) % 7;
+        return date.Date.AddDays(-diff);
+    }
+
     [ObservableProperty]
     private CalendarEvent? _selectedEvent;
+
+    /// <summary>Multi-line details of the selected event for the master/detail Details pane.</summary>
+    public string SelectedEventDetail => SelectedEvent?.DetailText ?? string.Empty;
+
+    /// <summary>True when the selected event is a locally-created appointment (editable/deletable).</summary>
+    public bool CanEditSelected => SelectedEvent?.IsUserCreated == true;
+
+    partial void OnSelectedEventChanged(CalendarEvent? value)
+    {
+        OnPropertyChanged(nameof(SelectedEventDetail));
+        OnPropertyChanged(nameof(CanEditSelected));
+    }
 
     /// <summary>True when the calendar pane is unavailable (--online mode).</summary>
     [ObservableProperty]
     private bool _isUnavailable;
 
-    public CalendarViewModel(ICalendarService calendarService, bool onlineMode, bool showDeclinedEvents)
+    public CalendarViewModel(ICalendarService calendarService, bool onlineMode, bool showDeclinedEvents,
+                             bool showFieldLabels = false)
     {
         _calendarService = calendarService;
         _onlineMode = onlineMode;
         _showDeclinedEvents = showDeclinedEvents;
+        _showFieldLabels = showFieldLabels;
+    }
+
+    /// <summary>
+    /// When true, each event row's accessible name uses field labels ("Subject …, when …"); when
+    /// false, concise data only. Mirrors the address book's ContactListShowFieldLabels. Updated live
+    /// from <c>MainViewModel.ApplySettings</c> when the setting changes.
+    /// </summary>
+    public bool ShowFieldLabels
+    {
+        get => _showFieldLabels;
+        set
+        {
+            if (_showFieldLabels == value) return;
+            _showFieldLabels = value;
+            ApplyFilters();
+        }
     }
 
     /// <summary>Loads events from the service and applies filters. Call on pane open.</summary>
@@ -90,18 +180,164 @@ public partial class CalendarViewModel : ObservableObject
                  AnnouncementCategory.Result);
     }
 
-    /// <summary>Toggles the Today filter. Bound to T.</summary>
+    /// <summary>
+    /// Bound to T. In Agenda, toggles the Today filter. In Day/Week, jumps the reference date to
+    /// today (the natural "go to today" action for those views).
+    /// </summary>
     [RelayCommand]
     private void ToggleTodayFilter()
     {
-        IsTodayFilter = !IsTodayFilter;
-        ApplyFilters();
-        if (IsTodayFilter)
-            Announce($"Today. {VisibleEvents.Count} event{(VisibleEvents.Count == 1 ? "" : "s")}.",
-                     AnnouncementCategory.Result);
+        if (ViewMode == CalendarViewMode.Agenda)
+        {
+            IsTodayFilter = !IsTodayFilter;
+            OnPropertyChanged(nameof(PeriodLabel));
+            ApplyFilters();
+            Announce(IsTodayFilter
+                    ? $"Today. {VisibleEvents.Count} event{(VisibleEvents.Count == 1 ? "" : "s")}."
+                    : $"All events. {VisibleEvents.Count} event{(VisibleEvents.Count == 1 ? "" : "s")}.",
+                AnnouncementCategory.Result);
+        }
         else
-            Announce($"All events. {VisibleEvents.Count} event{(VisibleEvents.Count == 1 ? "" : "s")}.",
-                     AnnouncementCategory.Result);
+        {
+            ReferenceDate = DateTime.Today;
+            ApplyFilters();
+            AnnouncePeriod();
+        }
+    }
+
+    /// <summary>Switches to Agenda view. Bound to A.</summary>
+    [RelayCommand] private void ShowAgenda() => SwitchView(CalendarViewMode.Agenda);
+
+    /// <summary>Switches to Day view. Bound to D.</summary>
+    [RelayCommand] private void ShowDay() => SwitchView(CalendarViewMode.Day);
+
+    /// <summary>Switches to Week view. Bound to W.</summary>
+    [RelayCommand] private void ShowWeek() => SwitchView(CalendarViewMode.Week);
+
+    private void SwitchView(CalendarViewMode mode)
+    {
+        ViewMode = mode;
+        ApplyFilters();
+        SelectedEvent = Events.Count > 0 ? Events[0] : null;
+        AnnouncePeriod();
+    }
+
+    /// <summary>Moves to the previous day/week. Bound to Ctrl+Left. No-op in Agenda.</summary>
+    [RelayCommand] private void PreviousPeriod() => Page(-1);
+
+    /// <summary>Moves to the next day/week. Bound to Ctrl+Right. No-op in Agenda.</summary>
+    [RelayCommand] private void NextPeriod() => Page(+1);
+
+    private void Page(int direction)
+    {
+        switch (ViewMode)
+        {
+            case CalendarViewMode.Day:  ReferenceDate = ReferenceDate.AddDays(direction); break;
+            case CalendarViewMode.Week: ReferenceDate = ReferenceDate.AddDays(7 * direction); break;
+            default: return; // Agenda doesn't page
+        }
+        ApplyFilters();
+        SelectedEvent = Events.Count > 0 ? Events[0] : null;
+        AnnouncePeriod();
+    }
+
+    private void AnnouncePeriod()
+        => Announce($"{PeriodLabel}. {VisibleEvents.Count} event{(VisibleEvents.Count == 1 ? "" : "s")}.",
+                    AnnouncementCategory.Status);
+
+    /// <summary>Opens the appointment editor to create a new local event. Bound to N / Ctrl+Shift+N.</summary>
+    [RelayCommand]
+    private void NewEvent()
+    {
+        if (_onlineMode) { Announce("Calendar is unavailable in online mode.", AnnouncementCategory.Result); return; }
+
+        var editor = new EventEditorViewModel(DateTime.Now);
+        editor.Saved += evt => _ = SaveEditedEventAsync(evt, isNew: true);
+        EditorRequested?.Invoke(editor);
+    }
+
+    /// <summary>Opens the appointment editor to edit the selected local event. Bound to E / Enter on a local event.</summary>
+    [RelayCommand]
+    private void EditEvent(CalendarEvent? evt)
+    {
+        evt ??= SelectedEvent;
+        if (evt == null) return;
+        if (!evt.IsUserCreated)
+        {
+            Announce("Only appointments you created can be edited.", AnnouncementCategory.Result);
+            return;
+        }
+
+        // A recurring event in the list is an expanded occurrence; edit the stored master so the
+        // whole series is edited from its true start (v1: edits apply to the entire series).
+        var master = _calendarService.Events.FirstOrDefault(x => x.Uid == evt.Uid && x.AccountId == evt.AccountId) ?? evt;
+        var editor = new EventEditorViewModel(master);
+        editor.Saved += updated => _ = SaveEditedEventAsync(updated, isNew: false);
+        EditorRequested?.Invoke(editor);
+    }
+
+    /// <summary>Exports the selected event as a .ics file (any event, local or invite-sourced).</summary>
+    [RelayCommand]
+    private void ExportEvent(CalendarEvent? evt)
+    {
+        evt ??= SelectedEvent;
+        if (evt == null) return;
+
+        // For a recurring occurrence, export the series master so the RRULE and true start go out.
+        var master = _calendarService.Events.FirstOrDefault(x => x.Uid == evt.Uid && x.AccountId == evt.AccountId) ?? evt;
+        var ics = IcsModel.ExportEvent(master);
+
+        var baseName = string.IsNullOrWhiteSpace(master.Summary) ? "appointment" : master.Summary;
+        foreach (var c in System.IO.Path.GetInvalidFileNameChars())
+            baseName = baseName.Replace(c, '_');
+        ExportRequested?.Invoke(baseName + ".ics", ics);
+    }
+
+    /// <summary>Deletes the selected local event (with confirmation). Bound to Delete.</summary>
+    [RelayCommand]
+    private void DeleteEvent(CalendarEvent? evt)
+    {
+        evt ??= SelectedEvent;
+        if (evt == null) return;
+        if (!evt.IsUserCreated)
+        {
+            Announce("Only appointments you created can be deleted.", AnnouncementCategory.Result);
+            return;
+        }
+
+        var target = evt;
+        DeleteConfirmRequested?.Invoke(target, () => _ = ConfirmDeleteAsync(target));
+    }
+
+    /// <summary>Persists a created/edited event, reloads, reselects it, and announces the result.</summary>
+    private async Task SaveEditedEventAsync(CalendarEvent evt, bool isNew)
+    {
+        await _calendarService.UpsertEventAsync(evt);
+        ApplyFilters();
+        SelectedEvent = Events.FirstOrDefault(e => e.Uid == evt.Uid && e.AccountId == evt.AccountId);
+        var when = evt.StartTime?.ToString("ddd, MMM d 'at' t") ?? "no date";
+        Announce($"Appointment {(isNew ? "created" : "updated")}. {evt.Summary}, {when}.",
+                 AnnouncementCategory.Result);
+        ListFocusRequested?.Invoke();
+    }
+
+    private async Task ConfirmDeleteAsync(CalendarEvent evt)
+    {
+        var index = _filteredEvents.FindIndex(e => e.Uid == evt.Uid && e.AccountId == evt.AccountId);
+        await _calendarService.DeleteEventAsync(evt.Uid, evt.AccountId);
+        ApplyFilters();
+        // Move selection to the neighbouring event so focus is never stranded.
+        if (VisibleEvents.Count > 0)
+        {
+            var next = Math.Min(index, VisibleEvents.Count - 1);
+            SelectedEvent = next >= 0 ? Events[next] : null;
+        }
+        else
+        {
+            SelectedEvent = null;
+        }
+        Announce($"Appointment deleted. {evt.Summary}.", AnnouncementCategory.Result);
+        ListFocusRequested?.Invoke();
     }
 
     /// <summary>Opens the source invite message. Bound to Enter.</summary>
@@ -129,29 +365,58 @@ public partial class CalendarViewModel : ObservableObject
     /// <summary>Reapplies filters without re-fetching from the service. Called after external status updates.</summary>
     public void ApplyFiltersFromExternalUpdate() => ApplyFilters();
 
-    /// <summary>Applies the today and declined filters, rebuilding the visible list.</summary>
+    /// <summary>
+    /// Rebuilds the visible list for the current view: applies declined/cancelled filters, windows
+    /// one-off events to the view's date range, and expands recurring masters into per-date
+    /// occurrences within that window.
+    /// </summary>
     private void ApplyFilters()
     {
-        var all = _calendarService.Events;
+        var baseEvents = _calendarService.Events
+            .Where(e => _showDeclinedEvents || e.ResponseStatus != CalendarResponseStatus.Declined)
+            .Where(e => e.ResponseStatus != CalendarResponseStatus.Cancelled)
+            .ToList();
 
-        IEnumerable<CalendarEvent> filtered = all;
-
-        // Hide declined unless the setting is on.
-        if (!_showDeclinedEvents)
-            filtered = filtered.Where(e => e.ResponseStatus != CalendarResponseStatus.Declined);
-
-        // Always hide cancelled events — the organizer cancelled the meeting,
-        // so it should not clutter the calendar list.
-        filtered = filtered.Where(e => e.ResponseStatus != CalendarResponseStatus.Cancelled);
-
-        // Today filter: events starting today (local date).
-        if (IsTodayFilter)
+        // The date window for the current view. Null = Agenda "all" (one-offs are not date-bounded).
+        (DateTime Start, DateTime End)? window = ViewMode switch
         {
-            var today = DateTime.Today;
-            filtered = filtered.Where(e => e.StartTime.HasValue && e.StartTime.Value.Date == today);
+            CalendarViewMode.Day  => (ReferenceDate.Date, ReferenceDate.Date.AddDays(1)),
+            CalendarViewMode.Week => (WeekStart(ReferenceDate), WeekStart(ReferenceDate).AddDays(7)),
+            _ => IsTodayFilter
+                    ? (DateTime.Today, DateTime.Today.AddDays(1))
+                    : ((DateTime Start, DateTime End)?)null,
+        };
+
+        // Recurring series are unbounded, so they always expand within a bounded window: the view's
+        // window, or (Agenda-all) a look-ahead from a week ago through 12 months out.
+        var recStart = window?.Start ?? DateTime.Today.AddDays(-7);
+        var recEnd   = window?.End   ?? DateTime.Today.AddMonths(12);
+
+        var result = new List<CalendarEvent>();
+        foreach (var e in baseEvents)
+        {
+            var rule = e.IsRecurring ? RecurrenceRule.Parse(e.RecurrenceRule) : null;
+            if (rule != null && e.StartTime.HasValue)
+            {
+                foreach (var occStart in RecurrenceExpander.Expand(e.StartTime.Value, rule, recStart, recEnd))
+                    result.Add(CloneOccurrence(e, occStart));
+            }
+            else if (window is { } w)
+            {
+                if (e.StartTime.HasValue && e.StartTime.Value >= w.Start && e.StartTime.Value < w.End)
+                    result.Add(e);
+            }
+            else
+            {
+                result.Add(e); // Agenda, no today filter: every one-off event
+            }
         }
 
-        _filteredEvents = filtered.OrderBy(e => e.StartTimeTicks ?? long.MaxValue).ToList();
+        _filteredEvents = result.OrderBy(e => e.StartTimeTicks ?? long.MaxValue).ToList();
+
+        // Stamp each row's accessible name per the field-labels setting (mirrors the address book).
+        foreach (var evt in _filteredEvents)
+            evt.AccessibleName = _showFieldLabels ? evt.LabeledLine : evt.DisplayLine;
 
         using (Events.BeginBatchScope())
         {
@@ -161,18 +426,48 @@ public partial class CalendarViewModel : ObservableObject
         }
     }
 
+    /// <summary>Builds a display-only occurrence of a recurring master at the given local start.</summary>
+    private static CalendarEvent CloneOccurrence(CalendarEvent master, DateTime occStart)
+    {
+        var durTicks = master.StartTimeTicks.HasValue && master.EndTimeTicks.HasValue
+            ? master.EndTimeTicks.Value - master.StartTimeTicks.Value
+            : TimeSpan.FromMinutes(30).Ticks;
+        var startUtcTicks = occStart.ToUniversalTime().Ticks;
+        return new CalendarEvent
+        {
+            Uid             = master.Uid,          // shared Uid → edit/delete act on the series
+            AccountId       = master.AccountId,
+            Summary         = master.Summary,
+            Description     = master.Description,
+            Location        = master.Location,
+            Organizer       = master.Organizer,
+            OrganizerName   = master.OrganizerName,
+            StartTimeTicks  = startUtcTicks,
+            EndTimeTicks    = startUtcTicks + durTicks,
+            Sequence        = master.Sequence,
+            Method          = master.Method,
+            SourceMessageId = master.SourceMessageId,
+            SourceFolder    = master.SourceFolder,
+            ResponseStatus  = master.ResponseStatus,
+            IsAllDay        = master.IsAllDay,
+            RecurrenceRule  = master.RecurrenceRule,
+            OccurrenceStart = occStart,
+        };
+    }
+
     private void AnnounceOpenHint()
     {
         var count = VisibleEvents.Count;
         if (count == 0)
         {
-            Announce("Calendar. No events.", AnnouncementCategory.Status);
+            Announce("Calendar. No events. Press N to create an appointment.", AnnouncementCategory.Hint);
         }
         else
         {
             Announce($"Calendar. {count} upcoming event{(count == 1 ? "" : "s")}. " +
-                     "Use Up and Down arrows to browse. Press Enter to open the invitation. " +
-                     "Press T to filter to today. Press Escape to return to the folder list.",
+                     "Use Up and Down arrows to browse. Press Enter to open. Press N for a new appointment, " +
+                     "E to edit, Delete to remove. Press A for agenda, D for day, W for week; " +
+                     "Control plus Left or Right to move between days or weeks. Press Escape to return to the folder list.",
                      AnnouncementCategory.Hint);
         }
     }

--- a/QuickMail/ViewModels/CalendarViewModel.cs
+++ b/QuickMail/ViewModels/CalendarViewModel.cs
@@ -24,6 +24,12 @@ public partial class CalendarViewModel : ObservableObject
     private readonly bool _showDeclinedEvents;
     private bool _showFieldLabels;
 
+    // Graph create push (save-target picker). Both optional: null in tests and when the app has
+    // no Graph accounts — the editor then offers only the local calendar. The provider is a
+    // deferred lookup because the account list loads after this VM is constructed.
+    private readonly IGraphCalendarSyncService? _graphSync;
+    private readonly Func<IReadOnlyList<AccountModel>>? _graphAccountsProvider;
+
     /// <summary>
     /// Raised when a screen reader announcement is needed.
     /// The View subscribes and calls <c>AccessibilityHelper.Announce(text, category)</c>.
@@ -191,12 +197,16 @@ public partial class CalendarViewModel : ObservableObject
     }
 
     public CalendarViewModel(ICalendarService calendarService, bool onlineMode, bool showDeclinedEvents,
-                             bool showFieldLabels = false)
+                             bool showFieldLabels = false,
+                             IGraphCalendarSyncService? graphSync = null,
+                             Func<IReadOnlyList<AccountModel>>? graphAccountsProvider = null)
     {
         _calendarService = calendarService;
         _onlineMode = onlineMode;
         _showDeclinedEvents = showDeclinedEvents;
         _showFieldLabels = showFieldLabels;
+        _graphSync = graphSync;
+        _graphAccountsProvider = graphAccountsProvider;
     }
 
     /// <summary>
@@ -329,9 +339,57 @@ public partial class CalendarViewModel : ObservableObject
     {
         if (_onlineMode) { Announce("Calendar is unavailable in online mode.", AnnouncementCategory.Result); return; }
 
-        var editor = new EventEditorViewModel(DateTime.Now);
-        editor.Saved += evt => _ = SaveEditedEventAsync(evt, isNew: true);
+        // Save targets: the local calendar (always, default) plus each Graph-backed account.
+        var accountTargets = (_graphAccountsProvider?.Invoke() ?? [])
+            .Select(a => new CalendarSaveTarget(a.AccountLabel, a.Id))
+            .ToList();
+        var editor = new EventEditorViewModel(DateTime.Now, accountTargets);
+        editor.Saved += evt => _ = SaveNewEventAsync(evt);
         EditorRequested?.Invoke(editor);
+    }
+
+    /// <summary>
+    /// Persists a NEW appointment to its chosen calendar: local save, or a Graph create push for
+    /// an account target. A failed push falls back to a local save so the user's data is never
+    /// lost, announced as such.
+    /// </summary>
+    internal async Task SaveNewEventAsync(CalendarEvent evt)
+    {
+        var account = evt.AccountId == CalendarEvent.LocalAccountId
+            ? null
+            : _graphAccountsProvider?.Invoke().FirstOrDefault(a => a.Id == evt.AccountId);
+
+        if (account is null || _graphSync is null)
+        {
+            // Local target — or an account target we can no longer resolve (account removed
+            // between opening the editor and saving): keep the data rather than fail.
+            evt.AccountId = CalendarEvent.LocalAccountId;
+            await SaveEditedEventAsync(evt, isNew: true);
+            return;
+        }
+
+        try
+        {
+            var created = await _graphSync.CreateEventAsync(account, evt);
+            await _calendarService.RefreshAsync(); // reload the in-memory list from the store
+            ApplyFilters();
+            SelectedEvent = Events.FirstOrDefault(e => e.Uid == created.Uid && e.AccountId == created.AccountId);
+            var when = created.StartTime?.ToString("ddd, MMM d 'at' t") ?? "no date";
+            Announce($"Appointment created on {account.AccountLabel}. {created.Summary}, {when}.",
+                     AnnouncementCategory.Result);
+            ListFocusRequested?.Invoke();
+        }
+        catch (Exception ex)
+        {
+            LogService.Log($"Graph calendar create failed for {account.AccountLabel}", ex);
+            evt.AccountId = CalendarEvent.LocalAccountId;
+            await _calendarService.UpsertEventAsync(evt);
+            ApplyFilters();
+            SelectedEvent = Events.FirstOrDefault(e => e.Uid == evt.Uid && e.AccountId == evt.AccountId);
+            Announce($"Could not save to {account.AccountLabel}. Saved to My Appointments instead.",
+                     AnnouncementCategory.Result);
+            ListFocusRequested?.Invoke();
+        }
     }
 
     /// <summary>Opens the appointment editor to edit the selected local event. Bound to E / Enter on a local event.</summary>

--- a/QuickMail/ViewModels/CalendarViewModel.cs
+++ b/QuickMail/ViewModels/CalendarViewModel.cs
@@ -388,7 +388,7 @@ public partial class CalendarViewModel : ObservableObject
             await _calendarService.UpsertEventAsync(evt);
             ApplyFilters();
             SelectedEvent = Events.FirstOrDefault(e => e.Uid == evt.Uid && e.AccountId == evt.AccountId);
-            Announce($"Could not save to {account.AccountLabel}. Saved to My Appointments instead.",
+            Announce($"Could not save to {account.AccountLabel}. Saved to Local Calendar instead.",
                      AnnouncementCategory.Result);
             ListFocusRequested?.Invoke();
         }

--- a/QuickMail/ViewModels/CalendarViewModel.cs
+++ b/QuickMail/ViewModels/CalendarViewModel.cs
@@ -24,9 +24,10 @@ public partial class CalendarViewModel : ObservableObject
     private readonly bool _showDeclinedEvents;
     private bool _showFieldLabels;
 
-    // Graph create push (save-target picker). Both optional: null in tests and when the app has
-    // no Graph accounts — the editor then offers only the local calendar. The provider is a
-    // deferred lookup because the account list loads after this VM is constructed.
+    // Server calendar push (save-target picker + edit/delete write-back). Both optional: null in
+    // tests and when the app has no server-backed (Microsoft or Google) accounts — the editor then
+    // offers only the local calendar. The provider is a deferred lookup because the account list
+    // loads after this VM is constructed.
     private readonly IGraphCalendarSyncService? _graphSync;
     private readonly Func<IReadOnlyList<AccountModel>>? _graphAccountsProvider;
 
@@ -339,7 +340,8 @@ public partial class CalendarViewModel : ObservableObject
     {
         if (_onlineMode) { Announce("Calendar is unavailable in online mode.", AnnouncementCategory.Result); return; }
 
-        // Save targets: the local calendar (always, default) plus each Graph-backed account.
+        // Save targets: the local calendar (always, default) plus each server-backed account
+        // (Microsoft or Google — whatever the provider supplies).
         var accountTargets = (_graphAccountsProvider?.Invoke() ?? [])
             .Select(a => new CalendarSaveTarget(a.AccountLabel, a.Id))
             .ToList();
@@ -349,9 +351,9 @@ public partial class CalendarViewModel : ObservableObject
     }
 
     /// <summary>
-    /// Persists a NEW appointment to its chosen calendar: local save, or a Graph create push for
-    /// an account target. A failed push falls back to a local save so the user's data is never
-    /// lost, announced as such.
+    /// Persists a NEW appointment to its chosen calendar: local save, or a server create push
+    /// (Microsoft or Google) for an account target. A failed push falls back to a local save so
+    /// the user's data is never lost, announced as such.
     /// </summary>
     internal async Task SaveNewEventAsync(CalendarEvent evt)
     {
@@ -400,9 +402,10 @@ public partial class CalendarViewModel : ObservableObject
         if (evt == null) return;
         if (!evt.IsUserCreated)
         {
-            // Microsoft-synced single events are editable (write-back); everything else server-side
-            // (Google rows, recurring server occurrences, harvested invites) stays read-only.
-            var pushAccount = GraphAccountFor(evt);
+            // Server-synced single events on a Microsoft or Google account are editable
+            // (write-back); everything else server-side (CalDAV rows, recurring server
+            // occurrences, harvested invites) stays read-only.
+            var pushAccount = ServerAccountFor(evt);
             if (pushAccount != null)
             {
                 if (evt.IsRecurring)
@@ -460,7 +463,7 @@ public partial class CalendarViewModel : ObservableObject
         if (evt == null) return;
         if (!evt.IsUserCreated)
         {
-            var pushAccount = GraphAccountFor(evt);
+            var pushAccount = ServerAccountFor(evt);
             if (pushAccount != null && !evt.IsRecurring)
             {
                 var serverTarget = evt;
@@ -488,15 +491,15 @@ public partial class CalendarViewModel : ObservableObject
     }
 
     /// <summary>
-    /// The Graph-backed account a server-synced row can write back to, or null when the row is
-    /// not writable from here (local rows, Google rows, no sync service wired).
+    /// The server-backed account (Microsoft or Google) a synced row can write back to, or null
+    /// when the row is not writable from here (local rows, CalDAV rows, no sync service wired).
     /// </summary>
-    private AccountModel? GraphAccountFor(CalendarEvent evt)
+    private AccountModel? ServerAccountFor(CalendarEvent evt)
         => evt.IsGraph && _graphSync != null
             ? _graphAccountsProvider?.Invoke().FirstOrDefault(a => a.Id == evt.AccountId)
             : null;
 
-    /// <summary>Pushes an edit of a Microsoft-synced event to the server; local state only changes on success.</summary>
+    /// <summary>Pushes an edit of a server-synced event to its calendar; local state only changes on success.</summary>
     private async Task ServerUpdateAsync(AccountModel account, CalendarEvent original, CalendarEvent edited)
     {
         try
@@ -519,7 +522,7 @@ public partial class CalendarViewModel : ObservableObject
         ListFocusRequested?.Invoke();
     }
 
-    /// <summary>Deletes a Microsoft-synced event on the server; local state only changes on success.</summary>
+    /// <summary>Deletes a server-synced event on its calendar; local state only changes on success.</summary>
     private async Task ServerDeleteAsync(AccountModel account, CalendarEvent evt)
     {
         try

--- a/QuickMail/ViewModels/CalendarViewModel.cs
+++ b/QuickMail/ViewModels/CalendarViewModel.cs
@@ -85,12 +85,18 @@ public partial class CalendarViewModel : ObservableObject
     [NotifyPropertyChangedFor(nameof(IsAgendaView))]
     [NotifyPropertyChangedFor(nameof(IsDayView))]
     [NotifyPropertyChangedFor(nameof(IsWeekView))]
+    [NotifyPropertyChangedFor(nameof(IsMonthView))]
+    [NotifyPropertyChangedFor(nameof(IsListView))]
     private CalendarViewMode _viewMode = CalendarViewMode.Agenda;
 
     /// <summary>Check-state helpers for the View Mode menu.</summary>
     public bool IsAgendaView => ViewMode == CalendarViewMode.Agenda;
     public bool IsDayView => ViewMode == CalendarViewMode.Day;
     public bool IsWeekView => ViewMode == CalendarViewMode.Week;
+    public bool IsMonthView => ViewMode == CalendarViewMode.Month;
+
+    /// <summary>True for the list-based views (Agenda/Day/Week); false when the Month grid shows.</summary>
+    public bool IsListView => ViewMode != CalendarViewMode.Month;
 
     /// <summary>The date Day/Week views are centred on. Ignored in Agenda.</summary>
     [ObservableProperty]
@@ -100,11 +106,21 @@ public partial class CalendarViewModel : ObservableObject
     /// <summary>Human-readable label for the current view + period, shown above the list.</summary>
     public string PeriodLabel => ViewMode switch
     {
-        CalendarViewMode.Day  => "Day: " + ReferenceDate.ToString("dddd, MMMM d, yyyy"),
-        CalendarViewMode.Week => "Week of " + WeekStart(ReferenceDate).ToString("MMMM d")
-                                 + " to " + WeekStart(ReferenceDate).AddDays(6).ToString("MMMM d"),
-        _                     => IsTodayFilter ? "Agenda: today" : "Agenda: all appointments",
+        CalendarViewMode.Day   => "Day: " + ReferenceDate.ToString("dddd, MMMM d, yyyy"),
+        CalendarViewMode.Week  => "Week of " + WeekStart(ReferenceDate).ToString("MMMM d")
+                                  + " to " + WeekStart(ReferenceDate).AddDays(6).ToString("MMMM d"),
+        CalendarViewMode.Month => ReferenceDate.ToString("MMMM yyyy"),
+        _                      => IsTodayFilter ? "Agenda: today" : "Agenda: all appointments",
     };
+
+    /// <summary>Day cells for the Month grid (leading/trailing days pad to full weeks).</summary>
+    public BatchObservableCollection<MonthCell> MonthCells { get; } = [];
+
+    [ObservableProperty]
+    private MonthCell? _selectedMonthCell;
+
+    partial void OnSelectedMonthCellChanged(MonthCell? value)
+        => OnPropertyChanged(nameof(SelectedEventDetail));
 
     private static DateTime WeekStart(DateTime date)
     {
@@ -116,8 +132,13 @@ public partial class CalendarViewModel : ObservableObject
     [ObservableProperty]
     private CalendarEvent? _selectedEvent;
 
-    /// <summary>Multi-line details of the selected event for the master/detail Details pane.</summary>
-    public string SelectedEventDetail => SelectedEvent?.DetailText ?? string.Empty;
+    /// <summary>
+    /// Multi-line details for the Details pane: the selected event's fields, or in Month view
+    /// the selected day's event list.
+    /// </summary>
+    public string SelectedEventDetail => ViewMode == CalendarViewMode.Month
+        ? SelectedMonthCell?.DayDetail ?? string.Empty
+        : SelectedEvent?.DetailText ?? string.Empty;
 
     /// <summary>True when the selected event is a locally-created appointment (editable/deletable).</summary>
     public bool CanEditSelected => SelectedEvent?.IsUserCreated == true;
@@ -240,6 +261,19 @@ public partial class CalendarViewModel : ObservableObject
     /// <summary>Switches to Week view. Bound to W.</summary>
     [RelayCommand] private void ShowWeek() => SwitchView(CalendarViewMode.Week);
 
+    /// <summary>Switches to Month view. Bound to M.</summary>
+    [RelayCommand] private void ShowMonth() => SwitchView(CalendarViewMode.Month);
+
+    /// <summary>Enter on a month cell: drill into that day's Day view.</summary>
+    [RelayCommand]
+    private void DrillIntoDay(MonthCell? cell)
+    {
+        cell ??= SelectedMonthCell;
+        if (cell == null) return;
+        ReferenceDate = cell.Date;
+        SwitchView(CalendarViewMode.Day);
+    }
+
     private void SwitchView(CalendarViewMode mode)
     {
         ViewMode = mode;
@@ -258,8 +292,9 @@ public partial class CalendarViewModel : ObservableObject
     {
         switch (ViewMode)
         {
-            case CalendarViewMode.Day:  ReferenceDate = ReferenceDate.AddDays(direction); break;
-            case CalendarViewMode.Week: ReferenceDate = ReferenceDate.AddDays(7 * direction); break;
+            case CalendarViewMode.Day:   ReferenceDate = ReferenceDate.AddDays(direction); break;
+            case CalendarViewMode.Week:  ReferenceDate = ReferenceDate.AddDays(7 * direction); break;
+            case CalendarViewMode.Month: ReferenceDate = ReferenceDate.AddMonths(direction); break;
             default: return; // Agenda doesn't page
         }
         ApplyFilters();
@@ -463,10 +498,12 @@ public partial class CalendarViewModel : ObservableObject
             .ToList();
 
         // The date window for the current view. Null = Agenda "all" (one-offs are not date-bounded).
+        var monthGridStart = WeekStart(new DateTime(ReferenceDate.Year, ReferenceDate.Month, 1));
         (DateTime Start, DateTime End)? window = ViewMode switch
         {
-            CalendarViewMode.Day  => (ReferenceDate.Date, ReferenceDate.Date.AddDays(1)),
-            CalendarViewMode.Week => (WeekStart(ReferenceDate), WeekStart(ReferenceDate).AddDays(7)),
+            CalendarViewMode.Day   => (ReferenceDate.Date, ReferenceDate.Date.AddDays(1)),
+            CalendarViewMode.Week  => (WeekStart(ReferenceDate), WeekStart(ReferenceDate).AddDays(7)),
+            CalendarViewMode.Month => (monthGridStart, monthGridStart.AddDays(42)),
             _ => IsTodayFilter
                     ? (DateTime.Today, DateTime.Today.AddDays(1))
                     : ((DateTime Start, DateTime End)?)null,
@@ -522,6 +559,31 @@ public partial class CalendarViewModel : ObservableObject
             foreach (var evt in _filteredEvents)
                 Events.Add(evt);
         }
+
+        if (ViewMode == CalendarViewMode.Month)
+            RebuildMonthCells(monthGridStart);
+    }
+
+    /// <summary>Builds the 42 day cells (6 full weeks) for the Month grid.</summary>
+    private void RebuildMonthCells(DateTime gridStart)
+    {
+        var byDate = _filteredEvents
+            .Where(e => e.StartTime.HasValue)
+            .GroupBy(e => e.StartTime!.Value.Date)
+            .ToDictionary(g => g.Key, g => g.ToList());
+
+        using (MonthCells.BeginBatchScope())
+        {
+            MonthCells.Clear();
+            for (var i = 0; i < 42; i++)
+            {
+                var date = gridStart.AddDays(i);
+                byDate.TryGetValue(date, out var dayEvents);
+                MonthCells.Add(new MonthCell(date, ReferenceDate.Month, dayEvents ?? []));
+            }
+        }
+        SelectedMonthCell = MonthCells.FirstOrDefault(c => c.Date == ReferenceDate.Date)
+                            ?? MonthCells.FirstOrDefault(c => c.IsInMonth);
     }
 
     /// <summary>Builds a display-only occurrence of a recurring master at the given local start.</summary>

--- a/QuickMail/ViewModels/CalendarViewModel.cs
+++ b/QuickMail/ViewModels/CalendarViewModel.cs
@@ -465,6 +465,13 @@ public partial class CalendarViewModel : ObservableObject
     private void OpenSourceMessage(CalendarEvent? evt)
     {
         if (evt == null) return;
+        if (evt.IsGraph)
+        {
+            // Graph-synced rows never had a source invite email; the stale-cache message would
+            // be wrong and confusing for them.
+            Announce("This event syncs from your Microsoft calendar.", AnnouncementCategory.Result);
+            return;
+        }
         if (string.IsNullOrEmpty(evt.SourceMessageId))
         {
             Announce("The original invitation email is no longer in your local message cache.",

--- a/QuickMail/ViewModels/CalendarViewModel.cs
+++ b/QuickMail/ViewModels/CalendarViewModel.cs
@@ -400,7 +400,26 @@ public partial class CalendarViewModel : ObservableObject
         if (evt == null) return;
         if (!evt.IsUserCreated)
         {
-            Announce("Only appointments you created can be edited.", AnnouncementCategory.Result);
+            // Microsoft-synced single events are editable (write-back); everything else server-side
+            // (Google rows, recurring server occurrences, harvested invites) stays read-only.
+            var pushAccount = GraphAccountFor(evt);
+            if (pushAccount != null)
+            {
+                if (evt.IsRecurring)
+                {
+                    Announce("Repeating events from your online calendar can't be edited yet.",
+                             AnnouncementCategory.Result);
+                    return;
+                }
+                var serverEditor = new EventEditorViewModel(evt);
+                serverEditor.Saved += updated => _ = ServerUpdateAsync(pushAccount, evt, updated);
+                EditorRequested?.Invoke(serverEditor);
+                return;
+            }
+            Announce(evt.IsGraph
+                    ? "This event syncs from your online calendar and can't be edited here."
+                    : "Only appointments you created can be edited.",
+                AnnouncementCategory.Result);
             return;
         }
 
@@ -441,7 +460,17 @@ public partial class CalendarViewModel : ObservableObject
         if (evt == null) return;
         if (!evt.IsUserCreated)
         {
-            Announce("Only appointments you created can be deleted.", AnnouncementCategory.Result);
+            var pushAccount = GraphAccountFor(evt);
+            if (pushAccount != null && !evt.IsRecurring)
+            {
+                var serverTarget = evt;
+                DeleteConfirmRequested?.Invoke(serverTarget, () => _ = ServerDeleteAsync(pushAccount, serverTarget));
+                return;
+            }
+            Announce(evt.IsGraph
+                    ? "This event syncs from your online calendar and can't be deleted here."
+                    : "Only appointments you created can be deleted.",
+                AnnouncementCategory.Result);
             return;
         }
 
@@ -456,6 +485,60 @@ public partial class CalendarViewModel : ObservableObject
         {
             DeleteConfirmRequested?.Invoke(target, () => _ = ConfirmDeleteAsync(target));
         }
+    }
+
+    /// <summary>
+    /// The Graph-backed account a server-synced row can write back to, or null when the row is
+    /// not writable from here (local rows, Google rows, no sync service wired).
+    /// </summary>
+    private AccountModel? GraphAccountFor(CalendarEvent evt)
+        => evt.IsGraph && _graphSync != null
+            ? _graphAccountsProvider?.Invoke().FirstOrDefault(a => a.Id == evt.AccountId)
+            : null;
+
+    /// <summary>Pushes an edit of a Microsoft-synced event to the server; local state only changes on success.</summary>
+    private async Task ServerUpdateAsync(AccountModel account, CalendarEvent original, CalendarEvent edited)
+    {
+        try
+        {
+            // Keep the server identity: same Uid and account, is_graph flag preserved by the
+            // sync service when it stores the server's returned copy.
+            edited.Uid = original.Uid;
+            edited.AccountId = account.Id;
+            var updated = await _graphSync!.UpdateEventAsync(account, edited);
+            await _calendarService.RefreshAsync();
+            ApplyFilters();
+            SelectedEvent = Events.FirstOrDefault(e => e.Uid == updated.Uid && e.AccountId == account.Id);
+            Announce($"Updated on your online calendar. {updated.Summary}.", AnnouncementCategory.Result);
+        }
+        catch (Exception ex)
+        {
+            LogService.Log("Calendar server update", ex);
+            Announce("Could not update your online calendar.", AnnouncementCategory.Result);
+        }
+        ListFocusRequested?.Invoke();
+    }
+
+    /// <summary>Deletes a Microsoft-synced event on the server; local state only changes on success.</summary>
+    private async Task ServerDeleteAsync(AccountModel account, CalendarEvent evt)
+    {
+        try
+        {
+            var index = _filteredEvents.FindIndex(e => ReferenceEquals(e, evt));
+            await _graphSync!.DeleteEventAsync(account, evt);
+            await _calendarService.RefreshAsync();
+            ApplyFilters();
+            SelectedEvent = VisibleEvents.Count > 0
+                ? Events[Math.Min(Math.Max(index, 0), VisibleEvents.Count - 1)]
+                : null;
+            Announce($"Deleted from your online calendar. {evt.Summary}.", AnnouncementCategory.Result);
+        }
+        catch (Exception ex)
+        {
+            LogService.Log("Calendar server delete", ex);
+            Announce("Could not update your online calendar.", AnnouncementCategory.Result);
+        }
+        ListFocusRequested?.Invoke();
     }
 
     /// <summary>

--- a/QuickMail/ViewModels/CalendarViewModel.cs
+++ b/QuickMail/ViewModels/CalendarViewModel.cs
@@ -542,9 +542,9 @@ public partial class CalendarViewModel : ObservableObject
         if (evt == null) return;
         if (evt.IsGraph)
         {
-            // Graph-synced rows never had a source invite email; the stale-cache message would
-            // be wrong and confusing for them.
-            Announce("This event syncs from your Microsoft calendar.", AnnouncementCategory.Result);
+            // Server-synced rows (Microsoft or Google) never had a source invite email; the
+            // stale-cache message would be wrong and confusing for them.
+            Announce("This event syncs from your online calendar.", AnnouncementCategory.Result);
             return;
         }
         if (string.IsNullOrEmpty(evt.SourceMessageId))

--- a/QuickMail/ViewModels/CalendarViewModel.cs
+++ b/QuickMail/ViewModels/CalendarViewModel.cs
@@ -51,6 +51,12 @@ public partial class CalendarViewModel : ObservableObject
     public event Action<CalendarEvent, Action>? DeleteConfirmRequested;
 
     /// <summary>
+    /// Raised to confirm deleting from a repeating series: the View offers "just this occurrence"
+    /// (first callback), "the whole series" (second), or cancel.
+    /// </summary>
+    public event Action<CalendarEvent, Action, Action>? RecurringDeleteConfirmRequested;
+
+    /// <summary>
     /// Raised after a create/edit/delete has persisted and the list rebuilt, so the View can
     /// place focus on the correct (new/neighbouring) row. Fires after the async save completes,
     /// which the editor window's synchronous Closed handler cannot wait for.
@@ -288,11 +294,15 @@ public partial class CalendarViewModel : ObservableObject
             return;
         }
 
-        // A recurring event in the list is an expanded occurrence; edit the stored master so the
-        // whole series is edited from its true start (v1: edits apply to the entire series).
-        var master = _calendarService.Events.FirstOrDefault(x => x.Uid == evt.Uid && x.AccountId == evt.AccountId) ?? evt;
-        var editor = new EventEditorViewModel(master);
-        editor.Saved += updated => _ = SaveEditedEventAsync(updated, isNew: false);
+        // A recurring occurrence opens on its own date/time with the This event / All events
+        // scope choice; anything else opens the stored master directly.
+        var source = evt.OccurrenceStart.HasValue
+            ? evt
+            : _calendarService.Events.FirstOrDefault(x => x.Uid == evt.Uid && x.AccountId == evt.AccountId) ?? evt;
+        var editor = new EventEditorViewModel(source);
+        editor.Saved += updated => _ = editor.IsDetachSave && editor.OccurrenceStart.HasValue
+            ? DetachOccurrenceAsync(source, editor.OccurrenceStart.Value, updated)
+            : SaveEditedEventAsync(updated, isNew: false);
         EditorRequested?.Invoke(editor);
     }
 
@@ -326,7 +336,62 @@ public partial class CalendarViewModel : ObservableObject
         }
 
         var target = evt;
-        DeleteConfirmRequested?.Invoke(target, () => _ = ConfirmDeleteAsync(target));
+        if (target.IsRecurring && target.OccurrenceStart.HasValue)
+        {
+            RecurringDeleteConfirmRequested?.Invoke(target,
+                () => _ = DeleteOccurrenceAsync(target),
+                () => _ = ConfirmDeleteAsync(target));
+        }
+        else
+        {
+            DeleteConfirmRequested?.Invoke(target, () => _ = ConfirmDeleteAsync(target));
+        }
+    }
+
+    /// <summary>
+    /// "This event only" save on a recurring occurrence: excludes the occurrence from the series
+    /// (EXDATE on the master) and inserts the edited copy as an independent appointment.
+    /// </summary>
+    private async Task DetachOccurrenceAsync(CalendarEvent occurrence, DateTime occurrenceStart, CalendarEvent standalone)
+    {
+        var master = _calendarService.Events.FirstOrDefault(
+            x => x.Uid == occurrence.Uid && x.AccountId == occurrence.AccountId);
+        if (master == null) return;
+
+        master.AddExDate(occurrenceStart);
+        await _calendarService.UpsertEventAsync(master);
+        await _calendarService.UpsertEventAsync(standalone);
+        ApplyFilters();
+        SelectedEvent = Events.FirstOrDefault(e => e.Uid == standalone.Uid);
+        Announce($"This occurrence updated. {standalone.Summary}, " +
+                 $"{standalone.StartTime?.ToString("ddd, MMM d 'at' t") ?? "no date"}. " +
+                 "The rest of the series is unchanged.", AnnouncementCategory.Result);
+        ListFocusRequested?.Invoke();
+    }
+
+    /// <summary>Deletes a single occurrence of a repeating series (EXDATE on the master).</summary>
+    private async Task DeleteOccurrenceAsync(CalendarEvent occurrence)
+    {
+        var master = _calendarService.Events.FirstOrDefault(
+            x => x.Uid == occurrence.Uid && x.AccountId == occurrence.AccountId);
+        if (master == null || !occurrence.OccurrenceStart.HasValue) return;
+
+        var index = _filteredEvents.FindIndex(e => ReferenceEquals(e, occurrence));
+        master.AddExDate(occurrence.OccurrenceStart.Value);
+        await _calendarService.UpsertEventAsync(master);
+        ApplyFilters();
+        if (VisibleEvents.Count > 0)
+        {
+            var next = Math.Min(Math.Max(index, 0), VisibleEvents.Count - 1);
+            SelectedEvent = Events[next];
+        }
+        else
+        {
+            SelectedEvent = null;
+        }
+        Announce($"Occurrence deleted. {occurrence.Summary}. The rest of the series is unchanged.",
+                 AnnouncementCategory.Result);
+        ListFocusRequested?.Invoke();
     }
 
     /// <summary>Persists a created/edited event, reloads, reselects it, and announces the result.</summary>
@@ -418,8 +483,10 @@ public partial class CalendarViewModel : ObservableObject
             var rule = e.IsRecurring ? RecurrenceRule.Parse(e.RecurrenceRule) : null;
             if (rule != null && e.StartTime.HasValue)
             {
+                var excluded = new HashSet<DateTime>(e.GetExDates());
                 foreach (var occStart in RecurrenceExpander.Expand(e.StartTime.Value, rule, recStart, recEnd))
-                    result.Add(CloneOccurrence(e, occStart));
+                    if (!excluded.Contains(occStart))
+                        result.Add(CloneOccurrence(e, occStart));
             }
             else if (window is { } w)
             {
@@ -482,6 +549,7 @@ public partial class CalendarViewModel : ObservableObject
             ResponseStatus  = master.ResponseStatus,
             IsAllDay        = master.IsAllDay,
             RecurrenceRule  = master.RecurrenceRule,
+            ExDates         = master.ExDates,
             OccurrenceStart = occStart,
         };
     }

--- a/QuickMail/ViewModels/CalendarViewModel.cs
+++ b/QuickMail/ViewModels/CalendarViewModel.cs
@@ -166,6 +166,23 @@ public partial class CalendarViewModel : ObservableObject
 
     partial void OnSearchTextChanged(string value) => ApplyFilters();
 
+    /// <summary>
+    /// Which calendar source the views show: null = all sources merged; Guid.Empty = locally
+    /// authored appointments only; otherwise that account's events (synced or invite-harvested).
+    /// Set by MainViewModel from the selected tree node before LoadAsync.
+    /// </summary>
+    private Guid? _accountFilter;
+    public Guid? AccountFilter
+    {
+        get => _accountFilter;
+        set
+        {
+            if (_accountFilter == value) return;
+            _accountFilter = value;
+            ApplyFilters();
+        }
+    }
+
     /// <summary>Clears and hides search, restoring the unfiltered view.</summary>
     public void ClearSearch()
     {
@@ -500,6 +517,7 @@ public partial class CalendarViewModel : ObservableObject
     private void ApplyFilters()
     {
         var baseEvents = _calendarService.Events
+            .Where(e => _accountFilter is not Guid f || e.AccountId == f)
             .Where(e => _showDeclinedEvents || e.ResponseStatus != CalendarResponseStatus.Declined)
             .Where(e => e.ResponseStatus != CalendarResponseStatus.Cancelled)
             .ToList();

--- a/QuickMail/ViewModels/CalendarViewModel.cs
+++ b/QuickMail/ViewModels/CalendarViewModel.cs
@@ -822,8 +822,8 @@ public partial class CalendarViewModel : ObservableObject
         var count = VisibleEvents.Count;
         if (count == 0)
         {
-            Announce("Calendar. No events.", AnnouncementCategory.Status);
-            Announce("Press N to create an appointment.", AnnouncementCategory.Hint);
+            Announce("Calendar. No events. Press N to create an appointment.",
+                     AnnouncementCategory.Hint);
         }
         else
         {

--- a/QuickMail/ViewModels/CalendarViewModel.cs
+++ b/QuickMail/ViewModels/CalendarViewModel.cs
@@ -434,7 +434,9 @@ public partial class CalendarViewModel : ObservableObject
         var editor = new EventEditorViewModel(source);
         editor.Saved += updated => _ = editor.IsDetachSave && editor.OccurrenceStart.HasValue
             ? DetachOccurrenceAsync(source, editor.OccurrenceStart.Value, updated)
-            : SaveEditedEventAsync(updated, isNew: false);
+            : source.OccurrenceStart.HasValue
+                ? SaveWholeSeriesAsync(source, updated)
+                : SaveEditedEventAsync(updated, isNew: false);
         EditorRequested?.Invoke(editor);
     }
 
@@ -527,7 +529,7 @@ public partial class CalendarViewModel : ObservableObject
     {
         try
         {
-            var index = _filteredEvents.FindIndex(e => ReferenceEquals(e, evt));
+            var index = _filteredEvents.FindIndex(e => e.Uid == evt.Uid && e.StartTimeTicks == evt.StartTimeTicks);
             await _graphSync!.DeleteEventAsync(account, evt);
             await _calendarService.RefreshAsync();
             ApplyFilters();
@@ -542,6 +544,31 @@ public partial class CalendarViewModel : ObservableObject
             Announce("Could not update your online calendar.", AnnouncementCategory.Result);
         }
         ListFocusRequested?.Invoke();
+    }
+
+    /// <summary>
+    /// "All events" save on a recurring occurrence: applies the edited fields to the series
+    /// master while preserving what the editor doesn't show — the excluded occurrences and the
+    /// series' original start DATE (the edited time-of-day and duration are applied to it).
+    /// Without this, saving a series edit resurrected deleted occurrences and re-anchored the
+    /// series on the edited occurrence's date.
+    /// </summary>
+    private async Task SaveWholeSeriesAsync(CalendarEvent occurrence, CalendarEvent updated)
+    {
+        var master = _calendarService.Events.FirstOrDefault(
+            x => x.Uid == occurrence.Uid && x.AccountId == occurrence.AccountId);
+        if (master != null)
+        {
+            updated.ExDates = master.ExDates;
+            if (master.StartTime.HasValue && updated.StartTime.HasValue && updated.EndTime.HasValue)
+            {
+                var duration = updated.EndTime.Value - updated.StartTime.Value;
+                var newStart = master.StartTime.Value.Date + updated.StartTime.Value.TimeOfDay;
+                updated.StartTimeTicks = newStart.ToUniversalTime().Ticks;
+                updated.EndTimeTicks   = (newStart + duration).ToUniversalTime().Ticks;
+            }
+        }
+        await SaveEditedEventAsync(updated, isNew: false);
     }
 
     /// <summary>
@@ -560,7 +587,7 @@ public partial class CalendarViewModel : ObservableObject
         ApplyFilters();
         SelectedEvent = Events.FirstOrDefault(e => e.Uid == standalone.Uid);
         Announce($"This occurrence updated. {standalone.Summary}, " +
-                 $"{standalone.StartTime?.ToString("ddd, MMM d 'at' t") ?? "no date"}. " +
+                 $"{standalone.WhenText}. " +
                  "The rest of the series is unchanged.", AnnouncementCategory.Result);
         ListFocusRequested?.Invoke();
     }
@@ -596,7 +623,7 @@ public partial class CalendarViewModel : ObservableObject
         await _calendarService.UpsertEventAsync(evt);
         ApplyFilters();
         SelectedEvent = Events.FirstOrDefault(e => e.Uid == evt.Uid && e.AccountId == evt.AccountId);
-        var when = evt.StartTime?.ToString("ddd, MMM d 'at' t") ?? "no date";
+        var when = evt.WhenText;
         Announce($"Appointment {(isNew ? "created" : "updated")}. {evt.Summary}, {when}.",
                  AnnouncementCategory.Result);
         ListFocusRequested?.Invoke();
@@ -696,7 +723,11 @@ public partial class CalendarViewModel : ObservableObject
             }
             else if (window is { } w)
             {
-                if (e.StartTime.HasValue && e.StartTime.Value >= w.Start && e.StartTime.Value < w.End)
+                // Overlap, not start-in-window: a multi-day or in-progress event must appear on
+                // every day it spans, not just its first.
+                if (e.StartTime.HasValue
+                    && e.StartTime.Value < w.End
+                    && (e.EndTime ?? e.StartTime.Value) >= w.Start)
                     result.Add(e);
             }
             else
@@ -779,6 +810,7 @@ public partial class CalendarViewModel : ObservableObject
             SourceFolder    = master.SourceFolder,
             ResponseStatus  = master.ResponseStatus,
             IsAllDay        = master.IsAllDay,
+            IsGraph         = master.IsGraph,
             RecurrenceRule  = master.RecurrenceRule,
             ExDates         = master.ExDates,
             OccurrenceStart = occStart,
@@ -790,7 +822,8 @@ public partial class CalendarViewModel : ObservableObject
         var count = VisibleEvents.Count;
         if (count == 0)
         {
-            Announce("Calendar. No events. Press N to create an appointment.", AnnouncementCategory.Hint);
+            Announce("Calendar. No events.", AnnouncementCategory.Status);
+            Announce("Press N to create an appointment.", AnnouncementCategory.Hint);
         }
         else
         {

--- a/QuickMail/ViewModels/EventEditorViewModel.cs
+++ b/QuickMail/ViewModels/EventEditorViewModel.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using QuickMail.Models;
@@ -41,10 +42,23 @@ public partial class EventEditorViewModel : ObservableObject
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(HasRepeat))]
     [NotifyPropertyChangedFor(nameof(RepeatUnitLabel))]
+    [NotifyPropertyChangedFor(nameof(IsWeekly))]
     private int _repeatIndex;
 
     [ObservableProperty] private int _repeatInterval = 1;
     [ObservableProperty] private DateTime? _repeatUntil;
+
+    // Weekly only: which days the appointment repeats on. All unchecked = the start date's weekday.
+    [ObservableProperty] private bool _repeatOnSunday;
+    [ObservableProperty] private bool _repeatOnMonday;
+    [ObservableProperty] private bool _repeatOnTuesday;
+    [ObservableProperty] private bool _repeatOnWednesday;
+    [ObservableProperty] private bool _repeatOnThursday;
+    [ObservableProperty] private bool _repeatOnFriday;
+    [ObservableProperty] private bool _repeatOnSaturday;
+
+    /// <summary>True when Weekly is selected — the View shows the day-of-week checkboxes.</summary>
+    public bool IsWeekly => RepeatIndex == 2;
 
     /// <summary>False when the appointment is all-day — the View disables the time fields.</summary>
     public bool HasTimes => !IsAllDay;
@@ -109,6 +123,8 @@ public partial class EventEditorViewModel : ObservableObject
             };
             RepeatInterval = rule.Interval;
             RepeatUntil = rule.Until;
+            foreach (var day in rule.ByDay)
+                SetRepeatDay(day, true);
         }
     }
 
@@ -204,7 +220,7 @@ public partial class EventEditorViewModel : ObservableObject
                 error = "The repeat end date is before the start date.";
                 return false;
             }
-            rrule = new RecurrenceRule
+            var rule = new RecurrenceRule
             {
                 Frequency = RepeatIndex switch
                 {
@@ -215,7 +231,10 @@ public partial class EventEditorViewModel : ObservableObject
                 },
                 Interval = RepeatInterval,
                 Until = RepeatUntil,
-            }.ToRRule();
+            };
+            if (RepeatIndex == 2)
+                rule.ByDay.AddRange(CheckedRepeatDays());
+            rrule = rule.ToRRule();
         }
 
         evt = new CalendarEvent
@@ -249,6 +268,31 @@ public partial class EventEditorViewModel : ObservableObject
         }
         ok = false;
         return date.Date;
+    }
+
+    private void SetRepeatDay(DayOfWeek day, bool value)
+    {
+        switch (day)
+        {
+            case DayOfWeek.Sunday: RepeatOnSunday = value; break;
+            case DayOfWeek.Monday: RepeatOnMonday = value; break;
+            case DayOfWeek.Tuesday: RepeatOnTuesday = value; break;
+            case DayOfWeek.Wednesday: RepeatOnWednesday = value; break;
+            case DayOfWeek.Thursday: RepeatOnThursday = value; break;
+            case DayOfWeek.Friday: RepeatOnFriday = value; break;
+            case DayOfWeek.Saturday: RepeatOnSaturday = value; break;
+        }
+    }
+
+    private IEnumerable<DayOfWeek> CheckedRepeatDays()
+    {
+        if (RepeatOnSunday) yield return DayOfWeek.Sunday;
+        if (RepeatOnMonday) yield return DayOfWeek.Monday;
+        if (RepeatOnTuesday) yield return DayOfWeek.Tuesday;
+        if (RepeatOnWednesday) yield return DayOfWeek.Wednesday;
+        if (RepeatOnThursday) yield return DayOfWeek.Thursday;
+        if (RepeatOnFriday) yield return DayOfWeek.Friday;
+        if (RepeatOnSaturday) yield return DayOfWeek.Saturday;
     }
 
     private static DateTime RoundUpToQuarterHour(DateTime dt)

--- a/QuickMail/ViewModels/EventEditorViewModel.cs
+++ b/QuickMail/ViewModels/EventEditorViewModel.cs
@@ -1,0 +1,259 @@
+using System;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using QuickMail.Models;
+
+namespace QuickMail.ViewModels;
+
+/// <summary>
+/// Authoring ViewModel for a single locally-created calendar appointment. Holds the editable
+/// fields (title, start/end date+time, location, notes), validates them, and produces a
+/// <see cref="CalendarEvent"/> on save. Pure VM: no View types, no window references. The View
+/// subscribes to <see cref="Saved"/> / <see cref="Cancelled"/> to close and persist, and to
+/// <see cref="AnnouncementRequested"/> for validation feedback.
+///
+/// v1 scope: timed events only. All-day support needs a persisted model flag and is deferred.
+/// </summary>
+public partial class EventEditorViewModel : ObservableObject
+{
+    private readonly string _uid;
+
+    /// <summary>True when editing an existing event; false when creating a new one.</summary>
+    public bool IsEdit { get; }
+
+    /// <summary>Window title text ("New appointment" / "Edit appointment").</summary>
+    public string WindowTitle => IsEdit ? "Edit appointment" : "New appointment";
+
+    [ObservableProperty] private string _title = string.Empty;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasTimes))]
+    private bool _isAllDay;
+
+    [ObservableProperty] private DateTime? _startDate;
+    [ObservableProperty] private string _startTime = string.Empty;
+    [ObservableProperty] private DateTime? _endDate;
+    [ObservableProperty] private string _endTime = string.Empty;
+    [ObservableProperty] private string _location = string.Empty;
+    [ObservableProperty] private string _notes = string.Empty;
+
+    // Recurrence — 0 = Does not repeat, 1 = Daily, 2 = Weekly, 3 = Monthly, 4 = Yearly.
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasRepeat))]
+    [NotifyPropertyChangedFor(nameof(RepeatUnitLabel))]
+    private int _repeatIndex;
+
+    [ObservableProperty] private int _repeatInterval = 1;
+    [ObservableProperty] private DateTime? _repeatUntil;
+
+    /// <summary>False when the appointment is all-day — the View disables the time fields.</summary>
+    public bool HasTimes => !IsAllDay;
+
+    /// <summary>True when a repeat frequency is selected — the View shows interval/until controls.</summary>
+    public bool HasRepeat => RepeatIndex > 0;
+
+    /// <summary>Unit word for the "every N ___" interval control.</summary>
+    public string RepeatUnitLabel => RepeatIndex switch
+    {
+        1 => "days", 2 => "weeks", 3 => "months", 4 => "years", _ => "",
+    };
+
+    /// <summary>Raised with the built event when the user saves and validation passes.</summary>
+    public event Action<CalendarEvent>? Saved;
+
+    /// <summary>Raised when the user cancels.</summary>
+    public event Action? Cancelled;
+
+    /// <summary>Raised for screen-reader feedback (validation errors). View calls AccessibilityHelper.Announce.</summary>
+    public event Action<string, AnnouncementCategory>? AnnouncementRequested;
+
+    /// <summary>Creates an editor for a new appointment defaulting to the given start (usually now, rounded).</summary>
+    public EventEditorViewModel(DateTime defaultStart)
+    {
+        _uid = "local-" + Guid.NewGuid().ToString("N");
+        IsEdit = false;
+        var start = RoundUpToQuarterHour(defaultStart);
+        StartDate = start.Date;
+        StartTime = start.ToString("t");
+        EndDate = start.Date;
+        EndTime = start.AddMinutes(30).ToString("t");
+    }
+
+    /// <summary>Creates an editor populated from an existing locally-created event.</summary>
+    public EventEditorViewModel(CalendarEvent existing)
+    {
+        _uid = existing.Uid;
+        IsEdit = true;
+        Title = existing.Summary;
+        Location = existing.Location;
+        Notes = existing.Description;
+        IsAllDay = existing.IsAllDay;
+
+        var start = existing.StartTime ?? DateTime.Now;
+        StartDate = start.Date;
+        StartTime = start.ToString("t");
+        var end = existing.EndTime ?? start.AddMinutes(30);
+        EndDate = end.Date;
+        EndTime = end.ToString("t");
+
+        var rule = Models.RecurrenceRule.Parse(existing.RecurrenceRule);
+        if (rule != null)
+        {
+            RepeatIndex = rule.Frequency switch
+            {
+                RecurrenceFrequency.Daily => 1,
+                RecurrenceFrequency.Weekly => 2,
+                RecurrenceFrequency.Monthly => 3,
+                RecurrenceFrequency.Yearly => 4,
+                _ => 0,
+            };
+            RepeatInterval = rule.Interval;
+            RepeatUntil = rule.Until;
+        }
+    }
+
+    [RelayCommand]
+    private void Save()
+    {
+        if (!TryBuildEvent(out var evt, out var error))
+        {
+            AnnouncementRequested?.Invoke(error, AnnouncementCategory.Result);
+            return;
+        }
+        Saved?.Invoke(evt);
+    }
+
+    [RelayCommand]
+    private void Cancel() => Cancelled?.Invoke();
+
+    /// <summary>
+    /// Validates the fields and, on success, produces the persisted <see cref="CalendarEvent"/>.
+    /// Returns false with a spoken-friendly <paramref name="error"/> message on failure.
+    /// </summary>
+    public bool TryBuildEvent(out CalendarEvent evt, out string error)
+    {
+        evt = null!;
+        error = string.Empty;
+
+        if (string.IsNullOrWhiteSpace(Title))
+        {
+            error = "Title is required.";
+            return false;
+        }
+        if (StartDate is null)
+        {
+            error = "Start date is required.";
+            return false;
+        }
+
+        DateTime start, end;
+
+        if (IsAllDay)
+        {
+            // All-day: span whole day(s). Single day => start 00:00, end 23:59:59 same date.
+            start = StartDate.Value.Date;
+            var endDay = (EndDate ?? StartDate.Value).Date;
+            if (endDay < start.Date)
+            {
+                error = "The end date is before the start date.";
+                return false;
+            }
+            end = endDay.AddDays(1).AddSeconds(-1);
+        }
+        else
+        {
+            start = CombineDateAndTime(StartDate.Value, StartTime, out var startOk);
+            if (!startOk)
+            {
+                error = "Start time is not a valid time. Try a format like 9:00 AM.";
+                return false;
+            }
+
+            var endBaseDate = EndDate ?? StartDate.Value;
+            if (string.IsNullOrWhiteSpace(EndTime))
+            {
+                end = start.AddMinutes(30);
+            }
+            else
+            {
+                end = CombineDateAndTime(endBaseDate, EndTime, out var endOk);
+                if (!endOk)
+                {
+                    error = "End time is not a valid time. Try a format like 9:30 AM.";
+                    return false;
+                }
+            }
+
+            if (end < start)
+            {
+                error = "The end time is before the start time.";
+                return false;
+            }
+        }
+
+        string? rrule = null;
+        if (RepeatIndex > 0)
+        {
+            if (RepeatInterval < 1)
+            {
+                error = "Repeat interval must be at least 1.";
+                return false;
+            }
+            if (RepeatUntil is DateTime u && u.Date < start.Date)
+            {
+                error = "The repeat end date is before the start date.";
+                return false;
+            }
+            rrule = new RecurrenceRule
+            {
+                Frequency = RepeatIndex switch
+                {
+                    1 => RecurrenceFrequency.Daily,
+                    2 => RecurrenceFrequency.Weekly,
+                    3 => RecurrenceFrequency.Monthly,
+                    _ => RecurrenceFrequency.Yearly,
+                },
+                Interval = RepeatInterval,
+                Until = RepeatUntil,
+            }.ToRRule();
+        }
+
+        evt = new CalendarEvent
+        {
+            Uid            = _uid,
+            AccountId      = CalendarEvent.LocalAccountId,
+            Summary        = Title.Trim(),
+            Location       = Location.Trim(),
+            Description    = Notes.Trim(),
+            StartTimeTicks = start.ToUniversalTime().Ticks,
+            EndTimeTicks   = end.ToUniversalTime().Ticks,
+            IsAllDay       = IsAllDay,
+            RecurrenceRule = rrule,
+            ResponseStatus = CalendarResponseStatus.Accepted,
+        };
+        return true;
+    }
+
+    /// <summary>Combines a date with a free-typed time string ("9", "9:00", "9:00 AM", "14:30").</summary>
+    private static DateTime CombineDateAndTime(DateTime date, string timeText, out bool ok)
+    {
+        if (string.IsNullOrWhiteSpace(timeText))
+        {
+            ok = true;
+            return date.Date; // midnight
+        }
+        if (DateTime.TryParse(timeText.Trim(), out var parsed))
+        {
+            ok = true;
+            return date.Date + parsed.TimeOfDay;
+        }
+        ok = false;
+        return date.Date;
+    }
+
+    private static DateTime RoundUpToQuarterHour(DateTime dt)
+    {
+        var minutes = (dt.Minute / 15 + 1) * 15;
+        return dt.Date.AddHours(dt.Hour).AddMinutes(minutes);
+    }
+}

--- a/QuickMail/ViewModels/EventEditorViewModel.cs
+++ b/QuickMail/ViewModels/EventEditorViewModel.cs
@@ -26,6 +26,8 @@ public partial class EventEditorViewModel : ObservableObject
 {
     private readonly string _uid;
     private readonly List<CalendarSaveTarget> _saveTargets;
+    private readonly int? _masterRepeatCount;
+    private readonly Guid _editAccountId = CalendarEvent.LocalAccountId;
 
     /// <summary>True when editing an existing event; false when creating a new one.</summary>
     public bool IsEdit { get; }
@@ -183,6 +185,8 @@ public partial class EventEditorViewModel : ObservableObject
     {
         _uid = existing.Uid;
         IsEdit = true;
+        _editAccountId = existing.AccountId;   // server rows keep their account; the
+                                               // recurring-stays-local rule can then fire on edits too
         // Editing never moves an appointment between calendars (v1) — no picker.
         _saveTargets = BuildSaveTargets(null);
         SaveTargetLabels = _saveTargets.ConvertAll(t => t.Label);
@@ -213,6 +217,7 @@ public partial class EventEditorViewModel : ObservableObject
             };
             RepeatInterval = rule.Interval;
             RepeatUntil = rule.Until;
+            _masterRepeatCount = rule.Count;   // preserved through a whole-series save (no UI yet)
             foreach (var day in rule.ByDay)
                 SetRepeatDay(day, true);
         }
@@ -325,6 +330,9 @@ public partial class EventEditorViewModel : ObservableObject
                 },
                 Interval = RepeatInterval,
                 Until = RepeatUntil,
+                // A COUNT-limited series must stay COUNT-limited across an edit even though the
+                // editor has no count field yet — dropping it made the series infinite.
+                Count = RepeatUntil is null ? _masterRepeatCount : null,
             };
             if (RepeatIndex == 2)
                 rule.ByDay.AddRange(CheckedRepeatDays());
@@ -332,9 +340,14 @@ public partial class EventEditorViewModel : ObservableObject
         }
 
         // v1 calendar push handles single events only — a repeating appointment must stay local.
-        var targetAccountId = IsEdit ? CalendarEvent.LocalAccountId : SelectedTargetAccountId;
+        var targetAccountId = IsDetachSave ? CalendarEvent.LocalAccountId
+            : IsEdit ? _editAccountId
+            : SelectedTargetAccountId;
         if (targetAccountId != CalendarEvent.LocalAccountId && rrule != null)
         {
+            // Fires for new appointments targeting an account AND for edits of server-synced
+            // events that try to add a repeat — previously the edit path skipped this and the
+            // whole edit was discarded post-close by the push's NotSupportedException.
             error = "Repeating appointments can only be saved to Local Calendar for now.";
             return false;
         }

--- a/QuickMail/ViewModels/EventEditorViewModel.cs
+++ b/QuickMail/ViewModels/EventEditorViewModel.cs
@@ -165,7 +165,7 @@ public partial class EventEditorViewModel : ObservableObject
     {
         var targets = new List<CalendarSaveTarget>
         {
-            new("My Appointments (this computer)", CalendarEvent.LocalAccountId),
+            new("Local Calendar (this computer)", CalendarEvent.LocalAccountId),
         };
         if (accountTargets != null)
             foreach (var t in accountTargets)
@@ -335,7 +335,7 @@ public partial class EventEditorViewModel : ObservableObject
         var targetAccountId = IsEdit ? CalendarEvent.LocalAccountId : SelectedTargetAccountId;
         if (targetAccountId != CalendarEvent.LocalAccountId && rrule != null)
         {
-            error = "Repeating appointments can only be saved to My Appointments for now.";
+            error = "Repeating appointments can only be saved to Local Calendar for now.";
             return false;
         }
 

--- a/QuickMail/ViewModels/EventEditorViewModel.cs
+++ b/QuickMail/ViewModels/EventEditorViewModel.cs
@@ -7,6 +7,12 @@ using QuickMail.Models;
 namespace QuickMail.ViewModels;
 
 /// <summary>
+/// One entry in the appointment editor's "Calendar" save-target picker: the local calendar
+/// (<see cref="CalendarEvent.LocalAccountId"/>) or a Graph-backed account's calendar.
+/// </summary>
+public sealed record CalendarSaveTarget(string Label, Guid AccountId);
+
+/// <summary>
 /// Authoring ViewModel for a single locally-created calendar appointment. Holds the editable
 /// fields (title, start/end date+time, location, notes), validates them, and produces a
 /// <see cref="CalendarEvent"/> on save. Pure VM: no View types, no window references. The View
@@ -18,9 +24,32 @@ namespace QuickMail.ViewModels;
 public partial class EventEditorViewModel : ObservableObject
 {
     private readonly string _uid;
+    private readonly List<CalendarSaveTarget> _saveTargets;
 
     /// <summary>True when editing an existing event; false when creating a new one.</summary>
     public bool IsEdit { get; }
+
+    /// <summary>
+    /// Labels for the "Calendar" save-target picker. Index 0 is always the local calendar;
+    /// the rest are Graph-backed accounts. Plain strings so the ComboBox items announce
+    /// correctly (Selector accessibility rule).
+    /// </summary>
+    public IReadOnlyList<string> SaveTargetLabels { get; }
+
+    /// <summary>Selected save target. Defaults to 0 (the local calendar).</summary>
+    [ObservableProperty] private int _selectedTargetIndex;
+
+    /// <summary>The account id the appointment will save to (resolved from the picker).</summary>
+    public Guid SelectedTargetAccountId =>
+        SelectedTargetIndex >= 0 && SelectedTargetIndex < _saveTargets.Count
+            ? _saveTargets[SelectedTargetIndex].AccountId
+            : CalendarEvent.LocalAccountId;
+
+    /// <summary>
+    /// True when the View should show the save-target picker: only for NEW appointments (an
+    /// appointment cannot move calendars in v1) and only when there is a real choice to make.
+    /// </summary>
+    public bool ShowSaveTarget => !IsEdit && _saveTargets.Count > 1;
 
     /// <summary>Window title text ("New appointment" / "Edit appointment").</summary>
     public string WindowTitle => IsEdit ? "Edit appointment" : "New appointment";
@@ -112,16 +141,36 @@ public partial class EventEditorViewModel : ObservableObject
     /// <summary>Raised for screen-reader feedback (validation errors). View calls AccessibilityHelper.Announce.</summary>
     public event Action<string, AnnouncementCategory>? AnnouncementRequested;
 
-    /// <summary>Creates an editor for a new appointment defaulting to the given start (usually now, rounded).</summary>
-    public EventEditorViewModel(DateTime defaultStart)
+    /// <summary>
+    /// Creates an editor for a new appointment defaulting to the given start (usually now,
+    /// rounded). <paramref name="accountTargets"/> lists the Graph-backed accounts the
+    /// appointment may alternatively be saved to; the local calendar is always offered first
+    /// and is the default.
+    /// </summary>
+    public EventEditorViewModel(DateTime defaultStart, IReadOnlyList<CalendarSaveTarget>? accountTargets = null)
     {
         _uid = "local-" + Guid.NewGuid().ToString("N");
         IsEdit = false;
+        _saveTargets = BuildSaveTargets(accountTargets);
+        SaveTargetLabels = _saveTargets.ConvertAll(t => t.Label);
         var start = RoundUpToQuarterHour(defaultStart);
         StartDate = start.Date;
         StartTime = start.ToString("t");
         EndDate = start.Date;
         EndTime = start.AddMinutes(30).ToString("t");
+    }
+
+    private static List<CalendarSaveTarget> BuildSaveTargets(IReadOnlyList<CalendarSaveTarget>? accountTargets)
+    {
+        var targets = new List<CalendarSaveTarget>
+        {
+            new("My Appointments (this computer)", CalendarEvent.LocalAccountId),
+        };
+        if (accountTargets != null)
+            foreach (var t in accountTargets)
+                if (t.AccountId != CalendarEvent.LocalAccountId)
+                    targets.Add(t);
+        return targets;
     }
 
     /// <summary>
@@ -133,6 +182,9 @@ public partial class EventEditorViewModel : ObservableObject
     {
         _uid = existing.Uid;
         IsEdit = true;
+        // Editing never moves an appointment between calendars (v1) — no picker.
+        _saveTargets = BuildSaveTargets(null);
+        SaveTargetLabels = _saveTargets.ConvertAll(t => t.Label);
         IsRecurringEdit = existing.IsRecurring && existing.OccurrenceStart.HasValue;
         OccurrenceStart = existing.OccurrenceStart;
         Title = existing.Summary;
@@ -278,10 +330,18 @@ public partial class EventEditorViewModel : ObservableObject
             rrule = rule.ToRRule();
         }
 
+        // v1 Graph push handles single events only — a repeating appointment must stay local.
+        var targetAccountId = IsEdit ? CalendarEvent.LocalAccountId : SelectedTargetAccountId;
+        if (targetAccountId != CalendarEvent.LocalAccountId && rrule != null)
+        {
+            error = "Repeating appointments can only be saved to My Appointments for now.";
+            return false;
+        }
+
         evt = new CalendarEvent
         {
             Uid            = IsDetachSave ? "local-" + Guid.NewGuid().ToString("N") : _uid,
-            AccountId      = CalendarEvent.LocalAccountId,
+            AccountId      = targetAccountId,
             Summary        = Title.Trim(),
             Location       = Location.Trim(),
             Description    = Notes.Trim(),

--- a/QuickMail/ViewModels/EventEditorViewModel.cs
+++ b/QuickMail/ViewModels/EventEditorViewModel.cs
@@ -8,7 +8,8 @@ namespace QuickMail.ViewModels;
 
 /// <summary>
 /// One entry in the appointment editor's "Calendar" save-target picker: the local calendar
-/// (<see cref="CalendarEvent.LocalAccountId"/>) or a Graph-backed account's calendar.
+/// (<see cref="CalendarEvent.LocalAccountId"/>) or a server-backed (Microsoft or Google)
+/// account's calendar.
 /// </summary>
 public sealed record CalendarSaveTarget(string Label, Guid AccountId);
 
@@ -31,8 +32,8 @@ public partial class EventEditorViewModel : ObservableObject
 
     /// <summary>
     /// Labels for the "Calendar" save-target picker. Index 0 is always the local calendar;
-    /// the rest are Graph-backed accounts. Plain strings so the ComboBox items announce
-    /// correctly (Selector accessibility rule).
+    /// the rest are server-backed (Microsoft or Google) accounts. Plain strings so the ComboBox
+    /// items announce correctly (Selector accessibility rule).
     /// </summary>
     public IReadOnlyList<string> SaveTargetLabels { get; }
 
@@ -143,7 +144,7 @@ public partial class EventEditorViewModel : ObservableObject
 
     /// <summary>
     /// Creates an editor for a new appointment defaulting to the given start (usually now,
-    /// rounded). <paramref name="accountTargets"/> lists the Graph-backed accounts the
+    /// rounded). <paramref name="accountTargets"/> lists the server-backed accounts the
     /// appointment may alternatively be saved to; the local calendar is always offered first
     /// and is the default.
     /// </summary>
@@ -330,7 +331,7 @@ public partial class EventEditorViewModel : ObservableObject
             rrule = rule.ToRRule();
         }
 
-        // v1 Graph push handles single events only — a repeating appointment must stay local.
+        // v1 calendar push handles single events only — a repeating appointment must stay local.
         var targetAccountId = IsEdit ? CalendarEvent.LocalAccountId : SelectedTargetAccountId;
         if (targetAccountId != CalendarEvent.LocalAccountId && rrule != null)
         {

--- a/QuickMail/ViewModels/EventEditorViewModel.cs
+++ b/QuickMail/ViewModels/EventEditorViewModel.cs
@@ -60,6 +60,37 @@ public partial class EventEditorViewModel : ObservableObject
     /// <summary>True when Weekly is selected — the View shows the day-of-week checkboxes.</summary>
     public bool IsWeekly => RepeatIndex == 2;
 
+    /// <summary>
+    /// True when editing one occurrence of a repeating series — the View shows the edit-scope
+    /// radio group (This event / All events).
+    /// </summary>
+    public bool IsRecurringEdit { get; }
+
+    /// <summary>The occurrence's original start (local), for excluding it when detaching.</summary>
+    public DateTime? OccurrenceStart { get; }
+
+    /// <summary>Edit scope: true = only this occurrence (default), false = the whole series.</summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(EditWholeSeries))]
+    [NotifyPropertyChangedFor(nameof(CanEditRepeat))]
+    private bool _editThisEventOnly = true;
+
+    /// <summary>Inverse radio binding for the "All events" option.</summary>
+    public bool EditWholeSeries
+    {
+        get => !EditThisEventOnly;
+        set => EditThisEventOnly = !value;
+    }
+
+    /// <summary>The Repeat controls only make sense when the edit applies to the series.</summary>
+    public bool CanEditRepeat => !(IsRecurringEdit && EditThisEventOnly);
+
+    /// <summary>
+    /// True when the save should detach this occurrence: caller must EXDATE the master at
+    /// <see cref="OccurrenceStart"/> and insert the returned standalone event.
+    /// </summary>
+    public bool IsDetachSave => IsRecurringEdit && EditThisEventOnly;
+
     /// <summary>False when the appointment is all-day — the View disables the time fields.</summary>
     public bool HasTimes => !IsAllDay;
 
@@ -93,11 +124,17 @@ public partial class EventEditorViewModel : ObservableObject
         EndTime = start.AddMinutes(30).ToString("t");
     }
 
-    /// <summary>Creates an editor populated from an existing locally-created event.</summary>
+    /// <summary>
+    /// Creates an editor populated from an existing locally-created event. For an expanded
+    /// occurrence of a repeating series (OccurrenceStart set), the editor opens on the
+    /// occurrence's own date/time and offers the This event / All events scope choice.
+    /// </summary>
     public EventEditorViewModel(CalendarEvent existing)
     {
         _uid = existing.Uid;
         IsEdit = true;
+        IsRecurringEdit = existing.IsRecurring && existing.OccurrenceStart.HasValue;
+        OccurrenceStart = existing.OccurrenceStart;
         Title = existing.Summary;
         Location = existing.Location;
         Notes = existing.Description;
@@ -208,7 +245,11 @@ public partial class EventEditorViewModel : ObservableObject
         }
 
         string? rrule = null;
-        if (RepeatIndex > 0)
+        if (IsDetachSave)
+        {
+            // Detached occurrence becomes an independent one-off appointment.
+        }
+        else if (RepeatIndex > 0)
         {
             if (RepeatInterval < 1)
             {
@@ -239,7 +280,7 @@ public partial class EventEditorViewModel : ObservableObject
 
         evt = new CalendarEvent
         {
-            Uid            = _uid,
+            Uid            = IsDetachSave ? "local-" + Guid.NewGuid().ToString("N") : _uid,
             AccountId      = CalendarEvent.LocalAccountId,
             Summary        = Title.Trim(),
             Location       = Location.Trim(),

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -210,6 +210,29 @@ public partial class MainViewModel : ObservableObject, IDisposable
         DisplayName = "Calendar"
     };
 
+    // Per-source calendar children under the Calendar node: " Calendar:{guid}" for one
+    // account's calendar, ":local" for locally-authored appointments, ":all" for the merged view.
+    internal const string CalendarSourcePrefix = " Calendar:";
+
+    /// <summary>True for the Calendar node or any of its per-source children.</summary>
+    internal static bool IsCalendarFolderName(string? fullName) =>
+        fullName != null
+        && (string.Equals(fullName, CalendarFolder.FullName, StringComparison.Ordinal)
+            || fullName.StartsWith(CalendarSourcePrefix, StringComparison.Ordinal));
+
+    /// <summary>
+    /// Maps a calendar folder name to the account filter it selects:
+    /// null = all sources; Guid.Empty = local appointments; else that account's calendar.
+    /// </summary>
+    internal static Guid? CalendarFilterFor(string fullName)
+    {
+        if (!fullName.StartsWith(CalendarSourcePrefix, StringComparison.Ordinal)) return null;
+        var tail = fullName[CalendarSourcePrefix.Length..];
+        if (tail == "all") return null;
+        if (tail == "local") return Guid.Empty;
+        return Guid.TryParse(tail, out var id) ? id : null;
+    }
+
     // Sentinel prefix for per-account "All Mail" virtual folders, e.g. "\u0000AccountMail:{guid}".
     internal const string AccountMailPrefix = "\u0000AccountMail:";
 
@@ -282,7 +305,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
                string.Equals(folder.FullName, AllSentFolder.FullName, StringComparison.Ordinal) ||
                string.Equals(folder.FullName, AllTrashFolder.FullName, StringComparison.Ordinal) ||
                string.Equals(folder.FullName, AllFlaggedFolder.FullName, StringComparison.Ordinal) ||
-               string.Equals(folder.FullName, CalendarFolder.FullName, StringComparison.Ordinal);
+               IsCalendarFolderName(folder.FullName);
     }
 
     // ── Saved views ───────────────────────────────────────────────────────────────
@@ -408,7 +431,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
     /// calendar event list is shown in place of the message list.
     /// </summary>
     public bool IsCalendarView => SelectedFolder != null &&
-        string.Equals(SelectedFolder.FullName, CalendarFolder.FullName, StringComparison.Ordinal);
+        IsCalendarFolderName(SelectedFolder.FullName);
 
     public ObservableCollection<FlagDefinition> FlagDefinitions { get; } = [];
 
@@ -2597,11 +2620,34 @@ public partial class MainViewModel : ObservableObject, IDisposable
         // Shown only when a calendar service is wired (skipped in tests / online-only builds).
         if (CalendarVm != null)
         {
-            roots.Add(new FolderTreeNode
+            var calNode = new FolderTreeNode
             {
                 Folder = CalendarFolder,
                 Label  = CalendarFolder.DisplayName,
+            };
+            calNode.Children.Add(new FolderTreeNode
+            {
+                Folder = new MailFolderModel { FullName = CalendarSourcePrefix + "all", DisplayName = "All Calendars" },
+                Label  = "All Calendars",
             });
+            calNode.Children.Add(new FolderTreeNode
+            {
+                Folder = new MailFolderModel { FullName = CalendarSourcePrefix + "local", DisplayName = "My Appointments" },
+                Label  = "My Appointments",
+            });
+            foreach (var acct in Accounts)
+            {
+                calNode.Children.Add(new FolderTreeNode
+                {
+                    Folder = new MailFolderModel
+                    {
+                        FullName    = CalendarSourcePrefix + acct.Id.ToString("D"),
+                        DisplayName = acct.AccountLabel,
+                    },
+                    Label = acct.AccountLabel,
+                });
+            }
+            roots.Add(calNode);
         }
 
         // "Views" group — shown only when the user has saved at least one view.
@@ -2991,9 +3037,9 @@ public partial class MainViewModel : ObservableObject, IDisposable
         }
 
         // Intercept the calendar virtual folder — it shows the event list, not messages.
-        if (string.Equals(folder.FullName, CalendarFolder.FullName, StringComparison.Ordinal))
+        if (IsCalendarFolderName(folder.FullName))
         {
-            await SelectCalendarAsync();
+            await SelectCalendarAsync(folder);
             return;
         }
 
@@ -3024,9 +3070,10 @@ public partial class MainViewModel : ObservableObject, IDisposable
     /// and requests focus to the event list. Called when the user selects the
     /// Calendar virtual folder from the folder tree.
     /// </summary>
-    private async Task SelectCalendarAsync()
+    private async Task SelectCalendarAsync(MailFolderModel? folder = null)
     {
         if (CalendarVm == null) return;
+        CalendarVm.AccountFilter = folder == null ? null : CalendarFilterFor(folder.FullName);
 
         _suppressFilterRebuild = true;
         ActiveFilter        = MessageFilter.All;
@@ -3035,7 +3082,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
         SearchText          = string.Empty;
         IsSearchActive      = false;
         ActiveView          = null;
-        SelectedFolder      = CalendarFolder;
+        SelectedFolder      = folder ?? CalendarFolder;
         MessageDetail       = null;
         IsMessageOpen       = false;
         _suppressFilterRebuild = false;

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -1501,7 +1501,13 @@ public partial class MainViewModel : ObservableObject, IDisposable
 
         registry.Register(new CommandDefinition(
             id: "view.search", category: "View", title: "Search Messages…",
-            execute: () => { IsSearchActive = true; SearchRequested?.Invoke(this, EventArgs.Empty); },
+            execute: () =>
+            {
+                // Context-aware: in the calendar this routes to appointment search (the View
+                // checks IsCalendarView); only mail search uses the mail search box state.
+                if (!IsCalendarView) IsSearchActive = true;
+                SearchRequested?.Invoke(this, EventArgs.Empty);
+            },
             defaultKey: Key.S, defaultModifiers: ModifierKeys.Control | ModifierKeys.Shift));
 
         registry.Register(new CommandDefinition(

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -912,8 +912,13 @@ public partial class MainViewModel : ObservableObject, IDisposable
         // Calendar — only when a calendar service is wired (skipped in tests).
         if (_calendarService != null)
         {
+            // The accounts provider is deferred (evaluated when the editor opens) because the
+            // account list loads after this constructor; only Graph-backed accounts have a
+            // Microsoft calendar to save to.
             CalendarVm = new CalendarViewModel(_calendarService, onlineMode, cfg.ShowDeclinedEvents,
-                                               cfg.CalendarListShowFieldLabels);
+                                               cfg.CalendarListShowFieldLabels,
+                                               _graphCalendarSync,
+                                               () => Accounts.Where(a => a.BackendKind == BackendKind.MicrosoftGraph).ToList());
             RemindersEnabled = cfg.CalendarReminders;
             ReminderLeadMinutes = cfg.CalendarReminderMinutes;
             StartReminderTimer();

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -34,6 +34,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
     private readonly ISendMailService _smtp;
     private readonly IFlagService? _flagService;
     private readonly ICalendarService? _calendarService;
+    private readonly IGraphCalendarSyncService? _graphCalendarSync;
     private readonly IUpdateCheckService? _updateCheckService;
     // Windows toast notifications for new mail. Null in tests and when the OS/platform is
     // unsupported. Calling into it is an OS side-effect a service owns, not a View-layer type,
@@ -64,6 +65,14 @@ public partial class MainViewModel : ObservableObject, IDisposable
     // Debounced calendar harvest: re-harvests events 2s after the last FolderSynced
     // event so we don't harvest on every folder during a multi-folder sync.
     private System.Threading.Timer? _calendarHarvestTimer;
+
+    // Periodic Graph calendar pull (read-down v1): first pass right after the startup mail sync,
+    // then every 15 minutes. Callback marshals to the UI thread via _ui.Post (like the harvest
+    // timer above). Disposed in Dispose; in-flight HTTP is cancelled via _graphCalSyncCts.
+    private System.Threading.Timer? _graphCalendarSyncTimer;
+    private CancellationTokenSource? _graphCalSyncCts;
+    private bool _graphCalendarSyncRunning; // UI-thread-owned re-entrancy guard (timer vs. F5)
+    private static readonly TimeSpan GraphCalendarSyncInterval = TimeSpan.FromMinutes(15);
 
     /// <summary>
     /// Cancels and disposes the old CTS, creates a new one, and outputs its token.
@@ -98,6 +107,9 @@ public partial class MainViewModel : ObservableObject, IDisposable
         _folderCountCts.Clear();
         _calendarHarvestTimer?.Dispose();
         _calendarHarvestTimer = null;
+        _graphCalendarSyncTimer?.Dispose();
+        _graphCalendarSyncTimer = null;
+        DrainCts(ref _graphCalSyncCts);
         _reminderTimer?.Dispose();
         _reminderTimer = null;
         GC.SuppressFinalize(this);
@@ -837,7 +849,8 @@ public partial class MainViewModel : ObservableObject, IDisposable
         IUiDispatcher? uiDispatcher = null,
         IThemeService? themeService = null,
         INotificationService? notificationService = null,
-        IContactSyncService? contactSyncService = null)
+        IContactSyncService? contactSyncService = null,
+        IGraphCalendarSyncService? graphCalendarSyncService = null)
     {
         _imap            = imap;
         _ui              = uiDispatcher ?? new WpfUiDispatcher();
@@ -858,6 +871,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
         _themeService         = themeService;
         _notifications        = notificationService;
         _contactSync          = contactSyncService;
+        _graphCalendarSync    = graphCalendarSyncService;
         OnlineMode            = onlineMode;
 
         var cfg = _configService.Load();
@@ -1666,6 +1680,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
             if (missingRecipients)
             {
                 await FetchAllMailAsync();
+                StartGraphCalendarSyncTimer(); // this path skips the full sync below but still counts as "startup done"
                 return;
             }
         }
@@ -1734,6 +1749,11 @@ public partial class MainViewModel : ObservableObject, IDisposable
             _suppressFolderSyncUpdates = false;
             progressCts.Cancel();
             try { await progressTask.ConfigureAwait(false); } catch { }
+
+            // Graph calendar sync: first pass now that the initial mail sync has finished (tokens
+            // are warm, so acquisition is silent), then every 15 minutes. In the finally so a sync
+            // error or cancellation doesn't leave the calendar permanently unsynced.
+            StartGraphCalendarSyncTimer();
         }
     }
 
@@ -3328,6 +3348,9 @@ public partial class MainViewModel : ObservableObject, IDisposable
         // through CommandRegistry, so an isAvailable guard alone can't disambiguate them.
         if (IsCalendarView)
         {
+            // Pull the latest Graph calendar slice first so F5 reflects the server, then let the
+            // calendar's own refresh reload from the store and announce the updated count.
+            await RunGraphCalendarSyncAsync(refreshAndAnnounce: false);
             if (CalendarVm != null)
                 await CalendarVm.RefreshCommand.ExecuteAsync(null);
             return;
@@ -5996,6 +6019,62 @@ public partial class MainViewModel : ObservableObject, IDisposable
         }, null, Timeout.Infinite, Timeout.Infinite);
 
         _calendarHarvestTimer.Change(TimeSpan.FromSeconds(2), Timeout.InfiniteTimeSpan);
+    }
+
+    // ── Graph calendar sync (read-down v1) ────────────────────────────────────────
+
+    /// <summary>
+    /// Starts the periodic Graph calendar pull: an immediate first pass (called after the startup
+    /// mail sync completes, so OAuth tokens are warm and the token acquisition is silent), then
+    /// every 15 minutes. Idempotent — a repeat call just restarts the schedule.
+    /// </summary>
+    private void StartGraphCalendarSyncTimer()
+    {
+        if (_graphCalendarSync == null || _calendarService == null || OnlineMode) return;
+
+        _graphCalendarSyncTimer ??= new System.Threading.Timer(
+            _ => _ui.Post(() => _ = RunGraphCalendarSyncAsync()), null, Timeout.Infinite, Timeout.Infinite);
+        _graphCalendarSyncTimer.Change(TimeSpan.Zero, GraphCalendarSyncInterval);
+    }
+
+    /// <summary>
+    /// One Graph calendar sync pass: pulls every Graph account's primary calendar into the local
+    /// store (replace-slice), then reloads the in-memory calendar. Announces the result (Status
+    /// category) only while the calendar view is active, so background passes stay silent.
+    /// Runs on the UI thread; overlapping passes (timer vs. F5) are skipped, not queued.
+    /// </summary>
+    private async Task RunGraphCalendarSyncAsync(bool refreshAndAnnounce = true)
+    {
+        if (_graphCalendarSync == null || _calendarService == null || OnlineMode) return;
+        if (_graphCalendarSyncRunning) return;
+        _graphCalendarSyncRunning = true;
+        try
+        {
+            ReplaceCts(ref _graphCalSyncCts, out var ct);
+            var result = await _graphCalendarSync.SyncAllAsync(ct);
+            // Nothing eligible (no Graph accounts) or nothing pulled — leave the calendar alone.
+            if (result.AccountsSynced == 0) return;
+            if (!refreshAndAnnounce) return; // F5 path: CalendarVm.RefreshAsync reloads + announces
+
+            await _calendarService.RefreshAsync(ct);
+            if (IsCalendarView)
+            {
+                CalendarVm?.ApplyFiltersFromExternalUpdate();
+                var n = result.EventsFetched;
+                Announce($"Calendar sync complete. {n} event{(n == 1 ? "" : "s")}.",
+                         AnnouncementCategory.Status);
+            }
+        }
+        catch (OperationCanceledException) { /* shutdown or superseded pass — normal */ }
+        catch (Exception ex)
+        {
+            // Best-effort background work: log, never surface a modal or break the caller.
+            LogService.Log("GraphCalendarSync (background pass)", ex);
+        }
+        finally
+        {
+            _graphCalendarSyncRunning = false;
+        }
     }
 
     // ── Calendar reminders ────────────────────────────────────────────────────────

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -220,6 +220,28 @@ public partial class MainViewModel : ObservableObject, IDisposable
         && (string.Equals(fullName, CalendarFolder.FullName, StringComparison.Ordinal)
             || fullName.StartsWith(CalendarSourcePrefix, StringComparison.Ordinal));
 
+    // The Settings-configured CalDAV calendar source, shown as an extra per-source child under
+    // the Calendar node. Its id is SYNTHETIC (deterministically derived from URL + username by
+    // CalDavCalendarClient.AccountIdFor — a CalDAV source is not a QuickMail account), so
+    // CalendarFilterFor's Guid parse routes it exactly like a real account's calendar, and the
+    // read-only guards hold because the id never matches a Graph account.
+    private Guid? _calDavAccountId;
+    private string _calDavDisplayName = "iCloud";
+
+    /// <summary>Refreshes the cached CalDAV source identity from config; true when it changed
+    /// (the folder tree then needs a rebuild).</summary>
+    private bool UpdateCalDavSource(ConfigModel cfg)
+    {
+        var newId = cfg.HasCalDavSource
+            ? CalDavCalendarClient.AccountIdFor(cfg.CalDavUrl, cfg.CalDavUsername)
+            : (Guid?)null;
+        var changed = newId != _calDavAccountId
+            || !string.Equals(cfg.CalDavDisplayName, _calDavDisplayName, StringComparison.Ordinal);
+        _calDavAccountId   = newId;
+        _calDavDisplayName = cfg.CalDavDisplayName;
+        return changed;
+    }
+
     /// <summary>
     /// Maps a calendar folder name to the account filter it selects:
     /// null = all sources; Guid.Empty = local appointments; else that account's calendar.
@@ -909,6 +931,8 @@ public partial class MainViewModel : ObservableObject, IDisposable
         _activeSort = ConfigModel.ParseSort(cfg.Sort);
         _announceFlagStatus = cfg.AnnounceFlagStatus;
 
+        UpdateCalDavSource(cfg);
+
         // Calendar — only when a calendar service is wired (skipped in tests).
         if (_calendarService != null)
         {
@@ -1394,6 +1418,10 @@ public partial class MainViewModel : ObservableObject, IDisposable
             CalendarVm.ShowFieldLabels = cfg.CalendarListShowFieldLabels;
         RemindersEnabled = cfg.CalendarReminders;
         ReminderLeadMinutes = cfg.CalendarReminderMinutes;
+
+        // A CalDAV source added/removed/renamed in Settings changes the calendar tree children.
+        if (UpdateCalDavSource(cfg) && CalendarVm != null)
+            BuildFolderTree();
 
         var newPreviewLines = cfg.PreviewLines;
         var newShowPreview  = newPreviewLines > 0;
@@ -2656,6 +2684,19 @@ public partial class MainViewModel : ObservableObject, IDisposable
                         DisplayName = acct.AccountLabel,
                     },
                     Label = acct.AccountLabel,
+                });
+            }
+            // The CalDAV source (e.g. iCloud) configured in Settings — synthetic account id.
+            if (_calDavAccountId is Guid calDavId)
+            {
+                calNode.Children.Add(new FolderTreeNode
+                {
+                    Folder = new MailFolderModel
+                    {
+                        FullName    = CalendarSourcePrefix + calDavId.ToString("D"),
+                        DisplayName = _calDavDisplayName,
+                    },
+                    Label = _calDavDisplayName,
                 });
             }
             roots.Add(calNode);

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -98,6 +98,8 @@ public partial class MainViewModel : ObservableObject, IDisposable
         _folderCountCts.Clear();
         _calendarHarvestTimer?.Dispose();
         _calendarHarvestTimer = null;
+        _reminderTimer?.Dispose();
+        _reminderTimer = null;
         GC.SuppressFinalize(this);
     }
 
@@ -875,6 +877,9 @@ public partial class MainViewModel : ObservableObject, IDisposable
         {
             CalendarVm = new CalendarViewModel(_calendarService, onlineMode, cfg.ShowDeclinedEvents,
                                                cfg.CalendarListShowFieldLabels);
+            RemindersEnabled = cfg.CalendarReminders;
+            ReminderLeadMinutes = cfg.CalendarReminderMinutes;
+            StartReminderTimer();
         }
 
         _syncService.FolderSynced    += OnFolderSynced;
@@ -1345,6 +1350,8 @@ public partial class MainViewModel : ObservableObject, IDisposable
         // Push the calendar field-labels preference live (re-stamps the event list).
         if (CalendarVm != null)
             CalendarVm.ShowFieldLabels = cfg.CalendarListShowFieldLabels;
+        RemindersEnabled = cfg.CalendarReminders;
+        ReminderLeadMinutes = cfg.CalendarReminderMinutes;
 
         var newPreviewLines = cfg.PreviewLines;
         var newShowPreview  = newPreviewLines > 0;
@@ -5989,6 +5996,72 @@ public partial class MainViewModel : ObservableObject, IDisposable
         }, null, Timeout.Infinite, Timeout.Infinite);
 
         _calendarHarvestTimer.Change(TimeSpan.FromSeconds(2), Timeout.InfiniteTimeSpan);
+    }
+
+    // ── Calendar reminders ────────────────────────────────────────────────────────
+
+    private System.Threading.Timer? _reminderTimer;
+    private readonly HashSet<(string Uid, DateTime Start)> _firedReminders = [];
+    internal bool RemindersEnabled;          // pushed from config at startup and ApplySettings
+    internal int ReminderLeadMinutes = 10;
+
+    /// <summary>Starts the once-a-minute reminder check (no-op without a calendar service).</summary>
+    private void StartReminderTimer()
+    {
+        if (_calendarService == null || OnlineMode) return;
+        _reminderTimer = new System.Threading.Timer(
+            _ => _ui.Post(CheckReminders), null,
+            TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(60));
+    }
+
+    /// <summary>
+    /// Fires one reminder per appointment occurrence whose start falls within the lead window.
+    /// Recurring series are expanded over the window; each (uid, start) fires at most once per run
+    /// of the app. Reminders are opt-in (CalendarReminders, default off).
+    /// </summary>
+    internal void CheckReminders()
+    {
+        if (!RemindersEnabled || _calendarService == null) return;
+
+        var now = DateTime.Now;
+        var windowEnd = now.AddMinutes(ReminderLeadMinutes);
+
+        foreach (var e in _calendarService.Events)
+        {
+            if (!e.StartTime.HasValue) continue;
+            if (e.ResponseStatus is CalendarResponseStatus.Declined or CalendarResponseStatus.Cancelled) continue;
+
+            var rule = e.IsRecurring ? RecurrenceRule.Parse(e.RecurrenceRule) : null;
+            IEnumerable<DateTime> starts;
+            if (rule != null)
+            {
+                var excluded = new HashSet<DateTime>(e.GetExDates());
+                starts = Helpers.RecurrenceExpander
+                    .Expand(e.StartTime.Value, rule, now, windowEnd)
+                    .Where(s => !excluded.Contains(s));
+            }
+            else
+            {
+                starts = e.StartTime.Value > now && e.StartTime.Value <= windowEnd
+                    ? [e.StartTime.Value] : [];
+            }
+
+            foreach (var start in starts)
+            {
+                if (!_firedReminders.Add((e.Uid, start))) continue;
+                var minutes = Math.Max(1, (int)Math.Round((start - now).TotalMinutes));
+                var title = string.IsNullOrWhiteSpace(e.Summary) ? "Appointment" : e.Summary;
+                var body = $"In {minutes} minute{(minutes == 1 ? "" : "s")}, at {start:t}"
+                           + (string.IsNullOrWhiteSpace(e.Location) ? "" : $". {e.Location}");
+                _notifications?.ShowInfo(title, body);
+                Announce($"Reminder. {title} in {minutes} minute{(minutes == 1 ? "" : "s")}, at {start:t}.",
+                         AnnouncementCategory.Result);
+            }
+        }
+
+        // Keep the fired set from growing without bound across long sessions.
+        if (_firedReminders.Count > 500)
+            _firedReminders.RemoveWhere(f => f.Start < now.AddDays(-1));
     }
 
     // Releases landing page — used when no specific update is known so the always-present

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -255,6 +255,15 @@ public partial class MainViewModel : ObservableObject, IDisposable
         return Guid.TryParse(tail, out var id) ? id : null;
     }
 
+    /// <summary>
+    /// True for accounts with a server calendar the app can push appointments to: Microsoft
+    /// (Graph backend) and Google-signed-in accounts (keyed by auth type — Gmail mail is IMAP).
+    /// Plain IMAP/password accounts have no server calendar. Mirrors the sync service's
+    /// per-provider eligibility.
+    /// </summary>
+    internal static bool IsCalendarPushAccount(AccountModel a)
+        => a.BackendKind == BackendKind.MicrosoftGraph || a.AuthType == AuthType.OAuth2Google;
+
     // Sentinel prefix for per-account "All Mail" virtual folders, e.g. "\u0000AccountMail:{guid}".
     internal const string AccountMailPrefix = "\u0000AccountMail:";
 
@@ -937,12 +946,15 @@ public partial class MainViewModel : ObservableObject, IDisposable
         if (_calendarService != null)
         {
             // The accounts provider is deferred (evaluated when the editor opens) because the
-            // account list loads after this constructor; only Graph-backed accounts have a
-            // Microsoft calendar to save to.
+            // account list loads after this constructor. Server calendars the app can write to:
+            // Microsoft (Graph backend) accounts and Google-signed-in accounts (Gmail mail is
+            // IMAP — the identity provider, not the mail backend, is what makes calendar push
+            // possible, mirroring calendar sync eligibility). Plain IMAP/password accounts have
+            // no server calendar and are excluded.
             CalendarVm = new CalendarViewModel(_calendarService, onlineMode, cfg.ShowDeclinedEvents,
                                                cfg.CalendarListShowFieldLabels,
                                                _graphCalendarSync,
-                                               () => Accounts.Where(a => a.BackendKind == BackendKind.MicrosoftGraph).ToList());
+                                               () => Accounts.Where(IsCalendarPushAccount).ToList());
             RemindersEnabled = cfg.CalendarReminders;
             ReminderLeadMinutes = cfg.CalendarReminderMinutes;
             StartReminderTimer();

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -262,7 +262,9 @@ public partial class MainViewModel : ObservableObject, IDisposable
     /// per-provider eligibility.
     /// </summary>
     internal static bool IsCalendarPushAccount(AccountModel a)
-        => a.BackendKind == BackendKind.MicrosoftGraph || a.AuthType == AuthType.OAuth2Google;
+        => a.BackendKind == BackendKind.MicrosoftGraph
+           || a.AuthType == AuthType.OAuth2Microsoft
+           || a.AuthType == AuthType.OAuth2Google;
 
     // Sentinel prefix for per-account "All Mail" virtual folders, e.g. "\u0000AccountMail:{guid}".
     internal const string AccountMailPrefix = "\u0000AccountMail:";
@@ -2683,8 +2685,8 @@ public partial class MainViewModel : ObservableObject, IDisposable
             });
             calNode.Children.Add(new FolderTreeNode
             {
-                Folder = new MailFolderModel { FullName = CalendarSourcePrefix + "local", DisplayName = "My Appointments" },
-                Label  = "My Appointments",
+                Folder = new MailFolderModel { FullName = CalendarSourcePrefix + "local", DisplayName = "Local Calendar" },
+                Label  = "Local Calendar",
             });
             foreach (var acct in Accounts)
             {

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -873,7 +873,8 @@ public partial class MainViewModel : ObservableObject, IDisposable
         // Calendar — only when a calendar service is wired (skipped in tests).
         if (_calendarService != null)
         {
-            CalendarVm = new CalendarViewModel(_calendarService, onlineMode, cfg.ShowDeclinedEvents);
+            CalendarVm = new CalendarViewModel(_calendarService, onlineMode, cfg.ShowDeclinedEvents,
+                                               cfg.CalendarListShowFieldLabels);
         }
 
         _syncService.FolderSynced    += OnFolderSynced;
@@ -1340,6 +1341,10 @@ public partial class MainViewModel : ObservableObject, IDisposable
         ReadAsPlainText   = cfg.ReadAsPlainText;
         _announceFlagStatus = cfg.AnnounceFlagStatus;
         OnPropertyChanged(nameof(AnnounceFlagStatus));
+
+        // Push the calendar field-labels preference live (re-stamps the event list).
+        if (CalendarVm != null)
+            CalendarVm.ShowFieldLabels = cfg.CalendarListShowFieldLabels;
 
         var newPreviewLines = cfg.PreviewLines;
         var newShowPreview  = newPreviewLines > 0;

--- a/QuickMail/ViewModels/SettingsViewModel.cs
+++ b/QuickMail/ViewModels/SettingsViewModel.cs
@@ -82,6 +82,12 @@ public partial class SettingsViewModel : ObservableObject
     private bool _calendarListShowFieldLabels;
 
     [ObservableProperty]
+    private bool _calendarReminders;
+
+    [ObservableProperty]
+    private int _calendarReminderMinutes = 10;
+
+    [ObservableProperty]
     private bool _confirmEmptyTrash;
 
     [ObservableProperty]
@@ -264,6 +270,8 @@ public partial class SettingsViewModel : ObservableObject
         AnnounceFlagStatus               = cfg.AnnounceFlagStatus;
         ContactListShowFieldLabels       = cfg.ContactListShowFieldLabels;
         CalendarListShowFieldLabels      = cfg.CalendarListShowFieldLabels;
+        CalendarReminders                = cfg.CalendarReminders;
+        CalendarReminderMinutes          = cfg.CalendarReminderMinutes;
         ConfirmEmptyTrash                = cfg.ConfirmEmptyTrash;
         NotifyOnNewMail                  = cfg.NotifyOnNewMail;
         CloseToTray                      = cfg.CloseToTray;
@@ -333,6 +341,8 @@ public partial class SettingsViewModel : ObservableObject
         cfg.AnnounceFlagStatus               = AnnounceFlagStatus;
         cfg.ContactListShowFieldLabels       = ContactListShowFieldLabels;
         cfg.CalendarListShowFieldLabels      = CalendarListShowFieldLabels;
+        cfg.CalendarReminders                = CalendarReminders;
+        cfg.CalendarReminderMinutes          = Math.Clamp(CalendarReminderMinutes, 1, 1440);
         cfg.ConfirmEmptyTrash                = ConfirmEmptyTrash;
         cfg.NotifyOnNewMail                  = NotifyOnNewMail;
         cfg.CloseToTray                      = CloseToTray;

--- a/QuickMail/ViewModels/SettingsViewModel.cs
+++ b/QuickMail/ViewModels/SettingsViewModel.cs
@@ -79,6 +79,9 @@ public partial class SettingsViewModel : ObservableObject
     private bool _contactListShowFieldLabels;
 
     [ObservableProperty]
+    private bool _calendarListShowFieldLabels;
+
+    [ObservableProperty]
     private bool _confirmEmptyTrash;
 
     [ObservableProperty]
@@ -260,6 +263,7 @@ public partial class SettingsViewModel : ObservableObject
         AnnounceFormattingWhileNavigating = cfg.AnnounceFormattingWhileNavigating;
         AnnounceFlagStatus               = cfg.AnnounceFlagStatus;
         ContactListShowFieldLabels       = cfg.ContactListShowFieldLabels;
+        CalendarListShowFieldLabels      = cfg.CalendarListShowFieldLabels;
         ConfirmEmptyTrash                = cfg.ConfirmEmptyTrash;
         NotifyOnNewMail                  = cfg.NotifyOnNewMail;
         CloseToTray                      = cfg.CloseToTray;
@@ -328,6 +332,7 @@ public partial class SettingsViewModel : ObservableObject
         cfg.AnnounceFormattingWhileNavigating = AnnounceFormattingWhileNavigating;
         cfg.AnnounceFlagStatus               = AnnounceFlagStatus;
         cfg.ContactListShowFieldLabels       = ContactListShowFieldLabels;
+        cfg.CalendarListShowFieldLabels      = CalendarListShowFieldLabels;
         cfg.ConfirmEmptyTrash                = ConfirmEmptyTrash;
         cfg.NotifyOnNewMail                  = NotifyOnNewMail;
         cfg.CloseToTray                      = CloseToTray;

--- a/QuickMail/ViewModels/SettingsViewModel.cs
+++ b/QuickMail/ViewModels/SettingsViewModel.cs
@@ -12,6 +12,8 @@ namespace QuickMail.ViewModels;
 public partial class SettingsViewModel : ObservableObject
 {
     private readonly IConfigService _configService;
+    private readonly ICredentialService? _credentials;
+    private readonly ICalDavCalendarClient? _calDavClient;
 
     [ObservableProperty]
     private int _previewLines;
@@ -86,6 +88,31 @@ public partial class SettingsViewModel : ObservableObject
 
     [ObservableProperty]
     private int _calendarReminderMinutes = 10;
+
+    // ── CalDAV calendar source ─────────────────────────────────────────────────────
+
+    [ObservableProperty]
+    private string _calDavUrl = string.Empty;
+
+    [ObservableProperty]
+    private string _calDavUsername = string.Empty;
+
+    [ObservableProperty]
+    private string _calDavDisplayName = "iCloud";
+
+    /// <summary>
+    /// The app-specific password, pushed from the View's PasswordBox (PasswordChanged handler —
+    /// the AccountManager precedent; PasswordBox.Password is not bindable). Never persisted to
+    /// config: Save() writes it to Windows Credential Manager only. Empty = keep the saved one.
+    /// </summary>
+    internal string CalDavPassword { get; set; } = string.Empty;
+
+    /// <summary>Outcome text of the last Test run, shown next to the Test button.</summary>
+    [ObservableProperty]
+    private string _calDavTestResult = string.Empty;
+
+    /// <summary>Raised when a Test run finishes, so the View can announce the result.</summary>
+    public event Action<string>? CalDavTestCompleted;
 
     [ObservableProperty]
     private bool _confirmEmptyTrash;
@@ -221,9 +248,13 @@ public partial class SettingsViewModel : ObservableObject
         IConfigService configService,
         ICommandRegistry registry,
         IThemeService? themeService = null,
-        System.Collections.Generic.IEnumerable<string>? fontFamilies = null)
+        System.Collections.Generic.IEnumerable<string>? fontFamilies = null,
+        ICredentialService? credentialService = null,
+        ICalDavCalendarClient? calDavClient = null)
     {
         _configService = configService;
+        _credentials   = credentialService;
+        _calDavClient  = calDavClient;
         var cfg = configService.Load();
 
         // Appearance: themes from the service; installed fonts from the View
@@ -272,6 +303,9 @@ public partial class SettingsViewModel : ObservableObject
         CalendarListShowFieldLabels      = cfg.CalendarListShowFieldLabels;
         CalendarReminders                = cfg.CalendarReminders;
         CalendarReminderMinutes          = cfg.CalendarReminderMinutes;
+        CalDavUrl                        = cfg.CalDavUrl;
+        CalDavUsername                   = cfg.CalDavUsername;
+        CalDavDisplayName                = cfg.CalDavDisplayName;
         ConfirmEmptyTrash                = cfg.ConfirmEmptyTrash;
         NotifyOnNewMail                  = cfg.NotifyOnNewMail;
         CloseToTray                      = cfg.CloseToTray;
@@ -343,6 +377,14 @@ public partial class SettingsViewModel : ObservableObject
         cfg.CalendarListShowFieldLabels      = CalendarListShowFieldLabels;
         cfg.CalendarReminders                = CalendarReminders;
         cfg.CalendarReminderMinutes          = Math.Clamp(CalendarReminderMinutes, 1, 1440);
+        cfg.CalDavUrl         = CalDavUrl.Trim();
+        cfg.CalDavUsername    = CalDavUsername.Trim();
+        cfg.CalDavDisplayName = string.IsNullOrWhiteSpace(CalDavDisplayName) ? "iCloud" : CalDavDisplayName.Trim();
+        // The password goes ONLY to Windows Credential Manager (never config.ini/JSON), keyed by
+        // username. An empty box means "keep the saved password" so reopening Settings and saving
+        // does not wipe the credential.
+        if (_credentials != null && !string.IsNullOrEmpty(CalDavPassword) && !string.IsNullOrWhiteSpace(CalDavUsername))
+            _credentials.SaveSecret(CalDavCalendarClient.SecretKeyFor(CalDavUsername), CalDavPassword);
         cfg.ConfirmEmptyTrash                = ConfirmEmptyTrash;
         cfg.NotifyOnNewMail                  = NotifyOnNewMail;
         cfg.CloseToTray                      = CloseToTray;
@@ -400,6 +442,49 @@ public partial class SettingsViewModel : ObservableObject
     private static void ClearHotkey(HotkeyRowViewModel? row)
     {
         row?.ClearCustomBinding();
+    }
+
+    /// <summary>
+    /// Validates the CalDAV settings by running the real discovery sequence (principal →
+    /// calendar home → first event calendar) against the entered values. Uses the typed
+    /// password when present, otherwise the saved one, so Test works after reopening
+    /// Settings without retyping. Catches everything: a failure is a result message, and
+    /// the dialog may close while a request is in flight (the client is disposed with it).
+    /// </summary>
+    [RelayCommand]
+    private async Task TestCalDavAsync()
+    {
+        if (_calDavClient == null)
+        {
+            CalDavTestResult = "Connection test is not available here.";
+            CalDavTestCompleted?.Invoke(CalDavTestResult);
+            return;
+        }
+
+        var url  = CalDavUrl.Trim();
+        var user = CalDavUsername.Trim();
+        var password = !string.IsNullOrEmpty(CalDavPassword)
+            ? CalDavPassword
+            : _credentials?.GetSecret(CalDavCalendarClient.SecretKeyFor(user));
+
+        if (string.IsNullOrEmpty(url) || string.IsNullOrEmpty(user) || string.IsNullOrEmpty(password))
+        {
+            CalDavTestResult = "Enter the server address, username, and app-specific password first.";
+            CalDavTestCompleted?.Invoke(CalDavTestResult);
+            return;
+        }
+
+        CalDavTestResult = "Testing…";
+        try
+        {
+            var calendar = await _calDavClient.DiscoverCalendarAsync(url, user, password);
+            CalDavTestResult = $"Connected. Found calendar: {calendar.DisplayName}.";
+        }
+        catch (Exception ex)
+        {
+            CalDavTestResult = $"Could not connect. {ex.Message}";
+        }
+        CalDavTestCompleted?.Invoke(CalDavTestResult);
     }
 
     internal HotkeyRowViewModel? FindConflict(Key key, ModifierKeys modifiers)

--- a/QuickMail/Views/EventEditorWindow.xaml
+++ b/QuickMail/Views/EventEditorWindow.xaml
@@ -5,8 +5,8 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         mc:Ignorable="d"
         Title="{Binding WindowTitle}"
-        Height="530" Width="500"
-        MinHeight="440" MinWidth="380"
+        Height="560" Width="500"
+        MinHeight="460" MinWidth="380"
         WindowStartupLocation="CenterOwner"
         ResizeMode="CanResizeWithGrip"
         ShowInTaskbar="False"
@@ -29,6 +29,7 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
@@ -39,56 +40,77 @@
             <ColumnDefinition Width="Auto"/>
         </Grid.ColumnDefinitions>
 
+        <!-- Edit scope — shown only when editing one occurrence of a repeating series.
+             Radio group: one tab stop, arrows cycle. -->
+        <StackPanel Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="4"
+                    Orientation="Horizontal" Margin="0,0,0,10"
+                    Visibility="{Binding IsRecurringEdit, Converter={StaticResource BoolToVis}}"
+                    KeyboardNavigation.TabNavigation="Once"
+                    KeyboardNavigation.DirectionalNavigation="Cycle">
+            <TextBlock Text="Change:" Margin="0,0,8,0" VerticalAlignment="Center"/>
+            <RadioButton Content="This event only"
+                         GroupName="EditScope"
+                         AutomationProperties.Name="This event only"
+                         IsChecked="{Binding EditThisEventOnly}"
+                         Margin="0,0,12,0" VerticalAlignment="Center"/>
+            <RadioButton Content="All events in the series"
+                         GroupName="EditScope"
+                         AutomationProperties.Name="All events in the series"
+                         IsChecked="{Binding EditWholeSeries}"
+                         VerticalAlignment="Center"/>
+        </StackPanel>
+
         <!-- Title -->
-        <TextBlock Grid.Row="0" Grid.Column="0" Text="Title:" Margin="0,0,8,10" VerticalAlignment="Center"/>
-        <TextBox   Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="2"
+        <TextBlock Grid.Row="1" Grid.Column="0" Text="Title:" Margin="0,0,8,10" VerticalAlignment="Center"/>
+        <TextBox   Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="2"
                    x:Name="TitleBox"
                    AutomationProperties.Name="Title"
                    Text="{Binding Title, UpdateSourceTrigger=PropertyChanged}"
                    MaxLength="200" Margin="0,0,8,10"/>
-        <CheckBox  Grid.Row="0" Grid.Column="3"
+        <CheckBox  Grid.Row="1" Grid.Column="3"
                    Content="_All day"
                    AutomationProperties.Name="All day"
                    IsChecked="{Binding IsAllDay}"
                    VerticalAlignment="Center" Margin="0,0,0,10"/>
 
         <!-- Start -->
-        <TextBlock  Grid.Row="1" Grid.Column="0" Text="Starts:" Margin="0,0,8,10" VerticalAlignment="Center"/>
-        <DatePicker Grid.Row="1" Grid.Column="1"
+        <TextBlock  Grid.Row="2" Grid.Column="0" Text="Starts:" Margin="0,0,8,10" VerticalAlignment="Center"/>
+        <DatePicker Grid.Row="2" Grid.Column="1"
                     x:Name="StartDatePicker"
                     AutomationProperties.Name="Start date"
                     SelectedDate="{Binding StartDate}" Margin="0,0,8,10"/>
-        <TextBlock  Grid.Row="1" Grid.Column="2" Text="at" Margin="0,0,8,10" VerticalAlignment="Center"/>
-        <TextBox    Grid.Row="1" Grid.Column="3"
+        <TextBlock  Grid.Row="2" Grid.Column="2" Text="at" Margin="0,0,8,10" VerticalAlignment="Center"/>
+        <TextBox    Grid.Row="2" Grid.Column="3"
                     AutomationProperties.Name="Start time"
                     Text="{Binding StartTime, UpdateSourceTrigger=PropertyChanged}"
                     IsEnabled="{Binding HasTimes}"
                     MinWidth="90" MaxLength="20" Margin="0,0,0,10"/>
 
         <!-- End -->
-        <TextBlock  Grid.Row="2" Grid.Column="0" Text="Ends:" Margin="0,0,8,10" VerticalAlignment="Center"/>
-        <DatePicker Grid.Row="2" Grid.Column="1"
+        <TextBlock  Grid.Row="3" Grid.Column="0" Text="Ends:" Margin="0,0,8,10" VerticalAlignment="Center"/>
+        <DatePicker Grid.Row="3" Grid.Column="1"
                     x:Name="EndDatePicker"
                     AutomationProperties.Name="End date"
                     SelectedDate="{Binding EndDate}" Margin="0,0,8,10"/>
-        <TextBlock  Grid.Row="2" Grid.Column="2" Text="at" Margin="0,0,8,10" VerticalAlignment="Center"/>
-        <TextBox    Grid.Row="2" Grid.Column="3"
+        <TextBlock  Grid.Row="3" Grid.Column="2" Text="at" Margin="0,0,8,10" VerticalAlignment="Center"/>
+        <TextBox    Grid.Row="3" Grid.Column="3"
                     AutomationProperties.Name="End time"
                     Text="{Binding EndTime, UpdateSourceTrigger=PropertyChanged}"
                     IsEnabled="{Binding HasTimes}"
                     MinWidth="90" MaxLength="20" Margin="0,0,0,10"/>
 
         <!-- Location -->
-        <TextBlock Grid.Row="3" Grid.Column="0" Text="Location:" Margin="0,0,8,10" VerticalAlignment="Center"/>
-        <TextBox   Grid.Row="3" Grid.Column="1" Grid.ColumnSpan="3"
+        <TextBlock Grid.Row="4" Grid.Column="0" Text="Location:" Margin="0,0,8,10" VerticalAlignment="Center"/>
+        <TextBox   Grid.Row="4" Grid.Column="1" Grid.ColumnSpan="3"
                    AutomationProperties.Name="Location"
                    Text="{Binding Location, UpdateSourceTrigger=PropertyChanged}"
                    MaxLength="300" Margin="0,0,0,10"/>
 
         <!-- Repeat -->
-        <TextBlock Grid.Row="4" Grid.Column="0" Text="Repeat:" Margin="0,0,8,10" VerticalAlignment="Center"/>
-        <StackPanel Grid.Row="4" Grid.Column="1" Grid.ColumnSpan="3"
+        <TextBlock Grid.Row="5" Grid.Column="0" Text="Repeat:" Margin="0,0,8,10" VerticalAlignment="Center"/>
+        <StackPanel Grid.Row="5" Grid.Column="1" Grid.ColumnSpan="3"
                     Orientation="Horizontal" Margin="0,0,0,10"
+                    IsEnabled="{Binding CanEditRepeat}"
                     KeyboardNavigation.TabNavigation="Continue">
             <ComboBox AutomationProperties.Name="Repeat"
                       SelectedIndex="{Binding RepeatIndex}"
@@ -113,10 +135,11 @@
         </StackPanel>
 
         <!-- Weekly day picker — visible only when Repeat = Weekly. All unchecked = start day. -->
-        <TextBlock Grid.Row="5" Grid.Column="0" Text="On days:" Margin="0,0,8,10" VerticalAlignment="Center"
+        <TextBlock Grid.Row="6" Grid.Column="0" Text="On days:" Margin="0,0,8,10" VerticalAlignment="Center"
                    Visibility="{Binding IsWeekly, Converter={StaticResource BoolToVis}}"/>
-        <WrapPanel Grid.Row="5" Grid.Column="1" Grid.ColumnSpan="3" Margin="0,0,0,10"
+        <WrapPanel Grid.Row="6" Grid.Column="1" Grid.ColumnSpan="3" Margin="0,0,0,10"
                    Visibility="{Binding IsWeekly, Converter={StaticResource BoolToVis}}"
+                   IsEnabled="{Binding CanEditRepeat}"
                    KeyboardNavigation.TabNavigation="Continue"
                    KeyboardNavigation.DirectionalNavigation="Contained">
             <CheckBox Content="Sun" AutomationProperties.Name="Sunday"
@@ -136,11 +159,11 @@
         </WrapPanel>
 
         <!-- Notes label -->
-        <TextBlock Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="4"
+        <TextBlock Grid.Row="7" Grid.Column="0" Grid.ColumnSpan="4"
                    Text="Notes:" Margin="0,0,0,4"/>
 
         <!-- Notes body -->
-        <TextBox   Grid.Row="7" Grid.Column="0" Grid.ColumnSpan="4"
+        <TextBox   Grid.Row="8" Grid.Column="0" Grid.ColumnSpan="4"
                    x:Name="NotesBox"
                    AutomationProperties.Name="Notes"
                    Text="{Binding Notes, UpdateSourceTrigger=PropertyChanged}"
@@ -149,7 +172,7 @@
                    MinHeight="80" Margin="0,0,0,10"/>
 
         <!-- Buttons -->
-        <StackPanel Grid.Row="8" Grid.Column="0" Grid.ColumnSpan="4"
+        <StackPanel Grid.Row="9" Grid.Column="0" Grid.ColumnSpan="4"
                     Orientation="Horizontal" HorizontalAlignment="Right">
             <Button x:Name="SaveButton"
                     Content="_Save"

--- a/QuickMail/Views/EventEditorWindow.xaml
+++ b/QuickMail/Views/EventEditorWindow.xaml
@@ -40,6 +40,21 @@
             <ColumnDefinition Width="Auto"/>
         </Grid.ColumnDefinitions>
 
+        <!-- Save target — NEW appointments only, and only when a Graph account offers a second
+             calendar. Shares row 0 with the edit-scope radios below: edit-scope shows only while
+             editing, this only while creating, so the two are never visible together. Items are
+             plain strings so each ComboBox item announces its label (Selector accessibility rule). -->
+        <StackPanel Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="4"
+                    Orientation="Horizontal" Margin="0,0,0,10"
+                    Visibility="{Binding ShowSaveTarget, Converter={StaticResource BoolToVis}}">
+            <TextBlock Text="Calendar:" Margin="0,0,8,0" VerticalAlignment="Center"/>
+            <ComboBox x:Name="SaveTargetCombo"
+                      AutomationProperties.Name="Calendar"
+                      ItemsSource="{Binding SaveTargetLabels}"
+                      SelectedIndex="{Binding SelectedTargetIndex}"
+                      MinWidth="220" VerticalAlignment="Center"/>
+        </StackPanel>
+
         <!-- Edit scope — shown only when editing one occurrence of a repeating series.
              Radio group: one tab stop, arrows cycle. -->
         <StackPanel Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="4"
@@ -112,7 +127,8 @@
                     Orientation="Horizontal" Margin="0,0,0,10"
                     IsEnabled="{Binding CanEditRepeat}"
                     KeyboardNavigation.TabNavigation="Continue">
-            <ComboBox AutomationProperties.Name="Repeat"
+            <ComboBox x:Name="RepeatCombo"
+                      AutomationProperties.Name="Repeat"
                       SelectedIndex="{Binding RepeatIndex}"
                       MinWidth="130" VerticalAlignment="Center">
                 <ComboBoxItem>Does not repeat</ComboBoxItem>

--- a/QuickMail/Views/EventEditorWindow.xaml
+++ b/QuickMail/Views/EventEditorWindow.xaml
@@ -1,0 +1,143 @@
+<Window x:Class="QuickMail.Views.EventEditorWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        mc:Ignorable="d"
+        Title="{Binding WindowTitle}"
+        Height="530" Width="500"
+        MinHeight="440" MinWidth="380"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="CanResizeWithGrip"
+        ShowInTaskbar="False"
+        PreviewKeyDown="Window_PreviewKeyDown"
+        Background="{DynamicResource Theme.WindowBackground}"
+        Foreground="{DynamicResource Theme.TextPrimary}"
+        FontFamily="{DynamicResource Theme.FontFamily}"
+        FontSize="{DynamicResource Theme.FontSizeBase}">
+
+    <Window.Resources>
+        <BooleanToVisibilityConverter x:Key="BoolToVis"/>
+    </Window.Resources>
+
+    <Grid Margin="14">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto"/>
+            <ColumnDefinition Width="*"/>
+            <ColumnDefinition Width="Auto"/>
+            <ColumnDefinition Width="Auto"/>
+        </Grid.ColumnDefinitions>
+
+        <!-- Title -->
+        <TextBlock Grid.Row="0" Grid.Column="0" Text="Title:" Margin="0,0,8,10" VerticalAlignment="Center"/>
+        <TextBox   Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="2"
+                   x:Name="TitleBox"
+                   AutomationProperties.Name="Title"
+                   Text="{Binding Title, UpdateSourceTrigger=PropertyChanged}"
+                   MaxLength="200" Margin="0,0,8,10"/>
+        <CheckBox  Grid.Row="0" Grid.Column="3"
+                   Content="_All day"
+                   AutomationProperties.Name="All day"
+                   IsChecked="{Binding IsAllDay}"
+                   VerticalAlignment="Center" Margin="0,0,0,10"/>
+
+        <!-- Start -->
+        <TextBlock  Grid.Row="1" Grid.Column="0" Text="Starts:" Margin="0,0,8,10" VerticalAlignment="Center"/>
+        <DatePicker Grid.Row="1" Grid.Column="1"
+                    x:Name="StartDatePicker"
+                    AutomationProperties.Name="Start date"
+                    SelectedDate="{Binding StartDate}" Margin="0,0,8,10"/>
+        <TextBlock  Grid.Row="1" Grid.Column="2" Text="at" Margin="0,0,8,10" VerticalAlignment="Center"/>
+        <TextBox    Grid.Row="1" Grid.Column="3"
+                    AutomationProperties.Name="Start time"
+                    Text="{Binding StartTime, UpdateSourceTrigger=PropertyChanged}"
+                    IsEnabled="{Binding HasTimes}"
+                    MinWidth="90" MaxLength="20" Margin="0,0,0,10"/>
+
+        <!-- End -->
+        <TextBlock  Grid.Row="2" Grid.Column="0" Text="Ends:" Margin="0,0,8,10" VerticalAlignment="Center"/>
+        <DatePicker Grid.Row="2" Grid.Column="1"
+                    x:Name="EndDatePicker"
+                    AutomationProperties.Name="End date"
+                    SelectedDate="{Binding EndDate}" Margin="0,0,8,10"/>
+        <TextBlock  Grid.Row="2" Grid.Column="2" Text="at" Margin="0,0,8,10" VerticalAlignment="Center"/>
+        <TextBox    Grid.Row="2" Grid.Column="3"
+                    AutomationProperties.Name="End time"
+                    Text="{Binding EndTime, UpdateSourceTrigger=PropertyChanged}"
+                    IsEnabled="{Binding HasTimes}"
+                    MinWidth="90" MaxLength="20" Margin="0,0,0,10"/>
+
+        <!-- Location -->
+        <TextBlock Grid.Row="3" Grid.Column="0" Text="Location:" Margin="0,0,8,10" VerticalAlignment="Center"/>
+        <TextBox   Grid.Row="3" Grid.Column="1" Grid.ColumnSpan="3"
+                   AutomationProperties.Name="Location"
+                   Text="{Binding Location, UpdateSourceTrigger=PropertyChanged}"
+                   MaxLength="300" Margin="0,0,0,10"/>
+
+        <!-- Repeat -->
+        <TextBlock Grid.Row="4" Grid.Column="0" Text="Repeat:" Margin="0,0,8,10" VerticalAlignment="Center"/>
+        <StackPanel Grid.Row="4" Grid.Column="1" Grid.ColumnSpan="3"
+                    Orientation="Horizontal" Margin="0,0,0,10"
+                    KeyboardNavigation.TabNavigation="Continue">
+            <ComboBox AutomationProperties.Name="Repeat"
+                      SelectedIndex="{Binding RepeatIndex}"
+                      MinWidth="130" VerticalAlignment="Center">
+                <ComboBoxItem>Does not repeat</ComboBoxItem>
+                <ComboBoxItem>Daily</ComboBoxItem>
+                <ComboBoxItem>Weekly</ComboBoxItem>
+                <ComboBoxItem>Monthly</ComboBoxItem>
+                <ComboBoxItem>Yearly</ComboBoxItem>
+            </ComboBox>
+            <StackPanel Orientation="Horizontal" VerticalAlignment="Center"
+                        Visibility="{Binding HasRepeat, Converter={StaticResource BoolToVis}}">
+                <TextBlock Text="every" Margin="10,0,6,0" VerticalAlignment="Center"/>
+                <TextBox AutomationProperties.Name="Repeat interval"
+                         Text="{Binding RepeatInterval, UpdateSourceTrigger=PropertyChanged}"
+                         Width="42" VerticalAlignment="Center"/>
+                <TextBlock Text="{Binding RepeatUnitLabel}" Margin="6,0,10,0" VerticalAlignment="Center"/>
+                <TextBlock Text="until" Margin="0,0,6,0" VerticalAlignment="Center"/>
+                <DatePicker AutomationProperties.Name="Repeat until date"
+                            SelectedDate="{Binding RepeatUntil}" MinWidth="120"/>
+            </StackPanel>
+        </StackPanel>
+
+        <!-- Notes label -->
+        <TextBlock Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="4"
+                   Text="Notes:" Margin="0,0,0,4"/>
+
+        <!-- Notes body -->
+        <TextBox   Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="4"
+                   x:Name="NotesBox"
+                   AutomationProperties.Name="Notes"
+                   Text="{Binding Notes, UpdateSourceTrigger=PropertyChanged}"
+                   AcceptsReturn="True" TextWrapping="Wrap"
+                   VerticalScrollBarVisibility="Auto"
+                   MinHeight="80" Margin="0,0,0,10"/>
+
+        <!-- Buttons -->
+        <StackPanel Grid.Row="7" Grid.Column="0" Grid.ColumnSpan="4"
+                    Orientation="Horizontal" HorizontalAlignment="Right">
+            <Button x:Name="SaveButton"
+                    Content="_Save"
+                    IsDefault="True"
+                    AutomationProperties.Name="Save appointment"
+                    MinWidth="90"
+                    Click="Save_Click"/>
+            <Button Content="Cancel"
+                    IsCancel="True"
+                    AutomationProperties.Name="Cancel"
+                    MinWidth="90" Margin="8,0,0,0"
+                    Click="Cancel_Click"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/QuickMail/Views/EventEditorWindow.xaml
+++ b/QuickMail/Views/EventEditorWindow.xaml
@@ -28,6 +28,7 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
@@ -111,12 +112,35 @@
             </StackPanel>
         </StackPanel>
 
+        <!-- Weekly day picker — visible only when Repeat = Weekly. All unchecked = start day. -->
+        <TextBlock Grid.Row="5" Grid.Column="0" Text="On days:" Margin="0,0,8,10" VerticalAlignment="Center"
+                   Visibility="{Binding IsWeekly, Converter={StaticResource BoolToVis}}"/>
+        <WrapPanel Grid.Row="5" Grid.Column="1" Grid.ColumnSpan="3" Margin="0,0,0,10"
+                   Visibility="{Binding IsWeekly, Converter={StaticResource BoolToVis}}"
+                   KeyboardNavigation.TabNavigation="Continue"
+                   KeyboardNavigation.DirectionalNavigation="Contained">
+            <CheckBox Content="Sun" AutomationProperties.Name="Sunday"
+                      IsChecked="{Binding RepeatOnSunday}" Margin="0,0,8,4"/>
+            <CheckBox Content="Mon" AutomationProperties.Name="Monday"
+                      IsChecked="{Binding RepeatOnMonday}" Margin="0,0,8,4"/>
+            <CheckBox Content="Tue" AutomationProperties.Name="Tuesday"
+                      IsChecked="{Binding RepeatOnTuesday}" Margin="0,0,8,4"/>
+            <CheckBox Content="Wed" AutomationProperties.Name="Wednesday"
+                      IsChecked="{Binding RepeatOnWednesday}" Margin="0,0,8,4"/>
+            <CheckBox Content="Thu" AutomationProperties.Name="Thursday"
+                      IsChecked="{Binding RepeatOnThursday}" Margin="0,0,8,4"/>
+            <CheckBox Content="Fri" AutomationProperties.Name="Friday"
+                      IsChecked="{Binding RepeatOnFriday}" Margin="0,0,8,4"/>
+            <CheckBox Content="Sat" AutomationProperties.Name="Saturday"
+                      IsChecked="{Binding RepeatOnSaturday}" Margin="0,0,8,4"/>
+        </WrapPanel>
+
         <!-- Notes label -->
-        <TextBlock Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="4"
+        <TextBlock Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="4"
                    Text="Notes:" Margin="0,0,0,4"/>
 
         <!-- Notes body -->
-        <TextBox   Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="4"
+        <TextBox   Grid.Row="7" Grid.Column="0" Grid.ColumnSpan="4"
                    x:Name="NotesBox"
                    AutomationProperties.Name="Notes"
                    Text="{Binding Notes, UpdateSourceTrigger=PropertyChanged}"
@@ -125,7 +149,7 @@
                    MinHeight="80" Margin="0,0,0,10"/>
 
         <!-- Buttons -->
-        <StackPanel Grid.Row="7" Grid.Column="0" Grid.ColumnSpan="4"
+        <StackPanel Grid.Row="8" Grid.Column="0" Grid.ColumnSpan="4"
                     Orientation="Horizontal" HorizontalAlignment="Right">
             <Button x:Name="SaveButton"
                     Content="_Save"

--- a/QuickMail/Views/EventEditorWindow.xaml.cs
+++ b/QuickMail/Views/EventEditorWindow.xaml.cs
@@ -85,8 +85,10 @@ public partial class EventEditorWindow : Window
             return;
         }
 
-        // Escape — cancel. Let an open DatePicker calendar consume Escape itself first.
-        if (e.Key == Key.Escape && !StartDatePicker.IsDropDownOpen && !EndDatePicker.IsDropDownOpen)
+        // Escape — cancel. Let an open DatePicker calendar or ComboBox dropdown consume
+        // Escape itself first (per the modeless-dialog Escape guard in CLAUDE.md).
+        if (e.Key == Key.Escape && !StartDatePicker.IsDropDownOpen && !EndDatePicker.IsDropDownOpen
+            && !RepeatCombo.IsDropDownOpen && !SaveTargetCombo.IsDropDownOpen)
         {
             e.Handled = true;
             _vm.CancelCommand.Execute(null);

--- a/QuickMail/Views/EventEditorWindow.xaml.cs
+++ b/QuickMail/Views/EventEditorWindow.xaml.cs
@@ -36,7 +36,10 @@ public partial class EventEditorWindow : Window
             TitleBox.Focus();
             TitleBox.SelectAll();
             AccessibilityHelper.Announce(this,
-                "Tab through the fields. Press Control plus Enter to save, Escape to cancel.",
+                vm.IsRecurringEdit
+                    ? "This is a repeating event. Choose what to change: this event only, or all events " +
+                      "in the series. Tab through the fields. Press Control plus Enter to save, Escape to cancel."
+                    : "Tab through the fields. Press Control plus Enter to save, Escape to cancel.",
                 category: AnnouncementCategory.Hint);
         };
     }

--- a/QuickMail/Views/EventEditorWindow.xaml.cs
+++ b/QuickMail/Views/EventEditorWindow.xaml.cs
@@ -69,15 +69,7 @@ public partial class EventEditorWindow : Window
             return;
         }
 
-        // Ctrl+Enter — save from anywhere, including the multi-line Notes box.
-        if (e.Key == Key.Enter && Keyboard.Modifiers == ModifierKeys.Control)
-        {
-            e.Handled = true;
-            _vm.SaveCommand.Execute(null);
-            return;
-        }
-
-        // F6 / Shift+F6 — cycle the logical field groups.
+        // F6 / Shift+F6 — cycle the logical field groups (framework-level, like the palette).
         if (e.Key == Key.F6)
         {
             e.Handled = true;
@@ -85,13 +77,21 @@ public partial class EventEditorWindow : Window
             return;
         }
 
-        // Escape — cancel. Let an open DatePicker calendar or ComboBox dropdown consume
-        // Escape itself first (per the modeless-dialog Escape guard in CLAUDE.md).
-        if (e.Key == Key.Escape && !StartDatePicker.IsDropDownOpen && !EndDatePicker.IsDropDownOpen
-            && !RepeatCombo.IsDropDownOpen && !SaveTargetCombo.IsDropDownOpen)
+        // Escape while a DatePicker calendar or ComboBox dropdown is open: let the control
+        // consume it (the modeless-dialog Escape guard in CLAUDE.md).
+        if (e.Key == Key.Escape
+            && (StartDatePicker.IsDropDownOpen || EndDatePicker.IsDropDownOpen
+                || RepeatCombo.IsDropDownOpen || SaveTargetCombo.IsDropDownOpen))
+            return;
+
+        // Registry dispatch (ComposeWindow pattern) — so editor.save / editor.cancel rebindings
+        // in the keyboard customizations dialog actually take effect.
+        var key = e.Key == Key.System ? e.SystemKey : e.Key;
+        var cmd = _registry.FindByGesture(key, Keyboard.Modifiers);
+        if (cmd != null && (cmd.IsAvailable?.Invoke() ?? true))
         {
             e.Handled = true;
-            _vm.CancelCommand.Execute(null);
+            cmd.Execute();
         }
     }
 

--- a/QuickMail/Views/EventEditorWindow.xaml.cs
+++ b/QuickMail/Views/EventEditorWindow.xaml.cs
@@ -1,0 +1,104 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using QuickMail.Models;
+using QuickMail.Services;
+using QuickMail.ViewModels;
+
+namespace QuickMail.Views;
+
+/// <summary>
+/// Modeless editor for a locally-created calendar appointment. Modeless per the CLAUDE.md modal
+/// rules — an editable-text dialog opened over the main window's live WebView2 reading pane must
+/// not use <c>ShowDialog()</c>. Escape / Cancel / Ctrl+Enter and the command palette are wired
+/// explicitly because a modeless window has no <c>DialogResult</c>.
+/// </summary>
+public partial class EventEditorWindow : Window
+{
+    private readonly EventEditorViewModel _vm;
+    private readonly CommandRegistry _registry = new();
+
+    public EventEditorWindow(EventEditorViewModel vm)
+    {
+        _vm = vm;
+        DataContext = vm;
+        InitializeComponent();
+
+        _vm.Saved += _ => Close();
+        _vm.Cancelled += Close;
+        _vm.AnnouncementRequested += (text, category) =>
+            AccessibilityHelper.Announce(this, text, category: category);
+
+        RegisterPaletteCommands();
+
+        Loaded += (_, _) =>
+        {
+            TitleBox.Focus();
+            TitleBox.SelectAll();
+            AccessibilityHelper.Announce(this,
+                "Tab through the fields. Press Control plus Enter to save, Escape to cancel.",
+                category: AnnouncementCategory.Hint);
+        };
+    }
+
+    private void RegisterPaletteCommands()
+    {
+        _registry.Register(new CommandDefinition(
+            id: "editor.save", category: "Calendar", title: "Save appointment",
+            execute: () => _vm.SaveCommand.Execute(null),
+            defaultKey: Key.Enter, defaultModifiers: ModifierKeys.Control));
+        _registry.Register(new CommandDefinition(
+            id: "editor.cancel", category: "Calendar", title: "Cancel",
+            execute: () => _vm.CancelCommand.Execute(null),
+            defaultKey: Key.Escape, defaultModifiers: ModifierKeys.None));
+    }
+
+    private void Save_Click(object sender, RoutedEventArgs e) => _vm.SaveCommand.Execute(null);
+    private void Cancel_Click(object sender, RoutedEventArgs e) => _vm.CancelCommand.Execute(null);
+
+    private void Window_PreviewKeyDown(object sender, KeyEventArgs e)
+    {
+        // Ctrl+Shift+P — command palette (framework-level; cannot dispatch through itself).
+        if (e.Key == Key.P && Keyboard.Modifiers == (ModifierKeys.Control | ModifierKeys.Shift))
+        {
+            e.Handled = true;
+            new CommandPaletteWindow(_registry) { Owner = this }.ShowDialog();
+            return;
+        }
+
+        // Ctrl+Enter — save from anywhere, including the multi-line Notes box.
+        if (e.Key == Key.Enter && Keyboard.Modifiers == ModifierKeys.Control)
+        {
+            e.Handled = true;
+            _vm.SaveCommand.Execute(null);
+            return;
+        }
+
+        // F6 / Shift+F6 — cycle the logical field groups.
+        if (e.Key == Key.F6)
+        {
+            e.Handled = true;
+            CycleFocus(forward: Keyboard.Modifiers != ModifierKeys.Shift);
+            return;
+        }
+
+        // Escape — cancel. Let an open DatePicker calendar consume Escape itself first.
+        if (e.Key == Key.Escape && !StartDatePicker.IsDropDownOpen && !EndDatePicker.IsDropDownOpen)
+        {
+            e.Handled = true;
+            _vm.CancelCommand.Execute(null);
+        }
+    }
+
+    /// <summary>Cycles focus across the editor's logical stops: Title → Start → Notes → Save.</summary>
+    private void CycleFocus(bool forward)
+    {
+        Control[] stops = { TitleBox, StartDatePicker, NotesBox, SaveButton };
+        var current = System.Array.FindIndex(stops, c => c.IsKeyboardFocusWithin);
+        if (current < 0) current = 0;
+        var next = forward
+            ? (current + 1) % stops.Length
+            : (current - 1 + stops.Length) % stops.Length;
+        stops[next].Focus();
+    }
+}

--- a/QuickMail/Views/MainWindow.xaml
+++ b/QuickMail/Views/MainWindow.xaml
@@ -1291,6 +1291,8 @@
                                  AutomationProperties.Name="Appointment details"
                                  Text="{Binding CalendarVm.SelectedEventDetail, Mode=OneWay}"
                                  IsReadOnly="True"
+                                 IsReadOnlyCaretVisible="True"
+                                 TextChanged="CalendarDetails_TextChanged"
                                  TabIndex="4"
                                  TextWrapping="Wrap"
                                  AcceptsReturn="True"

--- a/QuickMail/Views/MainWindow.xaml
+++ b/QuickMail/Views/MainWindow.xaml
@@ -394,6 +394,11 @@
                               IsCheckable="True"
                               IsChecked="{Binding CalendarVm.IsWeekView, Mode=OneWay}"
                               Command="{Binding CalendarVm.ShowWeekCommand}"/>
+                    <MenuItem Header="M_onth"
+                              Visibility="{Binding IsCalendarView, Converter={StaticResource BoolToVisibilityConverter}}"
+                              IsCheckable="True"
+                              IsChecked="{Binding CalendarVm.IsMonthView, Mode=OneWay}"
+                              Command="{Binding CalendarVm.ShowMonthCommand}"/>
                 </MenuItem>
                 <MenuItem Header="F_ilter">
                     <MenuItem Header="S_how All"
@@ -1162,7 +1167,9 @@
                             <Button Content="_Day" AutomationProperties.Name="Day view"
                                     MinWidth="52" Margin="0,0,4,0" Click="CalendarDay_Click"/>
                             <Button Content="_Week" AutomationProperties.Name="Week view"
-                                    MinWidth="56" Margin="0,0,12,0" Click="CalendarWeek_Click"/>
+                                    MinWidth="56" Margin="0,0,4,0" Click="CalendarWeek_Click"/>
+                            <Button Content="_Month" AutomationProperties.Name="Month view"
+                                    MinWidth="56" Margin="0,0,12,0" Click="CalendarMonth_Click"/>
                             <Button Content="◀" AutomationProperties.Name="Previous period"
                                     MinWidth="32" Margin="0,0,4,0" Click="CalendarPrev_Click"/>
                             <Button Content="Today" AutomationProperties.Name="Go to today"
@@ -1195,9 +1202,53 @@
                             </StackPanel>
                         </DockPanel>
 
+                        <!-- Month grid — a 7-column day grid shown instead of the event list in
+                             Month view. Arrows move spatially (left/right = day, up/down = week);
+                             Enter drills into that day. Each cell speaks "Tuesday June 9, 3 events". -->
+                        <ListBox x:Name="MonthGrid"
+                                 Grid.Row="2"
+                                 AutomationProperties.Name="Month grid"
+                                 Visibility="{Binding CalendarVm.IsMonthView, Converter={StaticResource BoolToVisibilityConverter}}"
+                                 ItemsSource="{Binding CalendarVm.MonthCells}"
+                                 SelectedItem="{Binding CalendarVm.SelectedMonthCell, Mode=TwoWay}"
+                                 BorderThickness="0"
+                                 KeyboardNavigation.TabNavigation="Once"
+                                 KeyboardNavigation.DirectionalNavigation="Contained"
+                                 ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                                 ScrollViewer.VerticalScrollBarVisibility="Disabled"
+                                 PreviewKeyDown="MonthGrid_PreviewKeyDown">
+                            <ListBox.ItemsPanel>
+                                <ItemsPanelTemplate>
+                                    <UniformGrid Columns="7"/>
+                                </ItemsPanelTemplate>
+                            </ListBox.ItemsPanel>
+                            <ListBox.ItemContainerStyle>
+                                <Style TargetType="ListBoxItem" BasedOn="{StaticResource {x:Type ListBoxItem}}">
+                                    <Setter Property="AutomationProperties.Name" Value="{Binding AccessibleName}"/>
+                                    <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+                                </Style>
+                            </ListBox.ItemContainerStyle>
+                            <ListBox.ItemTemplate>
+                                <DataTemplate>
+                                    <TextBlock Text="{Binding CellText}" Padding="6,8" TextAlignment="Center">
+                                        <TextBlock.Style>
+                                            <Style TargetType="TextBlock">
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding IsInMonth}" Value="False">
+                                                        <Setter Property="Opacity" Value="0.45"/>
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </TextBlock.Style>
+                                    </TextBlock>
+                                </DataTemplate>
+                            </ListBox.ItemTemplate>
+                        </ListBox>
+
                         <ListView x:Name="CalendarList"
                                   Grid.Row="2"
                                   AutomationProperties.Name="Calendar events"
+                                  Visibility="{Binding CalendarVm.IsListView, Converter={StaticResource BoolToVisibilityConverter}}"
                                   ItemsSource="{Binding CalendarVm.Events}"
                                   SelectedItem="{Binding CalendarVm.SelectedEvent, Mode=TwoWay}"
                                   BorderThickness="0"

--- a/QuickMail/Views/MainWindow.xaml
+++ b/QuickMail/Views/MainWindow.xaml
@@ -353,26 +353,47 @@
                           InputGestureText="Ctrl+Shift+H"/>
                 <Separator/>
                 <MenuItem Header="View _Mode">
+                    <!-- Mail view modes — hidden while the calendar is open. -->
                     <MenuItem Header="_Messages"
+                              Visibility="{Binding IsCalendarView, Converter={StaticResource InverseBoolToVisibilityConverter}}"
                               IsCheckable="True"
                               IsChecked="{Binding IsMessagesView, Mode=OneWay}"
                               Command="{Binding SetViewModeCommand}"
                               CommandParameter="Messages"/>
                     <MenuItem Header="_Conversations"
+                              Visibility="{Binding IsCalendarView, Converter={StaticResource InverseBoolToVisibilityConverter}}"
                               IsCheckable="True"
                               IsChecked="{Binding IsConversationsView, Mode=OneWay}"
                               Command="{Binding SetViewModeCommand}"
                               CommandParameter="Conversations"/>
                     <MenuItem Header="By _Sender"
+                              Visibility="{Binding IsCalendarView, Converter={StaticResource InverseBoolToVisibilityConverter}}"
                               IsCheckable="True"
                               IsChecked="{Binding IsFromView, Mode=OneWay}"
                               Command="{Binding SetViewModeCommand}"
                               CommandParameter="From"/>
                     <MenuItem Header="By _Recipient"
+                              Visibility="{Binding IsCalendarView, Converter={StaticResource InverseBoolToVisibilityConverter}}"
                               IsCheckable="True"
                               IsChecked="{Binding IsToView, Mode=OneWay}"
                               Command="{Binding SetViewModeCommand}"
                               CommandParameter="To"/>
+                    <!-- Calendar view modes — shown only while the calendar is open. -->
+                    <MenuItem Header="_Agenda"
+                              Visibility="{Binding IsCalendarView, Converter={StaticResource BoolToVisibilityConverter}}"
+                              IsCheckable="True"
+                              IsChecked="{Binding CalendarVm.IsAgendaView, Mode=OneWay}"
+                              Command="{Binding CalendarVm.ShowAgendaCommand}"/>
+                    <MenuItem Header="_Day"
+                              Visibility="{Binding IsCalendarView, Converter={StaticResource BoolToVisibilityConverter}}"
+                              IsCheckable="True"
+                              IsChecked="{Binding CalendarVm.IsDayView, Mode=OneWay}"
+                              Command="{Binding CalendarVm.ShowDayCommand}"/>
+                    <MenuItem Header="_Week"
+                              Visibility="{Binding IsCalendarView, Converter={StaticResource BoolToVisibilityConverter}}"
+                              IsCheckable="True"
+                              IsChecked="{Binding CalendarVm.IsWeekView, Mode=OneWay}"
+                              Command="{Binding CalendarVm.ShowWeekCommand}"/>
                 </MenuItem>
                 <MenuItem Header="F_ilter">
                     <MenuItem Header="S_how All"
@@ -660,25 +681,44 @@
                     <ContextMenu AutomationProperties.Name="View mode"
                                  DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
                         <MenuItem Header="_Messages"
+                                  Visibility="{Binding IsCalendarView, Converter={StaticResource InverseBoolToVisibilityConverter}}"
                                   IsCheckable="True"
                                   IsChecked="{Binding IsMessagesView, Mode=OneWay}"
                                   Command="{Binding SetViewModeCommand}"
                                   CommandParameter="Messages"/>
                         <MenuItem Header="_Conversations"
+                                  Visibility="{Binding IsCalendarView, Converter={StaticResource InverseBoolToVisibilityConverter}}"
                                   IsCheckable="True"
                                   IsChecked="{Binding IsConversationsView, Mode=OneWay}"
                                   Command="{Binding SetViewModeCommand}"
                                   CommandParameter="Conversations"/>
                         <MenuItem Header="_From"
+                                  Visibility="{Binding IsCalendarView, Converter={StaticResource InverseBoolToVisibilityConverter}}"
                                   IsCheckable="True"
                                   IsChecked="{Binding IsFromView, Mode=OneWay}"
                                   Command="{Binding SetViewModeCommand}"
                                   CommandParameter="From"/>
                         <MenuItem Header="_To"
+                                  Visibility="{Binding IsCalendarView, Converter={StaticResource InverseBoolToVisibilityConverter}}"
                                   IsCheckable="True"
                                   IsChecked="{Binding IsToView, Mode=OneWay}"
                                   Command="{Binding SetViewModeCommand}"
                                   CommandParameter="To"/>
+                        <MenuItem Header="_Agenda"
+                                  Visibility="{Binding IsCalendarView, Converter={StaticResource BoolToVisibilityConverter}}"
+                                  IsCheckable="True"
+                                  IsChecked="{Binding CalendarVm.IsAgendaView, Mode=OneWay}"
+                                  Command="{Binding CalendarVm.ShowAgendaCommand}"/>
+                        <MenuItem Header="_Day"
+                                  Visibility="{Binding IsCalendarView, Converter={StaticResource BoolToVisibilityConverter}}"
+                                  IsCheckable="True"
+                                  IsChecked="{Binding CalendarVm.IsDayView, Mode=OneWay}"
+                                  Command="{Binding CalendarVm.ShowDayCommand}"/>
+                        <MenuItem Header="_Week"
+                                  Visibility="{Binding IsCalendarView, Converter={StaticResource BoolToVisibilityConverter}}"
+                                  IsCheckable="True"
+                                  IsChecked="{Binding CalendarVm.IsWeekView, Mode=OneWay}"
+                                  Command="{Binding CalendarVm.ShowWeekCommand}"/>
                     </ContextMenu>
                 </Button.ContextMenu>
             </Button>
@@ -1099,40 +1139,107 @@
                     <!-- Standard list view and conversation tree occupy the same space;
                          only one is visible at a time based on ViewMode. -->
                     <Grid>
-                    <!-- Calendar event list — shown in place of the message list when the
-                         Calendar virtual folder is selected. Behaves like the flat message
-                         list: Up/Down to browse, Enter to open the source invite, T to
-                         filter to today, F5 to refresh, Escape to return to the folder tree. -->
-                    <ListBox x:Name="CalendarList"
-                             AutomationProperties.Name="Calendar events"
-                             Visibility="{Binding IsCalendarView, Converter={StaticResource BoolToVisibilityConverter}}"
-                             ItemsSource="{Binding CalendarVm.Events}"
-                             SelectedItem="{Binding CalendarVm.SelectedEvent, Mode=TwoWay}"
-                             BorderThickness="0"
-                             TabIndex="3"
-                             KeyboardNavigation.TabNavigation="Once"
-                             KeyboardNavigation.DirectionalNavigation="Contained"
-                             VirtualizingPanel.IsVirtualizing="True"
-                             VirtualizingPanel.VirtualizationMode="Recycling"
-                             ScrollViewer.HorizontalScrollBarVisibility="Disabled"
-                             ScrollViewer.VerticalScrollBarVisibility="Auto"
-                             GotKeyboardFocus="CalendarList_GotKeyboardFocus"
-                             PreviewKeyDown="CalendarList_PreviewKeyDown">
-                        <ListBox.ItemContainerStyle>
-                            <Style TargetType="ListBoxItem" BasedOn="{StaticResource {x:Type ListBoxItem}}">
-                                <Setter Property="AutomationProperties.Name" Value="{Binding DisplayLine}"/>
-                                <Setter Property="Padding" Value="8,4"/>
-                            </Style>
-                        </ListBox.ItemContainerStyle>
-                        <ListBox.ItemTemplate>
-                            <DataTemplate>
-                                <StackPanel>
-                                    <TextBlock Text="{Binding Summary}" FontWeight="SemiBold" TextTrimming="CharacterEllipsis"/>
-                                    <TextBlock Text="{Binding DisplayLine}" FontSize="{DynamicResource Theme.FontSizeSmall}" Opacity="0.75" TextTrimming="CharacterEllipsis"/>
-                                </StackPanel>
-                            </DataTemplate>
-                        </ListBox.ItemTemplate>
-                    </ListBox>
+                    <!-- Calendar (master/detail) — shown in place of the message list when the
+                         Calendar virtual folder is selected. A columned event list (Subject /
+                         When / Status) on top, a read-only Details pane below. Up/Down to browse,
+                         Enter to open (edit an appointment, or the source invite), N new, E edit,
+                         Delete to remove, T today, F5 refresh, Escape to return to the folder tree. -->
+                    <Grid Visibility="{Binding IsCalendarView, Converter={StaticResource BoolToVisibilityConverter}}">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="2*"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="1*"/>
+                        </Grid.RowDefinitions>
+
+                        <!-- View switch + period navigation. Arrows stay within the group. -->
+                        <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="6,4,6,0"
+                                    KeyboardNavigation.TabNavigation="Continue"
+                                    KeyboardNavigation.DirectionalNavigation="Contained">
+                            <Button Content="_Agenda" AutomationProperties.Name="Agenda view"
+                                    MinWidth="64" Margin="0,0,4,0" Click="CalendarAgenda_Click"/>
+                            <Button Content="_Day" AutomationProperties.Name="Day view"
+                                    MinWidth="52" Margin="0,0,4,0" Click="CalendarDay_Click"/>
+                            <Button Content="_Week" AutomationProperties.Name="Week view"
+                                    MinWidth="56" Margin="0,0,12,0" Click="CalendarWeek_Click"/>
+                            <Button Content="◀" AutomationProperties.Name="Previous period"
+                                    MinWidth="32" Margin="0,0,4,0" Click="CalendarPrev_Click"/>
+                            <Button Content="Today" AutomationProperties.Name="Go to today"
+                                    MinWidth="56" Margin="0,0,4,0" Click="CalendarToday_Click"/>
+                            <Button Content="▶" AutomationProperties.Name="Next period"
+                                    MinWidth="32" Click="CalendarNext_Click"/>
+                        </StackPanel>
+
+                        <!-- Period label + item toolbar -->
+                        <DockPanel Grid.Row="1" Margin="6,4" LastChildFill="False">
+                            <TextBlock DockPanel.Dock="Left"
+                                       Text="{Binding CalendarVm.PeriodLabel}"
+                                       FontWeight="SemiBold" VerticalAlignment="Center"/>
+                            <StackPanel DockPanel.Dock="Right" Orientation="Horizontal"
+                                        KeyboardNavigation.TabNavigation="Continue"
+                                        KeyboardNavigation.DirectionalNavigation="Contained">
+                                <Button Content="_New" AutomationProperties.Name="New appointment"
+                                        MinWidth="64" Margin="0,0,6,0" Click="CalendarNew_Click"/>
+                                <Button Content="_Edit" AutomationProperties.Name="Edit appointment"
+                                        MinWidth="64" Margin="0,0,6,0" Click="CalendarEdit_Click"/>
+                                <Button Content="De_lete" AutomationProperties.Name="Delete appointment"
+                                        MinWidth="64" Click="CalendarDelete_Click"/>
+                            </StackPanel>
+                        </DockPanel>
+
+                        <ListView x:Name="CalendarList"
+                                  Grid.Row="2"
+                                  AutomationProperties.Name="Calendar events"
+                                  ItemsSource="{Binding CalendarVm.Events}"
+                                  SelectedItem="{Binding CalendarVm.SelectedEvent, Mode=TwoWay}"
+                                  BorderThickness="0"
+                                  TabIndex="3"
+                                  KeyboardNavigation.TabNavigation="Once"
+                                  KeyboardNavigation.DirectionalNavigation="Contained"
+                                  VirtualizingPanel.IsVirtualizing="True"
+                                  VirtualizingPanel.VirtualizationMode="Recycling"
+                                  ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                                  ScrollViewer.VerticalScrollBarVisibility="Auto"
+                                  GotKeyboardFocus="CalendarList_GotKeyboardFocus"
+                                  PreviewKeyDown="CalendarList_PreviewKeyDown">
+                            <ListView.ItemContainerStyle>
+                                <Style TargetType="ListViewItem" BasedOn="{StaticResource {x:Type ListViewItem}}">
+                                    <!-- Row name = the stamped accessible name (data-only or field-labeled
+                                         per the CalendarListShowFieldLabels setting); the visual columns
+                                         aid sighted users. -->
+                                    <Setter Property="AutomationProperties.Name" Value="{Binding AccessibleName}"/>
+                                </Style>
+                            </ListView.ItemContainerStyle>
+                            <ListView.View>
+                                <GridView>
+                                    <GridViewColumn Header="Subject" Width="260"
+                                                    DisplayMemberBinding="{Binding Summary}"/>
+                                    <GridViewColumn Header="When" Width="170"
+                                                    DisplayMemberBinding="{Binding WhenText}"/>
+                                    <GridViewColumn Header="Status" Width="110"
+                                                    DisplayMemberBinding="{Binding StatusText}"/>
+                                </GridView>
+                            </ListView.View>
+                        </ListView>
+
+                        <GridSplitter Grid.Row="3" Height="4" HorizontalAlignment="Stretch"
+                                      ResizeBehavior="PreviousAndNext" ResizeDirection="Rows"
+                                      IsTabStop="False"
+                                      Background="{DynamicResource Theme.Border}"/>
+
+                        <TextBox x:Name="CalendarDetails"
+                                 Grid.Row="4"
+                                 AutomationProperties.Name="Appointment details"
+                                 Text="{Binding CalendarVm.SelectedEventDetail, Mode=OneWay}"
+                                 IsReadOnly="True"
+                                 TabIndex="4"
+                                 TextWrapping="Wrap"
+                                 AcceptsReturn="True"
+                                 VerticalScrollBarVisibility="Auto"
+                                 BorderThickness="0"
+                                 Margin="4"/>
+                    </Grid>
 
                     <ListView x:Name="MessageList"
                               AutomationProperties.Name="Messages"

--- a/QuickMail/Views/MainWindow.xaml
+++ b/QuickMail/Views/MainWindow.xaml
@@ -1215,8 +1215,7 @@
                                  KeyboardNavigation.TabNavigation="Once"
                                  KeyboardNavigation.DirectionalNavigation="Contained"
                                  ScrollViewer.HorizontalScrollBarVisibility="Disabled"
-                                 ScrollViewer.VerticalScrollBarVisibility="Disabled"
-                                 PreviewKeyDown="MonthGrid_PreviewKeyDown">
+                                 ScrollViewer.VerticalScrollBarVisibility="Disabled">
                             <ListBox.ItemsPanel>
                                 <ItemsPanelTemplate>
                                     <UniformGrid Columns="7"/>

--- a/QuickMail/Views/MainWindow.xaml
+++ b/QuickMail/Views/MainWindow.xaml
@@ -1171,11 +1171,18 @@
                                     MinWidth="32" Click="CalendarNext_Click"/>
                         </StackPanel>
 
-                        <!-- Period label + item toolbar -->
+                        <!-- Period label + search + item toolbar -->
                         <DockPanel Grid.Row="1" Margin="6,4" LastChildFill="False">
                             <TextBlock DockPanel.Dock="Left"
                                        Text="{Binding CalendarVm.PeriodLabel}"
                                        FontWeight="SemiBold" VerticalAlignment="Center"/>
+                            <TextBox x:Name="CalendarSearchBox"
+                                     DockPanel.Dock="Left"
+                                     AutomationProperties.Name="Search appointments"
+                                     Text="{Binding CalendarVm.SearchText, UpdateSourceTrigger=PropertyChanged}"
+                                     Visibility="{Binding CalendarVm.IsSearchActive, Converter={StaticResource BoolToVisibilityConverter}}"
+                                     MinWidth="160" Margin="12,0,0,0" VerticalAlignment="Center"
+                                     PreviewKeyDown="CalendarSearchBox_PreviewKeyDown"/>
                             <StackPanel DockPanel.Dock="Right" Orientation="Horizontal"
                                         KeyboardNavigation.TabNavigation="Continue"
                                         KeyboardNavigation.DirectionalNavigation="Contained">

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -1183,7 +1183,7 @@ public partial class MainWindow : Window
             id: "calendar.toggleTodayFilter", category: "View", title: "Toggle Today Filter",
             execute: () => _vm.CalendarVm?.ToggleTodayFilterCommand.Execute(null),
             defaultKey: Key.T, defaultModifiers: ModifierKeys.None,
-            isAvailable: () => CalendarList.IsKeyboardFocusWithin));
+            isAvailable: () => CalendarPaneFocused));
 
         _registry.Register(new CommandDefinition(
             id: "calendar.openSourceMessage", category: "View", title: "Open Calendar Event Source Message",
@@ -1196,7 +1196,7 @@ public partial class MainWindow : Window
             id: "calendar.newEvent", category: "Calendar", title: "New Appointment",
             execute: () => _vm.CalendarVm?.NewEventCommand.Execute(null),
             defaultKey: Key.N, defaultModifiers: ModifierKeys.None,
-            isAvailable: () => CalendarList.IsKeyboardFocusWithin));
+            isAvailable: () => CalendarPaneFocused));
 
         _registry.Register(new CommandDefinition(
             id: "calendar.editEvent", category: "Calendar", title: "Edit Appointment",
@@ -1219,34 +1219,39 @@ public partial class MainWindow : Window
             id: "calendar.search", category: "Calendar", title: "Search Appointments",
             execute: OpenCalendarSearch,
             defaultKey: Key.F, defaultModifiers: ModifierKeys.Control,
-            isAvailable: () => CalendarList.IsKeyboardFocusWithin || CalendarSearchBox.IsKeyboardFocusWithin));
+            isAvailable: () => CalendarPaneFocused || CalendarSearchBox.IsKeyboardFocusWithin));
 
         // ── Calendar views + period navigation (Calendar category) ──
         _registry.Register(new CommandDefinition(
             id: "calendar.viewAgenda", category: "Calendar", title: "Agenda View",
             execute: () => _vm.CalendarVm?.ShowAgendaCommand.Execute(null),
             defaultKey: Key.A, defaultModifiers: ModifierKeys.None,
-            isAvailable: () => CalendarList.IsKeyboardFocusWithin));
+            isAvailable: () => CalendarPaneFocused));
         _registry.Register(new CommandDefinition(
             id: "calendar.viewDay", category: "Calendar", title: "Day View",
             execute: () => _vm.CalendarVm?.ShowDayCommand.Execute(null),
             defaultKey: Key.D, defaultModifiers: ModifierKeys.None,
-            isAvailable: () => CalendarList.IsKeyboardFocusWithin));
+            isAvailable: () => CalendarPaneFocused));
         _registry.Register(new CommandDefinition(
             id: "calendar.viewWeek", category: "Calendar", title: "Week View",
             execute: () => _vm.CalendarVm?.ShowWeekCommand.Execute(null),
             defaultKey: Key.W, defaultModifiers: ModifierKeys.None,
-            isAvailable: () => CalendarList.IsKeyboardFocusWithin));
+            isAvailable: () => CalendarPaneFocused));
+        _registry.Register(new CommandDefinition(
+            id: "calendar.viewMonth", category: "Calendar", title: "Month View",
+            execute: () => _vm.CalendarVm?.ShowMonthCommand.Execute(null),
+            defaultKey: Key.M, defaultModifiers: ModifierKeys.None,
+            isAvailable: () => CalendarPaneFocused));
         _registry.Register(new CommandDefinition(
             id: "calendar.prevPeriod", category: "Calendar", title: "Previous Day or Week",
             execute: () => _vm.CalendarVm?.PreviousPeriodCommand.Execute(null),
             defaultKey: Key.Left, defaultModifiers: ModifierKeys.Control,
-            isAvailable: () => CalendarList.IsKeyboardFocusWithin));
+            isAvailable: () => CalendarPaneFocused));
         _registry.Register(new CommandDefinition(
             id: "calendar.nextPeriod", category: "Calendar", title: "Next Day or Week",
             execute: () => _vm.CalendarVm?.NextPeriodCommand.Execute(null),
             defaultKey: Key.Right, defaultModifiers: ModifierKeys.Control,
-            isAvailable: () => CalendarList.IsKeyboardFocusWithin));
+            isAvailable: () => CalendarPaneFocused));
 
         // Install the WM_CONTEXTMENU hook before WebView2 init. WebView2 initialization
         // creates an out-of-process HWND that grabs Win32 focus without WPF tracking it,
@@ -1557,7 +1562,7 @@ public partial class MainWindow : Window
                     e.Handled = true;
                     await CycleFocusAsync(true);
                     return;
-                case Key.Escape when _vm.IsCalendarView && CalendarList.IsKeyboardFocusWithin
+                case Key.Escape when _vm.IsCalendarView && CalendarPaneFocused
                                      && _vm.CalendarVm?.IsSearchActive == true:
                     // A search is active: first Escape clears it and stays in the list.
                     _vm.CalendarVm.ClearSearch();
@@ -1566,7 +1571,7 @@ public partial class MainWindow : Window
                         interrupt: true, category: AnnouncementCategory.Result);
                     e.Handled = true;
                     return;
-                case Key.Escape when _vm.IsCalendarView && CalendarList.IsKeyboardFocusWithin:
+                case Key.Escape when _vm.IsCalendarView && CalendarPaneFocused:
                     // Escape from the calendar list returns focus to the folder tree,
                     // matching the behaviour of Escape from the message list.
                     FocusFolderTree();
@@ -2089,6 +2094,17 @@ public partial class MainWindow : Window
     // and by the CalendarPaneFocusRequested event after SelectCalendarAsync loads events.
     private void FocusCalendarList()
     {
+        // Month view focuses the grid; the ListBox routes focus to the selected cell.
+        if (_vm.CalendarVm?.IsMonthView == true)
+        {
+            if (MonthGrid.SelectedItem != null
+                && MonthGrid.ItemContainerGenerator.ContainerFromItem(MonthGrid.SelectedItem) is ListBoxItem cell)
+                cell.Focus();
+            else
+                MonthGrid.Focus();
+            return;
+        }
+
         if (CalendarList.Items.Count == 0) { CalendarList.Focus(); return; }
         if (CalendarList.SelectedIndex < 0) CalendarList.SelectedIndex = 0;
 
@@ -2167,12 +2183,29 @@ public partial class MainWindow : Window
         => _vm.CalendarVm?.ShowDayCommand.Execute(null);
     private void CalendarWeek_Click(object sender, RoutedEventArgs e)
         => _vm.CalendarVm?.ShowWeekCommand.Execute(null);
+    private void CalendarMonth_Click(object sender, RoutedEventArgs e)
+        => _vm.CalendarVm?.ShowMonthCommand.Execute(null);
+
+    /// <summary>Enter on a month cell drills into that day's Day view; the list takes focus.</summary>
+    private void MonthGrid_PreviewKeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.Enter && _vm.CalendarVm?.SelectedMonthCell != null)
+        {
+            _vm.CalendarVm.DrillIntoDayCommand.Execute(null);
+            Dispatcher.InvokeAsync(FocusCalendarList, DispatcherPriority.Input);
+            e.Handled = true;
+        }
+    }
     private void CalendarPrev_Click(object sender, RoutedEventArgs e)
         => _vm.CalendarVm?.PreviousPeriodCommand.Execute(null);
     private void CalendarNext_Click(object sender, RoutedEventArgs e)
         => _vm.CalendarVm?.NextPeriodCommand.Execute(null);
     private void CalendarToday_Click(object sender, RoutedEventArgs e)
         => _vm.CalendarVm?.ToggleTodayFilterCommand.Execute(null);
+
+    /// <summary>True when the calendar's main content (event list or Month grid) has focus.</summary>
+    private bool CalendarPaneFocused =>
+        CalendarList.IsKeyboardFocusWithin || MonthGrid.IsKeyboardFocusWithin;
 
     private void CalendarNew_Click(object sender, RoutedEventArgs e)
         => _vm.CalendarVm?.NewEventCommand.Execute(null);
@@ -3411,7 +3444,7 @@ public partial class MainWindow : Window
         if (AccountList.IsKeyboardFocusWithin)  return 1;
         if (FolderList.IsKeyboardFocusWithin)   return 2;
         if (SearchBox.IsKeyboardFocusWithin)    return 6;
-        if (MessageList.IsKeyboardFocusWithin || ConversationTree.IsKeyboardFocusWithin || SenderGroupTree.IsKeyboardFocusWithin || ToGroupTree.IsKeyboardFocusWithin || CalendarList.IsKeyboardFocusWithin) return 3;
+        if (MessageList.IsKeyboardFocusWithin || ConversationTree.IsKeyboardFocusWithin || SenderGroupTree.IsKeyboardFocusWithin || ToGroupTree.IsKeyboardFocusWithin || CalendarList.IsKeyboardFocusWithin || MonthGrid.IsKeyboardFocusWithin) return 3;
         if (TabStrip.IsKeyboardFocusWithin)     return 7; // between message list and reading pane
         if (MessageBody.IsKeyboardFocusWithin)  return 4;
         if (MainStatusBar.IsKeyboardFocusWithin) return 5;

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -1214,6 +1214,12 @@ public partial class MainWindow : Window
             execute: () => _vm.CalendarVm?.ExportEventCommand.Execute(_vm.CalendarVm.SelectedEvent),
             isAvailable: () => CalendarList.IsKeyboardFocusWithin && _vm.CalendarVm?.SelectedEvent != null));
 
+        _registry.Register(new CommandDefinition(
+            id: "calendar.search", category: "Calendar", title: "Search Appointments",
+            execute: OpenCalendarSearch,
+            defaultKey: Key.F, defaultModifiers: ModifierKeys.Control,
+            isAvailable: () => CalendarList.IsKeyboardFocusWithin || CalendarSearchBox.IsKeyboardFocusWithin));
+
         // ── Calendar views + period navigation (Calendar category) ──
         _registry.Register(new CommandDefinition(
             id: "calendar.viewAgenda", category: "Calendar", title: "Agenda View",
@@ -1549,6 +1555,15 @@ public partial class MainWindow : Window
                 case Key.F6:
                     e.Handled = true;
                     await CycleFocusAsync(true);
+                    return;
+                case Key.Escape when _vm.IsCalendarView && CalendarList.IsKeyboardFocusWithin
+                                     && _vm.CalendarVm?.IsSearchActive == true:
+                    // A search is active: first Escape clears it and stays in the list.
+                    _vm.CalendarVm.ClearSearch();
+                    AccessibilityHelper.Announce(this,
+                        $"Search cleared. {_vm.CalendarVm.VisibleEvents.Count} appointment{(_vm.CalendarVm.VisibleEvents.Count == 1 ? "" : "s")}.",
+                        interrupt: true, category: AnnouncementCategory.Result);
+                    e.Handled = true;
                     return;
                 case Key.Escape when _vm.IsCalendarView && CalendarList.IsKeyboardFocusWithin:
                     // Escape from the calendar list returns focus to the folder tree,
@@ -2191,6 +2206,69 @@ public partial class MainWindow : Window
             Dispatcher.InvokeAsync(FocusCalendarList, DispatcherPriority.Input);
         };
         editor.Show();
+    }
+
+    // ── Calendar search (Ctrl+F while the calendar list has focus) ──
+
+    private System.Windows.Threading.DispatcherTimer? _calSearchAnnounceTimer;
+
+    private void OpenCalendarSearch()
+    {
+        if (_vm.CalendarVm == null) return;
+        _vm.CalendarVm.IsSearchActive = true;
+
+        // Debounced live count so the screen reader isn't chattering on every keystroke.
+        if (_calSearchAnnounceTimer == null)
+        {
+            _calSearchAnnounceTimer = new System.Windows.Threading.DispatcherTimer
+            {
+                Interval = TimeSpan.FromMilliseconds(600),
+            };
+            _calSearchAnnounceTimer.Tick += (_, _) =>
+            {
+                _calSearchAnnounceTimer!.Stop();
+                var n = _vm.CalendarVm?.VisibleEvents.Count ?? 0;
+                AccessibilityHelper.Announce(this, $"{n} appointment{(n == 1 ? "" : "s")}.",
+                    interrupt: true, category: AnnouncementCategory.Result);
+            };
+            _vm.CalendarVm.PropertyChanged += (_, e) =>
+            {
+                if (e.PropertyName == nameof(CalendarViewModel.SearchText)
+                    && _vm.CalendarVm!.IsSearchActive)
+                {
+                    _calSearchAnnounceTimer!.Stop();
+                    _calSearchAnnounceTimer.Start();
+                }
+            };
+        }
+
+        Dispatcher.InvokeAsync(() =>
+        {
+            CalendarSearchBox.Focus();
+            AccessibilityHelper.Announce(this, "Search appointments. Type to filter.",
+                interrupt: true, category: AnnouncementCategory.Hint);
+        }, DispatcherPriority.Input);
+    }
+
+    private void CalendarSearchBox_PreviewKeyDown(object sender, KeyEventArgs e)
+    {
+        if (_vm.CalendarVm == null) return;
+        if (e.Key == Key.Escape)
+        {
+            _calSearchAnnounceTimer?.Stop();
+            _vm.CalendarVm.ClearSearch();
+            var n = _vm.CalendarVm.VisibleEvents.Count;
+            FocusCalendarList();
+            AccessibilityHelper.Announce(this, $"Search cleared. {n} appointment{(n == 1 ? "" : "s")}.",
+                interrupt: true, category: AnnouncementCategory.Result);
+            e.Handled = true;
+        }
+        else if (e.Key == Key.Down || (e.Key == Key.Tab && Keyboard.Modifiers == ModifierKeys.None))
+        {
+            // Into the (filtered) list; search stays active so Escape there can clear it later.
+            FocusCalendarList();
+            e.Handled = true;
+        }
     }
 
     /// <summary>Shows a Save dialog and writes the exported .ics file (View concern).</summary>

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -1246,6 +1246,11 @@ public partial class MainWindow : Window
             defaultKey: Key.W, defaultModifiers: ModifierKeys.None,
             isAvailable: () => CalendarPaneFocused));
         _registry.Register(new CommandDefinition(
+            id: "calendar.drillIntoDay", category: "Calendar", title: "Open Selected Day",
+            execute: DrillIntoSelectedDay,
+            defaultKey: Key.Return, defaultModifiers: ModifierKeys.None,
+            isAvailable: () => MonthGrid.IsKeyboardFocusWithin && _vm.CalendarVm?.SelectedMonthCell != null));
+        _registry.Register(new CommandDefinition(
             id: "calendar.viewMonth", category: "Calendar", title: "Month View",
             execute: () => _vm.CalendarVm?.ShowMonthCommand.Execute(null),
             defaultKey: Key.M, defaultModifiers: ModifierKeys.None,
@@ -1579,9 +1584,10 @@ public partial class MainWindow : Window
                         interrupt: true, category: AnnouncementCategory.Result);
                     e.Handled = true;
                     return;
-                case Key.Escape when _vm.IsCalendarView && CalendarPaneFocused:
-                    // Escape from the calendar list returns focus to the folder tree,
-                    // matching the behaviour of Escape from the message list.
+                case Key.Escape when _vm.IsCalendarView
+                                     && (CalendarPaneFocused || CalendarDetails.IsKeyboardFocusWithin):
+                    // Escape from the calendar list, grid, or Details pane returns focus to the
+                    // folder tree, matching the behaviour of Escape from the message list.
                     FocusFolderTree();
                     e.Handled = true;
                     return;
@@ -2194,15 +2200,12 @@ public partial class MainWindow : Window
     private void CalendarMonth_Click(object sender, RoutedEventArgs e)
         => _vm.CalendarVm?.ShowMonthCommand.Execute(null);
 
-    /// <summary>Enter on a month cell drills into that day's Day view; the list takes focus.</summary>
-    private void MonthGrid_PreviewKeyDown(object sender, KeyEventArgs e)
+    /// <summary>Enter on a month cell: dispatched via the calendar.drillIntoDay registration.</summary>
+    private void DrillIntoSelectedDay()
     {
-        if (e.Key == Key.Enter && _vm.CalendarVm?.SelectedMonthCell != null)
-        {
-            _vm.CalendarVm.DrillIntoDayCommand.Execute(null);
-            Dispatcher.InvokeAsync(FocusCalendarList, DispatcherPriority.Input);
-            e.Handled = true;
-        }
+        if (_vm.CalendarVm?.SelectedMonthCell == null) return;
+        _vm.CalendarVm.DrillIntoDayCommand.Execute(null);
+        Dispatcher.InvokeAsync(FocusCalendarList, DispatcherPriority.Input);
     }
     private void CalendarPrev_Click(object sender, RoutedEventArgs e)
         => _vm.CalendarVm?.PreviousPeriodCommand.Execute(null);
@@ -2236,10 +2239,14 @@ public partial class MainWindow : Window
     {
         var evt = _vm.CalendarVm?.SelectedEvent;
         if (evt == null) return;
-        if (evt.IsUserCreated)
-            _vm.CalendarVm?.EditEventCommand.Execute(evt);
-        else
+        // Harvested email invites open their source message; everything else routes through
+        // EditEvent, which itself edits what is editable (local rows, single Microsoft/Google
+        // events) and announces the right read-only message otherwise — so Enter and E always
+        // agree on the same row.
+        if (!evt.IsUserCreated && !evt.IsGraph)
             _vm.CalendarVm?.OpenSourceMessageCommand.Execute(evt);
+        else
+            _vm.CalendarVm?.EditEventCommand.Execute(evt);
     }
 
     /// <summary>Opens the modeless appointment editor and restores focus to the list on close.</summary>
@@ -3456,7 +3463,7 @@ public partial class MainWindow : Window
         if (AccountList.IsKeyboardFocusWithin)  return 1;
         if (FolderList.IsKeyboardFocusWithin)   return 2;
         if (SearchBox.IsKeyboardFocusWithin)    return 6;
-        if (MessageList.IsKeyboardFocusWithin || ConversationTree.IsKeyboardFocusWithin || SenderGroupTree.IsKeyboardFocusWithin || ToGroupTree.IsKeyboardFocusWithin || CalendarList.IsKeyboardFocusWithin || MonthGrid.IsKeyboardFocusWithin) return 3;
+        if (MessageList.IsKeyboardFocusWithin || ConversationTree.IsKeyboardFocusWithin || SenderGroupTree.IsKeyboardFocusWithin || ToGroupTree.IsKeyboardFocusWithin || CalendarList.IsKeyboardFocusWithin || MonthGrid.IsKeyboardFocusWithin || CalendarDetails.IsKeyboardFocusWithin || CalendarSearchBox.IsKeyboardFocusWithin) return 3;
         if (TabStrip.IsKeyboardFocusWithin)     return 7; // between message list and reading pane
         if (MessageBody.IsKeyboardFocusWithin)  return 4;
         if (MainStatusBar.IsKeyboardFocusWithin) return 5;

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -5128,7 +5128,12 @@ public partial class MainWindow : Window
             .Select(f => f.Source)
             .OrderBy(n => n, StringComparer.CurrentCultureIgnoreCase)
             .ToList();
-        var vm = new SettingsViewModel(_configService, _registry, _themeService, fontNames);
+        // Per-dialog CalDAV client for the Test button; disposed when this method (and the
+        // modal dialog inside it) finishes. An in-flight Test at close just faults into the
+        // command's catch-all.
+        using var calDavClient = new CalDavCalendarClient();
+        var vm = new SettingsViewModel(_configService, _registry, _themeService, fontNames,
+                                       _credentials, calDavClient);
         var dialog = new SettingsDialog(vm) { Owner = this };
         if (dialog.ShowDialog() == true)
         {

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -842,6 +842,13 @@ public partial class MainWindow : Window
 
     private void OpenSearch()
     {
+        // Ctrl+Shift+S is the one search gesture app-wide: in the calendar it opens
+        // appointment search; everywhere else, the message search box.
+        if (_vm.IsCalendarView)
+        {
+            OpenCalendarSearch();
+            return;
+        }
         _vm.IsSearchActive = true;
         Dispatcher.InvokeAsync(() =>
         {
@@ -1215,11 +1222,12 @@ public partial class MainWindow : Window
             execute: () => _vm.CalendarVm?.ExportEventCommand.Execute(_vm.CalendarVm.SelectedEvent),
             isAvailable: () => CalendarList.IsKeyboardFocusWithin && _vm.CalendarVm?.SelectedEvent != null));
 
+        // No default key: Ctrl+Shift+S (view.search) routes here while the calendar is open,
+        // so search is ONE gesture app-wide. Palette entry + rebindable id kept.
         _registry.Register(new CommandDefinition(
             id: "calendar.search", category: "Calendar", title: "Search Appointments",
             execute: OpenCalendarSearch,
-            defaultKey: Key.F, defaultModifiers: ModifierKeys.Control,
-            isAvailable: () => CalendarPaneFocused || CalendarSearchBox.IsKeyboardFocusWithin));
+            isAvailable: () => _vm.IsCalendarView));
 
         // ── Calendar views + period navigation (Calendar category) ──
         _registry.Register(new CommandDefinition(

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -395,6 +395,11 @@ public partial class MainWindow : Window
                 AccessibilityHelper.Announce(this, text, interrupt: true, category: category);
             vm.CalendarVm.OpenSourceMessageRequested += (accountId, folder, messageId) =>
                 vm.OpenCalendarSourceMessage(accountId, folder, messageId);
+            vm.CalendarVm.EditorRequested += OpenEventEditor;
+            vm.CalendarVm.DeleteConfirmRequested += ConfirmDeleteAppointment;
+            vm.CalendarVm.ListFocusRequested += () =>
+                Dispatcher.InvokeAsync(FocusCalendarList, DispatcherPriority.Input);
+            vm.CalendarVm.ExportRequested += SaveAppointmentIcs;
         }
 
         vm.PropertyChanged += async (_, e) =>
@@ -1181,9 +1186,60 @@ public partial class MainWindow : Window
 
         _registry.Register(new CommandDefinition(
             id: "calendar.openSourceMessage", category: "View", title: "Open Calendar Event Source Message",
-            execute: () => _vm.CalendarVm?.OpenSourceMessageCommand.Execute(_vm.CalendarVm.SelectedEvent),
+            execute: ActivateSelectedCalendarEvent,
             defaultKey: Key.Return, defaultModifiers: ModifierKeys.None,
             isAvailable: () => CalendarList.IsKeyboardFocusWithin && _vm.CalendarVm?.SelectedEvent != null));
+
+        // ── Appointment authoring (Calendar category) ──
+        _registry.Register(new CommandDefinition(
+            id: "calendar.newEvent", category: "Calendar", title: "New Appointment",
+            execute: () => _vm.CalendarVm?.NewEventCommand.Execute(null),
+            defaultKey: Key.N, defaultModifiers: ModifierKeys.None,
+            isAvailable: () => CalendarList.IsKeyboardFocusWithin));
+
+        _registry.Register(new CommandDefinition(
+            id: "calendar.editEvent", category: "Calendar", title: "Edit Appointment",
+            execute: () => _vm.CalendarVm?.EditEventCommand.Execute(_vm.CalendarVm.SelectedEvent),
+            defaultKey: Key.E, defaultModifiers: ModifierKeys.None,
+            isAvailable: () => CalendarList.IsKeyboardFocusWithin && _vm.CalendarVm?.SelectedEvent != null));
+
+        _registry.Register(new CommandDefinition(
+            id: "calendar.deleteEvent", category: "Calendar", title: "Delete Appointment",
+            execute: () => _vm.CalendarVm?.DeleteEventCommand.Execute(_vm.CalendarVm.SelectedEvent),
+            defaultKey: Key.Delete, defaultModifiers: ModifierKeys.None,
+            isAvailable: () => CalendarList.IsKeyboardFocusWithin && _vm.CalendarVm?.SelectedEvent != null));
+
+        _registry.Register(new CommandDefinition(
+            id: "calendar.exportEvent", category: "Calendar", title: "Export Appointment as .ics",
+            execute: () => _vm.CalendarVm?.ExportEventCommand.Execute(_vm.CalendarVm.SelectedEvent),
+            isAvailable: () => CalendarList.IsKeyboardFocusWithin && _vm.CalendarVm?.SelectedEvent != null));
+
+        // ── Calendar views + period navigation (Calendar category) ──
+        _registry.Register(new CommandDefinition(
+            id: "calendar.viewAgenda", category: "Calendar", title: "Agenda View",
+            execute: () => _vm.CalendarVm?.ShowAgendaCommand.Execute(null),
+            defaultKey: Key.A, defaultModifiers: ModifierKeys.None,
+            isAvailable: () => CalendarList.IsKeyboardFocusWithin));
+        _registry.Register(new CommandDefinition(
+            id: "calendar.viewDay", category: "Calendar", title: "Day View",
+            execute: () => _vm.CalendarVm?.ShowDayCommand.Execute(null),
+            defaultKey: Key.D, defaultModifiers: ModifierKeys.None,
+            isAvailable: () => CalendarList.IsKeyboardFocusWithin));
+        _registry.Register(new CommandDefinition(
+            id: "calendar.viewWeek", category: "Calendar", title: "Week View",
+            execute: () => _vm.CalendarVm?.ShowWeekCommand.Execute(null),
+            defaultKey: Key.W, defaultModifiers: ModifierKeys.None,
+            isAvailable: () => CalendarList.IsKeyboardFocusWithin));
+        _registry.Register(new CommandDefinition(
+            id: "calendar.prevPeriod", category: "Calendar", title: "Previous Day or Week",
+            execute: () => _vm.CalendarVm?.PreviousPeriodCommand.Execute(null),
+            defaultKey: Key.Left, defaultModifiers: ModifierKeys.Control,
+            isAvailable: () => CalendarList.IsKeyboardFocusWithin));
+        _registry.Register(new CommandDefinition(
+            id: "calendar.nextPeriod", category: "Calendar", title: "Next Day or Week",
+            execute: () => _vm.CalendarVm?.NextPeriodCommand.Execute(null),
+            defaultKey: Key.Right, defaultModifiers: ModifierKeys.Control,
+            isAvailable: () => CalendarList.IsKeyboardFocusWithin));
 
         // Install the WM_CONTEXTMENU hook before WebView2 init. WebView2 initialization
         // creates an out-of-process HWND that grabs Win32 focus without WPF tracking it,
@@ -2085,6 +2141,96 @@ public partial class MainWindow : Window
         {
             e.Handled = true;
         }
+    }
+
+    // ── Calendar authoring: toolbar buttons, editor launch, delete confirm, Enter activation ──
+
+    private void CalendarAgenda_Click(object sender, RoutedEventArgs e)
+        => _vm.CalendarVm?.ShowAgendaCommand.Execute(null);
+    private void CalendarDay_Click(object sender, RoutedEventArgs e)
+        => _vm.CalendarVm?.ShowDayCommand.Execute(null);
+    private void CalendarWeek_Click(object sender, RoutedEventArgs e)
+        => _vm.CalendarVm?.ShowWeekCommand.Execute(null);
+    private void CalendarPrev_Click(object sender, RoutedEventArgs e)
+        => _vm.CalendarVm?.PreviousPeriodCommand.Execute(null);
+    private void CalendarNext_Click(object sender, RoutedEventArgs e)
+        => _vm.CalendarVm?.NextPeriodCommand.Execute(null);
+    private void CalendarToday_Click(object sender, RoutedEventArgs e)
+        => _vm.CalendarVm?.ToggleTodayFilterCommand.Execute(null);
+
+    private void CalendarNew_Click(object sender, RoutedEventArgs e)
+        => _vm.CalendarVm?.NewEventCommand.Execute(null);
+
+    private void CalendarEdit_Click(object sender, RoutedEventArgs e)
+        => _vm.CalendarVm?.EditEventCommand.Execute(_vm.CalendarVm.SelectedEvent);
+
+    private void CalendarDelete_Click(object sender, RoutedEventArgs e)
+        => _vm.CalendarVm?.DeleteEventCommand.Execute(_vm.CalendarVm.SelectedEvent);
+
+    /// <summary>
+    /// Enter on the calendar list: edit a locally-created appointment, or open the source
+    /// invitation email for a harvested invite (the original calendar behaviour).
+    /// </summary>
+    private void ActivateSelectedCalendarEvent()
+    {
+        var evt = _vm.CalendarVm?.SelectedEvent;
+        if (evt == null) return;
+        if (evt.IsUserCreated)
+            _vm.CalendarVm?.EditEventCommand.Execute(evt);
+        else
+            _vm.CalendarVm?.OpenSourceMessageCommand.Execute(evt);
+    }
+
+    /// <summary>Opens the modeless appointment editor and restores focus to the list on close.</summary>
+    private void OpenEventEditor(EventEditorViewModel editorVm)
+    {
+        var editor = new EventEditorWindow(editorVm) { Owner = this };
+        editor.Closed += (_, _) =>
+        {
+            // Return focus to the calendar list (virtualised — re-focus the selected row).
+            Dispatcher.InvokeAsync(FocusCalendarList, DispatcherPriority.Input);
+        };
+        editor.Show();
+    }
+
+    /// <summary>Shows a Save dialog and writes the exported .ics file (View concern).</summary>
+    private void SaveAppointmentIcs(string suggestedFileName, string icsBody)
+    {
+        var dialog = new Microsoft.Win32.SaveFileDialog
+        {
+            FileName = suggestedFileName,
+            DefaultExt = ".ics",
+            Filter = "Calendar file (*.ics)|*.ics|All files (*.*)|*.*",
+        };
+        if (dialog.ShowDialog(this) != true) return;
+
+        try
+        {
+            System.IO.File.WriteAllText(dialog.FileName, icsBody);
+            AccessibilityHelper.Announce(this,
+                $"Appointment exported to {System.IO.Path.GetFileName(dialog.FileName)}.",
+                category: AnnouncementCategory.Result);
+        }
+        catch (Exception ex)
+        {
+            LogService.Log("Export appointment .ics", ex);
+            AccessibilityHelper.Announce(this,
+                "Could not save the file. See the log for details.",
+                category: AnnouncementCategory.Result);
+        }
+    }
+
+    /// <summary>Confirms deleting an appointment (View concern); invokes the callback on Yes.</summary>
+    private void ConfirmDeleteAppointment(CalendarEvent evt, Action confirmed)
+    {
+        var prompt = evt.IsRecurring
+            ? $"Delete the repeating appointment “{evt.Summary}” and all its occurrences?"
+            : $"Delete the appointment “{evt.Summary}”?";
+        var result = MessageBox.Show(this, prompt,
+            "Delete appointment",
+            MessageBoxButton.YesNo, MessageBoxImage.Question, MessageBoxResult.No);
+        if (result == MessageBoxResult.Yes)
+            confirmed();
     }
 
     private void FocusItemAt(int idx)

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -397,6 +397,7 @@ public partial class MainWindow : Window
                 vm.OpenCalendarSourceMessage(accountId, folder, messageId);
             vm.CalendarVm.EditorRequested += OpenEventEditor;
             vm.CalendarVm.DeleteConfirmRequested += ConfirmDeleteAppointment;
+            vm.CalendarVm.RecurringDeleteConfirmRequested += ConfirmDeleteRecurring;
             vm.CalendarVm.ListFocusRequested += () =>
                 Dispatcher.InvokeAsync(FocusCalendarList, DispatcherPriority.Input);
             vm.CalendarVm.ExportRequested += SaveAppointmentIcs;
@@ -2309,6 +2310,24 @@ public partial class MainWindow : Window
             MessageBoxButton.YesNo, MessageBoxImage.Question, MessageBoxResult.No);
         if (result == MessageBoxResult.Yes)
             confirmed();
+    }
+
+    /// <summary>
+    /// Three-way confirm for deleting from a repeating series:
+    /// Yes = just this occurrence, No = the entire series, Cancel = nothing.
+    /// </summary>
+    private void ConfirmDeleteRecurring(CalendarEvent evt, Action deleteOccurrence, Action deleteSeries)
+    {
+        var when = evt.StartTime?.ToString("ddd, MMM d 'at' t") ?? "";
+        var result = MessageBox.Show(this,
+            $"“{evt.Summary}” repeats.\n\n" +
+            $"Yes: delete only this occurrence ({when}).\n" +
+            "No: delete the entire series.\n" +
+            "Cancel: keep everything.",
+            "Delete repeating appointment",
+            MessageBoxButton.YesNoCancel, MessageBoxImage.Question, MessageBoxResult.Cancel);
+        if (result == MessageBoxResult.Yes) deleteOccurrence();
+        else if (result == MessageBoxResult.No) deleteSeries();
     }
 
     private void FocusItemAt(int idx)

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -2215,6 +2215,10 @@ public partial class MainWindow : Window
     private bool CalendarPaneFocused =>
         CalendarList.IsKeyboardFocusWithin || MonthGrid.IsKeyboardFocusWithin;
 
+    /// <summary>New selection loaded into the Details pane: start reading from the first line.</summary>
+    private void CalendarDetails_TextChanged(object sender, TextChangedEventArgs e)
+        => CalendarDetails.CaretIndex = 0;
+
     private void CalendarNew_Click(object sender, RoutedEventArgs e)
         => _vm.CalendarVm?.NewEventCommand.Execute(null);
 

--- a/QuickMail/Views/SettingsDialog.xaml
+++ b/QuickMail/Views/SettingsDialog.xaml
@@ -133,6 +133,53 @@
                             </StackPanel>
                         </GroupBox>
 
+                        <!-- Internet Calendar (CalDAV) Group -->
+                        <GroupBox Header="_Internet Calendar" Padding="10" Margin="0,10,0,0"
+                                  AutomationProperties.Name="Internet calendar settings">
+                            <StackPanel>
+                                <TextBlock Text="Show events from an iCloud or other CalDAV calendar in the Calendar view. For iCloud, use https://caldav.icloud.com with your Apple ID and an app-specific password (created at appleid.apple.com). Leave the server address empty to turn this off."
+                                           Foreground="{DynamicResource Theme.TextSecondary}" FontSize="{DynamicResource Theme.FontSizeSmall}" Margin="0,0,0,8" TextWrapping="Wrap"/>
+
+                                <Label x:Name="CalDavUrlLabel" Content="Server a_ddress:"
+                                       Target="{Binding ElementName=CalDavUrlBox}" FontWeight="SemiBold"/>
+                                <TextBox x:Name="CalDavUrlBox"
+                                         Text="{Binding CalDavUrl, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                         AutomationProperties.Name="Calendar server address"/>
+
+                                <Label x:Name="CalDavUserLabel" Content="User_name:" Margin="0,8,0,0"
+                                       Target="{Binding ElementName=CalDavUsernameBox}" FontWeight="SemiBold"/>
+                                <TextBox x:Name="CalDavUsernameBox"
+                                         Text="{Binding CalDavUsername, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                         AutomationProperties.Name="Calendar username"/>
+
+                                <Label x:Name="CalDavPasswordLabel" Content="App-specific pass_word:" Margin="0,8,0,0"
+                                       Target="{Binding ElementName=CalDavPasswordBox}" FontWeight="SemiBold"/>
+                                <PasswordBox x:Name="CalDavPasswordBox"
+                                             PasswordChanged="CalDavPasswordBox_PasswordChanged"
+                                             AutomationProperties.Name="Calendar app-specific password"/>
+                                <TextBlock Text="Stored securely in Windows Credential Manager. Leave empty to keep the saved password."
+                                           Foreground="{DynamicResource Theme.TextSecondary}" FontSize="{DynamicResource Theme.FontSizeSmall}" Margin="0,3,0,0" TextWrapping="Wrap"/>
+
+                                <Label x:Name="CalDavNameLabel" Content="Calendar nam_e:" Margin="0,8,0,0"
+                                       Target="{Binding ElementName=CalDavNameBox}" FontWeight="SemiBold"/>
+                                <TextBox x:Name="CalDavNameBox"
+                                         Text="{Binding CalDavDisplayName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                         AutomationProperties.Name="Calendar name"/>
+                                <TextBlock Text="How this calendar is listed in the folder tree."
+                                           Foreground="{DynamicResource Theme.TextSecondary}" FontSize="{DynamicResource Theme.FontSizeSmall}" Margin="0,3,0,0" TextWrapping="Wrap"/>
+
+                                <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
+                                    <Button x:Name="CalDavTestButton" Content="_Test"
+                                            Command="{Binding TestCalDavCommand}"
+                                            MinWidth="80"
+                                            AutomationProperties.Name="Test calendar connection"/>
+                                    <TextBlock Text="{Binding CalDavTestResult}"
+                                               VerticalAlignment="Center" Margin="10,0,0,0" TextWrapping="Wrap"
+                                               MaxWidth="360"/>
+                                </StackPanel>
+                            </StackPanel>
+                        </GroupBox>
+
                         <!-- Mail Actions Group -->
                         <GroupBox Header="Mail _Actions" Padding="10" Margin="0,10,0,0"
                                   AutomationProperties.Name="Mail action settings">

--- a/QuickMail/Views/SettingsDialog.xaml
+++ b/QuickMail/Views/SettingsDialog.xaml
@@ -297,6 +297,11 @@
                                           IsChecked="{Binding ContactListShowFieldLabels, Mode=TwoWay}"
                                           Margin="16,4,0,0"
                                           AutomationProperties.Name="Show field labels in the address book contact list accessible names"/>
+
+                                <CheckBox Content="Show field labels in the _calendar event list"
+                                          IsChecked="{Binding CalendarListShowFieldLabels, Mode=TwoWay}"
+                                          Margin="16,4,0,0"
+                                          AutomationProperties.Name="Show field labels in the calendar event list accessible names"/>
                             </StackPanel>
                         </GroupBox>
                     </StackPanel>

--- a/QuickMail/Views/SettingsDialog.xaml
+++ b/QuickMail/Views/SettingsDialog.xaml
@@ -302,6 +302,18 @@
                                           IsChecked="{Binding CalendarListShowFieldLabels, Mode=TwoWay}"
                                           Margin="16,4,0,0"
                                           AutomationProperties.Name="Show field labels in the calendar event list accessible names"/>
+
+                                <CheckBox Content="Remind me before appoin_tments"
+                                          IsChecked="{Binding CalendarReminders, Mode=TwoWay}"
+                                          Margin="16,4,0,0"
+                                          AutomationProperties.Name="Remind me before appointments"/>
+                                <StackPanel Orientation="Horizontal" Margin="32,4,0,0"
+                                            IsEnabled="{Binding CalendarReminders}">
+                                    <TextBlock Text="Minutes before:" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                                    <TextBox Text="{Binding CalendarReminderMinutes, Mode=TwoWay}"
+                                             AutomationProperties.Name="Reminder minutes before appointment"
+                                             Width="48"/>
+                                </StackPanel>
                             </StackPanel>
                         </GroupBox>
                     </StackPanel>

--- a/QuickMail/Views/SettingsDialog.xaml.cs
+++ b/QuickMail/Views/SettingsDialog.xaml.cs
@@ -20,6 +20,19 @@ public partial class SettingsDialog : Window
         _vm = vm;
         InitializeComponent();
         DataContext = vm;
+
+        // Speak the CalDAV Test outcome (the visual text updates regardless). The dialog is
+        // modal and the VM dies with it, so no unsubscribe is needed.
+        vm.CalDavTestCompleted += text =>
+            AccessibilityHelper.Announce(CalDavTestButton, text, category: AnnouncementCategory.Result);
+    }
+
+    /// <summary>PasswordBox.Password is not bindable; push it to the VM by hand (the
+    /// AccountManager precedent). The VM stores it only in Windows Credential Manager.</summary>
+    private void CalDavPasswordBox_PasswordChanged(object sender, RoutedEventArgs e)
+    {
+        if (sender is PasswordBox pb)
+            _vm.CalDavPassword = pb.Password;
     }
 
     private void Window_Loaded(object sender, RoutedEventArgs e)

--- a/docs/ENTRA-APP-REGISTRATION.md
+++ b/docs/ENTRA-APP-REGISTRATION.md
@@ -77,6 +77,7 @@ declared scopes). Both must still be declared here.
 | --- | --- |
 | `Mail.ReadWrite` | Read/move/flag/delete mail; save drafts (Graph backend) |
 | `Mail.Send` | Send mail (Graph backend) |
+| `Calendars.ReadWrite` | Calendar sync — read/create/update/delete events (full-calendar spec M4). Added 2026-07-16 via the §7 device-code runbook (scope id `1ec239c2-d7c9-4623-a91a-a9775856bb36`). Code side: `OAuthService.GraphCalendarScopes` (explicit scope for personal accounts; work/school gets it via `.default`). |
 | `MailboxSettings.ReadWrite` | Server-side Inbox rules (messageRule API). **Superset of `MailboxSettings.Read`** — declare ReadWrite, not Read. |
 | `User.Read` | Resolve the signed-in user's address/profile |
 | `User.ReadBasic.All` | Resolve other users (recipient display names) |

--- a/docs/planning/full-calendar-pm-dev-spec.md
+++ b/docs/planning/full-calendar-pm-dev-spec.md
@@ -1,7 +1,7 @@
 # Full Calendar — Best-in-Class Accessible Calendar with Sync — PM & Dev Specification
 
-**Status:** Draft for review (greenfield planning)
-**Date:** June 26, 2026
+**Status:** Approved for M1 — §15 open questions Q1–Q7 resolved by Kelly on July 16, 2026 (see §15). M1 (local authoring, recurrence, time zones) may proceed; M2–M6 follow the resolved decisions below.
+**Date:** June 26, 2026 (decisions resolved July 16, 2026)
 **Target:** Phase 3+ (multi-release; sequenced into v-series milestones below)
 **Crew:** Bravo (PM → Dev Lead → Test Enforcer)
 **Depends on (shipped):**
@@ -128,7 +128,7 @@ The work reuses what already exists: the `ICalendarProvider` interface (designed
 | **Sync — ICS feed** | Read-only subscription by URL | Add by URL | off until added | M5 |
 | **Multiple calendars** | Per-account named calendars; color + text label; visibility toggle | Calendar list panel; `Space` toggles | all visible | M4 |
 | | Default calendar for new events | `DefaultCalendarId` | first writable | M4 |
-| **Reminders** | Pre-event notification (in-app banner + optional OS toast + optional sound) | `CalendarReminders` (bool), `DefaultReminderMinutes` | on / 10 min | M6 |
+| **Reminders** | Pre-event notification (Windows toast via existing `INotificationService` + in-app `Result` announcement) | `CalendarReminders` (bool), `DefaultReminderMinutes` | **off (opt-in)** / 10 min | M6 |
 | | Per-event override of reminder lead time | In editor | inherits default | M6 |
 | **Search** | Find events by text/date | `Ctrl+F` within calendar | — | M3 |
 | **RSVP integration** | Accepting an invite also writes the response to the synced calendar | — (automatic when synced) | on | M4 |
@@ -462,6 +462,15 @@ Each milestone is independently shippable and code-reviewable. M1–M3 deliver a
 
 ### M1 — Authoring, recurrence, time zones (local store)
 
+> **Progress — July 16, 2026 (branch `claude/local-calendar-authoring`).** Landed local M1 (partial) + part of M2:
+> - **Local appointment authoring** (create / edit / delete) via `EventEditorViewModel` + modeless `EventEditorWindow`; local events use `CalendarEvent.AccountId == Guid.Empty` as a "local calendar" sentinel.
+> - **Master/detail view** — columned `ListView` (Subject / When / Status) over a read-only Details pane (the ghmanage pattern Kelly asked for).
+> - **All-day appointments** — one additive `is_all_day` column (idempotent ALTER); editor checkbox disables the time fields; all-day-aware display.
+> - **Agenda / Day / Week views** (`CalendarViewMode`) — a windowed filter over the same accessible list plus a period label and navigation (A/D/W, Ctrl+Left/Right, T = today). New `Calendar` command category.
+> - Tests: `EventEditorViewModelTests`, `CalendarViewModelTests` (authoring + view windowing), `CalendarStoreTests` (all-day round-trip); 56 calendar + 35 XAML/construction pass.
+>
+> **Still open:** recurrence (RRULE parse/expand + `RecurrenceExpander`), TZID handling, `.ics` export, the **Month grid** (M3 — deliberately deferred: needs a custom `AutomationPeer` validated live with Kelly's screen reader per Q2), an optional richer 2-D week time-grid, and all sync/reminders (M4–M6). Open gesture is the already-shipped `Ctrl+Shift+C` (not `Ctrl+Shift+K` — the Q3 premise that no toggle existed was inaccurate). **Open a11y question for Kelly:** whether the Agenda list should navigate row-as-sentence (current) or column-by-column.
+
 **Goal:** Create/edit/delete events locally; recurring series expand correctly; TZID honored; single-event `.ics` export.
 
 **Deliverables:**
@@ -527,9 +536,9 @@ Each milestone is independently shippable and code-reviewable. M1–M3 deliver a
 
 ### M6 — Reminders & notifications
 
-**Goal:** Pre-event reminders (in-app banner + optional OS toast + sound), snooze, per-event override.
+**Goal:** Pre-event reminders (Windows toast via the existing `INotificationService`, plus the in-app `Result` announcement), snooze, per-event override. Reminders default **off** (opt-in).
 
-**Deliverables:** `ReminderService` (look-ahead timer over local store); reminder banner + commands; settings (on/off, default minutes, sound); editor reminder field already in M1.
+**Deliverables:** `ReminderService` (look-ahead timer over local store); `ShowReminder(...)` added to `INotificationService` / `WindowsToastNotificationService` (reuses the shipped toast dependency — no new package); reminder commands (Open / Snooze / Dismiss); settings (on/off default off, default minutes); editor reminder field already in M1.
 
 **Tests:** `ReminderServiceTests` (fires at correct lead time, snooze, respects setting), settings round-trip.
 
@@ -663,24 +672,40 @@ Each milestone is independently shippable and code-reviewable. M1–M3 deliver a
 
 ## 15. Open Questions — Decisions Needed Before M2
 
-> Per your instruction, each is written up with the viable options and a recommendation. None is locked.
+> **RESOLVED — July 16, 2026 (Kelly).** All seven questions are decided. Summary:
+>
+> | Q | Decision |
+> |---|---|
+> | Q1 | **CalDAV** for Google (one CalDAV path also serves iCloud/Fastmail/Nextcloud). |
+> | Q2 | **Real grid/table semantics** for the Month grid (Option A); custom `AutomationPeer`, validated live with a screen reader before M3 merge. |
+> | Q3 | **Both** — register a `Ctrl+Shift+K` command *and* keep folder-tree entry (Option C). |
+> | Q4 | **New `Calendar` category** (sixth category; update the category-validation list). |
+> | Q5 | **Unavailable with a Hint** in `--online` mode through M3 (Option A); reconsider remote-only after M4 sync lands. |
+> | Q6 | **Reminders default OFF (opt-in).** When enabled: 10-min lead. Sync poll 5 min. |
+> | Q7 | **Windows toast, reusing the existing notification service — no new dependency.** The `Microsoft.Toolkit.Uwp.Notifications` dependency this question worried about already ships (added for new-mail toasts); add a `ShowReminder(...)` method to `INotificationService` / `WindowsToastNotificationService`. |
+>
+> The per-question write-ups below are retained for rationale.
 
-**Q1 — Google sync stack: CalDAV vs Google Calendar API?**
+**Q1 — Google sync stack: CalDAV vs Google Calendar API?** — **DECIDED: CalDAV (Option A).**
 - *Option A — CalDAV (Google's CalDAV endpoint + Google OAuth).* Pro: one CalDAV code path also serves iCloud/Fastmail/Nextcloud; less Google-specific code. Con: Google's CalDAV is less feature-rich than its REST API; some edge cases (notifications, conferencing) unavailable.
 - *Option B — Google Calendar REST API.* Pro: richest features, clean incremental `syncToken`. Con: Google-specific code + possibly a NuGet dep (or hand-rolled DTOs, consistent with the raw-HttpClient mail decision); separate OAuth client/consent screen verification overhead.
 - **Recommendation:** **A** (CalDAV) for v1 to maximize reuse and minimize Google-specific surface; revisit B if users hit CalDAV limitations. *Your call.*
 
-**Q2 — Month-grid accessibility model: table semantics (A), list-of-days (B), or hybrid (C)?** See Decision 4. **Recommendation: A** (richest, real grid semantics) — but it is the most work and the highest a11y risk; **B** is a safe fallback if A proves unreliable with your screen reader. This is exactly the kind of call where your lived screen-reader expertise should decide; I will not assert what is "better" without your test.
+**Q2 — Month-grid accessibility model: table semantics (A), list-of-days (B), or hybrid (C)?** — **DECIDED: Option A, real grid/table semantics.** The custom `AutomationPeer` must be validated by Kelly with a real screen reader before M3 merge (per §16.2). See Decision 4. **Recommendation: A** (richest, real grid semantics) — but it is the most work and the highest a11y risk; **B** is a safe fallback if A proves unreliable with your screen reader. This is exactly the kind of call where your lived screen-reader expertise should decide; I will not assert what is "better" without your test.
 
-**Q3 — Canonical open gesture.** The minimal-calendar spec proposed `Ctrl+Shift+C`; the shipped build reaches the calendar via the folder tree (no dedicated toggle wired). Options: (A) adopt `Ctrl+Shift+K` as the calendar-mode shortcut; (B) keep folder-tree entry only; (C) both. **Recommendation: C** — register a command (so it's in the palette + customizable) *and* keep folder-tree entry. Confirm the key (`Ctrl+Shift+K` is currently free; verify against `CommandRegistry` at implementation time).
+**Q3 — Canonical open gesture.** — **DECIDED: Option C, both.** Register a `Ctrl+Shift+K` command (palette + customizable) and keep folder-tree entry; verify the key is free in `CommandRegistry` at implementation time. The minimal-calendar spec proposed `Ctrl+Shift+C`; the shipped build reaches the calendar via the folder tree (no dedicated toggle wired). Options: (A) adopt `Ctrl+Shift+K` as the calendar-mode shortcut; (B) keep folder-tree entry only; (C) both. **Recommendation: C** — register a command (so it's in the palette + customizable) *and* keep folder-tree entry. Confirm the key (`Ctrl+Shift+K` is currently free; verify against `CommandRegistry` at implementation time).
 
-**Q4 — Command category.** New commands could go under the existing `View` category or a new `Calendar` category. The enforced list today is `View, Mail, Account, Contacts, Settings, Help`. **Recommendation:** add a **`Calendar`** category (cleaner palette grouping) — but this touches the category-validation list; confirm you want a sixth category.
+**Q4 — Command category.** — **DECIDED: add a new `Calendar` category.** New commands could go under the existing `View` category or a new `Calendar` category. The enforced list today is `View, Mail, Account, Contacts, Settings, Help`. **Recommendation:** add a **`Calendar`** category (cleaner palette grouping) — but this touches the category-validation list; confirm you want a sixth category.
 
-**Q5 — `--online` behavior.** Option A: calendar unavailable with a Hint (matches shipped behavior, simplest). Option B: remote-only live mode (no reminders/search). **Recommendation: A** through M3; reconsider B after sync lands in M4.
+**Q5 — `--online` behavior.** — **DECIDED: Option A (unavailable with a Hint) through M3; reconsider remote-only after M4 sync lands.** Option A: calendar unavailable with a Hint (matches shipped behavior, simplest). Option B: remote-only live mode (no reminders/search). **Recommendation: A** through M3; reconsider B after sync lands in M4.
 
-**Q6 — Default sync cadence & reminder defaults.** Proposed: sync poll 5 min (configurable 1–60), reminders on by default at 10 min, sound off by default, OS toast on by default. Confirm defaults — especially whether reminders should default **on** or **off** (the announcement-infra convention leans toward off-by-default for anything potentially intrusive; reminders are arguably opt-in).
+**Q6 — Default sync cadence & reminder defaults.** — **DECIDED: reminders default OFF (opt-in); when enabled, 10-min lead; sync poll 5 min (configurable 1–60).** This matches the announcement-infra convention of off-by-default for potentially intrusive features. Original proposal (reminders on by default) is overridden.
 
-**Q7 — OS toast dependency.** Native Windows toast (via `Microsoft.Toolkit.Uwp.Notifications` / `CommunityToolkit`) adds a dependency and packaging considerations for the self-contained single-file exe. Alternative: in-app banner only (no dependency). **Recommendation:** in-app banner + sound for v1 (no new dep); add OS toast as a later enhancement if requested.
+**Q7 — OS toast dependency.** — **DECIDED: use native Windows toast, reusing the existing notification service. No new dependency.**
+
+This question's original premise is **out of date**: it was written before new-mail notifications shipped. `Microsoft.Toolkit.Uwp.Notifications` (v7.1.3) is **already** a `PackageReference` in `QuickMail.csproj` and already ships inside the self-contained single-file exe — it was added for new-mail toasts. `WindowsToastNotificationService` already uses `ToastNotificationManagerCompat`, which auto-registers the AppUserModelID + COM activator for an unpackaged Win32 app (no MSIX/appxmanifest); Velopack's Start Menu shortcut supplies the toast's app name/icon. There is therefore **no new dependency and no additional packaging work** for reminders.
+
+**Implementation:** extend `INotificationService` with a `ShowReminder(...)` method (event title, start time, calendar name; toast actions Open / Snooze / Dismiss) and implement it in `WindowsToastNotificationService` alongside `ShowNewMail` / `ShowInfo`, reusing the existing `Activated` argument-parsing/activation plumbing. Every platform call stays guarded (degrade to a logged no-op, never a crash), matching the existing service. A custom reminder window (Outlook-classic style) is explicitly **not** required for v1 and remains a possible later enhancement. The `AnnouncementCategory.Result` in-app announcement (§7) still fires regardless, so reminders are accessible even where the OS toast is unavailable.
 
 ---
 


### PR DESCRIPTION
Lands the local-calendar-authoring work on top of the mail-sync fixes already in main (#267–#270), as one combined branch. Version bumped to 0.8.34.

## What's here
- **Calendar work** (developed on `claude/local-calendar-authoring`): local calendar authoring, master/detail + month views, recurrence/TZID, iCloud/generic CalDAV sync, Google calendar sync + write-back, Microsoft Graph calendar sync + edit/delete/create, per-occurrence editing, reminders, open-calendar push, plus the final working-tree refinements.
- **Merge with main** was conflict-free — the calendar and mail-sync changes touch different regions of the shared files (ConfigModel, ConfigService, MainViewModel, SettingsViewModel, SettingsDialog).

## Independent review (done before this PR)
An independent agent reviewed the combined branch and the merge integration:
- **Empty-calendar hint** (`CalendarViewModel`): collapsed a Status+Hint pair into a single Hint so screen-reader users who disable Status announcements still hear the full "No events. Press N…" context.
- **Graph timezone tests**: the WIP intentionally switched the `Prefer: outlook.timezone` header from `UTC` to the machine's local Windows zone — this fixes all-day events displaying one day early (documented in `GraphCalendarSyncService` commit + code comment). Event bodies still send explicit UTC start/end, so timed events remain unambiguous. Tests updated to expect the local zone, made machine-independent via `TimeZoneInfo.Local.Id`.
- **Integration checks passed**: mail (`MailSyncPollMinutes`) and calendar config keys coexist across ConfigModel/ConfigService/SettingsViewModel/SettingsDialog; reminder timer created once, flag-gated, disposed; new Google/CalDAV clients are `IDisposable` and disposed in `App.OnExit`; CalDAV password stored only via Windows Credential Manager; virtual-folder `\x00` sentinels intact. No MVVM violations. No defects found.

## Testing
- `dotnet build` clean (0 errors; 2 pre-existing CS8625 nullable warnings in GoogleOAuthService, unrelated).
- Full suite: **1366 passed, 0 failed** (excluding the known `PropertiesViewModelTests.CopyAll` clipboard env-flake).
- Not yet exercised as an installed build — a full Velopack installer soak test follows once this is in main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
