### PR TITLE
Persist calendar_ics so the invite Accept/Decline card survives caching

### DIFF
--- a/QuickMail/Services/ImapMailService.cs
+++ b/QuickMail/Services/ImapMailService.cs
@@ -367,6 +367,7 @@ public class ImapMailService : IMailService, IChangeNotifier
             IcsModel? calendarInvite = null;
             var calendarIcsText = string.Empty;
             var calendarPart = FindCalendarPart(s.Body);
+
             if (calendarPart != null)
             {
                 try
@@ -401,6 +402,14 @@ public class ImapMailService : IMailService, IChangeNotifier
                 HtmlBody      = htmlText,
                 Attachments   = attachments,
                 CalendarInvite = calendarInvite,
+                // Persist the RAW ICS too, not just the parsed CalendarInvite. CalendarInvite lives
+                // only in memory; CalendarIcs is the column the local store caches. Without this, a
+                // freshly fetched invite shows its Accept/Decline card (CalendarInvite is set), but
+                // the moment the row is cached — which prefetch does almost immediately — the stored
+                // calendar_ics is empty, so every later cache-served open reconstructs a null invite
+                // and the card silently vanishes. This is the root cause of invites "randomly" not
+                // being acceptable across accounts (it was really a prefetch-vs-open race).
+                CalendarIcs   = calendarIcsText,
                 DraftComposeMode = ParseComposeMode(s.Headers?["X-QuickMail-Compose-Mode"]),
             };
         }


### PR DESCRIPTION
## The bug
Meeting invites showed the Accept/Decline card only on the **first** open, then lost it on every subsequent open — looking random and account-dependent.

## Root cause
`ImapMailService.GetMessageDetailCoreAsync` set `CalendarInvite` (parsed, in-memory) but **not** `CalendarIcs` (the raw ICS the local store persists). A fresh foreground open had `CalendarInvite` in memory → card showed. But the background **prefetch** cached the row with empty `calendar_ics` within milliseconds, and every later open is a cache hit → `CalendarInvite` reconstructed from empty ICS = `null` → **no card**. A prefetch-vs-open race, not a provider difference (Gmail/iCloud/IMAP all affected).

## Fix
One line: set `CalendarIcs = calendarIcsText` on the returned `MailMessageDetail`.

## Verification
- Full suite: 1422 passing.
- Live-verified across Gmail, iCloud, and IMAP: the Accept/Decline card now persists across repeated opens, and accepts send correctly from each receiving account for single-address invites.
- Store round-trip (`calendar_ics` → `CalendarInvite`) already covered by `CalendarStoreTests`; the omission was in the IMAP fetch path, not unit-testable without mocking MailKit.

## Follow-up (separate issues)
- #296 — invite sent to *multiple of your own accounts* threads copies into one conversation; accepts can route to one account.
- #295 — original invite-detection investigation (superseded by this root cause).