### PR TITLE
Move keyboard focus to the new view when switching calendar views

### DIFF
--- a/QuickMail/ViewModels/CalendarViewModel.cs
+++ b/QuickMail/ViewModels/CalendarViewModel.cs
@@ -341,6 +341,11 @@ public partial class CalendarViewModel : ObservableObject
         ApplyFilters();
         SelectedEvent = Events.Count > 0 ? Events[0] : null;
         AnnouncePeriod();
+        // Move keyboard focus to the control the new view shows (the Month grid, or the event list).
+        // Switching views swaps which control is visible; without this, focus is stranded on the
+        // now-hidden control and arrow keys do nothing until the user tabs away and back. The View's
+        // FocusCalendarList routes focus to the grid in Month view and the list otherwise.
+        ListFocusRequested?.Invoke();
     }
 
     /// <summary>Moves to the previous day/week. Bound to Ctrl+Left. No-op in Agenda.</summary>


### PR DESCRIPTION
Reported by Kelly: with focus in the calendar, pressing **M** (or any view key) shows the new view but leaves keyboard focus on the old, now-hidden control — so the four arrows don't move around the Month grid until you Tab away and back.

Fix: `CalendarViewModel.SwitchView` now raises `ListFocusRequested` after switching. The View already has `FocusCalendarList`, which routes focus to the **Month grid** in Month view and the **event list** otherwise — it just wasn't being triggered on a view switch. So A/D/W/M (and Go to Date from Agenda) now land focus in the control the new view shows.

Safe: every `SwitchView` caller is a user action (the view commands, drill-into-day, Go to Date), so it never steals focus at startup or during a background refresh. In tests `ListFocusRequested` has no subscriber, so it's a null-safe no-op.

Full suite **1441 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)