### PR TITLE
Calendar: no field labels in concise mode; show calendar in the edit box

### DIFF
--- a/QuickMail.Tests/CalendarViewModelTests.cs
+++ b/QuickMail.Tests/CalendarViewModelTests.cs
@@ -73,17 +73,21 @@ public class CalendarViewModelTests
     }
 
     [Fact]
-    public async Task FieldLabels_Off_StampsDataOnlyAccessibleName()
+    public async Task FieldLabels_Off_StampsDataOnlyAccessibleName_NoFieldLabelWords()
     {
-        var vm = MakeVm(new List<CalendarEvent> { MakeEvent("e1", DateTime.Today.AddHours(10)) },
-                        showFieldLabels: false);
+        var evt = MakeEvent("e1", DateTime.Today.AddHours(10));
+        evt.Location = "Erin's Snug Irish Pub";
+        var vm = MakeVm(new List<CalendarEvent> { evt }, showFieldLabels: false);
         await vm.LoadAsync();
 
         var name = vm.VisibleEvents[0].AccessibleName;
-        // Concise (no field labels) base line, with the calendar source appended for accessibility (#1).
+        // Concise mode carries NO field-label words — not "Subject", "Location:", or "calendar".
         Assert.StartsWith(vm.VisibleEvents[0].DisplayLine, name);
         Assert.DoesNotContain("Subject ", name);
-        Assert.Contains(", calendar ", name);
+        Assert.DoesNotContain("Location:", name);
+        Assert.DoesNotContain("calendar ", name);
+        Assert.Contains("Erin's Snug Irish Pub", name);   // location value present, just no label
+        Assert.EndsWith(", Account", name);               // calendar source appended as a bare value
     }
 
     [Fact]

--- a/QuickMail/Models/CalendarEvent.cs
+++ b/QuickMail/Models/CalendarEvent.cs
@@ -151,8 +151,9 @@ public partial class CalendarEvent : ObservableObject
         : null;
 
     /// <summary>
-    /// Human-readable, screen-reader-friendly one-line summary for the calendar list.
-    /// Example: "Team standup, today 10:00 to 10:30, Accepted. Location: Zoom."
+    /// Human-readable, screen-reader-friendly one-line summary for the calendar list, carrying NO
+    /// field labels (that's the labeled variant's job) — just the values, comma-separated. Example:
+    /// "Team standup, today 10:00 to 10:30, Accepted, Zoom".
     /// </summary>
     public string DisplayLine
     {
@@ -186,12 +187,15 @@ public partial class CalendarEvent : ObservableObject
             // meaningless for them, so only invite-sourced events announce a response status.
             if (!IsUserCreated)
                 sb.Append(", ").Append(ResponseStatus.ToString());
+            // Concise mode carries no field labels (that's what the labeled variant is for) — just
+            // the values, comma-separated. Location/organizer are appended without a "Location:" /
+            // "Organizer:" prefix.
             if (!string.IsNullOrWhiteSpace(Location))
-                sb.Append(". Location: ").Append(Location);
+                sb.Append(", ").Append(Location);
             if (!string.IsNullOrWhiteSpace(OrganizerName))
-                sb.Append(". Organizer: ").Append(OrganizerName);
+                sb.Append(", ").Append(OrganizerName);
             else if (!string.IsNullOrWhiteSpace(Organizer))
-                sb.Append(". Organizer: ").Append(Organizer);
+                sb.Append(", ").Append(Organizer);
 
             return sb.ToString();
         }

--- a/QuickMail/ViewModels/CalendarViewModel.cs
+++ b/QuickMail/ViewModels/CalendarViewModel.cs
@@ -859,8 +859,12 @@ public partial class CalendarViewModel : ObservableObject
         {
             var source = SourceLabelFor(evt, accountLabels);
             evt.CalendarSourceLabel = source;
+            // Field labels on: "…, calendar Apple: Family". Field labels off (concise): append the
+            // source as a bare value with no "calendar" label word — the whole row is label-free.
             var baseName = _showFieldLabels ? evt.LabeledLine : evt.DisplayLine;
-            evt.AccessibleName = string.IsNullOrEmpty(source) ? baseName : $"{baseName}, calendar {source}";
+            evt.AccessibleName = string.IsNullOrEmpty(source)
+                ? baseName
+                : _showFieldLabels ? $"{baseName}, calendar {source}" : $"{baseName}, {source}";
         }
 
         using (Events.BeginBatchScope())

--- a/QuickMail/ViewModels/EventEditorViewModel.cs
+++ b/QuickMail/ViewModels/EventEditorViewModel.cs
@@ -67,6 +67,16 @@ public partial class EventEditorViewModel : ObservableObject
     /// </summary>
     public bool ShowSaveTarget => !IsEdit && _saveTargets.Count > 1;
 
+    /// <summary>
+    /// Which calendar the appointment being edited lives on ("Apple: Family", "Local", …), shown
+    /// read-only in the editor (editing can't move an appointment between calendars in v1). Empty
+    /// for a new appointment (which uses the save-target picker instead).
+    /// </summary>
+    public string EditCalendarLabel { get; } = string.Empty;
+
+    /// <summary>True when the read-only "Calendar" line should show — i.e. editing a tagged event.</summary>
+    public bool ShowEditCalendar => IsEdit && !string.IsNullOrEmpty(EditCalendarLabel);
+
     /// <summary>Window title text ("New appointment" / "Edit appointment").</summary>
     public string WindowTitle => IsEdit ? "Edit appointment" : "New appointment";
 
@@ -200,6 +210,12 @@ public partial class EventEditorViewModel : ObservableObject
         IsEdit = true;
         _editAccountId = existing.AccountId;   // server rows keep their account; the
                                                // recurring-stays-local rule can then fire on edits too
+        // Show which calendar this appointment lives on (read-only). CalendarSourceLabel is stamped
+        // by CalendarViewModel for every list row ("Apple: Family" / "Local"); fall back to "Local"
+        // for a locally-authored row that wasn't stamped.
+        EditCalendarLabel = !string.IsNullOrEmpty(existing.CalendarSourceLabel)
+            ? existing.CalendarSourceLabel
+            : existing.AccountId == CalendarEvent.LocalAccountId ? "Local" : string.Empty;
         // Editing never moves an appointment between calendars (v1) — no picker.
         _saveTargets = BuildSaveTargets(null);
         SaveTargetLabels = _saveTargets.ConvertAll(t => t.Label);

--- a/QuickMail/Views/EventEditorWindow.xaml
+++ b/QuickMail/Views/EventEditorWindow.xaml
@@ -40,39 +40,52 @@
             <ColumnDefinition Width="Auto"/>
         </Grid.ColumnDefinitions>
 
-        <!-- Save target — NEW appointments only, and only when a Graph account offers a second
-             calendar. Shares row 0 with the edit-scope radios below: edit-scope shows only while
-             editing, this only while creating, so the two are never visible together. Items are
-             plain strings so each ComboBox item announces its label (Selector accessibility rule). -->
-        <StackPanel Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="4"
-                    Orientation="Horizontal" Margin="0,0,0,10"
-                    Visibility="{Binding ShowSaveTarget, Converter={StaticResource BoolToVis}}">
-            <TextBlock Text="Calendar:" Margin="0,0,8,0" VerticalAlignment="Center"/>
-            <ComboBox x:Name="SaveTargetCombo"
-                      AutomationProperties.Name="Calendar"
-                      ItemsSource="{Binding SaveTargetLabels}"
-                      SelectedIndex="{Binding SelectedTargetIndex}"
-                      MinWidth="220" VerticalAlignment="Center"/>
-        </StackPanel>
+        <!-- Row 0: the calendar picker (new) / read-only calendar (edit) / edit-scope radios
+             (recurring edit), stacked vertically so any combination coexists without overlapping. -->
+        <StackPanel Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="4">
 
-        <!-- Edit scope — shown only when editing one occurrence of a repeating series.
-             Radio group: one tab stop, arrows cycle. -->
-        <StackPanel Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="4"
-                    Orientation="Horizontal" Margin="0,0,0,10"
-                    Visibility="{Binding IsRecurringEdit, Converter={StaticResource BoolToVis}}"
-                    KeyboardNavigation.TabNavigation="Once"
-                    KeyboardNavigation.DirectionalNavigation="Cycle">
-            <TextBlock Text="Change:" Margin="0,0,8,0" VerticalAlignment="Center"/>
-            <RadioButton Content="This event only"
-                         GroupName="EditScope"
-                         AutomationProperties.Name="This event only"
-                         IsChecked="{Binding EditThisEventOnly}"
-                         Margin="0,0,12,0" VerticalAlignment="Center"/>
-            <RadioButton Content="All events in the series"
-                         GroupName="EditScope"
-                         AutomationProperties.Name="All events in the series"
-                         IsChecked="{Binding EditWholeSeries}"
-                         VerticalAlignment="Center"/>
+            <!-- Save target — NEW appointments only, and only when there's a calendar to choose.
+                 Items are plain strings so each ComboBox item announces its label. -->
+            <StackPanel Orientation="Horizontal" Margin="0,0,0,10"
+                        Visibility="{Binding ShowSaveTarget, Converter={StaticResource BoolToVis}}">
+                <TextBlock Text="Calendar:" Margin="0,0,8,0" VerticalAlignment="Center"/>
+                <ComboBox x:Name="SaveTargetCombo"
+                          AutomationProperties.Name="Calendar"
+                          ItemsSource="{Binding SaveTargetLabels}"
+                          SelectedIndex="{Binding SelectedTargetIndex}"
+                          MinWidth="220" VerticalAlignment="Center"/>
+            </StackPanel>
+
+            <!-- Calendar the appointment lives on — read-only when EDITING (can't move calendars
+                 in v1). A read-only TextBox keeps it in the tab order so a screen reader announces
+                 it, unlike a plain TextBlock. -->
+            <StackPanel Orientation="Horizontal" Margin="0,0,0,10"
+                        Visibility="{Binding ShowEditCalendar, Converter={StaticResource BoolToVis}}">
+                <TextBlock Text="Calendar:" Margin="0,0,8,0" VerticalAlignment="Center"/>
+                <TextBox Text="{Binding EditCalendarLabel, Mode=OneWay}"
+                         IsReadOnly="True"
+                         AutomationProperties.Name="Calendar"
+                         MinWidth="220" VerticalAlignment="Center"/>
+            </StackPanel>
+
+            <!-- Edit scope — shown only when editing one occurrence of a repeating series.
+                 Radio group: one tab stop, arrows cycle. -->
+            <StackPanel Orientation="Horizontal" Margin="0,0,0,10"
+                        Visibility="{Binding IsRecurringEdit, Converter={StaticResource BoolToVis}}"
+                        KeyboardNavigation.TabNavigation="Once"
+                        KeyboardNavigation.DirectionalNavigation="Cycle">
+                <TextBlock Text="Change:" Margin="0,0,8,0" VerticalAlignment="Center"/>
+                <RadioButton Content="This event only"
+                             GroupName="EditScope"
+                             AutomationProperties.Name="This event only"
+                             IsChecked="{Binding EditThisEventOnly}"
+                             Margin="0,0,12,0" VerticalAlignment="Center"/>
+                <RadioButton Content="All events in the series"
+                             GroupName="EditScope"
+                             AutomationProperties.Name="All events in the series"
+                             IsChecked="{Binding EditWholeSeries}"
+                             VerticalAlignment="Center"/>
+            </StackPanel>
         </StackPanel>
 
         <!-- Title -->


### PR DESCRIPTION
Two fixes reported by Kelly.

## 1. Field labels appearing when field labels are OFF

With the field-labels setting off, the concise calendar-list row still contained label words — the pre-existing **"Location:"** and the **"calendar"** prefix I'd added for the source column. Example she hit:
> Lunch with friends, …, Accepted. **Location:** Erin's Snug Irish Pub …, **calendar** apple: Family

Now the concise form carries **no field-label words**: `DisplayLine` drops the `Location:`/`Organizer:` prefixes (values only, comma-separated), and the calendar source is appended as a bare value — "…, Apple: Family" instead of "…, calendar Apple: Family". Field labels **on** is unchanged (still the labeled "…, calendar Apple: Family" form).

## 2. Calendar not shown when editing an appointment

The editor showed the calendar picker only for **new** appointments. Editing now shows a read-only **Calendar** field (from the event's `CalendarSourceLabel`, e.g. "Apple: Family" / "Local"). It's a read-only **TextBox** (not a plain label) so it's in the tab order and a screen reader announces it. Editing can't move an appointment between calendars in v1, hence read-only.

Full suite **1441 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)