### PR TITLE
Fix Gmail event delete on secondary calendars + prompt sub-calendar display

### DIFF
--- a/QuickMail.Tests/TestLogRedirect.cs
+++ b/QuickMail.Tests/TestLogRedirect.cs
@@ -1,0 +1,27 @@
+using System.IO;
+using System.Runtime.CompilerServices;
+using QuickMail.Services;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// Redirects <see cref="LogService"/> away from the user's real
+/// <c>%APPDATA%\QuickMail\quickmail.log</c> for the whole test run.
+///
+/// LogService defaults its output to the live app profile's log file and only moves when
+/// <see cref="LogService.Configure(string)"/> is called (the app calls it for <c>--profileDir</c>).
+/// Tests never called it, so any production code exercised under test appended fixture noise
+/// (fake accounts, deliberate "boom"/"denied" errors) into the developer's actual QuickMail log —
+/// which made the real log useless for diagnosing live issues. The module initializer below runs
+/// once when the test assembly loads, before any test, and points logging at an isolated temp dir.
+/// </summary>
+internal static class TestLogRedirect
+{
+    [ModuleInitializer]
+    internal static void Redirect()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "QuickMailTestLogs");
+        Directory.CreateDirectory(dir);
+        LogService.Configure(dir);
+    }
+}

--- a/QuickMail/Services/Google/GoogleCalendarClient.cs
+++ b/QuickMail/Services/Google/GoogleCalendarClient.cs
@@ -123,26 +123,34 @@ public sealed class GoogleCalendarClient : IDisposable
         return all;
     }
 
-    // ── Write path (single events on the primary calendar) ──────────────────────
+    // ── Write path (single events, targeting the event's own calendar) ──────────
+    // calendarId defaults to "primary" but MUST be the calendar the event actually lives on:
+    // the read path enumerates every calendar in the account, so an event on a secondary
+    // calendar can only be patched/deleted through that calendar's id. Targeting "primary"
+    // for such an event returns 404 and surfaces as "could not update the online calendar".
 
-    /// <summary>Creates an event (<c>POST calendars/primary/events</c>) and returns the server's copy.</summary>
+    /// <summary>Creates an event (<c>POST calendars/{calendarId}/events</c>) and returns the server's copy.</summary>
     internal Task<GoogleCalendarEvent> CreateEventAsync(
-        string username, GoogleEventWriteBody body, CancellationToken ct = default)
-        => SendWriteAsync(username, HttpMethod.Post, "calendars/primary/events", body, ct);
+        string username, GoogleEventWriteBody body, string calendarId = "primary", CancellationToken ct = default)
+        => SendWriteAsync(username, HttpMethod.Post,
+                          $"calendars/{Uri.EscapeDataString(calendarId)}/events", body, ct);
 
-    /// <summary>Patches an event (<c>PATCH calendars/primary/events/{id}</c>) and returns the server's copy.
+    /// <summary>Patches an event (<c>PATCH calendars/{calendarId}/events/{id}</c>) and returns the server's copy.
     /// Omitted (null) body fields are left unchanged on the server.</summary>
     internal Task<GoogleCalendarEvent> UpdateEventAsync(
-        string username, string eventId, GoogleEventWriteBody body, CancellationToken ct = default)
+        string username, string eventId, GoogleEventWriteBody body,
+        string calendarId = "primary", CancellationToken ct = default)
         => SendWriteAsync(username, HttpMethod.Patch,
-                          $"calendars/primary/events/{Uri.EscapeDataString(eventId)}", body, ct);
+                          $"calendars/{Uri.EscapeDataString(calendarId)}/events/{Uri.EscapeDataString(eventId)}", body, ct);
 
-    /// <summary>Deletes an event (<c>DELETE calendars/primary/events/{id}</c>).</summary>
-    internal async Task DeleteEventAsync(string username, string eventId, CancellationToken ct = default)
+    /// <summary>Deletes an event (<c>DELETE calendars/{calendarId}/events/{id}</c>).</summary>
+    internal async Task DeleteEventAsync(
+        string username, string eventId, string calendarId = "primary", CancellationToken ct = default)
     {
         var token = await _oauth.GetAccessTokenAsync(username, ct);
         using var req = new HttpRequestMessage(
-            HttpMethod.Delete, $"{BaseUrl}/calendars/primary/events/{Uri.EscapeDataString(eventId)}");
+            HttpMethod.Delete,
+            $"{BaseUrl}/calendars/{Uri.EscapeDataString(calendarId)}/events/{Uri.EscapeDataString(eventId)}");
         req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
         using var resp = await _http.SendAsync(req, ct);

--- a/QuickMail/Services/GraphCalendarSyncService.cs
+++ b/QuickMail/Services/GraphCalendarSyncService.cs
@@ -622,7 +622,7 @@ public sealed class GraphCalendarSyncService : IGraphCalendarSyncService
         // Dispatch order mirrors the read path (SyncOneAccountAsync): Graph → Google → iCloud.
         if (IsGoogleEligible(account))
         {
-            await _google!.DeleteEventAsync(account.Username, evt.Uid, ct);
+            await _google!.DeleteEventAsync(account.Username, evt.Uid, GoogleCalendarId(evt), ct);
             await _store.DeleteCalendarEventAsync(evt.Uid, account.Id);
             LogService.Log($"CalendarSync: deleted Google event on {account.AccountLabel} ({evt.Uid}).");
             return;
@@ -641,10 +641,17 @@ public sealed class GraphCalendarSyncService : IGraphCalendarSyncService
 
     // ── Google write path ────────────────────────────────────────────────────────
 
+    // Target the calendar the event actually lives on. A blank CalendarId (e.g. a brand-new
+    // event whose save target is the account's default) falls back to "primary". Using this for
+    // update/delete is the fix for events on secondary Google calendars, which 404 against primary.
+    private static string GoogleCalendarId(CalendarEvent evt)
+        => string.IsNullOrWhiteSpace(evt.CalendarId) ? "primary" : evt.CalendarId;
+
     private async Task<CalendarEvent> CreateGoogleEventAsync(AccountModel account, CalendarEvent evt, CancellationToken ct)
     {
-        var created = await _google!.CreateEventAsync(account.Username, BuildGoogleWriteBody(evt), ct);
-        var mapped = MapGoogleEvent(created, account.Id);
+        var calId = GoogleCalendarId(evt);
+        var created = await _google!.CreateEventAsync(account.Username, BuildGoogleWriteBody(evt), calId, ct);
+        var mapped = MapGoogleEvent(created, account.Id, calId, evt.CalendarName);
         await _store.UpsertCalendarEventAsync(mapped);
         LogService.Log($"CalendarSync: created Google event on {account.AccountLabel} ({mapped.Uid}).");
         return mapped;
@@ -652,8 +659,9 @@ public sealed class GraphCalendarSyncService : IGraphCalendarSyncService
 
     private async Task<CalendarEvent> UpdateGoogleEventAsync(AccountModel account, CalendarEvent evt, CancellationToken ct)
     {
-        var updated = await _google!.UpdateEventAsync(account.Username, evt.Uid, BuildGoogleWriteBody(evt), ct);
-        var mapped = MapGoogleEvent(updated, account.Id);
+        var calId = GoogleCalendarId(evt);
+        var updated = await _google!.UpdateEventAsync(account.Username, evt.Uid, BuildGoogleWriteBody(evt), calId, ct);
+        var mapped = MapGoogleEvent(updated, account.Id, calId, evt.CalendarName);
         await _store.UpsertCalendarEventAsync(mapped);
         LogService.Log($"CalendarSync: updated Google event on {account.AccountLabel} ({mapped.Uid}).");
         return mapped;

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -5964,6 +5964,11 @@ public partial class MainViewModel : ObservableObject, IDisposable
         // The reconnect loop below rebuilds again for any account that actually needs connecting.
         RebuildFolderListFromCache();
 
+        // A newly added / re-opted-in account's calendars are discovered by the calendar sync pass,
+        // which otherwise only runs every 15 minutes. Kick it now so its calendar node and any
+        // per-calendar sub-nodes appear promptly rather than after the next pass or a restart (#282).
+        TriggerCalendarSyncSoon();
+
         // Reconnect any account that isn't truly connected in its backend, OR whose folders aren't
         // cached in the VM (e.g. a newly added account). Checking the backend (_imap.IsConnected) —
         // not just _cachedFolders — is what catches an account that was re-consented / re-authed
@@ -6305,6 +6310,16 @@ public partial class MainViewModel : ObservableObject, IDisposable
             _ => _ui.Post(() => _ = RunGraphCalendarSyncAsync()), null, Timeout.Infinite, Timeout.Infinite);
         _graphCalendarSyncTimer.Change(TimeSpan.Zero, GraphCalendarSyncInterval);
     }
+
+    /// <summary>
+    /// Nudges the calendar sync timer to fire immediately (then resume its normal 15-minute
+    /// cadence). Called when the account list changes so a newly added — or newly calendar-opted-in
+    /// (#282) — account's calendars, and their per-calendar sub-nodes, appear right away instead of
+    /// only after the next timer pass or an app restart. No-op if the timer isn't running yet
+    /// (no calendar service, online mode, or startup hasn't reached StartGraphCalendarSyncTimer).
+    /// </summary>
+    private void TriggerCalendarSyncSoon()
+        => _graphCalendarSyncTimer?.Change(TimeSpan.Zero, GraphCalendarSyncInterval);
 
     /// <summary>
     /// One Graph calendar sync pass: pulls every Graph account's primary calendar into the local


### PR DESCRIPTION
## Two calendar bugs (reported by Kelly on a fresh 5-account install), plus a test-isolation fix.

### 1. Can't delete/edit Gmail events on non-primary calendars
The Google read path enumerates every calendar in the account and stores each event's `CalendarId`, but the write path (`GoogleCalendarClient` create/update/delete) was hardcoded to `calendars/primary/events`. Deleting or editing an event that lives on a secondary Google calendar (Family, Work, a shared/subscribed calendar) hit `primary`, got a 404, and surfaced as *"could not update the online calendar."*

Fix: added a URL-escaped `calendarId` parameter (default `primary`) to the three Google write methods; `GraphCalendarSyncService` now passes the event's own `CalendarId` (via `GoogleCalendarId`, primary fallback) for create, update **and** delete. Create stores the target calendar on the row so a delete before the next sync still targets correctly.

### 2. New account's sub-calendars don't appear until restart
The calendar sync that discovers an account's calendars and builds their tree nodes runs only every 15 min (or at startup / F5 in calendar view). `RefreshAccountList` rebuilt the mail tree immediately but never kicked a calendar sync, so a freshly added account's calendars didn't show until the timer fired or the app restarted.

Fix: `TriggerCalendarSyncSoon()` reschedules the existing timer to fire immediately (null-safe, re-entrancy-guarded by the existing running flag); called from `RefreshAccountList`.

### 3. Tests were polluting the real app log
`LogService` defaults to `%APPDATA%\QuickMail\quickmail.log` and only redirects when `Configure()` is called — which tests never did. Every test exercising code that logs appended fixture noise (fake accounts, deliberate `boom`/`denied` errors) into the developer's live log, making it useless for diagnosing real issues (it hid Kelly's actual run). Added a `[ModuleInitializer]` that redirects test logging to a temp dir.

Independent code review: clean, no correctness issues. Full suite: 1422 passing.