### PR TITLE
Fix rules-manager hang: open RulesManagerWindow modeless, not modal

### DIFF
--- a/QuickMail/ViewModels/RulesManagerViewModel.cs
+++ b/QuickMail/ViewModels/RulesManagerViewModel.cs
@@ -147,6 +147,17 @@ public partial class RulesManagerViewModel : ObservableObject
         Announce("New rule created. Enter a name and conditions.", AnnouncementCategory.Hint);
     }
 
+    /// <summary>
+    /// Adds a rule prefilled from a message (e.g. Ctrl+Shift+T) and selects it. Mirrors the
+    /// constructor's prefill path, for when the (modeless) window is already open.
+    /// </summary>
+    public void AddPrefilledRule(MailRule template)
+    {
+        Rules.Add(template);
+        SelectedRule = template;
+        Announce("New rule added from message. Edit its name and conditions.", AnnouncementCategory.Hint);
+    }
+
     [RelayCommand]
     private void DeleteRule()
     {

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -5751,8 +5751,18 @@ public partial class MainWindow : Window
             _vm.SelectViewCommand.Execute(viewToApply.Id.ToString());
     }
 
+    private RulesManagerWindow? _rulesWindow;
+
     private void OpenRulesManager(MailRule? template = null)
     {
+        // Single-instance: this window is modeless (see below), so a second open request
+        // would otherwise stack another copy. Bring the existing one forward instead.
+        if (_rulesWindow is { IsLoaded: true })
+        {
+            _rulesWindow.Activate();
+            return;
+        }
+
         var accounts = _vm.Accounts.ToList();
         var selectedMessages = _vm.Messages.ToList();
 
@@ -5762,32 +5772,46 @@ public partial class MainWindow : Window
             selectedMessagesForTest: selectedMessages);
 
         var dialog = new RulesManagerWindow(rulesVm, accounts, _vm.CachedFolders) { Owner = this };
-        dialog.ShowDialog();
+        _rulesWindow = dialog;
 
-        // Refresh the rules status text after the dialog closes
-        _vm.UpdateRulesStatusText();
-
-        // Apply rules to existing cached mail so newly created/edited rules
-        // take effect immediately without waiting for the next sync.
-        _ = Task.Run(async () =>
+        // Modeless (.Show, NOT .ShowDialog). Opening this window modally over MainWindow's
+        // live WebView2 reading pane hard-deadlocks the UI thread when a screen reader focuses
+        // one of its editable TextBoxes — e.g. arrow to a rule and Tab into the Name field.
+        // That is the GrabAddresses lockup class: a modal nested message loop + editable text +
+        // out-of-process WebView2 UIA provider + screen reader combine into a cross-apartment
+        // STA wait that never resolves. See CLAUDE.md "Modal Dialog Rules". Because Show() does
+        // not block, the after-close work runs from the Closed handler rather than inline.
+        dialog.Closed += (_, _) =>
         {
-            try
+            _rulesWindow = null;
+
+            // Refresh the rules status text now that the window has closed.
+            _vm.UpdateRulesStatusText();
+
+            // Apply rules to existing cached mail so newly created/edited rules
+            // take effect immediately without waiting for the next sync.
+            _ = Task.Run(async () =>
             {
-                using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
-                var removed = await _ruleService.ApplyRulesToExistingAsync(_localStore, cts.Token);
-                if (removed.Count > 0)
+                try
                 {
-                    await Dispatcher.InvokeAsync(() =>
+                    using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+                    var removed = await _ruleService.ApplyRulesToExistingAsync(_localStore, cts.Token);
+                    if (removed.Count > 0)
                     {
-                        _vm.RefreshCommand.Execute(null);
-                    });
+                        await Dispatcher.InvokeAsync(() =>
+                        {
+                            _vm.RefreshCommand.Execute(null);
+                        });
+                    }
                 }
-            }
-            catch (Exception ex)
-            {
-                LogService.Log("ApplyRulesToExisting failed", ex);
-            }
-        });
+                catch (Exception ex)
+                {
+                    LogService.Log("ApplyRulesToExisting failed", ex);
+                }
+            });
+        };
+
+        dialog.Show();
     }
 
     private void RulesStatusButton_Click(object sender, RoutedEventArgs e) => OpenRulesManager();

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -5756,12 +5756,19 @@ public partial class MainWindow : Window
     private void OpenRulesManager(MailRule? template = null)
     {
         // Single-instance: this window is modeless (see below), so a second open request
-        // would otherwise stack another copy. Bring the existing one forward instead.
-        if (_rulesWindow is { IsLoaded: true })
+        // would otherwise stack another copy. Bring the existing one forward — and if this
+        // request carries a rule prefilled from the current message (Ctrl+Shift+T), add it
+        // to the open window rather than silently dropping it.
+        if (_rulesWindow is { IsLoaded: true } existing)
         {
-            _rulesWindow.Activate();
+            if (template != null) existing.PrefillFromTemplate(template);
+            existing.Activate();
             return;
         }
+
+        // Remember what had focus so we can restore it when the (modeless) window closes;
+        // modal ShowDialog() returned focus to the owner automatically, Show() does not.
+        var previousFocus = Keyboard.FocusedElement as IInputElement;
 
         var accounts = _vm.Accounts.ToList();
         var selectedMessages = _vm.Messages.ToList();
@@ -5784,6 +5791,11 @@ public partial class MainWindow : Window
         dialog.Closed += (_, _) =>
         {
             _rulesWindow = null;
+
+            // Return focus to where it was before opening (falling back to the message list);
+            // Show() does not restore owner focus the way ShowDialog() did.
+            Activate();
+            (previousFocus ?? MessageList).Focus();
 
             // Refresh the rules status text now that the window has closed.
             _vm.UpdateRulesStatusText();

--- a/QuickMail/Views/RulesManagerWindow.xaml
+++ b/QuickMail/Views/RulesManagerWindow.xaml
@@ -120,7 +120,8 @@
                     <Separator Margin="0,0,0,6"/>
 
                     <TextBlock Text="Account"/>
-                    <ComboBox ItemsSource="{Binding AccountOptions}"
+                    <ComboBox x:Name="AccountScopeCombo"
+                              ItemsSource="{Binding AccountOptions}"
                               SelectedValue="{Binding SelectedRule.AccountId}"
                               SelectedValuePath="Id"
                               Style="{StaticResource RuleComboBox}"
@@ -200,7 +201,8 @@
                     <TextBlock Text="Action" FontWeight="SemiBold" Margin="0,12,0,4"/>
                     <Separator Margin="0,0,0,6"/>
 
-                    <ComboBox ItemsSource="{Binding ActionOptions}"
+                    <ComboBox x:Name="ActionCombo"
+                              ItemsSource="{Binding ActionOptions}"
                               SelectedValue="{Binding SelectedRule.Action}"
                               SelectedValuePath="Action"
                               DisplayMemberPath="DisplayName"

--- a/QuickMail/Views/RulesManagerWindow.xaml.cs
+++ b/QuickMail/Views/RulesManagerWindow.xaml.cs
@@ -66,6 +66,16 @@ public partial class RulesManagerWindow : Window
         Close();
     }
 
+    /// <summary>
+    /// Adds a rule prefilled from a message and focuses the list. Called when Ctrl+Shift+T is
+    /// pressed while this (modeless) window is already open, so the template isn't dropped.
+    /// </summary>
+    public void PrefillFromTemplate(MailRule template)
+    {
+        _vm.AddPrefilledRule(template);
+        RuleListBox.Focus();
+    }
+
     private bool OnConfirmDeleteRequested(string message, string title)
     {
         return MessageBox.Show(

--- a/QuickMail/Views/RulesManagerWindow.xaml.cs
+++ b/QuickMail/Views/RulesManagerWindow.xaml.cs
@@ -92,6 +92,26 @@ public partial class RulesManagerWindow : Window
         }
     }
 
+    protected override void OnPreviewKeyDown(KeyEventArgs e)
+    {
+        base.OnPreviewKeyDown(e);
+        if (e.Handled) return;
+
+        // This window is shown modeless (see MainWindow.OpenRulesManager) to avoid the
+        // modal-over-WebView2 dispatcher deadlock. A modeless window has no DialogResult,
+        // so the Close button's IsCancel="True" no longer closes it on Escape — wire that
+        // explicitly here. Step aside when an open combo dropdown needs Escape to dismiss
+        // itself, so we don't steal it (matches ComposeWindow's guard).
+        if (e.Key == Key.Escape)
+        {
+            if (AccountScopeCombo.IsDropDownOpen || ActionCombo.IsDropDownOpen)
+                return;
+
+            Close();
+            e.Handled = true;
+        }
+    }
+
     protected override void OnClosed(EventArgs e)
     {
         _vm.CloseRequested -= OnCloseRequested;


### PR DESCRIPTION
## The bug
Open a message → **Ctrl+Shift+T** (build a rule from the message) → arrow to the new rule → **Tab** into the Name field with a screen reader running → **the app hard-hangs.** Dispatcher frozen, no error, nothing logged (the freeze prevents logging).

## Root cause
The documented **GrabAddresses lockup** class (CLAUDE.md "Modal Dialog Rules"). `OpenRulesManager` showed `RulesManagerWindow` with **`ShowDialog()`** — a modal nested message loop — over `MainWindow`, whose **WebView2 reading pane (the open message) is live**. Tabbing into one of the window's editable `TextBox`es with a screen reader active combines the synchronous UIA query, the TextBox text/COM activation, the out-of-process WebView2 UIA provider, and the nested modal loop into a cross-apartment STA wait that never resolves.

This is the exact conversion the server-rules spec already flagged in **#334 §19.3** ("converting `RulesManagerWindow` from `ShowDialog()` to modeless").

## The fix (modal → modeless)
- **`OpenRulesManager`** uses `.Show()` instead of `.ShowDialog()`. Because `Show()` no longer blocks, the after-close work (rules status refresh + apply-rules-to-existing) moves into a `Closed` handler. Adds a **single-instance guard** so reopening activates the existing window instead of stacking a second.
- **`RulesManagerWindow`** gains a **guarded `Escape` → `Close()`** handler. A modeless window has no `DialogResult`, so the Close button's `IsCancel="True"` no longer closes on Escape. The guard steps aside when an Account/Action combo dropdown is open, so it doesn't steal Escape from the dropdown (matches the `ComposeWindow` idiom).
- Named the two ComboBoxes so the Escape guard can reference them.

## Verification
- `dotnet build` clean (0 warnings, 0 errors).
- XAML-parse + rules tests: **133 passed, 0 failed** (confirms the renamed ComboBoxes and modeless window still parse/construct).
- The actual deadlock is a screen-reader/WebView2 runtime interaction that can't be reproduced in CI — needs a manual retest of the repro with a screen reader.

## Behavior changes (expected from modeless)
- Rules window no longer blocks the main window.
- Escape still closes it; Enter still triggers Save (default button).
- Reopening while open activates the existing window instead of opening a second.
- Newly created/edited rules still apply to cached mail on close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)