### PR TITLE
Add message-action announcement category with its own toggle — #317

### DIFF
--- a/QuickMail.Tests/ConfigServiceSaveTests.cs
+++ b/QuickMail.Tests/ConfigServiceSaveTests.cs
@@ -49,6 +49,24 @@ public class ConfigServiceSaveTests
     }
 
     [Fact]
+    public void AnnounceMessageActions_DefaultsOn_AndRoundTrips()
+    {
+        // Issue #317: delete/archive announcements get their own toggle, on by default, and must
+        // survive a real INI write→read (it's written under [global], like the other announce keys).
+        var profile = MakeTempProfile();
+        var service = new ConfigService(profile);
+
+        Assert.True(service.Load().AnnounceMessageActions); // on by default
+
+        var config = service.Load();
+        config.AnnounceMessageActions = false;
+        service.Save(config);
+
+        var reloaded = new ConfigService(profile).Load();
+        Assert.False(reloaded.AnnounceMessageActions);
+    }
+
+    [Fact]
     public void NotifyOnNewMail_DefaultsOff_AndRoundTrips()
     {
         var profile = MakeTempProfile();

--- a/QuickMail.Tests/SettingsViewModelTests.cs
+++ b/QuickMail.Tests/SettingsViewModelTests.cs
@@ -241,6 +241,27 @@ public class SettingsViewModelTests
         Assert.False(vmLoad.AnnounceFlagStatus);
     }
 
+    [Fact]
+    public void AnnounceMessageActions_DefaultsToTrue()
+    {
+        // Issue #317: delete/archive announcements are on by default.
+        var vm = new SettingsViewModel(new StubConfigService(), new StubCommandRegistry());
+        Assert.True(vm.AnnounceMessageActions);
+    }
+
+    [Fact]
+    public void AnnounceMessageActions_LoadAndSave_RoundTrips()
+    {
+        var configService = new StubConfigService();
+
+        var vmSave = new SettingsViewModel(configService, new StubCommandRegistry());
+        vmSave.AnnounceMessageActions = false;
+        vmSave.SaveCommand.Execute(null);
+
+        var vmLoad = new SettingsViewModel(configService, new StubCommandRegistry());
+        Assert.False(vmLoad.AnnounceMessageActions);
+    }
+
     // ── Logging ────────────────────────────────────────────────────────────────────
 
     [Fact]

--- a/QuickMail/Models/AnnouncementCategory.cs
+++ b/QuickMail/Models/AnnouncementCategory.cs
@@ -2,7 +2,8 @@ namespace QuickMail.Models;
 
 public enum AnnouncementCategory
 {
-    Hint,    // instructional tips the user can silence once familiar
-    Status,  // background loading and sync progress
-    Result   // direct outcome of a user action
+    Hint,          // instructional tips the user can silence once familiar
+    Status,        // background loading and sync progress
+    Result,        // direct outcome of a user action
+    MessageAction  // outcome of a common message command (delete, archive) — its own toggle (issue #317)
 }

--- a/QuickMail/Models/ConfigModel.cs
+++ b/QuickMail/Models/ConfigModel.cs
@@ -101,6 +101,13 @@ public class ConfigModel
     /// <summary>Announce action results (search counts, move/delete confirmations).</summary>
     public bool AnnounceResults { get; set; } = true;
 
+    /// <summary>
+    /// Announce the outcome of common message commands — delete and archive (issue #317). Split out
+    /// from <see cref="AnnounceStatus"/> so users can silence this frequent chatter (it can interrupt
+    /// the screen reader reading the next message) without muting sync/loading progress. On by default.
+    /// </summary>
+    public bool AnnounceMessageActions { get; set; } = true;
+
     /// <summary>Announce spelling errors while typing (before the word is complete). Default off.</summary>
     public bool AnnounceSpellingWhileTyping { get; set; } = false;
 

--- a/QuickMail/Services/ConfigService.cs
+++ b/QuickMail/Services/ConfigService.cs
@@ -247,6 +247,7 @@ public class ConfigService : IConfigService
                     case "announcehints":        config.AnnounceHints        = ParseBool(value); break;
                     case "announcestatus":       config.AnnounceStatus       = ParseBool(value); break;
                     case "announceresults":      config.AnnounceResults      = ParseBool(value); break;
+                    case "announcemessageactions": config.AnnounceMessageActions = ParseBool(value); break;
                     case "announcespellingwhiletyping":      config.AnnounceSpellingWhileTyping      = ParseBool(value); break;
                     case "announcespellingwhilenavigating": config.AnnounceSpellingWhileNavigating = ParseBool(value); break;
                     case "announcespellingsuggestions":     config.AnnounceSpellingSuggestions     = ParseBool(value); break;
@@ -481,6 +482,11 @@ public class ConfigService : IConfigService
         sb.AppendLine($"AnnounceResults = {(config.AnnounceResults ? "on" : "off")}");
         sb.AppendLine("# Announce action outcomes such as search result counts and move confirmations.");
         sb.AppendLine("# Values: on, off.");
+        sb.AppendLine();
+
+        sb.AppendLine($"AnnounceMessageActions = {(config.AnnounceMessageActions ? "on" : "off")}");
+        sb.AppendLine("# Announce delete and archive outcomes (e.g. \"1 message archived\"). Split from");
+        sb.AppendLine("# AnnounceStatus so this frequent chatter can be silenced on its own. Values: on, off.");
         sb.AppendLine();
 
         sb.AppendLine($"AnnounceSpellingWhileTyping = {(config.AnnounceSpellingWhileTyping ? "on" : "off")}");

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -583,6 +583,28 @@ public partial class MainViewModel : ObservableObject, IDisposable
     [ObservableProperty]
     private string _statusText = "Ready";
 
+    /// <summary>
+    /// Category the View should use when announcing the *current* <see cref="StatusText"/> change to a
+    /// screen reader. A one-shot override: <see cref="SetStatus"/> sets it, assigns StatusText (whose
+    /// change the View handles synchronously and reads this value), then resets it to
+    /// <see cref="AnnouncementCategory.Status"/>. So a plain <c>StatusText = …</c> always announces as
+    /// Status, while delete/archive route their chatter through <see cref="AnnouncementCategory.MessageAction"/>
+    /// so it can be silenced independently (issue #317).
+    /// </summary>
+    public AnnouncementCategory StatusAnnouncementCategory { get; private set; } = AnnouncementCategory.Status;
+
+    /// <summary>
+    /// Sets the visible status text and tags the accompanying announcement with <paramref name="category"/>.
+    /// See <see cref="StatusAnnouncementCategory"/> for why the reset is safe (StatusText's PropertyChanged
+    /// fires synchronously, so the View captures the category before this method returns).
+    /// </summary>
+    private void SetStatus(string text, AnnouncementCategory category)
+    {
+        StatusAnnouncementCategory = category;
+        StatusText = text;
+        StatusAnnouncementCategory = AnnouncementCategory.Status;
+    }
+
     [ObservableProperty]
     private string _rulesStatusText = string.Empty;
 
@@ -4394,7 +4416,9 @@ public partial class MainViewModel : ObservableObject, IDisposable
 
         var minIdx = toDelete.Min(m => Messages.IndexOf(m));
         var label  = toDelete.Count == 1 ? "message" : $"{toDelete.Count} messages";
-        StatusText    = $"Deleting {label}…";
+        // Delete/archive progress + outcome go through the MessageAction category (issue #317) so users
+        // can silence this frequent chatter — it can interrupt the screen reader reading the next message.
+        SetStatus($"Deleting {label}…", AnnouncementCategory.MessageAction);
         IsBusy        = true;
         MessageDetail = null;
         IsMessageOpen = false;
@@ -4487,19 +4511,20 @@ public partial class MainViewModel : ObservableObject, IDisposable
                     ScheduleFolderCountRefresh(acctId);
 
             var count = toDelete.Count;
-            StatusText = Messages.Count > 0
+            SetStatus(Messages.Count > 0
                 ? $"{count} {(count == 1 ? "message" : "messages")} deleted."
-                : $"{count} {(count == 1 ? "message" : "messages")} deleted. Folder is now empty.";
+                : $"{count} {(count == 1 ? "message" : "messages")} deleted. Folder is now empty.",
+                AnnouncementCategory.MessageAction);
         }
         catch (OperationCanceledException)
         {
-            StatusText = "Delete cancelled.";
+            SetStatus("Delete cancelled.", AnnouncementCategory.MessageAction);
         }
         catch (Exception ex)
         {
-            // Honest uncertainty message — the delete may have partially or fully succeeded.
-            StatusText = "Delete may not have completed — refreshing.";
-            Announce("Delete may not have completed — refreshing.", AnnouncementCategory.Result);
+            // Honest uncertainty message — the delete may have partially or fully succeeded. Kept as a
+            // Result (not MessageAction) so the failure is still heard even if delete/archive chatter is off.
+            SetStatus("Delete may not have completed — refreshing.", AnnouncementCategory.Result);
             LogService.Log("DeleteMessages", ex);
 
             // Schedule targeted sync of affected folders to reconcile the UI with server state.
@@ -4608,17 +4633,17 @@ public partial class MainViewModel : ObservableObject, IDisposable
         if (plan.Count == 0)
         {
             if (anyMissingArchive)
-            {
-                StatusText = "No Archive folder for this account. Right-click a folder and choose Set as Archive Folder.";
-                Announce(StatusText, AnnouncementCategory.Result);
-            }
+                // Setup guidance stays a Result (not MessageAction): if archive silently did nothing,
+                // the user must hear why even if delete/archive chatter is turned off.
+                SetStatus("No Archive folder for this account. Right-click a folder and choose Set as Archive Folder.",
+                    AnnouncementCategory.Result);
             return;
         }
 
         var actionable = plan.SelectMany(p => p.Group).ToList();
         var minIdx = actionable.Min(m => Messages.IndexOf(m));
         var label  = actionable.Count == 1 ? "message" : $"{actionable.Count} messages";
-        StatusText    = $"Archiving {label}…";
+        SetStatus($"Archiving {label}…", AnnouncementCategory.MessageAction);
         IsBusy        = true;
         MessageDetail = null;
         IsMessageOpen = false;
@@ -4685,17 +4710,17 @@ public partial class MainViewModel : ObservableObject, IDisposable
                     ScheduleFolderCountRefresh(acctId);
 
             var count = actionable.Count;
-            StatusText = $"{count} {(count == 1 ? "message" : "messages")} archived.";
-            Announce(StatusText, AnnouncementCategory.Result);
+            SetStatus($"{count} {(count == 1 ? "message" : "messages")} archived.",
+                AnnouncementCategory.MessageAction);
         }
         catch (OperationCanceledException)
         {
-            StatusText = "Archive cancelled.";
+            SetStatus("Archive cancelled.", AnnouncementCategory.MessageAction);
         }
         catch (Exception ex)
         {
-            StatusText = "Archive may not have completed — refreshing.";
-            Announce("Archive may not have completed — refreshing.", AnnouncementCategory.Result);
+            // Kept as a Result (not MessageAction) so the failure is heard even if archive chatter is off.
+            SetStatus("Archive may not have completed — refreshing.", AnnouncementCategory.Result);
             LogService.Log("ArchiveMessages", ex);
 
             // Reconcile the affected source folders with server state after a short delay.

--- a/QuickMail/ViewModels/SettingsViewModel.cs
+++ b/QuickMail/ViewModels/SettingsViewModel.cs
@@ -48,6 +48,9 @@ public partial class SettingsViewModel : ObservableObject
     private bool _announceResults;
 
     [ObservableProperty]
+    private bool _announceMessageActions;
+
+    [ObservableProperty]
     private bool _announceSpellingWhileTyping;
 
     [ObservableProperty]
@@ -266,6 +269,7 @@ public partial class SettingsViewModel : ObservableObject
         AnnounceHints       = cfg.AnnounceHints;
         AnnounceStatus      = cfg.AnnounceStatus;
         AnnounceResults     = cfg.AnnounceResults;
+        AnnounceMessageActions = cfg.AnnounceMessageActions;
         AnnounceSpellingWhileTyping      = cfg.AnnounceSpellingWhileTyping;
         AnnounceSpellingWhileNavigating  = cfg.AnnounceSpellingWhileNavigating;
         AnnounceSpellingSuggestions      = cfg.AnnounceSpellingSuggestions;
@@ -338,6 +342,7 @@ public partial class SettingsViewModel : ObservableObject
         cfg.AnnounceHints       = AnnounceHints;
         cfg.AnnounceStatus      = AnnounceStatus;
         cfg.AnnounceResults     = AnnounceResults;
+        cfg.AnnounceMessageActions = AnnounceMessageActions;
         cfg.AnnounceSpellingWhileTyping      = AnnounceSpellingWhileTyping;
         cfg.AnnounceSpellingWhileNavigating  = AnnounceSpellingWhileNavigating;
         cfg.AnnounceSpellingSuggestions      = AnnounceSpellingSuggestions;

--- a/QuickMail/Views/AccessibilityHelper.cs
+++ b/QuickMail/Views/AccessibilityHelper.cs
@@ -19,18 +19,20 @@ internal static class AccessibilityHelper
 {
     private const string ActivityId = "QuickMailAnnouncement";
 
-    private static bool _masterEnabled  = true;
-    private static bool _hintsEnabled   = true;
-    private static bool _statusEnabled  = true;
-    private static bool _resultsEnabled = true;
+    private static bool _masterEnabled         = true;
+    private static bool _hintsEnabled          = true;
+    private static bool _statusEnabled         = true;
+    private static bool _resultsEnabled        = true;
+    private static bool _messageActionsEnabled = true;
 
     /// <summary>Called on startup and after every settings save so changes apply immediately.</summary>
     public static void Configure(ConfigModel config)
     {
-        _masterEnabled  = config.CustomAnnouncements;
-        _hintsEnabled   = config.AnnounceHints;
-        _statusEnabled  = config.AnnounceStatus;
-        _resultsEnabled = config.AnnounceResults;
+        _masterEnabled         = config.CustomAnnouncements;
+        _hintsEnabled          = config.AnnounceHints;
+        _statusEnabled         = config.AnnounceStatus;
+        _resultsEnabled        = config.AnnounceResults;
+        _messageActionsEnabled = config.AnnounceMessageActions;
     }
 
     /// <summary>
@@ -87,10 +89,11 @@ internal static class AccessibilityHelper
 
     private static bool IsCategoryEnabled(AnnouncementCategory c) => c switch
     {
-        AnnouncementCategory.Hint   => _hintsEnabled,
-        AnnouncementCategory.Status => _statusEnabled,
-        AnnouncementCategory.Result => _resultsEnabled,
-        _                           => true
+        AnnouncementCategory.Hint          => _hintsEnabled,
+        AnnouncementCategory.Status        => _statusEnabled,
+        AnnouncementCategory.Result        => _resultsEnabled,
+        AnnouncementCategory.MessageAction => _messageActionsEnabled,
+        _                                  => true
     };
 
     // ── Debug input trace ────────────────────────────────────────────────────

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -176,6 +176,9 @@ public partial class MainWindow : Window
     // "12 messages", …) coalesce into a single final reading by the screen reader.
     private DispatcherTimer? _statusAnnounceTimer;
     private string? _pendingStatusText;
+    // Category captured at queue time (issue #317) so delete/archive chatter announces under the
+    // MessageAction toggle while sync/loading updates stay Status. Last queued write wins.
+    private AnnouncementCategory _pendingStatusCategory = AnnouncementCategory.Status;
     private static readonly TimeSpan StatusAnnounceDebounce = TimeSpan.FromMilliseconds(500);
 
     // Debounces search result-count announcements so rapid keystrokes coalesce.
@@ -549,7 +552,7 @@ public partial class MainWindow : Window
             }
 
             if (e.PropertyName == nameof(MainViewModel.StatusText) && !string.IsNullOrEmpty(vm.StatusText))
-                QueueStatusAnnounce(vm.StatusText);
+                QueueStatusAnnounce(vm.StatusText, vm.StatusAnnouncementCategory);
 
             if (e.PropertyName == nameof(MainViewModel.SearchAnnouncement) && !string.IsNullOrEmpty(vm.SearchAnnouncement))
                 QueueSearchAnnounce(vm.SearchAnnouncement);
@@ -800,10 +803,11 @@ public partial class MainWindow : Window
     // Debounced UIA notification for rapid status-text changes during sync. Multiple
     // per-folder updates ("5 messages", "12 messages", …) are coalesced so the screen
     // reader hears only the final count once sync settles.
-    private void QueueStatusAnnounce(string text)
+    private void QueueStatusAnnounce(string text, AnnouncementCategory category = AnnouncementCategory.Status)
     {
         if (string.IsNullOrEmpty(text)) return;
-        _pendingStatusText = text;
+        _pendingStatusText     = text;
+        _pendingStatusCategory = category;   // captured now; the VM resets its one-shot override after this returns
 
         if (_statusAnnounceTimer == null)
         {
@@ -811,10 +815,11 @@ public partial class MainWindow : Window
             _statusAnnounceTimer.Tick += (_, _) =>
             {
                 _statusAnnounceTimer!.Stop();
-                var pending = _pendingStatusText;
+                var pending  = _pendingStatusText;
+                var category = _pendingStatusCategory;
                 _pendingStatusText = null;
                 if (!string.IsNullOrEmpty(pending))
-                    AccessibilityHelper.Announce(this, pending, category: AnnouncementCategory.Status);
+                    AccessibilityHelper.Announce(this, pending, category: category);
             };
         }
 

--- a/QuickMail/Views/SettingsDialog.xaml
+++ b/QuickMail/Views/SettingsDialog.xaml
@@ -270,6 +270,13 @@
                                           Margin="16,4,0,0"
                                           AutomationProperties.Name="Announce outcomes such as search result counts and move confirmations"/>
 
+                                <CheckBox Content="Announce _delete and archive actions"
+                                          IsChecked="{Binding AnnounceMessageActions, Mode=TwoWay}"
+                                          Margin="16,4,0,0"
+                                          AutomationProperties.Name="Announce delete and archive outcomes"/>
+                                <TextBlock Text="Turn off to stop delete and archive announcements from interrupting the next message."
+                                           Foreground="{DynamicResource Theme.TextSecondary}" FontSize="{DynamicResource Theme.FontSizeSmall}" Margin="16,0,0,8"/>
+
                                 <CheckBox Content="Announce spelling errors _when typing"
                                           IsChecked="{Binding AnnounceSpellingWhileTyping, Mode=TwoWay}"
                                           Margin="16,4,0,0"

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -261,6 +261,7 @@ When Reading Mode is set to **Window**, messages open in a separate window. Each
 | `Ctrl+Shift+R` | Reply All |
 | `Ctrl+F` | Forward |
 | `Delete` | Delete |
+| `Alt+Delete` | Archive |
 | `Ctrl+Q` | Mark as Read |
 | `Ctrl+Shift+G` | Grab Addresses |
 
@@ -277,6 +278,16 @@ Press `Ctrl+Q` to mark the selected message or messages as read. Messages are al
 ### Deleting Messages
 
 Press **Delete**. Deleted messages go to Trash. Press `Ctrl+Shift+E` to empty the Trash for the selected account.
+
+### Archiving Messages
+
+Press **Alt+Delete** to archive the selected message — move it to your account's Archive folder instead of deleting it. Use this for mail you want out of your inbox but want to keep. **Delete** is unchanged and still moves messages to Trash.
+
+Archiving works from every view. In the **From**, **To**, and **Conversations** groupings, archiving a group moves the whole group at once, the same way Delete does. Archive is also on the message context menu (Shift+F10) and in the command palette, and the **Alt+Delete** shortcut can be changed in **Settings → Keyboard**.
+
+**Each account archives to its own folder** — there is no single shared Archive folder. QuickMail uses the folder your provider marks as the Archive folder automatically, so most accounts need no setup. To choose a different folder, select a folder in the folder tree, open its context menu (Shift+F10), and choose **Set as Archive Folder**; choose **Use Automatic Archive Folder** to return to the automatic one.
+
+Gmail has no dedicated Archive folder — its archive is **All Mail**. To archive Gmail messages, set **[Gmail]/All Mail** as that account's Archive folder; archiving then removes the message from the inbox, which is exactly what archiving means in Gmail. If an account has no Archive folder and you have not set one, QuickMail tells you rather than doing nothing.
 
 ### Tabs
 
@@ -887,6 +898,7 @@ Control which categories of announcements QuickMail makes:
 | Announce hints | Instructional tips ("Press Escape to return") |
 | Announce status | Background progress (sync, loading, connection state) |
 | Announce results | Action outcomes (messages moved, addresses saved, flag changes) |
+| Announce delete and archive actions | Delete and archive outcomes ("1 message archived"). Turn off to stop these from interrupting the screen reader as it reads the next message; failures are still announced |
 | Announce formatting while navigating | Block type announced when caret enters a new paragraph type in HTML compose |
 | Announce flag status | Flag name prepended to message row when navigating the list |
 | Announce spelling suggestions | Suggestions included when a misspelling is announced |
@@ -981,6 +993,7 @@ Every announcement is optional and controlled by the settings above. No custom s
 | `Ctrl+Shift+R` | Reply All |
 | `Ctrl+F` | Forward |
 | `Delete` | Delete |
+| `Alt+Delete` | Archive (move to the account's Archive folder) |
 | `Ctrl+Q` | Mark as Read |
 | `Ctrl+A` | Select all messages (message list) |
 | `Alt+Enter` | Message properties |

--- a/docs/release-notes-v0.8.34.md
+++ b/docs/release-notes-v0.8.34.md
@@ -11,20 +11,30 @@ Two options are available for v0.8.34:
 
 Both downloads include the .NET 8 runtime — you do not need to install .NET separately.
 
-<!--
-Work in progress. Add user-facing sections as features and fixes land, following the
-0.8.33 notes for structure and voice:
-  ## New: <feature>
-  ## Fixed: <thing>
-  ## Accessibility        (only if there's release-specific behavior worth calling out)
-  ## Thank You to Contributors
-  ## Reporting Issues     (the standard footer below — keep it last-but-one, before Internal)
-  ## Internal             (per-PR technical changelog)
-Every release notes file must end with the Reporting Issues footer
-(docs/reporting-issues-footer.md). Publish the user guide with the release
-(gh workflow run publish-user-guide.yml --ref main — it does not auto-fire on a
-token-created release).
--->
+This release adds **archiving** — move messages out of your inbox into an Archive folder instead of deleting them, with a dedicated shortcut — and lets you **turn off the delete and archive announcements** on their own so they stop interrupting the screen reader as it reads the next message. If you installed QuickMail from the MSI, this update is delivered automatically.
+
+---
+
+## New: Archive messages
+
+You can now **archive** a message — move it to your account's Archive folder — instead of deleting it. This is for mail you want out of your inbox but kept, not thrown away.
+
+- Press **Alt+Delete** to archive the selected message. **Delete** still works exactly as before (moves to Trash). The archive shortcut is rebindable in **Settings → Keyboard**, and Archive is in the Command Palette and on the message menu and context menu.
+- Archiving works from every view. In the **From**, **To**, and **Conversations** groupings, archiving a group moves the whole group at once — the same way Delete does.
+- **Each account archives to its own folder.** QuickMail uses the folder your mail provider marks as the Archive folder automatically, so for most accounts there is nothing to set up. To choose a different folder, activate a folder in the folder tree, open its context menu, and select **Set as Archive Folder** (or **Use Automatic Archive Folder** to go back to the automatic one). There is no single shared archive folder — the choice is per account.
+- If an account has no Archive folder and you have not set one, QuickMail tells you so instead of doing nothing.
+
+## New: Turn off delete and archive announcements on their own
+
+When you delete or archive a message, QuickMail announces "Deleting message…" and "1 message deleted." Because those announcements shared the same setting as background loading and sync progress, turning them off also silenced sync progress — and left on, they can interrupt the screen reader as it starts reading the next message in the list.
+
+Delete and archive announcements now have **their own setting**. In **Settings → Screen Reader Announcements**, clear **Announce delete and archive actions** to silence just that chatter while keeping everything else. It is on by default, and the change takes effect immediately. Failure messages (for example, if a delete may not have completed) are still announced even when this is off.
+
+---
+
+## Thank You to Contributors
+
+Thank you, as always, to everyone who contributes to QuickMail through code, bug reports, feature suggestions, and other feedback — including the requests that shaped archiving and the report that the delete announcements were interrupting the reading of the next message.
 
 ---
 
@@ -37,3 +47,20 @@ Found a problem or have a suggestion? There are three ways to reach us — pick 
 3. **Email** [quickmailissues@theideaplace.net](mailto:quickmailissues@theideaplace.net). **Best when you don't mind sending email and want a personal follow-up.**
 
 Full details, including exactly what a report contains (and what it never contains), are in the [Reporting Issues section of the User Guide](https://kellylford.github.io/QuickMail/reporting-issues.html).
+
+---
+
+## Internal
+
+### Per-account message archiving (issue #318, PR #319)
+
+- New `mail.archive` command (default **Alt+Delete**, rebindable, in the Command Palette). Registered in `MainViewModel.RegisterCommands` and overridden in `MainWindow` with the same focus-aware guard as `mail.delete` so multi-selection in the list and group-tree nodes archive the whole selection/group via the controls' own `PreviewKeyDown` (an `IsArchiveGesture` helper normalizes `Key.System`→`SystemKey`, since Alt makes WPF report the key as `SystemKey`).
+- `MainViewModel.ArchiveMessagesAsync` mirrors `DeleteMessagesAsync`'s optimistic UI + focus landing, but the server op is a **move** (like `MoveSelectedMessagesToFolderAsync`): folder counts reconcile via `ScheduleFolderCountRefresh` and the account unread total is left intact (archived mail still belongs to the account). Messages are grouped by `(AccountId, FolderName)`, so one call on a From/To/conversation group archives across every account it spans, each to its own Archive folder. Already-archived messages are skipped; accounts with no Archive folder surface guidance rather than a silent no-op.
+- Archive folder resolution: explicit per-account override wins, else the server-flagged Archive folder. New `SpecialFolderKind.Archive`, detected in `ImapMailService.GetSpecialFolderKind` (IMAP `\Archive` attribute + name fallback) and `GraphMailService` (well-known `archive` + display-name fallback); Archive is **not** excluded from the All Mail aggregate. New `AccountModel.ArchiveFolderFullName` (nullable, auto-persists to accounts.json), set/cleared from the folder-tree context menu (**Set as Archive Folder** / **Use Automatic Archive Folder**). No global archive folder.
+- Gmail has no `\Archive`; pointing an account's archive folder at `[Gmail]/All Mail` archives correctly (the move removes the Inbox label). Tests: command registration + gesture; Graph "Archive" maps to `SpecialFolderKind.Archive`.
+
+### Message-action announcement category (issue #317, PR #320)
+
+- Delete/archive status announcements were emitted as `AnnouncementCategory.Status` (every `StatusText` change is announced by the View), so they rode the same toggle as sync/loading and interrupted the screen reader reading the next message. New `AnnouncementCategory.MessageAction` + `ConfigModel.AnnounceMessageActions` (default on; `config.ini` under `[global]`; honored in `AccessibilityHelper`, applied immediately by `ConfigService.Save → AccessibilityHelper.Configure`). Settings dialog: **Announce delete and archive actions**.
+- Status-bar announcements can now carry a category. `MainViewModel.SetStatus(text, category)` sets a one-shot `StatusAnnouncementCategory` and assigns `StatusText`; the View's `PropertyChanged` handler reads it synchronously (WPF raises `PropertyChanged` inline) in `QueueStatusAnnounce`, capturing the category at queue time before the VM resets it. Plain `StatusText = …` stays `Status`. Delete/archive progress/success/cancel route through `MessageAction`; failures and the archive "no Archive folder" guidance stay `Result` so they're heard even when the toggle is off. Reusable — move/copy can adopt `MessageAction` later.
+- Tests: `AnnounceMessageActions` default-on + config round-trip; settings-VM load/save round-trip.


### PR DESCRIPTION
Closes #317.

When you delete a message, the "Deleting message…" / "message deleted" announcements interrupt the screen reader reading the next selected message. Those came out as the general **Status** category, so silencing them meant silencing all sync/loading progress too. This gives common message actions their own category and on/off setting.

## What changed
- New `AnnouncementCategory.MessageAction` and `ConfigModel.AnnounceMessageActions` (on by default), parsed/written to `config.ini` and honored in `AccessibilityHelper`. Settings dialog gains **"Announce delete and archive actions"**; it applies immediately (`ConfigService.Save` reconfigures the helper).
- Status-bar announcements can now carry a category: `MainViewModel.SetStatus` sets a **one-shot** `StatusAnnouncementCategory` that the View captures synchronously in `QueueStatusAnnounce` before it resets. Plain `StatusText = …` assignments stay **Status**; delete/archive progress/success/cancel route through **MessageAction**.
- Failures ("…may not have completed") stay **Result**, and archive's "no Archive folder" setup guidance stays **Result**, so those are still heard even when the message-action toggle is off.
- Reusable infrastructure — move/copy and other commands can adopt `MessageAction` later; delete + archive are the first two.

## Notes
- This does not change announcement *timing/sequencing* (deliberately — hard to get right across screen readers, per the issue discussion). It gives users a clean switch to turn the chatter off.
- Depends on the archive work (#319, already merged to main).

## Tests / build
- `AnnounceMessageActions` default-on + config round-trip; settings-VM load/save round-trip.
- Full suite green (1467); clean release build with `-warnaserror`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)