### PR TITLE
Server rules: Graph messageRule service layer + round-trip safety gating (#333)

### DIFF
--- a/QuickMail.Tests/GraphServerRuleServiceTests.cs
+++ b/QuickMail.Tests/GraphServerRuleServiceTests.cs
@@ -160,6 +160,88 @@ public class GraphServerRuleServiceTests
         Assert.Contains("redirect to", rule.UnsupportedFields);
     }
 
+    [Theory]
+    [InlineData("subjectContains")]
+    [InlineData("senderContains")]
+    [InlineData("bodyOrSubjectContains")]
+    public async Task List_MultiValueStringPredicate_IsViewOnly(string predicate)
+    {
+        // Graph string predicates are COLLECTIONS; the editor holds a single value. Before this
+        // gating, such a rule mapped as "fully editable" while keeping only the first term, so
+        // renaming it and saving would PATCH back a one-element array and silently delete the rest —
+        // the exact §16 data-loss the design exists to prevent, at the cardinality level rather than
+        // the predicate-name level.
+        var handler = new RecordingHandler(Json(Collection(
+            $$"""
+            { "id": "r1", "displayName": "Multi", "sequence": 1, "isEnabled": true,
+              "conditions": { "{{predicate}}": ["invoice", "receipt"] },
+              "actions": { "markAsRead": true } }
+            """)));
+
+        var rule = (await Service(handler).ListAsync(_accountId)).Single();
+
+        Assert.False(rule.IsFullyEditable);
+        Assert.Contains(rule.UnsupportedFields, f => f.Contains("multiple values", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task List_SingleValueStringPredicate_StaysEditable()
+    {
+        // Control for the theory above: one term is representable, so editing stays available.
+        var handler = new RecordingHandler(Json(Collection(
+            """
+            { "id": "r1", "displayName": "Single", "sequence": 1, "isEnabled": true,
+              "conditions": { "subjectContains": ["invoice"] },
+              "actions": { "markAsRead": true } }
+            """)));
+
+        var rule = (await Service(handler).ListAsync(_accountId)).Single();
+
+        Assert.True(rule.IsFullyEditable);
+        Assert.Equal("invoice", rule.SubjectContains);
+    }
+
+    [Fact]
+    public async Task MultiValueRule_CannotBeSavedThroughUpdate()
+    {
+        // End-to-end guard: the gating above must actually block the write path, so the extra terms
+        // can never be dropped even if a caller ignores IsFullyEditable in the UI.
+        var handler = new RecordingHandler(Json(Collection(
+            """
+            { "id": "r1", "displayName": "Multi", "sequence": 1, "isEnabled": true,
+              "conditions": { "subjectContains": ["invoice", "receipt"] },
+              "actions": { "markAsRead": true } }
+            """)));
+        var svc = Service(handler);
+        var rule = (await svc.ListAsync(_accountId)).Single();
+
+        rule.DisplayName = "Renamed";
+        await Assert.ThrowsAsync<InvalidOperationException>(() => svc.UpdateAsync(_accountId, rule));
+
+        Assert.Single(handler.Methods);                 // only the initial GET
+        Assert.DoesNotContain("PATCH", handler.Methods);
+    }
+
+    [Fact]
+    public async Task List_MultiValueRecipientCollection_StaysEditable()
+    {
+        // fromAddresses/forwardTo are modelled as full lists, so multiple values round-trip fine —
+        // the cardinality gate must not over-trigger on them.
+        var handler = new RecordingHandler(Json(Collection(
+            """
+            { "id": "r1", "displayName": "Two senders", "sequence": 1, "isEnabled": true,
+              "conditions": { "fromAddresses": [
+                  { "emailAddress": { "address": "a@contoso.com" } },
+                  { "emailAddress": { "address": "b@contoso.com" } } ] },
+              "actions": { "markAsRead": true } }
+            """)));
+
+        var rule = (await Service(handler).ListAsync(_accountId)).Single();
+
+        Assert.True(rule.IsFullyEditable);
+        Assert.Equal(["a@contoso.com", "b@contoso.com"], rule.FromAddresses);
+    }
+
     [Fact]
     public async Task List_RuleWithExceptions_IsViewOnly()
     {

--- a/QuickMail.Tests/GraphServerRuleServiceTests.cs
+++ b/QuickMail.Tests/GraphServerRuleServiceTests.cs
@@ -1,0 +1,381 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using QuickMail.Models;
+using QuickMail.Services;
+using QuickMail.Services.Graph;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// Server-side rules over the Graph messageRule API: mapping, the round-trip-safety gating that
+/// keeps us from silently deleting predicates we don't model (spec §16), request shapes for
+/// create/update/toggle/reorder/delete, and the 403 → consent-exception translation.
+/// HTTP is stubbed with a queued handler (the GraphClientTests style); no live Graph.
+/// </summary>
+public class GraphServerRuleServiceTests
+{
+    private readonly Guid _accountId = Guid.NewGuid();
+
+    // ── Test plumbing ────────────────────────────────────────────────────────────
+
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        private readonly Queue<HttpResponseMessage> _responses;
+        public List<string> Urls { get; } = [];
+        public List<string> Methods { get; } = [];
+        public List<string?> Bodies { get; } = [];
+
+        public RecordingHandler(params HttpResponseMessage[] responses)
+            => _responses = new Queue<HttpResponseMessage>(responses);
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            Urls.Add(request.RequestUri!.ToString());
+            Methods.Add(request.Method.Method);
+            Bodies.Add(request.Content is null ? null : await request.Content.ReadAsStringAsync(ct));
+            return _responses.Count > 0 ? _responses.Dequeue() : Json("""{ "value": [] }""");
+        }
+    }
+
+    private sealed class FixedAccountService : IAccountService
+    {
+        private readonly List<AccountModel> _accounts;
+        public FixedAccountService(params AccountModel[] accounts) => _accounts = [.. accounts];
+        public List<AccountModel> LoadAccounts() => _accounts;
+        public void SaveAccounts(List<AccountModel> accounts) { }
+        public void SetDefaultAccount(Guid accountId) { }
+    }
+
+    private static HttpResponseMessage Json(string body, HttpStatusCode code = HttpStatusCode.OK)
+        => new(code) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
+
+    private AccountModel GraphAccount() => new()
+    {
+        Id = _accountId,
+        BackendKind = BackendKind.MicrosoftGraph,
+        Username = "user@contoso.com",
+    };
+
+    private GraphServerRuleService Service(RecordingHandler handler)
+        => new(new FixedAccountService(GraphAccount()),
+               new GraphClient(new StubOAuthService(), new HttpClient(handler), defaultRetryDelay: TimeSpan.Zero));
+
+    private static string Collection(params string[] rules) => $$"""{ "value": [ {{string.Join(",", rules)}} ] }""";
+
+    // ── List & mapping ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task List_MapsFields_AndOrdersBySequence()
+    {
+        var handler = new RecordingHandler(Json(Collection(
+            """
+            { "id": "r2", "displayName": "Second", "sequence": 2, "isEnabled": false,
+              "isReadOnly": true, "hasError": true,
+              "conditions": { "subjectContains": ["invoice"] },
+              "actions": { "markAsRead": true } }
+            """,
+            """
+            { "id": "r1", "displayName": "First", "sequence": 1, "isEnabled": true,
+              "conditions": { "senderContains": ["newsletter"] },
+              "actions": { "moveToFolder": "AAMkFolderId" } }
+            """)));
+
+        var rules = await Service(handler).ListAsync(_accountId);
+
+        Assert.Equal(2, rules.Count);
+        Assert.Equal(["r1", "r2"], rules.Select(r => r.Id));   // sorted by sequence, not payload order
+        Assert.Contains("messageRules", handler.Urls[0]);
+
+        var first = rules[0];
+        Assert.Equal("First", first.DisplayName);
+        Assert.True(first.IsEnabled);
+        Assert.Equal("newsletter", first.SenderContains);
+        Assert.Equal("AAMkFolderId", first.MoveToFolderId);
+        Assert.True(first.IsFullyEditable);
+
+        var second = rules[1];
+        Assert.False(second.IsEnabled);
+        Assert.True(second.IsReadOnly);
+        Assert.True(second.HasError);
+        Assert.Equal("invoice", second.SubjectContains);
+        Assert.True(second.MarkAsRead);
+    }
+
+    [Fact]
+    public async Task List_NullEmptyAndFalsePredicates_DoNotMakeRuleUneditable()
+    {
+        // Graph returns unset predicates as null / [] / false. Treating those as "present" would
+        // flag essentially every rule as non-editable.
+        var handler = new RecordingHandler(Json(Collection(
+            """
+            { "id": "r1", "displayName": "Sparse", "sequence": 1, "isEnabled": true,
+              "conditions": { "subjectContains": ["hi"], "bodyContains": null,
+                              "categories": [], "sentCcMe": false },
+              "actions": { "markAsRead": true, "assignCategories": null },
+              "exceptions": { "subjectContains": null } }
+            """)));
+
+        var rule = (await Service(handler).ListAsync(_accountId)).Single();
+
+        Assert.True(rule.IsFullyEditable);
+        Assert.Empty(rule.UnsupportedFields);
+    }
+
+    [Fact]
+    public async Task List_UnsupportedPredicate_MarksRuleViewOnly()
+    {
+        var handler = new RecordingHandler(Json(Collection(
+            """
+            { "id": "r1", "displayName": "Complex", "sequence": 1, "isEnabled": true,
+              "conditions": { "subjectContains": ["x"], "bodyContains": ["secret"] },
+              "actions": { "markAsRead": true } }
+            """)));
+
+        var rule = (await Service(handler).ListAsync(_accountId)).Single();
+
+        Assert.False(rule.IsFullyEditable);
+        Assert.Contains("body contains", rule.UnsupportedFields);
+    }
+
+    [Fact]
+    public async Task List_UnsupportedAction_MarksRuleViewOnly()
+    {
+        var handler = new RecordingHandler(Json(Collection(
+            """
+            { "id": "r1", "displayName": "Redirects", "sequence": 1, "isEnabled": true,
+              "conditions": { "subjectContains": ["x"] },
+              "actions": { "redirectTo": [ { "emailAddress": { "address": "a@b.com" } } ] } }
+            """)));
+
+        var rule = (await Service(handler).ListAsync(_accountId)).Single();
+
+        Assert.False(rule.IsFullyEditable);
+        Assert.Contains("redirect to", rule.UnsupportedFields);
+    }
+
+    [Fact]
+    public async Task List_RuleWithExceptions_IsViewOnly()
+    {
+        // We never author exceptions, so a rule that has them can't be safely rewritten.
+        var handler = new RecordingHandler(Json(Collection(
+            """
+            { "id": "r1", "displayName": "Has exceptions", "sequence": 1, "isEnabled": true,
+              "conditions": { "subjectContains": ["x"] },
+              "actions": { "markAsRead": true },
+              "exceptions": { "subjectContains": ["skip"] } }
+            """)));
+
+        var rule = (await Service(handler).ListAsync(_accountId)).Single();
+
+        Assert.False(rule.IsFullyEditable);
+        Assert.Contains("exceptions", rule.UnsupportedFields);
+    }
+
+    [Fact]
+    public async Task List_ExtractsRecipientAddresses()
+    {
+        var handler = new RecordingHandler(Json(Collection(
+            """
+            { "id": "r1", "displayName": "Fwd", "sequence": 1, "isEnabled": true,
+              "conditions": { "fromAddresses": [ { "emailAddress": { "address": "boss@contoso.com", "name": "Boss" } } ] },
+              "actions": { "forwardTo": [ { "emailAddress": { "address": "me@contoso.com" } } ] } }
+            """)));
+
+        var rule = (await Service(handler).ListAsync(_accountId)).Single();
+
+        Assert.Equal("boss@contoso.com", Assert.Single(rule.FromAddresses));
+        Assert.Equal("me@contoso.com", Assert.Single(rule.ForwardTo));
+        Assert.True(rule.IsFullyEditable);
+    }
+
+    // ── Round-trip safety (spec §16) ─────────────────────────────────────────────
+
+    [Fact]
+    public async Task Update_RefusesRuleThatIsNotFullyEditable()
+    {
+        // The critical guard: PATCH replaces conditions/actions wholesale, so saving a rule we only
+        // partially model would silently delete the user's other predicates.
+        var handler = new RecordingHandler();
+        var rule = new ServerRuleModel
+        {
+            Id = "r1",
+            DisplayName = "Complex",
+            IsFullyEditable = false,
+            UnsupportedFields = ["body contains"],
+        };
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => Service(handler).UpdateAsync(_accountId, rule));
+
+        Assert.Contains("Outlook", ex.Message);
+        Assert.Empty(handler.Urls); // nothing was sent to Graph
+    }
+
+    // ── Write paths ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Create_PostsRuleBody_AndReturnsServerCopy()
+    {
+        var handler = new RecordingHandler(Json(
+            """
+            { "id": "new-id", "displayName": "Newsletters", "sequence": 1, "isEnabled": true,
+              "conditions": { "senderContains": ["news"] },
+              "actions": { "moveToFolder": "FolderX" } }
+            """));
+
+        var created = await Service(handler).CreateAsync(_accountId, new ServerRuleModel
+        {
+            DisplayName = "Newsletters",
+            Sequence = 1,
+            SenderContains = "news",
+            MoveToFolderId = "FolderX",
+        });
+
+        Assert.Equal("POST", handler.Methods.Single());
+        Assert.EndsWith("/me/mailFolders/inbox/messageRules", handler.Urls.Single());
+
+        var body = handler.Bodies.Single()!;
+        Assert.Contains("\"displayName\":\"Newsletters\"", body);
+        Assert.Contains("senderContains", body);
+        Assert.Contains("moveToFolder", body);
+        Assert.DoesNotContain("exceptions", body);   // never written, so server-side exceptions survive
+
+        Assert.Equal("new-id", created.Id);
+    }
+
+    [Fact]
+    public async Task Update_PatchesRuleById()
+    {
+        var handler = new RecordingHandler(Json("{}"));
+
+        await Service(handler).UpdateAsync(_accountId, new ServerRuleModel
+        {
+            Id = "r1",
+            DisplayName = "Renamed",
+            SubjectContains = "invoice",
+            MarkAsRead = true,
+            IsFullyEditable = true,
+        });
+
+        Assert.Equal("PATCH", handler.Methods.Single());
+        Assert.EndsWith("/me/mailFolders/inbox/messageRules/r1", handler.Urls.Single());
+        var body = handler.Bodies.Single()!;
+        Assert.Contains("\"displayName\":\"Renamed\"", body);
+        Assert.Contains("subjectContains", body);
+        Assert.Contains("markAsRead", body);
+    }
+
+    [Fact]
+    public async Task SetEnabled_SendsOnlyIsEnabled_SoOtherFieldsSurvive()
+    {
+        var handler = new RecordingHandler(Json("{}"));
+
+        await Service(handler).SetEnabledAsync(_accountId, "r1", enabled: false);
+
+        Assert.Equal("PATCH", handler.Methods.Single());
+        Assert.EndsWith("/messageRules/r1", handler.Urls.Single());
+        var body = handler.Bodies.Single()!;
+        Assert.Contains("\"isEnabled\":false", body);
+        Assert.DoesNotContain("conditions", body);
+        Assert.DoesNotContain("actions", body);
+    }
+
+    [Fact]
+    public async Task Reorder_AssignsSequentialPositions()
+    {
+        var handler = new RecordingHandler(Json("{}"), Json("{}"), Json("{}"));
+
+        await Service(handler).ReorderAsync(_accountId, ["c", "a", "b"]);
+
+        Assert.Equal(3, handler.Urls.Count);
+        Assert.All(handler.Methods, m => Assert.Equal("PATCH", m));
+        Assert.EndsWith("/messageRules/c", handler.Urls[0]);
+        Assert.Contains("\"sequence\":1", handler.Bodies[0]!);
+        Assert.EndsWith("/messageRules/a", handler.Urls[1]);
+        Assert.Contains("\"sequence\":2", handler.Bodies[1]!);
+        Assert.EndsWith("/messageRules/b", handler.Urls[2]);
+        Assert.Contains("\"sequence\":3", handler.Bodies[2]!);
+    }
+
+    [Fact]
+    public async Task Delete_HitsRuleUrl()
+    {
+        var handler = new RecordingHandler(Json("{}"));
+
+        await Service(handler).DeleteAsync(_accountId, "r1");
+
+        Assert.Equal("DELETE", handler.Methods.Single());
+        Assert.EndsWith("/me/mailFolders/inbox/messageRules/r1", handler.Urls.Single());
+    }
+
+    // ── Permission handling ──────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Forbidden_SurfacesConsentRequiredException()
+    {
+        var handler = new RecordingHandler(Json("""{ "error": { "code": "ErrorAccessDenied" } }""", HttpStatusCode.Forbidden));
+
+        var ex = await Assert.ThrowsAsync<ServerRuleConsentRequiredException>(
+            () => Service(handler).ListAsync(_accountId));
+
+        Assert.Contains("administrator", ex.Message);
+    }
+
+    [Fact]
+    public async Task NonGraphAccount_IsRejected()
+    {
+        var imap = new AccountModel { Id = _accountId, BackendKind = BackendKind.ImapSmtp, Username = "u@example.com" };
+        var svc = new GraphServerRuleService(
+            new FixedAccountService(imap),
+            new GraphClient(new StubOAuthService(), new HttpClient(new RecordingHandler()), defaultRetryDelay: TimeSpan.Zero));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => svc.ListAsync(_accountId));
+    }
+
+    // ── Accessibility: the list row's announced text comes from ToString() ───────
+
+    [Fact]
+    public void ToString_CarriesNameStateAndSummary()
+    {
+        var rule = new ServerRuleModel
+        {
+            DisplayName = "Newsletters",
+            IsEnabled = false,
+            SubjectContains = "digest",
+            MoveToFolderId = "id",
+            MoveToFolderName = "Archive",
+        };
+
+        var text = rule.ToString();
+
+        Assert.Contains("Newsletters", text);
+        Assert.Contains("disabled", text);
+        Assert.Contains("subject contains 'digest'", text);
+        Assert.Contains("move to Archive", text);
+        Assert.DoesNotContain("ServerRuleModel", text);  // never the type name
+    }
+
+    [Fact]
+    public void DetailText_ExplainsWhyARuleIsNotEditable()
+    {
+        var rule = new ServerRuleModel
+        {
+            DisplayName = "Complex",
+            SubjectContains = "x",
+            IsFullyEditable = false,
+            UnsupportedFields = ["body contains"],
+        };
+
+        var text = rule.DetailText();
+
+        Assert.Contains("body contains", text);
+        Assert.Contains("Outlook", text);
+    }
+}

--- a/QuickMail/Models/ServerRuleModel.cs
+++ b/QuickMail/Models/ServerRuleModel.cs
@@ -1,0 +1,183 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+
+namespace QuickMail.Models;
+
+/// <summary>
+/// A server-side (Exchange / Microsoft 365) Inbox rule as the UI sees it — the rules that run on
+/// Microsoft's servers even when QuickMail is closed. Distinct from <see cref="MailRule"/>, which
+/// runs inside QuickMail during sync. See <c>docs/planning/server-rules-pm-dev-spec.md</c>.
+/// <para>
+/// Holds the <b>editable common subset</b> of Graph's rule model as typed fields, plus the
+/// <b>raw JSON</b> for conditions/actions/exceptions. Graph <c>PATCH</c> replaces those complex
+/// objects wholesale, so editing is gated to rules we can fully represent
+/// (<see cref="IsFullyEditable"/>) — otherwise saving would silently drop predicates the user set
+/// in Outlook (spec §16, the central correctness risk).
+/// </para>
+/// </summary>
+public sealed class ServerRuleModel
+{
+    public string Id { get; set; } = string.Empty;
+    public string DisplayName { get; set; } = string.Empty;
+
+    /// <summary>Execution order on the server. Lower runs first.</summary>
+    public int Sequence { get; set; }
+
+    public bool IsEnabled { get; set; } = true;
+
+    /// <summary>Server-set: the rule cannot be modified (edit/delete blocked).</summary>
+    public bool IsReadOnly { get; set; }
+
+    /// <summary>Server-set: the rule is in an error state on the server.</summary>
+    public bool HasError { get; set; }
+
+    // ── Conditions (editable subset) ────────────────────────────────────────
+
+    public string? SenderContains { get; set; }
+    public List<string> FromAddresses { get; set; } = [];
+    public string? SubjectContains { get; set; }
+    public string? BodyOrSubjectContains { get; set; }
+    public bool SentToMe { get; set; }
+    public bool SentOnlyToMe { get; set; }
+    public bool HasAttachments { get; set; }
+
+    /// <summary>"low", "normal", or "high". Null when not part of the rule.</summary>
+    public string? Importance { get; set; }
+
+    // ── Actions (editable subset) ───────────────────────────────────────────
+
+    /// <summary>Graph folder ID (the same opaque ID QuickMail uses as a folder's FullName).</summary>
+    public string? MoveToFolderId { get; set; }
+
+    /// <summary>Display name for <see cref="MoveToFolderId"/>, resolved for prose. Not sent to Graph.</summary>
+    public string? MoveToFolderName { get; set; }
+
+    public bool MarkAsRead { get; set; }
+
+    /// <summary>"low", "normal", or "high". Null when the rule doesn't set importance.</summary>
+    public string? MarkImportance { get; set; }
+
+    /// <summary>Move to Deleted Items (Graph's <c>delete</c> action — not a permanent delete).</summary>
+    public bool Delete { get; set; }
+
+    public List<string> ForwardTo { get; set; } = [];
+    public bool StopProcessingRules { get; set; }
+
+    // ── Round-trip safety ───────────────────────────────────────────────────
+
+    /// <summary>
+    /// False when the rule uses any predicate or action outside the editable subset, or has
+    /// exceptions. Such rules are view + toggle + delete only: editing them would replace the
+    /// server's richer object with our narrower one and silently lose data (spec §16).
+    /// </summary>
+    public bool IsFullyEditable { get; set; } = true;
+
+    /// <summary>
+    /// Human-readable names of the predicates/actions that put this rule outside the editable
+    /// subset. Surfaced to the user so they know what QuickMail can't represent yet.
+    /// </summary>
+    public List<string> UnsupportedFields { get; set; } = [];
+
+    /// <summary>Raw Graph JSON, retained so a future version can merge rather than replace.</summary>
+    public JsonElement? RawConditions { get; set; }
+    public JsonElement? RawActions { get; set; }
+    public JsonElement? RawExceptions { get; set; }
+
+    // ── Presentation ────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// A screen reader reads a data-bound Selector item's accessible name from <c>ToString()</c>
+    /// (DisplayMemberPath only drives the visual), so this must carry the full list-row content:
+    /// name, state, any markers, and a one-line rule summary. See CLAUDE.md.
+    /// </summary>
+    public override string ToString()
+    {
+        var name = string.IsNullOrWhiteSpace(DisplayName) ? "Unnamed rule" : DisplayName;
+        var parts = new List<string> { name, IsEnabled ? "enabled" : "disabled" };
+        if (IsReadOnly) parts.Add("read-only");
+        if (HasError) parts.Add("error");
+
+        var summary = OneLineSummary();
+        var head = string.Join(", ", parts);
+        return string.IsNullOrEmpty(summary) ? head : $"{head}. {summary}";
+    }
+
+    /// <summary>"If subject contains 'invoice' → move to Archive" — the list-row summary.</summary>
+    public string OneLineSummary()
+    {
+        var conditions = DescribeConditions();
+        var actions = DescribeActions();
+        if (conditions.Count == 0 && actions.Count == 0) return string.Empty;
+
+        var lhs = conditions.Count == 0 ? "All messages" : "If " + string.Join(" and ", conditions);
+        var rhs = actions.Count == 0 ? "do nothing" : string.Join(", then ", actions);
+        return $"{lhs} → {rhs}";
+    }
+
+    /// <summary>
+    /// Full prose for the detail region, including a note about anything outside the editable
+    /// subset — "view fidelity, edit subset" (spec §6.3), so the user can see the whole rule even
+    /// when QuickMail won't let them change it.
+    /// </summary>
+    public string DetailText()
+    {
+        var sb = new StringBuilder();
+        sb.Append(string.IsNullOrWhiteSpace(DisplayName) ? "Unnamed rule" : DisplayName);
+        sb.Append(IsEnabled ? " (enabled)" : " (disabled)");
+        sb.AppendLine();
+
+        var conditions = DescribeConditions();
+        sb.AppendLine(conditions.Count == 0
+            ? "Applies to: all messages."
+            : "Applies when: " + string.Join("; ", conditions) + ".");
+
+        var actions = DescribeActions();
+        sb.AppendLine(actions.Count == 0
+            ? "Does: nothing."
+            : "Does: " + string.Join("; ", actions) + ".");
+
+        if (IsReadOnly) sb.AppendLine("This rule is read-only on the server and cannot be changed.");
+        if (HasError) sb.AppendLine("This rule is in an error state on the server.");
+
+        if (!IsFullyEditable)
+        {
+            sb.Append("This rule uses ");
+            sb.Append(UnsupportedFields.Count > 0
+                ? "conditions or actions QuickMail can't edit yet (" + string.Join(", ", UnsupportedFields) + ")"
+                : "conditions or actions QuickMail can't edit yet");
+            sb.AppendLine(". You can enable, disable, or delete it here, or edit it in Outlook.");
+        }
+
+        return sb.ToString().TrimEnd();
+    }
+
+    private List<string> DescribeConditions()
+    {
+        var c = new List<string>();
+        if (!string.IsNullOrWhiteSpace(SenderContains)) c.Add($"sender contains '{SenderContains}'");
+        if (FromAddresses.Count > 0) c.Add($"from {string.Join(" or ", FromAddresses)}");
+        if (!string.IsNullOrWhiteSpace(SubjectContains)) c.Add($"subject contains '{SubjectContains}'");
+        if (!string.IsNullOrWhiteSpace(BodyOrSubjectContains)) c.Add($"subject or body contains '{BodyOrSubjectContains}'");
+        if (SentToMe) c.Add("sent to me");
+        if (SentOnlyToMe) c.Add("sent only to me");
+        if (HasAttachments) c.Add("has attachments");
+        if (!string.IsNullOrWhiteSpace(Importance)) c.Add($"importance is {Importance}");
+        return c;
+    }
+
+    private List<string> DescribeActions()
+    {
+        var a = new List<string>();
+        if (!string.IsNullOrWhiteSpace(MoveToFolderId))
+            a.Add($"move to {(string.IsNullOrWhiteSpace(MoveToFolderName) ? "another folder" : MoveToFolderName)}");
+        if (MarkAsRead) a.Add("mark as read");
+        if (!string.IsNullOrWhiteSpace(MarkImportance)) a.Add($"set importance to {MarkImportance}");
+        if (Delete) a.Add("move to Deleted Items");
+        if (ForwardTo.Count > 0) a.Add($"forward to {string.Join(", ", ForwardTo)}");
+        if (StopProcessingRules) a.Add("stop processing more rules");
+        return a;
+    }
+}

--- a/QuickMail/Services/Graph/GraphClient.cs
+++ b/QuickMail/Services/Graph/GraphClient.cs
@@ -233,8 +233,12 @@ public sealed class GraphClient : IDisposable
     {
         if (resp.IsSuccessStatusCode) return;
         var body = await resp.Content.ReadAsStringAsync(ct);
+        // Carry the status code on the exception (not just in the message text) so callers can
+        // branch on it without string-parsing — e.g. server rules mapping 403 to a typed
+        // consent-required exception. The message is unchanged.
         throw new HttpRequestException(
-            $"Graph request failed ({(int)resp.StatusCode} {resp.StatusCode}): {Truncate(body, 500)}");
+            $"Graph request failed ({(int)resp.StatusCode} {resp.StatusCode}): {Truncate(body, 500)}",
+            inner: null, statusCode: resp.StatusCode);
     }
 
     private static string Truncate(string s, int max) => s.Length <= max ? s : s[..max];

--- a/QuickMail/Services/Graph/GraphDtos.cs
+++ b/QuickMail/Services/Graph/GraphDtos.cs
@@ -1,8 +1,33 @@
 using System;
 using System.Collections.Generic;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace QuickMail.Services.Graph;
+
+/// <summary>
+/// A server-side Inbox rule (<c>GET/POST/PATCH/DELETE /me/mailFolders/inbox/messageRules</c>).
+/// <para>
+/// <b>conditions / actions / exceptions are kept as raw <see cref="JsonElement"/> deliberately.</b>
+/// Graph <c>PATCH</c> <i>replaces</i> these complex objects wholesale rather than merging individual
+/// predicates, so a model that only understands a subset would silently drop predicates the user set
+/// in Outlook. Retaining the raw JSON lets us (a) decide whether a rule is fully representable before
+/// allowing an edit, and (b) render the complete rule to the user even when it isn't editable.
+/// See <c>docs/planning/server-rules-pm-dev-spec.md</c> §16.
+/// </para>
+/// </summary>
+internal sealed class GraphMessageRule
+{
+    [JsonPropertyName("id")] public string Id { get; set; } = string.Empty;
+    [JsonPropertyName("displayName")] public string? DisplayName { get; set; }
+    [JsonPropertyName("sequence")] public int Sequence { get; set; }
+    [JsonPropertyName("isEnabled")] public bool IsEnabled { get; set; }
+    [JsonPropertyName("isReadOnly")] public bool IsReadOnly { get; set; }
+    [JsonPropertyName("hasError")] public bool HasError { get; set; }
+    [JsonPropertyName("conditions")] public JsonElement? Conditions { get; set; }
+    [JsonPropertyName("actions")] public JsonElement? Actions { get; set; }
+    [JsonPropertyName("exceptions")] public JsonElement? Exceptions { get; set; }
+}
 
 /// <summary>Paging envelope for a Microsoft Graph collection response.</summary>
 internal sealed class GraphCollection<T>

--- a/QuickMail/Services/Graph/ServerRuleMapper.cs
+++ b/QuickMail/Services/Graph/ServerRuleMapper.cs
@@ -1,0 +1,244 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using QuickMail.Models;
+
+namespace QuickMail.Services.Graph;
+
+/// <summary>
+/// Maps Graph <c>messageRule</c> JSON ⇄ <see cref="ServerRuleModel"/>, and decides whether a rule is
+/// safe to edit.
+/// <para>
+/// <b>Why the gating matters.</b> Graph <c>PATCH</c> <i>replaces</i> the whole
+/// <c>conditions</c>/<c>actions</c> object instead of merging individual predicates. If we let the
+/// user edit a rule containing predicates we don't model and then PATCH from our narrower model,
+/// those predicates are silently deleted from their mailbox. So any rule using anything outside the
+/// supported subset — or having exceptions — is marked not fully editable and becomes view + toggle
+/// + delete only. See <c>docs/planning/server-rules-pm-dev-spec.md</c> §16.
+/// </para>
+/// </summary>
+internal static class ServerRuleMapper
+{
+    /// <summary>Condition predicates QuickMail can represent and therefore safely rewrite.</summary>
+    internal static readonly HashSet<string> SupportedConditions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "senderContains", "fromAddresses", "subjectContains", "bodyOrSubjectContains",
+        "sentToMe", "sentOnlyToMe", "hasAttachments", "importance",
+    };
+
+    /// <summary>Actions QuickMail can represent and therefore safely rewrite.</summary>
+    internal static readonly HashSet<string> SupportedActions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "moveToFolder", "markAsRead", "markImportance", "delete", "forwardTo", "stopProcessingRules",
+    };
+
+    /// <summary>Friendlier labels for the predicates/actions we don't support yet.</summary>
+    private static readonly Dictionary<string, string> FriendlyNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["bodyContains"] = "body contains",
+        ["headerContains"] = "header contains",
+        ["recipientContains"] = "recipient contains",
+        ["sentToAddresses"] = "sent to specific addresses",
+        ["sentCcMe"] = "sent CC to me",
+        ["sentToOrCcMe"] = "sent to or CC me",
+        ["notSentToMe"] = "not sent to me",
+        ["categories"] = "categories",
+        ["sensitivity"] = "sensitivity",
+        ["messageActionFlag"] = "message flag",
+        ["withinSizeRange"] = "message size",
+        ["isAutomaticForward"] = "automatic forward",
+        ["isMeetingRequest"] = "meeting request",
+        ["isMeetingResponse"] = "meeting response",
+        ["isReadReceipt"] = "read receipt",
+        ["isPermissionControlled"] = "permission controlled",
+        ["isSigned"] = "signed",
+        ["isEncrypted"] = "encrypted",
+        ["isVoicemail"] = "voicemail",
+        ["isApprovalRequest"] = "approval request",
+        ["isAutomaticReply"] = "automatic reply",
+        ["isNonDeliveryReport"] = "non-delivery report",
+        ["copyToFolder"] = "copy to folder",
+        ["forwardAsAttachmentTo"] = "forward as attachment",
+        ["redirectTo"] = "redirect to",
+        ["assignCategories"] = "assign categories",
+        ["permanentDelete"] = "permanently delete",
+        ["exceptions"] = "exceptions",
+    };
+
+    // ── Graph → model ───────────────────────────────────────────────────────
+
+    internal static ServerRuleModel ToModel(GraphMessageRule dto)
+    {
+        var m = new ServerRuleModel
+        {
+            Id = dto.Id,
+            DisplayName = dto.DisplayName ?? string.Empty,
+            Sequence = dto.Sequence,
+            IsEnabled = dto.IsEnabled,
+            IsReadOnly = dto.IsReadOnly,
+            HasError = dto.HasError,
+            RawConditions = dto.Conditions,
+            RawActions = dto.Actions,
+            RawExceptions = dto.Exceptions,
+        };
+
+        var unsupported = new List<string>();
+
+        if (dto.Conditions is { ValueKind: JsonValueKind.Object } cond)
+        {
+            foreach (var p in cond.EnumerateObject())
+            {
+                if (!IsMeaningful(p.Value)) continue;
+                if (!SupportedConditions.Contains(p.Name)) { unsupported.Add(Friendly(p.Name)); continue; }
+
+                switch (p.Name.ToLowerInvariant())
+                {
+                    case "sendercontains": m.SenderContains = FirstString(p.Value); break;
+                    case "subjectcontains": m.SubjectContains = FirstString(p.Value); break;
+                    case "bodyorsubjectcontains": m.BodyOrSubjectContains = FirstString(p.Value); break;
+                    case "fromaddresses": m.FromAddresses = Recipients(p.Value); break;
+                    case "senttome": m.SentToMe = p.Value.ValueKind == JsonValueKind.True; break;
+                    case "sentonlytome": m.SentOnlyToMe = p.Value.ValueKind == JsonValueKind.True; break;
+                    case "hasattachments": m.HasAttachments = p.Value.ValueKind == JsonValueKind.True; break;
+                    case "importance": m.Importance = p.Value.GetString(); break;
+                }
+            }
+        }
+
+        if (dto.Actions is { ValueKind: JsonValueKind.Object } act)
+        {
+            foreach (var p in act.EnumerateObject())
+            {
+                if (!IsMeaningful(p.Value)) continue;
+                if (!SupportedActions.Contains(p.Name)) { unsupported.Add(Friendly(p.Name)); continue; }
+
+                switch (p.Name.ToLowerInvariant())
+                {
+                    case "movetofolder": m.MoveToFolderId = p.Value.GetString(); break;
+                    case "markasread": m.MarkAsRead = p.Value.ValueKind == JsonValueKind.True; break;
+                    case "markimportance": m.MarkImportance = p.Value.GetString(); break;
+                    case "delete": m.Delete = p.Value.ValueKind == JsonValueKind.True; break;
+                    case "forwardto": m.ForwardTo = Recipients(p.Value); break;
+                    case "stopprocessingrules": m.StopProcessingRules = p.Value.ValueKind == JsonValueKind.True; break;
+                }
+            }
+        }
+
+        // Exceptions are preserved on the wire but never authored here. A rule that has any means we
+        // cannot safely rewrite it from our model, so it is view-only (spec §16 / §18).
+        if (dto.Exceptions is { ValueKind: JsonValueKind.Object } exc &&
+            exc.EnumerateObject().Any(p => IsMeaningful(p.Value)))
+        {
+            unsupported.Add(Friendly("exceptions"));
+        }
+
+        m.UnsupportedFields = unsupported.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+        m.IsFullyEditable = m.UnsupportedFields.Count == 0;
+        return m;
+    }
+
+    // ── Model → Graph ───────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Builds the create/update body. Only ever called for a fully-editable rule — callers must
+    /// enforce that, because this writes <c>conditions</c>/<c>actions</c> wholesale.
+    /// <c>exceptions</c> is deliberately never written, so PATCH leaves any server-side exceptions
+    /// untouched.
+    /// </summary>
+    internal static Dictionary<string, object?> ToRequestBody(ServerRuleModel rule)
+    {
+        var conditions = new Dictionary<string, object?>();
+        if (!string.IsNullOrWhiteSpace(rule.SenderContains)) conditions["senderContains"] = new[] { rule.SenderContains };
+        if (!string.IsNullOrWhiteSpace(rule.SubjectContains)) conditions["subjectContains"] = new[] { rule.SubjectContains };
+        if (!string.IsNullOrWhiteSpace(rule.BodyOrSubjectContains)) conditions["bodyOrSubjectContains"] = new[] { rule.BodyOrSubjectContains };
+        if (rule.FromAddresses.Count > 0) conditions["fromAddresses"] = rule.FromAddresses.Select(ToRecipient).ToArray();
+        if (rule.SentToMe) conditions["sentToMe"] = true;
+        if (rule.SentOnlyToMe) conditions["sentOnlyToMe"] = true;
+        if (rule.HasAttachments) conditions["hasAttachments"] = true;
+        if (!string.IsNullOrWhiteSpace(rule.Importance)) conditions["importance"] = rule.Importance;
+
+        var actions = new Dictionary<string, object?>();
+        if (!string.IsNullOrWhiteSpace(rule.MoveToFolderId)) actions["moveToFolder"] = rule.MoveToFolderId;
+        if (rule.MarkAsRead) actions["markAsRead"] = true;
+        if (!string.IsNullOrWhiteSpace(rule.MarkImportance)) actions["markImportance"] = rule.MarkImportance;
+        if (rule.Delete) actions["delete"] = true;
+        if (rule.ForwardTo.Count > 0) actions["forwardTo"] = rule.ForwardTo.Select(ToRecipient).ToArray();
+        if (rule.StopProcessingRules) actions["stopProcessingRules"] = true;
+
+        return new Dictionary<string, object?>
+        {
+            ["displayName"] = rule.DisplayName,
+            ["sequence"] = rule.Sequence,
+            ["isEnabled"] = rule.IsEnabled,
+            ["conditions"] = conditions,
+            ["actions"] = actions,
+        };
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// True when a property actually participates in the rule. Graph returns unset predicates as
+    /// <c>null</c>, empty arrays, or <c>false</c>; treating those as "present" would flag every rule
+    /// as non-editable.
+    /// </summary>
+    internal static bool IsMeaningful(JsonElement v) => v.ValueKind switch
+    {
+        JsonValueKind.Null or JsonValueKind.Undefined => false,
+        JsonValueKind.False => false,
+        JsonValueKind.True => true,
+        JsonValueKind.Array => v.GetArrayLength() > 0,
+        JsonValueKind.String => !string.IsNullOrEmpty(v.GetString()),
+        JsonValueKind.Object => v.EnumerateObject().Any(),
+        _ => true,
+    };
+
+    /// <summary>Graph string predicates are collections; the editor exposes a single value.</summary>
+    private static string? FirstString(JsonElement v) => v.ValueKind switch
+    {
+        JsonValueKind.String => v.GetString(),
+        JsonValueKind.Array => v.EnumerateArray().FirstOrDefault().ValueKind == JsonValueKind.String
+            ? v.EnumerateArray().First().GetString()
+            : null,
+        _ => null,
+    };
+
+    /// <summary>Extracts addresses from a Graph recipient collection.</summary>
+    private static List<string> Recipients(JsonElement v)
+    {
+        var list = new List<string>();
+        if (v.ValueKind != JsonValueKind.Array) return list;
+        foreach (var item in v.EnumerateArray())
+        {
+            if (item.ValueKind != JsonValueKind.Object) continue;
+            if (item.TryGetProperty("emailAddress", out var ea) &&
+                ea.ValueKind == JsonValueKind.Object &&
+                ea.TryGetProperty("address", out var addr) &&
+                addr.ValueKind == JsonValueKind.String)
+            {
+                var s = addr.GetString();
+                if (!string.IsNullOrWhiteSpace(s)) list.Add(s);
+            }
+        }
+        return list;
+    }
+
+    private static object ToRecipient(string address)
+        => new Dictionary<string, object?> { ["emailAddress"] = new Dictionary<string, object?> { ["address"] = address } };
+
+    private static string Friendly(string graphName)
+    {
+        if (FriendlyNames.TryGetValue(graphName, out var friendly)) return friendly;
+
+        // Fallback: split camelCase into words so the user sees "sent to addresses", not a raw token.
+        var sb = new StringBuilder();
+        foreach (var ch in graphName)
+        {
+            if (char.IsUpper(ch) && sb.Length > 0) sb.Append(' ');
+            sb.Append(char.ToLowerInvariant(ch));
+        }
+        return sb.ToString();
+    }
+}

--- a/QuickMail/Services/Graph/ServerRuleMapper.cs
+++ b/QuickMail/Services/Graph/ServerRuleMapper.cs
@@ -34,6 +34,22 @@ internal static class ServerRuleMapper
         "moveToFolder", "markAsRead", "markImportance", "delete", "forwardTo", "stopProcessingRules",
     };
 
+    /// <summary>
+    /// Graph string predicates are <b>collections</b> — Outlook lets a user put several terms in one
+    /// (e.g. <c>subjectContains: ["invoice", "receipt"]</c>) — but the editor exposes a single value.
+    /// A rule carrying more than one term therefore is NOT fully representable: saving it would
+    /// PATCH back a one-element array and silently delete the rest. These are gated by cardinality
+    /// in <see cref="ToModel"/> even though the predicate name itself is supported.
+    /// <para>
+    /// Recipient collections (<c>fromAddresses</c>, <c>forwardTo</c>) are absent here on purpose —
+    /// they're modelled as full lists and round-trip completely.
+    /// </para>
+    /// </summary>
+    private static readonly HashSet<string> SingleValueStringPredicates = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "senderContains", "subjectContains", "bodyOrSubjectContains",
+    };
+
     /// <summary>Friendlier labels for the predicates/actions we don't support yet.</summary>
     private static readonly Dictionary<string, string> FriendlyNames = new(StringComparer.OrdinalIgnoreCase)
     {
@@ -92,6 +108,15 @@ internal static class ServerRuleMapper
             {
                 if (!IsMeaningful(p.Value)) continue;
                 if (!SupportedConditions.Contains(p.Name)) { unsupported.Add(Friendly(p.Name)); continue; }
+
+                // The predicate NAME is supported, but its CARDINALITY may not be: the editor holds
+                // one value, so a multi-term predicate can't be rewritten without dropping terms.
+                // Gate it rather than truncate — silent data loss is exactly what §16 exists to stop.
+                if (SingleValueStringPredicates.Contains(p.Name) && HasMultipleValues(p.Value))
+                {
+                    unsupported.Add($"{Friendly(p.Name)} (multiple values)");
+                    continue;
+                }
 
                 switch (p.Name.ToLowerInvariant())
                 {
@@ -194,6 +219,13 @@ internal static class ServerRuleMapper
         JsonValueKind.Object => v.EnumerateObject().Any(),
         _ => true,
     };
+
+    /// <summary>
+    /// True when a string-collection predicate carries more than one term — the case the editor
+    /// cannot represent (see <see cref="SingleValueStringPredicates"/>).
+    /// </summary>
+    private static bool HasMultipleValues(JsonElement v)
+        => v.ValueKind == JsonValueKind.Array && v.GetArrayLength() > 1;
 
     /// <summary>Graph string predicates are collections; the editor exposes a single value.</summary>
     private static string? FirstString(JsonElement v) => v.ValueKind switch

--- a/QuickMail/Services/GraphServerRuleService.cs
+++ b/QuickMail/Services/GraphServerRuleService.cs
@@ -1,0 +1,159 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using QuickMail.Models;
+using QuickMail.Services.Graph;
+
+namespace QuickMail.Services;
+
+/// <summary>
+/// Server-side Inbox rules over the Graph <c>messageRule</c> API
+/// (<c>/me/mailFolders/inbox/messageRules</c>). See
+/// <c>docs/planning/server-rules-pm-dev-spec.md</c>.
+/// <para>
+/// Tokens come from the account's default scope set — for work/school Graph accounts that is
+/// <c>graph.microsoft.com/.default</c>, which carries <c>MailboxSettings.ReadWrite</c> when the app
+/// registration declares it. A tenant that hasn't granted it produces <c>403</c>, surfaced here as
+/// <see cref="ServerRuleConsentRequiredException"/> for the View to render as an admin-directed
+/// message (spec §4/§5).
+/// </para>
+/// </summary>
+public sealed class GraphServerRuleService : IServerRuleService
+{
+    private const string RulesPath = "/me/mailFolders/inbox/messageRules";
+
+    private const string ConsentMessage =
+        "QuickMail can't manage server rules because your organization hasn't granted it permission. " +
+        "Ask your administrator to grant it, then sign in again.";
+
+    private readonly IAccountService _accounts;
+    private readonly GraphClient _client;
+
+    public GraphServerRuleService(IAccountService accounts, GraphClient client)
+    {
+        _accounts = accounts;
+        _client = client;
+    }
+
+    public async Task<IReadOnlyList<ServerRuleModel>> ListAsync(Guid accountId, CancellationToken ct = default)
+    {
+        var account = Account(accountId);
+        var dtos = await GuardAsync(() =>
+            _client.GetAllPagesAsync<GraphMessageRule>(account, RulesPath, ct));
+
+        var rules = dtos.Select(ServerRuleMapper.ToModel)
+                        .OrderBy(r => r.Sequence)
+                        .ToList();
+        LogService.Debug($"ServerRules: listed {rules.Count} rule(s) for {account.Username} " +
+                         $"({rules.Count(r => !r.IsFullyEditable)} not fully editable)");
+        return rules;
+    }
+
+    public async Task<ServerRuleModel> CreateAsync(Guid accountId, ServerRuleModel rule, CancellationToken ct = default)
+    {
+        var account = Account(accountId);
+        var body = ServerRuleMapper.ToRequestBody(rule);
+
+        var created = await GuardAsync(() => _client.PostReadAsync<GraphMessageRule>(
+            account, RulesPath, body, scopes: null, silentOnly: false, headers: null, ct));
+
+        if (created is null)
+            throw new InvalidOperationException("Graph accepted the new rule but returned no content.");
+
+        LogService.Log($"ServerRules: created rule '{rule.DisplayName}' for {account.Username}");
+        return ServerRuleMapper.ToModel(created);
+    }
+
+    public async Task UpdateAsync(Guid accountId, ServerRuleModel rule, CancellationToken ct = default)
+    {
+        // Belt-and-braces behind the UI's disabled Edit. Graph PATCH REPLACES conditions/actions, so
+        // rewriting a rule we can't fully represent would silently delete predicates the user set in
+        // Outlook. Refuse rather than corrupt the mailbox (spec §16).
+        if (!rule.IsFullyEditable)
+            throw new InvalidOperationException(
+                $"Rule '{rule.DisplayName}' uses conditions or actions QuickMail can't represent " +
+                "yet, so it cannot be saved from here without losing them. Edit it in Outlook.");
+
+        var account = Account(accountId);
+        var body = ServerRuleMapper.ToRequestBody(rule);
+
+        await GuardAsync(() => _client.PatchAsync(account, $"{RulesPath}/{Uri.EscapeDataString(rule.Id)}", body, ct));
+        LogService.Log($"ServerRules: updated rule '{rule.DisplayName}' for {account.Username}");
+    }
+
+    public async Task SetEnabledAsync(Guid accountId, string ruleId, bool enabled, CancellationToken ct = default)
+    {
+        var account = Account(accountId);
+        // Only isEnabled is sent, so conditions/actions are left untouched — safe even for rules
+        // outside the editable subset.
+        var body = new Dictionary<string, object?> { ["isEnabled"] = enabled };
+
+        await GuardAsync(() => _client.PatchAsync(account, $"{RulesPath}/{Uri.EscapeDataString(ruleId)}", body, ct));
+        LogService.Log($"ServerRules: {(enabled ? "enabled" : "disabled")} rule {ruleId} for {account.Username}");
+    }
+
+    public async Task ReorderAsync(Guid accountId, IReadOnlyList<string> ruleIdsInOrder, CancellationToken ct = default)
+    {
+        var account = Account(accountId);
+
+        // Sequence is 1-based on the server; assign positions in the given order. Only `sequence` is
+        // sent, so the rest of each rule is untouched.
+        for (var i = 0; i < ruleIdsInOrder.Count; i++)
+        {
+            ct.ThrowIfCancellationRequested();
+            var body = new Dictionary<string, object?> { ["sequence"] = i + 1 };
+            var id = ruleIdsInOrder[i];
+            await GuardAsync(() => _client.PatchAsync(account, $"{RulesPath}/{Uri.EscapeDataString(id)}", body, ct));
+        }
+
+        LogService.Log($"ServerRules: reordered {ruleIdsInOrder.Count} rule(s) for {account.Username}");
+    }
+
+    public async Task DeleteAsync(Guid accountId, string ruleId, CancellationToken ct = default)
+    {
+        var account = Account(accountId);
+        await GuardAsync(() => _client.DeleteAsync(account, $"{RulesPath}/{Uri.EscapeDataString(ruleId)}", ct));
+        LogService.Log($"ServerRules: deleted rule {ruleId} for {account.Username}");
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    private AccountModel Account(Guid accountId)
+        => _accounts.LoadAccounts().FirstOrDefault(
+               a => a.Id == accountId && a.BackendKind == BackendKind.MicrosoftGraph)
+           ?? throw new InvalidOperationException(
+               $"Server rules require a Microsoft 365 account; none found with id {accountId}.");
+
+    /// <summary>
+    /// Translates Graph's <c>403</c> into the typed consent exception so the View can show an
+    /// admin-directed message instead of a raw HTTP error. Everything else propagates unchanged —
+    /// a failure must never be swallowed into a silent empty state (CLAUDE.md).
+    /// </summary>
+    private static async Task<T> GuardAsync<T>(Func<Task<T>> op)
+    {
+        try
+        {
+            return await op().ConfigureAwait(false);
+        }
+        catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.Forbidden)
+        {
+            throw new ServerRuleConsentRequiredException(ConsentMessage, ex);
+        }
+    }
+
+    private static async Task GuardAsync(Func<Task> op)
+    {
+        try
+        {
+            await op().ConfigureAwait(false);
+        }
+        catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.Forbidden)
+        {
+            throw new ServerRuleConsentRequiredException(ConsentMessage, ex);
+        }
+    }
+}

--- a/QuickMail/Services/GraphServerRuleService.cs
+++ b/QuickMail/Services/GraphServerRuleService.cs
@@ -102,6 +102,13 @@ public sealed class GraphServerRuleService : IServerRuleService
 
         // Sequence is 1-based on the server; assign positions in the given order. Only `sequence` is
         // sent, so the rest of each rule is untouched.
+        //
+        // NOT ATOMIC, and it can't be: Graph exposes no batch/transactional reorder, so this is N
+        // sequential PATCHes. A failure partway leaves the server partially reordered, and duplicate
+        // sequence values exist transiently mid-loop (Graph tolerates this — it resolves ordering on
+        // read). The caller rolls back its LOCAL order on failure, which does not undo PATCHes
+        // already applied server-side; the next refresh shows the server's true order. Accepted for
+        // v1: the blast radius is rule ordering, not rule content.
         for (var i = 0; i < ruleIdsInOrder.Count; i++)
         {
             ct.ThrowIfCancellationRequested();

--- a/QuickMail/Services/IServerRuleService.cs
+++ b/QuickMail/Services/IServerRuleService.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using QuickMail.Models;
+
+namespace QuickMail.Services;
+
+/// <summary>
+/// Manages <b>server-side</b> Inbox rules on a Microsoft Graph account — the rules Exchange runs on
+/// its own servers, even when QuickMail is closed. Deliberately NOT part of
+/// <see cref="IMailService"/>: it is Graph-only and has no IMAP equivalent.
+/// <para>
+/// QuickMail's in-app rules (<see cref="IRuleService"/>) are a separate feature that runs during
+/// sync. The two are never merged or synchronized — see
+/// <c>docs/planning/server-rules-pm-dev-spec.md</c> §3.
+/// </para>
+/// </summary>
+public interface IServerRuleService
+{
+    /// <summary>All rules for the account, ordered by execution sequence.</summary>
+    Task<IReadOnlyList<ServerRuleModel>> ListAsync(Guid accountId, CancellationToken ct = default);
+
+    /// <summary>Creates a rule and returns it as stored by the server (including its new id).</summary>
+    Task<ServerRuleModel> CreateAsync(Guid accountId, ServerRuleModel rule, CancellationToken ct = default);
+
+    /// <summary>
+    /// Rewrites a rule's name, conditions, and actions.
+    /// <para>
+    /// Throws <see cref="InvalidOperationException"/> when the rule is not
+    /// <see cref="ServerRuleModel.IsFullyEditable"/>: Graph PATCH replaces the whole
+    /// conditions/actions object, so saving a partially-modelled rule would silently delete
+    /// predicates the user set elsewhere (spec §16).
+    /// </para>
+    /// </summary>
+    Task UpdateAsync(Guid accountId, ServerRuleModel rule, CancellationToken ct = default);
+
+    /// <summary>Enables or disables a rule. Safe even for rules outside the editable subset.</summary>
+    Task SetEnabledAsync(Guid accountId, string ruleId, bool enabled, CancellationToken ct = default);
+
+    /// <summary>Rewrites execution order; the given ids are assigned sequences 1..n in order.</summary>
+    Task ReorderAsync(Guid accountId, IReadOnlyList<string> ruleIdsInOrder, CancellationToken ct = default);
+
+    Task DeleteAsync(Guid accountId, string ruleId, CancellationToken ct = default);
+}

--- a/QuickMail/Services/ServerRuleConsentRequiredException.cs
+++ b/QuickMail/Services/ServerRuleConsentRequiredException.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace QuickMail.Services;
+
+/// <summary>
+/// Thrown when a server-rule operation is refused for lack of the <c>MailboxSettings.ReadWrite</c>
+/// permission (Graph returns <c>403</c>).
+/// <para>
+/// The View must surface this as an <b>admin-directed</b> message — never an in-app "Reauthorize"
+/// button. QuickMail requests the per-resource <c>.default</c> scope, so re-authorizing cannot grant
+/// a permission the tenant hasn't approved, and in admin-consent tenants the signed-in user is
+/// usually not the person who can approve it. See
+/// <c>docs/planning/server-rules-pm-dev-spec.md</c> §4 and §5.
+/// </para>
+/// </summary>
+public sealed class ServerRuleConsentRequiredException : Exception
+{
+    public ServerRuleConsentRequiredException()
+        : base("QuickMail doesn't have permission to manage server rules for this account.") { }
+
+    public ServerRuleConsentRequiredException(string message) : base(message) { }
+
+    public ServerRuleConsentRequiredException(string message, Exception? innerException)
+        : base(message, innerException) { }
+}


### PR DESCRIPTION
First slice of Exchange server-rule support for #333, implementing `docs/planning/server-rules-pm-dev-spec.md`.

**Service layer only — no UI and no DI wiring yet.** The tabbed Rules Manager (PR #334's design) lands in a follow-up so this stays reviewable on its own.

## What's here
| File | Role |
| --- | --- |
| `Graph/GraphDtos.cs` | `GraphMessageRule` DTO — conditions/actions/exceptions kept as raw `JsonElement` |
| `Models/ServerRuleModel.cs` | UI-facing model: editable subset as typed fields + raw JSON + `IsFullyEditable` + prose helpers |
| `Graph/ServerRuleMapper.cs` | Graph JSON ⇄ model, and the "is this safe to edit?" decision |
| `IServerRuleService` / `GraphServerRuleService` | list, create, update, enable/disable, reorder, delete |
| `ServerRuleConsentRequiredException` | typed `403` |

## The correctness risk, and how it's contained
Spec §16 flags the landmine: **Graph `PATCH` replaces the whole `conditions`/`actions` object rather than merging predicates.** Rewriting a rule we only partially model would *silently delete* predicates the user set in Outlook. Guarded three ways:

1. **Mapping gates editability.** Any meaningful predicate/action outside the supported subset — or any `exceptions` — sets `IsFullyEditable = false`, making the rule view + toggle + delete only, with `UnsupportedFields` naming what we couldn't represent.
2. **`UpdateAsync` refuses** a non-editable rule *before any request is sent* (verified by test — zero HTTP calls made).
3. **`SetEnabled` / `Reorder` send only `isEnabled` / `sequence`**, so they remain safe even for rules we can't represent. `exceptions` is never written, so server-side exceptions survive a PATCH.

One subtlety worth reviewing: **"meaningful" excludes `null`, `[]`, and `false`**, because Graph returns unset predicates that way. Treating those as present would flag nearly every real rule as uneditable — there's a test pinning this.

## Permissions
Tokens use the account's default scope set — for work/school that's `graph.microsoft.com/.default`, which carries `MailboxSettings.ReadWrite` when the registration declares it (it does). A tenant that hasn't granted it yields `403` → `ServerRuleConsentRequiredException`, which the View will render as an **admin-directed** message, never an in-app "Reauthorize" (which can't succeed under `.default`). Spec §4/§5.

## Accessibility
`ServerRuleModel.ToString()` carries **name + state + one-line summary**, because a screen reader reads a Selector item's accessible name from `ToString()`, not `DisplayMemberPath` — the exact bug that shipped once in the theme ComboBox. `DetailText()` gives the full prose including non-editable parts ("view fidelity, edit subset", §6.3). Both are tested.

## Incidental change
`GraphClient`'s failure path now passes the status code to `HttpRequestException` (`inner: null, statusCode: resp.StatusCode`) so callers can branch on `403` without string-parsing the message. **The message text is unchanged**; this only populates a previously-null property.

## Tests
16 new, covering mapping and sequence ordering, the editable/view-only matrix (unsupported condition, unsupported action, exceptions, and the null/empty/false case), recipient-address extraction, request shape + URL for every write path, the update refusal, `403` translation, non-Graph account rejection, and the `ToString()`/`DetailText()` accessibility strings.

**Full suite: 1488 passed, 0 failed.** Build clean at 0 warnings (`-warnaserror`).

## Next
Follow-up PR: `ServerRulesViewModel` + the tabbed Rules Manager window per #334, plus `App.xaml.cs` DI wiring (deliberately omitted here — nothing consumes the service yet, and an unused field would just be noise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
