### PR TITLE
Server rules: list and editor ViewModels (#333)

### DIFF
--- a/QuickMail.Tests/ServerRulesViewModelTests.cs
+++ b/QuickMail.Tests/ServerRulesViewModelTests.cs
@@ -225,6 +225,29 @@ public class ServerRulesViewModelTests
     }
 
     [Fact]
+    public async Task ToggleEnabled_RaisesCollectionChange_SoTheRowTextRefreshes()
+    {
+        // A row's announced text comes from ServerRuleModel.ToString(), which a ListView evaluates
+        // once per container. The model raises no change notification, so without re-assigning the
+        // slot the row would keep announcing "enabled" after the user disabled it.
+        var svc = new FakeServerRuleService { Stored = [Rule("a", "Alpha", enabled: true)] };
+        var vm = Vm(svc);
+        await vm.RefreshCommand.ExecuteAsync(null);
+
+        var replaced = false;
+        vm.Rules.CollectionChanged += (_, e) =>
+        {
+            if (e.Action == System.Collections.Specialized.NotifyCollectionChangedAction.Replace) replaced = true;
+        };
+
+        await vm.ToggleEnabledCommand.ExecuteAsync(null);
+
+        Assert.True(replaced);
+        Assert.Contains("disabled", vm.Rules[0].ToString());
+        Assert.Same(vm.Rules[0], vm.SelectedRule);   // selection survives the replace
+    }
+
+    [Fact]
     public async Task ToggleEnabled_IsAllowedOnRulesWeCannotEdit()
     {
         // Enable/disable only PATCHes isEnabled, so it stays safe for rules outside the subset.

--- a/QuickMail.Tests/ServerRulesViewModelTests.cs
+++ b/QuickMail.Tests/ServerRulesViewModelTests.cs
@@ -1,0 +1,405 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using QuickMail.Models;
+using QuickMail.Services;
+using QuickMail.ViewModels;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// Server-rules ViewModels: command availability (especially the edit gating that protects against
+/// Graph PATCH replacing predicates we don't model), the admin-directed permission path, reorder
+/// rollback, and editor validation/assembly. No View types are touched — confirmations and the
+/// permission message are raised as events, per the MVVM rules.
+/// </summary>
+public class ServerRulesViewModelTests
+{
+    private readonly Guid _accountId = Guid.NewGuid();
+
+    // ── Fakes ────────────────────────────────────────────────────────────────────
+
+    private sealed class FakeServerRuleService : IServerRuleService
+    {
+        public List<ServerRuleModel> Stored { get; set; } = [];
+        public Exception? ThrowOnWrite { get; set; }
+        public Exception? ThrowOnList { get; set; }
+
+        public List<string> Calls { get; } = [];
+        public IReadOnlyList<string>? LastReorder { get; private set; }
+        public (string Id, bool Enabled)? LastToggle { get; private set; }
+
+        public Task<IReadOnlyList<ServerRuleModel>> ListAsync(Guid accountId, CancellationToken ct = default)
+        {
+            Calls.Add("list");
+            if (ThrowOnList is not null) throw ThrowOnList;
+            return Task.FromResult<IReadOnlyList<ServerRuleModel>>(Stored);
+        }
+
+        public Task<ServerRuleModel> CreateAsync(Guid accountId, ServerRuleModel rule, CancellationToken ct = default)
+        {
+            Calls.Add("create");
+            if (ThrowOnWrite is not null) throw ThrowOnWrite;
+            rule.Id = "created-id";
+            return Task.FromResult(rule);
+        }
+
+        public Task UpdateAsync(Guid accountId, ServerRuleModel rule, CancellationToken ct = default)
+        {
+            Calls.Add("update");
+            if (ThrowOnWrite is not null) throw ThrowOnWrite;
+            return Task.CompletedTask;
+        }
+
+        public Task SetEnabledAsync(Guid accountId, string ruleId, bool enabled, CancellationToken ct = default)
+        {
+            Calls.Add("setEnabled");
+            LastToggle = (ruleId, enabled);
+            if (ThrowOnWrite is not null) throw ThrowOnWrite;
+            return Task.CompletedTask;
+        }
+
+        public Task ReorderAsync(Guid accountId, IReadOnlyList<string> ruleIdsInOrder, CancellationToken ct = default)
+        {
+            Calls.Add("reorder");
+            LastReorder = ruleIdsInOrder;
+            if (ThrowOnWrite is not null) throw ThrowOnWrite;
+            return Task.CompletedTask;
+        }
+
+        public Task DeleteAsync(Guid accountId, string ruleId, CancellationToken ct = default)
+        {
+            Calls.Add("delete");
+            if (ThrowOnWrite is not null) throw ThrowOnWrite;
+            return Task.CompletedTask;
+        }
+    }
+
+    private AccountModel GraphAccount() => new()
+    {
+        Id = _accountId,
+        BackendKind = BackendKind.MicrosoftGraph,
+        Username = "user@contoso.com",
+        AccountName = "Work",
+    };
+
+    private ServerRulesViewModel Vm(FakeServerRuleService svc, params AccountModel[] accounts)
+        => new(svc, accounts.Length > 0 ? accounts : [GraphAccount()]);
+
+    private static ServerRuleModel Rule(string id, string name, bool enabled = true,
+        bool editable = true, bool readOnly = false) => new()
+    {
+        Id = id,
+        DisplayName = name,
+        IsEnabled = enabled,
+        IsFullyEditable = editable,
+        IsReadOnly = readOnly,
+        SubjectContains = "x",
+        MarkAsRead = true,
+    };
+
+    // ── Listing ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Refresh_LoadsRulesAndSelectsFirst()
+    {
+        var svc = new FakeServerRuleService { Stored = [Rule("a", "Alpha"), Rule("b", "Beta", enabled: false)] };
+        var vm = Vm(svc);
+
+        await vm.RefreshCommand.ExecuteAsync(null);
+
+        Assert.Equal(2, vm.Rules.Count);
+        Assert.Equal("a", vm.SelectedRule!.Id);
+        Assert.Contains("2 rules", vm.StatusText);
+        Assert.Contains("1 disabled", vm.StatusText);
+    }
+
+    [Fact]
+    public async Task Refresh_Failure_ShowsMessage_NeverSilentlyEmpty()
+    {
+        var svc = new FakeServerRuleService { ThrowOnList = new InvalidOperationException("network down") };
+        var vm = Vm(svc);
+
+        await vm.RefreshCommand.ExecuteAsync(null);
+
+        Assert.Contains("network down", vm.StatusText);
+    }
+
+    [Fact]
+    public async Task Refresh_PermissionRefused_RaisesAdminDirectedEvent()
+    {
+        var svc = new FakeServerRuleService
+        {
+            ThrowOnList = new ServerRuleConsentRequiredException("Ask your administrator to grant it."),
+        };
+        var vm = Vm(svc);
+
+        string? blocked = null;
+        vm.WriteBlockedByPermission += m => blocked = m;
+
+        await vm.RefreshCommand.ExecuteAsync(null);
+
+        Assert.NotNull(blocked);
+        Assert.Contains("administrator", blocked);
+    }
+
+    // ── Edit gating (the §16 protection, surfaced in the UI) ─────────────────────
+
+    [Theory]
+    [InlineData(true, false, true)]    // fully editable, writable  → can edit
+    [InlineData(false, false, false)]  // not representable         → cannot edit
+    [InlineData(true, true, false)]    // read-only on the server   → cannot edit
+    public async Task CanEditSelected_ReflectsEditabilityAndReadOnly(bool editable, bool readOnly, bool expected)
+    {
+        var svc = new FakeServerRuleService { Stored = [Rule("a", "Alpha", editable: editable, readOnly: readOnly)] };
+        var vm = Vm(svc);
+        await vm.RefreshCommand.ExecuteAsync(null);
+
+        Assert.Equal(expected, vm.CanEditSelected);
+    }
+
+    [Fact]
+    public async Task EditRule_OnNonEditableRule_DoesNotOpenEditor_AndExplainsWhy()
+    {
+        var svc = new FakeServerRuleService { Stored = [Rule("a", "Complex", editable: false)] };
+        var vm = Vm(svc);
+        await vm.RefreshCommand.ExecuteAsync(null);
+
+        var opened = false;
+        vm.EditorRequested += _ => opened = true;
+
+        vm.EditRuleCommand.Execute(null);
+
+        Assert.False(opened);
+        Assert.Contains("Outlook", vm.StatusText);
+    }
+
+    [Fact]
+    public async Task EditRule_OnEditableRule_OpensPrefilledEditor()
+    {
+        var svc = new FakeServerRuleService { Stored = [Rule("a", "Alpha")] };
+        var vm = Vm(svc);
+        await vm.RefreshCommand.ExecuteAsync(null);
+
+        ServerRuleEditorViewModel? editor = null;
+        vm.EditorRequested += e => editor = e;
+
+        vm.EditRuleCommand.Execute(null);
+
+        Assert.NotNull(editor);
+        Assert.False(editor!.IsNew);
+        Assert.Equal("Alpha", editor.Name);
+    }
+
+    [Fact]
+    public void CreateRule_OpensEmptyEditor()
+    {
+        var vm = Vm(new FakeServerRuleService());
+
+        ServerRuleEditorViewModel? editor = null;
+        vm.EditorRequested += e => editor = e;
+
+        vm.CreateRuleCommand.Execute(null);
+
+        Assert.NotNull(editor);
+        Assert.True(editor!.IsNew);
+        Assert.Equal(string.Empty, editor.Name);
+    }
+
+    // ── Toggle / delete / reorder ───────────────────────────────────────────────
+
+    [Fact]
+    public async Task ToggleEnabled_FlipsStateAndCallsService()
+    {
+        var svc = new FakeServerRuleService { Stored = [Rule("a", "Alpha", enabled: true)] };
+        var vm = Vm(svc);
+        await vm.RefreshCommand.ExecuteAsync(null);
+
+        await vm.ToggleEnabledCommand.ExecuteAsync(null);
+
+        Assert.Equal(("a", false), svc.LastToggle);
+        Assert.False(vm.SelectedRule!.IsEnabled);
+    }
+
+    [Fact]
+    public async Task ToggleEnabled_IsAllowedOnRulesWeCannotEdit()
+    {
+        // Enable/disable only PATCHes isEnabled, so it stays safe for rules outside the subset.
+        var svc = new FakeServerRuleService { Stored = [Rule("a", "Complex", editable: false)] };
+        var vm = Vm(svc);
+        await vm.RefreshCommand.ExecuteAsync(null);
+
+        await vm.ToggleEnabledCommand.ExecuteAsync(null);
+
+        Assert.Contains("setEnabled", svc.Calls);
+    }
+
+    [Fact]
+    public async Task DeleteRule_WithoutConfirmation_DoesNothing()
+    {
+        var svc = new FakeServerRuleService { Stored = [Rule("a", "Alpha")] };
+        var vm = Vm(svc);
+        await vm.RefreshCommand.ExecuteAsync(null);
+        vm.ConfirmDeleteRequested += (_, _) => false;
+
+        await vm.DeleteRuleCommand.ExecuteAsync(null);
+
+        Assert.DoesNotContain("delete", svc.Calls);
+        Assert.Single(vm.Rules);
+    }
+
+    [Fact]
+    public async Task DeleteRule_Confirmed_RemovesAndMovesSelection()
+    {
+        var svc = new FakeServerRuleService { Stored = [Rule("a", "Alpha"), Rule("b", "Beta")] };
+        var vm = Vm(svc);
+        await vm.RefreshCommand.ExecuteAsync(null);
+        vm.ConfirmDeleteRequested += (_, _) => true;
+
+        await vm.DeleteRuleCommand.ExecuteAsync(null);
+
+        Assert.Contains("delete", svc.Calls);
+        Assert.Equal("b", Assert.Single(vm.Rules).Id);
+        Assert.Equal("b", vm.SelectedRule!.Id);
+    }
+
+    [Fact]
+    public async Task MoveDown_ReordersAndSendsNewOrder()
+    {
+        var svc = new FakeServerRuleService { Stored = [Rule("a", "Alpha"), Rule("b", "Beta")] };
+        var vm = Vm(svc);
+        await vm.RefreshCommand.ExecuteAsync(null);
+
+        await vm.MoveDownCommand.ExecuteAsync(null);
+
+        Assert.Equal(["b", "a"], vm.Rules.Select(r => r.Id));
+        Assert.Equal(["b", "a"], svc.LastReorder);
+        Assert.Equal([1, 2], vm.Rules.Select(r => r.Sequence));
+    }
+
+    [Fact]
+    public async Task Move_WhenServerRefuses_RollsBackLocalOrder()
+    {
+        var svc = new FakeServerRuleService { Stored = [Rule("a", "Alpha"), Rule("b", "Beta")] };
+        var vm = Vm(svc);
+        await vm.RefreshCommand.ExecuteAsync(null);
+        svc.ThrowOnWrite = new ServerRuleConsentRequiredException("Ask your administrator.");
+
+        await vm.MoveDownCommand.ExecuteAsync(null);
+
+        Assert.Equal(["a", "b"], vm.Rules.Select(r => r.Id));  // order restored
+    }
+
+    [Fact]
+    public void HasGraphAccount_FalseWithoutAGraphAccount()
+    {
+        var imap = new AccountModel { Id = Guid.NewGuid(), BackendKind = BackendKind.ImapSmtp, Username = "u@e.com" };
+        var vm = Vm(new FakeServerRuleService(), imap);
+
+        Assert.False(vm.HasGraphAccount);
+        Assert.False(vm.ShowAccountSelector);
+    }
+
+    // ── Editor ───────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Editor_RequiresName()
+    {
+        var editor = ServerRuleEditorViewModel.ForNew();
+        editor.MarkAsRead = true;
+
+        Assert.False(editor.Validate());
+        Assert.Contains("name", editor.NameError, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Editor_RequiresAtLeastOneAction()
+    {
+        var editor = ServerRuleEditorViewModel.ForNew();
+        editor.Name = "No actions";
+        editor.SubjectContains = "x";
+
+        Assert.False(editor.Validate());
+        Assert.Contains("action", editor.ActionsError, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Editor_MoveToFolderWithoutAFolder_IsInvalid()
+    {
+        var editor = ServerRuleEditorViewModel.ForNew();
+        editor.Name = "Filer";
+        editor.MoveToFolder = true;   // checked, but no folder picked
+
+        Assert.False(editor.Validate());
+        Assert.Contains("folder", editor.FolderError, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Editor_Save_RaisesSavedWithAssembledRule_AndCloses()
+    {
+        var editor = ServerRuleEditorViewModel.ForNew();
+        editor.Name = "  Newsletters  ";
+        editor.SubjectContains = "digest";
+        editor.ForwardTo = "a@b.com, c@d.com; e@f.com";
+        editor.MarkAsRead = true;
+
+        ServerRuleModel? saved = null;
+        var closed = false;
+        editor.Saved += r => saved = r;
+        editor.CloseRequested += () => closed = true;
+
+        editor.SaveCommand.Execute(null);
+
+        Assert.NotNull(saved);
+        Assert.Equal("Newsletters", saved!.DisplayName);      // trimmed
+        Assert.Equal("digest", saved.SubjectContains);
+        Assert.Equal(["a@b.com", "c@d.com", "e@f.com"], saved.ForwardTo);
+        Assert.True(saved.IsFullyEditable);
+        Assert.True(closed);
+    }
+
+    [Fact]
+    public void Editor_ForEdit_RoundTripsFields()
+    {
+        var original = new ServerRuleModel
+        {
+            Id = "r1",
+            Sequence = 3,
+            DisplayName = "Alpha",
+            IsEnabled = false,
+            SenderContains = "boss",
+            SubjectContains = "urgent",
+            SentOnlyToMe = true,
+            Importance = "high",
+            MoveToFolderId = "folder-1",
+            MoveToFolderName = "Priority",
+            StopProcessingRules = true,
+            IsFullyEditable = true,
+        };
+
+        var editor = ServerRuleEditorViewModel.ForEdit(original);
+        var result = editor.ToModel();
+
+        Assert.Equal("r1", result.Id);
+        Assert.Equal(3, result.Sequence);
+        Assert.Equal("Alpha", result.DisplayName);
+        Assert.False(result.IsEnabled);
+        Assert.Equal("boss", result.SenderContains);
+        Assert.True(result.SentOnlyToMe);
+        Assert.Equal("high", result.Importance);
+        Assert.Equal("folder-1", result.MoveToFolderId);
+        Assert.True(result.StopProcessingRules);
+    }
+
+    [Fact]
+    public void ImportanceOption_AnnouncesDisplayName_NotTypeName()
+    {
+        // Screen readers read a Selector item's name from ToString(), not DisplayMemberPath.
+        var option = ServerRuleEditorViewModel.ImportanceOptions.First(o => o.Value == "high");
+
+        Assert.Equal("High", option.ToString());
+    }
+}

--- a/QuickMail/ViewModels/ServerRuleEditorViewModel.cs
+++ b/QuickMail/ViewModels/ServerRuleEditorViewModel.cs
@@ -1,0 +1,245 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using QuickMail.Models;
+
+namespace QuickMail.ViewModels;
+
+/// <summary>
+/// Create/edit form for a single server rule, limited to the editable common subset
+/// (<c>docs/planning/server-rules-pm-dev-spec.md</c> §6.3). Rules outside that subset never reach
+/// this editor — the list VM blocks Edit — because Graph PATCH replaces conditions/actions wholesale
+/// and would drop what we don't model (§16).
+/// </summary>
+public partial class ServerRuleEditorViewModel : ObservableObject
+{
+    /// <summary>Identity carried through an edit so the save targets the right rule.</summary>
+    private string _ruleId = string.Empty;
+    private int _sequence;
+    private JsonElement? _rawConditions;
+    private JsonElement? _rawActions;
+    private JsonElement? _rawExceptions;
+
+    public bool IsNew { get; private init; }
+
+    public string Title => IsNew ? "New server rule" : "Edit server rule";
+
+    // ── Events (View subscribes) ────────────────────────────────────────────
+
+    /// <summary>Ask the View to open the folder picker; returns the chosen folder id (or null).</summary>
+    public event Func<(string Id, string Name)?>? PickFolderRequested;
+
+    /// <summary>Raised on a successful Save with the assembled rule. The owner persists it.</summary>
+    public event Action<ServerRuleModel>? Saved;
+
+    /// <summary>Raised when the editor window should close (Save or Cancel).</summary>
+    public event Action? CloseRequested;
+
+    public event Action<string, AnnouncementCategory>? AnnouncementRequested;
+
+    // ── Factories ───────────────────────────────────────────────────────────
+
+    public static ServerRuleEditorViewModel ForNew() => new() { IsNew = true, Name = string.Empty };
+
+    public static ServerRuleEditorViewModel ForEdit(ServerRuleModel rule)
+    {
+        var vm = new ServerRuleEditorViewModel
+        {
+            IsNew = false,
+            _ruleId = rule.Id,
+            _sequence = rule.Sequence,
+            _rawConditions = rule.RawConditions,
+            _rawActions = rule.RawActions,
+            _rawExceptions = rule.RawExceptions,
+            Name = rule.DisplayName,
+            IsEnabled = rule.IsEnabled,
+
+            SenderContains = rule.SenderContains ?? string.Empty,
+            FromAddresses = string.Join(", ", rule.FromAddresses),
+            SubjectContains = rule.SubjectContains ?? string.Empty,
+            BodyOrSubjectContains = rule.BodyOrSubjectContains ?? string.Empty,
+            SentToMe = rule.SentToMe,
+            SentOnlyToMe = rule.SentOnlyToMe,
+            HasAttachments = rule.HasAttachments,
+
+            MoveToFolder = !string.IsNullOrWhiteSpace(rule.MoveToFolderId),
+            MoveToFolderId = rule.MoveToFolderId,
+            MoveToFolderName = rule.MoveToFolderName,
+            MarkAsRead = rule.MarkAsRead,
+            Delete = rule.Delete,
+            ForwardTo = string.Join(", ", rule.ForwardTo),
+            StopProcessingRules = rule.StopProcessingRules,
+        };
+
+        vm.SelectedImportance = ImportanceOptions.FirstOrDefault(o =>
+            string.Equals(o.Value, rule.Importance, StringComparison.OrdinalIgnoreCase)) ?? ImportanceOptions[0];
+        vm.SelectedMarkImportance = ImportanceOptions.FirstOrDefault(o =>
+            string.Equals(o.Value, rule.MarkImportance, StringComparison.OrdinalIgnoreCase)) ?? ImportanceOptions[0];
+        return vm;
+    }
+
+    // ── Fields ──────────────────────────────────────────────────────────────
+
+    [ObservableProperty] private string _name = string.Empty;
+    [ObservableProperty] private bool _isEnabled = true;
+
+    // Conditions
+    [ObservableProperty] private string _senderContains = string.Empty;
+    [ObservableProperty] private string _fromAddresses = string.Empty;
+    [ObservableProperty] private string _subjectContains = string.Empty;
+    [ObservableProperty] private string _bodyOrSubjectContains = string.Empty;
+    [ObservableProperty] private bool _sentToMe;
+    [ObservableProperty] private bool _sentOnlyToMe;
+    [ObservableProperty] private bool _hasAttachments;
+    [ObservableProperty] private ImportanceOption _selectedImportance = ImportanceOptions[0];
+
+    // Actions
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsMoveToFolderSelected))]
+    private bool _moveToFolder;
+    [ObservableProperty] private string? _moveToFolderId;
+    [ObservableProperty] private string? _moveToFolderName;
+    [ObservableProperty] private bool _markAsRead;
+    [ObservableProperty] private ImportanceOption _selectedMarkImportance = ImportanceOptions[0];
+    [ObservableProperty] private bool _delete;
+    [ObservableProperty] private string _forwardTo = string.Empty;
+    [ObservableProperty] private bool _stopProcessingRules;
+
+    public bool IsMoveToFolderSelected => MoveToFolder;
+
+    // Validation surfaces
+    [ObservableProperty] private string _nameError = string.Empty;
+    [ObservableProperty] private string _folderError = string.Empty;
+    [ObservableProperty] private string _actionsError = string.Empty;
+
+    /// <summary>Importance choices for both the condition and the action ComboBoxes.</summary>
+    public static List<ImportanceOption> ImportanceOptions { get; } =
+    [
+        new() { Value = null, DisplayName = "Not set" },
+        new() { Value = "low", DisplayName = "Low" },
+        new() { Value = "normal", DisplayName = "Normal" },
+        new() { Value = "high", DisplayName = "High" },
+    ];
+
+    // ── Commands ────────────────────────────────────────────────────────────
+
+    [RelayCommand]
+    private void PickFolder()
+    {
+        if (PickFolderRequested?.Invoke() is not { } picked) return;
+        MoveToFolderId = picked.Id;
+        MoveToFolderName = picked.Name;
+        MoveToFolder = true;
+        FolderError = string.Empty;
+    }
+
+    [RelayCommand]
+    private void Save()
+    {
+        if (!Validate()) return;
+        Saved?.Invoke(ToModel());
+        CloseRequested?.Invoke();
+    }
+
+    [RelayCommand]
+    private void Cancel() => CloseRequested?.Invoke();
+
+    // ── Assembly & validation ───────────────────────────────────────────────
+
+    public ServerRuleModel ToModel() => new()
+    {
+        Id = _ruleId,
+        Sequence = _sequence,
+        DisplayName = Name.Trim(),
+        IsEnabled = IsEnabled,
+
+        SenderContains = Blank(SenderContains),
+        FromAddresses = SplitAddresses(FromAddresses),
+        SubjectContains = Blank(SubjectContains),
+        BodyOrSubjectContains = Blank(BodyOrSubjectContains),
+        SentToMe = SentToMe,
+        SentOnlyToMe = SentOnlyToMe,
+        HasAttachments = HasAttachments,
+        Importance = SelectedImportance?.Value,
+
+        MoveToFolderId = MoveToFolder ? MoveToFolderId : null,
+        MoveToFolderName = MoveToFolder ? MoveToFolderName : null,
+        MarkAsRead = MarkAsRead,
+        MarkImportance = SelectedMarkImportance?.Value,
+        Delete = Delete,
+        ForwardTo = SplitAddresses(ForwardTo),
+        StopProcessingRules = StopProcessingRules,
+
+        // Only fully-representable rules ever reach this editor, so the assembled model is safe to
+        // PATCH. Raw JSON is carried through unchanged for future merge-based editing.
+        IsFullyEditable = true,
+        RawConditions = _rawConditions,
+        RawActions = _rawActions,
+        RawExceptions = _rawExceptions,
+    };
+
+    public bool Validate()
+    {
+        NameError = FolderError = ActionsError = string.Empty;
+        var valid = true;
+
+        if (string.IsNullOrWhiteSpace(Name))
+        {
+            NameError = "Rule name is required.";
+            valid = false;
+        }
+
+        if (MoveToFolder && string.IsNullOrWhiteSpace(MoveToFolderId))
+        {
+            FolderError = "Choose a folder for the Move to folder action.";
+            valid = false;
+        }
+
+        if (!HasAnyAction())
+        {
+            ActionsError = "Choose at least one action.";
+            valid = false;
+        }
+
+        if (!valid)
+        {
+            var errors = new[] { NameError, FolderError, ActionsError }.Where(e => !string.IsNullOrEmpty(e));
+            AnnouncementRequested?.Invoke(string.Join(" ", errors), AnnouncementCategory.Result);
+        }
+
+        return valid;
+    }
+
+    private bool HasAnyAction()
+        => (MoveToFolder && !string.IsNullOrWhiteSpace(MoveToFolderId))
+           || MarkAsRead
+           || Delete
+           || StopProcessingRules
+           || !string.IsNullOrWhiteSpace(SelectedMarkImportance?.Value)
+           || SplitAddresses(ForwardTo).Count > 0;
+
+    private static string? Blank(string s) => string.IsNullOrWhiteSpace(s) ? null : s.Trim();
+
+    /// <summary>Parses a free-text recipient field ("a@b.com, c@d.com; e@f.com").</summary>
+    private static List<string> SplitAddresses(string text)
+        => string.IsNullOrWhiteSpace(text)
+            ? []
+            : text.Split([',', ';'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                  .Where(s => s.Length > 0)
+                  .ToList();
+}
+
+/// <summary>
+/// Importance choice for the condition/action ComboBoxes. <c>ToString()</c> is overridden because a
+/// screen reader reads a Selector item's accessible name from it, not from DisplayMemberPath.
+/// </summary>
+public class ImportanceOption
+{
+    /// <summary>Graph value ("low"/"normal"/"high"), or null for "not set".</summary>
+    public string? Value { get; set; }
+    public string DisplayName { get; set; } = string.Empty;
+    public override string ToString() => DisplayName;
+}

--- a/QuickMail/ViewModels/ServerRulesViewModel.cs
+++ b/QuickMail/ViewModels/ServerRulesViewModel.cs
@@ -1,0 +1,304 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using QuickMail.Models;
+using QuickMail.Services;
+
+namespace QuickMail.ViewModels;
+
+/// <summary>
+/// Backs the <b>"On the server"</b> tab of the Rules Manager — Exchange/Graph rules that run on
+/// Microsoft's servers even when QuickMail is closed. Separate from
+/// <see cref="RulesManagerViewModel"/> (the "In QuickMail" tab); the two are never merged or
+/// synchronized. See <c>docs/planning/server-rules-pm-dev-spec.md</c> §3/§9.
+/// </summary>
+public partial class ServerRulesViewModel : ObservableObject
+{
+    private readonly IServerRuleService _service;
+
+    // ── Events (View subscribes) ────────────────────────────────────────────
+
+    /// <summary>Ask the View for delete confirmation. (No MessageBox in a ViewModel.)</summary>
+    public event Func<string, string, bool>? ConfirmDeleteRequested;
+
+    /// <summary>Screen-reader announcement request: (text, category).</summary>
+    public event Action<string, AnnouncementCategory>? AnnouncementRequested;
+
+    /// <summary>
+    /// A write was refused for lack of <c>MailboxSettings.ReadWrite</c>. The View shows an
+    /// <b>admin-directed</b> message — never an in-app "Reauthorize", which cannot succeed under
+    /// <c>.default</c> (spec §4/§5).
+    /// </summary>
+    public event Action<string>? WriteBlockedByPermission;
+
+    /// <summary>The View should open the rule editor (modeless) for this prepared editor VM.</summary>
+    public event Action<ServerRuleEditorViewModel>? EditorRequested;
+
+    // ── Construction ────────────────────────────────────────────────────────
+
+    public ServerRulesViewModel(IServerRuleService service, IEnumerable<AccountModel> graphAccounts)
+    {
+        _service = service;
+
+        AccountOptions = graphAccounts
+            .Where(a => a.BackendKind == BackendKind.MicrosoftGraph)
+            .Select(a => new AccountOption { Id = a.Id, DisplayName = a.AccountLabel })
+            .ToList();
+
+        _selectedAccount = AccountOptions.FirstOrDefault();
+    }
+
+    // ── State ───────────────────────────────────────────────────────────────
+
+    public ObservableCollection<ServerRuleModel> Rules { get; } = [];
+
+    /// <summary>Graph accounts only — "All accounts" is meaningless for server rules.</summary>
+    public List<AccountOption> AccountOptions { get; }
+
+    /// <summary>The account ComboBox is only worth showing when there's a choice to make.</summary>
+    public bool ShowAccountSelector => AccountOptions.Count > 1;
+
+    /// <summary>False when the signed-in user has no Graph account — the tab is hidden entirely.</summary>
+    public bool HasGraphAccount => AccountOptions.Count > 0;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(CanEditSelected))]
+    [NotifyPropertyChangedFor(nameof(CanModifySelected))]
+    [NotifyPropertyChangedFor(nameof(DetailText))]
+    private ServerRuleModel? _selectedRule;
+
+    [ObservableProperty] private AccountOption? _selectedAccount;
+    [ObservableProperty] private string _statusText = string.Empty;
+    [ObservableProperty] private bool _isBusy;
+
+    /// <summary>
+    /// Editing is blocked for read-only rules and for rules using predicates/actions we can't
+    /// represent — saving those would replace the server's richer object with our narrower one and
+    /// silently drop the user's other predicates (spec §16).
+    /// </summary>
+    public bool CanEditSelected => SelectedRule is { IsFullyEditable: true, IsReadOnly: false };
+
+    /// <summary>Toggle/reorder/delete only need the rule to be writable, not fully representable.</summary>
+    public bool CanModifySelected => SelectedRule is { IsReadOnly: false };
+
+    /// <summary>Full prose for the detail region, including parts QuickMail can't edit.</summary>
+    public string DetailText => SelectedRule?.DetailText() ?? string.Empty;
+
+    partial void OnSelectedAccountChanged(AccountOption? value) => _ = RefreshCommand.ExecuteAsync(null);
+
+    // ── Commands ────────────────────────────────────────────────────────────
+
+    [RelayCommand]
+    private async Task RefreshAsync(CancellationToken ct)
+    {
+        if (SelectedAccount?.Id is not Guid accountId) return;
+
+        IsBusy = true;
+        try
+        {
+            var rules = await _service.ListAsync(accountId, ct);
+
+            var previouslySelected = SelectedRule?.Id;
+            Rules.Clear();
+            foreach (var r in rules) Rules.Add(r);
+
+            SelectedRule = Rules.FirstOrDefault(r => r.Id == previouslySelected) ?? Rules.FirstOrDefault();
+
+            var disabled = Rules.Count(r => !r.IsEnabled);
+            StatusText = Rules.Count == 0
+                ? "No server rules."
+                : $"{Rules.Count} rule{(Rules.Count == 1 ? "" : "s")}" + (disabled > 0 ? $", {disabled} disabled." : ".");
+            Announce(StatusText, AnnouncementCategory.Status);
+        }
+        catch (ServerRuleConsentRequiredException ex)
+        {
+            HandlePermissionRefusal(ex);
+        }
+        catch (Exception ex)
+        {
+            // Never a silent empty state — surface the failure (CLAUDE.md).
+            StatusText = $"Couldn't load server rules: {ex.Message}";
+            Announce(StatusText, AnnouncementCategory.Status);
+            LogService.Log("ServerRules: list failed", ex);
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    [RelayCommand]
+    private void CreateRule()
+    {
+        if (SelectedAccount?.Id is not Guid accountId) return;
+
+        var editor = ServerRuleEditorViewModel.ForNew();
+        editor.Saved += async rule => await SaveNewAsync(accountId, rule);
+        EditorRequested?.Invoke(editor);
+    }
+
+    [RelayCommand]
+    private void EditRule()
+    {
+        if (SelectedAccount?.Id is not Guid accountId) return;
+        if (SelectedRule is not { } rule) return;
+
+        if (!CanEditSelected)
+        {
+            var why = rule.IsReadOnly
+                ? "This rule is read-only on the server and can't be changed here."
+                : "This rule uses conditions or actions QuickMail can't edit yet. You can enable, disable, or delete it here, or edit it in Outlook.";
+            StatusText = why;
+            Announce(why, AnnouncementCategory.Hint);
+            return;
+        }
+
+        var editor = ServerRuleEditorViewModel.ForEdit(rule);
+        editor.Saved += async updated => await SaveExistingAsync(accountId, updated);
+        EditorRequested?.Invoke(editor);
+    }
+
+    [RelayCommand]
+    private async Task ToggleEnabledAsync(CancellationToken ct)
+    {
+        if (SelectedAccount?.Id is not Guid accountId) return;
+        if (SelectedRule is not { } rule) return;
+        if (!CanModifySelected) return;
+
+        var target = !rule.IsEnabled;
+        await RunWriteAsync(async () =>
+        {
+            await _service.SetEnabledAsync(accountId, rule.Id, target, ct);
+            rule.IsEnabled = target;
+            OnPropertyChanged(nameof(DetailText));
+            Announce(target ? "Rule enabled." : "Rule disabled.", AnnouncementCategory.Result);
+        });
+    }
+
+    [RelayCommand]
+    private Task MoveUpAsync(CancellationToken ct) => MoveAsync(-1, ct);
+
+    [RelayCommand]
+    private Task MoveDownAsync(CancellationToken ct) => MoveAsync(+1, ct);
+
+    [RelayCommand]
+    private async Task DeleteRuleAsync(CancellationToken ct)
+    {
+        if (SelectedAccount?.Id is not Guid accountId) return;
+        if (SelectedRule is not { } rule) return;
+        if (!CanModifySelected) return;
+
+        var confirmed = ConfirmDeleteRequested?.Invoke(
+            $"Delete server rule '{rule.DisplayName}'? It will stop running on the server.",
+            "Delete Server Rule") ?? false;
+        if (!confirmed) return;
+
+        await RunWriteAsync(async () =>
+        {
+            await _service.DeleteAsync(accountId, rule.Id, ct);
+
+            // Keep focus somewhere sensible: the next rule, or the one above if this was last.
+            var index = Rules.IndexOf(rule);
+            Rules.Remove(rule);
+            SelectedRule = Rules.Count == 0 ? null : Rules[Math.Min(index, Rules.Count - 1)];
+
+            Announce("Rule deleted.", AnnouncementCategory.Result);
+        });
+    }
+
+    // ── Internals ───────────────────────────────────────────────────────────
+
+    private async Task MoveAsync(int delta, CancellationToken ct)
+    {
+        if (SelectedAccount?.Id is not Guid accountId) return;
+        if (SelectedRule is not { } rule) return;
+
+        var from = Rules.IndexOf(rule);
+        var to = from + delta;
+        if (from < 0 || to < 0 || to >= Rules.Count) return;
+
+        Rules.Move(from, to);
+        SelectedRule = rule;
+
+        await RunWriteAsync(async () =>
+        {
+            await _service.ReorderAsync(accountId, Rules.Select(r => r.Id).ToList(), ct);
+
+            // Keep local sequence numbers consistent with what the server was just told.
+            for (var i = 0; i < Rules.Count; i++) Rules[i].Sequence = i + 1;
+
+            Announce($"Moved {(delta < 0 ? "up" : "down")}. Now {to + 1} of {Rules.Count}.",
+                AnnouncementCategory.Status);
+        }, onFailure: () => Rules.Move(to, from));   // put it back if the server refused
+    }
+
+    private async Task SaveNewAsync(Guid accountId, ServerRuleModel rule)
+    {
+        await RunWriteAsync(async () =>
+        {
+            var created = await _service.CreateAsync(accountId, rule);
+            Rules.Add(created);
+            SelectedRule = created;
+            Announce("Rule created.", AnnouncementCategory.Result);
+        });
+    }
+
+    private async Task SaveExistingAsync(Guid accountId, ServerRuleModel rule)
+    {
+        await RunWriteAsync(async () =>
+        {
+            await _service.UpdateAsync(accountId, rule);
+
+            var index = Rules.ToList().FindIndex(r => r.Id == rule.Id);
+            if (index >= 0) Rules[index] = rule;
+            SelectedRule = rule;
+
+            Announce("Rule updated.", AnnouncementCategory.Result);
+        });
+    }
+
+    /// <summary>
+    /// Runs a write, translating a permission refusal into the admin-directed path and never
+    /// swallowing other failures into a silent no-op.
+    /// </summary>
+    private async Task RunWriteAsync(Func<Task> write, Action? onFailure = null)
+    {
+        IsBusy = true;
+        try
+        {
+            await write();
+        }
+        catch (ServerRuleConsentRequiredException ex)
+        {
+            onFailure?.Invoke();
+            HandlePermissionRefusal(ex);
+        }
+        catch (Exception ex)
+        {
+            onFailure?.Invoke();
+            StatusText = ex.Message;
+            Announce(StatusText, AnnouncementCategory.Result);
+            LogService.Log("ServerRules: write failed", ex);
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    private void HandlePermissionRefusal(ServerRuleConsentRequiredException ex)
+    {
+        StatusText = ex.Message;
+        WriteBlockedByPermission?.Invoke(ex.Message);
+        Announce(ex.Message, AnnouncementCategory.Hint);
+        LogService.Log("ServerRules: blocked by missing MailboxSettings.ReadWrite");
+    }
+
+    private void Announce(string text, AnnouncementCategory category)
+        => AnnouncementRequested?.Invoke(text, category);
+}

--- a/QuickMail/ViewModels/ServerRulesViewModel.cs
+++ b/QuickMail/ViewModels/ServerRulesViewModel.cs
@@ -80,6 +80,13 @@ public partial class ServerRulesViewModel : ObservableObject
     /// Editing is blocked for read-only rules and for rules using predicates/actions we can't
     /// represent — saving those would replace the server's richer object with our narrower one and
     /// silently drop the user's other predicates (spec §16).
+    /// <para>
+    /// <b>Deliberately NOT wired to the commands' <c>CanExecute</c>.</b> A disabled control is
+    /// announced only as unavailable, which tells a screen-reader user nothing about <i>why</i> a
+    /// rule on their own mailbox can't be edited. Instead the commands stay executable and explain
+    /// the reason when invoked (see <see cref="EditRule"/>), which is the accessible behaviour. XAML
+    /// may still bind visual affordances to this property.
+    /// </para>
     /// </summary>
     public bool CanEditSelected => SelectedRule is { IsFullyEditable: true, IsReadOnly: false };
 
@@ -175,6 +182,7 @@ public partial class ServerRulesViewModel : ObservableObject
         {
             await _service.SetEnabledAsync(accountId, rule.Id, target, ct);
             rule.IsEnabled = target;
+            RefreshRow(rule);
             OnPropertyChanged(nameof(DetailText));
             Announce(target ? "Rule enabled." : "Rule disabled.", AnnouncementCategory.Result);
         });
@@ -212,6 +220,29 @@ public partial class ServerRulesViewModel : ObservableObject
     }
 
     // ── Internals ───────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Forces the list row to re-render after the rule was mutated in place.
+    /// <para>
+    /// A row's displayed <i>and announced</i> text comes from <see cref="ServerRuleModel.ToString()"/>,
+    /// which a <c>ListView</c> evaluates when it realises the container. <see cref="ServerRuleModel"/>
+    /// is a plain model (like <see cref="MailRule"/>) and raises no change notification, so mutating
+    /// <c>IsEnabled</c> alone would leave the row still reading "enabled" after the user disabled it.
+    /// Re-assigning the slot raises a Replace notification, which regenerates that one container.
+    /// </para>
+    /// <para>
+    /// Chosen over making the model observable because <c>ToString()</c> composes several properties;
+    /// per-property notification would not cause WPF to re-evaluate it anyway.
+    /// </para>
+    /// </summary>
+    private void RefreshRow(ServerRuleModel rule)
+    {
+        var index = Rules.IndexOf(rule);
+        if (index < 0) return;
+
+        Rules[index] = rule;
+        SelectedRule = rule;   // Replace clears selection; put it back so focus doesn't jump
+    }
 
     private async Task MoveAsync(int delta, CancellationToken ct)
     {


### PR DESCRIPTION
Second slice of Exchange server-rule support for #333.

> ⚠️ **Stacked on #335** (the service layer) — base branch is `feat/server-rules-service-333`, not `main`. Review #335 first; this PR's diff shows only the ViewModels. Happy to rebase onto `main` once #335 merges if you'd rather review it flat.

**ViewModels only — no XAML, no DI wiring.** The window itself waits on the modal-vs-modeless question I raised on #334, since that's structural rather than something to retrofit.

## What's here
- **`ServerRulesViewModel`** — backs the "On the server" tab: Graph-account selector, rule collection, refresh/create/edit/toggle/reorder/delete, and detail prose for the selected rule. Exposes `HasGraphAccount` so the tab can be hidden entirely for IMAP-only users.
- **`ServerRuleEditorViewModel`** — create/edit form over the editable common subset, with validation (name required; at least one action; folder required when *Move to folder* is checked) and assembly back into a `ServerRuleModel`.

## The §16 gating is enforced in the UI too, not just the service
`GraphServerRuleService.UpdateAsync` already refuses a non-representable rule, but a user shouldn't get that far. So:

- **`CanEditSelected`** is false for read-only rules **and** for rules using predicates/actions we can't represent.
- **`EditRule` refuses to open the editor** for those, and *says why* ("…can't edit yet. You can enable, disable, or delete it here, or edit it in Outlook") rather than failing silently.
- **Toggle / reorder / delete stay available** for them — those paths send only `isEnabled` / `sequence`, so they can't clobber conditions we don't model. There's a test asserting toggle works on a non-editable rule.

## Other behavior worth a look
- **Permission refusal** raises `WriteBlockedByPermission` for the View to render as an **admin-directed** message. No in-app "Reauthorize" — it can't succeed under `.default`.
- **Reorder is optimistic and rolls back** the local order if the server refuses (tested).
- **Non-permission failures set a visible status** rather than leaving a silent empty state (CLAUDE.md).
- **No `MessageBox` / `Window` / `Dispatcher` anywhere.** Delete confirmation, folder picking, editor opening, and announcements are all events the View subscribes to.
- **`ImportanceOption` overrides `ToString()`** so a screen reader announces "High" rather than the type name — the theme-ComboBox bug class. It'll need adding to `SelectorItemAccessibilityTests` when the XAML lands.

## Tests
22 new: listing + status text, the edit-gating matrix (`[Theory]` over editable × read-only), the editor-refusal path, create/edit editor wiring, toggle on a non-editable rule, delete confirm/decline, reorder + rollback on refusal, the permission event, and editor validation/round-trip.

**Full suite: 1509 passed.** The single red is the known `OpenClipboard Failed` flake, verified passing in isolation.

## Next
The tabbed Rules Manager window + `App.xaml.cs` wiring — gated on your call re: converting `RulesManagerWindow` to modeless (comment on #334).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
