### PR TITLE
Rules manager title (#347): unown the window so screen readers read it

### DIFF
--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -793,6 +793,7 @@ public partial class MainWindow : Window
         // them explicitly on a real main-window close, the same way compose windows are handled.
         foreach (var w in _openMessageWindows.ToList())
             w.Close();
+        _rulesWindow?.Close(); // unowned (#347), so not auto-closed with the main window
         _trayIcon?.Dispose(); // remove the tray icon so it doesn't linger after exit
         // Cancels all in-flight VM operations (sync, prefetch, loads) and releases
         // their CTS handles. OnClosed, not OnClosing — the close cannot be cancelled here.
@@ -5793,7 +5794,12 @@ public partial class MainWindow : Window
             return removed.Count;
         };
 
-        var dialog = new RulesManagerWindow(rulesVm, accounts, _vm.CachedFolders) { Owner = this };
+        // No Owner (issue #347): an owned window nests under MainWindow in the UIA tree, so some
+        // screen readers read the topmost ancestor's title (the main window) instead of "Rules
+        // Manager". Leaving it unowned makes it an independent peer that reads its own title — the
+        // same fix compose and standalone message windows use. Unowned windows aren't auto-closed
+        // with the main window, so it's tracked in _rulesWindow and closed in OnClosed.
+        var dialog = new RulesManagerWindow(rulesVm, accounts, _vm.CachedFolders);
         _rulesWindow = dialog;
 
         // Modeless (.Show, NOT .ShowDialog). Opening this window modally over MainWindow's

--- a/QuickMail/Views/RulesManagerWindow.xaml
+++ b/QuickMail/Views/RulesManagerWindow.xaml
@@ -6,7 +6,7 @@
         AutomationProperties.Name="Rules Manager"
         Width="750" Height="560"
         MinWidth="600" MinHeight="440"
-        WindowStartupLocation="CenterOwner"
+        WindowStartupLocation="CenterScreen"
         ResizeMode="CanResizeWithGrip"
         WindowStyle="SingleBorderWindow"
         Background="{DynamicResource Theme.WindowBackground}"


### PR DESCRIPTION
Kelly reported the rules-manager window title still read as the main window with some screen readers (and that the address book has the same problem), and pointed me at the prior fix. Found it: commit `54d4ae1` "make ComposeWindow a truly independent window so JAWS reads correct title."

**Root cause:** an **owned** window (`Owner = this`) nests under `MainWindow` in WPF's UIA tree, so some screen readers read the topmost ancestor's title — the main "… - QuickMail" window — instead of "Rules Manager". My earlier `ToolWindow → SingleBorderWindow` change in #351 didn't touch this, so it didn't fix it.

**Fix** (identical to what compose and standalone message windows already do):
- Drop `Owner = this` from the `RulesManagerWindow` creation → it becomes an independent UIA peer that exposes its own title.
- `WindowStartupLocation` → `CenterScreen` (CenterOwner is meaningless without an owner).
- Close the now-unowned window from `MainWindow.OnClosed` (WPF only auto-closes owned windows), reusing the existing `_rulesWindow` field.

Focus restoration on close still works — the `Closed` handler explicitly re-activates `MainWindow` and restores focus.

Build clean; XAML/rules/selector tests 61 passed. Needs a manual screen-reader retest of the title.

**Follow-up:** the address book (and likely other owned dialogs) has the same issue, but it's shown modally (`ShowDialog`), so unowning it needs more care — filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)