### PR TITLE
Guard wrong-identity sign-in and remove interactive sign-in timeout (#202, #203)

### DIFF
--- a/QuickMail.Tests/AccountEditorSignInTests.cs
+++ b/QuickMail.Tests/AccountEditorSignInTests.cs
@@ -1,0 +1,130 @@
+using System.Threading;
+using System.Threading.Tasks;
+using QuickMail.Models;
+using QuickMail.Services;
+using QuickMail.ViewModels;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// Sign-in behavior on the account editor: the wrong-identity guard (#202) and the removal of the
+/// short app-imposed interactive timeout (#203). Both live on <see cref="AccountEditorViewModel"/>
+/// and are exercised here through <see cref="AddAccountViewModel"/>.
+/// </summary>
+public class AccountEditorSignInTests
+{
+    /// <summary>Configurable OAuth fake: returns a chosen username and records the token it was handed.</summary>
+    private sealed class FakeOAuthService : IOAuthService
+    {
+        public string ReturnUsername = string.Empty;
+        public bool ReturnPersonal;
+        public CancellationToken LastSignInToken = new(canceled: true); // sentinel: a real call must overwrite it
+
+        private OAuthResult Capture(CancellationToken ct)
+        {
+            LastSignInToken = ct;
+            return new OAuthResult("token", ReturnUsername, ReturnPersonal);
+        }
+
+        public Task<OAuthResult> SignInInteractiveAsync(AccountModel account, CancellationToken ct = default)
+            => Task.FromResult(Capture(ct));
+        public Task<OAuthResult> SignInInteractiveWithContactsAsync(AccountModel account, CancellationToken ct = default)
+            => Task.FromResult(Capture(ct));
+
+        public Task<string> GetAccessTokenAsync(AccountModel account, CancellationToken ct = default) => Task.FromResult("token");
+        public Task<string> GetAccessTokenAsync(AccountModel account, string[] scopes, CancellationToken ct = default) => Task.FromResult("token");
+        public Task<string> GetAccessTokenSilentAsync(AccountModel account, string[] scopes, CancellationToken ct = default) => Task.FromResult("token");
+        public Task EnsureSilentTokenAsync(AccountModel account, CancellationToken ct = default) => Task.CompletedTask;
+        public Task RequestContactsConsentAsync(AccountModel account, CancellationToken ct = default) => Task.CompletedTask;
+        public Task RequestCalendarConsentAsync(AccountModel account, CancellationToken ct = default) => Task.CompletedTask;
+        public Task SignOutAsync(AccountModel account) => Task.CompletedTask;
+    }
+
+    private static (AddAccountViewModel Vm, FakeOAuthService Oauth) NewVm()
+    {
+        var oauth = new FakeOAuthService();
+        var vm = new AddAccountViewModel(new StubFeatureGate(), new StubImapMailService(), oauth);
+        return (vm, oauth);
+    }
+
+    // ── #202: wrong-identity guard ────────────────────────────────────────────────
+
+    [Fact]
+    public async Task MicrosoftSignIn_DifferentIdentity_DoesNotRebind_AndWarns()
+    {
+        var (vm, oauth) = NewVm();
+        vm.Username = "user@contoso.com";
+        oauth.ReturnUsername = "admin@contoso.com"; // an admin signed in to consent
+
+        (string entered, string actual)? warned = null;
+        vm.SignInIdentityMismatch += (e, a) => warned = (e, a);
+
+        await vm.SignInMicrosoftCommand.ExecuteAsync(null);
+
+        Assert.Equal("user@contoso.com", vm.Username);          // NOT overwritten with the admin
+        Assert.NotNull(warned);
+        Assert.Equal(("user@contoso.com", "admin@contoso.com"), warned);
+        Assert.Contains("not user@contoso.com", vm.StatusText); // status reflects the mismatch
+    }
+
+    [Fact]
+    public async Task MicrosoftSignIn_SameIdentity_AdoptsUsername_NoWarning()
+    {
+        var (vm, oauth) = NewVm();
+        vm.Username = "user@contoso.com";
+        oauth.ReturnUsername = "User@Contoso.com"; // same identity, different casing
+
+        var warned = false;
+        vm.SignInIdentityMismatch += (_, _) => warned = true;
+
+        await vm.SignInMicrosoftCommand.ExecuteAsync(null);
+
+        Assert.Equal("User@Contoso.com", vm.Username); // adopted (canonical casing from token)
+        Assert.False(warned);
+    }
+
+    [Fact]
+    public async Task MicrosoftSignIn_BlankEntry_AdoptsWhoeverSignsIn_NoWarning()
+    {
+        var (vm, oauth) = NewVm();
+        vm.Username = string.Empty;                 // user let the provider pick the account
+        oauth.ReturnUsername = "picked@contoso.com";
+
+        var warned = false;
+        vm.SignInIdentityMismatch += (_, _) => warned = true;
+
+        await vm.SignInMicrosoftCommand.ExecuteAsync(null);
+
+        Assert.Equal("picked@contoso.com", vm.Username);
+        Assert.False(warned);
+    }
+
+    // ── #203: no app-imposed interactive timeout ──────────────────────────────────
+
+    [Fact]
+    public async Task MicrosoftSignIn_UsesNonCancellingToken_NoShortTimeout()
+    {
+        var (vm, oauth) = NewVm();
+        vm.Username = "user@contoso.com";
+        oauth.ReturnUsername = "user@contoso.com";
+
+        await vm.SignInMicrosoftCommand.ExecuteAsync(null);
+
+        // A CancellationToken.None cannot be cancelled — proving no app-imposed timeout was attached.
+        Assert.False(oauth.LastSignInToken.CanBeCanceled);
+    }
+
+    [Fact]
+    public async Task GoogleSignIn_UsesNonCancellingToken_NoShortTimeout()
+    {
+        var (vm, oauth) = NewVm();
+        vm.AuthType = AuthType.OAuth2Google;
+        vm.Username = "user@example.com";
+        oauth.ReturnUsername = "user@example.com";
+
+        await vm.SignInGoogleCommand.ExecuteAsync(null);
+
+        Assert.False(oauth.LastSignInToken.CanBeCanceled);
+    }
+}

--- a/QuickMail/ViewModels/AccountEditorViewModel.cs
+++ b/QuickMail/ViewModels/AccountEditorViewModel.cs
@@ -133,6 +133,28 @@ public abstract partial class AccountEditorViewModel : ObservableObject
     /// </summary>
     public bool? IsPersonalMicrosoftAccount { get; private set; }
 
+    /// <summary>
+    /// Raised when interactive sign-in completed as a DIFFERENT identity than the one entered (#202) —
+    /// typically an administrator signing in to grant consent in an admin-approval tenant. The View
+    /// surfaces a focus-grabbing warning in response; the account is deliberately NOT rebound to the
+    /// signed-in identity. Args are (enteredUsername, actualSignedInUsername).
+    /// </summary>
+    public event Action<string, string>? SignInIdentityMismatch;
+
+    /// <summary>
+    /// True when a non-empty entered username differs (case-insensitively) from the username that
+    /// actually signed in — the wrong-identity case #202 guards against. Raises
+    /// <see cref="SignInIdentityMismatch"/> as a side effect so the View can warn. An empty entered
+    /// username (the user let the provider choose the account) is never treated as a mismatch.
+    /// </summary>
+    private bool IsSignInIdentityMismatch(string entered, string actual)
+    {
+        if (string.IsNullOrWhiteSpace(entered)) return false;
+        if (string.Equals(entered.Trim(), actual, StringComparison.OrdinalIgnoreCase)) return false;
+        SignInIdentityMismatch?.Invoke(entered.Trim(), actual);
+        return true;
+    }
+
     [RelayCommand]
     private async Task SignInMicrosoftAsync()
     {
@@ -140,11 +162,26 @@ public abstract partial class AccountEditorViewModel : ObservableObject
         StatusText = "Opening browser for Microsoft sign-in…";
         try
         {
-            using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(3));
+            // #203: no app-imposed timeout. Sign-in renders in the embedded window the user can close
+            // to cancel (MSAL treats the close as a cancellation), so there is no reason to force-cancel
+            // after a few minutes — admin-consent tenants and screen-reader navigation legitimately take
+            // longer than the old 3-minute cutoff, which tore the window down mid-sign-in.
+            var entered = Username;
             var tempAccount = new AccountModel { Username = Username, AuthType = AuthType.OAuth2Microsoft, BackendKind = BackendKind };
             var result = SyncContacts
-                ? await OAuthService.SignInInteractiveWithContactsAsync(tempAccount, cts.Token)
-                : await OAuthService.SignInInteractiveAsync(tempAccount, cts.Token);
+                ? await OAuthService.SignInInteractiveWithContactsAsync(tempAccount, CancellationToken.None)
+                : await OAuthService.SignInInteractiveAsync(tempAccount, CancellationToken.None);
+
+            // #202: guard against a DIFFERENT identity completing sign-in than the one entered —
+            // typically an admin signing in to approve consent in an admin-approval tenant. Adopting
+            // that identity silently rebinds the account to the admin's mailbox (often not REST-enabled)
+            // and loses the intended user. Keep the entered username and warn instead of overwriting.
+            if (IsSignInIdentityMismatch(entered, result.Username))
+            {
+                StatusText = $"Signed in as {result.Username}, not {entered}. Account unchanged — please sign in as {entered}.";
+                return;
+            }
+
             Username = result.Username;
             IsPersonalMicrosoftAccount = result.IsPersonalMicrosoftAccount;
             StatusText = $"Signed in as {result.Username}";
@@ -166,12 +203,22 @@ public abstract partial class AccountEditorViewModel : ObservableObject
         StatusText = "Opening browser for Google sign-in…";
         try
         {
-            using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
+            // #203: no app-imposed timeout — the user cancels by closing the sign-in window.
+            var entered = Username;
             var tempAccount = new AccountModel { Username = Username, AuthType = AuthType.OAuth2Google, BackendKind = BackendKind.ImapSmtp };
             // When contact sync is requested, Google grants mail + contacts in this single consent.
             var result = SyncContacts
-                ? await OAuthService.SignInInteractiveWithContactsAsync(tempAccount, cts.Token)
-                : await OAuthService.SignInInteractiveAsync(tempAccount, cts.Token);
+                ? await OAuthService.SignInInteractiveWithContactsAsync(tempAccount, CancellationToken.None)
+                : await OAuthService.SignInInteractiveAsync(tempAccount, CancellationToken.None);
+
+            // #202: same wrong-identity guard as the Microsoft path — never silently adopt a different
+            // account than the one entered.
+            if (IsSignInIdentityMismatch(entered, result.Username))
+            {
+                StatusText = $"Signed in as {result.Username}, not {entered}. Account unchanged — please sign in as {entered}.";
+                return;
+            }
+
             Username = result.Username;
             StatusText = $"Signed in as {result.Username}";
         }

--- a/QuickMail/Views/AccountManagerDialog.xaml.cs
+++ b/QuickMail/Views/AccountManagerDialog.xaml.cs
@@ -20,6 +20,19 @@ public partial class AccountManagerDialog : Window
             if (e.PropertyName == nameof(vm.StatusText) && !string.IsNullOrEmpty(vm.StatusText))
                 AccessibilityHelper.Announce(this, vm.StatusText, category: AnnouncementCategory.Status);
         };
+        // #202: warn with a focus-grabbing dialog when a different identity than the one entered signs
+        // in (typically an admin approving consent) — the account stays bound to the entered user.
+        vm.SignInIdentityMismatch += WarnIdentityMismatch;
+    }
+
+    private void WarnIdentityMismatch(string entered, string actual)
+    {
+        MessageBox.Show(this,
+            $"You entered {entered}, but sign-in completed as {actual}.\n\n" +
+            "This usually happens when an administrator signs in to approve access for your " +
+            $"organization. The account was not changed. Please sign in again as {entered}.",
+            "Different account signed in",
+            MessageBoxButton.OK, MessageBoxImage.Warning);
     }
 
     private void Window_Loaded(object sender, RoutedEventArgs e)

--- a/QuickMail/Views/AddAccountDialog.xaml.cs
+++ b/QuickMail/Views/AddAccountDialog.xaml.cs
@@ -23,6 +23,20 @@ public partial class AddAccountDialog : Window
             else if (e.PropertyName == nameof(vm.IsBusy))
                 OnIsBusyChanged();
         };
+        // #202: a different identity than the one entered completed sign-in (usually an admin approving
+        // consent). Warn with a focus-grabbing dialog rather than a passing status line, since a screen
+        // reader can miss the soft cue — the account is intentionally left bound to the entered user.
+        vm.SignInIdentityMismatch += WarnIdentityMismatch;
+    }
+
+    private void WarnIdentityMismatch(string entered, string actual)
+    {
+        MessageBox.Show(this,
+            $"You entered {entered}, but sign-in completed as {actual}.\n\n" +
+            "This usually happens when an administrator signs in to approve access for your " +
+            $"organization. The account was not changed. Please sign in again as {entered}.",
+            "Different account signed in",
+            MessageBoxButton.OK, MessageBoxImage.Warning);
     }
 
     private void Window_Loaded(object sender, RoutedEventArgs e)


### PR DESCRIPTION
Fixes #202 and #203 — two long-standing sign-in issues, both in `AccountEditorViewModel` (shared by Add Account and Account Manager).

## #202 — stop the admin-consent account hijack
In an admin-approval tenant, a user who enters `user@tenant` hits a "needs admin approval" wall; if an admin then signs in there to consent, MSAL returns the **admin's** identity. The code did `Username = result.Username`, silently rebinding the account to the admin — connecting to the admin's (often non-REST) mailbox and losing the intended user, with only a soft status line as the signal.

Now: after sign-in, if a **non-empty entered username** differs (case-insensitively) from the username that actually signed in, the account is **not** rebound. The entered username is kept and a new `SignInIdentityMismatch` event is raised; both account dialogs respond with a **focus-grabbing warning dialog** — the explicit, screen-reader-announced confirmation the issue asked for, not a passing status line. Empty entry (user let the provider pick) still adopts whoever signs in. Applied to the Google path too for consistency.

## #203 — remove the short interactive-sign-in timeout
The interactive path force-cancelled after `TimeSpan.FromMinutes(3)` (Microsoft) / `FromMinutes(5)` (Google). Admin-consent waits and screen-reader navigation legitimately take longer, so the embedded sign-in window got torn down mid-flow. Since sign-in now renders in the embedded window the user can **close to cancel**, the app-imposed timeout is unnecessary and removed (`CancellationToken.None`). `TestConnection`'s 30-second probe is a separate connection check and is unchanged.

This is distinct from #206/#207 (which made *background* connect silent-only); #203 is the *user-initiated* Add Account timer, which those PRs did not touch.

## Tests
New `AccountEditorSignInTests`:
- Mismatched identity does not rebind, raises the event, sets a clear status.
- Same identity (incl. different casing) adopts the canonical username, no warning.
- Blank entry adopts whoever signs in, no warning.
- Non-cancelling token on both Microsoft and Google sign-in (proves no app-imposed timeout).

Full suite: 1467 passed, the only red an environmental clipboard flake (`OpenClipboard Failed`) that passes in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
