### PR TITLE
Rules manager a11y: announce account in row; fix window title (#347)

### DIFF
--- a/QuickMail.Tests/SelectorItemAccessibilityTests.cs
+++ b/QuickMail.Tests/SelectorItemAccessibilityTests.cs
@@ -7,6 +7,7 @@ using System.Windows.Controls;
 using System.Windows.Threading;
 using QuickMail.Models;
 using QuickMail.ViewModels;
+using QuickMail.Views;
 using Xunit;
 
 namespace QuickMail.Tests;
@@ -102,6 +103,38 @@ public class SelectorItemAccessibilityTests
 
         var group = new GroupModel { Name = "Team" };
         Assert.Equal(group.Display, group.ToString());
+    }
+
+    // End-to-end against the REAL RulesManagerWindow: what a screen reader actually speaks for a
+    // rule row must be "name, account" (issue: account-in-row not announced). Reads the live
+    // ListBoxItemAutomationPeer name — the ground truth, not the eyeballed template.
+    [StaFact]
+    public void RulesManagerWindow_RuleRow_ItemPeerName_IncludesAccount()
+    {
+        var acctId = Guid.NewGuid();
+        var accounts = new[] { new AccountModel { Id = acctId, AccountName = "IdeaPlace" } };
+        var stub = new StubRuleService { LoadedRules = [new MailRule { Name = "Newsletters", AccountId = acctId }] };
+        var vm = new RulesManagerViewModel(stub, accounts);
+
+        var window = new RulesManagerWindow(vm, accounts, new Dictionary<Guid, List<MailFolderModel>>())
+        {
+            WindowStyle = WindowStyle.None, ShowInTaskbar = false, ShowActivated = false,
+        };
+        window.Show();
+        try
+        {
+            window.UpdateLayout();
+            DrainDispatcher();
+
+            var list = (ListBox)window.FindName("RuleListBox");
+            var names = (UIElementAutomationPeer.CreatePeerForElement(list).GetChildren() ?? new List<AutomationPeer>())
+                .OfType<ListBoxItemAutomationPeer>()
+                .Select(p => p.GetName())
+                .ToList();
+
+            Assert.Contains("Newsletters, IdeaPlace", names);
+        }
+        finally { window.Close(); }
     }
 
     [Fact]

--- a/QuickMail/Views/RulesManagerWindow.xaml
+++ b/QuickMail/Views/RulesManagerWindow.xaml
@@ -8,7 +8,7 @@
         MinWidth="600" MinHeight="440"
         WindowStartupLocation="CenterOwner"
         ResizeMode="CanResizeWithGrip"
-        WindowStyle="ToolWindow"
+        WindowStyle="SingleBorderWindow"
         Background="{DynamicResource Theme.WindowBackground}"
         Foreground="{DynamicResource Theme.TextPrimary}"
         FontFamily="{DynamicResource Theme.FontFamily}"
@@ -72,16 +72,17 @@
                     <ListBox.ItemContainerStyle>
                         <Style TargetType="ListBoxItem">
                             <Setter Property="Padding" Value="6,4"/>
+                            <!-- The screen reader reads the row from the ListBoxItem's own Name, not
+                                 from a child element's AutomationProperties.Name (verified by
+                                 SelectorItemAccessibilityTests against the live peer). So the composed
+                                 "name, account" (honouring the field-labels setting) must sit on the
+                                 container. The template below is visual only. -->
+                            <Setter Property="AutomationProperties.Name" Value="{Binding AccessibleName}"/>
                         </Style>
                     </ListBox.ItemContainerStyle>
                     <ListBox.ItemTemplate>
                         <DataTemplate>
-                            <!-- AccessibleName on the template root gives one utterance (rule +
-                                 account, honouring the field-labels setting) instead of the two
-                                 TextBlocks being read as separate cells; mirrors the address-book
-                                 contact row. The visual shows the account dimmed. -->
-                            <StackPanel Orientation="Horizontal"
-                                        AutomationProperties.Name="{Binding AccessibleName}">
+                            <StackPanel Orientation="Horizontal">
                                 <TextBlock Text="{Binding Name}"/>
                                 <TextBlock Text="{Binding AccountDisplay}"
                                            Opacity="0.6" Margin="12,0,0,0"/>


### PR DESCRIPTION
Follow-up to #349. Kelly tested the build and reported that two things weren't actually fixed: the rule rows didn't announce the account, and the window title still read as the main window with some screen readers. Both are fixed here, and the row fix is **verified against the live automation peer** rather than eyeballed.

## Rule row now announces "name, account"
The composed `AccessibleName` was on the `ItemTemplate`'s child element. A `ListBoxItem`'s UIA Name comes from the **container**, not from a child element's `AutomationProperties.Name` — so the item peer ignored it and a screen reader read only the rule name (via `MailRule.ToString()`). Moved the name onto the `ItemContainerStyle`.

**Verified, not guessed:** added `SelectorItemAccessibilityTests.RulesManagerWindow_RuleRow_ItemPeerName_IncludesAccount`, which shows the real `RulesManagerWindow` and reads `ListBoxItemAutomationPeer.GetName()`. It **fails** on the child-element version and **passes** on the container version — so this exact regression can't come back silently. (This is the CLAUDE.md rule: query the peer, don't eyeball the template. The child-element approach looked right and passed visual review, but the peer test proves it was silent for a screen reader.)

## #347 — window title
`RulesManagerWindow` used `WindowStyle="ToolWindow"`. As a **modeless** window (from the earlier hang fix), a tool window isn't treated as a distinct titled top-level window by some screen readers, which then read the owner (main) window's title. Switched to `SingleBorderWindow`, matching the modeless compose window and the address book — both read their titles correctly. This one can't be unit-tested (screen-reader window-title behavior), so it needs a manual retest.

## Verification
- Build clean (0/0); XAML-parse + rules + selector tests: 61 passed, incl. the new peer test.
- #347 title needs a manual screen-reader retest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)