### PR TITLE
Multiple calendars per account — separate, selectable tree nodes

### DIFF
--- a/QuickMail.Tests/CalDavCalendarSyncTests.cs
+++ b/QuickMail.Tests/CalDavCalendarSyncTests.cs
@@ -348,6 +348,57 @@ public class CalDavCalendarSyncTests : IDisposable
         Assert.Contains("time-range start=", report.Body);
     }
 
+    // Two VEVENT calendars in the home — Home and Work — so multi-calendar sync fetches each.
+    private const string TwoCalendarsXml =
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
+          <d:response>
+            <d:href>/123456/calendars/home/</d:href>
+            <d:propstat><d:prop>
+              <d:resourcetype><d:collection/><c:calendar/></d:resourcetype>
+              <d:displayname>Home</d:displayname>
+              <c:supported-calendar-component-set><c:comp name="VEVENT"/></c:supported-calendar-component-set>
+            </d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat>
+          </d:response>
+          <d:response>
+            <d:href>/123456/calendars/work/</d:href>
+            <d:propstat><d:prop>
+              <d:resourcetype><d:collection/><c:calendar/></d:resourcetype>
+              <d:displayname>Work</d:displayname>
+              <c:supported-calendar-component-set><c:comp name="VEVENT"/></c:supported-calendar-component-set>
+            </d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat>
+          </d:response>
+        </d:multistatus>
+        """;
+
+    [Fact]
+    public async Task Sync_MultipleCalendars_FetchesEach_AndTagsRows()
+    {
+        // Discovery returns two VEVENT calendars; sync issues one REPORT per calendar and tags rows.
+        var handler = new RecordingHandler(
+            Xml(PrincipalXml), Xml(HomeSetXml), Xml(TwoCalendarsXml),
+            Xml(ReportXml(TimedIcs)),   // Home
+            Xml(ReportXml(AllDayIcs))); // Work
+
+        var result = await Service(handler).SyncAllAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, result.EventsFetched);
+        // 3 discovery hops + one REPORT per calendar.
+        Assert.Equal(5, handler.Requests.Count);
+        Assert.Equal("REPORT", handler.Requests[3].Method);
+        Assert.Equal("https://p42-caldav.icloud.com/123456/calendars/home/", handler.Requests[3].Url);
+        Assert.Equal("REPORT", handler.Requests[4].Method);
+        Assert.Equal("https://p42-caldav.icloud.com/123456/calendars/work/", handler.Requests[4].Url);
+
+        var rows = await _store.LoadCalendarEventsAsync();
+        Assert.Equal("Home", rows.Single(r => r.Uid == "timed@icloud").CalendarName);
+        Assert.Equal("Work", rows.Single(r => r.Uid == "allday@icloud").CalendarName);
+        // The collection href is the calendar id (round-trips through the folder-tree encoding).
+        Assert.Equal("https://p42-caldav.icloud.com/123456/calendars/home/",
+                     rows.Single(r => r.Uid == "timed@icloud").CalendarId);
+    }
+
     [Fact]
     public async Task Sync_SecondPass_ReusesDiscoveredCalendar_AndReplacesSlice()
     {
@@ -541,8 +592,10 @@ public class CalDavCalendarSyncTests : IDisposable
     [Fact]
     public void MapCalDavEvents_DuplicateUids_CollapseToOneRow()
     {
-        var rows = GraphCalendarSyncService.MapCalDavEvents([TimedIcs, TimedIcs], _accountId);
+        var rows = GraphCalendarSyncService.MapCalDavEvents([TimedIcs, TimedIcs], _accountId, "cal-url", "Home");
         Assert.Single(rows);
+        Assert.Equal("cal-url", rows[0].CalendarId);   // tagged with the calendar it came from
+        Assert.Equal("Home", rows[0].CalendarName);
     }
 
     [Fact]
@@ -556,10 +609,51 @@ public class CalDavCalendarSyncTests : IDisposable
             "END:VEVENT",
             "END:VCALENDAR");
 
-        var first  = Assert.Single(GraphCalendarSyncService.MapCalDavEvents([ics], _accountId));
-        var second = Assert.Single(GraphCalendarSyncService.MapCalDavEvents([ics], _accountId));
+        var first  = Assert.Single(GraphCalendarSyncService.MapCalDavEvents([ics], _accountId, "cal-url", "Home"));
+        var second = Assert.Single(GraphCalendarSyncService.MapCalDavEvents([ics], _accountId, "cal-url", "Home"));
 
         Assert.StartsWith("caldav-", first.Uid);
         Assert.Equal(first.Uid, second.Uid); // stable across passes → replace-slice keeps identity
+    }
+
+    [Fact]
+    public void ParseAllVEventCalendars_ReturnsEveryVEventCollection()
+    {
+        // CollectionsXml has one VEVENT calendar (Home); add a second to prove all are returned.
+        const string twoCalendars =
+            """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
+              <d:response>
+                <d:href>/123456/calendars/home/</d:href>
+                <d:propstat><d:prop>
+                  <d:resourcetype><d:collection/><c:calendar/></d:resourcetype>
+                  <d:displayname>Home</d:displayname>
+                  <c:supported-calendar-component-set><c:comp name="VEVENT"/></c:supported-calendar-component-set>
+                </d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat>
+              </d:response>
+              <d:response>
+                <d:href>/123456/calendars/work/</d:href>
+                <d:propstat><d:prop>
+                  <d:resourcetype><d:collection/><c:calendar/></d:resourcetype>
+                  <d:displayname>Work</d:displayname>
+                  <c:supported-calendar-component-set><c:comp name="VEVENT"/></c:supported-calendar-component-set>
+                </d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat>
+              </d:response>
+              <d:response>
+                <d:href>/123456/calendars/tasks/</d:href>
+                <d:propstat><d:prop>
+                  <d:resourcetype><d:collection/><c:calendar/></d:resourcetype>
+                  <d:displayname>Reminders</d:displayname>
+                  <c:supported-calendar-component-set><c:comp name="VTODO"/></c:supported-calendar-component-set>
+                </d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat>
+              </d:response>
+            </d:multistatus>
+            """;
+
+        var calendars = CalDavCalendarClient.ParseAllVEventCalendars(twoCalendars);
+        Assert.Equal(2, calendars.Count); // both VEVENT calendars; the VTODO Reminders list is skipped
+        Assert.Equal(("/123456/calendars/home/", "Home"), calendars[0]);
+        Assert.Equal(("/123456/calendars/work/", "Work"), calendars[1]);
     }
 }

--- a/QuickMail.Tests/CalendarStoreTests.cs
+++ b/QuickMail.Tests/CalendarStoreTests.cs
@@ -50,6 +50,8 @@ public class CalendarStoreTests : IDisposable
             SourceMessageId = "msg-1",
             SourceFolder = "INBOX",
             ResponseStatus = CalendarResponseStatus.Accepted,
+            CalendarId = "cal-home",
+            CalendarName = "Home",
         };
 
         await _store.UpsertCalendarEventAsync(evt);
@@ -65,7 +67,40 @@ public class CalendarStoreTests : IDisposable
         Assert.Equal(evt.StartTimeTicks, r.StartTimeTicks);
         Assert.Equal(CalendarResponseStatus.Accepted, r.ResponseStatus);
         Assert.Equal("msg-1", r.SourceMessageId);
+        Assert.Equal("cal-home", r.CalendarId);
+        Assert.Equal("Home", r.CalendarName);
         Assert.False(r.IsAllDay);
+    }
+
+    [Fact]
+    public async Task LoadCalendarSources_ReturnsDistinctTaggedCalendars()
+    {
+        var acctA = Guid.NewGuid();
+        var acctB = Guid.NewGuid();
+
+        // Two calendars on account A (two events each) and one on account B.
+        await _store.ReplaceGraphCalendarEventsAsync(acctA,
+        [
+            new CalendarEvent { Uid = "a-home-1", AccountId = acctA, CalendarId = "cal-home", CalendarName = "Home" },
+            new CalendarEvent { Uid = "a-home-2", AccountId = acctA, CalendarId = "cal-home", CalendarName = "Home" },
+            new CalendarEvent { Uid = "a-work-1", AccountId = acctA, CalendarId = "cal-work", CalendarName = "Work" },
+        ]);
+        await _store.ReplaceGraphCalendarEventsAsync(acctB,
+        [
+            new CalendarEvent { Uid = "b-fam-1", AccountId = acctB, CalendarId = "cal-fam", CalendarName = "Family" },
+        ]);
+        // A local (untagged) row must be excluded — it has no distinct server calendar.
+        await _store.UpsertCalendarEventAsync(new CalendarEvent
+        {
+            Uid = "local-1", AccountId = CalendarEvent.LocalAccountId, Summary = "Mine",
+        });
+
+        var sources = await _store.LoadCalendarSourcesAsync();
+
+        Assert.Equal(3, sources.Count); // Home, Work, Family — distinct, untagged local excluded
+        Assert.Contains(sources, s => s.AccountId == acctA && s.CalendarId == "cal-home" && s.CalendarName == "Home");
+        Assert.Contains(sources, s => s.AccountId == acctA && s.CalendarId == "cal-work" && s.CalendarName == "Work");
+        Assert.Contains(sources, s => s.AccountId == acctB && s.CalendarId == "cal-fam"  && s.CalendarName == "Family");
     }
 
     [Fact]

--- a/QuickMail.Tests/CalendarViewModelTests.cs
+++ b/QuickMail.Tests/CalendarViewModelTests.cs
@@ -304,7 +304,7 @@ public class CalendarViewModelTests
     }
 
     [Fact]
-    public async Task AccountFilter_ShowsOnlyThatSource()
+    public async Task SourceFilter_ShowsOnlyThatSource()
     {
         var acctA = Guid.NewGuid();
         var local = new CalendarEvent
@@ -318,18 +318,36 @@ public class CalendarViewModelTests
 
         var vm = MakeVm(new List<CalendarEvent> { local, fromA, fromB });
         await vm.LoadAsync();
-        Assert.Equal(3, vm.VisibleEvents.Count);          // null filter = all
+        Assert.Equal(3, vm.VisibleEvents.Count);                              // null filter = all
 
-        vm.AccountFilter = acctA;                          // one account's calendar
+        vm.SourceFilter = new MainViewModel.CalendarFilter(acctA, null);      // one account's calendars
         Assert.Single(vm.VisibleEvents);
         Assert.Equal("a-1", vm.VisibleEvents[0].Uid);
 
-        vm.AccountFilter = Guid.Empty;                     // local appointments only
+        vm.SourceFilter = new MainViewModel.CalendarFilter(Guid.Empty, null); // local appointments only
         Assert.Single(vm.VisibleEvents);
         Assert.Equal("loc-1", vm.VisibleEvents[0].Uid);
 
-        vm.AccountFilter = null;                           // back to all
+        vm.SourceFilter = null;                                              // back to all
         Assert.Equal(3, vm.VisibleEvents.Count);
+    }
+
+    [Fact]
+    public async Task SourceFilter_SingleCalendar_ShowsOnlyThatCalendarsEvents()
+    {
+        var acct = Guid.NewGuid();
+        var home = MakeEvent("home-1", DateTime.Today.AddHours(9)); home.AccountId = acct; home.CalendarId = "cal-home";
+        var work = MakeEvent("work-1", DateTime.Today.AddHours(10)); work.AccountId = acct; work.CalendarId = "cal-work";
+
+        var vm = MakeVm(new List<CalendarEvent> { home, work });
+        await vm.LoadAsync();
+
+        vm.SourceFilter = new MainViewModel.CalendarFilter(acct, "cal-home"); // one specific calendar
+        Assert.Single(vm.VisibleEvents);
+        Assert.Equal("home-1", vm.VisibleEvents[0].Uid);
+
+        vm.SourceFilter = new MainViewModel.CalendarFilter(acct, null);       // all of the account's calendars
+        Assert.Equal(2, vm.VisibleEvents.Count);
     }
 
     [Fact]
@@ -337,9 +355,17 @@ public class CalendarViewModelTests
     {
         var id = Guid.NewGuid();
         Assert.Null(MainViewModel.CalendarFilterFor(MainViewModel.CalendarFolder.FullName));
-        Assert.Null(MainViewModel.CalendarFilterFor(MainViewModel.CalendarSourcePrefix + "all"));
-        Assert.Equal(Guid.Empty, MainViewModel.CalendarFilterFor(MainViewModel.CalendarSourcePrefix + "local"));
-        Assert.Equal(id, MainViewModel.CalendarFilterFor(MainViewModel.CalendarSourcePrefix + id.ToString("D")));
+        Assert.Equal(new MainViewModel.CalendarFilter(null, null),
+            MainViewModel.CalendarFilterFor(MainViewModel.CalendarSourcePrefix + "all"));
+        Assert.Equal(new MainViewModel.CalendarFilter(Guid.Empty, null),
+            MainViewModel.CalendarFilterFor(MainViewModel.CalendarSourcePrefix + "local"));
+        Assert.Equal(new MainViewModel.CalendarFilter(id, null),
+            MainViewModel.CalendarFilterFor(MainViewModel.CalendarSourcePrefix + id.ToString("D")));
+        // A single-calendar tail: "{guid}|{escapedCalId}" round-trips the (possibly slash-bearing) id.
+        var calId = "https://p42-caldav.icloud.com/123/calendars/home/";
+        Assert.Equal(new MainViewModel.CalendarFilter(id, calId),
+            MainViewModel.CalendarFilterFor(
+                MainViewModel.CalendarSourcePrefix + id.ToString("D") + "|" + Uri.EscapeDataString(calId)));
         Assert.True(MainViewModel.IsCalendarFolderName(MainViewModel.CalendarSourcePrefix + "local"));
         Assert.True(MainViewModel.IsCalendarFolderName(MainViewModel.CalendarFolder.FullName));
         Assert.False(MainViewModel.IsCalendarFolderName("INBOX"));

--- a/QuickMail.Tests/FlagServiceTests.cs
+++ b/QuickMail.Tests/FlagServiceTests.cs
@@ -155,6 +155,8 @@ sealed class RecordingFlagStore : ILocalStoreService
     public Task UpdateFlagIdBatchAsync(IEnumerable<(Guid AccountId, string FolderName, string MessageId)> items, string? flagId) => Task.CompletedTask;
     public Task UpsertCalendarEventAsync(CalendarEvent evt) => Task.CompletedTask;
     public Task<List<CalendarEvent>> LoadCalendarEventsAsync() => Task.FromResult(new List<CalendarEvent>());
+    public Task<IReadOnlyList<(Guid AccountId, string CalendarId, string CalendarName)>> LoadCalendarSourcesAsync()
+        => Task.FromResult<IReadOnlyList<(Guid, string, string)>>(new List<(Guid, string, string)>());
     public Task UpdateCalendarResponseStatusAsync(string uid, Guid accountId, CalendarResponseStatus status) => Task.CompletedTask;
     public Task DeleteCalendarEventAsync(string uid, Guid accountId) => Task.CompletedTask;
     public Task<List<(Guid AccountId, string FolderName, string MessageId, string IcsText)>> LoadAllCalendarIcsAsync()

--- a/QuickMail.Tests/GoogleCalendarSyncTests.cs
+++ b/QuickMail.Tests/GoogleCalendarSyncTests.cs
@@ -109,13 +109,28 @@ public class GoogleCalendarSyncTests : IDisposable
     private static string Page(string? nextPageToken, params string[] events)
         => $$"""{ "items": [{{string.Join(",", events)}}]{{(nextPageToken is null ? "" : $$""", "nextPageToken": "{{nextPageToken}}" """)}} }""";
 
+    /// <summary>A <c>users/me/calendarList</c> response — the enumeration step multi-calendar sync issues first.</summary>
+    private static string CalendarListPage(params (string Id, string Summary)[] cals)
+    {
+        var items = string.Join(",", cals.Select(c => $"{{ \"id\": \"{c.Id}\", \"summary\": \"{c.Summary}\", \"primary\": true }}"));
+        return $"{{ \"items\": [{items}] }}";
+    }
+
+    /// <summary>Handler for a single-calendar account: the calendar list, then that calendar's event pages.</summary>
+    private static RecordingHandler OneCalendarHandler(params HttpResponseMessage[] eventPages)
+    {
+        var responses = new List<HttpResponseMessage> { Json(CalendarListPage(("primary", "kelly@gmail.com"))) };
+        responses.AddRange(eventPages);
+        return new RecordingHandler(responses.ToArray());
+    }
+
     // ── Mapping ──────────────────────────────────────────────────────────────────
 
     [Fact]
     public async Task Sync_MapsTimedEvent_OffsetStamps_ToUtcTicks()
     {
         // 09:00 at -07:00 == 16:00 UTC.
-        var handler = new RecordingHandler(Json(Page(null,
+        var handler = OneCalendarHandler(Json(Page(null,
             EventJson("gid-1", "Standup",
                       startDateTime: "2026-08-01T09:00:00-07:00", endDateTime: "2026-08-01T09:30:00-07:00",
                       location: "Meet", description: "daily"))));
@@ -130,6 +145,8 @@ public class GoogleCalendarSyncTests : IDisposable
         Assert.Equal("gid-1", row.Uid);
         Assert.Equal(_accountId, row.AccountId);
         Assert.True(row.IsGraph); // is_graph = "server-synced row", Google included
+        Assert.Equal("primary", row.CalendarId);          // tagged with the calendar it came from
+        Assert.Equal("kelly@gmail.com", row.CalendarName);
         Assert.False(row.IsUserCreated);
         Assert.Equal("Standup", row.Summary);
         Assert.Equal("Meet", row.Location);
@@ -146,7 +163,7 @@ public class GoogleCalendarSyncTests : IDisposable
     [Fact]
     public async Task Sync_AllDayDateOnly_AnchorsToLocalDay_EndExclusive()
     {
-        var handler = new RecordingHandler(Json(Page(null,
+        var handler = OneCalendarHandler(Json(Page(null,
             EventJson("gid-allday", "Offsite", startDate: "2026-08-03", endDate: "2026-08-05"))));
 
         await Service(handler).SyncAllAsync(TestContext.Current.CancellationToken);
@@ -161,7 +178,7 @@ public class GoogleCalendarSyncTests : IDisposable
     [Fact]
     public async Task Sync_CancelledEvents_AreSkipped()
     {
-        var handler = new RecordingHandler(Json(Page(null,
+        var handler = OneCalendarHandler(Json(Page(null,
             EventJson("gid-live", "Live", startDateTime: "2026-08-01T09:00:00Z", endDateTime: "2026-08-01T10:00:00Z"),
             EventJson("gid-cancelled", "Gone", status: "cancelled",
                       startDateTime: "2026-08-02T09:00:00Z", endDateTime: "2026-08-02T10:00:00Z"))));
@@ -181,7 +198,7 @@ public class GoogleCalendarSyncTests : IDisposable
     [InlineData(null,                                                      CalendarResponseStatus.Accepted)]
     public async Task Sync_MapsSelfAttendeeResponseStatus(string? attendeesJson, CalendarResponseStatus expected)
     {
-        var handler = new RecordingHandler(Json(Page(null,
+        var handler = OneCalendarHandler(Json(Page(null,
             EventJson("gid-r", "R", startDateTime: "2026-08-01T09:00:00Z", endDateTime: "2026-08-01T10:00:00Z",
                       attendeesJson: attendeesJson))));
 
@@ -193,13 +210,15 @@ public class GoogleCalendarSyncTests : IDisposable
     // ── Request shape and paging ─────────────────────────────────────────────────
 
     [Fact]
-    public async Task Sync_RequestsPrimaryCalendar_SingleEvents_WithWindow()
+    public async Task Sync_EnumeratesCalendarList_ThenRequestsEachCalendar_SingleEvents_WithWindow()
     {
-        var handler = new RecordingHandler(Json(Page(null)));
+        var handler = OneCalendarHandler(Json(Page(null)));
 
         await Service(handler).SyncAllAsync(TestContext.Current.CancellationToken);
 
-        var url = Assert.Single(handler.Urls);
+        Assert.Equal(2, handler.Calls); // calendar list, then that calendar's events
+        Assert.Contains("/calendar/v3/users/me/calendarList", handler.Urls[0]);
+        var url = handler.Urls[1];
         Assert.Contains("/calendar/v3/calendars/primary/events?", url);
         Assert.Contains("timeMin=", url);
         Assert.Contains("timeMax=", url);
@@ -209,7 +228,7 @@ public class GoogleCalendarSyncTests : IDisposable
     [Fact]
     public async Task Sync_FollowsNextPageToken()
     {
-        var handler = new RecordingHandler(
+        var handler = OneCalendarHandler(
             Json(Page("tok-2",
                 EventJson("gid-a", "A", startDateTime: "2026-08-01T09:00:00Z", endDateTime: "2026-08-01T10:00:00Z"))),
             Json(Page(null,
@@ -217,11 +236,34 @@ public class GoogleCalendarSyncTests : IDisposable
 
         var result = await Service(handler).SyncAllAsync(TestContext.Current.CancellationToken);
 
-        Assert.Equal(2, handler.Calls);
-        Assert.Contains("pageToken=tok-2", handler.Urls[1]);
+        Assert.Equal(3, handler.Calls); // calendar list, event page 1, event page 2
+        Assert.Contains("pageToken=tok-2", handler.Urls[2]);
         Assert.Equal(2, result.EventsFetched);
         Assert.Equal(new[] { "gid-a", "gid-b" },
             (await _store.LoadCalendarEventsAsync()).Select(r => r.Uid).OrderBy(u => u).ToArray());
+    }
+
+    // ── Multiple calendars per account ───────────────────────────────────────────
+
+    [Fact]
+    public async Task Sync_EnumeratesEveryCalendar_TaggingRowsWithTheirCalendar()
+    {
+        var handler = new RecordingHandler(
+            Json(CalendarListPage(("primary", "kelly@gmail.com"), ("fam123@group.calendar.google.com", "Family"))),
+            Json(Page(null, EventJson("gid-me", "Mine", startDateTime: "2026-08-01T09:00:00Z", endDateTime: "2026-08-01T10:00:00Z"))),
+            Json(Page(null, EventJson("gid-fam", "Soccer", startDateTime: "2026-08-02T09:00:00Z", endDateTime: "2026-08-02T10:00:00Z"))));
+
+        var result = await Service(handler).SyncAllAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, result.EventsFetched);
+        Assert.Equal(3, handler.Calls);
+        Assert.Contains("/calendars/primary/events?", handler.Urls[1]);
+        Assert.Contains("/calendars/fam123%40group.calendar.google.com/events?", handler.Urls[2]);
+
+        var rows = await _store.LoadCalendarEventsAsync();
+        Assert.Equal("kelly@gmail.com", rows.Single(r => r.Uid == "gid-me").CalendarName);
+        Assert.Equal("Family", rows.Single(r => r.Uid == "gid-fam").CalendarName);
+        Assert.Equal("fam123@group.calendar.google.com", rows.Single(r => r.Uid == "gid-fam").CalendarId);
     }
 
     // ── Replace-slice and failure isolation ──────────────────────────────────────
@@ -229,10 +271,13 @@ public class GoogleCalendarSyncTests : IDisposable
     [Fact]
     public async Task SecondSync_RemovesEventsThatVanishedOnServer()
     {
+        // Two syncs — each enumerates the calendar list, then pulls the one calendar's events.
         var handler = new RecordingHandler(
+            Json(CalendarListPage(("primary", "kelly@gmail.com"))),
             Json(Page(null,
                 EventJson("gid-keep", "Keep", startDateTime: "2026-08-01T09:00:00Z", endDateTime: "2026-08-01T10:00:00Z"),
                 EventJson("gid-drop", "Drop", startDateTime: "2026-08-02T09:00:00Z", endDateTime: "2026-08-02T10:00:00Z"))),
+            Json(CalendarListPage(("primary", "kelly@gmail.com"))),
             Json(Page(null,
                 EventJson("gid-keep", "Keep", startDateTime: "2026-08-01T09:00:00Z", endDateTime: "2026-08-01T10:00:00Z"))));
 

--- a/QuickMail.Tests/GraphCalendarSyncServiceTests.cs
+++ b/QuickMail.Tests/GraphCalendarSyncServiceTests.cs
@@ -134,12 +134,27 @@ public class GraphCalendarSyncServiceTests : IDisposable
     private static string Page(string? nextLink, params string[] events)
         => $$"""{ "value": [{{string.Join(",", events)}}]{{(nextLink is null ? "" : $$""", "@odata.nextLink": "{{nextLink}}" """)}} }""";
 
+    /// <summary>A <c>/me/calendars</c> list response — the enumeration step multi-calendar sync issues first.</summary>
+    private static string CalendarsPage(params (string Id, string Name)[] cals)
+    {
+        var items = string.Join(",", cals.Select(c => $"{{ \"id\": \"{c.Id}\", \"name\": \"{c.Name}\" }}"));
+        return $"{{ \"value\": [{items}] }}";
+    }
+
+    /// <summary>Handler for a single-calendar account: the calendars list, then that calendar's view pages.</summary>
+    private static RecordingHandler OneCalendarHandler(params HttpResponseMessage[] viewPages)
+    {
+        var responses = new List<HttpResponseMessage> { Json(CalendarsPage(("cal-1", "Calendar"))) };
+        responses.AddRange(viewPages);
+        return new RecordingHandler(responses.ToArray());
+    }
+
     // ── Mapping ──────────────────────────────────────────────────────────────────
 
     [Fact]
     public async Task Sync_MapsTimedEvent_StoringUtcTicksAndGraphFlag()
     {
-        var handler = new RecordingHandler(Json(Page(null,
+        var handler = OneCalendarHandler(Json(Page(null,
             EventJson("gid-1", "Team sync", "2026-08-01T14:00:00.0000000", "2026-08-01T15:00:00.0000000",
                       location: "Room 1", preview: "agenda"))));
 
@@ -153,6 +168,8 @@ public class GraphCalendarSyncServiceTests : IDisposable
         Assert.Equal("gid-1", row.Uid);
         Assert.Equal(_accountId, row.AccountId);
         Assert.True(row.IsGraph);
+        Assert.Equal("cal-1", row.CalendarId);     // tagged with the calendar it came from
+        Assert.Equal("Calendar", row.CalendarName);
         Assert.False(row.IsUserCreated); // real account id → read-only in the UI
         Assert.Equal("Team sync", row.Summary);
         Assert.Equal("Room 1", row.Location);
@@ -174,7 +191,7 @@ public class GraphCalendarSyncServiceTests : IDisposable
     public async Task Sync_AllDayEvent_AnchorsToLocalDay()
     {
         // Graph all-day: midnight-to-midnight with an EXCLUSIVE end, in the preferred (UTC) zone.
-        var handler = new RecordingHandler(Json(Page(null,
+        var handler = OneCalendarHandler(Json(Page(null,
             EventJson("gid-allday", "Holiday", "2026-08-03T00:00:00.0000000", "2026-08-04T00:00:00.0000000", allDay: true))));
 
         await Service(handler).SyncAllAsync(TestContext.Current.CancellationToken);
@@ -202,21 +219,48 @@ public class GraphCalendarSyncServiceTests : IDisposable
     // ── Request shape ────────────────────────────────────────────────────────────
 
     [Fact]
-    public async Task Sync_SendsPreferUtcHeader_AndCalendarViewWindow()
+    public async Task Sync_EnumeratesCalendars_ThenSendsPreferUtcHeader_AndCalendarViewWindow()
     {
-        var handler = new RecordingHandler(Json(Page(null)));
+        var handler = OneCalendarHandler(Json(Page(null)));
 
         await Service(handler).SyncAllAsync(TestContext.Current.CancellationToken);
 
-        Assert.Equal(1, handler.Calls);
-        // We ask Graph for times in the machine's own Windows zone so all-day events come back
-        // as local midnights (a UTC Prefer header shifted them a day for users east of Greenwich).
-        Assert.Equal($"outlook.timezone=\"{TimeZoneInfo.Local.Id}\"", handler.PreferHeaders[0]);
-        var url = handler.Urls[0];
-        Assert.Contains("/me/calendarView?", url);
+        Assert.Equal(2, handler.Calls); // calendars list, then that calendar's view
+        // First: the calendar enumeration.
+        Assert.Contains("/me/calendars?", handler.Urls[0]);
+        // Second: the per-calendar calendarView, with the machine's own Windows zone Prefer header so
+        // all-day events come back as local midnights (a UTC header shifted them a day east of Greenwich).
+        Assert.Equal($"outlook.timezone=\"{TimeZoneInfo.Local.Id}\"", handler.PreferHeaders[1]);
+        var url = handler.Urls[1];
+        Assert.Contains("/me/calendars/cal-1/calendarView?", url);
         Assert.Contains("startDateTime=", url);
         Assert.Contains("endDateTime=", url);
         Assert.Contains("$select=", url);
+    }
+
+    // ── Multiple calendars per account ───────────────────────────────────────────
+
+    [Fact]
+    public async Task Sync_EnumeratesEveryCalendar_TaggingRowsWithTheirCalendar()
+    {
+        // Two calendars; each returns one event. Sync issues the list call, then one view per calendar.
+        var handler = new RecordingHandler(
+            Json(CalendarsPage(("cal-home", "Home"), ("cal-work", "Work"))),
+            Json(Page(null, EventJson("gid-home", "Dinner", "2026-08-01T18:00:00.0000000", "2026-08-01T19:00:00.0000000"))),
+            Json(Page(null, EventJson("gid-work", "Standup", "2026-08-02T09:00:00.0000000", "2026-08-02T09:30:00.0000000"))));
+
+        var result = await Service(handler).SyncAllAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, result.EventsFetched);
+        Assert.Equal(3, handler.Calls);
+        Assert.Contains("/me/calendars/cal-home/calendarView?", handler.Urls[1]);
+        Assert.Contains("/me/calendars/cal-work/calendarView?", handler.Urls[2]);
+
+        var rows = await _store.LoadCalendarEventsAsync();
+        Assert.Equal("Home", rows.Single(r => r.Uid == "gid-home").CalendarName);
+        Assert.Equal("cal-home", rows.Single(r => r.Uid == "gid-home").CalendarId);
+        Assert.Equal("Work", rows.Single(r => r.Uid == "gid-work").CalendarName);
+        Assert.Equal("cal-work", rows.Single(r => r.Uid == "gid-work").CalendarId);
     }
 
     // ── Paging ───────────────────────────────────────────────────────────────────
@@ -224,7 +268,7 @@ public class GraphCalendarSyncServiceTests : IDisposable
     [Fact]
     public async Task Sync_FollowsNextLink_AcrossPages()
     {
-        var handler = new RecordingHandler(
+        var handler = OneCalendarHandler(
             Json(Page("https://graph.microsoft.com/v1.0/me/calendarView?page=2",
                 EventJson("gid-a", "A", "2026-08-01T09:00:00.0000000", "2026-08-01T10:00:00.0000000"),
                 EventJson("gid-b", "B", "2026-08-02T09:00:00.0000000", "2026-08-02T10:00:00.0000000"))),
@@ -233,8 +277,8 @@ public class GraphCalendarSyncServiceTests : IDisposable
 
         var result = await Service(handler).SyncAllAsync(TestContext.Current.CancellationToken);
 
-        Assert.Equal(2, handler.Calls);
-        Assert.Contains("page=2", handler.Urls[1]);
+        Assert.Equal(3, handler.Calls); // calendars list, view page 1, view page 2
+        Assert.Contains("page=2", handler.Urls[2]);
         Assert.Equal(3, result.EventsFetched);
         var rows = await _store.LoadCalendarEventsAsync();
         Assert.Equal(new[] { "gid-a", "gid-b", "gid-c" }, rows.Select(r => r.Uid).OrderBy(u => u).ToArray());
@@ -245,13 +289,13 @@ public class GraphCalendarSyncServiceTests : IDisposable
     [Fact]
     public async Task Sync_RetriesOn429_HonoringRetryAfter()
     {
-        var handler = new RecordingHandler(
+        var handler = OneCalendarHandler(
             Json("{}", retryAfter: TimeSpan.Zero, code: (HttpStatusCode)429),
             Json(Page(null, EventJson("gid-429", "Throttled", "2026-08-01T09:00:00.0000000", "2026-08-01T10:00:00.0000000"))));
 
         var result = await Service(handler).SyncAllAsync(TestContext.Current.CancellationToken);
 
-        Assert.Equal(2, handler.Calls); // one 429, one successful retry
+        Assert.Equal(3, handler.Calls); // calendars list, one 429 on the view, one successful retry
         Assert.Null(result.Error);
         Assert.Equal("gid-429", Assert.Single(await _store.LoadCalendarEventsAsync()).Uid);
     }
@@ -261,10 +305,13 @@ public class GraphCalendarSyncServiceTests : IDisposable
     [Fact]
     public async Task SecondSync_RemovesEventsThatVanishedOnServer()
     {
+        // Two syncs — each enumerates calendars, then pulls the one calendar's view.
         var handler = new RecordingHandler(
+            Json(CalendarsPage(("cal-1", "Calendar"))),
             Json(Page(null,
                 EventJson("gid-keep", "Keep", "2026-08-01T09:00:00.0000000", "2026-08-01T10:00:00.0000000"),
                 EventJson("gid-drop", "Drop", "2026-08-02T09:00:00.0000000", "2026-08-02T10:00:00.0000000"))),
+            Json(CalendarsPage(("cal-1", "Calendar"))),
             Json(Page(null,
                 EventJson("gid-keep", "Keep", "2026-08-01T09:00:00.0000000", "2026-08-01T10:00:00.0000000"))));
 
@@ -292,7 +339,7 @@ public class GraphCalendarSyncServiceTests : IDisposable
             SourceMessageId = "msg-1", SourceFolder = "INBOX",
         });
 
-        var handler = new RecordingHandler(Json(Page(null,
+        var handler = OneCalendarHandler(Json(Page(null,
             EventJson("gid-1", "Graph event", "2026-08-01T09:00:00.0000000", "2026-08-01T10:00:00.0000000"))));
         await Service(handler).SyncAllAsync(TestContext.Current.CancellationToken);
 

--- a/QuickMail.Tests/MainViewModelFlagTests.cs
+++ b/QuickMail.Tests/MainViewModelFlagTests.cs
@@ -233,6 +233,8 @@ sealed class FilterableStoreForFlags : ILocalStoreService
     public Task UpdateFlagIdBatchAsync(IEnumerable<(Guid AccountId, string FolderName, string MessageId)> items, string? flagId) => Task.CompletedTask;
     public Task UpsertCalendarEventAsync(CalendarEvent evt) => Task.CompletedTask;
     public Task<List<CalendarEvent>> LoadCalendarEventsAsync() => Task.FromResult(new List<CalendarEvent>());
+    public Task<IReadOnlyList<(Guid AccountId, string CalendarId, string CalendarName)>> LoadCalendarSourcesAsync()
+        => Task.FromResult<IReadOnlyList<(Guid, string, string)>>(new List<(Guid, string, string)>());
     public Task UpdateCalendarResponseStatusAsync(string uid, Guid accountId, CalendarResponseStatus status) => Task.CompletedTask;
     public Task DeleteCalendarEventAsync(string uid, Guid accountId) => Task.CompletedTask;
     public Task<List<(Guid AccountId, string FolderName, string MessageId, string IcsText)>> LoadAllCalendarIcsAsync()

--- a/QuickMail.Tests/MarkReadOnOpenTests.cs
+++ b/QuickMail.Tests/MarkReadOnOpenTests.cs
@@ -143,6 +143,8 @@ public class MarkReadOnOpenTests
         public Task UpdateFlagIdBatchAsync(IEnumerable<(Guid AccountId, string FolderName, string MessageId)> items, string? flagId) => Task.CompletedTask;
         public Task UpsertCalendarEventAsync(CalendarEvent evt) => Task.CompletedTask;
         public Task<List<CalendarEvent>> LoadCalendarEventsAsync() => Task.FromResult(new List<CalendarEvent>());
+        public Task<IReadOnlyList<(Guid AccountId, string CalendarId, string CalendarName)>> LoadCalendarSourcesAsync()
+            => Task.FromResult<IReadOnlyList<(Guid, string, string)>>(new List<(Guid, string, string)>());
         public Task UpdateCalendarResponseStatusAsync(string uid, Guid accountId, CalendarResponseStatus status) => Task.CompletedTask;
         public Task DeleteCalendarEventAsync(string uid, Guid accountId) => Task.CompletedTask;
         public Task<List<(Guid AccountId, string FolderName, string MessageId, string IcsText)>> LoadAllCalendarIcsAsync()

--- a/QuickMail.Tests/MessageFilterTests.cs
+++ b/QuickMail.Tests/MessageFilterTests.cs
@@ -47,6 +47,8 @@ public class MessageFilterTests
         public Task UpdateFlagIdBatchAsync(IEnumerable<(Guid AccountId, string FolderName, string MessageId)> items, string? flagId) => Task.CompletedTask;
         public Task UpsertCalendarEventAsync(CalendarEvent evt) => Task.CompletedTask;
         public Task<List<CalendarEvent>> LoadCalendarEventsAsync() => Task.FromResult(new List<CalendarEvent>());
+        public Task<IReadOnlyList<(Guid AccountId, string CalendarId, string CalendarName)>> LoadCalendarSourcesAsync()
+            => Task.FromResult<IReadOnlyList<(Guid, string, string)>>(new List<(Guid, string, string)>());
         public Task UpdateCalendarResponseStatusAsync(string uid, Guid accountId, CalendarResponseStatus status) => Task.CompletedTask;
         public Task DeleteCalendarEventAsync(string uid, Guid accountId) => Task.CompletedTask;
         public Task<List<(Guid AccountId, string FolderName, string MessageId, string IcsText)>> LoadAllCalendarIcsAsync()

--- a/QuickMail.Tests/SavedViewsTests.cs
+++ b/QuickMail.Tests/SavedViewsTests.cs
@@ -840,6 +840,8 @@ public class SavedViewsMainViewModelTests
         public Task UpdateFlagIdBatchAsync(IEnumerable<(Guid AccountId, string FolderName, string MessageId)> items, string? flagId) => Task.CompletedTask;
         public Task UpsertCalendarEventAsync(CalendarEvent evt) => Task.CompletedTask;
         public Task<List<CalendarEvent>> LoadCalendarEventsAsync() => Task.FromResult(new List<CalendarEvent>());
+        public Task<IReadOnlyList<(Guid AccountId, string CalendarId, string CalendarName)>> LoadCalendarSourcesAsync()
+            => Task.FromResult<IReadOnlyList<(Guid, string, string)>>(new List<(Guid, string, string)>());
         public Task UpdateCalendarResponseStatusAsync(string uid, Guid accountId, CalendarResponseStatus status) => Task.CompletedTask;
         public Task DeleteCalendarEventAsync(string uid, Guid accountId) => Task.CompletedTask;
         public Task<List<(Guid AccountId, string FolderName, string MessageId, string IcsText)>> LoadAllCalendarIcsAsync()

--- a/QuickMail.Tests/SessionFeaturesTests.cs
+++ b/QuickMail.Tests/SessionFeaturesTests.cs
@@ -107,6 +107,8 @@ public class PreviewSuppressionTests
         public Task UpdateFlagIdBatchAsync(IEnumerable<(Guid AccountId, string FolderName, string MessageId)> items, string? flagId) => Task.CompletedTask;
         public Task UpsertCalendarEventAsync(CalendarEvent evt) => Task.CompletedTask;
         public Task<List<CalendarEvent>> LoadCalendarEventsAsync() => Task.FromResult(new List<CalendarEvent>());
+        public Task<IReadOnlyList<(Guid AccountId, string CalendarId, string CalendarName)>> LoadCalendarSourcesAsync()
+            => Task.FromResult<IReadOnlyList<(Guid, string, string)>>(new List<(Guid, string, string)>());
         public Task UpdateCalendarResponseStatusAsync(string uid, Guid accountId, CalendarResponseStatus status) => Task.CompletedTask;
         public Task DeleteCalendarEventAsync(string uid, Guid accountId) => Task.CompletedTask;
         public Task<List<(Guid AccountId, string FolderName, string MessageId, string IcsText)>> LoadAllCalendarIcsAsync()

--- a/QuickMail.Tests/StubServices.cs
+++ b/QuickMail.Tests/StubServices.cs
@@ -126,6 +126,8 @@ sealed class StubLocalStoreService : ILocalStoreService
     public Task UpdateFlagIdBatchAsync(IEnumerable<(Guid AccountId, string FolderName, string MessageId)> items, string? flagId) => Task.CompletedTask;
     public Task UpsertCalendarEventAsync(CalendarEvent evt) => Task.CompletedTask;
     public Task<List<CalendarEvent>> LoadCalendarEventsAsync() => Task.FromResult(new List<CalendarEvent>());
+    public Task<IReadOnlyList<(Guid AccountId, string CalendarId, string CalendarName)>> LoadCalendarSourcesAsync()
+        => Task.FromResult<IReadOnlyList<(Guid, string, string)>>(new List<(Guid, string, string)>());
     public Task UpdateCalendarResponseStatusAsync(string uid, Guid accountId, CalendarResponseStatus status) => Task.CompletedTask;
     public Task DeleteCalendarEventAsync(string uid, Guid accountId) => Task.CompletedTask;
     public Task<List<(Guid AccountId, string FolderName, string MessageId, string IcsText)>> LoadAllCalendarIcsAsync()

--- a/QuickMail/Models/CalendarEvent.cs
+++ b/QuickMail/Models/CalendarEvent.cs
@@ -46,6 +46,17 @@ public partial class CalendarEvent : ObservableObject
     public bool IsGraph { get; set; }
 
     /// <summary>
+    /// Provider identifier of the specific calendar this server-synced row belongs to (Graph calendar
+    /// id, Google calendarList id, or CalDAV collection href). Empty for locally-authored and
+    /// invite-harvested rows, which have no distinct server calendar. Lets one account's calendars
+    /// (Home, Work, Family) show as separate selectable tree nodes.
+    /// </summary>
+    public string CalendarId { get; set; } = string.Empty;
+
+    /// <summary>Human-readable name of the calendar in <see cref="CalendarId"/> (the tree node label). Empty when untagged.</summary>
+    public string CalendarName { get; set; } = string.Empty;
+
+    /// <summary>
     /// iCalendar RRULE string for a repeating appointment (e.g. "FREQ=WEEKLY;BYDAY=TU"), or null/empty
     /// for a one-off. Parse with <see cref="Models.RecurrenceRule.Parse"/>.
     /// </summary>

--- a/QuickMail/Services/CalDav/CalDavCalendarClient.cs
+++ b/QuickMail/Services/CalDav/CalDavCalendarClient.cs
@@ -31,6 +31,16 @@ public interface ICalDavCalendarClient
                                                    CancellationToken ct = default);
 
     /// <summary>
+    /// Resolves EVERY VEVENT-capable calendar collection for the account (same principal →
+    /// calendar-home-set → child-collections walk as <see cref="DiscoverCalendarAsync"/>, but keeps
+    /// all matching collections instead of the first). Used by multi-calendar sync so each of an
+    /// account's calendars (Home, Work, Family) becomes its own tagged, selectable source. Throws
+    /// when no event calendar is found.
+    /// </summary>
+    Task<List<CalDavCalendarInfo>> DiscoverCalendarsAsync(string serverUrl, string username, string password,
+                                                          CancellationToken ct = default);
+
+    /// <summary>
     /// REPORT calendar-query for VEVENTs intersecting the UTC window, returning each
     /// response's raw calendar-data ICS body (one body per event resource; a body may hold
     /// several VEVENTs — a recurring master plus overridden instances).
@@ -100,6 +110,12 @@ public sealed class CalDavCalendarClient : ICalDavCalendarClient, IDisposable
 
     public async Task<CalDavCalendarInfo> DiscoverCalendarAsync(string serverUrl, string username, string password,
                                                                 CancellationToken ct = default)
+        // The single-calendar entry point (and the Settings "Test" validation) is the first of the
+        // discovered set — the same walk, just keeping one collection.
+        => (await DiscoverCalendarsAsync(serverUrl, username, password, ct))[0];
+
+    public async Task<List<CalDavCalendarInfo>> DiscoverCalendarsAsync(string serverUrl, string username, string password,
+                                                                       CancellationToken ct = default)
     {
         var baseUri = NormalizeUri(serverUrl);
 
@@ -115,10 +131,14 @@ public sealed class CalDavCalendarClient : ICalDavCalendarClient, IDisposable
 
         var (collectionsXml, collectionsReqUri) =
             await SendAsync(PropfindMethod, new Uri(homeReqUri, homeHref), CollectionsBody, depth: "1", username, password, ct);
-        var (calendarHref, calendarName) = ParseFirstVEventCalendar(collectionsXml)
-            ?? throw new InvalidOperationException("No event calendar was found for this account.");
+        var calendars = ParseAllVEventCalendars(collectionsXml);
+        if (calendars.Count == 0)
+            throw new InvalidOperationException("No event calendar was found for this account.");
 
-        return new CalDavCalendarInfo(new Uri(collectionsReqUri, calendarHref).ToString(), calendarName);
+        // Resolve each collection href against the host that answered the Depth-1 PROPFIND.
+        return calendars
+            .Select(c => new CalDavCalendarInfo(new Uri(collectionsReqUri, c.Href).ToString(), c.DisplayName))
+            .ToList();
     }
 
     // ── Event fetch ──────────────────────────────────────────────────────────────
@@ -163,13 +183,24 @@ public sealed class CalDavCalendarClient : ICalDavCalendarClient, IDisposable
     }
 
     /// <summary>
-    /// The first response in a Depth-1 collections multistatus whose resourcetype marks a CalDAV
-    /// calendar collection AND whose supported-calendar-component-set includes VEVENT (a missing
-    /// component set counts as supporting everything). Skips VTODO-only collections (e.g.
-    /// Reminders lists) and non-calendar children (inbox/outbox/notifications).
+    /// The first VEVENT-capable calendar collection in a Depth-1 collections multistatus, or null.
+    /// Thin wrapper over <see cref="ParseAllVEventCalendars"/>.
     /// </summary>
     internal static (string Href, string DisplayName)? ParseFirstVEventCalendar(string xml)
     {
+        var all = ParseAllVEventCalendars(xml);
+        return all.Count > 0 ? all[0] : null;
+    }
+
+    /// <summary>
+    /// Every response in a Depth-1 collections multistatus whose resourcetype marks a CalDAV
+    /// calendar collection AND whose supported-calendar-component-set includes VEVENT (a missing
+    /// component set counts as supporting everything). Skips VTODO-only collections (e.g.
+    /// Reminders lists) and non-calendar children (inbox/outbox/notifications). Order preserved.
+    /// </summary>
+    internal static List<(string Href, string DisplayName)> ParseAllVEventCalendars(string xml)
+    {
+        var result = new List<(string, string)>();
         var doc = XDocument.Parse(xml);
         foreach (var response in doc.Descendants().Where(e => e.Name.LocalName == "response"))
         {
@@ -194,9 +225,9 @@ public sealed class CalDavCalendarClient : ICalDavCalendarClient, IDisposable
 
             var name = response.Descendants()
                 .FirstOrDefault(e => e.Name.LocalName == "displayname")?.Value.Trim();
-            return (href, string.IsNullOrEmpty(name) ? "Calendar" : name);
+            result.Add((href, string.IsNullOrEmpty(name) ? "Calendar" : name));
         }
-        return null;
+        return result;
     }
 
     /// <summary>Every non-empty calendar-data ICS body in a REPORT multistatus.</summary>

--- a/QuickMail/Services/Google/GoogleCalendarClient.cs
+++ b/QuickMail/Services/Google/GoogleCalendarClient.cs
@@ -46,13 +46,51 @@ public sealed class GoogleCalendarClient : IDisposable
     }
 
     /// <summary>
-    /// All events on the user's PRIMARY calendar within the UTC window, as server-expanded
-    /// occurrences (<c>singleEvents=true</c>), following <c>nextPageToken</c> until exhausted.
+    /// The user's calendar list (<c>GET users/me/calendarList</c>), following <c>nextPageToken</c>
+    /// until exhausted. One entry per calendar the account can see (its own Home/Work/Family plus
+    /// any subscribed calendars), each with an id, a display summary, and a <c>primary</c> flag.
     /// </summary>
-    internal async Task<List<GoogleCalendarEvent>> GetPrimaryEventsAsync(
-        string username, DateTime timeMinUtc, DateTime timeMaxUtc, CancellationToken ct = default)
+    internal async Task<List<GoogleCalendarListEntry>> GetCalendarListAsync(
+        string username, CancellationToken ct = default)
     {
-        var basePath = "calendars/primary/events"
+        var all = new List<GoogleCalendarListEntry>();
+        string? pageToken = null;
+        do
+        {
+            var token = await _oauth.GetAccessTokenAsync(username, ct);
+            var url = $"{BaseUrl}/users/me/calendarList?maxResults=250" +
+                      (string.IsNullOrEmpty(pageToken) ? string.Empty : $"&pageToken={Uri.EscapeDataString(pageToken)}");
+
+            using var req = new HttpRequestMessage(HttpMethod.Get, url);
+            req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+            using var resp = await _http.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, ct);
+            if (!resp.IsSuccessStatusCode)
+            {
+                var body = await resp.Content.ReadAsStringAsync(ct);
+                throw new HttpRequestException(
+                    $"Calendar API request failed ({(int)resp.StatusCode} {resp.StatusCode}): {Truncate(body, 500)}");
+            }
+
+            var page = await resp.Content.ReadFromJsonAsync<GoogleCalendarListResponse>(JsonOpts, ct);
+            if (page?.Items != null) all.AddRange(page.Items);
+            pageToken = page?.NextPageToken;
+        }
+        while (!string.IsNullOrEmpty(pageToken));
+
+        return all;
+    }
+
+    /// <summary>
+    /// All events on the given calendar (default the user's PRIMARY) within the UTC window, as
+    /// server-expanded occurrences (<c>singleEvents=true</c>), following <c>nextPageToken</c> until
+    /// exhausted.
+    /// </summary>
+    internal async Task<List<GoogleCalendarEvent>> GetEventsAsync(
+        string username, DateTime timeMinUtc, DateTime timeMaxUtc,
+        string calendarId = "primary", CancellationToken ct = default)
+    {
+        var basePath = $"calendars/{Uri.EscapeDataString(calendarId)}/events"
             + $"?timeMin={Uri.EscapeDataString(Rfc3339(timeMinUtc))}"
             + $"&timeMax={Uri.EscapeDataString(Rfc3339(timeMaxUtc))}"
             + "&singleEvents=true&maxResults=250";
@@ -152,6 +190,25 @@ internal sealed class GoogleCalendarEventsResponse
 {
     [JsonPropertyName("items")]         public List<GoogleCalendarEvent>? Items { get; set; }
     [JsonPropertyName("nextPageToken")] public string? NextPageToken { get; set; }
+}
+
+/// <summary>Paging envelope for <c>users/me/calendarList</c>.</summary>
+internal sealed class GoogleCalendarListResponse
+{
+    [JsonPropertyName("items")]         public List<GoogleCalendarListEntry>? Items { get; set; }
+    [JsonPropertyName("nextPageToken")] public string? NextPageToken { get; set; }
+}
+
+/// <summary>One calendar in the account's calendar list.</summary>
+internal sealed class GoogleCalendarListEntry
+{
+    [JsonPropertyName("id")]      public string Id { get; set; } = string.Empty;
+    /// <summary>Display name of the calendar (the tree-node label).</summary>
+    [JsonPropertyName("summary")] public string? Summary { get; set; }
+    /// <summary>True for the account's own primary calendar.</summary>
+    [JsonPropertyName("primary")] public bool Primary { get; set; }
+    /// <summary>True when the user has removed this calendar from their list — skip it.</summary>
+    [JsonPropertyName("deleted")] public bool Deleted { get; set; }
 }
 
 /// <summary>One event occurrence from the Calendar API (<c>singleEvents=true</c>).</summary>

--- a/QuickMail/Services/Graph/GraphDtos.cs
+++ b/QuickMail/Services/Graph/GraphDtos.cs
@@ -121,6 +121,13 @@ internal sealed class GraphScoredEmailAddress
 
 // ── Calendar sync (full-calendar spec, M4 read-down v1) ─────────────────────
 
+/// <summary>One calendar from <c>/me/calendars</c> — its id and display name (multi-calendar sync).</summary>
+internal sealed class GraphCalendar
+{
+    [JsonPropertyName("id")] public string Id { get; set; } = string.Empty;
+    [JsonPropertyName("name")] public string? Name { get; set; }
+}
+
 /// <summary>
 /// An event occurrence from <c>/me/calendarView</c>. calendarView expands recurring series
 /// server-side, so each item is a concrete occurrence with its own id — no RRULE handling needed.

--- a/QuickMail/Services/GraphCalendarSyncService.cs
+++ b/QuickMail/Services/GraphCalendarSyncService.cs
@@ -62,10 +62,11 @@ public sealed class GraphCalendarSyncService : IGraphCalendarSyncService
     private readonly ICalDavCalendarClient? _calDav;
     private readonly ICredentialService? _credentials;
 
-    // Resolved CalDAV calendar-collection URL per account (from discovery), so each iCloud account's
-    // home collection is found once and reused. Cleared for an account on fetch failure so a stale
-    // collection URL (e.g. calendar recreated server-side) heals on the next pass.
-    private readonly System.Collections.Concurrent.ConcurrentDictionary<Guid, string> _calDavUrlByAccount = new();
+    // Resolved CalDAV calendar collections per account (from discovery), so each iCloud account's
+    // calendars are found once and reused. A LIST now (multi-calendar): every VEVENT collection the
+    // account exposes. Cleared for an account on fetch failure so stale collection URLs (e.g. a
+    // calendar recreated server-side) heal on the next pass.
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<Guid, List<CalDavCalendarInfo>> _calDavCalendarsByAccount = new();
 
     public GraphCalendarSyncService(IAccountService accounts, ILocalStoreService store, GraphClient graph,
                                     GoogleCalendarClient? google = null,
@@ -185,7 +186,7 @@ public sealed class GraphCalendarSyncService : IGraphCalendarSyncService
     /// <summary>Removes an account's synced calendar rows (called when the user turns its sync off).</summary>
     public async Task RemoveAccountCalendarAsync(Guid accountId, CancellationToken ct = default)
     {
-        _calDavUrlByAccount.TryRemove(accountId, out _);
+        _calDavCalendarsByAccount.TryRemove(accountId, out _);
         await _store.ReplaceGraphCalendarEventsAsync(accountId, []);
     }
 
@@ -194,9 +195,8 @@ public sealed class GraphCalendarSyncService : IGraphCalendarSyncService
         var nowUtc = DateTime.UtcNow;
         var startUtc = nowUtc - WindowBack;
         var endUtc   = nowUtc + WindowForward;
-
-        var path = "/me/calendarView"
-            + $"?startDateTime={Uri.EscapeDataString(startUtc.ToString("yyyy-MM-dd'T'HH:mm:ss'Z'", CultureInfo.InvariantCulture))}"
+        var window =
+              $"startDateTime={Uri.EscapeDataString(startUtc.ToString("yyyy-MM-dd'T'HH:mm:ss'Z'", CultureInfo.InvariantCulture))}"
             + $"&endDateTime={Uri.EscapeDataString(endUtc.ToString("yyyy-MM-dd'T'HH:mm:ss'Z'", CultureInfo.InvariantCulture))}"
             + "&$select=id,subject,bodyPreview,location,organizer,start,end,isAllDay,isOrganizer,responseStatus"
             + "&$top=100";
@@ -205,16 +205,27 @@ public sealed class GraphCalendarSyncService : IGraphCalendarSyncService
         // contact sync). Consent comes from the account's normal sign-in: work/school accounts get
         // Calendars.ReadWrite via `.default` (declared on the app registration); personal accounts
         // acquire the explicit GraphCalendarScopes silently once granted.
-        var items = await _graph.GetAllPagesAsync<GraphCalendarEvent>(
-            account, path, OAuthService.GraphCalendarScopes, silentOnly: true, UtcPreferHeader, ct);
 
-        var mapped = items
-            .Where(e => !string.IsNullOrEmpty(e.Id))
-            .Select(e => MapEvent(e, account.Id))
-            .ToList();
+        // Enumerate every calendar, then pull each one's calendarView, tagging rows with the
+        // calendar they came from so Home / Work / Family show as separate selectable nodes.
+        var calendars = await _graph.GetAllPagesAsync<GraphCalendar>(
+            account, "/me/calendars?$select=id,name", OAuthService.GraphCalendarScopes, silentOnly: true, headers: null, ct);
 
-        await _store.ReplaceGraphCalendarEventsAsync(account.Id, mapped);
-        return mapped.Count;
+        var union = new List<CalendarEvent>();
+        foreach (var cal in calendars)
+        {
+            if (string.IsNullOrEmpty(cal.Id)) continue;
+            var calName = string.IsNullOrWhiteSpace(cal.Name) ? "Calendar" : cal.Name.Trim();
+            var path = $"/me/calendars/{Uri.EscapeDataString(cal.Id)}/calendarView?{window}";
+            var items = await _graph.GetAllPagesAsync<GraphCalendarEvent>(
+                account, path, OAuthService.GraphCalendarScopes, silentOnly: true, UtcPreferHeader, ct);
+            union.AddRange(items
+                .Where(e => !string.IsNullOrEmpty(e.Id))
+                .Select(e => MapEvent(e, account.Id, cal.Id, calName)));
+        }
+
+        await _store.ReplaceGraphCalendarEventsAsync(account.Id, union);
+        return union.Count;
     }
 
     // ── Google (read-down v1) ────────────────────────────────────────────────────
@@ -222,26 +233,39 @@ public sealed class GraphCalendarSyncService : IGraphCalendarSyncService
     private async Task<int> SyncGoogleAccountAsync(AccountModel account, CancellationToken ct)
     {
         var nowUtc = DateTime.UtcNow;
-        var items = await _google!.GetPrimaryEventsAsync(
-            account.Username, nowUtc - WindowBack, nowUtc + WindowForward, ct);
+        var timeMin = nowUtc - WindowBack;
+        var timeMax = nowUtc + WindowForward;
 
-        var mapped = items
-            .Where(e => !string.IsNullOrEmpty(e.Id))
-            // Cancelled occurrences can appear despite the default filters; they are deletions.
-            .Where(e => !string.Equals(e.Status, "cancelled", StringComparison.OrdinalIgnoreCase))
-            .Select(e => MapGoogleEvent(e, account.Id))
-            .ToList();
+        // Enumerate the account's calendars, then pull each one's events, tagging rows with the
+        // calendar they came from so each shows as its own selectable node.
+        var calendars = await _google!.GetCalendarListAsync(account.Username, ct);
 
-        await _store.ReplaceGraphCalendarEventsAsync(account.Id, mapped);
-        return mapped.Count;
+        var union = new List<CalendarEvent>();
+        foreach (var cal in calendars)
+        {
+            if (string.IsNullOrEmpty(cal.Id) || cal.Deleted) continue;
+            var calName = string.IsNullOrWhiteSpace(cal.Summary) ? "Calendar" : cal.Summary.Trim();
+            var items = await _google!.GetEventsAsync(account.Username, timeMin, timeMax, cal.Id, ct);
+            union.AddRange(items
+                .Where(e => !string.IsNullOrEmpty(e.Id))
+                // Cancelled occurrences can appear despite the default filters; they are deletions.
+                .Where(e => !string.Equals(e.Status, "cancelled", StringComparison.OrdinalIgnoreCase))
+                .Select(e => MapGoogleEvent(e, account.Id, cal.Id, calName)));
+        }
+
+        await _store.ReplaceGraphCalendarEventsAsync(account.Id, union);
+        return union.Count;
     }
 
     /// <summary>
     /// Maps one Google Calendar occurrence to a local row. Stored exactly like a Graph row —
     /// is_graph=1 here means "server-synced calendar row", regardless of which provider it came
-    /// from; the account id says whose calendar it is.
+    /// from; the account id says whose calendar it is. <paramref name="calendarId"/>/
+    /// <paramref name="calendarName"/> tag which of the account's calendars it belongs to (empty for
+    /// the write-back path, which re-tags on the next full sync).
     /// </summary>
-    internal static CalendarEvent MapGoogleEvent(GoogleCalendarEvent e, Guid accountId)
+    internal static CalendarEvent MapGoogleEvent(GoogleCalendarEvent e, Guid accountId,
+        string calendarId = "", string calendarName = "")
     {
         long? startTicks, endTicks;
         var allDay = e.Start?.Date != null; // all-day events carry date-only start/end
@@ -272,6 +296,8 @@ public sealed class GraphCalendarSyncService : IGraphCalendarSyncService
             Uid             = e.Id,
             AccountId       = accountId,
             IsGraph         = true, // "server-synced row" — see remark above
+            CalendarId      = calendarId,
+            CalendarName    = calendarName,
             Summary         = e.Summary?.Trim() ?? string.Empty,
             Description     = e.Description?.Trim() ?? string.Empty,
             Location        = e.Location?.Trim() ?? string.Empty,
@@ -333,29 +359,33 @@ public sealed class GraphCalendarSyncService : IGraphCalendarSyncService
             throw new InvalidOperationException(
                 $"no app-specific password saved for {account.Username} — re-enter it in Manage Accounts.");
 
-        if (!_calDavUrlByAccount.TryGetValue(account.Id, out var calendarUrl))
+        if (!_calDavCalendarsByAccount.TryGetValue(account.Id, out var calendars))
         {
-            var info = await _calDav!.DiscoverCalendarAsync(ICloudCalDavUrl, account.Username, password, ct);
-            calendarUrl = info.Url;
-            _calDavUrlByAccount[account.Id] = calendarUrl;
+            calendars = await _calDav!.DiscoverCalendarsAsync(ICloudCalDavUrl, account.Username, password, ct);
+            _calDavCalendarsByAccount[account.Id] = calendars;
         }
 
         var nowUtc = DateTime.UtcNow;
-        List<string> icsBodies;
+        var union = new List<CalendarEvent>();
         try
         {
-            icsBodies = await _calDav!.FetchEventIcsAsync(calendarUrl, account.Username, password,
-                                                          nowUtc - WindowBack, nowUtc + WindowForward, ct);
+            // Fetch each discovered calendar, tagging rows with the collection href / display name
+            // so each calendar is its own selectable source.
+            foreach (var cal in calendars)
+            {
+                var icsBodies = await _calDav!.FetchEventIcsAsync(cal.Url, account.Username, password,
+                                                                  nowUtc - WindowBack, nowUtc + WindowForward, ct);
+                union.AddRange(MapCalDavEvents(icsBodies, account.Id, cal.Url, cal.DisplayName));
+            }
         }
         catch
         {
-            _calDavUrlByAccount.TryRemove(account.Id, out _); // stale collection URL? re-discover next pass
+            _calDavCalendarsByAccount.TryRemove(account.Id, out _); // stale collections? re-discover next pass
             throw;
         }
 
-        var mapped = MapCalDavEvents(icsBodies, account.Id);
-        await _store.ReplaceGraphCalendarEventsAsync(account.Id, mapped);
-        return mapped.Count;
+        await _store.ReplaceGraphCalendarEventsAsync(account.Id, union);
+        return union.Count;
     }
 
     /// <summary>
@@ -367,7 +397,8 @@ public sealed class GraphCalendarSyncService : IGraphCalendarSyncService
     /// rescheduled occurrence shows at its original series slot; and STATUS:CANCELLED events are
     /// dropped. Duplicate UIDs across bodies collapse to one row (last wins).
     /// </summary>
-    internal static List<CalendarEvent> MapCalDavEvents(IEnumerable<string> icsBodies, Guid accountId)
+    internal static List<CalendarEvent> MapCalDavEvents(IEnumerable<string> icsBodies, Guid accountId,
+        string calendarId = "", string calendarName = "")
     {
         var byUid = new Dictionary<string, CalendarEvent>(StringComparer.Ordinal);
         foreach (var body in icsBodies)
@@ -376,15 +407,16 @@ public sealed class GraphCalendarSyncService : IGraphCalendarSyncService
             {
                 if (string.Equals(ics.Status, "CANCELLED", StringComparison.OrdinalIgnoreCase)) continue;
                 if (!string.IsNullOrEmpty(ics.RecurrenceId)) continue;
-                var evt = MapCalDavEvent(ics, accountId);
+                var evt = MapCalDavEvent(ics, accountId, calendarId, calendarName);
                 byUid[evt.Uid] = evt;
             }
         }
         return byUid.Values.ToList();
     }
 
-    /// <summary>Maps one parsed VEVENT to a local row (is_graph=1 = "server-synced").</summary>
-    internal static CalendarEvent MapCalDavEvent(IcsModel ics, Guid accountId)
+    /// <summary>Maps one parsed VEVENT to a local row (is_graph=1 = "server-synced"), tagged with its calendar.</summary>
+    internal static CalendarEvent MapCalDavEvent(IcsModel ics, Guid accountId,
+        string calendarId = "", string calendarName = "")
     {
         long? startTicks, endTicks;
         if (ics.IsAllDay)
@@ -419,6 +451,8 @@ public sealed class GraphCalendarSyncService : IGraphCalendarSyncService
             Uid             = uid,
             AccountId       = accountId,
             IsGraph         = true, // "server-synced row" — read-only in UI, replace-slice owned
+            CalendarId      = calendarId,
+            CalendarName    = calendarName,
             Summary         = ics.Summary?.Trim() ?? string.Empty,
             Description     = ics.Description?.Trim() ?? string.Empty,
             Location        = ics.Location?.Trim() ?? string.Empty,
@@ -614,8 +648,13 @@ public sealed class GraphCalendarSyncService : IGraphCalendarSyncService
         TimeZone = "UTC",
     };
 
-    /// <summary>Maps one Graph calendarView occurrence to a local <see cref="CalendarEvent"/> row.</summary>
-    internal static CalendarEvent MapEvent(GraphCalendarEvent e, Guid accountId)
+    /// <summary>
+    /// Maps one Graph calendarView occurrence to a local <see cref="CalendarEvent"/> row.
+    /// <paramref name="calendarId"/>/<paramref name="calendarName"/> tag which of the account's
+    /// calendars it belongs to (empty for the write-back path, which re-tags on the next full sync).
+    /// </summary>
+    internal static CalendarEvent MapEvent(GraphCalendarEvent e, Guid accountId,
+        string calendarId = "", string calendarName = "")
     {
         long? startTicks, endTicks;
         if (e.IsAllDay)
@@ -647,6 +686,8 @@ public sealed class GraphCalendarSyncService : IGraphCalendarSyncService
             Uid             = e.Id,
             AccountId       = accountId,
             IsGraph         = true,
+            CalendarId      = calendarId,
+            CalendarName    = calendarName,
             Summary         = e.Subject?.Trim() ?? string.Empty,
             Description     = e.BodyPreview?.Trim() ?? string.Empty,
             Location        = e.Location?.DisplayName?.Trim() ?? string.Empty,

--- a/QuickMail/Services/ILocalStoreService.cs
+++ b/QuickMail/Services/ILocalStoreService.cs
@@ -73,6 +73,13 @@ public interface ILocalStoreService
     /// <summary>Loads all calendar events, ordered by start time ascending (nulls last).</summary>
     Task<List<CalendarEvent>> LoadCalendarEventsAsync();
 
+    /// <summary>
+    /// Returns the distinct server calendars (one row per account + calendar) across all synced rows
+    /// (<c>is_graph = 1</c> with a non-empty <c>calendar_id</c>), for building the per-calendar
+    /// grandchild nodes under each account in the folder tree.
+    /// </summary>
+    Task<IReadOnlyList<(Guid AccountId, string CalendarId, string CalendarName)>> LoadCalendarSourcesAsync();
+
     /// <summary>Updates only the response status for an event.</summary>
     Task UpdateCalendarResponseStatusAsync(string uid, Guid accountId, CalendarResponseStatus status);
 

--- a/QuickMail/Services/LocalStoreService.cs
+++ b/QuickMail/Services/LocalStoreService.cs
@@ -130,6 +130,12 @@ public class LocalStoreService : ILocalStoreService
         // Idempotent ALTER, mirroring is_all_day.
         RunMigration(conn, "ALTER TABLE CalendarEvent ADD COLUMN is_graph INTEGER NOT NULL DEFAULT 0;");
 
+        // Per-calendar tagging (multi-calendar-per-account): the specific server calendar a synced
+        // row belongs to, so one account's calendars show as separate tree nodes. Empty for local /
+        // invite-harvested rows. Unversioned idempotent ALTERs, like is_all_day/is_graph above.
+        RunMigration(conn, "ALTER TABLE CalendarEvent ADD COLUMN calendar_id   TEXT NOT NULL DEFAULT '';");
+        RunMigration(conn, "ALTER TABLE CalendarEvent ADD COLUMN calendar_name TEXT NOT NULL DEFAULT '';");
+
         RunDataMigrations(conn);
     }
 
@@ -809,8 +815,8 @@ public class LocalStoreService : ILocalStoreService
             INSERT INTO CalendarEvent(uid, account_id, summary, description, location,
                                       organizer, organizer_name, start_time_ticks, end_time_ticks,
                                       sequence, method, source_message_id, source_folder, response_status,
-                                      is_all_day, recurrence_rule, exdates, is_graph)
-            VALUES($uid, $aid, $sum, $desc, $loc, $org, $orgn, $st, $et, $seq, $meth, $smid, $sf, $rs, $allday, $rrule, $exd, $graph)
+                                      is_all_day, recurrence_rule, exdates, is_graph, calendar_id, calendar_name)
+            VALUES($uid, $aid, $sum, $desc, $loc, $org, $orgn, $st, $et, $seq, $meth, $smid, $sf, $rs, $allday, $rrule, $exd, $graph, $calid, $calname)
             ON CONFLICT(uid, account_id) DO UPDATE SET
                 summary           = excluded.summary,
                 description       = excluded.description,
@@ -825,7 +831,12 @@ public class LocalStoreService : ILocalStoreService
                 source_folder     = excluded.source_folder,
                 is_all_day        = excluded.is_all_day,
                 recurrence_rule   = excluded.recurrence_rule,
-                exdates           = excluded.exdates
+                exdates           = excluded.exdates,
+                -- Preserve an existing calendar tag when the incoming row is untagged (e.g. a server
+                -- write-back that targets the default calendar and carries no tag); the next full
+                -- sync re-tags it. A non-empty incoming tag always wins.
+                calendar_id       = CASE WHEN excluded.calendar_id   = '' THEN calendar_id   ELSE excluded.calendar_id   END,
+                calendar_name     = CASE WHEN excluded.calendar_name = '' THEN calendar_name ELSE excluded.calendar_name END
             WHERE CalendarEvent.is_graph = 0 OR excluded.is_graph = 1;
             """;
         // The DO UPDATE ... WHERE guard: server-synced rows (is_graph=1) are owned by the calendar
@@ -852,6 +863,8 @@ public class LocalStoreService : ILocalStoreService
         cmd.Parameters.AddWithValue("$rrule", (object?)evt.RecurrenceRule ?? DBNull.Value);
         cmd.Parameters.AddWithValue("$exd",  (object?)evt.ExDates ?? DBNull.Value);
         cmd.Parameters.AddWithValue("$graph", evt.IsGraph ? 1 : 0);
+        cmd.Parameters.AddWithValue("$calid", evt.CalendarId);
+        cmd.Parameters.AddWithValue("$calname", evt.CalendarName);
         await cmd.ExecuteNonQueryAsync();
         await tx.CommitAsync();
     }
@@ -881,8 +894,8 @@ public class LocalStoreService : ILocalStoreService
                 INSERT OR REPLACE INTO CalendarEvent(uid, account_id, summary, description, location,
                                           organizer, organizer_name, start_time_ticks, end_time_ticks,
                                           sequence, method, source_message_id, source_folder, response_status,
-                                          is_all_day, recurrence_rule, exdates, is_graph)
-                VALUES($uid, $aid, $sum, $desc, $loc, $org, $orgn, $st, $et, $seq, $meth, $smid, $sf, $rs, $allday, $rrule, $exd, 1);
+                                          is_all_day, recurrence_rule, exdates, is_graph, calendar_id, calendar_name)
+                VALUES($uid, $aid, $sum, $desc, $loc, $org, $orgn, $st, $et, $seq, $meth, $smid, $sf, $rs, $allday, $rrule, $exd, 1, $calid, $calname);
                 """;
             var pUid  = ins.Parameters.Add("$uid",  Microsoft.Data.Sqlite.SqliteType.Text);
             var pAid  = ins.Parameters.Add("$aid",  Microsoft.Data.Sqlite.SqliteType.Text);
@@ -901,6 +914,8 @@ public class LocalStoreService : ILocalStoreService
             var pAll  = ins.Parameters.Add("$allday", Microsoft.Data.Sqlite.SqliteType.Integer);
             var pRr   = ins.Parameters.Add("$rrule", Microsoft.Data.Sqlite.SqliteType.Text);
             var pExd  = ins.Parameters.Add("$exd",  Microsoft.Data.Sqlite.SqliteType.Text);
+            var pCid  = ins.Parameters.Add("$calid",   Microsoft.Data.Sqlite.SqliteType.Text);
+            var pCn   = ins.Parameters.Add("$calname", Microsoft.Data.Sqlite.SqliteType.Text);
 
             foreach (var evt in events)
             {
@@ -921,6 +936,8 @@ public class LocalStoreService : ILocalStoreService
                 pAll.Value  = evt.IsAllDay ? 1 : 0;
                 pRr.Value   = (object?)evt.RecurrenceRule ?? DBNull.Value;
                 pExd.Value  = (object?)evt.ExDates ?? DBNull.Value;
+                pCid.Value  = evt.CalendarId;
+                pCn.Value   = evt.CalendarName;
                 await ins.ExecuteNonQueryAsync();
             }
         }
@@ -936,7 +953,8 @@ public class LocalStoreService : ILocalStoreService
         cmd.CommandText = """
             SELECT uid, account_id, summary, description, location, organizer, organizer_name,
                    start_time_ticks, end_time_ticks, sequence, method, source_message_id,
-                   source_folder, response_status, is_all_day, recurrence_rule, exdates, is_graph
+                   source_folder, response_status, is_all_day, recurrence_rule, exdates, is_graph,
+                   calendar_id, calendar_name
             FROM CalendarEvent
             ORDER BY start_time_ticks IS NULL, start_time_ticks ASC;
             """;
@@ -963,8 +981,29 @@ public class LocalStoreService : ILocalStoreService
                 RecurrenceRule   = r.IsDBNull(15) ? null : r.GetString(15),
                 ExDates          = r.IsDBNull(16) ? null : r.GetString(16),
                 IsGraph          = !r.IsDBNull(17) && r.GetInt32(17) != 0,
+                CalendarId       = r.IsDBNull(18) ? string.Empty : r.GetString(18),
+                CalendarName     = r.IsDBNull(19) ? string.Empty : r.GetString(19),
             });
         }
+        return list;
+    }
+
+    public async Task<IReadOnlyList<(Guid AccountId, string CalendarId, string CalendarName)>> LoadCalendarSourcesAsync()
+    {
+        var list = new List<(Guid, string, string)>();
+        await using var conn = await OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        // Distinct server calendars across all synced rows — one row per (account, calendar), used to
+        // build the per-calendar grandchild nodes under each account in the folder tree.
+        cmd.CommandText = """
+            SELECT DISTINCT account_id, calendar_id, calendar_name
+            FROM CalendarEvent
+            WHERE is_graph = 1 AND calendar_id <> ''
+            ORDER BY calendar_name;
+            """;
+        await using var r = await cmd.ExecuteReaderAsync();
+        while (await r.ReadAsync())
+            list.Add((Guid.Parse(r.GetString(0)), r.GetString(1), r.GetString(2)));
         return list;
     }
 

--- a/QuickMail/ViewModels/CalendarViewModel.cs
+++ b/QuickMail/ViewModels/CalendarViewModel.cs
@@ -174,18 +174,18 @@ public partial class CalendarViewModel : ObservableObject
     partial void OnSearchTextChanged(string value) => ApplyFilters();
 
     /// <summary>
-    /// Which calendar source the views show: null = all sources merged; Guid.Empty = locally
-    /// authored appointments only; otherwise that account's events (synced or invite-harvested).
-    /// Set by MainViewModel from the selected tree node before LoadAsync.
+    /// Which calendar source(s) the views show: null = all sources merged; otherwise the
+    /// <see cref="MainViewModel.CalendarFilter"/> chosen from the selected tree node (an account, one
+    /// of its calendars, or the local calendar). Set by MainViewModel before LoadAsync.
     /// </summary>
-    private Guid? _accountFilter;
-    public Guid? AccountFilter
+    private MainViewModel.CalendarFilter? _sourceFilter;
+    public MainViewModel.CalendarFilter? SourceFilter
     {
-        get => _accountFilter;
+        get => _sourceFilter;
         set
         {
-            if (_accountFilter == value) return;
-            _accountFilter = value;
+            if (_sourceFilter == value) return;
+            _sourceFilter = value;
             ApplyFilters();
         }
     }
@@ -726,7 +726,8 @@ public partial class CalendarViewModel : ObservableObject
     private void ApplyFilters()
     {
         var baseEvents = _calendarService.Events
-            .Where(e => _accountFilter is not Guid f || e.AccountId == f)
+            .Where(e => (_sourceFilter?.Account is not Guid a || e.AccountId == a)
+                        && (_sourceFilter?.CalendarId is not string c || e.CalendarId == c))
             .Where(e => _showDeclinedEvents || e.ResponseStatus != CalendarResponseStatus.Declined)
             .Where(e => e.ResponseStatus != CalendarResponseStatus.Cancelled)
             .ToList();
@@ -849,6 +850,10 @@ public partial class CalendarViewModel : ObservableObject
             ResponseStatus  = master.ResponseStatus,
             IsAllDay        = master.IsAllDay,
             IsGraph         = master.IsGraph,
+            // Carry the calendar tag so an expanded occurrence of a recurring server calendar
+            // (e.g. a CalDAV series) still filters under its own calendar node.
+            CalendarId      = master.CalendarId,
+            CalendarName    = master.CalendarName,
             RecurrenceRule  = master.RecurrenceRule,
             ExDates         = master.ExDates,
             OccurrenceStart = occStart,

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -35,6 +35,11 @@ public partial class MainViewModel : ObservableObject, IDisposable
     private readonly IFlagService? _flagService;
     private readonly ICalendarService? _calendarService;
     private readonly IGraphCalendarSyncService? _graphCalendarSync;
+
+    // Distinct per-account server calendars (from the local store), cached on the UI thread so the
+    // synchronous BuildFolderTree can add a grandchild node per calendar. Refreshed after each
+    // calendar sync and on initial load.
+    private IReadOnlyList<(Guid AccountId, string CalendarId, string CalendarName)> _calendarSources = [];
     private readonly IUpdateCheckService? _updateCheckService;
     // Windows toast notifications for new mail. Null in tests and when the OS/platform is
     // unsupported. Calling into it is an OS side-effect a service owns, not a View-layer type,
@@ -215,7 +220,8 @@ public partial class MainViewModel : ObservableObject, IDisposable
     };
 
     // Per-source calendar children under the Calendar node: " Calendar:{guid}" for one
-    // account's calendar, ":local" for locally-authored appointments, ":all" for the merged view.
+    // account, "local" for locally-authored appointments, "all" for the merged view, and
+    // "{guid}|{escapedCalId}" for a single specific calendar of that account.
     internal const string CalendarSourcePrefix = " Calendar:";
 
     /// <summary>True for the Calendar node or any of its per-source children.</summary>
@@ -225,17 +231,35 @@ public partial class MainViewModel : ObservableObject, IDisposable
             || fullName.StartsWith(CalendarSourcePrefix, StringComparison.Ordinal));
 
     /// <summary>
-    /// Maps a calendar folder name to the account filter it selects:
-    /// null = all sources; Guid.Empty = local appointments; else that account's calendar.
+    /// Maps a calendar folder name to the source filter it selects. Returns null only for a name that
+    /// is not a per-source child (e.g. the bare Calendar node); the "all" child returns a filter that
+    /// matches every source. See <see cref="CalendarSourcePrefix"/> for the tail encoding.
     /// </summary>
-    internal static Guid? CalendarFilterFor(string fullName)
+    internal static CalendarFilter? CalendarFilterFor(string fullName)
     {
         if (!fullName.StartsWith(CalendarSourcePrefix, StringComparison.Ordinal)) return null;
         var tail = fullName[CalendarSourcePrefix.Length..];
-        if (tail == "all") return null;
-        if (tail == "local") return Guid.Empty;
-        return Guid.TryParse(tail, out var id) ? id : null;
+        if (tail == "all")   return new CalendarFilter(null, null);
+        if (tail == "local") return new CalendarFilter(Guid.Empty, null);
+
+        // "{guid}|{escapedCalId}" selects one specific calendar; "{guid}" selects all of that
+        // account's calendars.
+        var sep = tail.IndexOf('|');
+        if (sep >= 0)
+        {
+            var calId = Uri.UnescapeDataString(tail[(sep + 1)..]);
+            return Guid.TryParse(tail[..sep], out var gid) ? new CalendarFilter(gid, calId) : null;
+        }
+        return Guid.TryParse(tail, out var id) ? new CalendarFilter(id, null) : null;
     }
+
+    /// <summary>
+    /// Which calendar source(s) the calendar list shows. <see cref="Account"/> null = every source
+    /// merged; <see cref="Guid.Empty"/> = locally-authored appointments only; otherwise that
+    /// account's rows. <see cref="CalendarId"/> null = all of that account's calendars; otherwise the
+    /// single tagged calendar.
+    /// </summary>
+    public sealed record CalendarFilter(Guid? Account, string? CalendarId);
 
     /// <summary>
     /// True for accounts with a server calendar the app can push appointments to: Microsoft
@@ -1663,6 +1687,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
             : "Connecting and syncing…";
         ConnectionStatusText = "Connecting…";
         StartPrefetchTopOfFolder();
+        await ReloadCalendarSourcesAsync(); // populate before the tree is built so calendars show at startup
         RebuildFolderListFromCache();
     }
 
@@ -2805,7 +2830,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
             // Only accounts the user opted into calendar sync for (#282) get a source node.
             foreach (var acct in Accounts.Where(a => a.SyncCalendar))
             {
-                calNode.Children.Add(new FolderTreeNode
+                var acctNode = new FolderTreeNode
                 {
                     Folder = new MailFolderModel
                     {
@@ -2813,7 +2838,24 @@ public partial class MainViewModel : ObservableObject, IDisposable
                         DisplayName = acct.AccountLabel,
                     },
                     Label = acct.AccountLabel,
-                });
+                };
+
+                // A grandchild per discovered calendar so the user can view Home vs. Work vs. Family.
+                // With 0 or 1 calendars the account node alone suffices (no redundant single child).
+                var acctCalendars = _calendarSources.Where(s => s.AccountId == acct.Id).ToList();
+                if (acctCalendars.Count > 1)
+                    foreach (var (_, calId, calName) in acctCalendars)
+                        acctNode.Children.Add(new FolderTreeNode
+                        {
+                            Folder = new MailFolderModel
+                            {
+                                FullName    = CalendarSourcePrefix + acct.Id.ToString("D") + "|" + Uri.EscapeDataString(calId),
+                                DisplayName = calName,
+                            },
+                            Label = calName,
+                        });
+
+                calNode.Children.Add(acctNode);
             }
             roots.Add(calNode);
         }
@@ -3241,7 +3283,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
     private async Task SelectCalendarAsync(MailFolderModel? folder = null)
     {
         if (CalendarVm == null) return;
-        CalendarVm.AccountFilter = folder == null ? null : CalendarFilterFor(folder.FullName);
+        CalendarVm.SourceFilter = folder == null ? null : CalendarFilterFor(folder.FullName);
 
         _suppressFilterRebuild = true;
         ActiveFilter        = MessageFilter.All;
@@ -6264,6 +6306,18 @@ public partial class MainViewModel : ObservableObject, IDisposable
     /// category) only while the calendar view is active, so background passes stay silent.
     /// Runs on the UI thread; overlapping passes (timer vs. F5) are skipped, not queued.
     /// </summary>
+    /// <summary>
+    /// Reloads the distinct per-account calendar sources from the local store into
+    /// <see cref="_calendarSources"/> (best-effort; leaves the prior list on failure). Callers rebuild
+    /// the folder tree afterward. No-op without a calendar service or in online mode.
+    /// </summary>
+    private async Task ReloadCalendarSourcesAsync()
+    {
+        if (_calendarService == null || OnlineMode) { _calendarSources = []; return; }
+        try { _calendarSources = await _localStore.LoadCalendarSourcesAsync(); }
+        catch (Exception ex) { LogService.Log("LoadCalendarSources", ex); }
+    }
+
     private async Task RunGraphCalendarSyncAsync(bool refreshAndAnnounce = true)
     {
         if (_graphCalendarSync == null || _calendarService == null || OnlineMode) return;
@@ -6273,6 +6327,10 @@ public partial class MainViewModel : ObservableObject, IDisposable
         {
             ReplaceCts(ref _graphCalSyncCts, out var ct);
             var result = await _graphCalendarSync.SyncAllAsync(ct);
+            // Refresh the per-calendar source list and rebuild the tree so newly discovered calendars
+            // appear as their own nodes (and vanished ones drop off).
+            await ReloadCalendarSourcesAsync();
+            BuildFolderTree();
             // Nothing eligible (no Graph accounts) or nothing pulled — leave the calendar alone.
             if (result.AccountsSynced == 0) return;
             if (!refreshAndAnnounce) return; // F5 path: CalendarVm.RefreshAsync reloads + announces

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -564,10 +564,10 @@ Expand the **Calendar** node in the folder tree to choose which events you are l
 
 - **All Calendars** — everything, merged together.
 - **Local Calendar** — only the appointments you created in QuickMail, stored on this computer.
-- **One entry per account** — the events from each email account's online calendar (see [Connecting an online calendar](#connecting-an-online-calendar)).
-- **iCloud** (or whatever you named it) — appears when you have set up an internet calendar in Settings.
+- **One entry per account** — the events from each account you turned calendar sync on for (see [Connecting an online calendar](#connecting-an-online-calendar)). Selecting the account shows all of its calendars merged.
+- **Each calendar under an account** — if an account has more than one calendar (for example iCloud's Home, Family, and Work, or several Google or Outlook calendars), each appears as its own node beneath the account, so you can look at just that one.
 
-Selecting a source filters the list to just that calendar. "All Calendars" is the usual choice for day-to-day use.
+Selecting a source filters the list to it. "All Calendars" is the usual choice for day-to-day use.
 
 ### The four views
 

--- a/docs/release-notes-v0.8.33.md
+++ b/docs/release-notes-v0.8.33.md
@@ -106,7 +106,7 @@ Thank you, as always, to everyone who contributes to QuickMail through code, bug
 - All-day events are fully supported and persisted (`is_all_day` column; re-anchored to local midnight across all providers to avoid off-by-one-day display). The "timed events only / deferred" comment in `EventEditorViewModel` is stale and should be removed.
 - Times stored as UTC ticks; TZID handling per provider (`Prefer: outlook.timezone` for Graph, RFC3339 offsets for Google, kind-carrying stamps for CalDAV).
 - Sync engine (`GraphCalendarSyncService`, name predates multi-provider): read-down window −30…+365 days, replace-slice per account, background pass every 15 min plus one after startup mail sync, best-effort (never throws), `silentOnly` (no interactive sign-in). Write-back is Microsoft + Google **single events only** (recurring push rejected pre-network with `NotSupportedException`); iCloud CalDAV (`CalDavCalendarClient`) is read-only. Failed server create/edit falls back to a local save, announced. Which accounts sync is the per-account opt-in below.
-- Folder tree: `Calendar` sentinel node with `All Calendars` / `Local Calendar` / one child per opted-in account; `CalendarFilterFor` maps a node to `CalendarViewModel.AccountFilter`.
+- Folder tree: `Calendar` sentinel node with `All Calendars` / `Local Calendar` / one child per opted-in account, and — when an account has more than one calendar — a grandchild per calendar. `CalendarFilterFor` maps a node to `CalendarViewModel.SourceFilter` (a `CalendarFilter(Guid? Account, string? CalendarId)` record).
 - Invitations: `LocalCacheCalendarProvider` harvests `text/calendar` parts; Accept/Tentative/Decline event card in the reading pane sends an ICS REPLY and upserts the response status immediately; `METHOD:CANCEL` marks events cancelled (filtered from all views).
 - Reminders: opt-in 60-second timer (`CalendarReminders` / `CalendarReminderMinutes`, default off / 10 min), Windows notification + `AnnouncementCategory.Result`, fired at most once per `(uid, start)` per run.
 - Export via `IcsModel.ExportEvent` (`calendar.exportEvent`, no default key).
@@ -120,6 +120,12 @@ Thank you, as always, to everyone who contributes to QuickMail through code, bug
 - **Consent**: Microsoft gets a one-time `RequestCalendarConsentAsync` (`Calendars.ReadWrite`) at opt-in; Google's calendar scope is already granted at mail sign-in; iCloud needs none. The `OAuthRouter` routes only Microsoft to the consent call.
 - **Removed** the interim global Settings → Internet Calendar (CalDAV) source: its UI, `SettingsViewModel` CalDav members, `[caldav]` config keys, and the synthetic-id (`AccountIdFor` / `SecretKeyFor`) helpers — all superseded by the per-account model.
 - New palette command `calendar.syncNow` ("Sync Calendars Now"). Tests: per-account CalDAV sync (rewritten `CalDavCalendarSyncTests`), opt-in gating, `ShowCalendarSyncOption`, `IsCalendarPushAccount`.
+
+### Multiple calendars per account (separate & selectable)
+
+- Each account's calendars (Home / Family / Work …) now sync and appear as **separate selectable nodes** under the account in the folder tree, instead of only the primary/default calendar. `CalendarEvent` gains `CalendarId`/`CalendarName` (two idempotent `ALTER TABLE` migrations, no schema-version bump); every event is tagged with its source calendar.
+- All three providers enumerate every calendar and union them into the existing per-account replace-slice (one `ReplaceGraphCalendarEventsAsync(account.Id, union)`): Microsoft `GET /me/calendars` → per-calendar `calendarView`; Google `calendarList` → per-calendar events; iCloud CalDAV keeps **all** VEVENT collections (discovery cache is now a per-account list) and issues one REPORT per calendar. A single calendar's fetch failing leaves the prior slice intact.
+- Tree grandchildren (only when an account has >1 calendar) are fed from a new `LocalStoreService.LoadCalendarSourcesAsync` (DISTINCT account/calendar), cached and refreshed on startup and after each sync. Selecting a calendar node filters to that calendar; the account node still shows all its calendars merged.
 
 ### iCloud contacts via CardDAV
 


### PR DESCRIPTION
Each account's calendars (Home / Family / Work …) now sync and appear as **their own selectable nodes** under the account in the folder tree — the last piece of the comprehensive per-account-services model. Previously only the primary/default calendar synced, so multi-calendar accounts (e.g. iCloud with a Family calendar) showed just one calendar's events.

## What you get

- Each account you've turned calendar sync on for lists **each of its calendars** as a node beneath it. Select one to see just that calendar; select the account to see them all merged; **All Calendars** merges every source.
- Works for **iCloud** (CalDAV — all your calendar collections), **Microsoft** (`/me/calendars`), and **Google** (`calendarList`).

## How

- `CalendarEvent` gains `CalendarId`/`CalendarName` (two idempotent `ALTER TABLE` migrations, no schema-version bump); every synced event is tagged with its source calendar.
- Each provider enumerates all calendars, fetches each, and **unions them into the existing per-account replace-slice** — one `ReplaceGraphCalendarEventsAsync(account.Id, union)`. Calendars can't wipe each other, and a mid-loop fetch failure leaves the prior slice intact.
- Folder filter is now a `CalendarFilter(Guid? Account, string? CalendarId)` record; per-calendar grandchild nodes (only when an account has >1 calendar) come from a new `LoadCalendarSourcesAsync`, cached and refreshed on startup and after each sync.

## Review & verification

- **Independent review: no blockers.** It confirmed the replace-slice ordering (no calendar wipes another), schema column threading, filter round-trip, and refresh timing are all correct. Applied its two safe fixes: default an empty calendar name to "Calendar", and skip Google calendars the user has deleted.
- Full suite **1421 passing**; production build clean; app **smoke-launch OK**.

## One product decision to flag (not blocking)

Google (and CalDAV) return **every** calendar — including subscribed holiday calendars and shared/read-only ones — so those would each become a node. For iCloud that's usually just your own calendars, but Google users may see holiday/subscription clutter. I kept all non-deleted calendars for now (respecting "separate and selectable"). If you'd rather I filter to just your own/selected calendars, that's a quick follow-up — tell me which behavior you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)