### PR TITLE
Rules manager: account-in-row display + field-labels toggle; fix #344/#346/#347/#348

### DIFF
--- a/QuickMail.Tests/RulesManagerViewModelTests.cs
+++ b/QuickMail.Tests/RulesManagerViewModelTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using QuickMail.Models;
 using QuickMail.Services;
 using QuickMail.ViewModels;
@@ -425,5 +426,83 @@ public class RulesManagerViewModelTests
         Assert.Null(options[0].Id); // "All accounts" has null Id
         Assert.Equal("All accounts", options[0].DisplayName);
         Assert.Equal(account.Id, options[1].Id);
+    }
+
+    // ── Account-in-row display (rule name, account) ─────────────────────────────
+
+    [Fact]
+    public void RuleRows_StampAccountScope_ConciseByDefault()
+    {
+        var acctId = Guid.NewGuid();
+        var accounts = new[] { new AccountModel { Id = acctId, AccountName = "IdeaPlace" } };
+        var stub = new StubRuleService
+        {
+            LoadedRules =
+            [
+                new MailRule { Name = "Newsletters", AccountId = acctId },
+                new MailRule { Name = "Global" }, // null AccountId → All accounts
+            ],
+        };
+
+        var vm = new RulesManagerViewModel(stub, accounts);
+
+        var scoped = vm.Rules.First(r => r.Name == "Newsletters");
+        var global = vm.Rules.First(r => r.Name == "Global");
+
+        Assert.Equal("IdeaPlace", scoped.AccountDisplay);
+        Assert.Equal("All accounts", global.AccountDisplay);
+        Assert.Equal("Newsletters, IdeaPlace", scoped.AccessibleName);   // concise, no field labels
+        Assert.Equal("Global, All accounts", global.AccessibleName);
+    }
+
+    [Fact]
+    public void RuleRows_UseFieldLabels_WhenConfigured()
+    {
+        var acctId = Guid.NewGuid();
+        var accounts = new[] { new AccountModel { Id = acctId, AccountName = "IdeaPlace" } };
+        var cfg = new StubConfigService();
+        cfg.Save(new ConfigModel { RuleListShowFieldLabels = true });
+        var stub = new StubRuleService { LoadedRules = [new MailRule { Name = "Newsletters", AccountId = acctId }] };
+
+        var vm = new RulesManagerViewModel(stub, accounts, configService: cfg);
+
+        Assert.Equal("Rule Newsletters, account IdeaPlace", vm.Rules.Single().AccessibleName);
+    }
+
+    [Fact]
+    public void NewRule_IsStampedWithAllAccounts()
+    {
+        var vm = new RulesManagerViewModel(new StubRuleService(), accounts: []);
+
+        vm.NewRuleCommand.Execute(null);
+
+        Assert.Equal("All accounts", vm.SelectedRule!.AccountDisplay);
+        Assert.Contains("All accounts", vm.SelectedRule.AccessibleName);
+    }
+
+    // ── Run on existing mail (issue #346) ───────────────────────────────────────
+
+    [Fact]
+    public async Task RunOnExisting_InvokesOwner_AndReportsCount()
+    {
+        var vm = new RulesManagerViewModel(new StubRuleService(), accounts: []);
+        var invoked = false;
+        vm.RunOnExistingRequested += () => { invoked = true; return Task.FromResult(3); };
+
+        await vm.RunOnExistingCommand.ExecuteAsync(null);
+
+        Assert.True(invoked);
+        Assert.Contains("3 messages moved or deleted", vm.StatusText);
+    }
+
+    [Fact]
+    public async Task RunOnExisting_ZeroMoved_StillConfirms()
+    {
+        var vm = new RulesManagerViewModel(new StubRuleService(), accounts: []);
+        vm.RunOnExistingRequested += () => Task.FromResult(0);
+
+        await vm.RunOnExistingCommand.ExecuteAsync(null);
+
+        Assert.Contains("Applied rules to existing mail", vm.StatusText);
     }
 }

--- a/QuickMail/Models/ConfigModel.cs
+++ b/QuickMail/Models/ConfigModel.cs
@@ -144,6 +144,14 @@ public class ConfigModel
     public bool CalendarListShowFieldLabels { get; set; } = false;
 
     /// <summary>
+    /// When true, the rules list speaks field labels in each row's accessible name
+    /// ("Rule … account …"); when false (default) it speaks concise data only
+    /// ("Newsletters, IdeaPlace"), matching how the contact and calendar lists read.
+    /// Mirrors <see cref="ContactListShowFieldLabels"/>.
+    /// </summary>
+    public bool RuleListShowFieldLabels { get; set; } = false;
+
+    /// <summary>
     /// Fire a notification before each appointment. OFF by default (opt-in, per the
     /// announcement-infra convention for potentially intrusive features; full-calendar spec Q6).
     /// </summary>

--- a/QuickMail/Models/MailRule.cs
+++ b/QuickMail/Models/MailRule.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text.Json.Serialization;
 
 namespace QuickMail.Models;
 
@@ -17,7 +18,25 @@ public class MailRule
     // A screen reader reads a data-bound Selector item's UIA Name from ToString()
     // (DisplayMemberPath only sets the visual). Without this the Rules list announces
     // "QuickMail.Models.MailRule" for every row. See CLAUDE.md.
+    // The Rules list itself binds AutomationProperties.Name to AccessibleName below (so
+    // it can include the account and honour the field-labels setting); ToString() remains
+    // for any other Selector that binds MailRule without a template.
     public override string ToString() => Name;
+
+    /// <summary>
+    /// Display-only, resolved by <c>RulesManagerViewModel</c> — never serialized. The account
+    /// scope shown in the list row: an account's label, or "All accounts" for an unscoped rule.
+    /// </summary>
+    [JsonIgnore]
+    public string AccountDisplay { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Display-only, resolved by <c>RulesManagerViewModel</c> — never serialized. The composed
+    /// row accessible name (rule + account), labeled or concise per the <c>RuleListShowFieldLabels</c>
+    /// setting, surfaced via <c>AutomationProperties.Name</c> on the list row.
+    /// </summary>
+    [JsonIgnore]
+    public string AccessibleName { get; set; } = string.Empty;
 
     /// <summary>When false, the rule is skipped during evaluation.</summary>
     public bool IsEnabled { get; set; } = true;

--- a/QuickMail/ViewModels/RulesManagerViewModel.cs
+++ b/QuickMail/ViewModels/RulesManagerViewModel.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using QuickMail.Models;
@@ -14,6 +15,8 @@ public partial class RulesManagerViewModel : ObservableObject
     private readonly IRuleService _ruleService;
     private readonly IEnumerable<AccountModel> _accounts;
     private readonly IEnumerable<MailMessageSummary>? _selectedMessagesForTest;
+    private readonly Dictionary<Guid, string> _accountLabels = [];
+    private readonly bool _showFieldLabels;
 
     // ── Events (View subscribes) ────────────────────────────────────────────
 
@@ -29,23 +32,40 @@ public partial class RulesManagerViewModel : ObservableObject
     /// <summary>Raised when the View should open a folder picker for the target folder.</summary>
     public event Func<string?>? PickFolderRequested;
 
+    /// <summary>
+    /// Raised when the user asks to run all enabled rules against existing cached mail. The owner
+    /// (which holds the local store) performs the run and returns how many messages were moved or
+    /// deleted. Rules already run automatically when the window closes; this makes that explicit and
+    /// on-demand (issue #346).
+    /// </summary>
+    public event Func<Task<int>>? RunOnExistingRequested;
+
     // ── Constructor ─────────────────────────────────────────────────────────
 
     public RulesManagerViewModel(
         IRuleService ruleService,
         IEnumerable<AccountModel> accounts,
         MailRule? prefillTemplate = null,
-        IEnumerable<MailMessageSummary>? selectedMessagesForTest = null)
+        IEnumerable<MailMessageSummary>? selectedMessagesForTest = null,
+        IConfigService? configService = null)
     {
         _ruleService = ruleService;
         _accounts = accounts;
         _selectedMessagesForTest = selectedMessagesForTest;
 
+        // Account id → label, so each rule row can show which account it applies to.
+        foreach (var a in _accounts)
+            _accountLabels[a.Id] = a.AccountLabel;
+
+        _showFieldLabels = configService?.Load().RuleListShowFieldLabels ?? false;
+
         var rules = _ruleService.LoadRules();
+        foreach (var r in rules) StampDisplay(r);
         Rules = new ObservableCollection<MailRule>(rules);
 
         if (prefillTemplate != null)
         {
+            StampDisplay(prefillTemplate);
             Rules.Add(prefillTemplate);
             SelectedRule = prefillTemplate;
             Announce("New rule created from message. Fill in the action and save.",
@@ -142,6 +162,7 @@ public partial class RulesManagerViewModel : ObservableObject
     private void NewRule()
     {
         var rule = new MailRule { Name = "New rule" };
+        StampDisplay(rule);
         Rules.Add(rule);
         SelectedRule = rule;
         Announce("New rule created. Enter a name and conditions.", AnnouncementCategory.Hint);
@@ -153,9 +174,40 @@ public partial class RulesManagerViewModel : ObservableObject
     /// </summary>
     public void AddPrefilledRule(MailRule template)
     {
+        StampDisplay(template);
         Rules.Add(template);
         SelectedRule = template;
         Announce("New rule added from message. Edit its name and conditions.", AnnouncementCategory.Hint);
+    }
+
+    /// <summary>
+    /// Resolves the account scope and composes the list row's accessible name for a rule. Concise
+    /// by default ("Newsletters, IdeaPlace"), or labeled when the <c>RuleListShowFieldLabels</c>
+    /// setting is on ("Rule Newsletters, account IdeaPlace"). Mirrors the address-book contact list.
+    /// </summary>
+    private void StampDisplay(MailRule rule)
+    {
+        rule.AccountDisplay = rule.AccountId is { } id && _accountLabels.TryGetValue(id, out var label)
+            ? label
+            : "All accounts";
+
+        var name = string.IsNullOrWhiteSpace(rule.Name) ? "Unnamed rule" : rule.Name;
+        rule.AccessibleName = _showFieldLabels
+            ? $"Rule {name}, account {rule.AccountDisplay}"
+            : $"{name}, {rule.AccountDisplay}";
+    }
+
+    /// <summary>
+    /// Re-renders a list row after its in-place fields changed. <see cref="MailRule"/> raises no
+    /// change notification, so re-assigning the slot triggers a Replace and regenerates that one
+    /// container (so a renamed rule or a changed account shows immediately).
+    /// </summary>
+    private void RefreshRow(MailRule rule)
+    {
+        var index = Rules.IndexOf(rule);
+        if (index < 0) return;
+        Rules[index] = rule;
+        SelectedRule = rule;   // Replace clears selection; restore it
     }
 
     [RelayCommand]
@@ -184,6 +236,8 @@ public partial class RulesManagerViewModel : ObservableObject
         if (!Validate(SelectedRule)) return;
 
         _ruleService.SaveRules(Rules.ToList());
+        StampDisplay(SelectedRule);
+        RefreshRow(SelectedRule);   // reflect a renamed rule or changed account in the list row
         StatusText = $"Rule '{SelectedRule.Name}' saved.";
         Announce($"Rule '{SelectedRule.Name}' saved.", AnnouncementCategory.Result);
     }
@@ -215,6 +269,38 @@ public partial class RulesManagerViewModel : ObservableObject
     private void Close()
     {
         CloseRequested?.Invoke();
+    }
+
+    /// <summary>
+    /// Runs all enabled rules against existing cached mail on demand and reports the outcome, so the
+    /// user isn't left wondering whether saving a rule did anything to messages already in the
+    /// mailbox (issue #346). The owner performs the work (it holds the local store); the count is
+    /// messages moved or deleted — actions like Mark as read still apply but aren't counted here.
+    /// </summary>
+    [RelayCommand]
+    private async Task RunOnExistingAsync()
+    {
+        if (RunOnExistingRequested is null) return;
+
+        StatusText = "Running rules on existing mail…";
+        Announce(StatusText, AnnouncementCategory.Status);
+
+        int affected;
+        try
+        {
+            affected = await RunOnExistingRequested.Invoke();
+        }
+        catch (Exception ex)
+        {
+            StatusText = $"Couldn't run rules on existing mail: {ex.Message}";
+            Announce(StatusText, AnnouncementCategory.Result);
+            return;
+        }
+
+        StatusText = affected > 0
+            ? $"Applied rules to existing mail: {affected} message{(affected == 1 ? "" : "s")} moved or deleted."
+            : "Applied rules to existing mail.";
+        Announce(StatusText, AnnouncementCategory.Result);
     }
 
     [RelayCommand]

--- a/QuickMail/ViewModels/SettingsViewModel.cs
+++ b/QuickMail/ViewModels/SettingsViewModel.cs
@@ -88,6 +88,9 @@ public partial class SettingsViewModel : ObservableObject
     private bool _calendarListShowFieldLabels;
 
     [ObservableProperty]
+    private bool _ruleListShowFieldLabels;
+
+    [ObservableProperty]
     private bool _calendarReminders;
 
     [ObservableProperty]
@@ -278,6 +281,7 @@ public partial class SettingsViewModel : ObservableObject
         AnnounceFlagStatus               = cfg.AnnounceFlagStatus;
         ContactListShowFieldLabels       = cfg.ContactListShowFieldLabels;
         CalendarListShowFieldLabels      = cfg.CalendarListShowFieldLabels;
+        RuleListShowFieldLabels          = cfg.RuleListShowFieldLabels;
         CalendarReminders                = cfg.CalendarReminders;
         CalendarReminderMinutes          = cfg.CalendarReminderMinutes;
         ConfirmEmptyTrash                = cfg.ConfirmEmptyTrash;
@@ -351,6 +355,7 @@ public partial class SettingsViewModel : ObservableObject
         cfg.AnnounceFlagStatus               = AnnounceFlagStatus;
         cfg.ContactListShowFieldLabels       = ContactListShowFieldLabels;
         cfg.CalendarListShowFieldLabels      = CalendarListShowFieldLabels;
+        cfg.RuleListShowFieldLabels          = RuleListShowFieldLabels;
         cfg.CalendarReminders                = CalendarReminders;
         cfg.CalendarReminderMinutes          = Math.Clamp(CalendarReminderMinutes, 1, 1440);
         cfg.ConfirmEmptyTrash                = ConfirmEmptyTrash;

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -5776,7 +5776,19 @@ public partial class MainWindow : Window
         var rulesVm = new RulesManagerViewModel(
             _ruleService, accounts,
             prefillTemplate: template,
-            selectedMessagesForTest: selectedMessages);
+            selectedMessagesForTest: selectedMessages,
+            configService: _configService);
+
+        // On-demand "Run on Existing Mail" (issue #346): the VM has no local store, so the owner
+        // performs the run and returns how many messages were moved or deleted for the VM to report.
+        rulesVm.RunOnExistingRequested += async () =>
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+            var removed = await _ruleService.ApplyRulesToExistingAsync(_localStore, cts.Token);
+            if (removed.Count > 0)
+                await Dispatcher.InvokeAsync(() => _vm.RefreshCommand.Execute(null));
+            return removed.Count;
+        };
 
         var dialog = new RulesManagerWindow(rulesVm, accounts, _vm.CachedFolders) { Owner = this };
         _rulesWindow = dialog;

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -5781,12 +5781,15 @@ public partial class MainWindow : Window
 
         // On-demand "Run on Existing Mail" (issue #346): the VM has no local store, so the owner
         // performs the run and returns how many messages were moved or deleted for the VM to report.
+        // ApplyRulesToExisting loads all cached summaries and matches every rule against them, so run
+        // it off the UI thread (as the on-close path does) to keep the dispatcher responsive.
         rulesVm.RunOnExistingRequested += async () =>
         {
             using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
-            var removed = await _ruleService.ApplyRulesToExistingAsync(_localStore, cts.Token);
+            var removed = await Task.Run(
+                () => _ruleService.ApplyRulesToExistingAsync(_localStore, cts.Token));
             if (removed.Count > 0)
-                await Dispatcher.InvokeAsync(() => _vm.RefreshCommand.Execute(null));
+                _vm.RefreshCommand.Execute(null);   // back on the UI thread after the await
             return removed.Count;
         };
 

--- a/QuickMail/Views/RulesManagerWindow.xaml
+++ b/QuickMail/Views/RulesManagerWindow.xaml
@@ -3,6 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="clr-namespace:QuickMail.Views"
         Title="Rules Manager"
+        AutomationProperties.Name="Rules Manager"
         Width="750" Height="560"
         MinWidth="600" MinHeight="440"
         WindowStartupLocation="CenterOwner"
@@ -51,28 +52,42 @@
                     <RowDefinition Height="*"/>
                 </Grid.RowDefinitions>
 
-                <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,6">
+                <WrapPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,6">
                     <Button Content="New Rule" Command="{Binding NewRuleCommand}"
-                            Width="80" Height="26" Margin="0,0,6,0"
+                            Width="80" Height="26" Margin="0,0,6,6"
                             AutomationProperties.Name="Create new rule"/>
                     <Button Content="Delete" Command="{Binding DeleteRuleCommand}"
-                            Width="60" Height="26"
+                            Width="60" Height="26" Margin="0,0,6,6"
                             AutomationProperties.Name="Delete selected rule"/>
-                </StackPanel>
+                    <Button Content="Run on Existing Mail" Command="{Binding RunOnExistingCommand}"
+                            Height="26" Padding="8,0" Margin="0,0,0,6"
+                            AutomationProperties.Name="Run all rules on existing mail now"/>
+                </WrapPanel>
 
                 <ListBox Grid.Row="1"
                          x:Name="RuleListBox"
                          ItemsSource="{Binding Rules}"
                          SelectedItem="{Binding SelectedRule}"
-                         DisplayMemberPath="Name"
                          AutomationProperties.Name="Rules list">
                     <ListBox.ItemContainerStyle>
                         <Style TargetType="ListBoxItem">
                             <Setter Property="Padding" Value="6,4"/>
+                            <!-- Accessible name carries rule + account (and honours the
+                                 field-labels setting); the visual template below shows the
+                                 same, with the account dimmed. -->
                             <Setter Property="AutomationProperties.Name"
-                                    Value="{Binding Name}"/>
+                                    Value="{Binding AccessibleName}"/>
                         </Style>
                     </ListBox.ItemContainerStyle>
+                    <ListBox.ItemTemplate>
+                        <DataTemplate>
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="{Binding Name}"/>
+                                <TextBlock Text="{Binding AccountDisplay}"
+                                           Opacity="0.6" Margin="12,0,0,0"/>
+                            </StackPanel>
+                        </DataTemplate>
+                    </ListBox.ItemTemplate>
                 </ListBox>
             </Grid>
 
@@ -211,11 +226,14 @@
 
                     <!-- Target folder -->
                     <TextBlock Text="Target folder"/>
+                    <!-- Accessible name tracks the chosen folder (issue #344): a static name made
+                         a screen reader always say "Choose target folder" even after a folder was
+                         picked. PickFolder raises PropertyChanged(SelectedRule), refreshing both. -->
                     <Button Content="{Binding SelectedRule.TargetFolder, TargetNullValue=Choose Folder…, FallbackValue=Choose Folder…}"
                             Command="{Binding PickFolderCommand}"
                             Width="140" Height="26" Margin="0,2,0,8"
                             HorizontalAlignment="Left"
-                            AutomationProperties.Name="Choose target folder"/>
+                            AutomationProperties.Name="{Binding SelectedRule.TargetFolder, TargetNullValue=Choose target folder, FallbackValue=Choose target folder}"/>
                     <TextBlock Text="{Binding FolderError}" Foreground="{DynamicResource Theme.Error}"
                                KeyboardNavigation.IsTabStop="False"
                                AutomationProperties.LiveSetting="Assertive">

--- a/QuickMail/Views/RulesManagerWindow.xaml
+++ b/QuickMail/Views/RulesManagerWindow.xaml
@@ -72,16 +72,16 @@
                     <ListBox.ItemContainerStyle>
                         <Style TargetType="ListBoxItem">
                             <Setter Property="Padding" Value="6,4"/>
-                            <!-- Accessible name carries rule + account (and honours the
-                                 field-labels setting); the visual template below shows the
-                                 same, with the account dimmed. -->
-                            <Setter Property="AutomationProperties.Name"
-                                    Value="{Binding AccessibleName}"/>
                         </Style>
                     </ListBox.ItemContainerStyle>
                     <ListBox.ItemTemplate>
                         <DataTemplate>
-                            <StackPanel Orientation="Horizontal">
+                            <!-- AccessibleName on the template root gives one utterance (rule +
+                                 account, honouring the field-labels setting) instead of the two
+                                 TextBlocks being read as separate cells; mirrors the address-book
+                                 contact row. The visual shows the account dimmed. -->
+                            <StackPanel Orientation="Horizontal"
+                                        AutomationProperties.Name="{Binding AccessibleName}">
                                 <TextBlock Text="{Binding Name}"/>
                                 <TextBlock Text="{Binding AccountDisplay}"
                                            Opacity="0.6" Margin="12,0,0,0"/>

--- a/QuickMail/Views/RulesManagerWindow.xaml.cs
+++ b/QuickMail/Views/RulesManagerWindow.xaml.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Data;
 using System.Windows.Input;
 using QuickMail.Models;
@@ -43,8 +44,28 @@ public partial class RulesManagerWindow : Window
         vm.AnnouncementRequested += OnAnnouncementRequested;
         vm.PickFolderRequested += OnPickFolderRequested;
 
-        // Focus the rule list on open
-        Loaded += (_, _) => RuleListBox.Focus();
+        // Focus the first rule in the list on open (issue #348). Focusing the ListBox alone does
+        // not reliably move keyboard focus onto an item for some screen readers, so focus the
+        // first item's container directly.
+        Loaded += (_, _) => FocusFirstRule();
+    }
+
+    private void FocusFirstRule()
+    {
+        if (RuleListBox.Items.Count == 0)
+        {
+            RuleListBox.Focus();
+            return;
+        }
+
+        if (RuleListBox.SelectedIndex < 0)
+            RuleListBox.SelectedIndex = 0;
+
+        RuleListBox.UpdateLayout();
+        if (RuleListBox.ItemContainerGenerator.ContainerFromIndex(RuleListBox.SelectedIndex) is ListBoxItem item)
+            item.Focus();
+        else
+            RuleListBox.Focus();
     }
 
     private string? OnPickFolderRequested()

--- a/QuickMail/Views/SettingsDialog.xaml
+++ b/QuickMail/Views/SettingsDialog.xaml
@@ -332,6 +332,11 @@
                                           Margin="16,4,0,0"
                                           AutomationProperties.Name="Show field labels in the calendar event list accessible names"/>
 
+                                <CheckBox Content="Show field labels in the r_ules list"
+                                          IsChecked="{Binding RuleListShowFieldLabels, Mode=TwoWay}"
+                                          Margin="16,4,0,0"
+                                          AutomationProperties.Name="Show field labels in the rules list accessible names"/>
+
                                 <CheckBox Content="Remind me before appoin_tments"
                                           IsChecked="{Binding CalendarReminders, Mode=TwoWay}"
                                           Margin="16,4,0,0"


### PR DESCRIPTION
Bundles the rules-manager account-in-row feature with four rules-manager bug fixes (all touch the same window).

## Feature — see which account each rule applies to, in the list
Today the rule list shows only the rule **name**, so you can't tell a rule's account scope without selecting it and reading the Account dropdown — and there's no account switcher. This puts the scope **in the row**.

- Rows read **"name, account"** — `Newsletters, IdeaPlace` / `Global, All accounts` — visible and announced without selecting each rule (account shown dimmed visually).
- New **`RuleListShowFieldLabels`** setting (default off), mirroring the existing contact/calendar field-label toggles: off = concise (`Newsletters, IdeaPlace`), on = labeled (`Rule Newsletters, account IdeaPlace`).
- `RulesManagerViewModel` resolves account labels and stamps `AccountDisplay` + `AccessibleName` per rule (display-only, `[JsonIgnore]` on `MailRule`); re-stamps on save and refreshes the row so a rename / account change shows immediately.

## Fixes
- **#344** — the target-folder button's accessible name was a static "Choose target folder", so a screen reader read that even after a folder was chosen. Bound it to the chosen folder; now announces the folder name.
- **#346** — rules already apply to existing cached mail on window close, but silently/undiscoverably. Added an explicit **"Run on Existing Mail"** button that runs all enabled rules on demand and announces the result (owner runs it via a VM event; count = messages moved or deleted).
- **#347** — `RulesManagerWindow` had a `Title` but no `AutomationProperties.Name`, so some screen readers read the main-window title. Added it (matches the address book).
- **#348** — opening the manager focused the ListBox but not an item; now focuses the first rule's container.

## Verification
- Build clean (0/0). Rules/settings/XAML/selector tests: 86 passed (incl. new coverage for account stamping, field-labels on/off, and run-on-existing).
- Full suite: 1529 passed. The only failures are 2 pre-existing, date-dependent `EventEditorViewModelTests` (calendar) that fail identically on clean `main` — unrelated to this PR.
- Screen-reader behaviors (#344/#347/#348 announcements) need a manual retest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)