### PR TITLE
iCloud contacts via CardDAV — contacts checkbox for iCloud accounts

### DIFF
--- a/QuickMail.Tests/CardDavContactSyncTests.cs
+++ b/QuickMail.Tests/CardDavContactSyncTests.cs
@@ -1,0 +1,422 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using QuickMail.Models;
+using QuickMail.Services;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// Per-account iCloud CardDAV contact sync (read-down v1) through <see cref="ICloudContactSource"/>
+/// and the raw <see cref="CardDavContactClient"/>: discovery (PROPFIND principal →
+/// addressbook-home-set → first addressbook, with a cross-host redirect that must keep Basic auth),
+/// addressbook-query REPORT parsing, vCard parsing, and the missing-password guard. Only accounts
+/// whose IMAP host is <c>imap.mail.me.com</c> are eligible, using the account's own app-specific
+/// password (<see cref="ICredentialService.GetPassword"/>). HTTP is stubbed with a queued
+/// <see cref="HttpMessageHandler"/>, mirroring CalDavCalendarSyncTests.
+/// </summary>
+public class CardDavContactSyncTests
+{
+    private const string ServerUrl = "https://contacts.icloud.com";
+    private const string Username  = "kelly@example.com";
+    private static readonly Guid AccountId = Guid.NewGuid();
+
+    // ── Test plumbing ────────────────────────────────────────────────────────────
+
+    private sealed record RecordedRequest(string Method, string Url, string? Depth, string? Auth, string Body);
+
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        private readonly Queue<HttpResponseMessage> _responses;
+        public List<RecordedRequest> Requests { get; } = [];
+
+        public RecordingHandler(params HttpResponseMessage[] responses)
+            => _responses = new Queue<HttpResponseMessage>(responses);
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            Requests.Add(new RecordedRequest(
+                request.Method.Method,
+                request.RequestUri!.ToString(),
+                request.Headers.TryGetValues("Depth", out var d) ? d.First() : null,
+                request.Headers.Authorization?.ToString(),
+                request.Content == null ? string.Empty : await request.Content.ReadAsStringAsync(ct)));
+            return _responses.Count > 0 ? _responses.Dequeue() : Xml(EmptyMultistatus);
+        }
+    }
+
+    /// <summary>Returns saved passwords keyed by account id, mirroring the real per-account model.</summary>
+    private sealed class StubCredentials : ICredentialService
+    {
+        private readonly Dictionary<Guid, string> _passwords = [];
+        public StubCredentials(Guid? accountId = null, string? password = null)
+        {
+            if (accountId is { } id && password != null) _passwords[id] = password;
+        }
+        public void SavePassword(Guid accountId, string password) => _passwords[accountId] = password;
+        public string? GetPassword(Guid accountId) => _passwords.TryGetValue(accountId, out var v) ? v : null;
+        public void DeletePassword(Guid accountId) => _passwords.Remove(accountId);
+        public void SaveSecret(string key, string value) { }
+        public string? GetSecret(string key) => null;
+        public void DeleteSecret(string key) { }
+    }
+
+    private static HttpResponseMessage Xml(string body, HttpStatusCode code = (HttpStatusCode)207)
+        => new(code) { Content = new StringContent(body, Encoding.UTF8, "application/xml") };
+
+    private static AccountModel ICloudAccount() => new()
+    {
+        Id = AccountId,
+        AuthType = AuthType.Password,
+        BackendKind = BackendKind.ImapSmtp,
+        ImapHost = "imap.mail.me.com",
+        Username = Username,
+    };
+
+    private static ICloudContactSource Source(RecordingHandler handler, ICredentialService? credentials = null)
+        => new(new CardDavContactClient(new HttpClient(handler)),
+               credentials ?? new StubCredentials(AccountId, "app-pass"));
+
+    // ── XML fixtures ─────────────────────────────────────────────────────────────
+
+    private const string EmptyMultistatus =
+        """<?xml version="1.0"?><d:multistatus xmlns:d="DAV:"/>""";
+
+    private const string PrincipalXml =
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <d:multistatus xmlns:d="DAV:">
+          <d:response>
+            <d:href>/</d:href>
+            <d:propstat>
+              <d:prop>
+                <d:current-user-principal><d:href>/123456/principal/</d:href></d:current-user-principal>
+              </d:prop>
+              <d:status>HTTP/1.1 200 OK</d:status>
+            </d:propstat>
+          </d:response>
+        </d:multistatus>
+        """;
+
+    // iCloud reports the addressbook home on the user's partition host — an ABSOLUTE href.
+    private const string HomeSetXml =
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:carddav">
+          <d:response>
+            <d:href>/123456/principal/</d:href>
+            <d:propstat>
+              <d:prop>
+                <c:addressbook-home-set><d:href>https://p42-contacts.icloud.com/123456/carddav/</d:href></c:addressbook-home-set>
+              </d:prop>
+              <d:status>HTTP/1.1 200 OK</d:status>
+            </d:propstat>
+          </d:response>
+        </d:multistatus>
+        """;
+
+    // Home children: the home itself (plain collection — must be skipped), then the first addressbook.
+    private const string CollectionsXml =
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:carddav">
+          <d:response>
+            <d:href>/123456/carddav/</d:href>
+            <d:propstat><d:prop><d:resourcetype><d:collection/></d:resourcetype></d:prop>
+            <d:status>HTTP/1.1 200 OK</d:status></d:propstat>
+          </d:response>
+          <d:response>
+            <d:href>/123456/carddav/home/</d:href>
+            <d:propstat><d:prop>
+              <d:resourcetype><d:collection/><c:addressbook/></d:resourcetype>
+              <d:displayname>Contacts</d:displayname>
+            </d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat>
+          </d:response>
+        </d:multistatus>
+        """;
+
+    /// <summary>Wraps vCard bodies (XML-safe in these fixtures) in a REPORT multistatus.</summary>
+    private static string ReportXml(params string[] vcards)
+    {
+        var sb = new StringBuilder();
+        sb.Append("""<?xml version="1.0" encoding="UTF-8"?>""");
+        sb.Append("""<d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:carddav">""");
+        var i = 0;
+        foreach (var vcard in vcards)
+        {
+            sb.Append($"<d:response><d:href>/123456/carddav/home/{++i}.vcf</d:href>")
+              .Append("<d:propstat><d:prop><d:getetag>\"etag\"</d:getetag><c:address-data>")
+              .Append(vcard)
+              .Append("</c:address-data></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response>");
+        }
+        sb.Append("</d:multistatus>");
+        return sb.ToString();
+    }
+
+    private static string Card(string uid, string fn, string email) => string.Join("\n",
+        "BEGIN:VCARD",
+        "VERSION:3.0",
+        $"UID:{uid}",
+        $"FN:{fn}",
+        $"EMAIL;TYPE=INTERNET:{email}",
+        "END:VCARD");
+
+    private RecordingHandler FullSyncHandler(params string[] vcards)
+        => new(Xml(PrincipalXml), Xml(HomeSetXml), Xml(CollectionsXml), Xml(ReportXml(vcards)));
+
+    // ── Full pipeline: discovery + REPORT + mapping ──────────────────────────────
+
+    [Fact]
+    public async Task Fetch_FullPipeline_ReturnsContacts()
+    {
+        var handler = FullSyncHandler(
+            Card("card-1", "John Doe", "john@icloud.test"),
+            Card("card-2", "Jane Roe", "jane@icloud.test"));
+
+        var contacts = await Source(handler).FetchAsync(ICloudAccount(), TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, contacts.Count);
+        Assert.All(contacts, c => Assert.False(c.IsPriorRecipient));
+        var john = contacts.Single(c => c.SourceId == "card-1");
+        Assert.Equal("John Doe", john.DisplayName);
+        Assert.Equal("john@icloud.test", john.EmailAddress);
+    }
+
+    [Fact]
+    public async Task Fetch_Discovery_WalksPrincipalHomeAndCollections_WithAuthAndDepth()
+    {
+        var handler = FullSyncHandler(Card("card-1", "John Doe", "john@icloud.test"));
+
+        await Source(handler).FetchAsync(ICloudAccount(), TestContext.Current.CancellationToken);
+
+        Assert.Equal(4, handler.Requests.Count);
+        var expectedAuth = "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes($"{Username}:app-pass"));
+        Assert.All(handler.Requests, r => Assert.Equal(expectedAuth, r.Auth));
+
+        Assert.Equal(("PROPFIND", "https://contacts.icloud.com/", "0"),
+                     (handler.Requests[0].Method, handler.Requests[0].Url, handler.Requests[0].Depth));
+        Assert.Contains("current-user-principal", handler.Requests[0].Body);
+
+        Assert.Equal(("PROPFIND", "https://contacts.icloud.com/123456/principal/", "0"),
+                     (handler.Requests[1].Method, handler.Requests[1].Url, handler.Requests[1].Depth));
+        Assert.Contains("addressbook-home-set", handler.Requests[1].Body);
+
+        // The home-set href was ABSOLUTE on the partition host — must be honored.
+        Assert.Equal(("PROPFIND", "https://p42-contacts.icloud.com/123456/carddav/", "1"),
+                     (handler.Requests[2].Method, handler.Requests[2].Url, handler.Requests[2].Depth));
+
+        var report = handler.Requests[3];
+        Assert.Equal("REPORT", report.Method);
+        Assert.Equal("https://p42-contacts.icloud.com/123456/carddav/home/", report.Url);
+        Assert.Equal("1", report.Depth);
+        Assert.Contains("addressbook-query", report.Body);
+        Assert.Contains("address-data", report.Body);
+    }
+
+    [Fact]
+    public async Task Fetch_SecondPass_ReusesDiscoveredAddressbook()
+    {
+        var handler = FullSyncHandler(Card("card-1", "John Doe", "john@icloud.test"));
+        var source = Source(handler);
+        var account = ICloudAccount();
+
+        await source.FetchAsync(account, TestContext.Current.CancellationToken);
+        // Enqueue only a REPORT response — discovery must be cached per account.
+        handler.Requests.Clear();
+        await source.FetchAsync(account, TestContext.Current.CancellationToken);
+
+        Assert.Single(handler.Requests);
+        Assert.Equal("REPORT", handler.Requests[0].Method);
+    }
+
+    // ── Failure isolation ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Fetch_HttpFailure_Throws()
+    {
+        var handler = new RecordingHandler(
+            new HttpResponseMessage(HttpStatusCode.Unauthorized) { Content = new StringContent("bad app password") });
+
+        var ex = await Assert.ThrowsAsync<HttpRequestException>(() =>
+            Source(handler).FetchAsync(ICloudAccount(), TestContext.Current.CancellationToken));
+        Assert.Contains("401", ex.Message);
+    }
+
+    [Fact]
+    public async Task Fetch_MissingSavedPassword_Throws_WithoutAnyRequest()
+    {
+        var handler = FullSyncHandler(Card("card-1", "John Doe", "john@icloud.test"));
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            Source(handler, new StubCredentials()).FetchAsync(ICloudAccount(), TestContext.Current.CancellationToken));
+
+        Assert.Contains("Manage Accounts", ex.Message);
+        Assert.Empty(handler.Requests);
+    }
+
+    // ── Redirect handling (iCloud partition hosts) ───────────────────────────────
+
+    [Fact]
+    public async Task Discovery_FollowsCrossHostRedirect_ReattachingBasicAuth()
+    {
+        var redirect = new HttpResponseMessage(HttpStatusCode.MovedPermanently);
+        redirect.Headers.Location = new Uri("https://p42-contacts.icloud.com/");
+        var handler = new RecordingHandler(redirect, Xml(PrincipalXml), Xml(HomeSetXml), Xml(CollectionsXml));
+        using var client = new CardDavContactClient(new HttpClient(handler));
+
+        var info = await client.DiscoverAddressbookAsync(ServerUrl, Username, "app-pass",
+                                                         TestContext.Current.CancellationToken);
+
+        // 1 redirected principal hop + re-issue, then home-set, then collections.
+        Assert.Equal(4, handler.Requests.Count);
+        Assert.Equal("https://p42-contacts.icloud.com/", handler.Requests[1].Url);
+        // .NET strips Authorization on cross-host auto-redirects; the manual re-issue must not.
+        Assert.All(handler.Requests, r => Assert.StartsWith("Basic ", r.Auth));
+        // Relative hrefs resolve against the host that ANSWERED (the redirect target).
+        Assert.Equal("https://p42-contacts.icloud.com/123456/carddav/home/", info.Url);
+        Assert.Equal("Contacts", info.DisplayName);
+    }
+
+    // ── Client parsing units ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void ParseInnerHref_FindsNestedHref_RegardlessOfPrefix()
+    {
+        Assert.Equal("/123456/principal/",
+            CardDavContactClient.ParseInnerHref(PrincipalXml, "current-user-principal"));
+        Assert.Equal("https://p42-contacts.icloud.com/123456/carddav/",
+            CardDavContactClient.ParseInnerHref(HomeSetXml, "addressbook-home-set"));
+        Assert.Null(CardDavContactClient.ParseInnerHref(EmptyMultistatus, "current-user-principal"));
+    }
+
+    [Fact]
+    public void ParseFirstAddressbook_SkipsPlainCollections()
+    {
+        var (href, name) = CardDavContactClient.ParseFirstAddressbook(CollectionsXml)!.Value;
+        Assert.Equal("/123456/carddav/home/", href);
+        Assert.Equal("Contacts", name);
+    }
+
+    [Fact]
+    public void ParseFirstAddressbook_NoAddressbook_ReturnsNull()
+    {
+        Assert.Null(CardDavContactClient.ParseFirstAddressbook(EmptyMultistatus));
+    }
+
+    [Fact]
+    public void ParseAddressData_ExtractsEveryVCardBody()
+    {
+        var bodies = CardDavContactClient.ParseAddressData(ReportXml(
+            Card("card-1", "John Doe", "john@icloud.test"),
+            Card("card-2", "Jane Roe", "jane@icloud.test")));
+        Assert.Equal(2, bodies.Count);
+        Assert.Contains("UID:card-1", bodies[0]);
+        Assert.Contains("UID:card-2", bodies[1]);
+    }
+
+    // ── vCard parsing units ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void ParseAll_ExtractsUidFnEmail()
+    {
+        var card = Assert.Single(VCardModel.ParseAll(Card("card-1", "John Doe", "john@icloud.test")));
+        Assert.Equal("card-1", card.Uid);
+        Assert.Equal("John Doe", card.DisplayName);
+        Assert.Equal("john@icloud.test", card.Email);
+    }
+
+    [Fact]
+    public void ParseAll_MultipleCardsInOneBody()
+    {
+        var body = Card("a", "Alice A", "alice@icloud.test") + "\n" + Card("b", "Bob B", "bob@icloud.test");
+        var cards = VCardModel.ParseAll(body).ToList();
+        Assert.Equal(2, cards.Count);
+        Assert.Equal("alice@icloud.test", cards[0].Email);
+        Assert.Equal("bob@icloud.test", cards[1].Email);
+    }
+
+    [Fact]
+    public void ParseAll_FirstEmailWins_WhenSeveralPresent()
+    {
+        var body = string.Join("\n",
+            "BEGIN:VCARD",
+            "UID:multi",
+            "FN:Multi Mail",
+            "EMAIL;TYPE=HOME:first@icloud.test",
+            "EMAIL;TYPE=WORK:second@icloud.test",
+            "END:VCARD");
+        Assert.Equal("first@icloud.test", Assert.Single(VCardModel.ParseAll(body)).Email);
+    }
+
+    [Fact]
+    public void ParseAll_GroupedEmail_IsCaptured()
+    {
+        // Apple/iCloud emit custom-labelled emails as grouped properties (RFC 6350 §3.3):
+        // "item1.EMAIL". The group prefix must be stripped or the email — and the whole card — is lost.
+        var body = string.Join("\n",
+            "BEGIN:VCARD",
+            "UID:grouped-1",
+            "FN:Grouped Person",
+            "item1.EMAIL;type=INTERNET;type=pref:grouped@icloud.test",
+            "item1.X-ABLabel:_$!<School>!$_",
+            "END:VCARD");
+        Assert.Equal("grouped@icloud.test", Assert.Single(VCardModel.ParseAll(body)).Email);
+    }
+
+    [Fact]
+    public void ParseAll_MissingUid_GetsStableSyntheticId()
+    {
+        var body = string.Join("\n",
+            "BEGIN:VCARD",
+            "FN:No Uid",
+            "EMAIL:nouid@icloud.test",
+            "END:VCARD");
+
+        var first  = Assert.Single(VCardModel.ParseAll(body));
+        var second = Assert.Single(VCardModel.ParseAll(body));
+
+        Assert.StartsWith("carddav-", first.Uid);
+        Assert.Equal(first.Uid, second.Uid); // stable across passes → replace-slice keeps identity
+    }
+
+    [Fact]
+    public void ParseAll_FallsBackToStructuredName_WhenFnAbsent()
+    {
+        var body = string.Join("\n",
+            "BEGIN:VCARD",
+            "UID:nname",
+            "N:Doe;John;;;",
+            "EMAIL:n@icloud.test",
+            "END:VCARD");
+        Assert.Equal("John Doe", Assert.Single(VCardModel.ParseAll(body)).DisplayName);
+    }
+
+    [Fact]
+    public async Task Fetch_DropsCardsWithoutEmail()
+    {
+        var noEmail = string.Join("\n",
+            "BEGIN:VCARD",
+            "UID:no-email",
+            "FN:No Email",
+            "END:VCARD");
+        var handler = FullSyncHandler(noEmail, Card("card-1", "John Doe", "john@icloud.test"));
+
+        var contacts = await Source(handler).FetchAsync(ICloudAccount(), TestContext.Current.CancellationToken);
+
+        // The e-mail-less card is dropped; only the usable one survives.
+        Assert.Equal("card-1", Assert.Single(contacts).SourceId);
+    }
+
+    [Fact]
+    public void ParseAll_MalformedInput_ReturnsEmpty()
+    {
+        Assert.Empty(VCardModel.ParseAll(""));
+        Assert.Empty(VCardModel.ParseAll("not a vcard at all"));
+    }
+}

--- a/QuickMail.Tests/ContactSyncScopeAndViewModelTests.cs
+++ b/QuickMail.Tests/ContactSyncScopeAndViewModelTests.cs
@@ -94,3 +94,31 @@ public class AddressBookViewModelSyncTests
         Assert.Equal(1, recorder.SyncAllCount);
     }
 }
+
+/// <summary>
+/// AccountManagerViewModel contact-sync eligibility: the checkbox is offered for Microsoft, Google,
+/// and iCloud accounts (CardDAV), a superset matching calendar sync.
+/// </summary>
+public class AccountManagerContactSyncScopeTests
+{
+    private static AccountManagerViewModel NewManager() =>
+        new(new StubAccountService(), new StubCredentialService(), new StubImapMailService(),
+            new StubOAuthService(), new StubLocalStoreService(), new StubConfigService(),
+            new StubFeatureGate(), new StubContactSyncService());
+
+    [Fact]
+    public void CanSyncContacts_TrueForICloudAccount()
+    {
+        var vm = NewManager();
+        vm.SelectedAccount = new AccountModel { AuthType = AuthType.Password, ImapHost = "imap.mail.me.com" };
+        Assert.True(vm.CanSyncContacts);
+    }
+
+    [Fact]
+    public void CanSyncContacts_FalseForPlainImapAccount()
+    {
+        var vm = NewManager();
+        vm.SelectedAccount = new AccountModel { AuthType = AuthType.Password, ImapHost = "imap.example.com" };
+        Assert.False(vm.CanSyncContacts);
+    }
+}

--- a/QuickMail.Tests/ContactSyncServiceTests.cs
+++ b/QuickMail.Tests/ContactSyncServiceTests.cs
@@ -94,6 +94,53 @@ public class ContactSyncServiceTests
     }
 
     [Fact]
+    public async Task SyncAccount_ICloud_RoutesToICloudSourceByImapHost()
+    {
+        var (contacts, dir) = MakeContacts();
+        try
+        {
+            var ms = new FakeSource { Source = ContactSource.Microsoft };
+            var google = new FakeSource { Source = ContactSource.Google };
+            var icloud = new FakeSource { Source = ContactSource.ICloud, OnFetch = _ => [Server("i1", "a@icloud.test")] };
+            var sut = new ContactSyncService(new FakeAccountService(), contacts, ms, google, icloud);
+            // An iCloud account is a plain Password/IMAP account — routed by IMAP host, not auth type.
+            var account = new AccountModel { AuthType = AuthType.Password, ImapHost = "imap.mail.me.com" };
+
+            Assert.True(sut.CanSync(account));
+            var result = await sut.SyncAccountAsync(account);
+
+            Assert.Equal(1, result.AccountsSynced);
+            Assert.Equal(1, result.ContactsFetched);
+            Assert.Equal(1, icloud.FetchCount);
+            Assert.Equal(0, ms.FetchCount);
+            var stored = await contacts.LoadAllContactsAsync();
+            Assert.Equal(ContactSource.ICloud, Assert.Single(stored).Source);
+        }
+        finally { Cleanup(dir); }
+    }
+
+    [Fact]
+    public async Task SyncAccount_PlainPasswordOtherHost_IsStillNoOp_EvenWithICloudSource()
+    {
+        var (contacts, dir) = MakeContacts();
+        try
+        {
+            var ms = new FakeSource { Source = ContactSource.Microsoft };
+            var google = new FakeSource { Source = ContactSource.Google };
+            var icloud = new FakeSource { Source = ContactSource.ICloud, OnFetch = _ => [Server("i1", "a@icloud.test")] };
+            var sut = new ContactSyncService(new FakeAccountService(), contacts, ms, google, icloud);
+            var account = new AccountModel { AuthType = AuthType.Password, ImapHost = "imap.example.com" };
+
+            Assert.False(sut.CanSync(account));
+            var result = await sut.SyncAccountAsync(account);
+
+            Assert.Equal(0, result.AccountsSynced);
+            Assert.Equal(0, icloud.FetchCount);
+        }
+        finally { Cleanup(dir); }
+    }
+
+    [Fact]
     public async Task SyncAccount_SourceThrows_ReturnsErrorAndDoesNotThrow()
     {
         var (contacts, dir) = MakeContacts();

--- a/QuickMail.Tests/PerAccountCalendarSyncTests.cs
+++ b/QuickMail.Tests/PerAccountCalendarSyncTests.cs
@@ -61,6 +61,27 @@ public class PerAccountCalendarSyncTests
     }
 
     [Fact]
+    public void ShowContactSyncOption_TrueForICloud()
+    {
+        // Contact sync (CardDAV) is offered for iCloud too, keyed on the iCloud IMAP host, so typing
+        // an iCloud address (which auto-fills that host) must flip the contacts checkbox on.
+        var vm = NewEditor();
+        Assert.False(vm.ShowContactSyncOption);   // nothing typed yet
+        vm.Username = "someone@icloud.com";
+        Assert.Equal("imap.mail.me.com", vm.ImapHost);
+        Assert.True(vm.ShowContactSyncOption);
+    }
+
+    [Fact]
+    public void ShowContactSyncOption_FalseForPlainImap()
+    {
+        var vm = NewEditor();
+        vm.AuthType = AuthType.Password;
+        vm.ImapHost = "imap.example.com";
+        Assert.False(vm.ShowContactSyncOption);
+    }
+
+    [Fact]
     public void ToAccountModel_KeepsCalendarFlagOnlyWhenOptionShown()
     {
         // Checked while iCloud → persists.

--- a/QuickMail/App.xaml.cs
+++ b/QuickMail/App.xaml.cs
@@ -17,6 +17,7 @@ public partial class App : Application
     private GooglePeopleClient? _googlePeopleClient;
     private GoogleCalendarClient? _googleCalendarClient;
     private CalDavCalendarClient? _calDavCalendarClient;
+    private CardDavContactClient? _cardDavContactClient;
     private TemplateService? _templateService;
     private ChangeNotifierRouter? _changeNotifier;
     private GraphChangeNotifier? _graphNotifier;
@@ -235,7 +236,12 @@ public partial class App : Application
             var graphContactSource  = new GraphContactSource(graphBackend.Client);
             _googlePeopleClient     = new GooglePeopleClient(googleOAuth);
             var googleContactSource = new GoogleContactSource(_googlePeopleClient);
-            var contactSyncService  = new ContactSyncService(accountService, contactService, graphContactSource, googleContactSource);
+            // iCloud contacts run per-account over CardDAV: for each account the user opted into whose
+            // IMAP host is imap.mail.me.com, the source discovers/fetches its address book using the
+            // account's own app-specific password (no separate credential, no OAuth).
+            _cardDavContactClient   = new CardDavContactClient();
+            var iCloudContactSource = new ICloudContactSource(_cardDavContactClient, credentialService);
+            var contactSyncService  = new ContactSyncService(accountService, contactService, graphContactSource, googleContactSource, iCloudContactSource);
 
             var startupCfg = configService.Load();
             Views.AccessibilityHelper.Configure(startupCfg);
@@ -323,6 +329,7 @@ public partial class App : Application
         _googlePeopleClient?.Dispose();
         _googleCalendarClient?.Dispose();
         _calDavCalendarClient?.Dispose();
+        _cardDavContactClient?.Dispose();
         _contactService?.Dispose();
         _templateService?.Dispose();
         _updateCheckService?.Dispose();

--- a/QuickMail/Models/ContactSource.cs
+++ b/QuickMail/Models/ContactSource.cs
@@ -17,4 +17,7 @@ public enum ContactSource
 
     /// <summary>Synced from a Google account via the People API (connections and other contacts).</summary>
     Google = 2,
+
+    /// <summary>Synced from an iCloud account via CardDAV (the account's address book).</summary>
+    ICloud = 3,
 }

--- a/QuickMail/Models/VCardModel.cs
+++ b/QuickMail/Models/VCardModel.cs
@@ -1,0 +1,167 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using QuickMail.Services;
+
+namespace QuickMail.Models;
+
+/// <summary>One contact parsed out of a vCard body: the fields QuickMail's address book needs.</summary>
+public sealed record ParsedVCard(string Uid, string DisplayName, string Email);
+
+/// <summary>
+/// Minimal RFC 6350 vCard reader for CardDAV contact sync (read-down v1). Extracts UID, a display
+/// name (FN, falling back to the structured N), and the first EMAIL. Mirrors
+/// <see cref="IcsModel"/>'s parsing style: identical line-unfolding, a BEGIN/END block scan, and
+/// the same text unescaping (<c>\, \; \n \\</c>). Never throws — malformed input yields no cards.
+/// </summary>
+public static class VCardModel
+{
+    /// <summary>
+    /// Parses every VCARD block in a body. Cards without a usable EMAIL are still returned here
+    /// (the caller drops them); a card without a UID gets a stable synthetic id from FN|EMAIL so
+    /// it keeps its identity across re-syncs.
+    /// </summary>
+    public static IEnumerable<ParsedVCard> ParseAll(string body)
+    {
+        var result = new List<ParsedVCard>();
+        if (string.IsNullOrWhiteSpace(body)) return result;
+
+        try
+        {
+            var lines = UnfoldLines(body);
+            string? uid = null, fn = null, structuredName = null, email = null;
+            var inCard = false;
+
+            void Flush()
+            {
+                var displayName = !string.IsNullOrWhiteSpace(fn) ? fn! : structuredName ?? string.Empty;
+                var mail = email ?? string.Empty;
+                var id = !string.IsNullOrWhiteSpace(uid)
+                    ? uid!
+                    : CardDavContactClient.SyntheticUid($"{displayName}|{mail}");
+                result.Add(new ParsedVCard(id, displayName.Trim(), mail.Trim()));
+                uid = fn = structuredName = email = null;
+            }
+
+            foreach (var rawLine in lines)
+            {
+                var line = rawLine.Trim();
+                if (line.Length == 0) continue;
+
+                if (line.StartsWith("BEGIN:VCARD", StringComparison.OrdinalIgnoreCase))
+                {
+                    uid = fn = structuredName = email = null; // defensive: unterminated previous card
+                    inCard = true;
+                    continue;
+                }
+                if (line.StartsWith("END:VCARD", StringComparison.OrdinalIgnoreCase))
+                {
+                    if (inCard) Flush();
+                    inCard = false;
+                    continue;
+                }
+                if (!inCard) continue;
+
+                var colonIdx = line.IndexOf(':');
+                if (colonIdx < 0) continue;
+
+                var prop = line[..colonIdx];
+                var value = line[(colonIdx + 1)..];
+
+                // Strip property parameters, e.g. "EMAIL;TYPE=INTERNET,HOME" → "EMAIL".
+                var semicolonIdx = prop.IndexOf(';');
+                var propName = (semicolonIdx >= 0 ? prop[..semicolonIdx] : prop);
+
+                // Strip a vCard group prefix (RFC 6350 §3.3), e.g. Apple/iCloud emit custom-labelled
+                // emails as "item1.EMAIL;type=pref:…". Without this the property name reads as
+                // "ITEM1.EMAIL", no case matches, and the contact's email — and thus the whole
+                // contact — is silently dropped. Groups apply to any property, so strip before the dot.
+                var dotIdx = propName.LastIndexOf('.');
+                if (dotIdx >= 0) propName = propName[(dotIdx + 1)..];
+
+                propName = propName.ToUpperInvariant();
+
+                switch (propName)
+                {
+                    case "UID":
+                        uid = UnescapeText(value).Trim();
+                        break;
+                    case "FN":
+                        fn = UnescapeText(value);
+                        break;
+                    case "N":
+                        // Structured name "Family;Given;Additional;Prefix;Suffix" — only a fallback
+                        // when FN is absent. Presented as "Given Family", then any remaining parts.
+                        structuredName ??= JoinStructuredName(value);
+                        break;
+                    case "EMAIL":
+                        // First non-empty EMAIL wins (a card may list several).
+                        var e = UnescapeText(value).Trim();
+                        if (email is null && e.Length > 0) email = e;
+                        break;
+                }
+            }
+            if (inCard) Flush(); // defensive: truncated input missing END:VCARD
+
+            return result;
+        }
+        catch
+        {
+            return [];
+        }
+    }
+
+    /// <summary>Builds a display name from a structured N value ("Family;Given;Add;Prefix;Suffix").</summary>
+    private static string JoinStructuredName(string value)
+    {
+        var parts = value.Split(';');
+        var family = parts.Length > 0 ? UnescapeText(parts[0]).Trim() : string.Empty;
+        var given  = parts.Length > 1 ? UnescapeText(parts[1]).Trim() : string.Empty;
+
+        var ordered = new List<string>();
+        if (given.Length > 0)  ordered.Add(given);
+        if (family.Length > 0) ordered.Add(family);
+        // Additional name / prefix / suffix, if the common two were empty, so at least something shows.
+        for (var i = 2; i < parts.Length; i++)
+        {
+            var p = UnescapeText(parts[i]).Trim();
+            if (p.Length > 0) ordered.Add(p);
+        }
+        return string.Join(' ', ordered);
+    }
+
+    /// <summary>vCard content lines fold identically to iCal (continuation begins with space/tab).</summary>
+    private static List<string> UnfoldLines(string content)
+    {
+        var result = new List<string>();
+        var current = new StringBuilder();
+        foreach (var line in content.Split('\n'))
+        {
+            var trimmed = line.TrimEnd('\r');
+            if (trimmed.Length > 0 && (trimmed[0] == ' ' || trimmed[0] == '\t'))
+            {
+                current.Append(trimmed[1..]);
+            }
+            else
+            {
+                if (current.Length > 0)
+                    result.Add(current.ToString());
+                current.Clear();
+                current.Append(trimmed);
+            }
+        }
+        if (current.Length > 0)
+            result.Add(current.ToString());
+        return result;
+    }
+
+    private static string UnescapeText(string text)
+    {
+        return text
+            .Replace("\\n", "\n")
+            .Replace("\\N", "\n")
+            .Replace("\\,", ",")
+            .Replace("\\;", ";")
+            .Replace("\\\\", "\\");
+    }
+}

--- a/QuickMail/Services/CardDav/CardDavContactClient.cs
+++ b/QuickMail/Services/CardDav/CardDavContactClient.cs
@@ -1,0 +1,248 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+
+namespace QuickMail.Services;
+
+/// <summary>One discovered CardDAV addressbook collection: its absolute URL and display name.</summary>
+public sealed record CardDavAddressbookInfo(string Url, string DisplayName);
+
+/// <summary>
+/// Minimal CardDAV client for generic contact sync (read-down v1, iCloud-first). Discovery and
+/// vCard fetch only — the CardDAV sibling of <see cref="ICalDavCalendarClient"/>.
+/// </summary>
+public interface ICardDavContactClient
+{
+    /// <summary>
+    /// Resolves the server's first addressbook collection:
+    /// PROPFIND current-user-principal → addressbook-home-set → the home's child collections.
+    /// Throws (with a presentable message) when any step fails.
+    /// </summary>
+    Task<CardDavAddressbookInfo> DiscoverAddressbookAsync(string serverUrl, string username, string password,
+                                                          CancellationToken ct = default);
+
+    /// <summary>
+    /// REPORT addressbook-query against the collection, returning each resource's raw vCard body
+    /// (one body per contact resource). A body may in principle carry several VCARDs.
+    /// </summary>
+    Task<List<string>> FetchVCardsAsync(string addressbookUrl, string username, string password,
+                                        CancellationToken ct = default);
+}
+
+/// <summary>
+/// Raw-HttpClient CardDAV client (no new NuGet dependency), mirroring
+/// <see cref="CalDavCalendarClient"/>. Built against iCloud
+/// (<c>https://contacts.icloud.com</c>) but intentionally generic — any RFC 6352 server speaks
+/// the same discovery chain and addressbook-query REPORT.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Redirects are followed manually.</b> iCloud's discovery entry point 301-redirects to the
+/// user's partition host (e.g. <c>p123-contacts.icloud.com</c>), and .NET strips the
+/// Authorization header on cross-host auto-redirects — which would turn every discovery into a
+/// silent 401. The own-constructed handler therefore disables auto-redirect and this class
+/// re-issues the request (same method, body, and freshly attached Basic auth) to the Location
+/// target, up to <see cref="MaxRedirects"/> hops.
+/// </para>
+/// <para>
+/// XML parsing matches by element local name (namespace-prefix agnostic) but requires the
+/// CardDAV namespace (<c>urn:ietf:params:xml:ns:carddav</c>) where it is semantically
+/// load-bearing (the <c>addressbook</c> resourcetype), since <c>DAV:</c> also defines unrelated
+/// names.
+/// </para>
+/// </remarks>
+public sealed class CardDavContactClient : ICardDavContactClient, IDisposable
+{
+    private const int MaxRedirects = 5;
+    internal const string CardDavNs = "urn:ietf:params:xml:ns:carddav";
+
+    private static readonly HttpMethod PropfindMethod = new("PROPFIND");
+    private static readonly HttpMethod ReportMethod   = new("REPORT");
+
+    private readonly HttpClient _http;
+    private readonly bool _ownsHttp;
+
+    public CardDavContactClient(HttpClient? http = null)
+    {
+        // AllowAutoRedirect=false: redirects must be re-issued with auth re-attached (see remarks).
+        _http     = http ?? new HttpClient(new HttpClientHandler { AllowAutoRedirect = false });
+        _ownsHttp = http is null;
+    }
+
+    // ── Identity helpers ─────────────────────────────────────────────────────────
+
+    /// <summary>Deterministic fallback id for a vCard that (against RFC 6350) carries no UID.</summary>
+    internal static string SyntheticUid(string seed)
+    {
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(seed));
+        return "carddav-" + Convert.ToHexString(hash.AsSpan(0, 12)).ToLowerInvariant();
+    }
+
+    // ── Discovery ────────────────────────────────────────────────────────────────
+
+    private const string PrincipalBody =
+        """<?xml version="1.0" encoding="utf-8"?><d:propfind xmlns:d="DAV:"><d:prop><d:current-user-principal/></d:prop></d:propfind>""";
+
+    private const string HomeSetBody =
+        """<?xml version="1.0" encoding="utf-8"?><d:propfind xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:carddav"><d:prop><c:addressbook-home-set/></d:prop></d:propfind>""";
+
+    private const string CollectionsBody =
+        """<?xml version="1.0" encoding="utf-8"?><d:propfind xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:carddav"><d:prop><d:resourcetype/><d:displayname/></d:prop></d:propfind>""";
+
+    public async Task<CardDavAddressbookInfo> DiscoverAddressbookAsync(string serverUrl, string username, string password,
+                                                                       CancellationToken ct = default)
+    {
+        var baseUri = NormalizeUri(serverUrl);
+
+        var (principalXml, principalReqUri) =
+            await SendAsync(PropfindMethod, baseUri, PrincipalBody, depth: "0", username, password, ct);
+        var principalHref = ParseInnerHref(principalXml, "current-user-principal")
+            ?? throw new InvalidOperationException("The server did not report an account principal — check the server address.");
+
+        var (homeXml, homeReqUri) =
+            await SendAsync(PropfindMethod, new Uri(principalReqUri, principalHref), HomeSetBody, depth: "0", username, password, ct);
+        var homeHref = ParseInnerHref(homeXml, "addressbook-home-set")
+            ?? throw new InvalidOperationException("The server did not report an address-book home for this account.");
+
+        var (collectionsXml, collectionsReqUri) =
+            await SendAsync(PropfindMethod, new Uri(homeReqUri, homeHref), CollectionsBody, depth: "1", username, password, ct);
+        var (addressbookHref, addressbookName) = ParseFirstAddressbook(collectionsXml)
+            ?? throw new InvalidOperationException("No address book was found for this account.");
+
+        return new CardDavAddressbookInfo(new Uri(collectionsReqUri, addressbookHref).ToString(), addressbookName);
+    }
+
+    // ── vCard fetch ──────────────────────────────────────────────────────────────
+
+    private const string AddressbookQueryBody =
+        """
+        <?xml version="1.0" encoding="utf-8"?>
+        <c:addressbook-query xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:carddav">
+          <d:prop><d:getetag/><c:address-data/></d:prop>
+          <c:filter/>
+        </c:addressbook-query>
+        """;
+
+    public async Task<List<string>> FetchVCardsAsync(string addressbookUrl, string username, string password,
+                                                     CancellationToken ct = default)
+    {
+        var (xml, _) = await SendAsync(ReportMethod, NormalizeUri(addressbookUrl), AddressbookQueryBody, depth: "1", username, password, ct);
+        return ParseAddressData(xml);
+    }
+
+    // ── Multistatus XML parsing (internal for tests) ─────────────────────────────
+
+    /// <summary>The d:href nested inside the named property (e.g. current-user-principal,
+    /// addressbook-home-set), or null. Matches by local name so any prefix works.</summary>
+    internal static string? ParseInnerHref(string xml, string propLocalName)
+    {
+        var doc = XDocument.Parse(xml);
+        var prop = doc.Descendants()
+            .FirstOrDefault(e => e.Name.LocalName.Equals(propLocalName, StringComparison.OrdinalIgnoreCase));
+        var href = prop?.Descendants().FirstOrDefault(e => e.Name.LocalName == "href")?.Value.Trim();
+        return string.IsNullOrEmpty(href) ? null : href;
+    }
+
+    /// <summary>
+    /// The first response in a Depth-1 collections multistatus whose resourcetype marks a CardDAV
+    /// addressbook collection. Requires the carddav namespace on the "addressbook" resourcetype,
+    /// since that name is only meaningful there; skips plain collections and non-addressbook
+    /// children.
+    /// </summary>
+    internal static (string Href, string DisplayName)? ParseFirstAddressbook(string xml)
+    {
+        var doc = XDocument.Parse(xml);
+        foreach (var response in doc.Descendants().Where(e => e.Name.LocalName == "response"))
+        {
+            var href = response.Elements().FirstOrDefault(e => e.Name.LocalName == "href")?.Value.Trim();
+            if (string.IsNullOrEmpty(href)) continue;
+
+            var isAddressbook = response.Descendants()
+                .Where(e => e.Name.LocalName == "resourcetype")
+                .Any(rt => rt.Elements().Any(c => c.Name.LocalName == "addressbook" &&
+                                                  c.Name.NamespaceName == CardDavNs));
+            if (!isAddressbook) continue;
+
+            var name = response.Descendants()
+                .FirstOrDefault(e => e.Name.LocalName == "displayname")?.Value.Trim();
+            return (href, string.IsNullOrEmpty(name) ? "Contacts" : name);
+        }
+        return null;
+    }
+
+    /// <summary>Every non-empty address-data vCard body in a REPORT multistatus.</summary>
+    internal static List<string> ParseAddressData(string xml)
+    {
+        var doc = XDocument.Parse(xml);
+        return doc.Descendants()
+            .Where(e => e.Name.LocalName == "address-data")
+            .Select(e => e.Value)
+            .Where(v => !string.IsNullOrWhiteSpace(v))
+            .ToList();
+    }
+
+    // ── HTTP plumbing ────────────────────────────────────────────────────────────
+
+    private static Uri NormalizeUri(string url)
+    {
+        var trimmed = url.Trim();
+        if (!trimmed.Contains("://", StringComparison.Ordinal))
+            trimmed = "https://" + trimmed;
+        return new Uri(trimmed);
+    }
+
+    /// <summary>
+    /// Sends one WebDAV request with Basic auth, following redirects manually (auth re-attached
+    /// on each hop — see class remarks). Returns the response body and the FINAL request URI so
+    /// relative hrefs in the response resolve against the host that actually answered.
+    /// </summary>
+    private async Task<(string Body, Uri FinalUri)> SendAsync(HttpMethod method, Uri uri, string body,
+        string depth, string username, string password, CancellationToken ct)
+    {
+        var auth = new AuthenticationHeaderValue("Basic",
+            Convert.ToBase64String(Encoding.UTF8.GetBytes($"{username}:{password}")));
+
+        for (var hop = 0; hop <= MaxRedirects; hop++)
+        {
+            using var req = new HttpRequestMessage(method, uri);
+            req.Headers.Authorization = auth;
+            req.Headers.TryAddWithoutValidation("Depth", depth);
+            req.Content = new StringContent(body, Encoding.UTF8, "application/xml");
+
+            using var resp = await _http.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, ct);
+
+            if ((int)resp.StatusCode is 301 or 302 or 307 or 308 && resp.Headers.Location != null)
+            {
+                uri = resp.Headers.Location.IsAbsoluteUri
+                    ? resp.Headers.Location
+                    : new Uri(uri, resp.Headers.Location);
+                continue;
+            }
+
+            if (!resp.IsSuccessStatusCode) // 207 Multi-Status is a success code
+            {
+                var errBody = await resp.Content.ReadAsStringAsync(ct);
+                throw new HttpRequestException(
+                    $"CardDAV request failed ({(int)resp.StatusCode} {resp.StatusCode}): {Truncate(errBody, 300)}");
+            }
+
+            return (await resp.Content.ReadAsStringAsync(ct), uri);
+        }
+
+        throw new HttpRequestException("CardDAV request failed: too many redirects.");
+    }
+
+    private static string Truncate(string s, int max) => s.Length <= max ? s : s[..max];
+
+    public void Dispose()
+    {
+        if (_ownsHttp) _http.Dispose();
+    }
+}

--- a/QuickMail/Services/ContactSyncService.cs
+++ b/QuickMail/Services/ContactSyncService.cs
@@ -12,6 +12,7 @@ public sealed class ContactSyncService : IContactSyncService
     private readonly IContactService _contacts;
     private readonly IProviderContactSource _microsoftSource;
     private readonly IProviderContactSource _googleSource;
+    private readonly IProviderContactSource? _iCloudSource;
 
     // Process-lifetime throttle for the automatic background trigger. UtcNow is only read here (not in
     // a resumable/replayable context), so it's safe.
@@ -22,25 +23,36 @@ public sealed class ContactSyncService : IContactSyncService
         IAccountService accounts,
         IContactService contacts,
         IProviderContactSource microsoftSource,
-        IProviderContactSource googleSource)
+        IProviderContactSource googleSource,
+        IProviderContactSource? iCloudSource = null)
     {
         _accounts        = accounts;
         _contacts        = contacts;
         _microsoftSource = microsoftSource;
         _googleSource    = googleSource;
+        _iCloudSource    = iCloudSource;
     }
 
     public bool CanSync(AccountModel account) => SourceFor(account) is not null;
 
-    private IProviderContactSource? SourceFor(AccountModel account) => account.AuthType switch
+    private IProviderContactSource? SourceFor(AccountModel account)
     {
-        // Keyed by auth type, not backend: a Gmail account is IMAP + Google OAuth (not the Graph
-        // backend), and an Outlook.com account can be IMAP + Microsoft OAuth. The contact API follows
-        // the identity provider, so a valid OAuth token is what makes contact sync possible.
-        AuthType.OAuth2Microsoft => _microsoftSource,
-        AuthType.OAuth2Google    => _googleSource,
-        _                        => null,
-    };
+        // iCloud is keyed by IMAP host, not auth type: an iCloud account is a plain Password/IMAP
+        // account, and CardDAV reuses that app-specific password. Check this before the auth switch.
+        if (_iCloudSource != null &&
+            account.ImapHost.Equals("imap.mail.me.com", StringComparison.OrdinalIgnoreCase))
+            return _iCloudSource;
+
+        return account.AuthType switch
+        {
+            // Keyed by auth type, not backend: a Gmail account is IMAP + Google OAuth (not the Graph
+            // backend), and an Outlook.com account can be IMAP + Microsoft OAuth. The contact API follows
+            // the identity provider, so a valid OAuth token is what makes contact sync possible.
+            AuthType.OAuth2Microsoft => _microsoftSource,
+            AuthType.OAuth2Google    => _googleSource,
+            _                        => null,
+        };
+    }
 
     public async Task<ContactSyncResult> SyncAccountAsync(AccountModel account, CancellationToken ct = default)
     {

--- a/QuickMail/Services/Contacts/ICloudContactSource.cs
+++ b/QuickMail/Services/Contacts/ICloudContactSource.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using QuickMail.Models;
+
+namespace QuickMail.Services;
+
+/// <summary>
+/// Pulls contacts from an iCloud account over CardDAV (contacts.icloud.com), using the account's
+/// own app-specific password — the same one IMAP uses, so there is no separate credential and no
+/// OAuth. The CardDAV sibling of <see cref="GraphContactSource"/> / <see cref="GoogleContactSource"/>,
+/// and the contact counterpart of the iCloud CalDAV calendar path. iCloud exposes no relevance-ranked
+/// "prior recipients" API, so every returned contact is a saved address-book entry
+/// (<see cref="ContactModel.IsPriorRecipient"/> = false).
+/// </summary>
+public sealed class ICloudContactSource : IProviderContactSource
+{
+    private const string ICloudCardDavUrl = "https://contacts.icloud.com";
+
+    private readonly ICardDavContactClient _client;
+    private readonly ICredentialService _credentials;
+
+    // Resolved addressbook-collection URL per account (from discovery), so each account's home
+    // addressbook is found once and reused. Cleared for an account on fetch failure so a stale
+    // collection URL (e.g. addressbook recreated server-side) heals on the next pass — mirrors the
+    // CalDAV calendar path's per-account discovery cache.
+    private readonly ConcurrentDictionary<Guid, string> _addressbookUrlByAccount = new();
+
+    public ICloudContactSource(ICardDavContactClient client, ICredentialService credentials)
+    {
+        _client      = client;
+        _credentials = credentials;
+    }
+
+    public ContactSource Source => ContactSource.ICloud;
+
+    public async Task<IReadOnlyList<ContactModel>> FetchAsync(AccountModel account, CancellationToken ct = default)
+    {
+        var password = _credentials.GetPassword(account.Id);
+        if (string.IsNullOrEmpty(password))
+            throw new InvalidOperationException(
+                $"no app-specific password saved for {account.Username} — re-enter it in Manage Accounts.");
+
+        if (!_addressbookUrlByAccount.TryGetValue(account.Id, out var addressbookUrl))
+        {
+            var info = await _client.DiscoverAddressbookAsync(ICloudCardDavUrl, account.Username, password, ct);
+            addressbookUrl = info.Url;
+            _addressbookUrlByAccount[account.Id] = addressbookUrl;
+        }
+
+        List<string> vcards;
+        try
+        {
+            vcards = await _client.FetchVCardsAsync(addressbookUrl, account.Username, password, ct);
+        }
+        catch
+        {
+            _addressbookUrlByAccount.TryRemove(account.Id, out _); // stale collection URL? re-discover next pass
+            throw;
+        }
+
+        var results = new List<ContactModel>();
+        // De-dup emails within the provider result (a card can repeat an address).
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var body in vcards)
+        {
+            foreach (var card in VCardModel.ParseAll(body))
+            {
+                // Every returned contact MUST have a non-empty stable SourceId and email or the
+                // store drops it, so skip cards missing either here.
+                if (string.IsNullOrWhiteSpace(card.Uid) || string.IsNullOrWhiteSpace(card.Email)) continue;
+                if (!seen.Add(card.Email)) continue;
+                results.Add(new ContactModel
+                {
+                    SourceId         = card.Uid,
+                    DisplayName      = card.DisplayName,
+                    EmailAddress     = card.Email,
+                    IsPriorRecipient = false,
+                });
+            }
+        }
+
+        return results;
+    }
+}

--- a/QuickMail/ViewModels/AccountEditorViewModel.cs
+++ b/QuickMail/ViewModels/AccountEditorViewModel.cs
@@ -23,6 +23,7 @@ public abstract partial class AccountEditorViewModel : ObservableObject
     [ObservableProperty] private string _password = string.Empty;
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(IsICloudAccount))]
+    [NotifyPropertyChangedFor(nameof(ShowContactSyncOption))]
     [NotifyPropertyChangedFor(nameof(ShowCalendarSyncOption))]
     private string _imapHost = string.Empty;
     [ObservableProperty] private int    _imapPort = 993;
@@ -51,8 +52,11 @@ public abstract partial class AccountEditorViewModel : ObservableObject
     [ObservableProperty]
     private bool _syncContacts;
 
-    /// <summary>Contact sync is only offered for OAuth accounts — the backends with a contact API.</summary>
-    public bool ShowContactSyncOption => IsOAuth2 || IsGoogleOAuth;
+    /// <summary>
+    /// Contact sync is offered for Microsoft and Google (OAuth contact APIs) plus iCloud (CardDAV
+    /// via the account's app-specific password) — a superset matching calendar sync.
+    /// </summary>
+    public bool ShowContactSyncOption => IsOAuth2 || IsGoogleOAuth || IsICloudAccount;
 
     /// <summary>
     /// Bound to the "Sync calendar from this account" checkbox (#282). Like contact sync it can be

--- a/QuickMail/ViewModels/AccountManagerViewModel.cs
+++ b/QuickMail/ViewModels/AccountManagerViewModel.cs
@@ -33,12 +33,14 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
     public bool IsEditing => SelectedAccount != null;
 
     /// <summary>
-    /// Contact sync (issue #256) is offered only for OAuth accounts — the only backends that expose
-    /// a contact API. Password/IMAP accounts show no checkbox at all (spec §6 Path F).
+    /// Contact sync (issue #256) is offered for Microsoft and Google (OAuth contact APIs), plus
+    /// iCloud accounts (CardDAV via the account's app-specific password) — a superset matching
+    /// calendar sync. Other password/IMAP accounts show no checkbox.
     /// </summary>
     public bool CanSyncContacts =>
-        _contactSync != null &&
-        SelectedAccount is { AuthType: AuthType.OAuth2Microsoft or AuthType.OAuth2Google };
+        _contactSync != null && SelectedAccount is { } acct &&
+        (acct.AuthType is AuthType.OAuth2Microsoft or AuthType.OAuth2Google
+         || acct.ImapHost.Equals("imap.mail.me.com", StringComparison.OrdinalIgnoreCase));
 
     // SyncContacts / SyncCalendar are inherited from AccountEditorViewModel (shared with Add Account).
 
@@ -120,8 +122,17 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
             {
                 if (!CanSyncContacts) return; // box is hidden for these accounts; defensive
                 account.SyncContacts = true;
-                StatusText = "Requesting permission to read your contacts…";
-                await _oauth.RequestContactsConsentAsync(account);
+                // Both OAuth providers need an explicit contact-scope consent here: unlike calendar
+                // (Google's calendar scope rides along with mail sign-in), the Google CONTACTS scope
+                // is NOT in the base sign-in, so toggling contacts on for a Google account must
+                // request it (RequestContactsConsentAsync re-authorizes for Google, acquires the
+                // Graph scope for Microsoft). iCloud uses the account's app-specific password over
+                // CardDAV — no OAuth, no prompt.
+                if (account.AuthType is AuthType.OAuth2Microsoft or AuthType.OAuth2Google)
+                {
+                    StatusText = "Requesting permission to read your contacts…";
+                    await _oauth.RequestContactsConsentAsync(account);
+                }
                 _accountService.SaveAccounts([.. Accounts]);
                 // Pull an initial snapshot so contacts appear without waiting for the next launch.
                 _contactSync?.SyncAccountAsync(account).LogFaults("contact sync after enable");

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -131,7 +131,7 @@ Enter your iCloud address (`@icloud.com`, `@me.com`, or `@mac.com`) in the **Ema
 
 **App-specific password required.** Apple does not allow third-party apps to use your Apple ID password directly. Generate an app-specific password at **appleid.apple.com** (Sign-In & Security → App-Specific Passwords) and enter it in the Password field. QuickMail shows a reminder in the password area when it detects an iCloud address.
 
-To show your iCloud calendar in the Calendar view, check **Sync calendar from this account** — QuickMail uses the same app-specific password, so there's nothing else to set up. iCloud calendars are read-only in QuickMail. See the [Calendar](#calendar) section for details.
+To bring in your iCloud data, check **Sync contacts from this account** and/or **Sync calendar from this account** — QuickMail uses the same app-specific password for both, so there's nothing else to set up. iCloud contacts and calendars are read-only in QuickMail. See [Syncing Contacts from Your Accounts](#syncing-contacts-from-your-accounts) and the [Calendar](#calendar) section for details.
 
 ### Managing Accounts
 
@@ -442,13 +442,13 @@ The address book lists everyone you have sent mail to or explicitly added, plus 
 
 ### Syncing Contacts from Your Accounts
 
-QuickMail can fill the address book from the contacts and prior recipients already stored in your Microsoft and Google accounts, so the people your account knows are available for autocomplete when you address a message.
+QuickMail can fill the address book from the contacts already stored in your Microsoft, Google, and iCloud accounts, so the people your account knows are available for autocomplete when you address a message.
 
-- **Turn it on per account.** When adding a Microsoft or Google account, check **Sync contacts from this account** in the Add Account dialog before you sign in. For an account you already have, open **Settings → Accounts**, edit the account, and check the same box — it takes effect immediately, with no separate Save step. Enabling sync asks your account for read-only access to your contacts (for Google this is part of the normal sign-in; for Microsoft it is granted right after sign-in).
+- **Turn it on per account.** When adding a Microsoft, Google, or iCloud account, check **Sync contacts from this account** in the Add Account dialog. For an account you already have, open **Settings → Accounts**, select the account, and check the same box — it takes effect immediately, with no separate Save step. Enabling sync asks your account for read-only access to your contacts (for Google this is part of the normal sign-in; for Microsoft it is granted right after sign-in; **for iCloud it uses the app-specific password you already entered**, so there is no extra prompt).
 - **Synced contacts are read-only.** They come from the server into QuickMail only — QuickMail never writes changes back to your account. Synced people appear in the list but cannot be edited or deleted there. Contacts you added yourself stay fully editable, even if someone has the same address. Turning the switch off removes that account's synced contacts from QuickMail.
 - **Refreshing.** QuickMail refreshes synced contacts quietly in the background about twice a day. To pull the latest right away, use the **Sync Now** button in the address book, or the **Sync Contacts Now** command in the Command Palette.
 
-Contact sync is one-directional and read-only in this release: no changes are written back, and iCloud/CardDAV accounts are not yet supported.
+Contact sync is one-directional and read-only in this release: no changes are written back. For Microsoft and Google it also pulls the people you've recently emailed; iCloud brings in your saved contacts (its CardDAV service has no separate "recent recipients" list).
 
 ### Groups
 

--- a/docs/release-notes-v0.8.33.md
+++ b/docs/release-notes-v0.8.33.md
@@ -121,6 +121,11 @@ Thank you, as always, to everyone who contributes to QuickMail through code, bug
 - **Removed** the interim global Settings → Internet Calendar (CalDAV) source: its UI, `SettingsViewModel` CalDav members, `[caldav]` config keys, and the synthetic-id (`AccountIdFor` / `SecretKeyFor`) helpers — all superseded by the per-account model.
 - New palette command `calendar.syncNow` ("Sync Calendars Now"). Tests: per-account CalDAV sync (rewritten `CalDavCalendarSyncTests`), opt-in gating, `ShowCalendarSyncOption`, `IsCalendarPushAccount`.
 
+### iCloud contacts via CardDAV
+
+- The "Sync contacts from this account" checkbox (#256) now also appears for **iCloud** accounts, alongside Microsoft and Google — so every account offers a checkbox for each service QuickMail can read. iCloud contacts sync over **CardDAV** (`https://contacts.icloud.com`) using the account's own app-specific password (`GetPassword(account.Id)`), no OAuth.
+- New `CardDavContactClient` (mirrors `CalDavCalendarClient`: manual-redirect Basic-auth `SendAsync`, `current-user-principal` → `addressbook-home-set` → collections discovery, `addressbook-query` REPORT) + minimal vCard parsing (`VCardModel`, reusing `IcsModel`'s unfolding/block-scan/unescape). `ICloudContactSource : IProviderContactSource` (`ContactSource.ICloud`) plugs into `ContactSyncService` via an iCloud host guard in `SourceFor`. `ShowContactSyncOption` / `CanSyncContacts` extended to the iCloud host; consent is requested for Microsoft and Google only (iCloud reuses the app password). iCloud contacts are saved contacts only (CardDAV has no "recent recipients" concept).
+
 ### Go to Date (PR #279)
 
 - `calendar.goToDate` (default **Ctrl+G**, rebindable, in the Command Palette) opens a modeless `GoToDateWindow` (DatePicker). Day/Week/Month keep their view and recenter; Agenda switches to Day. `RequestGoToDate` announces unavailability in online mode; the picker is single-instance.


### PR DESCRIPTION
Extends per-account contact sync (#256) to **iCloud**, so every account offers a checkbox for each service QuickMail can read — contacts *and* calendar. Part of making the account-services model comprehensive.

## What this delivers

Add (or manage) an iCloud account, check **Sync contacts from this account**, and your iCloud contacts flow into the address book — using the app-specific password you already gave the account. No OAuth, no separate setup. The checkbox now appears for iCloud just like it does for Microsoft/Google.

## How

- **`CardDavContactClient`** — mirrors the CalDAV calendar client: manual-redirect Basic-auth `SendAsync` (re-attaches auth across iCloud partition-host redirects), `current-user-principal` → `addressbook-home-set` → collections discovery, `addressbook-query` REPORT for `address-data`.
- **`VCardModel`** — minimal vCard parsing reusing `IcsModel`'s line-unfolding / block-scan / unescape. Handles multiple cards, first-email-wins, synthetic UID fallback, FN→N fallback, and **strips vCard group prefixes** (`item1.EMAIL`) so Apple's custom-labelled emails aren't silently dropped.
- **`ICloudContactSource : IProviderContactSource`** (`ContactSource.ICloud`) — reads `GetPassword(account.Id)`, per-account discovery cache, drops cards with no email/UID.
- **`ContactSyncService.SourceFor`** — iCloud host guard before the auth-type switch. `ShowContactSyncOption` / `CanSyncContacts` extended to the iCloud host. Consent requested for Microsoft **and** Google (Google's contact scope isn't in mail sign-in), skipped for iCloud.

## Review & fixes

Independent review caught two real bugs, both fixed with tests:
1. **Google consent regression** — the toggle path had been narrowed to Microsoft-only; restored so Google contact-sync opt-in still requests its contact scope.
2. **vCard group-prefix email loss** — `item1.EMAIL:…` (how iCloud emits labelled emails) was parsed as property `ITEM1.EMAIL` and the email — and the whole contact — was dropped. Now the group prefix is stripped.

## Verification

- Full suite **1415 passing**; production build clean; app **smoke-launch OK**.
- **One live-only unknown to flag:** iCloud is historically picky about `addressbook-query`. The REPORT is spec-correct and unit-tested against a stubbed server, but whether iCloud accepts the empty-`<filter/>` form can only be confirmed against a real account — that's part of your live check. If it returns no contacts, the fallback (PROPFIND + multiget) is a quick swap.

Docs (Adding Accounts, Syncing Contacts, iCloud) and v0.8.33 release notes updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)