### PR TITLE
Prep v0.8.33: fix version, full calendar guide + release notes

### DIFF
--- a/QuickMail/QuickMail.csproj
+++ b/QuickMail/QuickMail.csproj
@@ -15,9 +15,9 @@
          System.Windows(.Media) types this codebase uses unqualified (Point, Size, Color, Brush,
          Application, MessageBox, ...). -->
     <UseWindowsForms>true</UseWindowsForms>
-    <Version>0.8.34</Version>
-    <AssemblyVersion>0.8.34</AssemblyVersion>
-    <FileVersion>0.8.34</FileVersion>
+    <Version>0.8.33</Version>
+    <AssemblyVersion>0.8.33</AssemblyVersion>
+    <FileVersion>0.8.33</FileVersion>
     <!-- Velopack needs a hand-written Main that runs VelopackApp.Build().Run() before WPF
          initializes (install/update/uninstall hooks run and may exit the process). App.xaml
          therefore compiles as Page (no generated Main) and the entry point is declared here. -->

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -538,20 +538,177 @@ Press the assigned hotkey from anywhere in the main window to switch to that vie
 
 ## Calendar
 
-QuickMail tracks upcoming appointments drawn from meeting-invitation emails (`.ics` attachments) in your mailbox. This is not a general-purpose calendar — it exists so that once you accept a meeting invitation in QuickMail, you have a place to see what you accepted.
+QuickMail has a full, keyboard-first calendar. You can create and edit your own appointments, keep repeating events, get reminders, respond to meeting invitations, and — if you connect an online account — see and (for some providers) change the events already on your Microsoft, Google, or iCloud calendar. Everything is stored locally so the calendar works offline, and every part of it is reachable with the keyboard and announced by screen readers.
 
-A **Calendar** node appears in the folder tree. Select it to replace the message list with a list of upcoming events, sorted by date and time.
+This page is long because the calendar does a lot. If you just want the essentials: press **Ctrl+Shift+C** to open the calendar, press **N** to create an appointment, and use the arrow keys to move through your events. The rest of this page fills in the detail, including a clear list of [what the calendar does and does not do](#what-the-calendar-does-and-does-not-do).
 
-- **Arrow keys** move through the event list.
-- **Enter** opens the email the selected event came from. If that message is no longer in your local cache, QuickMail announces this and does nothing rather than attempting a failing fetch.
-- **T** filters the list to today's events.
-- **Ctrl+G** opens **Go to Date**: choose a date and press **Go** to jump the calendar there. In Day, Week, or Month view the current view is kept and recentred on the date you chose; from the Agenda list it switches to Day view for that date. A **Go To Date…** button on the calendar toolbar does the same thing.
-- **F5** refreshes the calendar.
-- **F6** cycles to the next pane as usual.
+### Opening the Calendar
 
-### Responding to Invitations
+There are two ways in:
 
-Open a meeting invitation email as you would any message. Below the invitation details (organizer, time, location, description), the message body shows three response links: **Accept**, **Tentative**, and **Decline**. Activating one records your response and updates the Calendar immediately — no restart or refresh needed. These links are not shown on a cancellation notice. When you receive an updated or cancelled invitation, the corresponding calendar entry updates or is removed automatically.
+- Press **Ctrl+Shift+C** from anywhere in the main window.
+- Select the **Calendar** node in the folder tree. It sits alongside your mail folders.
+
+Either way, the message list is replaced by your list of events, and a small toolbar appears above it with buttons for the views, date navigation, and creating or editing appointments. Everything on that toolbar has a keyboard shortcut too, listed at the end of this page.
+
+> The calendar needs QuickMail's local cache, so it is **not available when you run QuickMail in online mode** (`--online`). In that mode the calendar announces that it is unavailable.
+
+### Calendars (sources)
+
+Expand the **Calendar** node in the folder tree to choose which events you are looking at:
+
+- **All Calendars** — everything, merged together.
+- **Local Calendar** — only the appointments you created in QuickMail, stored on this computer.
+- **One entry per account** — the events from each email account's online calendar (see [Connecting an online calendar](#connecting-an-online-calendar)).
+- **iCloud** (or whatever you named it) — appears when you have set up an internet calendar in Settings.
+
+Selecting a source filters the list to just that calendar. "All Calendars" is the usual choice for day-to-day use.
+
+### The four views
+
+Your events can be shown four ways. Switch between them with the toolbar buttons or these keys while the event list has focus:
+
+- **Agenda** (press **A**) — a running list of upcoming events, oldest first. This is the default and the simplest to browse. Press **T** to filter it down to just today, and **T** again to show everything.
+- **Day** (press **D**) — a single day's events.
+- **Week** (press **W**) — one week, starting on whatever your Windows region setting uses as the first day of the week.
+- **Month** (press **M**) — a grid of the whole month. Arrow keys move day by day and week by week; press **Enter** on a day to open that day in Day view.
+
+The header above the list always tells you which view and which period you are looking at (for example, "Week of March 9 to March 15").
+
+### Moving around the calendar
+
+In Day, Week, and Month views:
+
+- **Ctrl+Left** and **Ctrl+Right** move to the previous or next day, week, or month (whichever view you are in).
+- **T** jumps back to today.
+- **Ctrl+G** opens **Go to Date**: type or pick a date, then press **Go**. Day, Week, and Month views keep their view and recenter on the date you chose; from the Agenda list, Go to Date switches to Day view for that date. A **Go To Date…** button on the toolbar does the same thing.
+
+(In Agenda view there is no "previous/next period" — the list is already continuous — so **Ctrl+Left/Right** do nothing there, and **T** toggles the today filter instead of jumping.)
+
+### Reading an appointment
+
+Move through the list with the arrow keys. Each row is announced as a short summary — for example, "Team standup, today 10:00 to 10:30, Accepted. Location: Zoom." A **details** area below the list shows the full appointment (title, when, whether it repeats, location, and for meeting invitations the organizer and your response status), read from the top so a screen reader can review it line by line.
+
+If you prefer each row spoken with field labels ("Subject …, when …, location …") instead of the concise form, turn on **Show field labels in the calendar event list** in **Settings → General**. It takes effect immediately.
+
+### Creating an appointment
+
+Press **N** (or the **New** toolbar button) to open the appointment editor. It is a normal window you can tab through:
+
+- **Title** — required.
+- **All day** — check this for an all-day event; the time fields then switch off.
+- **Starts / Ends** — a date and a time for each. You can type the time naturally: "9", "9:00", "9:00 AM", or "14:30" all work. If you leave the end time blank, QuickMail uses 30 minutes after the start.
+- **Location** — optional.
+- **Repeat** — leave as "Does not repeat" for a one-off, or set up a repeating appointment (see below).
+- **Notes** — free text.
+- **Calendar** — when you have a Microsoft or Google account connected, a picker lets you choose whether the new appointment is saved to your **Local Calendar** or pushed to that account. With no connected calendar this picker does not appear and everything is saved locally.
+
+Press **Enter** (or the **Save** button) to save, or **Escape** to cancel.
+
+### Repeating appointments
+
+In the editor's **Repeat** field choose Daily, Weekly, Monthly, or Yearly. You can then set:
+
+- **Every N** — for example "every 2 weeks."
+- **Until** — an optional date the repetition stops on.
+- **On days** (Weekly only) — check the days of the week it should fall on. Leave them all unchecked to repeat on the same weekday as the start date.
+
+When you later edit or delete one occurrence of a repeating appointment, QuickMail asks whether you mean **this event only** or **all events in the series**:
+
+- **This event only** — changes (or removes) just that one date and leaves the rest of the series alone.
+- **All events in the series** — changes (or removes) the whole repeating appointment.
+
+### Editing and deleting
+
+- Press **E** (or the **Edit** button) to edit the selected appointment.
+- Press **Delete** (or the **Delete** button) to delete it. QuickMail always confirms before deleting.
+
+What you can change depends on where the appointment lives:
+
+- **Your own (Local Calendar) appointments** — fully editable and deletable.
+- **Single events from a connected Microsoft or Google calendar** — editable and deletable; your change is sent back to that account.
+- **Repeating events from a connected online calendar** — read-only for now; QuickMail tells you so rather than changing them.
+- **iCloud / internet-calendar events and meeting invitations** — read-only. QuickMail explains why instead of failing silently.
+
+If saving a change to an online account ever fails, QuickMail saves your appointment to the Local Calendar instead so your work is never lost, and tells you it did.
+
+### Reminders
+
+Reminders are **off by default**. To turn them on, open **Settings → General**, check **Remind me before appointments**, and set the **Minutes before** value (10 by default). When a reminder is due, QuickMail shows a Windows notification and announces it, telling you how long until the appointment and where it is. Each reminder fires once per session.
+
+There is a single reminder lead time for all appointments; per-appointment reminder times and snoozing are not offered.
+
+### Exporting an appointment
+
+To share an appointment as a standard calendar file, select it and choose **Export Appointment as .ics** from the command palette (**Ctrl+Shift+P**) or the toolbar/menu. QuickMail writes a `.ics` file you can send to someone or import elsewhere. (Exporting one occurrence of a repeating appointment exports the whole series.) This action has no default keyboard shortcut, but you can assign one in **Settings → Keyboard**.
+
+### Searching your appointments
+
+Press **Ctrl+Shift+S** while the calendar is open to search. Type to filter the list by title, location, or notes; the count of matches is announced as you type. Press **Escape** to clear the search and return to the full list.
+
+### Responding to meeting invitations
+
+When you open an email that contains a meeting invitation, QuickMail adds an event card to the top of the message with three buttons: **Accept**, **Tentative**, and **Decline**. Choosing one sends your reply to the organizer and updates your calendar right away — no restart or refresh needed. If the invitation has been cancelled by the organizer, the card says so instead of offering buttons, and the matching calendar entry is removed. From the calendar list, pressing **Enter** on an invitation-based event opens the original email it came from.
+
+### Connecting an online calendar
+
+QuickMail can sync with online calendars. What it can do depends on the provider:
+
+| Provider | See your events | Create / edit / delete from QuickMail | How to set it up |
+|----------|-----------------|----------------------------------------|------------------|
+| **Local Calendar** | — (they live here) | Full | Nothing to set up; it is always there. |
+| **Microsoft** (Outlook.com, Microsoft 365) | Yes | Yes, for single (non-repeating) events | Automatic once you add the Microsoft account for mail and grant calendar access. |
+| **Google** | Yes | Yes, for single (non-repeating) events | Automatic once the Google account is connected for mail. |
+| **iCloud / other internet calendars (CalDAV)** | Yes | No — read-only | **Settings → General → Internet Calendar**: enter the server address, your username, and an app-specific password, then press **Test**. For iCloud use `https://caldav.icloud.com`, your Apple ID, and an app-specific password. |
+
+Connected calendars refresh automatically in the background (roughly every 15 minutes, and once shortly after startup). Press **F5** to refresh on demand. Syncing is one-directional download plus, for Microsoft and Google, the single-event write-back described above; it never opens a sign-in prompt on its own — if an account needs you to sign in again for calendar access, QuickMail tells you.
+
+### What the calendar does and does not do
+
+To set expectations clearly:
+
+**It does:**
+
+- Let you create, edit, and delete your own appointments, including all-day and repeating ones.
+- Show four views (Agenda, Day, Week, Month) and jump to any date.
+- Remind you before appointments (when you turn reminders on).
+- Respond to meeting invitations and keep your reply in sync.
+- Download events from Microsoft, Google, and iCloud/CalDAV calendars, and send single-event changes back to Microsoft and Google.
+- Export any appointment as a `.ics` file.
+
+**It does not (yet):**
+
+- Work in online mode — it needs the local cache.
+- Send **repeating** appointments to an online account (repeating appointments are saved to the Local Calendar).
+- Edit **repeating** events that came from an online calendar, or edit anything on an **iCloud/CalDAV** calendar (those are read-only).
+- Subscribe to public `.ics` calendar feeds (holidays, sports schedules, and the like).
+- Offer multiple named calendars, calendar colors, per-appointment reminder times, or reminder snoozing.
+
+By default, invitations you have **declined** are hidden. Showing them is an advanced option set in the configuration file (`ShowDeclinedEvents`) and takes effect after a restart.
+
+Repeating appointments are expanded for browsing from about a week ago through the next twelve months; events far outside that window may not appear in the continuous Agenda list until you navigate to their date.
+
+### Calendar keyboard shortcuts
+
+These work while the calendar list (or, where noted, the Month grid) has focus:
+
+| Shortcut | Action |
+|----------|--------|
+| `Ctrl+Shift+C` | Open the Calendar |
+| `A` / `D` / `W` / `M` | Agenda / Day / Week / Month view |
+| `T` | Today (filter to today in Agenda; jump to today in Day/Week/Month) |
+| `Ctrl+Left` / `Ctrl+Right` | Previous / next day, week, or month |
+| `Ctrl+G` | Go to Date |
+| `Enter` | Open an invitation's source email, edit your own appointment, or (in Month view) open the selected day |
+| `N` | New appointment |
+| `E` | Edit appointment |
+| `Delete` | Delete appointment |
+| `Ctrl+Shift+S` | Search appointments |
+| `Escape` | Clear search / leave the calendar |
+| `F5` | Refresh |
+| `F6` | Move to the next pane |
+
+Export as `.ics`, and the invitation responses (Accept, Tentative, Decline), are available from the command palette (**Ctrl+Shift+P**) and have no default key until you assign one.
 
 ---
 
@@ -785,7 +942,7 @@ Every announcement is optional and controlled by the settings above. No custom s
 
 **Move to Folder…** and **Copy to Folder…** are available from the context menu (Shift+F10) or the command palette; they have no default keyboard shortcut. **Manage Themes**, **Next Theme**, **Previous Theme**, and **Report a Bug** are likewise command-palette-only unless you assign a shortcut yourself in Settings → Keyboard.
 
-**Calendar list** (when the Calendar folder is selected): `T` filters to today's events; `Enter` opens the source invitation email; `F5` refreshes; arrow keys browse.
+**Calendar** (`Ctrl+Shift+C` to open): `A`/`D`/`W`/`M` switch views, `T` goes to today, `Ctrl+Left`/`Ctrl+Right` move between periods, `Ctrl+G` goes to a date, `N`/`E`/`Delete` create/edit/delete appointments, and `Ctrl+Shift+S` searches. See the [Calendar](#calendar) section for the full list.
 
 ### Tabs
 

--- a/docs/release-notes-v0.8.33.md
+++ b/docs/release-notes-v0.8.33.md
@@ -1,25 +1,76 @@
 # QuickMail v0.8.33 Release Notes
 
-> **Draft** — started from what has merged to `main` since v0.8.32. Add to the sections below as more lands before the release is tagged.
-
 ## Download
 
 Two options are available for v0.8.33:
 
 | Download | When to use |
 |----------|-------------|
-| **`QuickMail-0.8.33-win.msi`** — Windows installer | Recommended for most users. A standard setup wizard with license agreement; installs per-user with no elevation required, adds the WebView2 Runtime if missing, and enables automatic updates. |
+| **`QuickMail-win.msi`** — Windows installer | Recommended for most users. A standard setup wizard with license agreement; installs per-user with no elevation required, adds the WebView2 Runtime if missing, and enables automatic updates. |
 | **`QuickMail.exe`** — standalone portable executable | No installation required. Copy it anywhere and run. |
 
 Both downloads include the .NET 8 runtime — you do not need to install .NET separately.
 
-This release fixes **opening a message in a tab**, which previously showed a copy of the message list with the message crammed into a small strip at the bottom instead of showing just the message. If you installed QuickMail from the MSI, this update is delivered automatically. Everything from v0.8.32 — contact sync, easy folder creation, personal Microsoft sign-in, and the reply-quoting fix — is included.
+This is a big release. QuickMail now has a **full calendar**: create your own appointments, keep repeating events, get reminders, respond to meeting invitations, and connect your Microsoft, Google, or iCloud calendar. It also makes **new-mail sync more reliable**, quiets down **notifications after your computer wakes**, and fixes **opening a message in a tab**. See the [Calendar section of the User Guide](https://kellylford.github.io/QuickMail/calendar.html) for the full walkthrough. If you installed QuickMail from the MSI, this update is delivered automatically.
 
 ---
 
-## Fixed in 0.8.33
+## New: The Calendar
 
-### Opening a message in a tab now shows just the message
+QuickMail now has a real, keyboard-first calendar. Press **Ctrl+Shift+C** (or select the **Calendar** node in the folder tree) to open it. Everything is stored locally, so the calendar works offline, and every part of it is reachable with the keyboard and announced by screen readers.
+
+The [Calendar page of the User Guide](https://kellylford.github.io/QuickMail/calendar.html) covers all of this in detail. In brief:
+
+### Create and manage your own appointments
+
+Press **N** to create an appointment. You get a title, all-day or timed start and end (type times naturally — "9", "9:00 AM", "14:30"), location, notes, and repeat options. Press **E** to edit and **Delete** to delete; QuickMail always confirms before deleting.
+
+**Repeating appointments** support Daily, Weekly, Monthly, and Yearly patterns, an "every N" interval, an optional end date, and — for weekly events — a day-of-week picker. When you edit or delete one occurrence, QuickMail asks whether you mean **this event only** or **the whole series**.
+
+### Four views and quick date navigation
+
+Switch between **Agenda**, **Day**, **Week**, and **Month** views with **A**, **D**, **W**, and **M**. Move between periods with **Ctrl+Left** and **Ctrl+Right**, jump to today with **T**, and jump to any date with **Ctrl+G** (Go to Date). In Month view, arrow keys move day by day and **Enter** opens the selected day.
+
+### Reminders
+
+Turn on **Remind me before appointments** in **Settings → General** and choose how many minutes ahead you want them. QuickMail then shows a Windows notification and announces each reminder as it comes due. Reminders are off by default.
+
+### Meeting invitations
+
+Open an email that contains a meeting invitation and QuickMail adds an event card to the top with **Accept**, **Tentative**, and **Decline** buttons. Choosing one replies to the organizer and updates your calendar right away. Cancellations remove the matching entry automatically.
+
+### Connect an online calendar
+
+Connect an account and QuickMail shows its calendar too:
+
+- **Microsoft** (Outlook.com, Microsoft 365) and **Google** — see your events, and create, edit, or delete **single** (non-repeating) events, with the change sent back to that account.
+- **iCloud and other internet calendars (CalDAV)** — see your events (read-only). Set this up in **Settings → General → Internet Calendar** with the server address, your username, and an app-specific password.
+
+Connected calendars refresh in the background; **F5** refreshes on demand. Repeating appointments are always saved to your local calendar, and repeating events that come from an online calendar are read-only for now — the guide's [what the calendar does and does not do](https://kellylford.github.io/QuickMail/calendar.html) list lays out the current limits.
+
+### Search and export
+
+Press **Ctrl+Shift+S** to search your appointments by title, location, or notes. Export any appointment as a standard `.ics` file from the command palette.
+
+---
+
+## New: More reliable new-mail sync
+
+QuickMail primarily learns about new mail through a live server connection (IMAP IDLE). This release adds a safety net behind that connection and fixes two related reliability problems:
+
+- **A periodic new-mail check.** If a server never pushes, a held connection dies quietly, or you read or flag messages in another app, QuickMail now re-checks your inboxes on a schedule. Set it in **Settings → General**, under **Sync**, at **"Check for new mail every"** (Off, 1, 5, 15, 30, or 60 minutes; 5 by default). Changes apply without a restart.
+- **No more "connection was forcibly closed" after idle.** Pooled connections that have been idle for a while are now checked and reconnected before reuse, so opening a message after your machine has been sitting a while no longer fails.
+- **Read state stays in sync.** A message you read in another client (for example, Gmail on the web) now stops showing as unread in QuickMail.
+
+---
+
+## New: Quieter notifications after your computer wakes
+
+When your computer wakes from sleep or a dropped connection reconnects, all the mail that arrived during the gap arrives at once. Previously that produced a single large "9 new messages" burst notification, and it could repeat on each wake. QuickMail now recognizes a catch-up backlog (more than a handful of messages in one batch) and skips the toast for it — the messages are still marked as seen so nothing re-fires. Real-time arrivals, a few at a time, notify normally.
+
+---
+
+## Fixed: Opening a message in a tab now shows just the message
 
 When you set messages to open in a **tab** (Settings → Windowing → Reading mode → Tab), activating a message opened a tab that showed a *copy of the whole message list* with the message itself squeezed into a small, fixed strip at the bottom — not the message on its own. Opening in a **window** worked correctly.
 
@@ -35,17 +86,46 @@ The list also stays visible while a message is still loading, and if a message f
 
 ## Accessibility
 
+- The entire calendar is keyboard-only and screen-reader-first: every view, the appointment editor, Go to Date, search, and the invitation response buttons are reachable without a mouse and announced. Each event row is spoken as a concise summary by default; turn on **Show field labels in the calendar event list** in Settings for a labeled reading ("Subject …, when …, location …") instead. The details area is read from the top so you can review an appointment line by line.
 - With a message open in a tab, the message list is removed from the view and from **F6** pane cycling, so F6 moves cleanly between the folder tree, the tab strip, and the open message without stopping on a list that isn't shown. Pressing **Escape** brings the list back and returns focus to it. While a message is loading — or if its load fails — the list stays in place and in the F6 cycle, so focus is never stranded on an empty pane.
 
 ---
 
 ## Thank You to Contributors
 
-Thank you, as always, to everyone who contributes to QuickMail through code, bug reports, feature suggestions, and other feedback — including the report that identified the tab-open behavior during the theming review.
+Thank you, as always, to everyone who contributes to QuickMail through code, bug reports, feature suggestions, and other feedback — including the reports that shaped the calendar's design, the tab-open behavior found during the theming review, and the notification and sync-reliability reports.
 
 ---
 
 ## Internal
+
+### Full calendar (PR #273, spec `docs/planning/full-calendar-pm-dev-spec.md`)
+
+- Local authoring with a modeless `EventEditorWindow` (per the modal-dialog rules — editable fields over the live WebView2), master/detail list + details pane, and four views (`Agenda`/`Day`/`Week`/`Month`) driven by `CalendarViewModel.ViewMode` + `ReferenceDate`. Month is a 42-cell grid with arrow navigation and Enter-to-drill.
+- Recurrence is a practical RFC-5545 subset (`RecurrenceRule`, `RecurrenceExpander`): `FREQ` daily/weekly/monthly/yearly, `INTERVAL`, weekly `BYDAY`, and one `COUNT`/`UNTIL` end condition. Expansion is local wall-clock (DST-safe) with a ~10-year iteration cap. Per-occurrence edit/delete uses `EXDATE` + detach; whole-series edits preserve `EXDATE`s and the original start.
+- All-day events are fully supported and persisted (`is_all_day` column; re-anchored to local midnight across all providers to avoid off-by-one-day display). The "timed events only / deferred" comment in `EventEditorViewModel` is stale and should be removed.
+- Times stored as UTC ticks; TZID handling per provider (`Prefer: outlook.timezone` for Graph, RFC3339 offsets for Google, kind-carrying stamps for CalDAV).
+- Sync engine (`GraphCalendarSyncService`, name predates multi-provider): read-down window −30…+365 days, replace-slice per source, background pass every 15 min plus one after startup mail sync, best-effort (never throws), `silentOnly` (no interactive sign-in). Write-back is Microsoft + Google **single events only** (recurring push rejected pre-network with `NotSupportedException`); CalDAV (`CalDavCalendarClient`) is read-only. Failed server create/edit falls back to a local save, announced. Providers gated by `IsCalendarPushAccount` / `IsGraphEligible` / `IsGoogleEligible`.
+- Folder tree: `Calendar` sentinel node with `All Calendars` / `Local Calendar` / per-account / CalDAV children; `CalendarFilterFor` maps a node to `CalendarViewModel.AccountFilter`.
+- Invitations: `LocalCacheCalendarProvider` harvests `text/calendar` parts; Accept/Tentative/Decline event card in the reading pane sends an ICS REPLY and upserts the response status immediately; `METHOD:CANCEL` marks events cancelled (filtered from all views).
+- Reminders: opt-in 60-second timer (`CalendarReminders` / `CalendarReminderMinutes`, default off / 10 min), Windows notification + `AnnouncementCategory.Result`, fired at most once per `(uid, start)` per run.
+- Export via `IcsModel.ExportEvent` (`calendar.exportEvent`, no default key).
+- Settings: Internet Calendar (CalDAV) group with Test; Calendar field labels; Calendar reminders + minutes. `ShowDeclinedEvents` remains config-only (read at construction; not live-updated).
+
+### Go to Date (PR #279)
+
+- `calendar.goToDate` (default **Ctrl+G**, rebindable, in the Command Palette) opens a modeless `GoToDateWindow` (DatePicker). Day/Week/Month keep their view and recenter; Agenda switches to Day. `RequestGoToDate` announces unavailability in online mode; the picker is single-instance.
+
+### Mail-sync reliability (PRs #271, #272, split from #240)
+
+- **#267 (PR #272):** `ConfigModel.MailSyncPollMinutes` (default 5; 0 disables; clamped 1–120) drives `StartFallbackSyncAsync` in `MainViewModel`, a periodic inbox re-sync behind IMAP IDLE. New Settings → Sync control; re-reads the interval each cycle so changes apply without a restart; notifies through the shared de-dupe path.
+- **#268 (PR #271):** NOOP-probe pooled IMAP connections idle beyond 30s before reuse, fixing "An existing connection was forcibly closed by the remote host" when opening a message after a long idle.
+- **#269 (PR #271):** reconcile `\Seen` for already-cached messages on folder sync, so a message read in another client stops showing unread.
+- **#270 (PRs #271, #274):** the new-mail notify breakdown (incoming/unread/fresh counts and UIDs) logs at **Log** level when a toast actually fires (`fresh > 0`), so users who enable logging via Settings → Advanced (Log, not Debug) can capture it; the frequent `fresh == 0` evaluations stay Debug-only.
+
+### Wake/reconnect toast suppression (PR #275)
+
+- When one notify evaluation yields more than `MaxNotifyBatchSize` (5) genuinely-new messages, treat it as a catch-up backlog and skip the toast (messages still marked notified so they don't re-fire; count logged). The startup backlog was already excluded by the notify threshold; this is its mid-session equivalent for wake/reconnect bursts.
 
 ### Tab open-mode showed the message list instead of the message (issue #177, PR #264)
 


### PR DESCRIPTION
Housekeeping ahead of the v0.8.33 release.

## 1. Version fixed to 0.8.33

The version had been double-bumped to **0.8.34**. Reverted `Version` / `AssemblyVersion` / `FileVersion` in `QuickMail.csproj` to **0.8.33**. 0.8.34 was never tagged, and 0.8.33 stays greater than the last released tag `v0.8.32`, so auto-update is unaffected. (The stray `0.8.34` strings under `installer/Output/` are gitignored local build artifacts and regenerate at 0.8.33.)

## 2. Release notes rewritten

`docs/release-notes-v0.8.33.md` previously covered only the older tab-open fix. It now covers everything merged since v0.8.32:

- **The full calendar** (PR #273) — authoring, four views, recurrence, reminders, meeting invitations, and Microsoft/Google/CalDAV sync — headlined with a link to the new guide page.
- **Mail-sync reliability** — fallback new-mail poll (#267), stale-connection retry (#268), read-state reconcile (#269), notify logging (#270).
- **Wake/reconnect toast suppression** (PR #275).
- **Go to Date** (PR #279).
- The existing **tab-open fix** (#177 / PR #264), retained.

## 3. Dedicated Calendar guide page

The User Guide's short, outdated Calendar section (it still described invite-only tracking) is replaced with a comprehensive dedicated page. Because the guide is split per `##` heading, this publishes as **`calendar.html`**, mirroring how v0.8.0 shipped `themes.html`. It covers opening the calendar, sources, the four views, date navigation, reading/creating/editing appointments, recurrence, reminders, export, search, invitations, connecting online calendars (with a per-provider capability table), an explicit **what it does / does not do** list, and a keyboard table.

### Accuracy

Content was built from a code-verified survey of the calendar implementation. Settings labels and locations ("Remind me before appointments", "Show field labels in the calendar event list", the Sync group's "Check for new mail every", Internet Calendar/CalDAV) were checked against `SettingsDialog.xaml`, and the open shortcut (Ctrl+Shift+C) and per-provider capabilities against the calendar code. Two stale in-code comments were noted for follow-up (they do not affect users): the "all-day deferred" comment in `EventEditorViewModel` and the "Month is a future surface" comment in `CalendarViewMode` — both features are fully implemented and shipping.

Release build passes at 0.8.33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)