### PR TITLE
Calendar list: add a Calendar column (which calendar an appointment is on)

### DIFF
--- a/QuickMail.Tests/CalendarViewModelTests.cs
+++ b/QuickMail.Tests/CalendarViewModelTests.cs
@@ -80,8 +80,36 @@ public class CalendarViewModelTests
         await vm.LoadAsync();
 
         var name = vm.VisibleEvents[0].AccessibleName;
-        Assert.Equal(vm.VisibleEvents[0].DisplayLine, name);
+        // Concise (no field labels) base line, with the calendar source appended for accessibility (#1).
+        Assert.StartsWith(vm.VisibleEvents[0].DisplayLine, name);
         Assert.DoesNotContain("Subject ", name);
+        Assert.Contains(", calendar ", name);
+    }
+
+    [Fact]
+    public async Task CalendarSourceLabel_LocalAndTaggedCalendar()
+    {
+        var acctId = Guid.NewGuid();
+        var local = new CalendarEvent
+        {
+            Uid = "loc", AccountId = CalendarEvent.LocalAccountId, Summary = "Mine",
+            StartTimeTicks = DateTime.Today.AddHours(9).ToUniversalTime().Ticks,
+            ResponseStatus = CalendarResponseStatus.Accepted,
+        };
+        var tagged = new CalendarEvent
+        {
+            Uid = "fam", AccountId = acctId, IsGraph = true, Summary = "Reunion",
+            CalendarName = "Family",
+            StartTimeTicks = DateTime.Today.AddHours(10).ToUniversalTime().Ticks,
+            ResponseStatus = CalendarResponseStatus.Accepted,
+        };
+        var svc = new StubCalendarService { StoredEvents = [local, tagged] };
+        var vm = new CalendarViewModel(svc, onlineMode: false, showDeclinedEvents: false,
+            allAccountsProvider: () => new[] { new AccountModel { Id = acctId, AccountName = "Apple" } });
+        await vm.LoadAsync();
+
+        Assert.Equal("Local", vm.VisibleEvents.First(e => e.Uid == "loc").CalendarSourceLabel);
+        Assert.Equal("Apple: Family", vm.VisibleEvents.First(e => e.Uid == "fam").CalendarSourceLabel);
     }
 
     [Fact]

--- a/QuickMail/Models/CalendarEvent.cs
+++ b/QuickMail/Models/CalendarEvent.cs
@@ -223,6 +223,19 @@ public partial class CalendarEvent : ObservableObject
         set => _accessibleName = value;
     }
 
+    /// <summary>
+    /// Column text for the "Calendar" grid column — which calendar this appointment belongs to,
+    /// as "AccountLabel: CalendarName" (e.g. "Apple: Family"), the account label alone for events
+    /// with no specific calendar (invites), or "Local" for locally-authored appointments. Stamped by
+    /// <see cref="ViewModels.CalendarViewModel"/>, which has the account labels; empty otherwise.
+    /// </summary>
+    private string _calendarSourceLabel = string.Empty;
+    public string CalendarSourceLabel
+    {
+        get => _calendarSourceLabel;
+        set => _calendarSourceLabel = value;
+    }
+
     /// <summary>Column text for the "When" grid column — a friendly date/time range.</summary>
     public string WhenText
     {

--- a/QuickMail/ViewModels/CalendarViewModel.cs
+++ b/QuickMail/ViewModels/CalendarViewModel.cs
@@ -197,10 +197,15 @@ public partial class CalendarViewModel : ObservableObject
         IsSearchActive = false;
     }
 
+    // Resolves EVERY account's label for the "Calendar" column (the graph-accounts provider above is
+    // push-capable accounts only, so it omits iCloud). Null in tests.
+    private readonly Func<IReadOnlyList<AccountModel>>? _allAccountsProvider;
+
     public CalendarViewModel(ICalendarService calendarService, bool onlineMode, bool showDeclinedEvents,
                              bool showFieldLabels = false,
                              IGraphCalendarSyncService? graphSync = null,
-                             Func<IReadOnlyList<AccountModel>>? graphAccountsProvider = null)
+                             Func<IReadOnlyList<AccountModel>>? graphAccountsProvider = null,
+                             Func<IReadOnlyList<AccountModel>>? allAccountsProvider = null)
     {
         _calendarService = calendarService;
         _onlineMode = onlineMode;
@@ -208,6 +213,20 @@ public partial class CalendarViewModel : ObservableObject
         _showFieldLabels = showFieldLabels;
         _graphSync = graphSync;
         _graphAccountsProvider = graphAccountsProvider;
+        _allAccountsProvider = allAccountsProvider;
+    }
+
+    /// <summary>
+    /// Builds the "Calendar" source label for a row: "Local" for locally-authored appointments,
+    /// "AccountLabel: CalendarName" (e.g. "Apple: Family") for a tagged server calendar, or the
+    /// account label alone when the row has no specific calendar (e.g. a harvested invitation).
+    /// </summary>
+    private string SourceLabelFor(CalendarEvent e, IReadOnlyDictionary<Guid, string> labels)
+    {
+        if (e.AccountId == CalendarEvent.LocalAccountId) return "Local";
+        var acct = labels.TryGetValue(e.AccountId, out var label) && !string.IsNullOrWhiteSpace(label)
+            ? label : "Account";
+        return string.IsNullOrWhiteSpace(e.CalendarName) ? acct : $"{acct}: {e.CalendarName.Trim()}";
     }
 
     /// <summary>
@@ -788,9 +807,18 @@ public partial class CalendarViewModel : ObservableObject
 
         _filteredEvents = result.OrderBy(e => e.StartTimeTicks ?? long.MaxValue).ToList();
 
-        // Stamp each row's accessible name per the field-labels setting (mirrors the address book).
+        // Stamp each row's accessible name (per the field-labels setting, mirroring the address book)
+        // plus the "Calendar" source column, which also gets spoken so screen-reader users hear which
+        // calendar a row belongs to (#1). Build the account-label map once.
+        var accountLabels = (_allAccountsProvider?.Invoke() ?? [])
+            .GroupBy(a => a.Id).ToDictionary(g => g.Key, g => g.First().AccountLabel);
         foreach (var evt in _filteredEvents)
-            evt.AccessibleName = _showFieldLabels ? evt.LabeledLine : evt.DisplayLine;
+        {
+            var source = SourceLabelFor(evt, accountLabels);
+            evt.CalendarSourceLabel = source;
+            var baseName = _showFieldLabels ? evt.LabeledLine : evt.DisplayLine;
+            evt.AccessibleName = string.IsNullOrEmpty(source) ? baseName : $"{baseName}, calendar {source}";
+        }
 
         using (Events.BeginBatchScope())
         {

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -961,7 +961,8 @@ public partial class MainViewModel : ObservableObject, IDisposable
             CalendarVm = new CalendarViewModel(_calendarService, onlineMode, cfg.ShowDeclinedEvents,
                                                cfg.CalendarListShowFieldLabels,
                                                _graphCalendarSync,
-                                               () => Accounts.Where(IsCalendarPushAccount).ToList());
+                                               () => Accounts.Where(IsCalendarPushAccount).ToList(),
+                                               () => Accounts.ToList());
             RemindersEnabled = cfg.CalendarReminders;
             ReminderLeadMinutes = cfg.CalendarReminderMinutes;
             StartReminderTimer();

--- a/QuickMail/Views/MainWindow.xaml
+++ b/QuickMail/Views/MainWindow.xaml
@@ -1278,6 +1278,8 @@
                                                     DisplayMemberBinding="{Binding WhenText}"/>
                                     <GridViewColumn Header="Status" Width="110"
                                                     DisplayMemberBinding="{Binding StatusText}"/>
+                                    <GridViewColumn Header="Calendar" Width="150"
+                                                    DisplayMemberBinding="{Binding CalendarSourceLabel}"/>
                                 </GridView>
                             </ListView.View>
                         </ListView>

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -592,7 +592,7 @@ In Day, Week, and Month views:
 
 ### Reading an appointment
 
-Move through the list with the arrow keys. Each row is announced as a short summary — for example, "Team standup, today 10:00 to 10:30, Accepted. Location: Zoom." A **details** area below the list shows the full appointment (title, when, whether it repeats, location, and for meeting invitations the organizer and your response status), read from the top so a screen reader can review it line by line.
+Move through the list with the arrow keys. The list has **Subject**, **When**, **Status**, and **Calendar** columns; the Calendar column shows which calendar the appointment belongs to — for example **Apple: Family**, or **Local** for an appointment you created here. Each row is announced as a short summary that includes the calendar — for example, "Team standup, today 10:00 to 10:30, Accepted. Location: Zoom, calendar Apple: Family." A **details** area below the list shows the full appointment (title, when, whether it repeats, location, and for meeting invitations the organizer and your response status), read from the top so a screen reader can review it line by line.
 
 If you prefer each row spoken with field labels ("Subject …, when …, location …") instead of the concise form, turn on **Show field labels in the calendar event list** in **Settings → General**. It takes effect immediately.
 


### PR DESCRIPTION
Requested by Kelly (#1 of two follow-ups): the calendar list should show which calendar each appointment belongs to, accessibly, like "Apple: Family".

## What you get

The calendar list gains a **Calendar** column showing the source calendar per row:
- **`Apple: Family`** — account label + calendar name for a synced calendar
- **`Apple`** — account label alone when there's no specific calendar (e.g. a harvested meeting invitation)
- **`Local`** — an appointment you created in QuickMail

It's both a visible grid column **and** appended to each row's accessible name, so screen-reader users hear it too (e.g. "…Location: Zoom, **calendar Apple: Family**").

## How

- `CalendarEvent.CalendarSourceLabel` — stamped by the VM, same pattern as `AccessibleName`.
- `CalendarViewModel` gains an all-accounts resolver, because the existing account provider only returns push-capable (Microsoft/Google) accounts and omits iCloud. `ApplyFilters` builds the account-label map once and stamps the column + accessible name.
- New `Calendar` `GridViewColumn` in the calendar `ListView`.

Full suite **1422 passing** (one known WPF/STA flake, green on re-run). Verified by launching the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)