### PR TITLE
Fix invite feedback (#329) and bare-key shortcuts (#330); add startup folder (#328)

### DIFF
--- a/QuickMail.Tests/GestureHelperTests.cs
+++ b/QuickMail.Tests/GestureHelperTests.cs
@@ -1,0 +1,56 @@
+using System.Windows.Input;
+using QuickMail.Helpers;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+// Covers bare-key bindings (issue #330): Delete/Backspace/Insert/F-keys must be capturable and must
+// round-trip through the gesture string, while ordinary text and dialog-navigation keys must not.
+public class GestureHelperTests
+{
+    [Theory]
+    [InlineData(Key.Delete, true)]
+    [InlineData(Key.Back, true)]
+    [InlineData(Key.Insert, true)]
+    [InlineData(Key.F1, true)]
+    [InlineData(Key.F5, true)]
+    [InlineData(Key.F24, true)]
+    [InlineData(Key.A, false)]
+    [InlineData(Key.D5, false)]
+    [InlineData(Key.Space, false)]
+    [InlineData(Key.Enter, false)]
+    [InlineData(Key.Escape, false)]
+    [InlineData(Key.Tab, false)]
+    public void IsBindableBareKey_AllowsOnlyTheIntendedKeys(Key key, bool expected)
+        => Assert.Equal(expected, GestureHelper.IsBindableBareKey(key));
+
+    [Theory]
+    [InlineData(Key.Delete, "Delete")]
+    [InlineData(Key.Back, "Backspace")]
+    [InlineData(Key.Insert, "Insert")]
+    [InlineData(Key.F3, "F3")]
+    public void BareKey_RoundTripsThroughFormatAndTryParse(Key key, string expectedGesture)
+    {
+        var gesture = GestureHelper.Format(key, ModifierKeys.None);
+        Assert.Equal(expectedGesture, gesture);
+
+        Assert.True(GestureHelper.TryParse(gesture, out var parsedKey, out var parsedMods));
+        Assert.Equal(key, parsedKey);
+        Assert.Equal(ModifierKeys.None, parsedMods);
+    }
+
+    [Theory]
+    [InlineData("A")]        // bare letter — not allowlisted
+    [InlineData("Space")]    // bare space
+    [InlineData("Enter")]    // dialog-navigation key
+    public void TryParse_RejectsBareNonAllowlistedKeys(string gesture)
+        => Assert.False(GestureHelper.TryParse(gesture, out _, out _));
+
+    [Fact]
+    public void TryParse_StillParsesModifierCombos()
+    {
+        Assert.True(GestureHelper.TryParse("Ctrl+Shift+Delete", out var key, out var mods));
+        Assert.Equal(Key.Delete, key);
+        Assert.Equal(ModifierKeys.Control | ModifierKeys.Shift, mods);
+    }
+}

--- a/QuickMail.Tests/InviteCardTests.cs
+++ b/QuickMail.Tests/InviteCardTests.cs
@@ -1,0 +1,55 @@
+using System;
+using QuickMail.Models;
+using QuickMail.ViewModels;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+// Reading-pane invite card (issue #329): the card must carry an aria-live status region so a response
+// can be confirmed reliably from inside the WebView2 (a host-window notification alone was getting
+// dropped because focus is in the WebView2 document).
+public class InviteCardTests
+{
+    private static MainViewModel MakeVm() => new(
+        new StubImapMailService(), new StubAccountService(), new StubCredentialService(),
+        new StubLocalStoreService(), new StubOAuthService(), new StubSyncService(),
+        new StubConfigService(), new StubCommandRegistry(), new StubViewService(),
+        new StubRuleService(), new StubSmtpService());
+
+    private static MailMessageDetail DetailWithInvite() => new()
+    {
+        AccountId = Guid.NewGuid(),
+        MessageId = "m1",
+        FolderName = "INBOX",
+        Subject = "Lunch",
+        CalendarInvite = new IcsModel
+        {
+            Uid = "lunch-1",
+            Summary = "Lunch",
+            Organizer = "org@example.com",
+            StartTime = new DateTime(2026, 7, 22, 17, 0, 0, DateTimeKind.Utc),
+            Method = "REQUEST",
+        },
+    };
+
+    [Fact]
+    public void EventCard_WithInvite_IncludesAriaLiveStatusRegion()
+    {
+        var vm = MakeVm();
+        vm.MessageDetail = DetailWithInvite();
+
+        var html = vm.BuildEventCardHtml();
+
+        Assert.Contains("id=\"qm-invite-status\"", html);
+        Assert.Contains("aria-live=\"assertive\"", html);
+        // Sanity: the response buttons are still present for a REQUEST.
+        Assert.Contains("quickmail:ics-accept", html);
+    }
+
+    [Fact]
+    public void EventCard_NoInvite_IsEmpty()
+    {
+        var vm = MakeVm();
+        Assert.Equal(string.Empty, vm.BuildEventCardHtml());
+    }
+}

--- a/QuickMail.Tests/StartupFolderTests.cs
+++ b/QuickMail.Tests/StartupFolderTests.cs
@@ -1,0 +1,55 @@
+using System;
+using System.IO;
+using QuickMail.Models;
+using QuickMail.Services;
+using QuickMail.ViewModels;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+// Startup folder (issue #328): the folder is persisted as an INI-safe token, since config.ini cannot
+// hold the NUL-prefixed virtual-folder sentinels.
+public class StartupFolderTests
+{
+    [Fact]
+    public void EncodeToken_VirtualFolder_StripsNulSentinel()
+    {
+        // AllMailFolder.FullName is "\0AllMail"; the token must be INI-safe ("#AllMail").
+        var token = MainViewModel.EncodeStartupFolderToken(MainViewModel.AllMailFolder);
+        Assert.Equal("#AllMail", token);
+        Assert.DoesNotContain('\0', token);
+    }
+
+    [Fact]
+    public void EncodeToken_RealFolder_CarriesAccountAndFullName()
+    {
+        var accountId = Guid.NewGuid();
+        var folder = new MailFolderModel { AccountId = accountId, FullName = "INBOX/Projects" };
+
+        var token = MainViewModel.EncodeStartupFolderToken(folder);
+
+        Assert.Equal($"@{accountId:N}|INBOX/Projects", token);
+        Assert.DoesNotContain('\0', token);
+    }
+
+    [Fact]
+    public void ConfigService_RoundTripsStartupFolder()
+    {
+        var profile = new ProfileContext(Path.Combine(Path.GetTempPath(), $"QM-SF-{Guid.NewGuid():N}"));
+        var service = new ConfigService(profile);
+
+        var config = service.Load();
+        config.StartupFolder = "#AllInboxes";
+        service.Save(config);
+
+        var reloaded = new ConfigService(profile).Load();
+        Assert.Equal("#AllInboxes", reloaded.StartupFolder);
+    }
+
+    [Fact]
+    public void ConfigService_DefaultStartupFolder_IsEmpty()
+    {
+        var profile = new ProfileContext(Path.Combine(Path.GetTempPath(), $"QM-SF-{Guid.NewGuid():N}"));
+        Assert.Equal(string.Empty, new ConfigService(profile).Load().StartupFolder);
+    }
+}

--- a/QuickMail/Helpers/GestureHelper.cs
+++ b/QuickMail/Helpers/GestureHelper.cs
@@ -13,6 +13,18 @@ public static class GestureHelper
     private static readonly Dictionary<Key, string> _keyToName = BuildKeyToName();
     private static readonly Dictionary<string, Key> _nameToKey = BuildNameToKey();
 
+    /// <summary>
+    /// True for the modifier-less keys that may be bound as a bare shortcut: Delete, Backspace,
+    /// Insert, and F1–F24. Ordinary text keys (letters/digits/space) and the dialog-navigation
+    /// keys (Enter/Escape/Tab) are deliberately excluded, so capturing a shortcut can never turn
+    /// normal typing into a global hotkey. Both the capture dialog and <see cref="TryParse"/> use
+    /// this, so a bare binding round-trips through config. Bare Delete already ships as a default
+    /// (e.g. the delete-message command), which is why the capture UI must accept it too. See #330.
+    /// </summary>
+    public static bool IsBindableBareKey(Key key) =>
+        key is Key.Delete or Key.Back or Key.Insert
+            || (key >= Key.F1 && key <= Key.F24);
+
     public static string Format(Key key, ModifierKeys modifiers)
     {
         if (key == Key.None) return string.Empty;
@@ -43,7 +55,22 @@ public static class GestureHelper
         if (string.IsNullOrWhiteSpace(gesture)) return false;
 
         var parts = gesture.Split('+');
-        if (parts.Length < 2) return false;
+
+        // Bare single-key gesture (no modifier) — accepted only for the allowlisted keys, so a
+        // custom bare Delete/Backspace/Insert/F-key round-trips through config. See #330.
+        if (parts.Length == 1)
+        {
+            var bare = parts[0].Trim();
+            if ((_nameToKey.TryGetValue(bare, out key)
+                    || (Enum.TryParse(bare, ignoreCase: true, out key) && key != Key.None))
+                && IsBindableBareKey(key))
+            {
+                modifiers = ModifierKeys.None;
+                return true;
+            }
+            key = Key.None;
+            return false;
+        }
 
         for (int i = 0; i < parts.Length - 1; i++)
         {

--- a/QuickMail/Models/ConfigModel.cs
+++ b/QuickMail/Models/ConfigModel.cs
@@ -35,6 +35,14 @@ public class ConfigModel
     public string Sort { get; set; } = "dateDesc";
 
     /// <summary>
+    /// The folder QuickMail opens at startup, as an INI-safe token produced by MainViewModel's
+    /// startup-folder encoding ("#&lt;key&gt;" for a global virtual folder, "@&lt;accountId&gt;|&lt;fullName&gt;"
+    /// for a real folder). Empty = the default All Mail view. Set from the folder tree context menu,
+    /// not by hand. Issue #328.
+    /// </summary>
+    public string StartupFolder { get; set; } = string.Empty;
+
+    /// <summary>
     /// How many days of mail to sync. 0 = sync all mail (no date filter).
     /// Supported values: 7, 30, 180, 365, or 0 (all).
     /// </summary>

--- a/QuickMail/Services/ConfigService.cs
+++ b/QuickMail/Services/ConfigService.cs
@@ -211,6 +211,10 @@ public class ConfigService : IConfigService
                             _               => "messages",
                         };
                         break;
+                    case "startupfolder":
+                        // Opaque INI-safe token (see MainViewModel startup-folder encoding); stored verbatim.
+                        config.StartupFolder = value;
+                        break;
                     case "syncdays":
                         if (int.TryParse(value, out var sd)) config.SyncDays = Math.Max(0, sd);
                         break;
@@ -383,6 +387,12 @@ public class ConfigService : IConfigService
         sb.AppendLine($"ViewMode = {config.ViewMode}");
         sb.AppendLine("# How to display the message list.");
         sb.AppendLine("# Values: messages (flat list), conversations (grouped by subject), from (grouped by sender).");
+        sb.AppendLine();
+
+        sb.AppendLine($"StartupFolder = {config.StartupFolder}");
+        sb.AppendLine("# The folder to open at startup. Empty = All Mail (the default).");
+        sb.AppendLine("# Set this from the folder tree context menu (\"Set as Startup Folder\") rather than by hand;");
+        sb.AppendLine("# it holds an internal token identifying the folder.");
         sb.AppendLine();
 
         sb.AppendLine($"SyncDays = {config.SyncDays}");

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -2654,6 +2654,9 @@ public partial class MainViewModel : ObservableObject, IDisposable
 
         IsBusy = false;
         RebuildFolderListFromCache();
+        // Real folders exist only now (post-connect), so a configured startup folder (#328) is applied
+        // here — the earliest point it can resolve — not in InitialLoadAsync. Runs once per launch.
+        await ApplyStartupFolderOnceAsync();
         StatusText = _cachedFolders.Count > 0
             ? $"{_cachedFolders.Count} of {Accounts.Count} account(s) connected."
             : "No accounts could be connected.";
@@ -4604,6 +4607,89 @@ public partial class MainViewModel : ObservableObject, IDisposable
         _accountService.SaveAccounts([.. Accounts]);
     }
 
+    // ── Startup folder (issue #328) ───────────────────────────────────────────────
+    // The folder opened at launch is stored in config.ini, which cannot hold the NUL-prefixed
+    // virtual-folder sentinels, so it is persisted as an INI-safe token:
+    //   "#<key>"                     — a global virtual folder (its FullName minus the leading NUL)
+    //   "@<accountId:N>|<fullName>"  — a real per-account folder
+    // Only the global virtual folders and real folders are offered as startup targets.
+    private bool _startupFolderApplied;
+
+    private static readonly MailFolderModel[] StartupVirtualFolders =
+        { AllMailFolder, AllInboxesFolder, AllDraftsFolder, AllSentFolder, AllTrashFolder };
+
+    internal static string EncodeStartupFolderToken(MailFolderModel folder) =>
+        folder.FullName.Length > 0 && folder.FullName[0] == '\0'
+            ? "#" + folder.FullName[1..]
+            : "@" + folder.AccountId.ToString("N") + "|" + folder.FullName;
+
+    private MailFolderModel? ResolveStartupFolder(string token)
+    {
+        if (string.IsNullOrEmpty(token)) return null;
+
+        if (token[0] == '#')
+        {
+            var fullName = "\0" + token[1..];
+            return StartupVirtualFolders.FirstOrDefault(
+                f => string.Equals(f.FullName, fullName, StringComparison.Ordinal));
+        }
+        if (token[0] == '@')
+        {
+            var sep = token.IndexOf('|');
+            if (sep < 0) return null;
+            if (!Guid.TryParseExact(token[1..sep], "N", out var accountId)) return null;
+            var fullName = token[(sep + 1)..];
+            return _cachedFolders.TryGetValue(accountId, out var folders)
+                ? folders.FirstOrDefault(f => string.Equals(f.FullName, fullName, StringComparison.Ordinal))
+                : null;
+        }
+        return null;
+    }
+
+    /// <summary>Persists <paramref name="folder"/> as the startup folder (folder tree context command).</summary>
+    public void SetStartupFolder(MailFolderModel folder)
+    {
+        if (folder is null || folder.IsHeader) return;
+        var cfg = _configService.Load();
+        cfg.StartupFolder = EncodeStartupFolderToken(folder);
+        _configService.Save(cfg);
+    }
+
+    /// <summary>Clears the startup folder, so launch returns to the default All Mail view.</summary>
+    public void ClearStartupFolder()
+    {
+        var cfg = _configService.Load();
+        cfg.StartupFolder = string.Empty;
+        _configService.Save(cfg);
+    }
+
+    /// <summary>True when a startup folder is configured (drives the "Clear" menu item's enabled state).</summary>
+    public bool HasStartupFolder => !string.IsNullOrEmpty(_configService.Load().StartupFolder);
+
+    // Applies the configured startup folder exactly once per launch, right after the first post-connect
+    // folder rebuild. Falls back to All Mail (no-op) if nothing is configured, the folder no longer
+    // exists, or the user already navigated away during connect — so it can never strand startup.
+    private async Task ApplyStartupFolderOnceAsync()
+    {
+        if (_startupFolderApplied) return;
+        _startupFolderApplied = true;
+
+        var token = _configService.Load().StartupFolder;
+        if (string.IsNullOrEmpty(token)) return;
+
+        // Respect a folder the user already chose while connecting.
+        if (SelectedFolder != null &&
+            !string.Equals(SelectedFolder.FullName, AllMailFolder.FullName, StringComparison.Ordinal))
+            return;
+
+        var folder = ResolveStartupFolder(token);
+        if (folder == null ||
+            string.Equals(folder.FullName, AllMailFolder.FullName, StringComparison.Ordinal))
+            return;
+
+        await SelectFolderAsync(folder);
+    }
+
     /// <summary>
     /// Moves the given messages to each account's Archive folder (issue #318). Mirrors the optimistic
     /// UI of <see cref="DeleteMessagesAsync"/> — messages vanish immediately, focus lands on the next
@@ -4764,6 +4850,13 @@ public partial class MainViewModel : ObservableObject, IDisposable
     public event Action? ManageAccountsRequested;
     public event Action? MessageListFocusRequested;
     public event EventHandler<(string Text, AnnouncementCategory Category)>? AnnouncementRequested;
+
+    /// <summary>
+    /// Raised after a meeting response is sent for the invite currently open in the reading pane, so
+    /// the View can update the in-WebView2 event card in place. Args: (actionLabel, eventTitle) — e.g.
+    /// ("accepted", "Team standup"). See MainWindow.OnOpenInviteResponded and issue #329.
+    /// </summary>
+    public event Action<string, string>? OpenInviteResponded;
     public event EventHandler? RulesManagerRequested;
     public event EventHandler<MailRule>? CreateRuleFromMessageRequested;
     public event EventHandler? TutorialRequested;
@@ -6405,6 +6498,13 @@ public partial class MainViewModel : ObservableObject, IDisposable
             sb.Append("</div>");
         }
 
+        // Empty aria-live region, filled after a response completes (see MainWindow.OnOpenInviteResponded).
+        // Because it lives inside the document the screen reader is already reading, updating it is
+        // announced reliably — unlike a host-window notification raised while focus is in the WebView2,
+        // which is what made responses feel silent (#329). It also leaves a durable, re-readable
+        // confirmation in the card.
+        sb.Append($"<div id=\"qm-invite-status\" role=\"status\" aria-live=\"assertive\" style=\"margin-top:8px;font-weight:600;color:{Color("success", "#2E6B3E")};\"></div>");
+
         sb.Append("</div>");
         return sb.ToString();
     }
@@ -6430,7 +6530,15 @@ public partial class MainViewModel : ObservableObject, IDisposable
     private async Task SendIcsReply(string partStat, string actionLabel)
     {
         var invite = MessageDetail?.CalendarInvite;
-        if (invite == null) return;
+        if (invite == null)
+        {
+            // The card was shown but the invite data isn't available (e.g. a cache-served reopen before
+            // reconstruction). Say so instead of silently doing nothing — the old silent return is what
+            // made Accept feel like it "did nothing" (#329).
+            Announce("This invitation can't be answered right now. Open it again from the message list and try once it has loaded.",
+                     AnnouncementCategory.Result);
+            return;
+        }
 
         var account = Accounts.FirstOrDefault(a => a.Id == MessageDetail!.AccountId);
         if (account == null)
@@ -6505,6 +6613,10 @@ public partial class MainViewModel : ObservableObject, IDisposable
     {
         try
         {
+            // Immediate feedback: the send is a network round-trip, so without this the user gets no
+            // acknowledgement until it completes (a large part of why Accept felt unresponsive, #329).
+            Announce($"Sending your {actionLabel} response\u2026", AnnouncementCategory.Status);
+
             var attendeeName = account.SenderDisplayName;
             var attendeeEmail = account.Username;
             var icsContent = invite.GenerateReply(attendeeEmail, attendeeName, partStat);
@@ -6514,6 +6626,13 @@ public partial class MainViewModel : ObservableObject, IDisposable
 
             var eventTitle = invite.Summary ?? "calendar event";
             Announce($"Calendar response sent: {actionLabel} \u2014 {eventTitle}.", AnnouncementCategory.Result);
+
+            // If this reply was for the invite currently open in the reading pane, update its card in
+            // place (durable confirmation + an in-document aria-live announcement that is heard even
+            // though focus is inside the WebView2). See MainWindow.OnOpenInviteResponded.
+            if (IsMessageOpen && MessageDetail?.CalendarInvite != null &&
+                string.Equals(MessageDetail.CalendarInvite.Uid, invite.Uid, StringComparison.Ordinal))
+                OpenInviteResponded?.Invoke(actionLabel, eventTitle);
 
             // Update the calendar event's response status so the calendar pane reflects the reply.
             if (_calendarService != null && !string.IsNullOrEmpty(invite.Uid))

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -4616,7 +4616,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
     private bool _startupFolderApplied;
 
     private static readonly MailFolderModel[] StartupVirtualFolders =
-        { AllMailFolder, AllInboxesFolder, AllDraftsFolder, AllSentFolder, AllTrashFolder };
+        { AllMailFolder, AllInboxesFolder, AllDraftsFolder, AllSentFolder, AllTrashFolder, AllFlaggedFolder };
 
     internal static string EncodeStartupFolderToken(MailFolderModel folder) =>
         folder.FullName.Length > 0 && folder.FullName[0] == '\0'
@@ -4662,9 +4662,6 @@ public partial class MainViewModel : ObservableObject, IDisposable
         cfg.StartupFolder = string.Empty;
         _configService.Save(cfg);
     }
-
-    /// <summary>True when a startup folder is configured (drives the "Clear" menu item's enabled state).</summary>
-    public bool HasStartupFolder => !string.IsNullOrEmpty(_configService.Load().StartupFolder);
 
     // Applies the configured startup folder exactly once per launch, right after the first post-connect
     // folder rebuild. Falls back to All Mail (no-op) if nothing is configured, the folder no longer

--- a/QuickMail/Views/KeyCaptureDialog.xaml.cs
+++ b/QuickMail/Views/KeyCaptureDialog.xaml.cs
@@ -55,7 +55,13 @@ public partial class KeyCaptureDialog : Window
             return;
 
         var modifiers = Keyboard.Modifiers;
-        if (modifiers == ModifierKeys.None) return;
+
+        // A modifier-less press is accepted only for keys that make sense as a bare shortcut
+        // (Delete, Backspace, Insert, F1–F24) — bare Delete already ships as a default binding,
+        // so the capture UI must be able to reproduce it (#330). Bare letters/digits/space and the
+        // dialog-navigation keys (Enter/Escape/Tab) fall through to normal handling instead of
+        // becoming a global hotkey.
+        if (modifiers == ModifierKeys.None && !GestureHelper.IsBindableBareKey(e.Key)) return;
 
         _capturedKey       = e.Key;
         _capturedModifiers = modifiers;

--- a/QuickMail/Views/MainWindow.xaml
+++ b/QuickMail/Views/MainWindow.xaml
@@ -251,6 +251,13 @@
                       AutomationProperties.Name="Use Automatic Archive Folder"
                       Click="FolderContextMenu_ClearArchive_Click"/>
             <Separator/>
+            <MenuItem Header="Set as _Startup Folder"
+                      AutomationProperties.Name="Set as Startup Folder"
+                      Click="FolderContextMenu_SetStartup_Click"/>
+            <MenuItem Header="Clear Startup _Folder"
+                      AutomationProperties.Name="Clear Startup Folder"
+                      Click="FolderContextMenu_ClearStartup_Click"/>
+            <Separator/>
             <MenuItem Header="_Delete Folder"
                       AutomationProperties.Name="Delete Folder"
                       Click="FolderContextMenu_DeleteFolder_Click"/>

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -313,6 +313,7 @@ public partial class MainWindow : Window
         vm.MessageListFocusRequested += ReturnFocusToMessageList;
         vm.AnnouncementRequested += (_, args) =>
             AccessibilityHelper.Announce(this, args.Text, interrupt: true, category: args.Category);
+        vm.OpenInviteResponded += OnOpenInviteResponded;
         vm.SearchRequested += (_, _) => OpenSearch();
         vm.SaveViewRequested    += (_, _) => OpenViewManager(createMode: true);
         vm.ManageViewsRequested += (_, _) => OpenViewManager(createMode: false);
@@ -3205,6 +3206,20 @@ public partial class MainWindow : Window
             _vm.DeclineInviteCommand.Execute(null);
     }
 
+    // After a meeting response is sent for the open invite, fill the card's aria-live status region
+    // (updating an in-document live region is announced reliably even though focus is in the WebView2 —
+    // the host-window notification alone was getting dropped, #329) and leave a durable confirmation.
+    private async void OnOpenInviteResponded(string actionLabel, string eventTitle)
+    {
+        if (!_webViewReady || MessageBody.CoreWebView2 is null) return;
+        var confirmation = $"You {actionLabel} this meeting. Your reply was sent to the organizer.";
+        // JsonSerializer produces a safe, quoted JS string literal; textContent avoids any HTML injection.
+        var js = "(function(){var s=document.getElementById('qm-invite-status');" +
+                 "if(s){s.textContent=" + System.Text.Json.JsonSerializer.Serialize(confirmation) + ";}})();";
+        try { await MessageBody.CoreWebView2.ExecuteScriptAsync(js); }
+        catch (Exception ex) { LogService.Log("OnOpenInviteResponded", ex); }
+    }
+
     // Message content is untrusted; only allow-listed schemes (http/https/mailto)
     // may leave the app via ShellExecute. See ExternalUriPolicy.
     private static void OpenExternal(string uri) =>
@@ -5280,6 +5295,29 @@ public partial class MainWindow : Window
         _vm.SetArchiveFolder(folder.AccountId, null);
         AccessibilityHelper.Announce(this,
             "This account will use its automatic Archive folder.",
+            category: AnnouncementCategory.Result);
+    }
+
+    // ── Startup folder assignment (issue #328) ────────────────────────────────
+    // Global (not per-account): the chosen folder is opened at the next launch. Real folders and the
+    // global "All …" virtual folders are valid targets; account header rows are not.
+    private void FolderContextMenu_SetStartup_Click(object sender, RoutedEventArgs e)
+    {
+        var node = GetContextMenuFolderNode(sender);
+        if (node is null || node.IsHeader || node.Folder is not { } folder ||
+            folder.FullName.Length == 0)
+            return;
+        _vm.SetStartupFolder(folder);
+        AccessibilityHelper.Announce(this,
+            $"{folder.DisplayName} set as the startup folder.",
+            category: AnnouncementCategory.Result);
+    }
+
+    private void FolderContextMenu_ClearStartup_Click(object sender, RoutedEventArgs e)
+    {
+        _vm.ClearStartupFolder();
+        AccessibilityHelper.Announce(this,
+            "Startup folder cleared. QuickMail will open to All Mail.",
             category: AnnouncementCategory.Result);
     }
 

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -246,6 +246,10 @@ Create a new folder in any of these ways:
 
 The new folder is created under the folder currently selected in the folder tree, or under the account root when a header or nothing is selected.
 
+### Startup Folder
+
+By default QuickMail opens to **All Mail**. To open a different folder at launch, select it in the folder tree, press **Shift+F10** (or the Applications key) for its context menu, and choose **Set as Startup Folder**. The next time you start QuickMail it opens to that folder. Choose **Clear Startup Folder** from the same menu to return to opening All Mail. You can pick a real folder (such as an account's Inbox) or one of the "All …" views. If the folder you chose no longer exists — for example the account was removed — QuickMail quietly opens All Mail instead.
+
 ### Moving and Copying Messages
 
 Select one or more messages (or a sender/recipient group, or a conversation) and choose **Move to Folder…** or **Copy to Folder…** from the context menu (Shift+F10) or the command palette. Both open a folder picker showing the same hierarchical tree used in the main folder panel — folders nested under their parent, with account names as headers when more than one account is present. Arrow through the tree and press Enter to complete the move or copy. If you need a destination that does not exist yet, activate **New Folder** (or **Alt+N**) in the picker to create one under the selected folder and move into it without leaving the dialog.
@@ -278,6 +282,8 @@ Press **Ctrl+Shift+P** to open the command palette. Type any part of a command n
 ### Keyboard Customization
 
 Open **Settings → Keyboard** to reassign any shortcut to a different key. Type in the field for a command to capture a new key combination. Changes take effect immediately and survive restarts.
+
+Most shortcuts use a modifier (Ctrl, Shift, or Alt) with another key, but you can also assign a bare **Delete**, **Backspace**, or **Insert** key, or a function key (**F1**–**F24**), with no modifier. Other single keys on their own (letters, digits, Space, Enter, Escape, Tab) are reserved and cannot be captured. If you ever change a shortcut and want it back the way it shipped, select the command and choose **Restore Default**.
 
 ### Checking for Updates
 
@@ -753,7 +759,7 @@ Press **Ctrl+Shift+S** while the calendar is open to search. Type to filter the 
 
 ### Responding to meeting invitations
 
-When you open an email that contains a meeting invitation, QuickMail adds an event card to the top of the message with three buttons: **Accept**, **Tentative**, and **Decline**. Choosing one sends your reply to the organizer and updates your calendar right away — no restart or refresh needed. If the invitation has been cancelled by the organizer, the card says so instead of offering buttons, and the matching calendar entry is removed. From the calendar list, pressing **Enter** on an invitation-based event opens the original email it came from.
+When you open an email that contains a meeting invitation, QuickMail adds an event card to the top of the message with three buttons: **Accept**, **Tentative**, and **Decline**. Choosing one sends your reply to the organizer and updates your calendar right away — no restart or refresh needed. QuickMail tells you it is sending your response, and once it is sent the card shows a confirmation that stays in place, such as "You accepted this meeting. Your reply was sent to the organizer." If the invitation has been cancelled by the organizer, the card says so instead of offering buttons, and the matching calendar entry is removed. From the calendar list, pressing **Enter** on an invitation-based event opens the original email it came from.
 
 ### Connecting an online calendar
 

--- a/docs/release-notes-v0.8.35.md
+++ b/docs/release-notes-v0.8.35.md
@@ -27,6 +27,18 @@ When you open a meeting invitation in a Microsoft 365 / Outlook.com mailbox, Qui
 
 Note for this first release: responding notifies the organizer and updates your calendar **inside QuickMail**. Your response is not yet written back to the Microsoft 365 server calendar, so other clients (Outlook on the web, your phone) may still show the meeting as unanswered. Fuller server-side handling is planned for a later release.
 
+## New: Choose which folder opens at startup
+
+QuickMail has always opened to All Mail. Now you can pick any folder to open at launch instead: from the folder tree, open a folder's context menu (Applications key or Shift+F10) and choose **Set as Startup Folder**. Choose **Clear Startup Folder** to go back to opening All Mail. Your choice takes effect the next time you start QuickMail; if that folder no longer exists, QuickMail simply opens All Mail. (#328)
+
+## Fixed: clearer feedback when you respond to a meeting invitation
+
+Pressing **Accept**, **Tentative**, or **Decline** on a meeting invitation now confirms what happened. QuickMail announces that it is sending your response, and once sent, the invitation card itself shows a confirmation ("You accepted this meeting. Your reply was sent to the organizer.") that stays on screen. Previously the confirmation could be missed entirely. (#329)
+
+## Fixed: Delete and Backspace can now be assigned as shortcuts
+
+You can now assign a bare **Delete** or **Backspace** key (as well as **Insert** and the function keys) as a keyboard shortcut in **Settings → Keyboard customizations** — previously the shortcut editor ignored any key pressed without Ctrl, Shift, or Alt, which meant you could not, for example, move the delete-message shortcut and reassign plain Delete to another command. If you ever get stuck, selecting a command and choosing **Restore Default** always puts its original shortcut back. (#330)
+
 ## Fixed: signing in as the wrong account, and sign-in timeouts
 
 - When you sign in to a Microsoft or Google account and a **different** account completes the sign-in — common when an administrator signs in at an approval screen — QuickMail no longer silently switches your account to that identity. It keeps the address you entered and shows a clear warning. (#202)
@@ -61,3 +73,6 @@ Per-PR technical changelog for this release (changes since the v0.8.34 tag):
 - **Sign-in identity mismatch guard + interactive sign-in timeout removed** (#202, #203, #322). Interactive sign-in no longer rebinds the account to a different identity than the one entered (raises `SignInIdentityMismatch`, surfaced as a focus-grabbing warning in both account dialogs); the 3-/5-minute `CancellationTokenSource` on the interactive path is dropped. `AccountEditorSignInTests` added.
 - **Docs: Entra scope guidance corrected** after #323 (`Contacts.Read` requested explicitly; `.default` contradictions removed). Commits 6a35f65, 8366fcc.
 - **User Guide:** rewrote the Microsoft account instructions around the Microsoft 365 / Outlook.com account type and added a **For Microsoft 365 Administrators and Tenant Owners** section (admin consent, delegated permissions, roles, one-click consent URL, troubleshooting).
+- **Configurable startup folder** (#328). New `ConfigModel.StartupFolder` (INI-safe token: `#<key>` for a global virtual folder, `@<accountId>|<fullName>` for a real folder); folder-tree context commands **Set as Startup Folder** / **Clear Startup Folder**; applied once per launch in `ConnectAllAccountsAsync` right after the first post-connect `RebuildFolderListFromCache` (earliest point real folders resolve), with graceful fallback to All Mail. Tests in `StartupFolderTests`.
+- **Invite-response feedback** (#329). `SendIcsReplyForAsync` now announces "Sending…" before the network send and raises `OpenInviteResponded` on success; `BuildEventCardHtml` gained an `aria-live` status region that `MainWindow.OnOpenInviteResponded` fills via `ExecuteScriptAsync` (announced reliably from inside the WebView2, unlike a host-window notification while focus is in the document). The silent null-invite return now announces instead. Tests in `InviteCardTests`.
+- **Bare-key shortcuts** (#330). `GestureHelper.IsBindableBareKey` (Delete/Backspace/Insert/F1–F24) gates both `KeyCaptureDialog.CaptureKey` and single-token `GestureHelper.TryParse`, so a bare key can be captured and round-trips through config. Fixes the asymmetry where bare Delete shipped as a default the capture UI could not reproduce. Tests in `GestureHelperTests`.


### PR DESCRIPTION
Implements the three issues diagnosed in #328/#329/#330, targeting the un-tagged v0.8.35 release. Each was scoped from the diagnostic comments already on those issues.

## #329 — no feedback when responding to an invite
The reading-pane card's Accept/Decline are `<a>` links **inside the WebView2**, and the success announcement was raised on the host WPF window while focus is in the WebView2 document — so it was dropped. Fixes:
- `BuildEventCardHtml` now includes an empty `aria-live="assertive"` status region. After a response, `MainWindow.OnOpenInviteResponded` fills it via `ExecuteScriptAsync` — an in-document live region the screen reader is already reading, so it announces reliably and leaves a **durable** confirmation on the card ("You accepted this meeting. Your reply was sent to the organizer.").
- `SendIcsReplyForAsync` announces "Sending…" **before** the network send (immediate feedback), and raises `OpenInviteResponded` on success when the reply is for the open message.
- The silent null-invite return in `SendIcsReply` now announces instead of doing nothing.
- ⚠️ **Screen-reader verification requested:** per CLAUDE.md I can't verify AT behavior. The aria-live approach is the standard web pattern, but please confirm with your screen reader before release.

## #330 — can't bind Delete/Backspace
Root cause: `KeyCaptureDialog.CaptureKey` rejected every modifier-less key, yet bare Delete ships as a default binding. New `GestureHelper.IsBindableBareKey` (Delete, Backspace, Insert, F1–F24) gates both the capture dialog **and** single-token `GestureHelper.TryParse` (which also required ≥2 parts), so a bare key captures and round-trips through config. Letters/digits/Space/Enter/Escape/Tab stay reserved.

## #328 — configurable startup folder (enhancement)
New `ConfigModel.StartupFolder` stored as an INI-safe token (`#<key>` for a global virtual folder, `@<accountId>|<fullName>` for a real folder — config.ini can't hold the NUL-prefixed sentinels). Folder-tree context commands **Set as Startup Folder** / **Clear Startup Folder**. Applied once per launch in `ConnectAllAccountsAsync` right after the first post-connect `RebuildFolderListFromCache` — the earliest real folders resolve (they don't exist yet in `InitialLoadAsync`) — with graceful fallback to All Mail if the folder is gone or the user already navigated.

## Tests
`GestureHelperTests`, `StartupFolderTests`, `InviteCardTests` added. Build clean (`-warnaserror`); full suite green apart from a known `LogServiceTests` parallel-write flake that passes in isolation.

## Docs
Release notes (v0.8.35) and User Guide updated (startup folder, bare-key shortcuts, invite confirmation).

## Notes
- Two pre-existing NUL bytes in `MainViewModel.cs` (lines 227/230, virtual-folder sentinel area) are on `main` already — not introduced here.
- #328 applies post-connect rather than in `InitialLoadAsync` because real folders aren't loaded until connect; documented in code.

Closes #329, #330, #328