### PR TITLE
Bump to 0.8.34 + start release notes

### DIFF
--- a/QuickMail/QuickMail.csproj
+++ b/QuickMail/QuickMail.csproj
@@ -15,9 +15,9 @@
          System.Windows(.Media) types this codebase uses unqualified (Point, Size, Color, Brush,
          Application, MessageBox, ...). -->
     <UseWindowsForms>true</UseWindowsForms>
-    <Version>0.8.33</Version>
-    <AssemblyVersion>0.8.33</AssemblyVersion>
-    <FileVersion>0.8.33</FileVersion>
+    <Version>0.8.34</Version>
+    <AssemblyVersion>0.8.34</AssemblyVersion>
+    <FileVersion>0.8.34</FileVersion>
     <!-- Velopack needs a hand-written Main that runs VelopackApp.Build().Run() before WPF
          initializes (install/update/uninstall hooks run and may exit the process). App.xaml
          therefore compiles as Page (no generated Main) and the entry point is declared here. -->

--- a/docs/release-notes-v0.8.34.md
+++ b/docs/release-notes-v0.8.34.md
@@ -1,0 +1,39 @@
+# QuickMail v0.8.34 Release Notes
+
+## Download
+
+Two options are available for v0.8.34:
+
+| Download | When to use |
+|----------|-------------|
+| **`QuickMail-win.msi`** — Windows installer | Recommended for most users. A standard setup wizard with license agreement; installs per-user with no elevation required, adds the WebView2 Runtime if missing, and enables automatic updates. |
+| **`QuickMail.exe`** — standalone portable executable | No installation required. Copy it anywhere and run. |
+
+Both downloads include the .NET 8 runtime — you do not need to install .NET separately.
+
+<!--
+Work in progress. Add user-facing sections as features and fixes land, following the
+0.8.33 notes for structure and voice:
+  ## New: <feature>
+  ## Fixed: <thing>
+  ## Accessibility        (only if there's release-specific behavior worth calling out)
+  ## Thank You to Contributors
+  ## Reporting Issues     (the standard footer below — keep it last-but-one, before Internal)
+  ## Internal             (per-PR technical changelog)
+Every release notes file must end with the Reporting Issues footer
+(docs/reporting-issues-footer.md). Publish the user guide with the release
+(gh workflow run publish-user-guide.yml --ref main — it does not auto-fire on a
+token-created release).
+-->
+
+---
+
+## Reporting Issues
+
+Found a problem or have a suggestion? There are three ways to reach us — pick the one that fits:
+
+1. **Report a Bug → Send** (Help menu, inside QuickMail). Files the report for you anonymously — it includes no email address or other identifying information, so there is no way to follow up with you. **Best when you don't want any follow-up.**
+2. **Report a Bug → Copy report and open GitHub** (Help menu). Opens a pre-filled issue that you submit under your own GitHub account, so your GitHub contact information is attached. **Best when you have a GitHub account and want automatic filing plus direct contact.**
+3. **Email** [quickmailissues@theideaplace.net](mailto:quickmailissues@theideaplace.net). **Best when you don't mind sending email and want a personal follow-up.**
+
+Full details, including exactly what a report contains (and what it never contains), are in the [Reporting Issues section of the User Guide](https://kellylford.github.io/QuickMail/reporting-issues.html).


### PR DESCRIPTION
v0.8.33 shipped. Bumps csproj to 0.8.34 (all three version fields) and scaffolds `docs/release-notes-v0.8.34.md` (download section + Reporting Issues footer + a WIP guide comment). Next version must stay > 0.8.33 for auto-update ordering.