### PR TITLE
Respond to pending invitations from the calendar (Enter → Accept/Decline menu)

### DIFF
--- a/QuickMail.Tests/CalendarEventTests.cs
+++ b/QuickMail.Tests/CalendarEventTests.cs
@@ -29,4 +29,40 @@ public class CalendarEventTests
         Assert.Contains(nameof(CalendarEvent.ResponseStatus), raisedProperties);
         Assert.Contains(nameof(CalendarEvent.DisplayLine), raisedProperties);
     }
+
+    [Theory]
+    // A harvested invite (real account, not graph) that is still Pending is the only pending invite.
+    [InlineData(false, CalendarResponseStatus.Pending, true)]
+    [InlineData(false, CalendarResponseStatus.Accepted, false)]
+    [InlineData(false, CalendarResponseStatus.Declined, false)]
+    [InlineData(false, CalendarResponseStatus.Tentative, false)]
+    [InlineData(false, CalendarResponseStatus.Cancelled, false)]
+    // Server-synced (graph) rows are never pending invites even at Pending status.
+    [InlineData(true, CalendarResponseStatus.Pending, false)]
+    public void IsPendingInvite_TrueOnlyForUnansweredHarvestedInvite(
+        bool isGraph, CalendarResponseStatus status, bool expected)
+    {
+        var evt = new CalendarEvent
+        {
+            Uid = "e1",
+            AccountId = Guid.NewGuid(),   // real (non-empty) account => not user-created
+            IsGraph = isGraph,
+            ResponseStatus = status,
+        };
+
+        Assert.Equal(expected, evt.IsPendingInvite);
+    }
+
+    [Fact]
+    public void IsPendingInvite_FalseForUserCreatedAppointment()
+    {
+        var evt = new CalendarEvent
+        {
+            Uid = "local-1",
+            AccountId = CalendarEvent.LocalAccountId,   // user-created
+            ResponseStatus = CalendarResponseStatus.Pending,
+        };
+
+        Assert.False(evt.IsPendingInvite);
+    }
 }

--- a/QuickMail.Tests/MainViewModelCalendarTests.cs
+++ b/QuickMail.Tests/MainViewModelCalendarTests.cs
@@ -126,4 +126,101 @@ public class MainViewModelCalendarTests
 
         Assert.Equal(0, calendarService.RefreshCallCount);
     }
+
+    [Fact]
+    public async Task RespondToCalendarInviteAsync_SendsFromReceivingAccount_AndUpdatesStatus()
+    {
+        var receivingAccountId = Guid.NewGuid();
+        var otherAccountId = Guid.NewGuid();
+
+        var smtp = new StubSmtpService();
+        var localStore = new StubLocalStoreService
+        {
+            // The cached source invite email the calendar row points back to.
+            SeededDetail = new MailMessageDetail
+            {
+                AccountId = receivingAccountId,
+                FolderName = "INBOX",
+                MessageId = "msg-1",
+                CalendarInvite = new IcsModel
+                {
+                    Uid = "inv-1",
+                    Summary = "Planning meeting",
+                    Organizer = "organizer@example.com",
+                    StartTime = DateTime.Today.AddHours(9),
+                    EndTime = DateTime.Today.AddHours(10),
+                },
+            },
+        };
+        var calendarService = new StubCalendarService();
+
+        var evt = new CalendarEvent
+        {
+            Uid = "inv-1",
+            AccountId = receivingAccountId,
+            Summary = "Planning meeting",
+            SourceMessageId = "msg-1",
+            SourceFolder = "INBOX",
+            ResponseStatus = CalendarResponseStatus.Pending,
+        };
+        calendarService.StoredEvents.Add(evt);
+
+        var vm = new MainViewModel(
+            new StubImapMailService(), new StubAccountService(), new StubCredentialService(),
+            localStore, new StubOAuthService(), new StubSyncService(), new StubConfigService(),
+            new StubCommandRegistry(), new StubViewService(), new StubRuleService(), smtp,
+            calendarService: calendarService);
+
+        // Both accounts present; the reply MUST route from the one that received the invite (#296).
+        vm.Accounts.Add(new AccountModel
+        {
+            Id = otherAccountId, Username = "wrong@example.com", DisplayName = "Wrong Account",
+        });
+        vm.Accounts.Add(new AccountModel
+        {
+            Id = receivingAccountId, Username = "me@example.com", DisplayName = "Me",
+        });
+
+        await vm.RespondToCalendarInviteAsync(evt, "ACCEPTED", "accepted");
+
+        // Exactly one reply, sent from the receiving account (not the default/first account).
+        var reply = Assert.Single(smtp.SentReplies);
+        Assert.Equal(receivingAccountId, reply.Account.Id);
+        Assert.Equal("organizer@example.com", reply.OrganizerEmail);
+        Assert.Contains("PARTSTAT=ACCEPTED", reply.Ics);
+
+        // The calendar row now reflects the response.
+        Assert.Equal(CalendarResponseStatus.Accepted,
+            calendarService.StoredEvents.Find(e => e.Uid == "inv-1")!.ResponseStatus);
+    }
+
+    [Fact]
+    public async Task RespondToCalendarInviteAsync_NoSourceMessage_AnnouncesAndSendsNothing()
+    {
+        var smtp = new StubSmtpService();
+        var calendarService = new StubCalendarService();
+        var vm = new MainViewModel(
+            new StubImapMailService(), new StubAccountService(), new StubCredentialService(),
+            new StubLocalStoreService(), new StubOAuthService(), new StubSyncService(), new StubConfigService(),
+            new StubCommandRegistry(), new StubViewService(), new StubRuleService(), smtp,
+            calendarService: calendarService);
+
+        var accountId = Guid.NewGuid();
+        vm.Accounts.Add(new AccountModel { Id = accountId, Username = "me@example.com" });
+
+        var announced = new System.Collections.Generic.List<string>();
+        vm.AnnouncementRequested += (_, e) => announced.Add(e.Text);
+
+        var evt = new CalendarEvent
+        {
+            Uid = "inv-2", AccountId = accountId,
+            SourceMessageId = string.Empty,   // source email no longer available
+            ResponseStatus = CalendarResponseStatus.Pending,
+        };
+
+        await vm.RespondToCalendarInviteAsync(evt, "DECLINED", "declined");
+
+        Assert.Empty(smtp.SentReplies);
+        Assert.Contains(announced, a => a.Contains("no longer available"));
+    }
 }

--- a/QuickMail.Tests/StubServices.cs
+++ b/QuickMail.Tests/StubServices.cs
@@ -51,9 +51,16 @@ sealed class StubImapMailService : IMailService
 
 sealed class StubSmtpService : ISendMailService
 {
+    /// <summary>Records every ICS reply sent, so tests can assert which account it was routed from.</summary>
+    public List<(AccountModel Account, string Ics, string OrganizerEmail)> SentReplies { get; } = new();
+
     public Task SendAsync(ComposeModel compose, AccountModel account, string? password, CancellationToken ct = default) => Task.CompletedTask;
     public Task SendIcsReplyAsync(string icsReplyContent, AccountModel account, string? password,
-        string organizerEmail, CancellationToken ct = default) => Task.CompletedTask;
+        string organizerEmail, CancellationToken ct = default)
+    {
+        SentReplies.Add((account, icsReplyContent, organizerEmail));
+        return Task.CompletedTask;
+    }
 }
 
 sealed class StubAccountService : IAccountService
@@ -118,7 +125,10 @@ sealed class StubLocalStoreService : ILocalStoreService
     public Task UpdatePreviewsBatchAsync(Guid accountId, string folderName, IEnumerable<(string MessageId, string Preview)> updates) => Task.CompletedTask;
     public Task<bool> HasSummariesMissingRecipientsAsync() => Task.FromResult(false);
     public Task UpsertDetailAsync(MailMessageDetail detail) => Task.CompletedTask;
-    public Task<MailMessageDetail?> LoadDetailAsync(Guid accountId, string folderName, string messageId) => Task.FromResult<MailMessageDetail?>(null);
+    /// <summary>When set, <see cref="LoadDetailAsync"/> returns this seeded detail (tests use it to
+    /// stand in for a cached invite email); otherwise it returns null like the real cache-miss path.</summary>
+    public MailMessageDetail? SeededDetail { get; set; }
+    public Task<MailMessageDetail?> LoadDetailAsync(Guid accountId, string folderName, string messageId) => Task.FromResult(SeededDetail);
     public Task<string> GetMaxMessageKeyAsync(Guid accountId, string folderName) => Task.FromResult("0");
     public Task<HashSet<string>> GetAllMessageIdsAsync(Guid accountId, string folderName) => Task.FromResult(new HashSet<string>());
     public Task<int> CountSummariesAsync(Guid accountId) => Task.FromResult(0);

--- a/QuickMail/Models/CalendarEvent.cs
+++ b/QuickMail/Models/CalendarEvent.cs
@@ -140,6 +140,14 @@ public partial class CalendarEvent : ObservableObject
     /// <summary>True when the organizer cancelled the event (ICS METHOD:CANCEL).</summary>
     public bool IsCancelled => ResponseStatus == CalendarResponseStatus.Cancelled;
 
+    /// <summary>
+    /// True when this is a harvested email invitation the user has not yet responded to — a pending
+    /// RSVP: not user-authored, not a server-synced row, still <see cref="CalendarResponseStatus.Pending"/>.
+    /// Enter on such a row opens the Accept / Tentative / Decline response menu instead of the source email.
+    /// </summary>
+    public bool IsPendingInvite =>
+        !IsUserCreated && !IsGraph && ResponseStatus == CalendarResponseStatus.Pending;
+
     /// <summary>Start time as a nullable DateTime (local), for display and sorting.</summary>
     public DateTime? StartTime => StartTimeTicks.HasValue
         ? new DateTime(StartTimeTicks.Value, DateTimeKind.Utc).ToLocalTime()

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -6176,6 +6176,70 @@ public partial class MainViewModel : ObservableObject, IDisposable
             return;
         }
 
+        await SendIcsReplyForAsync(invite, account, partStat, actionLabel,
+            MessageDetail!.MessageId, MessageDetail!.FolderName);
+    }
+
+    /// <summary>
+    /// Responds to a pending meeting invitation directly from the calendar list (Accept / Tentative /
+    /// Decline) without opening the source email. Loads the invite from its source message (local
+    /// cache first, IMAP fallback) and routes the reply through the account that RECEIVED the invite
+    /// (<paramref name="evt"/>.AccountId) \u2014 never a default account (see issue #296).
+    /// </summary>
+    public async Task RespondToCalendarInviteAsync(CalendarEvent evt, string partStat, string actionLabel)
+    {
+        if (evt == null) return;
+
+        if (string.IsNullOrEmpty(evt.SourceMessageId))
+        {
+            Announce("The original invitation email is no longer available, so a response can't be sent.",
+                     AnnouncementCategory.Result);
+            return;
+        }
+
+        // Route strictly through the account that received the invite (#296 wrong-account routing).
+        var account = Accounts.FirstOrDefault(a => a.Id == evt.AccountId);
+        if (account == null)
+        {
+            Announce("Cannot send calendar response: account not found.", AnnouncementCategory.Result);
+            return;
+        }
+
+        MailMessageDetail? detail;
+        try
+        {
+            detail = await _localStore.LoadDetailAsync(evt.AccountId, evt.SourceFolder, evt.SourceMessageId)
+                     ?? await _imap.GetMessageDetailAsync(evt.AccountId, evt.SourceFolder, evt.SourceMessageId);
+        }
+        catch (Exception ex)
+        {
+            LogService.Log("RespondToCalendarInvite: load source", ex);
+            Announce("The original invitation email couldn't be opened, so a response can't be sent.",
+                     AnnouncementCategory.Result);
+            return;
+        }
+
+        var invite = detail?.CalendarInvite;
+        if (invite == null)
+        {
+            Announce("The original invitation email is no longer available, so a response can't be sent.",
+                     AnnouncementCategory.Result);
+            return;
+        }
+
+        await SendIcsReplyForAsync(invite, account, partStat, actionLabel,
+            evt.SourceMessageId, evt.SourceFolder);
+    }
+
+    /// <summary>
+    /// Core ICS reply logic shared by the reading-pane RSVP buttons and the calendar-list response
+    /// menu. Generates the REPLY, sends it from <paramref name="account"/> (the account that RECEIVED
+    /// the invite \u2014 never a default), announces the outcome, and updates the calendar row's
+    /// response status so the calendar reflects the reply immediately.
+    /// </summary>
+    private async Task SendIcsReplyForAsync(IcsModel invite, AccountModel account, string partStat,
+        string actionLabel, string sourceMessageId, string sourceFolder)
+    {
         try
         {
             var attendeeName = account.SenderDisplayName;
@@ -6216,8 +6280,8 @@ public partial class MainViewModel : ObservableObject, IDisposable
                     EndTimeTicks     = invite.EndTime?.ToUniversalTime().Ticks,
                     Sequence         = invite.Sequence,
                     Method           = invite.Method,
-                    SourceMessageId  = MessageDetail!.MessageId,
-                    SourceFolder     = MessageDetail!.FolderName,
+                    SourceMessageId  = sourceMessageId,
+                    SourceFolder     = sourceFolder,
                     ResponseStatus   = status,
                 };
                 await _calendarService.UpsertEventAsync(evt);

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -1231,6 +1231,30 @@ public partial class MainWindow : Window
             execute: () => _vm.CalendarVm?.ExportEventCommand.Execute(_vm.CalendarVm.SelectedEvent),
             isAvailable: () => CalendarList.IsKeyboardFocusWithin && _vm.CalendarVm?.SelectedEvent != null));
 
+        // ── Respond to a pending invitation (Enter opens the menu; these are the palette entries) ──
+        // No default key: Enter (calendar.openSourceMessage) shows the response menu, which is the
+        // primary entry point. These keep the actions discoverable and rebindable in the palette.
+        bool PendingInviteFocused() =>
+            CalendarList.IsKeyboardFocusWithin && _vm.CalendarVm?.SelectedEvent?.IsPendingInvite == true;
+        void RespondSelected(string partStat, string actionLabel)
+        {
+            var evt = _vm.CalendarVm?.SelectedEvent;
+            if (evt != null) _ = _vm.RespondToCalendarInviteAsync(evt, partStat, actionLabel);
+        }
+
+        _registry.Register(new CommandDefinition(
+            id: "calendar.acceptInvite", category: "Calendar", title: "Accept Invitation",
+            execute: () => RespondSelected("ACCEPTED", "accepted"),
+            isAvailable: PendingInviteFocused));
+        _registry.Register(new CommandDefinition(
+            id: "calendar.tentativeInvite", category: "Calendar", title: "Tentative Invitation",
+            execute: () => RespondSelected("TENTATIVE", "tentatively accepted"),
+            isAvailable: PendingInviteFocused));
+        _registry.Register(new CommandDefinition(
+            id: "calendar.declineInvite", category: "Calendar", title: "Decline Invitation",
+            execute: () => RespondSelected("DECLINED", "declined"),
+            isAvailable: PendingInviteFocused));
+
         // No default key: Ctrl+Shift+S (view.search) routes here while the calendar is open,
         // so search is ONE gesture app-wide. Palette entry + rebindable id kept.
         _registry.Register(new CommandDefinition(
@@ -2253,6 +2277,16 @@ public partial class MainWindow : Window
     {
         var evt = _vm.CalendarVm?.SelectedEvent;
         if (evt == null) return;
+
+        // A pending meeting invitation opens an RSVP context menu (Accept / Tentative / Decline /
+        // Open full appointment) so the user can respond without leaving the calendar to find the
+        // source email. Every other row keeps its existing behaviour.
+        if (evt.IsPendingInvite)
+        {
+            ShowInviteResponseMenu(evt);
+            return;
+        }
+
         // Harvested email invites open their source message; everything else routes through
         // EditEvent, which itself edits what is editable (local rows, single Microsoft/Google
         // events) and announces the right read-only message otherwise — so Enter and E always
@@ -2261,6 +2295,70 @@ public partial class MainWindow : Window
             _vm.CalendarVm?.OpenSourceMessageCommand.Execute(evt);
         else
             _vm.CalendarVm?.EditEventCommand.Execute(evt);
+    }
+
+    /// <summary>
+    /// Shows the RSVP context menu for a pending meeting invitation, anchored below the focused
+    /// calendar row. Accept / Tentative / Decline send the response through the VM (from the account
+    /// that received the invite); "Open full appointment" opens the source email. Focus returns to
+    /// the calendar list when the menu closes. UI-only concern (menu + keyboard + focus) — the
+    /// respond logic itself lives in the ViewModel.
+    /// </summary>
+    private void ShowInviteResponseMenu(CalendarEvent evt)
+    {
+        var menu = new ContextMenu();
+
+        MenuItem Item(string header, RoutedEventHandler onClick)
+        {
+            var mi = new MenuItem { Header = header };
+            mi.Click += onClick;
+            return mi;
+        }
+
+        menu.Items.Add(Item("Accept", async (_, _) =>
+        {
+            await _vm.RespondToCalendarInviteAsync(evt, "ACCEPTED", "accepted");
+            FocusCalendarList();
+        }));
+        menu.Items.Add(Item("Tentative", async (_, _) =>
+        {
+            await _vm.RespondToCalendarInviteAsync(evt, "TENTATIVE", "tentatively accepted");
+            FocusCalendarList();
+        }));
+        menu.Items.Add(Item("Decline", async (_, _) =>
+        {
+            await _vm.RespondToCalendarInviteAsync(evt, "DECLINED", "declined");
+            FocusCalendarList();
+        }));
+        menu.Items.Add(new Separator());
+        menu.Items.Add(Item("Open full appointment", (_, _) =>
+            _vm.CalendarVm?.OpenSourceMessageCommand.Execute(evt)));
+
+        // Anchor below the focused row when we can obtain its container; otherwise the list itself.
+        UIElement target = CalendarList;
+        if (CalendarList.SelectedIndex >= 0
+            && CalendarList.ItemContainerGenerator.ContainerFromIndex(CalendarList.SelectedIndex) is ListBoxItem row)
+            target = row;
+
+        menu.PlacementTarget = target;
+        menu.Placement = System.Windows.Controls.Primitives.PlacementMode.Bottom;
+        menu.Closed += (_, _) => Dispatcher.InvokeAsync(FocusCalendarList, DispatcherPriority.Input);
+
+        // A ContextMenu opened programmatically (IsOpen = true) does not reliably land keyboard focus
+        // on the first item the way a right-click does — so a screen reader may not announce the menu.
+        // Focus the first item explicitly once the menu is up so the user hears "Accept" straight away.
+        menu.Opened += (_, _) => Dispatcher.InvokeAsync(() =>
+        {
+            if (menu.ItemContainerGenerator.ContainerFromIndex(0) is MenuItem first)
+            {
+                first.Focus();
+                Keyboard.Focus(first);
+            }
+        }, DispatcherPriority.Input);
+
+        // Short Hint (respects the user's hint preference) — the menu items self-voice on focus.
+        AccessibilityHelper.Announce(this, "Respond to invitation.", category: AnnouncementCategory.Hint);
+        menu.IsOpen = true;
     }
 
     /// <summary>Opens the modeless appointment editor and restores focus to the list on close.</summary>

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -597,9 +597,18 @@ Move through the list with the **Up and Down arrows**. The list has **Subject**,
 From any event you have two quick ways to see more:
 
 - Press **Tab** once to move into a **details box** below the list that shows the full appointment (title, when, whether it repeats, location, and for meeting invitations the organizer and your response status), read from the top so a screen reader can review it line by line.
-- Press **Enter** to open the full appointment: your own appointments open in the editor, and a meeting invitation opens its source email.
+- Press **Enter** to act on the appointment. On an invitation you **haven't answered yet**, Enter opens a short menu — **Accept**, **Tentative**, **Decline**, or **Open full appointment** — so you can respond right from the calendar (see below). On your own appointment, Enter opens the editor; on an invitation you've already answered, it opens the source email.
 
 If you prefer each row spoken with field labels ("Subject …, when …, location …") instead of the concise form, turn on **Show field labels in the calendar event list** in **Settings → General**. It takes effect immediately.
+
+### Responding to a meeting invitation
+
+Invitations you receive by email show in the calendar with a **Pending** status until you answer them. You can respond without opening the email:
+
+1. Arrow to the pending invitation and press **Enter**. A menu opens with focus on the first choice.
+2. Choose **Accept**, **Tentative**, or **Decline** — or **Open full appointment** to read the original email instead. Press **Escape** to close the menu without responding.
+
+QuickMail sends your reply to the organizer from the account that received the invitation and updates the appointment's status, so it no longer shows as pending. Accept, Tentative, and Decline are also in the Command Palette (**Ctrl+Shift+P**) when a pending invitation is selected.
 
 ### Creating an appointment
 
@@ -712,7 +721,7 @@ These work while the calendar list (or, where noted, the Month grid) has focus:
 | `T` | Today (filter to today in Agenda; jump to today in Day/Week/Month) |
 | `Ctrl+Left` / `Ctrl+Right` | Previous / next day, week, or month |
 | `Ctrl+G` | Go to Date |
-| `Enter` | Open an invitation's source email, edit your own appointment, or (in Month view) open the selected day |
+| `Enter` | Respond to a pending invitation (Accept / Tentative / Decline menu); or edit your own appointment; or open an answered invitation's source email; or (in Month view) open the selected day |
 | `N` | New appointment |
 | `E` | Edit appointment |
 | `Delete` | Delete appointment |

--- a/docs/release-notes-v0.8.33.md
+++ b/docs/release-notes-v0.8.33.md
@@ -39,6 +39,8 @@ Turn on **Remind me before appointments** in **Settings → General** and choose
 
 Open an email that contains a meeting invitation and QuickMail adds an event card to the top with **Accept**, **Tentative**, and **Decline** buttons. Choosing one replies to the organizer and updates your calendar right away. Cancellations remove the matching entry automatically.
 
+You can also respond straight from the calendar: an invitation you haven't answered shows as **Pending**, and pressing **Enter** on it opens a short menu — **Accept**, **Tentative**, **Decline**, or **Open full appointment** — so you can reply without leaving the calendar to find the email.
+
 ### Connect an online calendar — per account
 
 Calendars connect **per account**, just like contact sync. When you add an account — or later, in **Manage Accounts** — check **Sync calendar from this account** and QuickMail shows that account's calendar:
@@ -181,3 +183,8 @@ Full details, including exactly what a report contains (and what it never contai
 ### Markdown preview window opened blank (#301)
 
 - `MarkdownPreviewWindow`'s `NavigationStarting` handler cancelled every navigation except `about:`, which cancelled its own `data:text/html` content — how current WebView2 runtimes deliver `NavigateToString` — leaving a blank `about:blank` page. It now allows `data:` through (as `MessageWindow` already does); external `http`/`https`/`mailto` links still route to the default browser and the content stays CSP-locked in `BuildHtml`.
+
+### Respond to invitations from the calendar
+
+- Pressing **Enter** on a pending email invitation in the calendar (new `CalendarEvent.IsPendingInvite` = `!IsUserCreated && !IsGraph && ResponseStatus == Pending`) opens a `ContextMenu` (Accept / Tentative / Decline / — / Open full appointment) instead of jumping to the source email. The menu is anchored to the focused row and, because a programmatically-opened `ContextMenu` doesn't reliably focus its first item, an `Opened` handler focuses "Accept" so a screen reader announces it; `Closed` returns focus to the list. Every non-pending row keeps its prior Enter dispatch (edit / open source / drill day).
+- `MainViewModel.SendIcsReply` was refactored into a shared `SendIcsReplyForAsync(invite, account, partStat, actionLabel, sourceMessageId, sourceFolder)`; the reading-pane card and the new `RespondToCalendarInviteAsync(evt, partStat, actionLabel)` both call it. The calendar path loads the invite's source message (`LoadDetailAsync` → `GetMessageDetailAsync` fallback), replies **from the account that received the invite** (`evt.AccountId` — not any default, guarding against the #296 mis-routing), announces the result, and updates the row's response status. Palette commands `calendar.acceptInvite` / `calendar.tentativeInvite` / `calendar.declineInvite` (no default key) are available when a pending invitation is selected. Tests: reply routes from the receiving account and updates status; empty-source guard; `IsPendingInvite` predicate.


### PR DESCRIPTION
## Feature
Pending email invitations were visible in the calendar but couldn't be answered without leaving to find the source email. Now **Enter** on a **pending** invitation opens a context menu — **Accept / Tentative / Decline / Open full appointment** — so you can respond in place. Non-pending rows keep their existing Enter behavior.

## How it works
- `CalendarEvent.IsPendingInvite` = `!IsUserCreated && !IsGraph && ResponseStatus == Pending`.
- `ActivateSelectedCalendarEvent` branches to a `ContextMenu` anchored to the focused row. A programmatically-opened menu doesn't reliably focus its first item, so an `Opened` handler focuses **Accept**; `Closed` returns focus to the list. **Kelly verified the screen-reader behavior live.**
- `SendIcsReply` refactored into a shared `SendIcsReplyForAsync`; the reading-pane card and the new `RespondToCalendarInviteAsync` both use it. The calendar path loads the invite's source message and replies **from the receiving account** (`evt.AccountId`), guarding against the #296 mis-routing.
- Palette: `calendar.acceptInvite`/`tentativeInvite`/`declineInvite` (no default key), available when a pending invitation is selected.

## Tests / docs
- New: reply routes from the receiving account + updates status; empty-source guard; `IsPendingInvite` predicate. Full suite **1439** passing.
- Docs: user guide (*Reading an appointment* + new *Responding to a meeting invitation* + shortcuts table); release notes (*Meeting invitations* + Internal).