### PR TITLE
Regression tests: Google calendar write targeting (#293) + invite cache (#297)

### DIFF
--- a/QuickMail.Tests/CalendarStoreTests.cs
+++ b/QuickMail.Tests/CalendarStoreTests.cs
@@ -545,4 +545,57 @@ public class CalendarStoreTests : IDisposable
         Assert.Single(events);
         Assert.Equal(CalendarResponseStatus.Cancelled, events[0].ResponseStatus);
     }
+
+    // ── Invite card survives caching (regression for #297) ───────────────────────
+    // A meeting invite showed its Accept/Decline card only on the first (in-memory) open, then lost
+    // it once the row was cached, because the raw calendar_ics was not persisted. These pin the
+    // cache-served reconstruction: when calendar_ics IS stored, a cache-served open must rebuild a
+    // non-null CalendarInvite; when it's absent, the invite is null (no phantom card).
+
+    [Fact]
+    public async Task LoadDetail_WithCalendarIcs_ReconstructsInviteOnCacheServedOpen()
+    {
+        var accountId = Guid.NewGuid();
+        await _store.UpsertSummariesAsync(new[] { new MailMessageSummary
+        {
+            MessageId = "msg-invite", AccountId = accountId, FolderName = "INBOX",
+            From = "org@example.com", Subject = "Lunch invite", Date = DateTimeOffset.UtcNow,
+        }});
+        await _store.UpsertDetailAsync(new MailMessageDetail
+        {
+            MessageId = "msg-invite", AccountId = accountId, FolderName = "INBOX",
+            From = "org@example.com", Subject = "Lunch invite", Date = DateTimeOffset.UtcNow,
+            CalendarIcs = "BEGIN:VCALENDAR\r\nMETHOD:REQUEST\r\nBEGIN:VEVENT\r\nUID:lunch-1\r\n" +
+                          "SUMMARY:Lunch\r\nDTSTART:20260801T160000Z\r\nEND:VEVENT\r\nEND:VCALENDAR",
+        });
+
+        var loaded = await _store.LoadDetailAsync(accountId, "INBOX", "msg-invite");
+
+        Assert.NotNull(loaded);
+        Assert.NotNull(loaded!.CalendarInvite);          // the Accept/Decline card would render
+        Assert.Equal("lunch-1", loaded.CalendarInvite!.Uid);
+        Assert.Equal("Lunch", loaded.CalendarInvite.Summary);
+    }
+
+    [Fact]
+    public async Task LoadDetail_WithoutCalendarIcs_HasNoInvite()
+    {
+        var accountId = Guid.NewGuid();
+        await _store.UpsertSummariesAsync(new[] { new MailMessageSummary
+        {
+            MessageId = "msg-plain", AccountId = accountId, FolderName = "INBOX",
+            From = "a@example.com", Subject = "Hello", Date = DateTimeOffset.UtcNow,
+        }});
+        await _store.UpsertDetailAsync(new MailMessageDetail
+        {
+            MessageId = "msg-plain", AccountId = accountId, FolderName = "INBOX",
+            From = "a@example.com", Subject = "Hello", Date = DateTimeOffset.UtcNow,
+            PlainTextBody = "just a message",
+        });
+
+        var loaded = await _store.LoadDetailAsync(accountId, "INBOX", "msg-plain");
+
+        Assert.NotNull(loaded);
+        Assert.Null(loaded!.CalendarInvite);
+    }
 }

--- a/QuickMail.Tests/GoogleCalendarSyncTests.cs
+++ b/QuickMail.Tests/GoogleCalendarSyncTests.cs
@@ -48,6 +48,7 @@ public class GoogleCalendarSyncTests : IDisposable
         private readonly Queue<HttpResponseMessage> _responses;
         public int Calls { get; private set; }
         public List<string> Urls { get; } = [];
+        public List<string> Methods { get; } = [];
 
         public RecordingHandler(params HttpResponseMessage[] responses)
             => _responses = new Queue<HttpResponseMessage>(responses);
@@ -56,6 +57,7 @@ public class GoogleCalendarSyncTests : IDisposable
         {
             Calls++;
             Urls.Add(request.RequestUri!.ToString());
+            Methods.Add(request.Method.Method);
             return Task.FromResult(_responses.Count > 0 ? _responses.Dequeue() : Json("""{ "items": [] }"""));
         }
     }
@@ -320,5 +322,80 @@ public class GoogleCalendarSyncTests : IDisposable
 
         Assert.Equal(0, handler.Calls);
         Assert.Equal(GraphCalendarSyncResult.None, result);
+    }
+
+    // ── Write-path calendar targeting (regression for #293) ──────────────────────
+    // The Google write path was hardcoded to calendars/primary/events, so create/edit/delete of an
+    // event living on a SECONDARY calendar hit the primary calendar and 404'd ("could not update the
+    // online calendar"). Each write must target the event's own CalendarId (URL-escaped), with a
+    // "primary" fallback when the event carries no calendar id.
+
+    private CalendarEvent GoogleEvt(string uid, string calendarId) => new()
+    {
+        Uid            = uid,
+        AccountId      = _accountId,
+        CalendarId     = calendarId,
+        CalendarName   = "Family",
+        Summary        = "Lunch",
+        StartTimeTicks = new DateTime(2026, 8, 1, 16, 0, 0, DateTimeKind.Utc).Ticks,
+        EndTimeTicks   = new DateTime(2026, 8, 1, 17, 0, 0, DateTimeKind.Utc).Ticks,
+        IsGraph        = true,
+    };
+
+    private static HttpResponseMessage GoogleEventResponse(string id) => Json(EventJson(
+        id, "Lunch", startDateTime: "2026-08-01T16:00:00+00:00", endDateTime: "2026-08-01T17:00:00+00:00"));
+
+    [Fact]
+    public async Task DeleteEvent_OnSecondaryCalendar_TargetsThatCalendar_NotPrimary()
+    {
+        var handler = new RecordingHandler(); // default 200 OK is fine for DELETE
+        var evt = GoogleEvt("gid-x", "fam123@group.calendar.google.com");
+
+        await Service(handler).DeleteEventAsync(GoogleAccount(), evt, TestContext.Current.CancellationToken);
+
+        Assert.Equal("DELETE", handler.Methods[0]);
+        Assert.Contains("/calendars/fam123%40group.calendar.google.com/events/gid-x", handler.Urls[0]);
+        Assert.DoesNotContain("/calendars/primary/", handler.Urls[0]);
+    }
+
+    [Fact]
+    public async Task UpdateEvent_OnSecondaryCalendar_PatchesThatCalendar_AndKeepsTag()
+    {
+        var handler = new RecordingHandler(GoogleEventResponse("gid-x"));
+        var evt = GoogleEvt("gid-x", "fam123@group.calendar.google.com");
+
+        await Service(handler).UpdateEventAsync(GoogleAccount(), evt, TestContext.Current.CancellationToken);
+
+        Assert.Equal("PATCH", handler.Methods[0]);
+        Assert.Contains("/calendars/fam123%40group.calendar.google.com/events/gid-x", handler.Urls[0]);
+        // The stored row stays tagged with the secondary calendar so a follow-up edit before the
+        // next full sync still targets the right calendar.
+        Assert.Equal("fam123@group.calendar.google.com",
+            Assert.Single(await _store.LoadCalendarEventsAsync()).CalendarId);
+    }
+
+    [Fact]
+    public async Task CreateEvent_OnSecondaryCalendar_PostsToThatCalendar()
+    {
+        var handler = new RecordingHandler(GoogleEventResponse("gid-new"));
+        var evt = GoogleEvt("", "fam123@group.calendar.google.com");
+
+        await Service(handler).CreateEventAsync(GoogleAccount(), evt, TestContext.Current.CancellationToken);
+
+        Assert.Equal("POST", handler.Methods[0]);
+        Assert.Contains("/calendars/fam123%40group.calendar.google.com/events", handler.Urls[0]);
+        Assert.DoesNotContain("/calendars/primary/", handler.Urls[0]);
+    }
+
+    [Fact]
+    public async Task CreateEvent_BlankCalendarId_FallsBackToPrimary()
+    {
+        var handler = new RecordingHandler(GoogleEventResponse("gid-new"));
+        var evt = GoogleEvt("", ""); // no calendar specified → "primary" fallback
+
+        await Service(handler).CreateEventAsync(GoogleAccount(), evt, TestContext.Current.CancellationToken);
+
+        Assert.Equal("POST", handler.Methods[0]);
+        Assert.Contains("/calendars/primary/events", handler.Urls[0]);
     }
 }


### PR DESCRIPTION
Adds cheap regression guards for the two calendar bugs that shipped with no coverage.

- **GoogleCalendarSyncTests** — delete/update/create of a secondary-calendar Google event must target `/calendars/{id}/events` (URL-escaped), not `primary`; blank CalendarId → `primary` fallback. (Recorded the request HTTP method on the test handler.)
- **CalendarStoreTests** — a persisted `calendar_ics` reconstructs a non-null `CalendarInvite` on a cache-served `LoadDetailAsync` (card renders); empty `calendar_ics` → no invite.

Against the pre-fix code these fail. Full suite 1428 passing. The exact #297 production site (ImapMailService live-IMAP path) still isn't unit-testable without a refactor — noted for follow-up.