### PR TITLE
Docs: correct Entra scope guidance after #323 (Contacts.Read)

### DIFF
--- a/docs/ENTRA-APP-REGISTRATION.md
+++ b/docs/ENTRA-APP-REGISTRATION.md
@@ -53,10 +53,17 @@ above; the embedded view intercepts that navigation internally (no loopback list
 
 ## 3. API permissions (delegated, Microsoft Graph + Exchange Online)
 
-Only the **Graph** backend uses the per-resource **`.default` scope** at sign-in
+The **Graph mail** backend uses the per-resource **`.default` scope** at **mail sign-in**
 (`https://graph.microsoft.com/.default`), which asks for **exactly the delegated Graph permissions
-declared here** — nothing more, no runtime incremental consent. See
-`docs/planning/oauth-default-scope-pm-dev-spec.md`.
+declared here** — nothing more. See `docs/planning/oauth-default-scope-pm-dev-spec.md`.
+
+> **`.default` is not the whole story.** Contact sync and calendar sync run **separate,
+> incremental consent flows** (`RequestContactsConsentAsync` / `RequestCalendarConsentAsync`) that
+> request **explicit** scopes — `Contacts.Read` + `People.Read`, and `Calendars.ReadWrite` — for
+> **every** account type, work/school included. They do **not** go through `.default`. AAD matches
+> the **exact requested scope string**, so each of those scopes must be declared here in its own
+> right; a broader relative is not a substitute (a granted `Contacts.ReadWrite` does **not** satisfy
+> an explicit `Contacts.Read` request). Getting this wrong is what caused #323.
 
 The **IMAP/SMTP-over-OAuth** path requests **explicit** scopes (`IMAP.AccessAsUser.All` + `SMTP.Send`),
 **not** `.default` — `.default` on `outlook.office.com` is invalid for personal Microsoft accounts and
@@ -96,12 +103,20 @@ Plus `offline_access` (refresh tokens) — a standard OIDC scope that **MSAL add
 the public-client desktop flow, so refresh tokens still issue even though the code now requests only
 `.default` (verified live). It is not listed in `OAuthService.cs` and needs no separate portal entry.
 
-> Because the app requests `.default`, adding a permission is **entirely a registration action**:
-> declare it in this list **and** re-grant admin consent in each admin-consent tenant. There is no
-> code scope list to update and no runtime consent prompt — a permission the code needs but that is
-> not declared+granted here surfaces as a feature-level `403`, not a consent dialog (§6). Declaring
-> a new scope **before** GA (while no account has consented yet) means the first consent captures it
-> and no one is ever re-prompted.
+> For scopes reached through **`.default`** (the mail path), adding a permission is **entirely a
+> registration action**: declare it in this list **and** re-grant admin consent in each
+> admin-consent tenant. There is no code scope list to update, and a permission the code needs but
+> that is not declared+granted here surfaces as a feature-level `403`. Declaring a new scope
+> **before** GA (while no account has consented yet) means the first consent captures it and no one
+> is ever re-prompted.
+>
+> **The explicitly-requested scopes behave differently and fail differently.** For contacts and
+> calendar (see the callout above), an undeclared or un-consented scope surfaces as a **consent
+> prompt** — and in an admin-consent tenant, as a dead-end "needs admin approval" wall — **not** as
+> a `403`. Adding one is still a registration action, but it also requires the scope string to match
+> what `OAuthService` requests exactly, so check `GraphContactScopes` / `GraphCalendarScopes` when
+> declaring it. If a sync feature dead-ends at an approval wall, suspect a missing **exact** scope
+> here before suspecting the code.
 
 **Live registration reconciled (2026-07-14):** the actual registration (tenant
 `793722c2-ea04-49a3-8183-af139211b24f`, app object `c9ca6292-3799-4b87-8e88-48ea7d04e692`) was

--- a/docs/ENTRA-APP-REGISTRATION.md
+++ b/docs/ENTRA-APP-REGISTRATION.md
@@ -77,9 +77,10 @@ declared scopes). Both must still be declared here.
 | --- | --- |
 | `Mail.ReadWrite` | Read/move/flag/delete mail; save drafts (Graph backend) |
 | `Mail.Send` | Send mail (Graph backend) |
-| `Calendars.ReadWrite` | Calendar sync — read/create/update/delete events (full-calendar spec M4). Added 2026-07-16 via the §7 device-code runbook (scope id `1ec239c2-d7c9-4623-a91a-a9775856bb36`). Code side: `OAuthService.GraphCalendarScopes` (explicit scope for personal accounts; work/school gets it via `.default`). |
-| `Contacts.ReadWrite` | Contact sync (#256, shipped v0.8.32) reads saved contacts from `/me/contacts`. The code requests only **`Contacts.Read`** (`OAuthService.GraphContactScopes`, read-only) — the **write half is a deliberate forward declaration** for a future two-way contact sync; no code path writes contacts yet. Scope id `d56682ec-c09e-4743-aaf4-1a3aac4caa21`, added 2026-07-21 via the §7 device-code runbook. Work/school accounts get the full `ReadWrite` via `.default`; personal accounts request the read-only `Contacts.Read` explicitly through the separate contact-consent flow. |
-| `People.Read` | **In use** — contact sync (#256, shipped v0.8.32) reads relevance-ranked prior recipients from `/me/people` (`OAuthService.GraphContactScopes`). Scope id `ba47897c-39ec-4d83-8086-ee8256fa737d`, added 2026-07-21 via the §7 device-code runbook; the registration had drifted without it, so work/school `.default` sign-ins couldn't acquire it silently until now. Personal accounts request it explicitly. |
+| `Calendars.ReadWrite` | Calendar sync — read/create/update/delete events (full-calendar spec M4). Added 2026-07-16 via the §7 device-code runbook (scope id `1ec239c2-d7c9-4623-a91a-a9775856bb36`). Code side: `OAuthService.GraphCalendarScopes` — like the contact scopes, `RequestCalendarConsentAsync` requests this **explicitly for BOTH work/school and personal accounts**, **not** via `.default`, so this exact scope must be declared and admin-consented. |
+| `Contacts.Read` | **In use, required.** Contact sync (#256, shipped v0.8.32) reads saved contacts from `/me/contacts` via `OAuthService.GraphContactScopes`. **The contact-consent flow requests this scope EXPLICITLY for BOTH work/school and personal accounts** (`RequestContactsConsentAsync` → `GetAccessTokenAsync(GraphContactScopes)`), **not** via `.default` — so this exact scope string must be declared and admin-consented, or the request dead-ends. Declaring only `Contacts.ReadWrite` does **not** satisfy an explicit `Contacts.Read` request (AAD matches the exact scope). This scope was missing until 2026-07-21 (only `ReadWrite` was declared), which is why contact sync dead-ended on admin-consent tenants — see #323. Added 2026-07-21 via the §7 device-code runbook. |
+| `Contacts.ReadWrite` | **Forward declaration only** — the write half for a future two-way contact sync; no code path writes contacts yet. Scope id `d56682ec-c09e-4743-aaf4-1a3aac4caa21`, added 2026-07-21. Note this does **not** cover the read path: the code requests `Contacts.Read` explicitly (see the row above). |
+| `People.Read` | **In use** — contact sync (#256, shipped v0.8.32) reads relevance-ranked prior recipients from `/me/people` (`OAuthService.GraphContactScopes`). Like `Contacts.Read`, it is requested **explicitly** by the contact-consent flow for work/school and personal accounts alike — not via `.default`. Scope id `ba47897c-39ec-4d83-8086-ee8256fa737d`, added 2026-07-21 via the §7 device-code runbook. |
 | `MailboxSettings.ReadWrite` | Server-side Inbox rules (messageRule API). **Superset of `MailboxSettings.Read`** — declare ReadWrite, not Read. |
 | `User.Read` | Resolve the signed-in user's address/profile |
 | `User.ReadBasic.All` | Resolve other users (recipient display names) |
@@ -115,20 +116,23 @@ may show bare GUIDs (`652390e4-…` = IMAP.AccessAsUser.All, `258f6531-…` = SM
 names — this is cosmetic. Because the declared set changed, accounts that consented before this
 date will be re-prompted on their next interactive sign-in.
 
-**Scopes added (2026-07-21):** `Contacts.ReadWrite` and `People.Read` were added via the §7
-device-code runbook (`PATCH /applications/{id}`, whole-set replace). This **corrected pre-existing
-drift**: contact sync (#256, shipped v0.8.32) reads `/me/contacts` and `/me/people` via
-`OAuthService.GraphContactScopes` (`Contacts.Read` + `People.Read`), but the registration declared
-neither — so work/school accounts, which acquire via `.default`, couldn't get them silently.
-`People.Read` and the **read half** of `Contacts.ReadWrite` are now actively used; the **write
-half** of `Contacts.ReadWrite` is a deliberate forward declaration for a future two-way contact
-sync (no code writes contacts yet). This makes the full declared Graph set nine scopes (the six
-functional ones + `offline_access` + `Calendars.ReadWrite` + these two). Note: `People.Read` had
-been present as *drift* at the 2026-07-14 reconciliation and was removed then; its reappearance
-here is intentional, not a regression. As with any set change, already-consented work/school
-accounts (which use `.default`) get one re-consent prompt on next interactive sign-in; personal
-accounts are unaffected (they request `Contacts.Read` / `People.Read` explicitly through the
-contact-consent flow, independent of `.default`).
+**Scopes added (2026-07-21):** `Contacts.ReadWrite` and `People.Read` were added earlier in the
+day; a **follow-up correction** then added **`Contacts.Read`** after issue #323 live-reproduced
+contact sync still dead-ending. The correction is the important lesson: the contact-consent flow
+(`RequestContactsConsentAsync`) requests `OAuthService.GraphContactScopes` = **`Contacts.Read` +
+`People.Read`** as **explicit** scopes for **all** account types (work/school and personal) — it
+does **not** use `.default` (`.default` can't be combined with the mail sign-in, and the flow runs
+separately). So declaring `Contacts.ReadWrite` alone was insufficient: AAD matches the exact
+requested scope string, and an explicit `Contacts.Read` request is not satisfied by a granted
+`Contacts.ReadWrite`. Declaring `Contacts.Read` fixed it. `Contacts.Read`, `People.Read`, and the
+read side of contact sync are now actively used; `Contacts.ReadWrite` remains a deliberate forward
+declaration for a future two-way sync (no code writes contacts yet). This makes the full declared
+Graph set **ten** scopes (Mail.ReadWrite, Mail.Send, MailboxSettings.ReadWrite, User.Read,
+User.ReadBasic.All, Calendars.ReadWrite, Contacts.Read, Contacts.ReadWrite, People.Read +
+`offline_access`). Note: `People.Read` had been present as *drift* at the 2026-07-14 reconciliation
+and was removed then; its reappearance here is intentional, not a regression. As with any set
+change, already-consented accounts get one re-consent prompt on next sign-in, and **admin-consent
+tenants must re-grant admin consent** (§4) before the newly-declared scopes become acquirable.
 
 **Code audit (2026-07-21):** this list was re-checked against every Graph, IMAP, and SMTP call in
 the codebase (supersedes the 2026-07-14 audit, which predated contact and calendar sync). It is
@@ -136,8 +140,9 @@ the codebase (supersedes the 2026-07-14 audit, which predated contact and calend
 use or a documented forward declaration.
 
 - **In use:** `Mail.ReadWrite` / `Mail.Send` (Graph mail backend), `User.Read` (resolve the
-  signed-in address), `Contacts.Read` (the read half of `Contacts.ReadWrite` — `/me/contacts`) and
-  `People.Read` (`/me/people`) via contact sync (#256), and `Calendars.ReadWrite`
+  signed-in address), `Contacts.Read` (`/me/contacts`, requested explicitly — **not** the same as
+  the forward-declared `Contacts.ReadWrite`) and `People.Read` (`/me/people`) via contact sync
+  (#256), and `Calendars.ReadWrite`
   (`/me/calendars` + `/me/events`, including event creation) via `GraphCalendarSyncService` (#282);
   plus the two Exchange Online scopes for the IMAP/SMTP backend.
 - **Deliberate forward declarations** (specced but not yet implemented; the "declare before GA"


### PR DESCRIPTION
Docs-only. Corrects `docs/ENTRA-APP-REGISTRATION.md` §3 after resolving #323.

## What was wrong

Issue #323 reported calendar and contact sync dead-ending on admin-consent tenants, and predicted that `Calendars.ReadWrite`, `Contacts.Read` and `People.Read` were all undeclared on the live registration.

Auditing the live registration (`bcdc84f1-…`) showed that was only partly right. Already declared:

```
Mail.ReadWrite, Mail.Send, MailboxSettings.ReadWrite, User.Read,
User.ReadBasic.All, offline_access, Calendars.ReadWrite,
Contacts.ReadWrite, People.Read
```

The one genuinely missing scope was **`Contacts.Read`** — which has since been added to the registration (whole-set PATCH, verified).

## The misconception this PR fixes

The doc claimed work/school accounts receive the contact and calendar scopes via `.default`. **They do not.** `RequestContactsConsentAsync` and `RequestCalendarConsentAsync` acquire `GraphContactScopes` / `GraphCalendarScopes` as **explicit** scopes for every account type. AAD matches the exact requested scope string, so a granted `Contacts.ReadWrite` does not satisfy an explicit `Contacts.Read` request — which is precisely why contact sync dead-ended.

## Changes

- Split the contacts entry into `Contacts.Read` (in use, required) and `Contacts.ReadWrite` (forward declaration only).
- Correct the `Calendars.ReadWrite` and `People.Read` rows to state the scopes are requested explicitly for all account types, not via `.default`.
- Rewrite the 2026-07-21 change note to record the `Contacts.Read` correction, the ten-scope declared set, and that admin-consent tenants must re-grant consent before newly declared scopes become acquirable.

## Note

This branch also carries doc edits that were already uncommitted in the working tree when this work started. Same topic, so it reads as one coherent change, but flagging that they weren't authored here.

No code changes; nothing to build or test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
