### PR TITLE
Allow binding bare Delete/Backspace/Insert/F-keys as hotkeys (#330)

### DIFF
--- a/QuickMail.Tests/GestureHelperTests.cs
+++ b/QuickMail.Tests/GestureHelperTests.cs
@@ -1,0 +1,56 @@
+using System.Windows.Input;
+using QuickMail.Helpers;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+// Covers bare-key bindings (issue #330): Delete/Backspace/Insert/F-keys must be capturable and must
+// round-trip through the gesture string, while ordinary text and dialog-navigation keys must not.
+public class GestureHelperTests
+{
+    [Theory]
+    [InlineData(Key.Delete, true)]
+    [InlineData(Key.Back, true)]
+    [InlineData(Key.Insert, true)]
+    [InlineData(Key.F1, true)]
+    [InlineData(Key.F5, true)]
+    [InlineData(Key.F24, true)]
+    [InlineData(Key.A, false)]
+    [InlineData(Key.D5, false)]
+    [InlineData(Key.Space, false)]
+    [InlineData(Key.Enter, false)]
+    [InlineData(Key.Escape, false)]
+    [InlineData(Key.Tab, false)]
+    public void IsBindableBareKey_AllowsOnlyTheIntendedKeys(Key key, bool expected)
+        => Assert.Equal(expected, GestureHelper.IsBindableBareKey(key));
+
+    [Theory]
+    [InlineData(Key.Delete, "Delete")]
+    [InlineData(Key.Back, "Backspace")]
+    [InlineData(Key.Insert, "Insert")]
+    [InlineData(Key.F3, "F3")]
+    public void BareKey_RoundTripsThroughFormatAndTryParse(Key key, string expectedGesture)
+    {
+        var gesture = GestureHelper.Format(key, ModifierKeys.None);
+        Assert.Equal(expectedGesture, gesture);
+
+        Assert.True(GestureHelper.TryParse(gesture, out var parsedKey, out var parsedMods));
+        Assert.Equal(key, parsedKey);
+        Assert.Equal(ModifierKeys.None, parsedMods);
+    }
+
+    [Theory]
+    [InlineData("A")]        // bare letter — not allowlisted
+    [InlineData("Space")]    // bare space
+    [InlineData("Enter")]    // dialog-navigation key
+    public void TryParse_RejectsBareNonAllowlistedKeys(string gesture)
+        => Assert.False(GestureHelper.TryParse(gesture, out _, out _));
+
+    [Fact]
+    public void TryParse_StillParsesModifierCombos()
+    {
+        Assert.True(GestureHelper.TryParse("Ctrl+Shift+Delete", out var key, out var mods));
+        Assert.Equal(Key.Delete, key);
+        Assert.Equal(ModifierKeys.Control | ModifierKeys.Shift, mods);
+    }
+}

--- a/QuickMail/Helpers/GestureHelper.cs
+++ b/QuickMail/Helpers/GestureHelper.cs
@@ -13,6 +13,18 @@ public static class GestureHelper
     private static readonly Dictionary<Key, string> _keyToName = BuildKeyToName();
     private static readonly Dictionary<string, Key> _nameToKey = BuildNameToKey();
 
+    /// <summary>
+    /// True for the modifier-less keys that may be bound as a bare shortcut: Delete, Backspace,
+    /// Insert, and F1–F24. Ordinary text keys (letters/digits/space) and the dialog-navigation
+    /// keys (Enter/Escape/Tab) are deliberately excluded, so capturing a shortcut can never turn
+    /// normal typing into a global hotkey. Both the capture dialog and <see cref="TryParse"/> use
+    /// this, so a bare binding round-trips through config. Bare Delete already ships as a default
+    /// (e.g. the delete-message command), which is why the capture UI must accept it too. See #330.
+    /// </summary>
+    public static bool IsBindableBareKey(Key key) =>
+        key is Key.Delete or Key.Back or Key.Insert
+            || (key >= Key.F1 && key <= Key.F24);
+
     public static string Format(Key key, ModifierKeys modifiers)
     {
         if (key == Key.None) return string.Empty;
@@ -43,7 +55,22 @@ public static class GestureHelper
         if (string.IsNullOrWhiteSpace(gesture)) return false;
 
         var parts = gesture.Split('+');
-        if (parts.Length < 2) return false;
+
+        // Bare single-key gesture (no modifier) — accepted only for the allowlisted keys, so a
+        // custom bare Delete/Backspace/Insert/F-key round-trips through config. See #330.
+        if (parts.Length == 1)
+        {
+            var bare = parts[0].Trim();
+            if ((_nameToKey.TryGetValue(bare, out key)
+                    || (Enum.TryParse(bare, ignoreCase: true, out key) && key != Key.None))
+                && IsBindableBareKey(key))
+            {
+                modifiers = ModifierKeys.None;
+                return true;
+            }
+            key = Key.None;
+            return false;
+        }
 
         for (int i = 0; i < parts.Length - 1; i++)
         {

--- a/QuickMail/Views/KeyCaptureDialog.xaml.cs
+++ b/QuickMail/Views/KeyCaptureDialog.xaml.cs
@@ -55,7 +55,13 @@ public partial class KeyCaptureDialog : Window
             return;
 
         var modifiers = Keyboard.Modifiers;
-        if (modifiers == ModifierKeys.None) return;
+
+        // A modifier-less press is accepted only for keys that make sense as a bare shortcut
+        // (Delete, Backspace, Insert, F1–F24) — bare Delete already ships as a default binding,
+        // so the capture UI must be able to reproduce it (#330). Bare letters/digits/space and the
+        // dialog-navigation keys (Enter/Escape/Tab) fall through to normal handling instead of
+        // becoming a global hotkey.
+        if (modifiers == ModifierKeys.None && !GestureHelper.IsBindableBareKey(e.Key)) return;
 
         _capturedKey       = e.Key;
         _capturedModifiers = modifiers;


### PR DESCRIPTION
Re-applies the **#330** fix from the reverted #342 (commit `ded0577`), unchanged and verified against current `main`. Confirmed the bug is live on main today (the capture dialog and `TryParse` both reject bare keys) and that bare Delete ships as a default binding in four places — so once a user rebinds it, they can't restore it. The reporter is currently stuck with delete=shift+delete because of this.

## The fix
- `GestureHelper.IsBindableBareKey` — allowlists **Delete, Backspace, Insert, F1–F24**, and deliberately excludes letters/digits/space and the dialog-nav keys (Enter/Escape/Tab), so capturing a shortcut can never turn normal typing into a global hotkey.
- `KeyCaptureDialog` accepts a modifier-less press only for allowlisted keys; everything else falls through to normal handling.
- `GestureHelper.TryParse` round-trips bare allowlisted keys through config.

## Verification
- Build clean (0/0).
- Gesture/hotkey/command tests: 43 passed, including the restored `GestureHelperTests` (allowlist matrix, bare-key Format↔TryParse round-trip, rejection of non-allowlisted bare keys, and modifier combos still parse).

Cleanly separated from the #328/#329 code that shared the reverted commit. Closes #330.

🤖 Generated with [Claude Code](https://claude.com/claude-code)