### PR TITLE
Add calendar Go to Date (Ctrl+G)

### DIFF
--- a/QuickMail.Tests/CalendarViewModelTests.cs
+++ b/QuickMail.Tests/CalendarViewModelTests.cs
@@ -212,15 +212,21 @@ public class CalendarViewModelTests
     }
 
     [Fact]
-    public void RequestGoToDate_OnlineMode_DoesNotRaise()
+    public void RequestGoToDate_OnlineMode_DoesNotRaise_ButAnnounces()
     {
         var vm = MakeVm(new List<CalendarEvent> { MakeEvent("e1") }, onlineMode: true);
 
         bool raised = false;
+        string? announced = null;
+        AnnouncementCategory? cat = null;
         vm.GoToDateRequested += _ => raised = true;
+        vm.AnnouncementRequested += (t, c) => { announced = t; cat = c; };
+
         vm.RequestGoToDateCommand.Execute(null);
 
         Assert.False(raised);
+        Assert.Contains("unavailable in online mode", announced);
+        Assert.Equal(AnnouncementCategory.Result, cat);
     }
 
     [Fact]

--- a/QuickMail.Tests/CalendarViewModelTests.cs
+++ b/QuickMail.Tests/CalendarViewModelTests.cs
@@ -184,6 +184,101 @@ public class CalendarViewModelTests
     }
 
     [Fact]
+    public async Task RequestGoToDate_RaisesRequest_SeededWithReferenceDate()
+    {
+        var vm = MakeVm(new List<CalendarEvent> { MakeEvent("e1", DateTime.Today.AddHours(9)) });
+        await vm.LoadAsync();
+        vm.ShowDayCommand.Execute(null);
+        vm.NextPeriodCommand.Execute(null);          // reference = tomorrow
+
+        DateTime? seed = null;
+        vm.GoToDateRequested += d => seed = d;
+        vm.RequestGoToDateCommand.Execute(null);
+
+        Assert.Equal(DateTime.Today.AddDays(1), seed);
+    }
+
+    [Fact]
+    public async Task RequestGoToDate_InAgenda_SeedsToday()
+    {
+        var vm = MakeVm(new List<CalendarEvent> { MakeEvent("e1", DateTime.Today.AddHours(9)) });
+        await vm.LoadAsync();                          // Agenda ignores ReferenceDate
+
+        DateTime? seed = null;
+        vm.GoToDateRequested += d => seed = d;
+        vm.RequestGoToDateCommand.Execute(null);
+
+        Assert.Equal(DateTime.Today, seed);
+    }
+
+    [Fact]
+    public void RequestGoToDate_OnlineMode_DoesNotRaise()
+    {
+        var vm = MakeVm(new List<CalendarEvent> { MakeEvent("e1") }, onlineMode: true);
+
+        bool raised = false;
+        vm.GoToDateRequested += _ => raised = true;
+        vm.RequestGoToDateCommand.Execute(null);
+
+        Assert.False(raised);
+    }
+
+    [Fact]
+    public async Task GoToDate_InDayView_MovesReferenceAndFiltersToThatDay()
+    {
+        var target = DateTime.Today.AddDays(5);
+        var vm = MakeVm(new List<CalendarEvent>
+        {
+            MakeEvent("today", DateTime.Today.AddHours(9)),
+            MakeEvent("target", target.AddHours(9)),
+        });
+        await vm.LoadAsync();
+        vm.ShowDayCommand.Execute(null);
+        Assert.Equal("today", vm.VisibleEvents[0].Uid);
+
+        vm.GoToDate(target);
+
+        Assert.True(vm.IsDayView);
+        Assert.Equal(target, vm.ReferenceDate.Date);
+        Assert.Single(vm.VisibleEvents);
+        Assert.Equal("target", vm.VisibleEvents[0].Uid);
+    }
+
+    [Fact]
+    public async Task GoToDate_FromAgenda_SwitchesToDayView()
+    {
+        var target = DateTime.Today.AddDays(3);
+        var vm = MakeVm(new List<CalendarEvent>
+        {
+            MakeEvent("today", DateTime.Today.AddHours(9)),
+            MakeEvent("target", target.AddHours(9)),
+        });
+        await vm.LoadAsync();                          // Agenda
+
+        vm.GoToDate(target);
+
+        Assert.True(vm.IsDayView);                     // Agenda ignores ReferenceDate → show the day
+        Assert.Equal(target, vm.ReferenceDate.Date);
+        Assert.Single(vm.VisibleEvents);
+        Assert.Equal("target", vm.VisibleEvents[0].Uid);
+    }
+
+    [Fact]
+    public async Task GoToDate_InMonthView_KeepsMonthViewAndMovesMonth()
+    {
+        var target = DateTime.Today.AddMonths(2);
+        var vm = MakeVm(new List<CalendarEvent> { MakeEvent("e1", DateTime.Today.AddHours(9)) });
+        await vm.LoadAsync();
+        vm.ShowMonthCommand.Execute(null);
+
+        vm.GoToDate(target);
+
+        Assert.True(vm.IsMonthView);                   // view mode preserved
+        Assert.Equal(target.Date, vm.ReferenceDate.Date);
+        Assert.Contains(target.ToString("MMMM yyyy"), vm.PeriodLabel);
+    }
+
+    [Fact]
     public async Task WeekView_IncludesWholeWeek_ExcludesNextWeek()
     {
         var today = DateTime.Today;

--- a/QuickMail.Tests/GoToDateViewModelTests.cs
+++ b/QuickMail.Tests/GoToDateViewModelTests.cs
@@ -1,0 +1,67 @@
+using System;
+using QuickMail.Models;
+using QuickMail.ViewModels;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// Tests for <see cref="GoToDateViewModel"/> — the Go To Date picker's authoring VM.
+/// Pure VM logic, no UI or STA thread.
+/// </summary>
+public class GoToDateViewModelTests
+{
+    [Fact]
+    public void Constructor_SeedsSelectedDateFromInitial()
+    {
+        var initial = new DateTime(2026, 3, 14, 10, 30, 0);
+        var vm = new GoToDateViewModel(initial);
+
+        Assert.Equal(initial.Date, vm.SelectedDate);   // time component dropped
+    }
+
+    [Fact]
+    public void Confirm_WithDate_RaisesSavedWithDateOnly()
+    {
+        var vm = new GoToDateViewModel(DateTime.Today)
+        {
+            SelectedDate = new DateTime(2026, 7, 4, 13, 0, 0),
+        };
+
+        DateTime? saved = null;
+        vm.Saved += d => saved = d;
+        vm.ConfirmCommand.Execute(null);
+
+        Assert.Equal(new DateTime(2026, 7, 4), saved);
+    }
+
+    [Fact]
+    public void Confirm_WithNullDate_AnnouncesAndDoesNotRaiseSaved()
+    {
+        var vm = new GoToDateViewModel(DateTime.Today) { SelectedDate = null };
+
+        bool saved = false;
+        string? announced = null;
+        AnnouncementCategory? cat = null;
+        vm.Saved += _ => saved = true;
+        vm.AnnouncementRequested += (t, c) => { announced = t; cat = c; };
+
+        vm.ConfirmCommand.Execute(null);
+
+        Assert.False(saved);
+        Assert.Contains("Choose a date", announced);
+        Assert.Equal(AnnouncementCategory.Result, cat);
+    }
+
+    [Fact]
+    public void Cancel_RaisesCancelled()
+    {
+        var vm = new GoToDateViewModel(DateTime.Today);
+
+        bool cancelled = false;
+        vm.Cancelled += () => cancelled = true;
+        vm.CancelCommand.Execute(null);
+
+        Assert.True(cancelled);
+    }
+}

--- a/QuickMail/ViewModels/CalendarViewModel.cs
+++ b/QuickMail/ViewModels/CalendarViewModel.cs
@@ -345,7 +345,11 @@ public partial class CalendarViewModel : ObservableObject
     [RelayCommand]
     private void RequestGoToDate()
     {
-        if (_onlineMode) return;
+        if (_onlineMode)
+        {
+            Announce("Calendar is unavailable in online mode.", AnnouncementCategory.Result);
+            return;
+        }
         var seed = ViewMode == CalendarViewMode.Agenda ? DateTime.Today : ReferenceDate;
         GoToDateRequested?.Invoke(seed);
     }

--- a/QuickMail/ViewModels/CalendarViewModel.cs
+++ b/QuickMail/ViewModels/CalendarViewModel.cs
@@ -334,6 +334,40 @@ public partial class CalendarViewModel : ObservableObject
         => Announce($"{PeriodLabel}. {VisibleEvents.Count} event{(VisibleEvents.Count == 1 ? "" : "s")}.",
                     AnnouncementCategory.Status);
 
+    /// <summary>Raised to open the Go To Date picker, seeded with the current reference date.</summary>
+    public event Action<DateTime>? GoToDateRequested;
+
+    /// <summary>
+    /// Bound to Ctrl+G (calendar.goToDate). Opens the Go To Date picker so the user can jump the
+    /// calendar to any date. Seeds the picker with the current reference date (today in Agenda,
+    /// which ignores it).
+    /// </summary>
+    [RelayCommand]
+    private void RequestGoToDate()
+    {
+        if (_onlineMode) return;
+        var seed = ViewMode == CalendarViewMode.Agenda ? DateTime.Today : ReferenceDate;
+        GoToDateRequested?.Invoke(seed);
+    }
+
+    /// <summary>
+    /// Jumps the calendar to <paramref name="date"/>. Day/Week/Month keep their view mode and
+    /// recentre on the date; Agenda (which ignores ReferenceDate) switches to Day view so the
+    /// chosen date is actually shown. Called by the View when the Go To Date picker confirms.
+    /// </summary>
+    public void GoToDate(DateTime date)
+    {
+        ReferenceDate = date.Date;
+        if (ViewMode == CalendarViewMode.Agenda)
+        {
+            SwitchView(CalendarViewMode.Day); // applies filters, reselects, announces the day
+            return;
+        }
+        ApplyFilters();
+        SelectedEvent = Events.Count > 0 ? Events[0] : null;
+        AnnouncePeriod();
+    }
+
     /// <summary>Opens the appointment editor to create a new local event. Bound to N / Ctrl+Shift+N.</summary>
     [RelayCommand]
     private void NewEvent()

--- a/QuickMail/ViewModels/GoToDateViewModel.cs
+++ b/QuickMail/ViewModels/GoToDateViewModel.cs
@@ -1,0 +1,48 @@
+using System;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using QuickMail.Models;
+
+namespace QuickMail.ViewModels;
+
+/// <summary>
+/// Tiny authoring ViewModel for the Go To Date picker: holds the chosen date and raises
+/// <see cref="Saved"/> / <see cref="Cancelled"/>. Pure VM — no View types, no window references.
+/// The View subscribes to <see cref="Saved"/> (apply the date and close) and <see cref="Cancelled"/>
+/// (close), and to <see cref="AnnouncementRequested"/> for validation feedback.
+/// </summary>
+public partial class GoToDateViewModel : ObservableObject
+{
+    public GoToDateViewModel(DateTime initial) => _selectedDate = initial.Date;
+
+    /// <summary>The date the user has chosen. Bound two-way to the DatePicker.</summary>
+    [ObservableProperty] private DateTime? _selectedDate;
+
+    /// <summary>Raised with the chosen date when the user confirms.</summary>
+    public event Action<DateTime>? Saved;
+
+    /// <summary>Raised when the user cancels.</summary>
+    public event Action? Cancelled;
+
+    /// <summary>
+    /// Raised to request a screen-reader announcement. The View subscribes and calls
+    /// <c>AccessibilityHelper.Announce(text, category)</c>.
+    /// </summary>
+    public event Action<string, AnnouncementCategory>? AnnouncementRequested;
+
+    /// <summary>Confirms the chosen date. Bound to the Go button and Enter.</summary>
+    [RelayCommand]
+    private void Confirm()
+    {
+        if (SelectedDate is not { } date)
+        {
+            AnnouncementRequested?.Invoke("Choose a date first.", AnnouncementCategory.Result);
+            return;
+        }
+        Saved?.Invoke(date.Date);
+    }
+
+    /// <summary>Dismisses the picker without changing the calendar. Bound to Cancel and Escape.</summary>
+    [RelayCommand]
+    private void Cancel() => Cancelled?.Invoke();
+}

--- a/QuickMail/Views/GoToDateWindow.xaml
+++ b/QuickMail/Views/GoToDateWindow.xaml
@@ -1,0 +1,52 @@
+<Window x:Class="QuickMail.Views.GoToDateWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        mc:Ignorable="d"
+        Title="Go to date"
+        SizeToContent="WidthAndHeight"
+        MinWidth="320"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="NoResize"
+        ShowInTaskbar="False"
+        PreviewKeyDown="Window_PreviewKeyDown"
+        Background="{DynamicResource Theme.WindowBackground}"
+        Foreground="{DynamicResource Theme.TextPrimary}"
+        FontFamily="{DynamicResource Theme.FontFamily}"
+        FontSize="{DynamicResource Theme.FontSizeBase}">
+
+    <Grid Margin="14">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto"/>
+            <ColumnDefinition Width="*"/>
+        </Grid.ColumnDefinitions>
+
+        <TextBlock Grid.Row="0" Grid.Column="0" Text="Date:"
+                   Margin="0,0,8,12" VerticalAlignment="Center"/>
+        <DatePicker Grid.Row="0" Grid.Column="1"
+                    x:Name="DatePickerBox"
+                    AutomationProperties.Name="Date"
+                    SelectedDate="{Binding SelectedDate}"
+                    MinWidth="150" Margin="0,0,0,12"/>
+
+        <StackPanel Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2"
+                    Orientation="Horizontal" HorizontalAlignment="Right">
+            <Button x:Name="GoButton"
+                    Content="_Go"
+                    IsDefault="True"
+                    AutomationProperties.Name="Go to date"
+                    MinWidth="90"
+                    Click="Go_Click"/>
+            <Button Content="Cancel"
+                    IsCancel="True"
+                    AutomationProperties.Name="Cancel"
+                    MinWidth="90" Margin="8,0,0,0"
+                    Click="Cancel_Click"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/QuickMail/Views/GoToDateWindow.xaml.cs
+++ b/QuickMail/Views/GoToDateWindow.xaml.cs
@@ -1,0 +1,102 @@
+using System.Windows;
+using System.Windows.Input;
+using QuickMail.Models;
+using QuickMail.Services;
+using QuickMail.ViewModels;
+
+namespace QuickMail.Views;
+
+/// <summary>
+/// Modeless picker for jumping the calendar to a date. Modeless per the CLAUDE.md modal rules —
+/// an editable-field dialog (the DatePicker) opened over the main window's live WebView2 reading
+/// pane must not use <c>ShowDialog()</c>. Escape / Cancel / Enter and the command palette are wired
+/// explicitly because a modeless window has no <c>DialogResult</c>.
+/// </summary>
+public partial class GoToDateWindow : Window
+{
+    private readonly GoToDateViewModel _vm;
+    private readonly CommandRegistry _registry = new();
+
+    public GoToDateWindow(GoToDateViewModel vm)
+    {
+        _vm = vm;
+        DataContext = vm;
+        InitializeComponent();
+
+        _vm.Saved += _ => Close();
+        _vm.Cancelled += Close;
+        _vm.AnnouncementRequested += (text, category) =>
+            AccessibilityHelper.Announce(this, text, category: category);
+
+        RegisterPaletteCommands();
+
+        Loaded += (_, _) =>
+        {
+            DatePickerBox.Focus();
+            AccessibilityHelper.Announce(this,
+                "Choose a date, then press Go. Press Escape to cancel.",
+                category: AnnouncementCategory.Hint);
+        };
+    }
+
+    private void RegisterPaletteCommands()
+    {
+        _registry.Register(new CommandDefinition(
+            id: "gotodate.confirm", category: "Calendar", title: "Go to date",
+            execute: () => _vm.ConfirmCommand.Execute(null),
+            defaultKey: Key.Enter, defaultModifiers: ModifierKeys.Control));
+        _registry.Register(new CommandDefinition(
+            id: "gotodate.cancel", category: "Calendar", title: "Cancel",
+            execute: () => _vm.CancelCommand.Execute(null),
+            defaultKey: Key.Escape, defaultModifiers: ModifierKeys.None));
+    }
+
+    private void Go_Click(object sender, RoutedEventArgs e) => _vm.ConfirmCommand.Execute(null);
+    private void Cancel_Click(object sender, RoutedEventArgs e) => _vm.CancelCommand.Execute(null);
+
+    private void Window_PreviewKeyDown(object sender, KeyEventArgs e)
+    {
+        // Ctrl+Shift+P — command palette (framework-level; cannot dispatch through itself).
+        if (e.Key == Key.P && Keyboard.Modifiers == (ModifierKeys.Control | ModifierKeys.Shift))
+        {
+            e.Handled = true;
+            new CommandPaletteWindow(_registry) { Owner = this }.ShowDialog();
+            return;
+        }
+
+        // F6 / Shift+F6 — cycle the logical stops (framework-level, like the palette).
+        if (e.Key == Key.F6)
+        {
+            e.Handled = true;
+            CycleFocus(forward: Keyboard.Modifiers != ModifierKeys.Shift);
+            return;
+        }
+
+        // Escape while the DatePicker calendar drop-down is open: let the control consume it
+        // (the modeless-dialog Escape guard in CLAUDE.md) rather than closing the window.
+        if (e.Key == Key.Escape && DatePickerBox.IsDropDownOpen)
+            return;
+
+        // Registry dispatch (ComposeWindow pattern) — so gotodate.confirm / gotodate.cancel
+        // rebindings in the keyboard customizations dialog actually take effect.
+        var key = e.Key == Key.System ? e.SystemKey : e.Key;
+        var cmd = _registry.FindByGesture(key, Keyboard.Modifiers);
+        if (cmd != null && (cmd.IsAvailable?.Invoke() ?? true))
+        {
+            e.Handled = true;
+            cmd.Execute();
+        }
+    }
+
+    /// <summary>Cycles focus across the picker's logical stops: Date → Go.</summary>
+    private void CycleFocus(bool forward)
+    {
+        System.Windows.Controls.Control[] stops = { DatePickerBox, GoButton };
+        var current = System.Array.FindIndex(stops, c => c.IsKeyboardFocusWithin);
+        if (current < 0) current = 0;
+        var next = forward
+            ? (current + 1) % stops.Length
+            : (current - 1 + stops.Length) % stops.Length;
+        stops[next].Focus();
+    }
+}

--- a/QuickMail/Views/GoToDateWindow.xaml.cs
+++ b/QuickMail/Views/GoToDateWindow.xaml.cs
@@ -42,7 +42,7 @@ public partial class GoToDateWindow : Window
     private void RegisterPaletteCommands()
     {
         _registry.Register(new CommandDefinition(
-            id: "gotodate.confirm", category: "Calendar", title: "Go to date",
+            id: "gotodate.confirm", category: "Calendar", title: "Go to Date",
             execute: () => _vm.ConfirmCommand.Execute(null),
             defaultKey: Key.Enter, defaultModifiers: ModifierKeys.Control));
         _registry.Register(new CommandDefinition(

--- a/QuickMail/Views/MainWindow.xaml
+++ b/QuickMail/Views/MainWindow.xaml
@@ -1175,7 +1175,9 @@
                             <Button Content="Today" AutomationProperties.Name="Go to today"
                                     MinWidth="56" Margin="0,0,4,0" Click="CalendarToday_Click"/>
                             <Button Content="▶" AutomationProperties.Name="Next period"
-                                    MinWidth="32" Click="CalendarNext_Click"/>
+                                    MinWidth="32" Margin="0,0,12,0" Click="CalendarNext_Click"/>
+                            <Button Content="_Go To Date…" AutomationProperties.Name="Go to date"
+                                    MinWidth="96" Click="CalendarGoToDate_Click"/>
                         </StackPanel>
 
                         <!-- Period label + search + item toolbar -->

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -2270,18 +2270,31 @@ public partial class MainWindow : Window
     private void CalendarGoToDate_Click(object sender, RoutedEventArgs e)
         => _vm.CalendarVm?.RequestGoToDateCommand.Execute(null);
 
+    private GoToDateWindow? _goToDateWindow;
+
     /// <summary>
     /// Opens the modeless Go To Date picker seeded with <paramref name="initial"/>. On confirm it
     /// jumps the calendar; either way focus returns to the calendar list on close. Modeless per the
-    /// CLAUDE.md modal rules (editable DatePicker over the live WebView2 reading pane).
+    /// CLAUDE.md modal rules (editable DatePicker over the live WebView2 reading pane). Only one
+    /// picker is shown at a time — a second request activates the existing one.
     /// </summary>
     private void OpenGoToDateDialog(DateTime initial)
     {
+        if (_goToDateWindow != null)
+        {
+            _goToDateWindow.Activate();
+            return;
+        }
+
         var pickerVm = new GoToDateViewModel(initial);
         pickerVm.Saved += date => _vm.CalendarVm?.GoToDate(date);
         var picker = new GoToDateWindow(pickerVm) { Owner = this };
+        _goToDateWindow = picker;
         picker.Closed += (_, _) =>
+        {
+            _goToDateWindow = null;
             Dispatcher.InvokeAsync(FocusCalendarList, DispatcherPriority.Input);
+        };
         picker.Show();
     }
 

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -396,6 +396,7 @@ public partial class MainWindow : Window
             vm.CalendarVm.OpenSourceMessageRequested += (accountId, folder, messageId) =>
                 vm.OpenCalendarSourceMessage(accountId, folder, messageId);
             vm.CalendarVm.EditorRequested += OpenEventEditor;
+            vm.CalendarVm.GoToDateRequested += OpenGoToDateDialog;
             vm.CalendarVm.DeleteConfirmRequested += ConfirmDeleteAppointment;
             vm.CalendarVm.RecurringDeleteConfirmRequested += ConfirmDeleteRecurring;
             vm.CalendarVm.ListFocusRequested += () =>
@@ -1265,6 +1266,11 @@ public partial class MainWindow : Window
             execute: () => _vm.CalendarVm?.NextPeriodCommand.Execute(null),
             defaultKey: Key.Right, defaultModifiers: ModifierKeys.Control,
             isAvailable: () => CalendarPaneFocused));
+        _registry.Register(new CommandDefinition(
+            id: "calendar.goToDate", category: "Calendar", title: "Go to Date",
+            execute: () => _vm.CalendarVm?.RequestGoToDateCommand.Execute(null),
+            defaultKey: Key.G, defaultModifiers: ModifierKeys.Control,
+            isAvailable: () => _vm.IsCalendarView));
 
         // Install the WM_CONTEXTMENU hook before WebView2 init. WebView2 initialization
         // creates an out-of-process HWND that grabs Win32 focus without WPF tracking it,
@@ -2259,6 +2265,24 @@ public partial class MainWindow : Window
             Dispatcher.InvokeAsync(FocusCalendarList, DispatcherPriority.Input);
         };
         editor.Show();
+    }
+
+    private void CalendarGoToDate_Click(object sender, RoutedEventArgs e)
+        => _vm.CalendarVm?.RequestGoToDateCommand.Execute(null);
+
+    /// <summary>
+    /// Opens the modeless Go To Date picker seeded with <paramref name="initial"/>. On confirm it
+    /// jumps the calendar; either way focus returns to the calendar list on close. Modeless per the
+    /// CLAUDE.md modal rules (editable DatePicker over the live WebView2 reading pane).
+    /// </summary>
+    private void OpenGoToDateDialog(DateTime initial)
+    {
+        var pickerVm = new GoToDateViewModel(initial);
+        pickerVm.Saved += date => _vm.CalendarVm?.GoToDate(date);
+        var picker = new GoToDateWindow(pickerVm) { Owner = this };
+        picker.Closed += (_, _) =>
+            Dispatcher.InvokeAsync(FocusCalendarList, DispatcherPriority.Input);
+        picker.Show();
     }
 
     // ── Calendar search (Ctrl+F while the calendar list has focus) ──

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -545,6 +545,7 @@ A **Calendar** node appears in the folder tree. Select it to replace the message
 - **Arrow keys** move through the event list.
 - **Enter** opens the email the selected event came from. If that message is no longer in your local cache, QuickMail announces this and does nothing rather than attempting a failing fetch.
 - **T** filters the list to today's events.
+- **Ctrl+G** opens **Go to Date**: choose a date and press **Go** to jump the calendar there. In Day, Week, or Month view the current view is kept and recentred on the date you chose; from the Agenda list it switches to Day view for that date. A **Go To Date…** button on the calendar toolbar does the same thing.
 - **F5** refreshes the calendar.
 - **F6** cycles to the next pane as usual.
 


### PR DESCRIPTION
## Summary

Adds a **Go to Date** feature to the calendar so users can jump the view to any date, rather than only paging one period at a time with Ctrl+Left/Right. Requested as a follow-up to the full-calendar work.

Entry points, all wired to the same action:
- **Ctrl+G** (configurable — registered as `calendar.goToDate`, so it's rebindable in keyboard customizations)
- **Command Palette** (`Ctrl+Shift+P` → "Go to Date")
- **Go To Date…** toolbar button next to the period-navigation buttons

## Behavior

Opens a small **Go to Date** picker (a `DatePicker` + Go/Cancel). On confirm:
- **Day / Week / Month** view: keeps the current view mode and recentres it on the chosen date.
- **Agenda** list (which ignores the reference date): switches to **Day** view showing the chosen date.

The new period is announced through the existing `AnnouncementCategory.Status` pipeline, consistent with `Ctrl+Left/Right` paging and "go to today".

## Implementation notes

- **Modeless dialog** (`GoToDateWindow` uses `.Show()`, not `ShowDialog()`) per the CLAUDE.md modal rules — an editable `DatePicker` opened over the main window's live WebView2 reading pane must not run a nested modal loop. Escape / Cancel / Enter, the command palette, and F6 are wired explicitly because a modeless window has no `DialogResult`. Focus returns to the calendar list on close.
- **MVVM**: `GoToDateViewModel` is a pure VM (raises `Saved`/`Cancelled`/`AnnouncementRequested`); `CalendarViewModel` raises `GoToDateRequested` and exposes `GoToDate(date)`. The View owns all window/dialog concerns.
- **Ctrl+G** was free in `MainWindow`'s registry (`Ctrl+Shift+G` is Grab Addresses; the `Ctrl+G` hits elsewhere are in the separate Address Book window's own registry).
- Command `isAvailable` is scoped to `IsCalendarView` (like `calendar.search`), so Ctrl+G passes through unaffected everywhere else in the app.

## Tests

- `CalendarViewModelTests`: request seeding (reference date vs. today in Agenda), online-mode guard, and `GoToDate` behavior in Day/Agenda/Month.
- `GoToDateViewModelTests`: confirm with/without a date, date-only normalization, cancel.
- Full suite green: **1389 passed, 0 failed**.

## Docs

- User guide: added a Ctrl+G / Go to Date bullet to the Calendar section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)