### PR TITLE
Purge orphaned calendar events (duplicate appointments after account remove/re-add)

### DIFF
--- a/QuickMail.Tests/CalendarStoreTests.cs
+++ b/QuickMail.Tests/CalendarStoreTests.cs
@@ -598,4 +598,51 @@ public class CalendarStoreTests : IDisposable
         Assert.NotNull(loaded);
         Assert.Null(loaded!.CalendarInvite);
     }
+
+    // ── Orphaned-account purge (duplicate appointments after remove/re-add) ───────
+    // An account removed and re-added gets a new id; its old id's calendar events linger and show as
+    // duplicates. The startup purge drops events for accounts not in the current set, but keeps local
+    // events (empty account id).
+
+    [Fact]
+    public async Task PurgeCalendarEventsForUnknownAccounts_RemovesOrphans_KeepsKnownAndLocal()
+    {
+        var known  = Guid.NewGuid();
+        var orphan = Guid.NewGuid();
+
+        async Task Seed(Guid acct, string uid) => await _store.UpsertCalendarEventAsync(new CalendarEvent
+        {
+            Uid = uid, AccountId = acct, Summary = "Dad party",
+            StartTimeTicks = new DateTime(2026, 6, 20, 16, 45, 0, DateTimeKind.Utc).Ticks,
+            EndTimeTicks   = new DateTime(2026, 6, 20, 18, 45, 0, DateTimeKind.Utc).Ticks,
+            IsGraph = true,
+        });
+
+        await Seed(known,  "uid-known");
+        await Seed(orphan, "uid-orphan");
+        await Seed(Guid.Empty, "uid-local"); // a locally-created appointment
+
+        await _store.PurgeCalendarEventsForUnknownAccountsAsync(new[] { known });
+
+        var remaining = await _store.LoadCalendarEventsAsync();
+        var accounts = remaining.Select(e => e.AccountId).ToHashSet();
+        Assert.Contains(known, accounts);        // kept
+        Assert.Contains(Guid.Empty, accounts);   // local events preserved
+        Assert.DoesNotContain(orphan, accounts); // orphan purged
+    }
+
+    [Fact]
+    public async Task PurgeCalendarEventsForUnknownAccounts_NoOrphans_IsNoOp()
+    {
+        var known = Guid.NewGuid();
+        await _store.UpsertCalendarEventAsync(new CalendarEvent
+        {
+            Uid = "uid-1", AccountId = known, Summary = "Keep me",
+            StartTimeTicks = DateTime.UtcNow.Ticks, EndTimeTicks = DateTime.UtcNow.Ticks, IsGraph = true,
+        });
+
+        await _store.PurgeCalendarEventsForUnknownAccountsAsync(new[] { known });
+
+        Assert.Single(await _store.LoadCalendarEventsAsync());
+    }
 }

--- a/QuickMail.Tests/FlagServiceTests.cs
+++ b/QuickMail.Tests/FlagServiceTests.cs
@@ -135,6 +135,7 @@ sealed class RecordingFlagStore : ILocalStoreService
     public Task<List<MailMessageSummary>> LoadFolderSummariesAsync(Guid accountId, string folderName, int? limit = null) => Task.FromResult(new List<MailMessageSummary>());
     public Task DeleteSummariesAsync(Guid accountId, string folderName, IEnumerable<string> messageIds) => Task.CompletedTask;
     public Task DeleteAccountDataAsync(Guid accountId) => Task.CompletedTask;
+    public Task PurgeCalendarEventsForUnknownAccountsAsync(IReadOnlyCollection<Guid> knownAccountIds) => Task.CompletedTask;
     public Task UpdateIsReadAsync(Guid accountId, string folderName, string messageId, bool isRead) => Task.CompletedTask;
     public Task UpdateIsReadBatchAsync(IEnumerable<(Guid AccountId, string FolderName, string MessageId)> items, bool isRead) => Task.CompletedTask;
     public Task UpdatePreviewAsync(Guid accountId, string folderName, string messageId, string preview) => Task.CompletedTask;

--- a/QuickMail.Tests/MainViewModelFlagTests.cs
+++ b/QuickMail.Tests/MainViewModelFlagTests.cs
@@ -218,6 +218,7 @@ sealed class FilterableStoreForFlags : ILocalStoreService
     public Task<List<MailMessageSummary>> LoadFolderSummariesAsync(Guid accountId, string folderName, int? limit = null) => Task.FromResult(new List<MailMessageSummary>(_messages));
     public Task DeleteSummariesAsync(Guid accountId, string folderName, IEnumerable<string> messageIds) => Task.CompletedTask;
     public Task DeleteAccountDataAsync(Guid accountId) => Task.CompletedTask;
+    public Task PurgeCalendarEventsForUnknownAccountsAsync(IReadOnlyCollection<Guid> knownAccountIds) => Task.CompletedTask;
     public Task UpdateIsReadAsync(Guid accountId, string folderName, string messageId, bool isRead) => Task.CompletedTask;
     public Task UpdateIsReadBatchAsync(IEnumerable<(Guid AccountId, string FolderName, string MessageId)> items, bool isRead) => Task.CompletedTask;
     public Task UpdatePreviewAsync(Guid accountId, string folderName, string messageId, string preview) => Task.CompletedTask;

--- a/QuickMail.Tests/MarkReadOnOpenTests.cs
+++ b/QuickMail.Tests/MarkReadOnOpenTests.cs
@@ -129,6 +129,7 @@ public class MarkReadOnOpenTests
         public Task<List<MailMessageSummary>> LoadFolderSummariesAsync(Guid accountId, string folderName, int? limit = null) => Task.FromResult(new List<MailMessageSummary>());
         public Task DeleteSummariesAsync(Guid accountId, string folderName, IEnumerable<string> messageIds) => Task.CompletedTask;
         public Task DeleteAccountDataAsync(Guid accountId) => Task.CompletedTask;
+        public Task PurgeCalendarEventsForUnknownAccountsAsync(IReadOnlyCollection<Guid> knownAccountIds) => Task.CompletedTask;
         public Task UpdateIsReadAsync(Guid accountId, string folderName, string messageId, bool isRead) => Task.CompletedTask;
         public Task UpdateIsReadBatchAsync(IEnumerable<(Guid AccountId, string FolderName, string MessageId)> items, bool isRead) => Task.CompletedTask;
         public Task UpdatePreviewAsync(Guid accountId, string folderName, string messageId, string preview) => Task.CompletedTask;

--- a/QuickMail.Tests/MessageFilterTests.cs
+++ b/QuickMail.Tests/MessageFilterTests.cs
@@ -32,6 +32,7 @@ public class MessageFilterTests
         public Task<List<MailMessageSummary>> LoadFolderSummariesAsync(Guid accountId, string folderName, int? limit = null) => Task.FromResult(new List<MailMessageSummary>(_messages));
         public Task DeleteSummariesAsync(Guid accountId, string folderName, IEnumerable<string> messageIds) => Task.CompletedTask;
         public Task DeleteAccountDataAsync(Guid accountId) => Task.CompletedTask;
+        public Task PurgeCalendarEventsForUnknownAccountsAsync(IReadOnlyCollection<Guid> knownAccountIds) => Task.CompletedTask;
         public Task UpdateIsReadAsync(Guid accountId, string folderName, string messageId, bool isRead) => Task.CompletedTask;
         public Task UpdateIsReadBatchAsync(IEnumerable<(Guid AccountId, string FolderName, string MessageId)> items, bool isRead) => Task.CompletedTask;
         public Task UpdatePreviewAsync(Guid accountId, string folderName, string messageId, string preview) => Task.CompletedTask;

--- a/QuickMail.Tests/SavedViewsTests.cs
+++ b/QuickMail.Tests/SavedViewsTests.cs
@@ -825,6 +825,7 @@ public class SavedViewsMainViewModelTests
         public Task<List<MailMessageSummary>> LoadFolderSummariesAsync(Guid accountId, string folderName, int? limit = null) => Task.FromResult(new List<MailMessageSummary>(_messages));
         public Task DeleteSummariesAsync(Guid accountId, string folderName, IEnumerable<string> messageIds) => Task.CompletedTask;
         public Task DeleteAccountDataAsync(Guid accountId) => Task.CompletedTask;
+        public Task PurgeCalendarEventsForUnknownAccountsAsync(IReadOnlyCollection<Guid> knownAccountIds) => Task.CompletedTask;
         public Task UpdateIsReadAsync(Guid accountId, string folderName, string messageId, bool isRead) => Task.CompletedTask;
         public Task UpdateIsReadBatchAsync(IEnumerable<(Guid AccountId, string FolderName, string MessageId)> items, bool isRead) => Task.CompletedTask;
         public Task UpdatePreviewAsync(Guid accountId, string folderName, string messageId, string preview) => Task.CompletedTask;

--- a/QuickMail.Tests/SessionFeaturesTests.cs
+++ b/QuickMail.Tests/SessionFeaturesTests.cs
@@ -92,6 +92,7 @@ public class PreviewSuppressionTests
         public Task<List<MailMessageSummary>> LoadFolderSummariesAsync(Guid accountId, string folderName, int? limit = null) => Task.FromResult(new List<MailMessageSummary>(_messages));
         public Task DeleteSummariesAsync(Guid accountId, string folderName, IEnumerable<string> messageIds) => Task.CompletedTask;
         public Task DeleteAccountDataAsync(Guid accountId) => Task.CompletedTask;
+        public Task PurgeCalendarEventsForUnknownAccountsAsync(IReadOnlyCollection<Guid> knownAccountIds) => Task.CompletedTask;
         public Task UpdateIsReadAsync(Guid accountId, string folderName, string messageId, bool isRead) => Task.CompletedTask;
         public Task UpdateIsReadBatchAsync(IEnumerable<(Guid AccountId, string FolderName, string MessageId)> items, bool isRead) => Task.CompletedTask;
         public Task UpdatePreviewAsync(Guid accountId, string folderName, string messageId, string preview) => Task.CompletedTask;

--- a/QuickMail.Tests/StubServices.cs
+++ b/QuickMail.Tests/StubServices.cs
@@ -111,6 +111,7 @@ sealed class StubLocalStoreService : ILocalStoreService
     public Task<List<MailMessageSummary>> LoadFolderSummariesAsync(Guid accountId, string folderName, int? limit = null) => Task.FromResult(new List<MailMessageSummary>());
     public Task DeleteSummariesAsync(Guid accountId, string folderName, IEnumerable<string> messageIds) => Task.CompletedTask;
     public Task DeleteAccountDataAsync(Guid accountId) => Task.CompletedTask;
+    public Task PurgeCalendarEventsForUnknownAccountsAsync(IReadOnlyCollection<Guid> knownAccountIds) => Task.CompletedTask;
     public Task UpdateIsReadAsync(Guid accountId, string folderName, string messageId, bool isRead) => Task.CompletedTask;
     public Task UpdateIsReadBatchAsync(IEnumerable<(Guid AccountId, string FolderName, string MessageId)> items, bool isRead) => Task.CompletedTask;
     public Task UpdatePreviewAsync(Guid accountId, string folderName, string messageId, string preview) => Task.CompletedTask;

--- a/QuickMail/Services/ILocalStoreService.cs
+++ b/QuickMail/Services/ILocalStoreService.cs
@@ -15,6 +15,12 @@ public interface ILocalStoreService
     Task<List<MailMessageSummary>> LoadFolderSummariesAsync(Guid accountId, string folderName, int? limit = null);
     Task DeleteSummariesAsync(Guid accountId, string folderName, IEnumerable<string> messageIds);
     Task DeleteAccountDataAsync(Guid accountId);
+
+    /// <summary>
+    /// Deletes calendar events for accounts not in <paramref name="knownAccountIds"/> (orphans from a
+    /// removed-and-re-added account or a cache rebuild). Local events (<see cref="Guid.Empty"/>) are kept.
+    /// </summary>
+    Task PurgeCalendarEventsForUnknownAccountsAsync(IReadOnlyCollection<Guid> knownAccountIds);
     Task UpdateIsReadAsync(Guid accountId, string folderName, string messageId, bool isRead);
     Task UpdateIsReadBatchAsync(IEnumerable<(Guid AccountId, string FolderName, string MessageId)> items, bool isRead);
     Task UpdatePreviewAsync(Guid accountId, string folderName, string messageId, string preview);

--- a/QuickMail/Services/LocalStoreService.cs
+++ b/QuickMail/Services/LocalStoreService.cs
@@ -475,6 +475,43 @@ public class LocalStoreService : ILocalStoreService
         await tx.CommitAsync();
     }
 
+    /// <summary>
+    /// Deletes calendar events whose <c>account_id</c> is not among <paramref name="knownAccountIds"/> —
+    /// orphans left behind when an account is removed and re-added (the re-added account gets a new id,
+    /// so the old id's events linger and show as duplicates), or after a cache rebuild. Local events
+    /// (<see cref="Guid.Empty"/>) are always kept. No-op when there are no orphans.
+    /// </summary>
+    public async Task PurgeCalendarEventsForUnknownAccountsAsync(IReadOnlyCollection<Guid> knownAccountIds)
+    {
+        await using var conn = await OpenAsync();
+
+        var keep = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { Guid.Empty.ToString() };
+        foreach (var id in knownAccountIds) keep.Add(id.ToString());
+
+        var present = new List<string>();
+        await using (var q = conn.CreateCommand())
+        {
+            q.CommandText = "SELECT DISTINCT account_id FROM CalendarEvent;";
+            await using var r = await q.ExecuteReaderAsync();
+            while (await r.ReadAsync()) present.Add(r.GetString(0));
+        }
+
+        var orphans = present.Where(a => !keep.Contains(a)).ToList();
+        if (orphans.Count == 0) return;
+
+        await using var del = conn.CreateCommand();
+        del.CommandText = "DELETE FROM CalendarEvent WHERE account_id = $aid;";
+        var p = del.CreateParameter();
+        p.ParameterName = "$aid";
+        del.Parameters.Add(p);
+        foreach (var orphan in orphans)
+        {
+            p.Value = orphan;
+            await del.ExecuteNonQueryAsync();
+        }
+        LogService.Log($"LocalStoreService: purged calendar events for {orphans.Count} unknown account(s).");
+    }
+
     public async Task UpdateIsReadAsync(Guid accountId, string folderName, string messageId, bool isRead)
     {
         await using var conn = await OpenAsync();

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -1693,6 +1693,10 @@ public partial class MainViewModel : ObservableObject, IDisposable
             : "Connecting and syncing…";
         ConnectionStatusText = "Connecting…";
         StartPrefetchTopOfFolder();
+        // Drop calendar events left behind by accounts that no longer exist — e.g. an account removed
+        // and re-added during setup gets a new id, so its old events would otherwise linger and show
+        // as duplicates (one per stale id). Local events (empty account id) are kept.
+        await _localStore.PurgeCalendarEventsForUnknownAccountsAsync(Accounts.Select(a => a.Id).ToList());
         await ReloadCalendarSourcesAsync(); // populate before the tree is built so calendars show at startup
         RebuildFolderListFromCache();
     }


### PR DESCRIPTION
## Symptom
Appointments appeared twice — once under the live account ("apple: Family") and once under a stale account whose label no longer resolves ("Account: Family").

## Cause
An account removed and re-added gets a **new** internal id; the old id's calendar events were never purged, so the same server event synced under both ids and rendered twice. `accounts.json` was clean (4 accounts) but the store held events under two orphaned account ids (~half the rows were duplicates).

Account **deletion** already cascades (`DeleteAccountDataAsync`), so this only occurs when the id changes without a formal delete — re-auth/re-add, or a cache rebuild.

## Fix
`ILocalStoreService.PurgeCalendarEventsForUnknownAccountsAsync(known)` deletes calendar events whose `account_id` is not a current account, **keeping local events** (empty id). Called once in `InitialLoadAsync` before the calendar tree builds, so orphans are cleaned on launch and can't accumulate.

## Tests
Orphan removed / known + local kept; no-op when clean. Full suite **1430** passing.

Note: mail (summary/detail) can orphan the same way but doesn't cause visible duplication; scoped to calendar here.