### PR TITLE
iCloud calendar write (CalDAV): create/edit/delete single events

### DIFF
--- a/QuickMail.Tests/CalDavCalendarSyncTests.cs
+++ b/QuickMail.Tests/CalDavCalendarSyncTests.cs
@@ -317,6 +317,22 @@ public class CalDavCalendarSyncTests : IDisposable
     }
 
     [Fact]
+    public async Task Sync_StoresResourceHref_ResolvedAbsolute_EvenWhenHrefFilenameDiffersFromUid()
+    {
+        // ReportXml names each resource /123456/calendars/home/{n}.ics — a filename that is NOT the
+        // event UID (exactly how Apple stores iPhone/web-created events). The stored ResourceUrl must
+        // be that real href, resolved absolute against the collection host that answered the REPORT,
+        // so a later edit/delete targets the right resource rather than {collection}/{uid}.ics.
+        var handler = FullSyncHandler(TimedIcs);
+        await Service(handler).SyncAllAsync(TestContext.Current.CancellationToken);
+
+        var row = Assert.Single(await _store.LoadCalendarEventsAsync());
+        Assert.Equal("timed@icloud", row.Uid);
+        Assert.Equal("https://p42-caldav.icloud.com/123456/calendars/home/1.ics", row.ResourceUrl);
+        Assert.NotEqual(CalDavCalendarClient.EventResourceUrl(row.CalendarId, row.Uid), row.ResourceUrl);
+    }
+
+    [Fact]
     public async Task Sync_Discovery_WalksPrincipalHomeAndCollections_WithAuthAndDepth()
     {
         var handler = FullSyncHandler(TimedIcs);
@@ -579,12 +595,25 @@ public class CalDavCalendarSyncTests : IDisposable
     }
 
     [Fact]
-    public void ParseCalendarData_ExtractsEveryIcsBody()
+    public void ParseCalendarData_ExtractsEveryIcsBody_WithItsHref()
     {
         var bodies = CalDavCalendarClient.ParseCalendarData(ReportXml(TimedIcs, AllDayIcs));
         Assert.Equal(2, bodies.Count);
-        Assert.Contains("UID:timed@icloud", bodies[0]);
-        Assert.Contains("UID:allday@icloud", bodies[1]);
+        Assert.Contains("UID:timed@icloud", bodies[0].Ics);
+        Assert.Contains("UID:allday@icloud", bodies[1].Ics);
+        // Each body is paired with its own sibling <href> (raw, no base to resolve against here).
+        Assert.Equal("/123456/calendars/home/1.ics", bodies[0].Href);
+        Assert.Equal("/123456/calendars/home/2.ics", bodies[1].Href);
+    }
+
+    [Fact]
+    public void ParseCalendarData_ResolvesRelativeHref_AgainstBaseUri()
+    {
+        var baseUri = new Uri("https://p42-caldav.icloud.com/123456/calendars/home/");
+        var bodies = CalDavCalendarClient.ParseCalendarData(ReportXml(TimedIcs), baseUri);
+        // Relative href resolves absolute against the collection that answered.
+        Assert.Equal("https://p42-caldav.icloud.com/123456/calendars/home/1.ics",
+                     Assert.Single(bodies).Href);
     }
 
     // ── Mapping units ────────────────────────────────────────────────────────────
@@ -592,10 +621,33 @@ public class CalDavCalendarSyncTests : IDisposable
     [Fact]
     public void MapCalDavEvents_DuplicateUids_CollapseToOneRow()
     {
-        var rows = GraphCalendarSyncService.MapCalDavEvents([TimedIcs, TimedIcs], _accountId, "cal-url", "Home");
+        var rows = GraphCalendarSyncService.MapCalDavEvents(
+            [("/cal/a.ics", TimedIcs), ("/cal/b.ics", TimedIcs)], _accountId, "cal-url", "Home");
         Assert.Single(rows);
         Assert.Equal("cal-url", rows[0].CalendarId);   // tagged with the calendar it came from
         Assert.Equal("Home", rows[0].CalendarName);
+    }
+
+    [Fact]
+    public void MapCalDavEvents_TagsRowWithResourceHref_EvenWhenHrefFilenameDiffersFromUid()
+    {
+        // Apple names an iPhone/web-created resource randomly — filename ≠ UID. The mapped row must
+        // carry that real href so edit/delete target the right resource, not {collection}/{uid}.ics.
+        var href = "https://p42-caldav.icloud.com/123456/calendars/home/AB12-random.ics";
+        var row = Assert.Single(GraphCalendarSyncService.MapCalDavEvents(
+            [(href, TimedIcs)], _accountId,
+            "https://p42-caldav.icloud.com/123456/calendars/home/", "Home"));
+        Assert.Equal("timed@icloud", row.Uid);
+        Assert.Equal(href, row.ResourceUrl);
+    }
+
+    [Fact]
+    public void MapCalDavEvents_ResolvesRelativeHref_AgainstCalendarCollection()
+    {
+        var row = Assert.Single(GraphCalendarSyncService.MapCalDavEvents(
+            [("/123456/calendars/home/random.ics", TimedIcs)], _accountId,
+            "https://p42-caldav.icloud.com/123456/calendars/home/", "Home"));
+        Assert.Equal("https://p42-caldav.icloud.com/123456/calendars/home/random.ics", row.ResourceUrl);
     }
 
     [Fact]
@@ -609,8 +661,8 @@ public class CalDavCalendarSyncTests : IDisposable
             "END:VEVENT",
             "END:VCALENDAR");
 
-        var first  = Assert.Single(GraphCalendarSyncService.MapCalDavEvents([ics], _accountId, "cal-url", "Home"));
-        var second = Assert.Single(GraphCalendarSyncService.MapCalDavEvents([ics], _accountId, "cal-url", "Home"));
+        var first  = Assert.Single(GraphCalendarSyncService.MapCalDavEvents([("/cal/a.ics", ics)], _accountId, "cal-url", "Home"));
+        var second = Assert.Single(GraphCalendarSyncService.MapCalDavEvents([("/cal/a.ics", ics)], _accountId, "cal-url", "Home"));
 
         Assert.StartsWith("caldav-", first.Uid);
         Assert.Equal(first.Uid, second.Uid); // stable across passes → replace-slice keeps identity

--- a/QuickMail.Tests/CalDavCalendarWriteTests.cs
+++ b/QuickMail.Tests/CalDavCalendarWriteTests.cs
@@ -1,0 +1,347 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using QuickMail.Models;
+using QuickMail.Services;
+using QuickMail.Services.Graph;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// iCloud CalDAV WRITE (create / edit / delete of single events): the raw
+/// <see cref="CalDavCalendarClient"/> PUT/DELETE wire format (resource URL, If-None-Match,
+/// text/calendar body, cross-host redirect re-attaching Basic auth) and the
+/// <see cref="GraphCalendarSyncService"/> iCloud write branch (ICS PUT, store upsert, missing
+/// password). HTTP is stubbed with a queued handler; persistence uses a real temp-profile store,
+/// mirroring <see cref="CalDavCalendarSyncTests"/>.
+/// </summary>
+public class CalDavCalendarWriteTests : IDisposable
+{
+    private const string Collection = "https://p42-caldav.icloud.com/123456/calendars/home";
+    private const string Username   = "kelly@example.com";
+
+    private readonly string _tempDir;
+    private readonly LocalStoreService _store;
+    private readonly Guid _accountId = Guid.NewGuid();
+
+    public CalDavCalendarWriteTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"qm-caldav-write-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        _store = new LocalStoreService(new ProfileContext(_tempDir));
+        _store.Initialize();
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); } catch { }
+        GC.SuppressFinalize(this);
+    }
+
+    // ── Test plumbing ────────────────────────────────────────────────────────────
+
+    private sealed record RecordedRequest(string Method, string Url, string? Auth, string? IfNoneMatch,
+                                          string? ContentType, string Body);
+
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        private readonly Queue<HttpResponseMessage> _responses;
+        public List<RecordedRequest> Requests { get; } = [];
+
+        public RecordingHandler(params HttpResponseMessage[] responses)
+            => _responses = new Queue<HttpResponseMessage>(responses);
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            Requests.Add(new RecordedRequest(
+                request.Method.Method,
+                request.RequestUri!.ToString(),
+                request.Headers.Authorization?.ToString(),
+                request.Headers.TryGetValues("If-None-Match", out var m) ? m.First() : null,
+                request.Content?.Headers.ContentType?.ToString(),
+                request.Content == null ? string.Empty : await request.Content.ReadAsStringAsync(ct)));
+            return _responses.Count > 0 ? _responses.Dequeue() : new HttpResponseMessage(HttpStatusCode.NoContent);
+        }
+    }
+
+    private static HttpResponseMessage Created()   => new(HttpStatusCode.Created);
+    private static HttpResponseMessage NoContent() => new(HttpStatusCode.NoContent);
+
+    private sealed class StubCredentials : ICredentialService
+    {
+        private readonly Dictionary<Guid, string> _passwords = [];
+        public StubCredentials(Guid? accountId = null, string? password = null)
+        {
+            if (accountId is { } id && password != null) _passwords[id] = password;
+        }
+        public void SavePassword(Guid accountId, string password) => _passwords[accountId] = password;
+        public string? GetPassword(Guid accountId) => _passwords.TryGetValue(accountId, out var v) ? v : null;
+        public void DeletePassword(Guid accountId) => _passwords.Remove(accountId);
+        public void SaveSecret(string key, string value) { }
+        public string? GetSecret(string key) => null;
+        public void DeleteSecret(string key) { }
+    }
+
+    private sealed class FixedAccountService : IAccountService
+    {
+        private readonly List<AccountModel> _accounts;
+        public FixedAccountService(params AccountModel[] accounts) => _accounts = [.. accounts];
+        public List<AccountModel> LoadAccounts() => _accounts;
+        public void SaveAccounts(List<AccountModel> accounts) { }
+        public void SetDefaultAccount(Guid accountId) { }
+    }
+
+    private AccountModel ICloudAccount() => new()
+    {
+        Id = _accountId,
+        AuthType = AuthType.Password,
+        BackendKind = BackendKind.ImapSmtp,
+        ImapHost = "imap.mail.me.com",
+        Username = Username,
+        SyncCalendar = true,
+    };
+
+    private GraphCalendarSyncService Service(RecordingHandler handler, ICredentialService? credentials = null)
+        => new(new FixedAccountService(ICloudAccount()),
+               _store,
+               new GraphClient(new StubOAuthService(), new HttpClient(new RecordingHandler()), defaultRetryDelay: TimeSpan.Zero),
+               google: null,
+               calDav: new CalDavCalendarClient(new HttpClient(handler)),
+               credentials: credentials ?? new StubCredentials(_accountId, "app-pass"));
+
+    private CalendarEvent TimedEvent(string uid = "lunch-1", string calendarId = Collection) => new()
+    {
+        Uid = uid,
+        CalendarId = calendarId,
+        Summary = "Lunch",
+        Location = "Cafe",
+        StartTimeTicks = new DateTime(2026, 8, 1, 12, 0, 0, DateTimeKind.Utc).Ticks,
+        EndTimeTicks   = new DateTime(2026, 8, 1, 13, 0, 0, DateTimeKind.Utc).Ticks,
+        ResponseStatus = CalendarResponseStatus.Accepted,
+    };
+
+    // ── Raw client: PUT / DELETE wire format ─────────────────────────────────────
+
+    [Fact]
+    public async Task PutEvent_Create_SendsIfNoneMatch_TextCalendar_ToResourceUrl()
+    {
+        var handler = new RecordingHandler(Created());
+        using var client = new CalDavCalendarClient(new HttpClient(handler));
+        var ics = IcsModel.ExportEvent(TimedEvent());
+
+        var url = await client.PutEventAsync($"{Collection}/lunch-1.ics", ics, Username, "app-pass",
+                                             ifNoneMatch: true, TestContext.Current.CancellationToken);
+
+        Assert.Equal($"{Collection}/lunch-1.ics", url);
+        var req = Assert.Single(handler.Requests);
+        Assert.Equal("PUT", req.Method);
+        Assert.Equal($"{Collection}/lunch-1.ics", req.Url);
+        Assert.Equal("*", req.IfNoneMatch);
+        Assert.StartsWith("text/calendar", req.ContentType);
+        Assert.StartsWith("Basic ", req.Auth);
+        Assert.Contains("UID:lunch-1", req.Body);
+        Assert.Contains("SUMMARY:Lunch", req.Body);
+    }
+
+    [Fact]
+    public async Task PutEvent_Update_OmitsIfNoneMatch()
+    {
+        var handler = new RecordingHandler(NoContent());
+        using var client = new CalDavCalendarClient(new HttpClient(handler));
+        var ics = IcsModel.ExportEvent(TimedEvent());
+
+        await client.PutEventAsync($"{Collection}/lunch-1.ics", ics, Username, "app-pass",
+                                   ifNoneMatch: false, TestContext.Current.CancellationToken);
+
+        var req = Assert.Single(handler.Requests);
+        Assert.Equal("PUT", req.Method);
+        Assert.Null(req.IfNoneMatch);
+    }
+
+    [Fact]
+    public async Task DeleteEvent_SendsDelete_NoBody()
+    {
+        var handler = new RecordingHandler(NoContent());
+        using var client = new CalDavCalendarClient(new HttpClient(handler));
+
+        await client.DeleteEventAsync($"{Collection}/lunch-1.ics", Username, "app-pass",
+                                      TestContext.Current.CancellationToken);
+
+        var req = Assert.Single(handler.Requests);
+        Assert.Equal("DELETE", req.Method);
+        Assert.Equal($"{Collection}/lunch-1.ics", req.Url);
+        Assert.Equal(string.Empty, req.Body);
+        Assert.StartsWith("Basic ", req.Auth);
+    }
+
+    [Fact]
+    public async Task Put_FollowsCrossHostRedirect_ReattachingBasicAuth()
+    {
+        var redirect = new HttpResponseMessage(HttpStatusCode.MovedPermanently);
+        redirect.Headers.Location = new Uri("https://p99-caldav.icloud.com/123456/calendars/home/lunch-1.ics");
+        var handler = new RecordingHandler(redirect, Created());
+        using var client = new CalDavCalendarClient(new HttpClient(handler));
+        var ics = IcsModel.ExportEvent(TimedEvent());
+
+        await client.PutEventAsync($"{Collection}/lunch-1.ics", ics, Username, "app-pass",
+                                   ifNoneMatch: true, TestContext.Current.CancellationToken);
+
+        // Redirected hop + re-issue; the re-issue keeps method PUT, the body, and Basic auth.
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.All(handler.Requests, r => Assert.StartsWith("Basic ", r.Auth));
+        Assert.All(handler.Requests, r => Assert.Equal("PUT", r.Method));
+        Assert.Equal("https://p99-caldav.icloud.com/123456/calendars/home/lunch-1.ics", handler.Requests[1].Url);
+        Assert.Contains("UID:lunch-1", handler.Requests[1].Body);
+    }
+
+    [Fact]
+    public async Task Put_NonSuccess_ThrowsWithBody()
+    {
+        var handler = new RecordingHandler(
+            new HttpResponseMessage(HttpStatusCode.PreconditionFailed) { Content = new StringContent("resource exists") });
+        using var client = new CalDavCalendarClient(new HttpClient(handler));
+        var ics = IcsModel.ExportEvent(TimedEvent());
+
+        var ex = await Assert.ThrowsAsync<HttpRequestException>(() =>
+            client.PutEventAsync($"{Collection}/lunch-1.ics", ics, Username, "app-pass", ifNoneMatch: true,
+                                 TestContext.Current.CancellationToken));
+        Assert.Contains("412", ex.Message);
+        Assert.Contains("resource exists", ex.Message);
+    }
+
+    // ── Sync service iCloud write branch ─────────────────────────────────────────
+
+    [Fact]
+    public async Task CreateEvent_ICloud_PutsIcsAndUpsertsServerRow()
+    {
+        var handler = new RecordingHandler(Created());
+        var created = await Service(handler).CreateEventAsync(ICloudAccount(), TimedEvent(),
+                                                              TestContext.Current.CancellationToken);
+
+        Assert.True(created.IsGraph);              // server-synced row
+        Assert.Equal(_accountId, created.AccountId);
+        var req = Assert.Single(handler.Requests);
+        Assert.Equal("PUT", req.Method);
+        Assert.Equal($"{Collection}/lunch-1.ics", req.Url);
+        Assert.Equal("*", req.IfNoneMatch);
+
+        var row = Assert.Single(await _store.LoadCalendarEventsAsync());
+        Assert.Equal("lunch-1", row.Uid);
+        Assert.True(row.IsGraph);
+        Assert.Equal(Collection, row.CalendarId);
+        // The created row records the resource URL it PUT to, so an immediate edit (before the next
+        // read-sync captures the server's real href) still targets the right resource.
+        Assert.Equal($"{Collection}/lunch-1.ics", row.ResourceUrl);
+    }
+
+    [Fact]
+    public async Task UpdateEvent_ICloud_TargetsStoredResourceUrl_WhenItDiffersFromUidName()
+    {
+        // Apple stored this event at a random filename ≠ UID; the stored ResourceUrl differs from
+        // {collection}/{uid}.ics. The edit must PUT to the stored href, not the reconstructed one.
+        const string realHref = "https://p42-caldav.icloud.com/123456/calendars/home/AB12-random.ics";
+        var handler = new RecordingHandler(NoContent());
+        var evt = TimedEvent();
+        evt.ResourceUrl = realHref;
+        evt.Summary = "Lunch (moved)";
+
+        await Service(handler).UpdateEventAsync(ICloudAccount(), evt, TestContext.Current.CancellationToken);
+
+        var req = Assert.Single(handler.Requests);
+        Assert.Equal("PUT", req.Method);
+        Assert.Equal(realHref, req.Url);                        // stored href, not {collection}/lunch-1.ics
+        Assert.NotEqual($"{Collection}/lunch-1.ics", req.Url);
+        Assert.Equal(realHref, Assert.Single(await _store.LoadCalendarEventsAsync()).ResourceUrl);
+    }
+
+    [Fact]
+    public async Task DeleteEvent_ICloud_TargetsStoredResourceUrl_WhenItDiffersFromUidName()
+    {
+        const string realHref = "https://p42-caldav.icloud.com/123456/calendars/home/AB12-random.ics";
+        await _store.UpsertCalendarEventAsync(new CalendarEvent
+        {
+            Uid = "lunch-1", AccountId = _accountId, IsGraph = true, CalendarId = Collection,
+            Summary = "Lunch", ResourceUrl = realHref,
+        });
+        var handler = new RecordingHandler(NoContent());
+        var evt = TimedEvent();
+        evt.ResourceUrl = realHref;
+
+        await Service(handler).DeleteEventAsync(ICloudAccount(), evt, TestContext.Current.CancellationToken);
+
+        var req = Assert.Single(handler.Requests);
+        Assert.Equal("DELETE", req.Method);
+        Assert.Equal(realHref, req.Url);                        // stored href, not {collection}/lunch-1.ics
+        Assert.NotEqual($"{Collection}/lunch-1.ics", req.Url);
+        Assert.Empty(await _store.LoadCalendarEventsAsync());
+    }
+
+    [Fact]
+    public async Task UpdateEvent_ICloud_PutsWithoutIfNoneMatch()
+    {
+        var handler = new RecordingHandler(NoContent());
+        var evt = TimedEvent();
+        evt.Summary = "Lunch (moved)";
+
+        var updated = await Service(handler).UpdateEventAsync(ICloudAccount(), evt,
+                                                             TestContext.Current.CancellationToken);
+
+        Assert.True(updated.IsGraph);
+        var req = Assert.Single(handler.Requests);
+        Assert.Equal("PUT", req.Method);
+        Assert.Null(req.IfNoneMatch);
+        Assert.Contains("SUMMARY:Lunch (moved)", req.Body);
+        Assert.Equal("Lunch (moved)", Assert.Single(await _store.LoadCalendarEventsAsync()).Summary);
+    }
+
+    [Fact]
+    public async Task DeleteEvent_ICloud_DeletesResourceAndRemovesRow()
+    {
+        // Seed a stored row for the event being deleted.
+        await _store.UpsertCalendarEventAsync(new CalendarEvent
+        {
+            Uid = "lunch-1", AccountId = _accountId, IsGraph = true, CalendarId = Collection, Summary = "Lunch",
+        });
+        var handler = new RecordingHandler(NoContent());
+
+        await Service(handler).DeleteEventAsync(ICloudAccount(), TimedEvent(),
+                                               TestContext.Current.CancellationToken);
+
+        var req = Assert.Single(handler.Requests);
+        Assert.Equal("DELETE", req.Method);
+        Assert.Equal($"{Collection}/lunch-1.ics", req.Url);
+        Assert.Empty(await _store.LoadCalendarEventsAsync());
+    }
+
+    [Fact]
+    public async Task CreateEvent_ICloud_MissingPassword_Throws_WithoutRequest()
+    {
+        var handler = new RecordingHandler(Created());
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            Service(handler, credentials: new StubCredentials()).CreateEventAsync(
+                ICloudAccount(), TimedEvent(), TestContext.Current.CancellationToken));
+
+        Assert.Contains("Manage Accounts", ex.Message);
+        Assert.Empty(handler.Requests);
+        Assert.Empty(await _store.LoadCalendarEventsAsync());
+    }
+
+    [Fact]
+    public async Task CreateEvent_ICloud_Recurring_Rejected_BeforeAnyRequest()
+    {
+        var handler = new RecordingHandler(Created());
+        var evt = TimedEvent();
+        evt.RecurrenceRule = "FREQ=WEEKLY";
+
+        await Assert.ThrowsAsync<NotSupportedException>(() =>
+            Service(handler).CreateEventAsync(ICloudAccount(), evt, TestContext.Current.CancellationToken));
+        Assert.Empty(handler.Requests);
+    }
+}

--- a/QuickMail.Tests/CalendarStoreTests.cs
+++ b/QuickMail.Tests/CalendarStoreTests.cs
@@ -73,6 +73,62 @@ public class CalendarStoreTests : IDisposable
     }
 
     [Fact]
+    public async Task ResourceUrl_RoundTrips_ThroughUpsertAndReplaceSlice()
+    {
+        var accountId = Guid.NewGuid();
+        const string href = "https://p42-caldav.icloud.com/123456/calendars/home/AB12-random.ics";
+
+        // Upsert path (write-back / local create).
+        await _store.UpsertCalendarEventAsync(new CalendarEvent
+        {
+            Uid = "res-upsert", AccountId = accountId, IsGraph = true, Summary = "Upsert",
+            CalendarId = "cal-home", ResourceUrl = href,
+        });
+        // Replace-slice path (read-sync).
+        await _store.ReplaceGraphCalendarEventsAsync(accountId,
+        [
+            new CalendarEvent { Uid = "res-slice", AccountId = accountId, CalendarId = "cal-home", ResourceUrl = href },
+        ]);
+
+        var rows = await _store.LoadCalendarEventsAsync();
+        Assert.Equal(href, rows.Single(r => r.Uid == "res-slice").ResourceUrl);
+
+        // A row with no href round-trips as empty (Graph/Google/local/invite rows).
+        await _store.UpsertCalendarEventAsync(new CalendarEvent
+        {
+            Uid = "res-none", AccountId = CalendarEvent.LocalAccountId, Summary = "No href",
+        });
+        Assert.Equal(string.Empty,
+            (await _store.LoadCalendarEventsAsync()).Single(r => r.Uid == "res-none").ResourceUrl);
+    }
+
+    [Fact]
+    public async Task ResourceUrl_Preserved_WhenUpsertWriteBackCarriesNoHref()
+    {
+        var accountId = Guid.NewGuid();
+        const string href = "https://p42-caldav.icloud.com/123456/calendars/home/AB12-random.ics";
+
+        // Read-sync captured the real server href.
+        await _store.UpsertCalendarEventAsync(new CalendarEvent
+        {
+            Uid = "res-keep", AccountId = accountId, IsGraph = true, Summary = "Original",
+            CalendarId = "cal-home", ResourceUrl = href,
+        });
+
+        // A later write-back for the same row that carries NO href (e.g. an untagged edit) must not
+        // wipe the stored one — mirrors the calendar_id CASE-preserve idiom.
+        await _store.UpsertCalendarEventAsync(new CalendarEvent
+        {
+            Uid = "res-keep", AccountId = accountId, IsGraph = true, Summary = "Edited",
+            CalendarId = "cal-home", ResourceUrl = string.Empty,
+        });
+
+        var row = Assert.Single(await _store.LoadCalendarEventsAsync());
+        Assert.Equal("Edited", row.Summary);
+        Assert.Equal(href, row.ResourceUrl); // preserved, not wiped
+    }
+
+    [Fact]
     public async Task LoadCalendarSources_ReturnsDistinctTaggedCalendars()
     {
         var acctA = Guid.NewGuid();

--- a/QuickMail.Tests/CalendarViewModelTests.cs
+++ b/QuickMail.Tests/CalendarViewModelTests.cs
@@ -902,15 +902,55 @@ public class CalendarViewModelTests
     }
 
     [Fact]
-    public void IsCalendarPushAccount_CoversGraphAndGoogle_WhenOptedIn()
+    public void IsCalendarPushAccount_CoversGraphGoogleAndICloud_WhenOptedIn()
     {
         // Push targets require BOTH a supported provider AND the per-account calendar opt-in (#282).
         Assert.True(MainViewModel.IsCalendarPushAccount(new AccountModel { BackendKind = BackendKind.MicrosoftGraph, SyncCalendar = true }));
         Assert.True(MainViewModel.IsCalendarPushAccount(new AccountModel { AuthType = AuthType.OAuth2Google, SyncCalendar = true }));
+        // iCloud is a CalDAV push target, detected by IMAP host.
+        Assert.True(MainViewModel.IsCalendarPushAccount(new AccountModel { ImapHost = "imap.mail.me.com", SyncCalendar = true }));
         Assert.False(MainViewModel.IsCalendarPushAccount(new AccountModel { AuthType = AuthType.Password, SyncCalendar = true }));
         // Not opted in → not a push target even for a supported provider.
         Assert.False(MainViewModel.IsCalendarPushAccount(new AccountModel { BackendKind = BackendKind.MicrosoftGraph, SyncCalendar = false }));
         Assert.False(MainViewModel.IsCalendarPushAccount(new AccountModel { AuthType = AuthType.OAuth2Google, SyncCalendar = false }));
+        Assert.False(MainViewModel.IsCalendarPushAccount(new AccountModel { ImapHost = "imap.mail.me.com", SyncCalendar = false }));
+    }
+
+    [Fact]
+    public void NewEvent_ICloudAccount_OffersOneTargetPerCalendar_PlusLocal()
+    {
+        var apple = new AccountModel
+        {
+            Id = Guid.NewGuid(), ImapHost = "imap.mail.me.com", AccountName = "Apple", SyncCalendar = true,
+        };
+        var store = new StubCalendarService();
+        var vm = new CalendarViewModel(store, onlineMode: false, showDeclinedEvents: false,
+            showFieldLabels: false, graphSync: new StubGraphCalendarSyncService(),
+            graphAccountsProvider: () => new[] { apple },
+            calendarSourcesProvider: () => new[]
+            {
+                (apple.Id, "https://p42-caldav.icloud.com/1/calendars/home/", "Home"),
+                (apple.Id, "https://p42-caldav.icloud.com/1/calendars/family/", "Family"),
+            });
+
+        EventEditorViewModel? editor = null;
+        vm.EditorRequested += e => editor = e;
+        vm.NewEventCommand.Execute(null);
+
+        Assert.NotNull(editor);
+        Assert.True(editor!.ShowSaveTarget);
+        // Local first, then one target per discovered iCloud calendar.
+        Assert.Equal(3, editor.SaveTargetLabels.Count);
+        Assert.Contains("Apple: Home", editor.SaveTargetLabels);
+        Assert.Contains("Apple: Family", editor.SaveTargetLabels);
+
+        // Selecting the second iCloud calendar stamps the built event with that collection URL.
+        editor.SelectedTargetIndex = 2; // Apple: Family
+        editor.Title = "Reunion";
+        Assert.True(editor.TryBuildEvent(out var evt, out _));
+        Assert.Equal(apple.Id, evt.AccountId);
+        Assert.Equal("https://p42-caldav.icloud.com/1/calendars/family/", evt.CalendarId);
+        Assert.Equal("Family", evt.CalendarName);
     }
 
     [Fact]

--- a/QuickMail/Models/CalendarEvent.cs
+++ b/QuickMail/Models/CalendarEvent.cs
@@ -57,6 +57,16 @@ public partial class CalendarEvent : ObservableObject
     public string CalendarName { get; set; } = string.Empty;
 
     /// <summary>
+    /// The CalDAV resource href (absolute URL) this row lives at on the server — captured during
+    /// read-sync. Apple stores an event created on iPhone / iCloud-web at a RANDOM filename that is
+    /// not the UID, so edit/delete must target this real href rather than the reconstructed
+    /// <c>{collection}/{uid}.ics</c>. Empty for Graph/Google/local/invite rows, and empty for a
+    /// QuickMail-created iCloud row that has not yet been re-synced (edit/delete falls back to
+    /// <see cref="Services.CalDavCalendarClient.EventResourceUrl"/> in that case).
+    /// </summary>
+    public string ResourceUrl { get; set; } = string.Empty;
+
+    /// <summary>
     /// iCalendar RRULE string for a repeating appointment (e.g. "FREQ=WEEKLY;BYDAY=TU"), or null/empty
     /// for a one-off. Parse with <see cref="Models.RecurrenceRule.Parse"/>.
     /// </summary>

--- a/QuickMail/Models/IcsModel.cs
+++ b/QuickMail/Models/IcsModel.cs
@@ -282,17 +282,21 @@ public class IcsModel
     }
 
     /// <summary>
-    /// Serializes a calendar event to a standalone .ics file body (METHOD:PUBLISH) suitable for
-    /// saving to disk and importing into any calendar application. All-day events use DATE values;
-    /// timed events use UTC; a recurrence rule is carried through as RRULE.
+    /// Serializes a calendar event to a standalone .ics VCALENDAR body. All-day events use DATE
+    /// values; timed events use UTC; a recurrence rule is carried through as RRULE.
+    /// <paramref name="includeMethod"/> controls the <c>METHOD:PUBLISH</c> property: true (the
+    /// default) for a file exported to disk / imported elsewhere; false for a CalDAV PUT, because
+    /// RFC 4791 §4.1 says a stored calendar object resource must NOT contain a METHOD (iCloud and
+    /// other CalDAV servers can reject a PUT that carries one).
     /// </summary>
-    public static string ExportEvent(CalendarEvent evt)
+    public static string ExportEvent(CalendarEvent evt, bool includeMethod = true)
     {
         var sb = new StringBuilder();
         sb.AppendLine("BEGIN:VCALENDAR");
         sb.AppendLine("VERSION:2.0");
         sb.AppendLine("PRODID:-//QuickMail//EN");
-        sb.AppendLine("METHOD:PUBLISH");
+        if (includeMethod)
+            sb.AppendLine("METHOD:PUBLISH");
         sb.AppendLine("BEGIN:VEVENT");
         sb.AppendLine($"UID:{(string.IsNullOrWhiteSpace(evt.Uid) ? Guid.NewGuid().ToString("N") : evt.Uid)}");
         sb.AppendLine($"DTSTAMP:{DateTime.UtcNow:yyyyMMdd'T'HHmmss'Z'}");

--- a/QuickMail/Services/CalDav/CalDavCalendarClient.cs
+++ b/QuickMail/Services/CalDav/CalDavCalendarClient.cs
@@ -41,12 +41,29 @@ public interface ICalDavCalendarClient
                                                           CancellationToken ct = default);
 
     /// <summary>
-    /// REPORT calendar-query for VEVENTs intersecting the UTC window, returning each
-    /// response's raw calendar-data ICS body (one body per event resource; a body may hold
-    /// several VEVENTs — a recurring master plus overridden instances).
+    /// REPORT calendar-query for VEVENTs intersecting the UTC window, returning each response's
+    /// resource href (absolute URL, resolved against the collection that answered) paired with its
+    /// raw calendar-data ICS body (one body per event resource; a body may hold several VEVENTs — a
+    /// recurring master plus overridden instances). The href is the real resource URL — Apple names
+    /// iPhone/web-created resources randomly (≠ UID), so it is what edit/delete must target.
     /// </summary>
-    Task<List<string>> FetchEventIcsAsync(string calendarUrl, string username, string password,
+    Task<List<(string Href, string Ics)>> FetchEventIcsAsync(string calendarUrl, string username, string password,
                                           DateTime startUtc, DateTime endUtc, CancellationToken ct = default);
+
+    /// <summary>
+    /// PUTs an ICS calendar object to a specific event resource URL. For a create, the caller builds
+    /// the URL with <see cref="CalDavCalendarClient.EventResourceUrl"/> (naming the resource after
+    /// the UID); for an edit, the caller passes the resource's REAL href captured on read-sync (Apple
+    /// names iPhone/web-created resources randomly, ≠ UID). <paramref name="ifNoneMatch"/> true sends
+    /// <c>If-None-Match: *</c> so a create fails rather than clobbering an existing resource; false is
+    /// an unconditional replace (edit). Returns the resource URL the event now lives at. Throws on a
+    /// non-success status with the response body.
+    /// </summary>
+    Task<string> PutEventAsync(string eventResourceUrl, string icsBody,
+                               string username, string password, bool ifNoneMatch, CancellationToken ct = default);
+
+    /// <summary>DELETEs an event resource by its absolute .ics URL. Throws on a non-success status.</summary>
+    Task DeleteEventAsync(string eventResourceUrl, string username, string password, CancellationToken ct = default);
 }
 
 /// <summary>
@@ -97,6 +114,17 @@ public sealed class CalDavCalendarClient : ICalDavCalendarClient, IDisposable
         return "caldav-" + Convert.ToHexString(hash.AsSpan(0, 12)).ToLowerInvariant();
     }
 
+    /// <summary>
+    /// The .ics resource URL for an event UID within a calendar collection:
+    /// <c>{collection}/{escaped-uid}.ics</c>. RFC 4791 lets the client choose the resource name;
+    /// naming a QuickMail-CREATED event after its UID lets create address it without the server
+    /// handing a location back. Used for creates, and as the edit/delete fallback for a
+    /// QuickMail-created row not yet re-synced (once read-sync captures the server's real href —
+    /// which for an Apple-created event is a random name ≠ UID — edit/delete target that instead).
+    /// </summary>
+    public static string EventResourceUrl(string calendarCollectionUrl, string uid)
+        => $"{calendarCollectionUrl.TrimEnd('/')}/{Uri.EscapeDataString(uid)}.ics";
+
     // ── Discovery ────────────────────────────────────────────────────────────────
 
     private const string PrincipalBody =
@@ -143,7 +171,7 @@ public sealed class CalDavCalendarClient : ICalDavCalendarClient, IDisposable
 
     // ── Event fetch ──────────────────────────────────────────────────────────────
 
-    public async Task<List<string>> FetchEventIcsAsync(string calendarUrl, string username, string password,
+    public async Task<List<(string Href, string Ics)>> FetchEventIcsAsync(string calendarUrl, string username, string password,
                                                        DateTime startUtc, DateTime endUtc, CancellationToken ct = default)
     {
         var body =
@@ -161,9 +189,37 @@ public sealed class CalDavCalendarClient : ICalDavCalendarClient, IDisposable
             </c:calendar-query>
             """;
 
-        var (xml, _) = await SendAsync(ReportMethod, NormalizeUri(calendarUrl), body, depth: "1", username, password, ct);
-        return ParseCalendarData(xml);
+        // finalUri is the collection host that actually answered (after any partition redirect);
+        // relative resource hrefs in the multistatus resolve against it.
+        var (xml, finalUri) = await SendAsync(ReportMethod, NormalizeUri(calendarUrl), body, depth: "1", username, password, ct);
+        return ParseCalendarData(xml, finalUri);
     }
+
+    // ── Event write (create / edit / delete) ─────────────────────────────────────
+
+    public async Task<string> PutEventAsync(string eventResourceUrl, string icsBody,
+        string username, string password, bool ifNoneMatch, CancellationToken ct = default)
+    {
+        await SendCoreAsync(NormalizeUri(eventResourceUrl), username, password, target =>
+        {
+            // StringContent stamps "text/calendar; charset=utf-8" — the media type CalDAV requires.
+            var req = new HttpRequestMessage(HttpMethod.Put, target)
+            {
+                Content = new StringContent(icsBody, Encoding.UTF8, "text/calendar"),
+            };
+            // If-None-Match: * makes a create refuse to overwrite an existing resource; an edit
+            // omits it (unconditional replace — v1 is last-write-wins, no ETag round-trip yet).
+            if (ifNoneMatch)
+                req.Headers.TryAddWithoutValidation("If-None-Match", "*");
+            return req;
+        }, ct);
+        return eventResourceUrl;
+    }
+
+    public Task DeleteEventAsync(string eventResourceUrl, string username, string password, CancellationToken ct = default)
+        // DELETE carries no body and no Depth header — just the manual redirect + auth re-attach.
+        => SendCoreAsync(NormalizeUri(eventResourceUrl), username, password,
+                         target => new HttpRequestMessage(HttpMethod.Delete, target), ct);
 
     private static string Stamp(DateTime utc)
         => DateTime.SpecifyKind(utc, DateTimeKind.Utc)
@@ -230,15 +286,31 @@ public sealed class CalDavCalendarClient : ICalDavCalendarClient, IDisposable
         return result;
     }
 
-    /// <summary>Every non-empty calendar-data ICS body in a REPORT multistatus.</summary>
-    internal static List<string> ParseCalendarData(string xml)
+    /// <summary>
+    /// Every response in a REPORT multistatus that carries a non-empty calendar-data ICS body,
+    /// paired with that response's own resource href. The href is resolved absolute against
+    /// <paramref name="baseUri"/> (the collection that answered) when supplied — so an edit/delete
+    /// can target the resource directly, whatever name the server gave it. Walks per-response
+    /// (mirroring <see cref="ParseAllVEventCalendars"/>) so each body keeps its own sibling href;
+    /// a response's href is its direct child, the body is nested under propstat/prop.
+    /// </summary>
+    internal static List<(string Href, string Ics)> ParseCalendarData(string xml, Uri? baseUri = null)
     {
+        var result = new List<(string, string)>();
         var doc = XDocument.Parse(xml);
-        return doc.Descendants()
-            .Where(e => e.Name.LocalName == "calendar-data")
-            .Select(e => e.Value)
-            .Where(v => !string.IsNullOrWhiteSpace(v))
-            .ToList();
+        foreach (var response in doc.Descendants().Where(e => e.Name.LocalName == "response"))
+        {
+            var ics = response.Descendants()
+                .FirstOrDefault(e => e.Name.LocalName == "calendar-data")?.Value;
+            if (string.IsNullOrWhiteSpace(ics)) continue;
+
+            var href = response.Elements().FirstOrDefault(e => e.Name.LocalName == "href")?.Value.Trim() ?? string.Empty;
+            if (baseUri != null && !string.IsNullOrEmpty(href) && Uri.TryCreate(baseUri, href, out var abs))
+                href = abs.ToString();
+
+            result.Add((href, ics));
+        }
+        return result;
     }
 
     // ── HTTP plumbing ────────────────────────────────────────────────────────────
@@ -252,22 +324,39 @@ public sealed class CalDavCalendarClient : ICalDavCalendarClient, IDisposable
     }
 
     /// <summary>
-    /// Sends one WebDAV request with Basic auth, following redirects manually (auth re-attached
-    /// on each hop — see class remarks). Returns the response body and the FINAL request URI so
+    /// Sends one WebDAV request with a body and a Depth header (the PROPFIND / REPORT shape),
+    /// following redirects manually. Returns the response body and the FINAL request URI so
     /// relative hrefs in the response resolve against the host that actually answered.
     /// </summary>
-    private async Task<(string Body, Uri FinalUri)> SendAsync(HttpMethod method, Uri uri, string body,
+    private Task<(string Body, Uri FinalUri)> SendAsync(HttpMethod method, Uri uri, string body,
         string depth, string username, string password, CancellationToken ct)
+        => SendCoreAsync(uri, username, password, target =>
+        {
+            var req = new HttpRequestMessage(method, target);
+            req.Headers.TryAddWithoutValidation("Depth", depth);
+            req.Content = new StringContent(body, Encoding.UTF8, "application/xml");
+            return req;
+        }, ct);
+
+    /// <summary>
+    /// Core send loop shared by the XML (PROPFIND/REPORT) and write (PUT/DELETE) paths. Follows
+    /// redirects manually, re-attaching Basic auth on every hop — .NET strips the Authorization
+    /// header on cross-host auto-redirects, which iCloud's partition-host redirect would otherwise
+    /// turn into a silent 401 (see class remarks). <paramref name="buildRequest"/> is invoked once
+    /// per hop because an <see cref="HttpRequestMessage"/> and its content can only be sent once;
+    /// it must NOT set Authorization (the loop owns that). Returns the response body and the FINAL
+    /// request URI. Throws on a non-success status with the response body.
+    /// </summary>
+    private async Task<(string Body, Uri FinalUri)> SendCoreAsync(Uri uri, string username, string password,
+        Func<Uri, HttpRequestMessage> buildRequest, CancellationToken ct)
     {
         var auth = new AuthenticationHeaderValue("Basic",
             Convert.ToBase64String(Encoding.UTF8.GetBytes($"{username}:{password}")));
 
         for (var hop = 0; hop <= MaxRedirects; hop++)
         {
-            using var req = new HttpRequestMessage(method, uri);
+            using var req = buildRequest(uri);
             req.Headers.Authorization = auth;
-            req.Headers.TryAddWithoutValidation("Depth", depth);
-            req.Content = new StringContent(body, Encoding.UTF8, "application/xml");
 
             using var resp = await _http.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, ct);
 
@@ -279,7 +368,7 @@ public sealed class CalDavCalendarClient : ICalDavCalendarClient, IDisposable
                 continue;
             }
 
-            if (!resp.IsSuccessStatusCode) // 207 Multi-Status is a success code
+            if (!resp.IsSuccessStatusCode) // 2xx incl. 201/204 (writes) and 207 Multi-Status (reads)
             {
                 var errBody = await resp.Content.ReadAsStringAsync(ct);
                 throw new HttpRequestException(

--- a/QuickMail/Services/GraphCalendarSyncService.cs
+++ b/QuickMail/Services/GraphCalendarSyncService.cs
@@ -98,7 +98,7 @@ public sealed class GraphCalendarSyncService : IGraphCalendarSyncService
     /// CalDAV client or credential service isn't wired (tests).
     /// </summary>
     private bool IsICloudCalendarEligible(AccountModel account)
-        => _calDav != null && _credentials != null
+        => _calDav != null && _credentials != null && account.SyncCalendar
            && account.ImapHost.Equals("imap.mail.me.com", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>True when the account has a calendar QuickMail can pull, regardless of the opt-in flag.</summary>
@@ -354,10 +354,7 @@ public sealed class GraphCalendarSyncService : IGraphCalendarSyncService
     /// </summary>
     private async Task<int> SyncICloudCalendarAsync(AccountModel account, CancellationToken ct)
     {
-        var password = _credentials!.GetPassword(account.Id);
-        if (string.IsNullOrEmpty(password))
-            throw new InvalidOperationException(
-                $"no app-specific password saved for {account.Username} — re-enter it in Manage Accounts.");
+        var password = ICloudPassword(account);
 
         if (!_calDavCalendarsByAccount.TryGetValue(account.Id, out var calendars))
         {
@@ -373,9 +370,9 @@ public sealed class GraphCalendarSyncService : IGraphCalendarSyncService
             // so each calendar is its own selectable source.
             foreach (var cal in calendars)
             {
-                var icsBodies = await _calDav!.FetchEventIcsAsync(cal.Url, account.Username, password,
+                var resources = await _calDav!.FetchEventIcsAsync(cal.Url, account.Username, password,
                                                                   nowUtc - WindowBack, nowUtc + WindowForward, ct);
-                union.AddRange(MapCalDavEvents(icsBodies, account.Id, cal.Url, cal.DisplayName));
+                union.AddRange(MapCalDavEvents(resources, account.Id, cal.Url, cal.DisplayName));
             }
         }
         catch
@@ -397,26 +394,36 @@ public sealed class GraphCalendarSyncService : IGraphCalendarSyncService
     /// rescheduled occurrence shows at its original series slot; and STATUS:CANCELLED events are
     /// dropped. Duplicate UIDs across bodies collapse to one row (last wins).
     /// </summary>
-    internal static List<CalendarEvent> MapCalDavEvents(IEnumerable<string> icsBodies, Guid accountId,
+    internal static List<CalendarEvent> MapCalDavEvents(IEnumerable<(string Href, string Ics)> icsBodies, Guid accountId,
         string calendarId = "", string calendarName = "")
     {
         var byUid = new Dictionary<string, CalendarEvent>(StringComparer.Ordinal);
-        foreach (var body in icsBodies)
+        foreach (var (href, body) in icsBodies)
         {
+            // Resolve the resource href absolute against the calendar collection when the server
+            // gave a relative one (the client normally resolves it already). This is the REAL
+            // resource URL — Apple names iPhone/web-created resources randomly (≠ UID), so it is
+            // what edit/delete must target.
+            var resourceUrl = href;
+            if (!string.IsNullOrEmpty(href) && !Uri.IsWellFormedUriString(href, UriKind.Absolute)
+                && Uri.TryCreate(calendarId, UriKind.Absolute, out var baseUri)
+                && Uri.TryCreate(baseUri, href, out var abs))
+                resourceUrl = abs.ToString();
+
             foreach (var ics in IcsModel.ParseAllEvents(body))
             {
                 if (string.Equals(ics.Status, "CANCELLED", StringComparison.OrdinalIgnoreCase)) continue;
                 if (!string.IsNullOrEmpty(ics.RecurrenceId)) continue;
-                var evt = MapCalDavEvent(ics, accountId, calendarId, calendarName);
+                var evt = MapCalDavEvent(ics, accountId, calendarId, calendarName, resourceUrl);
                 byUid[evt.Uid] = evt;
             }
         }
         return byUid.Values.ToList();
     }
 
-    /// <summary>Maps one parsed VEVENT to a local row (is_graph=1 = "server-synced"), tagged with its calendar.</summary>
+    /// <summary>Maps one parsed VEVENT to a local row (is_graph=1 = "server-synced"), tagged with its calendar and CalDAV resource href.</summary>
     internal static CalendarEvent MapCalDavEvent(IcsModel ics, Guid accountId,
-        string calendarId = "", string calendarName = "")
+        string calendarId = "", string calendarName = "", string resourceUrl = "")
     {
         long? startTicks, endTicks;
         if (ics.IsAllDay)
@@ -453,6 +460,7 @@ public sealed class GraphCalendarSyncService : IGraphCalendarSyncService
             IsGraph         = true, // "server-synced row" — read-only in UI, replace-slice owned
             CalendarId      = calendarId,
             CalendarName    = calendarName,
+            ResourceUrl     = resourceUrl,
             Summary         = ics.Summary?.Trim() ?? string.Empty,
             Description     = ics.Description?.Trim() ?? string.Empty,
             Location        = ics.Location?.Trim() ?? string.Empty,
@@ -473,6 +481,85 @@ public sealed class GraphCalendarSyncService : IGraphCalendarSyncService
         return evt;
     }
 
+    /// <summary>The account's app-specific password (the same one IMAP uses), or a clear error.</summary>
+    private string ICloudPassword(AccountModel account)
+    {
+        var password = _credentials!.GetPassword(account.Id);
+        if (string.IsNullOrEmpty(password))
+            throw new InvalidOperationException(
+                $"no app-specific password saved for {account.Username} — re-enter it in Manage Accounts.");
+        return password;
+    }
+
+    // ── iCloud CalDAV write (create / edit / delete, single events) ───────────────
+    // A locally-authored appointment is serialized to a VCALENDAR (IcsModel.ExportEvent) and PUT to
+    // its calendar collection; the row is stored is_graph so it shows immediately and survives the
+    // next replace-slice sync (which re-fetches it from the server). v1 is last-write-wins — no
+    // ETag / If-Match round-trip yet (a create still uses If-None-Match to avoid clobbering).
+
+    private async Task<CalendarEvent> CreateICloudEventAsync(AccountModel account, CalendarEvent evt, CancellationToken ct)
+    {
+        var password = ICloudPassword(account);
+        if (string.IsNullOrWhiteSpace(evt.CalendarId))
+            throw new InvalidOperationException("No iCloud calendar was selected for the new appointment.");
+        if (string.IsNullOrWhiteSpace(evt.Uid))
+            evt.Uid = Guid.NewGuid().ToString("N") + "@quickmail";
+
+        var ics = IcsModel.ExportEvent(evt, includeMethod: false); // RFC 4791: no METHOD on a stored CalDAV resource
+        // A new resource: QuickMail chooses its name (after the UID). Record the URL it PUT to so an
+        // immediate edit (before the next read-sync captures the server's real href) still targets it.
+        var resourceUrl = CalDavCalendarClient.EventResourceUrl(evt.CalendarId, evt.Uid);
+        await _calDav!.PutEventAsync(resourceUrl, ics, account.Username, password, ifNoneMatch: true, ct);
+
+        evt.AccountId = account.Id;
+        evt.IsGraph = true; // "server-synced row"
+        evt.ResponseStatus = CalendarResponseStatus.Accepted;
+        evt.ResourceUrl = resourceUrl;
+        await _store.UpsertCalendarEventAsync(evt);
+        LogService.Log($"CalendarSync: created iCloud event on {account.AccountLabel} ({evt.Uid}).");
+        return evt;
+    }
+
+    private async Task<CalendarEvent> UpdateICloudEventAsync(AccountModel account, CalendarEvent evt, CancellationToken ct)
+    {
+        var password = ICloudPassword(account);
+        if (string.IsNullOrWhiteSpace(evt.CalendarId))
+            throw new InvalidOperationException("This iCloud appointment has no calendar to update.");
+
+        var ics = IcsModel.ExportEvent(evt, includeMethod: false); // RFC 4791: no METHOD on a stored CalDAV resource
+        // Edit the resource where it actually lives: the real href captured on read-sync when we have
+        // one (Apple names iPhone/web-created resources randomly, ≠ UID), else the QuickMail-created
+        // name (a row not yet re-synced). Using {collection}/{uid}.ics blindly 404s / duplicates.
+        var resourceUrl = string.IsNullOrEmpty(evt.ResourceUrl)
+            ? CalDavCalendarClient.EventResourceUrl(evt.CalendarId, evt.Uid)
+            : evt.ResourceUrl;
+        await _calDav!.PutEventAsync(resourceUrl, ics, account.Username, password, ifNoneMatch: false, ct);
+
+        evt.AccountId = account.Id;
+        evt.IsGraph = true;
+        evt.ResourceUrl = resourceUrl;
+        await _store.UpsertCalendarEventAsync(evt);
+        LogService.Log($"CalendarSync: updated iCloud event on {account.AccountLabel} ({evt.Uid}).");
+        return evt;
+    }
+
+    private async Task DeleteICloudEventAsync(AccountModel account, CalendarEvent evt, CancellationToken ct)
+    {
+        var password = ICloudPassword(account);
+        if (string.IsNullOrWhiteSpace(evt.CalendarId))
+            throw new InvalidOperationException("This iCloud appointment has no calendar to delete from.");
+
+        // Delete the resource where it actually lives: the real href captured on read-sync when we
+        // have one (Apple names iPhone/web-created resources randomly, ≠ UID), else the
+        // QuickMail-created name (a row not yet re-synced). Blindly using {collection}/{uid}.ics 404s.
+        var resourceUrl = string.IsNullOrEmpty(evt.ResourceUrl)
+            ? CalDavCalendarClient.EventResourceUrl(evt.CalendarId, evt.Uid)
+            : evt.ResourceUrl;
+        await _calDav!.DeleteEventAsync(resourceUrl, account.Username, password, ct);
+        await _store.DeleteCalendarEventAsync(evt.Uid, account.Id);
+        LogService.Log($"CalendarSync: deleted iCloud event on {account.AccountLabel} ({evt.Uid}).");
+    }
+
     // ── Create/edit/delete push (Microsoft + Google) ─────────────────────────────
     // Each public method dispatches on the account: Google-signed-in accounts push to the Google
     // Calendar API, everything else takes the Graph path. Both providers reject recurring events
@@ -483,8 +570,13 @@ public sealed class GraphCalendarSyncService : IGraphCalendarSyncService
     {
         if (evt.IsRecurring)
             throw new NotSupportedException("v1 calendar push handles single events only.");
+        // Dispatch order mirrors the read path (SyncOneAccountAsync): Graph → Google → iCloud.
+        // Graph is the default body; the guarded providers keep Google before iCloud. Predicates are
+        // mutually exclusive, so ordering is for consistency, not behavior.
         if (IsGoogleEligible(account))
             return await CreateGoogleEventAsync(account, evt, ct);
+        if (IsICloudCalendarEligible(account))
+            return await CreateICloudEventAsync(account, evt, ct);
 
         var body = BuildCreateBody(evt);
 
@@ -507,8 +599,11 @@ public sealed class GraphCalendarSyncService : IGraphCalendarSyncService
     {
         if (evt.IsRecurring)
             throw new NotSupportedException("v1 calendar push handles single events only.");
+        // Dispatch order mirrors the read path (SyncOneAccountAsync): Graph → Google → iCloud.
         if (IsGoogleEligible(account))
             return await UpdateGoogleEventAsync(account, evt, ct);
+        if (IsICloudCalendarEligible(account))
+            return await UpdateICloudEventAsync(account, evt, ct);
 
         var body = BuildCreateBody(evt); // PATCH accepts the same shape; omitted fields are unchanged
         var updated = await _graph.PatchReadAsync<GraphCalendarEvent>(
@@ -524,11 +619,17 @@ public sealed class GraphCalendarSyncService : IGraphCalendarSyncService
 
     public async Task DeleteEventAsync(AccountModel account, CalendarEvent evt, CancellationToken ct = default)
     {
+        // Dispatch order mirrors the read path (SyncOneAccountAsync): Graph → Google → iCloud.
         if (IsGoogleEligible(account))
         {
             await _google!.DeleteEventAsync(account.Username, evt.Uid, ct);
             await _store.DeleteCalendarEventAsync(evt.Uid, account.Id);
             LogService.Log($"CalendarSync: deleted Google event on {account.AccountLabel} ({evt.Uid}).");
+            return;
+        }
+        if (IsICloudCalendarEligible(account))
+        {
+            await DeleteICloudEventAsync(account, evt, ct);
             return;
         }
 

--- a/QuickMail/Services/LocalStoreService.cs
+++ b/QuickMail/Services/LocalStoreService.cs
@@ -136,6 +136,12 @@ public class LocalStoreService : ILocalStoreService
         RunMigration(conn, "ALTER TABLE CalendarEvent ADD COLUMN calendar_id   TEXT NOT NULL DEFAULT '';");
         RunMigration(conn, "ALTER TABLE CalendarEvent ADD COLUMN calendar_name TEXT NOT NULL DEFAULT '';");
 
+        // CalDAV resource href for a server-synced iCloud row — the real URL the event lives at on
+        // the server (Apple names iPhone/web-created resources randomly, ≠ UID), so edit/delete can
+        // target it instead of a reconstructed {collection}/{uid}.ics. Empty for Graph/Google/local/
+        // invite rows. Unversioned idempotent ALTER, like calendar_id/calendar_name above.
+        RunMigration(conn, "ALTER TABLE CalendarEvent ADD COLUMN resource_url TEXT NOT NULL DEFAULT '';");
+
         RunDataMigrations(conn);
     }
 
@@ -815,8 +821,9 @@ public class LocalStoreService : ILocalStoreService
             INSERT INTO CalendarEvent(uid, account_id, summary, description, location,
                                       organizer, organizer_name, start_time_ticks, end_time_ticks,
                                       sequence, method, source_message_id, source_folder, response_status,
-                                      is_all_day, recurrence_rule, exdates, is_graph, calendar_id, calendar_name)
-            VALUES($uid, $aid, $sum, $desc, $loc, $org, $orgn, $st, $et, $seq, $meth, $smid, $sf, $rs, $allday, $rrule, $exd, $graph, $calid, $calname)
+                                      is_all_day, recurrence_rule, exdates, is_graph, calendar_id, calendar_name,
+                                      resource_url)
+            VALUES($uid, $aid, $sum, $desc, $loc, $org, $orgn, $st, $et, $seq, $meth, $smid, $sf, $rs, $allday, $rrule, $exd, $graph, $calid, $calname, $resurl)
             ON CONFLICT(uid, account_id) DO UPDATE SET
                 summary           = excluded.summary,
                 description       = excluded.description,
@@ -836,7 +843,10 @@ public class LocalStoreService : ILocalStoreService
                 -- write-back that targets the default calendar and carries no tag); the next full
                 -- sync re-tags it. A non-empty incoming tag always wins.
                 calendar_id       = CASE WHEN excluded.calendar_id   = '' THEN calendar_id   ELSE excluded.calendar_id   END,
-                calendar_name     = CASE WHEN excluded.calendar_name = '' THEN calendar_name ELSE excluded.calendar_name END
+                calendar_name     = CASE WHEN excluded.calendar_name = '' THEN calendar_name ELSE excluded.calendar_name END,
+                -- Preserve a stored CalDAV resource href when the incoming row carries none (a local
+                -- create/edit write-back has no href until the next read-sync captures the real one).
+                resource_url      = CASE WHEN excluded.resource_url  = '' THEN resource_url  ELSE excluded.resource_url  END
             WHERE CalendarEvent.is_graph = 0 OR excluded.is_graph = 1;
             """;
         // The DO UPDATE ... WHERE guard: server-synced rows (is_graph=1) are owned by the calendar
@@ -865,6 +875,7 @@ public class LocalStoreService : ILocalStoreService
         cmd.Parameters.AddWithValue("$graph", evt.IsGraph ? 1 : 0);
         cmd.Parameters.AddWithValue("$calid", evt.CalendarId);
         cmd.Parameters.AddWithValue("$calname", evt.CalendarName);
+        cmd.Parameters.AddWithValue("$resurl", evt.ResourceUrl);
         await cmd.ExecuteNonQueryAsync();
         await tx.CommitAsync();
     }
@@ -894,8 +905,9 @@ public class LocalStoreService : ILocalStoreService
                 INSERT OR REPLACE INTO CalendarEvent(uid, account_id, summary, description, location,
                                           organizer, organizer_name, start_time_ticks, end_time_ticks,
                                           sequence, method, source_message_id, source_folder, response_status,
-                                          is_all_day, recurrence_rule, exdates, is_graph, calendar_id, calendar_name)
-                VALUES($uid, $aid, $sum, $desc, $loc, $org, $orgn, $st, $et, $seq, $meth, $smid, $sf, $rs, $allday, $rrule, $exd, 1, $calid, $calname);
+                                          is_all_day, recurrence_rule, exdates, is_graph, calendar_id, calendar_name,
+                                          resource_url)
+                VALUES($uid, $aid, $sum, $desc, $loc, $org, $orgn, $st, $et, $seq, $meth, $smid, $sf, $rs, $allday, $rrule, $exd, 1, $calid, $calname, $resurl);
                 """;
             var pUid  = ins.Parameters.Add("$uid",  Microsoft.Data.Sqlite.SqliteType.Text);
             var pAid  = ins.Parameters.Add("$aid",  Microsoft.Data.Sqlite.SqliteType.Text);
@@ -916,6 +928,7 @@ public class LocalStoreService : ILocalStoreService
             var pExd  = ins.Parameters.Add("$exd",  Microsoft.Data.Sqlite.SqliteType.Text);
             var pCid  = ins.Parameters.Add("$calid",   Microsoft.Data.Sqlite.SqliteType.Text);
             var pCn   = ins.Parameters.Add("$calname", Microsoft.Data.Sqlite.SqliteType.Text);
+            var pRes  = ins.Parameters.Add("$resurl",  Microsoft.Data.Sqlite.SqliteType.Text);
 
             foreach (var evt in events)
             {
@@ -938,6 +951,7 @@ public class LocalStoreService : ILocalStoreService
                 pExd.Value  = (object?)evt.ExDates ?? DBNull.Value;
                 pCid.Value  = evt.CalendarId;
                 pCn.Value   = evt.CalendarName;
+                pRes.Value  = evt.ResourceUrl;
                 await ins.ExecuteNonQueryAsync();
             }
         }
@@ -954,7 +968,7 @@ public class LocalStoreService : ILocalStoreService
             SELECT uid, account_id, summary, description, location, organizer, organizer_name,
                    start_time_ticks, end_time_ticks, sequence, method, source_message_id,
                    source_folder, response_status, is_all_day, recurrence_rule, exdates, is_graph,
-                   calendar_id, calendar_name
+                   calendar_id, calendar_name, resource_url
             FROM CalendarEvent
             ORDER BY start_time_ticks IS NULL, start_time_ticks ASC;
             """;
@@ -983,6 +997,7 @@ public class LocalStoreService : ILocalStoreService
                 IsGraph          = !r.IsDBNull(17) && r.GetInt32(17) != 0,
                 CalendarId       = r.IsDBNull(18) ? string.Empty : r.GetString(18),
                 CalendarName     = r.IsDBNull(19) ? string.Empty : r.GetString(19),
+                ResourceUrl      = r.IsDBNull(20) ? string.Empty : r.GetString(20),
             });
         }
         return list;

--- a/QuickMail/ViewModels/CalendarViewModel.cs
+++ b/QuickMail/ViewModels/CalendarViewModel.cs
@@ -201,11 +201,16 @@ public partial class CalendarViewModel : ObservableObject
     // push-capable accounts only, so it omits iCloud). Null in tests.
     private readonly Func<IReadOnlyList<AccountModel>>? _allAccountsProvider;
 
+    // Discovered calendar sources (AccountId, CalendarId, CalendarName) — used to offer one save
+    // target per iCloud calendar (Home / Family). Null in tests and until sync has discovered any.
+    private readonly Func<IReadOnlyList<(Guid AccountId, string CalendarId, string CalendarName)>>? _calendarSourcesProvider;
+
     public CalendarViewModel(ICalendarService calendarService, bool onlineMode, bool showDeclinedEvents,
                              bool showFieldLabels = false,
                              IGraphCalendarSyncService? graphSync = null,
                              Func<IReadOnlyList<AccountModel>>? graphAccountsProvider = null,
-                             Func<IReadOnlyList<AccountModel>>? allAccountsProvider = null)
+                             Func<IReadOnlyList<AccountModel>>? allAccountsProvider = null,
+                             Func<IReadOnlyList<(Guid AccountId, string CalendarId, string CalendarName)>>? calendarSourcesProvider = null)
     {
         _calendarService = calendarService;
         _onlineMode = onlineMode;
@@ -214,7 +219,16 @@ public partial class CalendarViewModel : ObservableObject
         _graphSync = graphSync;
         _graphAccountsProvider = graphAccountsProvider;
         _allAccountsProvider = allAccountsProvider;
+        _calendarSourcesProvider = calendarSourcesProvider;
     }
+
+    /// <summary>
+    /// iCloud accounts save per-calendar: each discovered CalDAV collection is its own save target
+    /// (Home / Family), unlike Microsoft/Google which save to their default calendar. Detected by
+    /// IMAP host, matching the sync service's eligibility.
+    /// </summary>
+    private static bool IsICloudAccount(AccountModel a)
+        => a.ImapHost.Equals("imap.mail.me.com", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
     /// Builds the "Calendar" source label for a row: "Local" for locally-authored appointments,
@@ -397,11 +411,26 @@ public partial class CalendarViewModel : ObservableObject
     {
         if (_onlineMode) { Announce("Calendar is unavailable in online mode.", AnnouncementCategory.Result); return; }
 
-        // Save targets: the local calendar (always, default) plus each server-backed account
-        // (Microsoft or Google — whatever the provider supplies).
-        var accountTargets = (_graphAccountsProvider?.Invoke() ?? [])
-            .Select(a => new CalendarSaveTarget(a.AccountLabel, a.Id))
-            .ToList();
+        // Save targets: the local calendar (always, default; added by the editor) plus each
+        // server-backed account. Microsoft/Google contribute one target (their default calendar);
+        // an iCloud account contributes one target PER discovered calendar so the user picks Home
+        // vs. Family.
+        var sources = _calendarSourcesProvider?.Invoke() ?? [];
+        var accountTargets = new List<CalendarSaveTarget>();
+        foreach (var a in _graphAccountsProvider?.Invoke() ?? [])
+        {
+            if (IsICloudAccount(a))
+            {
+                foreach (var (_, calId, calName) in sources.Where(s => s.AccountId == a.Id))
+                    accountTargets.Add(new CalendarSaveTarget($"{a.AccountLabel}: {calName}", a.Id, calId, calName));
+                // No discovered calendars yet (never synced) → offer nothing rather than a target
+                // that can't resolve a collection to PUT to.
+            }
+            else
+            {
+                accountTargets.Add(new CalendarSaveTarget(a.AccountLabel, a.Id));
+            }
+        }
         var editor = new EventEditorViewModel(DateTime.Now, accountTargets);
         editor.Saved += evt => _ = SaveNewEventAsync(evt);
         EditorRequested?.Invoke(editor);
@@ -421,8 +450,11 @@ public partial class CalendarViewModel : ObservableObject
         if (account is null || _graphSync is null)
         {
             // Local target — or an account target we can no longer resolve (account removed
-            // between opening the editor and saving): keep the data rather than fail.
+            // between opening the editor and saving): keep the data rather than fail. Drop any
+            // server calendar tag so the row reads as a clean local appointment.
             evt.AccountId = CalendarEvent.LocalAccountId;
+            evt.CalendarId = string.Empty;
+            evt.CalendarName = string.Empty;
             await SaveEditedEventAsync(evt, isNew: true);
             return;
         }
@@ -442,6 +474,8 @@ public partial class CalendarViewModel : ObservableObject
         {
             LogService.Log($"Graph calendar create failed for {account.AccountLabel}", ex);
             evt.AccountId = CalendarEvent.LocalAccountId;
+            evt.CalendarId = string.Empty;
+            evt.CalendarName = string.Empty;
             await _calendarService.UpsertEventAsync(evt);
             ApplyFilters();
             SelectedEvent = Events.FirstOrDefault(e => e.Uid == evt.Uid && e.AccountId == evt.AccountId);
@@ -564,9 +598,13 @@ public partial class CalendarViewModel : ObservableObject
         try
         {
             // Keep the server identity: same Uid and account, is_graph flag preserved by the
-            // sync service when it stores the server's returned copy.
+            // sync service when it stores the server's returned copy. Carry the original's calendar
+            // tag too — an iCloud update PUTs back to the collection the event lives on (Microsoft
+            // and Google ignore it).
             edited.Uid = original.Uid;
             edited.AccountId = account.Id;
+            edited.CalendarId = original.CalendarId;
+            edited.CalendarName = original.CalendarName;
             var updated = await _graphSync!.UpdateEventAsync(account, edited);
             await _calendarService.RefreshAsync();
             ApplyFilters();

--- a/QuickMail/ViewModels/EventEditorViewModel.cs
+++ b/QuickMail/ViewModels/EventEditorViewModel.cs
@@ -8,10 +8,13 @@ namespace QuickMail.ViewModels;
 
 /// <summary>
 /// One entry in the appointment editor's "Calendar" save-target picker: the local calendar
-/// (<see cref="CalendarEvent.LocalAccountId"/>) or a server-backed (Microsoft or Google)
-/// account's calendar.
+/// (<see cref="CalendarEvent.LocalAccountId"/>) or a server-backed account's calendar.
+/// <paramref name="CalendarId"/> is the CalDAV collection URL for an iCloud target (which offers
+/// one entry per calendar, e.g. Home / Family); it is null for Local, Microsoft, and Google
+/// targets, which save to the account's default/primary calendar.
 /// </summary>
-public sealed record CalendarSaveTarget(string Label, Guid AccountId);
+public sealed record CalendarSaveTarget(string Label, Guid AccountId,
+                                        string? CalendarId = null, string? CalendarName = null);
 
 /// <summary>
 /// Authoring ViewModel for a single locally-created calendar appointment. Holds the editable
@@ -43,10 +46,20 @@ public partial class EventEditorViewModel : ObservableObject
     [ObservableProperty] private int _selectedTargetIndex;
 
     /// <summary>The account id the appointment will save to (resolved from the picker).</summary>
-    public Guid SelectedTargetAccountId =>
+    public Guid SelectedTargetAccountId => SelectedTarget?.AccountId ?? CalendarEvent.LocalAccountId;
+
+    /// <summary>
+    /// The chosen target's calendar (CalDAV collection URL) and display name — set only for an
+    /// iCloud target, which the save uses to tag and route the event. Null for Local / Microsoft /
+    /// Google (their default calendar).
+    /// </summary>
+    public string? SelectedTargetCalendarId => SelectedTarget?.CalendarId;
+    public string? SelectedTargetCalendarName => SelectedTarget?.CalendarName;
+
+    private CalendarSaveTarget? SelectedTarget =>
         SelectedTargetIndex >= 0 && SelectedTargetIndex < _saveTargets.Count
-            ? _saveTargets[SelectedTargetIndex].AccountId
-            : CalendarEvent.LocalAccountId;
+            ? _saveTargets[SelectedTargetIndex]
+            : null;
 
     /// <summary>
     /// True when the View should show the save-target picker: only for NEW appointments (an
@@ -356,6 +369,11 @@ public partial class EventEditorViewModel : ObservableObject
         {
             Uid            = IsDetachSave ? "local-" + Guid.NewGuid().ToString("N") : _uid,
             AccountId      = targetAccountId,
+            // Tag with the chosen calendar for a new iCloud target (empty for Local / Microsoft /
+            // Google / detach). An edit keeps its stored calendar via the caller (ServerUpdate),
+            // and the edit editor offers only the local target, so this resolves to empty there.
+            CalendarId     = SelectedTargetCalendarId ?? string.Empty,
+            CalendarName   = SelectedTargetCalendarName ?? string.Empty,
             Summary        = Title.Trim(),
             Location       = Location.Trim(),
             Description    = Notes.Trim(),

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -263,15 +263,17 @@ public partial class MainViewModel : ObservableObject, IDisposable
 
     /// <summary>
     /// True for accounts with a server calendar the app can push appointments to: Microsoft
-    /// (Graph backend) and Google-signed-in accounts (keyed by auth type — Gmail mail is IMAP).
-    /// Plain IMAP/password accounts have no server calendar. Mirrors the sync service's
-    /// per-provider eligibility.
+    /// (Graph backend), Google-signed-in accounts (keyed by auth type — Gmail mail is IMAP), and
+    /// iCloud accounts (IMAP host imap.mail.me.com — CalDAV over the app-specific password). Plain
+    /// IMAP/password accounts have no server calendar. Mirrors the sync service's per-provider
+    /// eligibility; membership here also drives edit/delete write-back (ServerAccountFor).
     /// </summary>
     internal static bool IsCalendarPushAccount(AccountModel a)
         => a.SyncCalendar
            && (a.BackendKind == BackendKind.MicrosoftGraph
                || a.AuthType == AuthType.OAuth2Microsoft
-               || a.AuthType == AuthType.OAuth2Google);
+               || a.AuthType == AuthType.OAuth2Google
+               || a.ImapHost.Equals("imap.mail.me.com", StringComparison.OrdinalIgnoreCase));
 
     // Sentinel prefix for per-account "All Mail" virtual folders, e.g. "\u0000AccountMail:{guid}".
     internal const string AccountMailPrefix = "\u0000AccountMail:";
@@ -962,7 +964,10 @@ public partial class MainViewModel : ObservableObject, IDisposable
                                                cfg.CalendarListShowFieldLabels,
                                                _graphCalendarSync,
                                                () => Accounts.Where(IsCalendarPushAccount).ToList(),
-                                               () => Accounts.ToList());
+                                               () => Accounts.ToList(),
+                                               // Discovered calendar sources (per iCloud calendar) feed the
+                                               // save-target picker so each iCloud calendar is its own target.
+                                               () => _calendarSources);
             RemindersEnabled = cfg.CalendarReminders;
             ReminderLeadMinutes = cfg.CalendarReminderMinutes;
             StartReminderTimer();

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -131,7 +131,7 @@ Enter your iCloud address (`@icloud.com`, `@me.com`, or `@mac.com`) in the **Ema
 
 **App-specific password required.** Apple does not allow third-party apps to use your Apple ID password directly. Generate an app-specific password at **appleid.apple.com** (Sign-In & Security → App-Specific Passwords) and enter it in the Password field. QuickMail shows a reminder in the password area when it detects an iCloud address.
 
-To bring in your iCloud data, check **Sync contacts from this account** and/or **Sync calendar from this account** — QuickMail uses the same app-specific password for both, so there's nothing else to set up. iCloud contacts and calendars are read-only in QuickMail. See [Syncing Contacts from Your Accounts](#syncing-contacts-from-your-accounts) and the [Calendar](#calendar) section for details.
+To bring in your iCloud data, check **Sync contacts from this account** and/or **Sync calendar from this account** — QuickMail uses the same app-specific password for both, so there's nothing else to set up. iCloud **contacts** are read-only; iCloud **calendars** you can also add, edit, and delete single (non-repeating) appointments on. See [Syncing Contacts from Your Accounts](#syncing-contacts-from-your-accounts) and the [Calendar](#calendar) section for details.
 
 ### Managing Accounts
 
@@ -606,7 +606,7 @@ Press **N** (or the **New** toolbar button) to open the appointment editor. It i
 - **Location** — optional.
 - **Repeat** — leave as "Does not repeat" for a one-off, or set up a repeating appointment (see below).
 - **Notes** — free text.
-- **Calendar** — when you have a Microsoft or Google account connected, a picker lets you choose whether the new appointment is saved to your **Local Calendar** or pushed to that account. With no connected calendar this picker does not appear and everything is saved locally.
+- **Calendar** — when you have a Microsoft, Google, or iCloud account connected, a picker lets you choose where the new appointment is saved: your **Local Calendar** or a connected account. For iCloud the picker lists each of your Apple calendars (Home, Family, …) so you can choose which one. With no connected calendar this picker does not appear and everything is saved locally.
 
 Press **Enter** (or the **Save** button) to save, or **Escape** to cancel.
 
@@ -631,9 +631,9 @@ When you later edit or delete one occurrence of a repeating appointment, QuickMa
 What you can change depends on where the appointment lives:
 
 - **Your own (Local Calendar) appointments** — fully editable and deletable.
-- **Single events from a connected Microsoft or Google calendar** — editable and deletable; your change is sent back to that account.
+- **Single events from a connected Microsoft, Google, or iCloud calendar** — editable and deletable; your change is sent back to that account.
 - **Repeating events from a connected online calendar** — read-only for now; QuickMail tells you so rather than changing them.
-- **iCloud / internet-calendar events and meeting invitations** — read-only. QuickMail explains why instead of failing silently.
+- **Meeting invitations** — read-only. QuickMail explains why instead of failing silently.
 
 If saving a change to an online account ever fails, QuickMail saves your appointment to the Local Calendar instead so your work is never lost, and tells you it did.
 
@@ -664,7 +664,7 @@ Calendars connect **per account**, the same way contact sync does. When you add 
 | **Local Calendar** | — (they live here) | Full | Nothing to set up; it is always there. |
 | **Microsoft** (Outlook.com, Microsoft 365) | Yes | Yes, for single (non-repeating) events | Check **Sync calendar from this account**. Microsoft asks once for calendar permission. |
 | **Google** | Yes | Yes, for single (non-repeating) events | Check **Sync calendar from this account**. Permission was granted when you signed in for mail. |
-| **iCloud** | Yes | No — read-only | Check **Sync calendar from this account**. QuickMail uses the app-specific password you already entered for the account — no separate setup. |
+| **iCloud** | Yes | Yes, for single (non-repeating) events | Check **Sync calendar from this account**. QuickMail uses the app-specific password you already entered for the account — no separate setup. When you create an appointment you can choose which iCloud calendar (Home, Family, …) it goes on. |
 
 **Turning it on for an account you already have:** open **Manage Accounts**, select the account, and check **Sync calendar from this account**. It applies immediately — a **Calendar → [account]** node appears in the folder tree and the events sync in the background. Unchecking it removes them.
 
@@ -680,14 +680,14 @@ To set expectations clearly:
 - Show four views (Agenda, Day, Week, Month) and jump to any date.
 - Remind you before appointments (when you turn reminders on).
 - Respond to meeting invitations and keep your reply in sync.
-- Download events from Microsoft, Google, and iCloud/CalDAV calendars, and send single-event changes back to Microsoft and Google.
+- Download events from Microsoft, Google, and iCloud calendars, and create, edit, and delete single (non-repeating) events on any of them.
 - Export any appointment as a `.ics` file.
 
 **It does not (yet):**
 
 - Work in online mode — it needs the local cache.
 - Send **repeating** appointments to an online account (repeating appointments are saved to the Local Calendar).
-- Edit **repeating** events that came from an online calendar, or change anything on an **iCloud** calendar (iCloud is read-only in QuickMail).
+- Edit or delete **repeating** events that came from an online calendar (repeating server events are read-only).
 - Connect calendars from generic CalDAV servers other than iCloud (Fastmail, Nextcloud, and the like).
 - Subscribe to public `.ics` calendar feeds (holidays, sports schedules, and the like).
 - Offer multiple named calendars, calendar colors, per-appointment reminder times, or reminder snoozing.

--- a/docs/release-notes-v0.8.33.md
+++ b/docs/release-notes-v0.8.33.md
@@ -127,6 +127,12 @@ Thank you, as always, to everyone who contributes to QuickMail through code, bug
 - All three providers enumerate every calendar and union them into the existing per-account replace-slice (one `ReplaceGraphCalendarEventsAsync(account.Id, union)`): Microsoft `GET /me/calendars` → per-calendar `calendarView`; Google `calendarList` → per-calendar events; iCloud CalDAV keeps **all** VEVENT collections (discovery cache is now a per-account list) and issues one REPORT per calendar. A single calendar's fetch failing leaves the prior slice intact.
 - Tree grandchildren (only when an account has >1 calendar) are fed from a new `LocalStoreService.LoadCalendarSourcesAsync` (DISTINCT account/calendar), cached and refreshed on startup and after each sync. Selecting a calendar node filters to that calendar; the account node still shows all its calendars merged.
 
+### iCloud calendar write (CalDAV)
+
+- iCloud calendars are no longer read-only: you can **create, edit, and delete single (non-repeating) appointments** on them, alongside the existing Microsoft/Google write-back. When creating an appointment, the save-target picker lists each of your Apple calendars (e.g. "Apple: Home", "Apple: Family") so you choose which one.
+- `CalDavCalendarClient` gains `PutEventAsync`/`DeleteEventAsync` (the redirect/Basic-auth `SendAsync` refactored into a shared `SendCoreAsync` so reads and writes share it); PUT sends `text/calendar` with `If-None-Match: *` on create; the VCALENDAR body omits `METHOD` per RFC 4791. `GraphCalendarSyncService` create/edit/delete gain an iCloud branch; `IsCalendarPushAccount` includes iCloud.
+- Read-sync now stores each event's real CalDAV resource URL (`CalendarEvent.ResourceUrl`, new `resource_url` column), so editing or deleting an event **created on another device** targets the correct server resource (Apple names resources by a random filename, not the UID). Recurring events stay read-only; last-write-wins (no ETag/If-Match in v1).
+
 ### iCloud contacts via CardDAV
 
 - The "Sync contacts from this account" checkbox (#256) now also appears for **iCloud** accounts, alongside Microsoft and Google — so every account offers a checkbox for each service QuickMail can read. iCloud contacts sync over **CardDAV** (`https://contacts.icloud.com`) using the account's own app-specific password (`GetPassword(account.Id)`), no OAuth.


### PR DESCRIPTION
Requested by Kelly: make Apple a save target so you can create appointments on your iCloud calendars (they were read-only).

## What you get

iCloud calendars become writable for **single (non-repeating)** events, alongside Microsoft/Google:
- **Create** an appointment and pick which Apple calendar it goes on — the save-target picker lists "Apple: Home", "Apple: Family", etc.
- **Edit / delete** single iCloud events, including ones created on your iPhone or iCloud web.

## How

- `CalDavCalendarClient` gains `PutEventAsync` / `DeleteEventAsync`. The redirect + Basic-auth `SendAsync` was refactored into a shared `SendCoreAsync` so reads (PROPFIND/REPORT) and writes (PUT/DELETE) share identical cross-host-redirect auth handling. PUT sends `text/calendar` with `If-None-Match: *` on create; the VCALENDAR body omits `METHOD` (RFC 4791 — a stored resource must not carry one, which iCloud can reject).
- `GraphCalendarSyncService` create/edit/delete get an iCloud branch; `IsCalendarPushAccount` includes iCloud; the save-target model carries a per-calendar `CalendarId`.
- **Resource-URL tracking** (the review's blocker, fixed): read-sync now stores each event's real CalDAV resource href (`CalendarEvent.ResourceUrl`, new `resource_url` column), because Apple names resources by a random filename — not the event UID. Edit/delete target that stored URL, with a `{collection}/{uid}.ics` fallback for a QuickMail-created row not yet re-synced. Without this, editing/deleting externally-created iCloud events would have failed.

## Review & verification

- **Two independent reviews.** The first confirmed the write core is solid (shared redirect handler correct, MS/Google paths untouched, recurring rejected, local fallback preserved) and caught the resource-URL blocker; the second-round fix (href tracking) is in with tests. I also pre-empted the `METHOD:PUBLISH` issue it flagged.
- Full suite **1441 passing**; production build clean.

## Live-only caveat

I can unit-test the CalDAV write against a stubbed server, but whether Apple accepts our exact PUT/DELETE (resource naming, percent-encoding of the href it returns, no-ETag last-write-wins) can only be confirmed against a real iCloud account — that's your live check. Recurring events remain read-only; no ETag/If-Match concurrency in v1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)