### PR TITLE
Graph: show Accept/Decline card for Exchange meeting invites

### DIFF
--- a/QuickMail.Tests/GraphMailServiceTests.cs
+++ b/QuickMail.Tests/GraphMailServiceTests.cs
@@ -234,6 +234,90 @@ public class GraphMailServiceTests
         Assert.Equal(1234, att.FileSize);
     }
 
+    // A raw RFC 822 meeting request whose text/calendar part carries the invite. CRLF line endings
+    // so MimeKit and the ICS parser see well-formed content regardless of the test file's encoding.
+    private static string MeetingRequestMime() => string.Join("\r\n", new[]
+    {
+        "From: Org <org@contoso.com>",
+        "To: me@contoso.com",
+        "Subject: Lunch",
+        "MIME-Version: 1.0",
+        "Content-Type: multipart/alternative; boundary=\"b\"",
+        "",
+        "--b",
+        "Content-Type: text/plain; charset=utf-8",
+        "",
+        "You're invited to lunch.",
+        "--b",
+        "Content-Type: text/calendar; method=REQUEST; charset=utf-8",
+        "",
+        "BEGIN:VCALENDAR",
+        "VERSION:2.0",
+        "METHOD:REQUEST",
+        "BEGIN:VEVENT",
+        "UID:lunch-1",
+        "SUMMARY:Lunch",
+        "DTSTART:20260722T170000Z",
+        "DTEND:20260722T180000Z",
+        "ORGANIZER;CN=Org:mailto:org@contoso.com",
+        "END:VEVENT",
+        "END:VCALENDAR",
+        "--b--",
+        "",
+    });
+
+    [Fact]
+    public async Task GetMessageDetailAsync_MeetingRequest_ExtractsCalendarInviteFromRawMime()
+    {
+        // A meeting-request message is a derived type; Graph annotates it with @odata.type. The
+        // message JSON has no text/calendar part, so the service must fetch the raw MIME ($value)
+        // and extract the ICS — lighting up the reading-pane Accept/Decline card. Issue #332.
+        const string detail = """
+            {"id":"m1","@odata.type":"#microsoft.graph.eventMessageRequest","subject":"Lunch",
+             "body":{"contentType":"html","content":"<p>invite</p>"},
+             "from":{"emailAddress":{"address":"org@contoso.com"}},
+             "toRecipients":[{"emailAddress":{"address":"me@contoso.com"}}],
+             "ccRecipients":[],"receivedDateTime":"2026-07-22T00:00:00Z","isRead":false,"hasAttachments":false}
+            """;
+        var (svc, handler) = Make(url =>
+              url.Contains("/me?")   ? (HttpStatusCode.OK, MeJson)
+            : url.Contains("$value") ? (HttpStatusCode.OK, MeetingRequestMime())
+            : (HttpStatusCode.OK, detail));
+
+        var account = GraphAccount();
+        await svc.ConnectAsync(account, ct: TestContext.Current.CancellationToken);
+        var d = await svc.GetMessageDetailAsync(account.Id, "inbox", "m1", TestContext.Current.CancellationToken);
+
+        Assert.Contains(handler.Requests, u => u.Contains("/messages/m1/$value"));
+        Assert.NotNull(d.CalendarInvite);
+        Assert.Equal("lunch-1", d.CalendarInvite!.Uid);
+        Assert.Equal("Lunch", d.CalendarInvite.Summary);
+        Assert.Equal("REQUEST", d.CalendarInvite.Method);
+        Assert.Contains("BEGIN:VCALENDAR", d.CalendarIcs); // raw ICS persisted so the invite survives caching
+    }
+
+    [Fact]
+    public async Task GetMessageDetailAsync_OrdinaryMessage_DoesNotFetchRawMime()
+    {
+        // No @odata.type annotation → ordinary mail → no $value round-trip and no invite card.
+        const string detail = """
+            {"id":"m1","subject":"Hello",
+             "body":{"contentType":"html","content":"<p>Hi</p>"},
+             "from":{"emailAddress":{"address":"alice@x.com"}},
+             "toRecipients":[{"emailAddress":{"address":"me@x.com"}}],
+             "ccRecipients":[],"receivedDateTime":"2024-01-02T03:04:05Z","isRead":true,"hasAttachments":false}
+            """;
+        var (svc, handler) = Make(url => url.Contains("/me?") ? (HttpStatusCode.OK, MeJson) : (HttpStatusCode.OK, detail));
+
+        var account = GraphAccount();
+        await svc.ConnectAsync(account, ct: TestContext.Current.CancellationToken);
+        var d = await svc.GetMessageDetailAsync(account.Id, "inbox", "m1", TestContext.Current.CancellationToken);
+
+        Assert.DoesNotContain(handler.Requests, u => u.Contains("$value"));
+        Assert.Null(d.CalendarInvite);
+        Assert.Equal(string.Empty, d.CalendarIcs);
+    }
+
     [Fact]
     public async Task GetMessagesSinceDateAsync_AddsReceivedDateTimeFilter()
     {

--- a/QuickMail.Tests/GraphMailServiceTests.cs
+++ b/QuickMail.Tests/GraphMailServiceTests.cs
@@ -319,6 +319,45 @@ public class GraphMailServiceTests
     }
 
     [Fact]
+    public async Task GetMessageDetailAsync_MeetingMessageWithoutCalendarPart_OpensWithoutInvite()
+    {
+        // A meeting-typed message whose raw MIME carries no text/calendar part (e.g. a malformed or
+        // partial invite, or an .ics delivered only as an application/ics attachment). The $value
+        // fetch still happens, but extraction finds nothing and must fall through cleanly: the
+        // message opens with no invite card rather than throwing. Guards the calendar == null branch.
+        const string detail = """
+            {"id":"m1","@odata.type":"#microsoft.graph.eventMessageRequest","subject":"Lunch",
+             "body":{"contentType":"html","content":"<p>invite</p>"},
+             "from":{"emailAddress":{"address":"org@contoso.com"}},
+             "toRecipients":[{"emailAddress":{"address":"me@contoso.com"}}],
+             "ccRecipients":[],"receivedDateTime":"2026-07-22T00:00:00Z","isRead":false,"hasAttachments":false}
+            """;
+        var noCalendarMime = string.Join("\r\n", new[]
+        {
+            "From: Org <org@contoso.com>",
+            "To: me@contoso.com",
+            "Subject: Lunch",
+            "MIME-Version: 1.0",
+            "Content-Type: text/plain; charset=utf-8",
+            "",
+            "You're invited to lunch, but the calendar part is missing.",
+            "",
+        });
+        var (svc, handler) = Make(url =>
+              url.Contains("/me?")   ? (HttpStatusCode.OK, MeJson)
+            : url.Contains("$value") ? (HttpStatusCode.OK, noCalendarMime)
+            : (HttpStatusCode.OK, detail));
+
+        var account = GraphAccount();
+        await svc.ConnectAsync(account, ct: TestContext.Current.CancellationToken);
+        var d = await svc.GetMessageDetailAsync(account.Id, "inbox", "m1", TestContext.Current.CancellationToken);
+
+        Assert.Contains(handler.Requests, u => u.Contains("/messages/m1/$value")); // meeting type still triggers the fetch
+        Assert.Null(d.CalendarInvite);                                             // …but no invite is surfaced
+        Assert.Equal(string.Empty, d.CalendarIcs);
+    }
+
+    [Fact]
     public async Task GetMessagesSinceDateAsync_AddsReceivedDateTimeFilter()
     {
         var (svc, handler) = Make(url => url.Contains("/me?") ? (HttpStatusCode.OK, MeJson) : (HttpStatusCode.OK, """{"value":[]}"""));

--- a/QuickMail/Services/Graph/GraphDtos.cs
+++ b/QuickMail/Services/Graph/GraphDtos.cs
@@ -73,6 +73,14 @@ internal sealed class GraphAttachment
 
 internal sealed class GraphMessage
 {
+    /// <summary>
+    /// OData type annotation. For a meeting-request message the instance is a derived type
+    /// (<c>#microsoft.graph.eventMessageRequest</c> / <c>eventMessageResponse</c> /
+    /// <c>eventMessage</c>), which Graph's minimal metadata emits here because it differs from the
+    /// base <c>message</c> type. Absent (null) for ordinary mail. Used to decide whether to fetch
+    /// the raw MIME and extract the ICS invite (issue #332).
+    /// </summary>
+    [JsonPropertyName("@odata.type")] public string? ODataType { get; set; }
     [JsonPropertyName("id")] public string Id { get; set; } = string.Empty;
     [JsonPropertyName("subject")] public string? Subject { get; set; }
     [JsonPropertyName("bodyPreview")] public string? BodyPreview { get; set; }

--- a/QuickMail/Services/GraphMailService.cs
+++ b/QuickMail/Services/GraphMailService.cs
@@ -208,8 +208,45 @@ public class GraphMailService : IMailService
                    "&$expand=attachments($select=id,name,contentType,size,isInline)";
         var m = await _client.GetAsync<GraphMessage>(Account(accountId), path, ct)
             ?? throw new InvalidOperationException($"Graph message {messageId} not found.");
-        return MapToDetail(m, accountId, folderName);
+        var detail = MapToDetail(m, accountId, folderName);
+        await TryAttachCalendarInviteAsync(accountId, messageId, m, detail, ct);
+        return detail;
     }
+
+    // Graph's message JSON never surfaces the text/calendar MIME part, so a meeting request arrives
+    // with no invite to drive the reading-pane Accept/Decline card. For those messages only, fetch
+    // the raw RFC 822 MIME ($value) and extract the ICS — reusing IcsModel and the existing IMAP RSVP
+    // flow (MainViewModel.RespondToCalendarInviteAsync). CalendarIcs is set alongside CalendarInvite so
+    // the invite survives caching (see the ImapMailService note; same prefetch-vs-open race). Issue #332.
+    private async Task TryAttachCalendarInviteAsync(
+        Guid accountId, string messageId, GraphMessage m, MailMessageDetail detail, CancellationToken ct)
+    {
+        if (!IsMeetingMessage(m.ODataType)) return;
+        try
+        {
+            var mime = await _client.GetBytesAsync(Account(accountId), $"/me/messages/{messageId}/$value", ct);
+            using var stream = new MemoryStream(mime);
+            var message = await MimeMessage.LoadAsync(stream, ct);
+            var calendar = message.BodyParts.OfType<TextPart>()
+                .FirstOrDefault(p => p.ContentType.IsMimeType("text", "calendar"));
+            if (calendar != null && !string.IsNullOrWhiteSpace(calendar.Text))
+            {
+                detail.CalendarIcs = calendar.Text;
+                detail.CalendarInvite = IcsModel.Parse(calendar.Text);
+            }
+        }
+        catch (Exception ex)
+        {
+            // A missing/garbled invite must never break opening the message — fall through to the
+            // normal (invite-less) detail, exactly as the IMAP path does on a parse failure.
+            LogService.Log($"GraphMailService: failed to fetch/parse calendar invite for {messageId}: {ex.Message}");
+        }
+    }
+
+    /// <summary>True when the message instance is a meeting-related derived type (invite, response,
+    /// or cancellation), signalled by Graph's <c>@odata.type</c> annotation.</summary>
+    private static bool IsMeetingMessage(string? odataType)
+        => odataType != null && odataType.Contains("eventMessage", StringComparison.OrdinalIgnoreCase);
 
     // Graph GET does not set the Seen flag, so prefetch is identical to a normal detail fetch.
     public Task<MailMessageDetail> PrefetchMessageDetailAsync(


### PR DESCRIPTION
## Summary

Meeting invites opened from an Exchange (Graph) account had no **Accept / Decline / Tentative** buttons. The invite card is driven by `MailMessageDetail.CalendarInvite`, which was only ever populated on the IMAP path — `GraphMailService` never set it, so the card never rendered for Exchange mail.

This wires up the invite card for Graph using the **basic (iMIP) option** from #332:

- Graph's message JSON doesn't surface the `text/calendar` MIME part. For meeting-request messages only — detected via Graph's `@odata.type` derived-type annotation (`#microsoft.graph.eventMessageRequest`, etc.) — we now fetch the raw RFC 822 MIME (`GET /me/messages/{id}/$value`), extract the `text/calendar` part with MimeKit, and populate `CalendarInvite` + `CalendarIcs` exactly as the IMAP path does.
- This reuses the whole existing RSVP flow (`MainViewModel.RespondToCalendarInviteAsync`). Reply-sending already routes Graph accounts through Graph `/sendMail` (`SmtpService.SendIcsReplyAsync` → `_graphSmtp`), so no further wiring was needed.
- A fetch/parse failure falls through to a normal invite-less open — opening the message never breaks — matching the IMAP path's behavior on a bad calendar part.
- `CalendarIcs` is persisted alongside `CalendarInvite` so the invite survives caching (same prefetch-vs-open race the IMAP path documents).

Ordinary mail is unaffected: no `@odata.type` annotation → no extra `$value` round-trip.

## Changes

- `GraphDtos.cs` — add `@odata.type` (`ODataType`) to `GraphMessage`.
- `GraphMailService.cs` — `GetMessageDetailAsync` calls new `TryAttachCalendarInviteAsync`; gated by `IsMeetingMessage`.
- `GraphMailServiceTests.cs` — two tests: meeting request extracts the invite (and persists raw ICS); ordinary message makes no `$value` call and shows no card.

## Testing

- `dotnet test --filter GraphMailServiceTests` → 12/12 pass.
- Main project builds clean (0 warnings).
- ⚠️ Not yet exercised against a live Exchange mailbox — worth a manual accept/decline round-trip before the feature gate is flipped.

## Known limitations (tracked in #332)

This is the basic option. It notifies the **organizer** and reflects the response **inside QuickMail**, but does **not** update the user's Exchange server calendar — so OWA / Outlook / phone still show the meeting as unanswered, and a subsequent Graph calendar sync can revert QuickMail's local status. The native Graph response actions (`/accept`, `/decline`, `/tentativelyAccept`) are deferred to a later release.

Refs #332
