### PR TITLE
Log new-mail notification breakdown at Log level when a toast fires (#270)

### DIFF
--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -2242,18 +2242,26 @@ public partial class MainViewModel : ObservableObject, IDisposable
 
         var fresh = Helpers.NewMailFilter.SelectNew(incoming, _notifyThresholdUtc, _notifiedMessageKeys);
 
-        // #270 instrumentation: the user reports an inflated count that re-notifies every ~30 min
-        // (the IDLE reconnect cadence). Log enough to tell whether the SAME message re-notifies each
-        // cycle (dedup key not matching / session reset) or a genuinely new one arrives. UIDs are the
-        // dedup key input, so logging them pins which mechanism is at play. Debug-only (Advanced log).
-        LogService.Debug(
+        // #270 diagnostics: the user reports an inflated count that re-notifies every ~30 min. This
+        // line tells whether the SAME message re-notifies each cycle (dedup key not matching / session
+        // reset) or a genuinely new one arrives — freshUids are the dedup key input, so they pin which
+        // mechanism is at play. When a notification actually fires (fresh > 0) it is logged at Log
+        // level so it is captured by the Settings → Advanced logging toggle (users don't launch with
+        // /debug); the frequent no-op evaluations (fresh == 0, one per IDLE fire and poll cycle) stay
+        // Debug-only so a normal log isn't flooded.
+        var diag =
             $"NewMail notify [{account.AccountLabel}]: incoming={incoming.Count} " +
             $"unread={incoming.Count(m => !m.IsRead)} fresh={fresh.Count} " +
             $"notifiedSetSize={_notifiedMessageKeys.Count} threshold={_notifyThresholdUtc:o} " +
-            $"freshUids=[{string.Join(",", fresh.Select(m => m.MessageId))}]");
+            $"freshUids=[{string.Join(",", fresh.Select(m => m.MessageId))}]";
 
-        if (fresh.Count == 0) return;
+        if (fresh.Count == 0)
+        {
+            LogService.Debug(diag);
+            return;
+        }
 
+        LogService.Log(diag);
         _notifications.ShowNewMail(account.AccountLabel, account.Id, fresh);
     }
 


### PR DESCRIPTION
Follow-up to #270. The notification diagnostic line (`NewMail notify … incoming/unread/fresh/notifiedSetSize/freshUids`) was `LogService.Debug`, so it only appeared with `/debug` on the command line. A user told to "turn on logging in Settings → Advanced" enables `Log` level, not `Debug` — so they could not capture the data needed to diagnose the inflated/repeating notification.

This logs the line at **Log** level when a notification actually fires (`fresh > 0`), and keeps the frequent no-op evaluations (`fresh == 0`, one per IDLE fire and per poll cycle) at Debug so a normal log isn't flooded. No behavior change to notifications themselves.

Verified in the live `/debug` log that the same data is what we want the customer to capture: each fired toast records its fresh count and UIDs, which distinguishes a dedup-key mismatch (same UID re-notifies) from a genuine batch (new sequential UIDs, e.g. after a sleep/reconnect).

Tests: build clean, 1366 passed / 0 failed (excluding the known clipboard env-flake).

🤖 Generated with [Claude Code](https://claude.com/claude-code)