### PR TITLE
Invite RSVP feedback via in-card aria-live region (#329)

### DIFF
--- a/QuickMail.Tests/InviteCardTests.cs
+++ b/QuickMail.Tests/InviteCardTests.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Threading.Tasks;
+using QuickMail.Models;
+using QuickMail.ViewModels;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+// Reading-pane invite card (issue #329): the card must carry an aria-live status region so an RSVP
+// can be confirmed reliably from inside the WebView2 — a host-window notification alone is dropped
+// because focus is in the WebView2 document. The View injects sending/success/failure text into that
+// region via ExecuteScriptAsync.
+public class InviteCardTests
+{
+    private static MainViewModel MakeVm() => new(
+        new StubImapMailService(), new StubAccountService(), new StubCredentialService(),
+        new StubLocalStoreService(), new StubOAuthService(), new StubSyncService(),
+        new StubConfigService(), new StubCommandRegistry(), new StubViewService(),
+        new StubRuleService(), new StubSmtpService());
+
+    private static MailMessageDetail DetailWithInvite() => new()
+    {
+        AccountId = Guid.NewGuid(),
+        MessageId = "m1",
+        FolderName = "INBOX",
+        Subject = "Lunch",
+        CalendarInvite = new IcsModel
+        {
+            Uid = "lunch-1",
+            Summary = "Lunch",
+            Organizer = "org@example.com",
+            StartTime = new DateTime(2026, 7, 22, 17, 0, 0, DateTimeKind.Utc),
+            Method = "REQUEST",
+        },
+    };
+
+    [Fact]
+    public void EventCard_WithInvite_IncludesAriaLiveStatusRegion()
+    {
+        var vm = MakeVm();
+        vm.MessageDetail = DetailWithInvite();
+
+        var html = vm.BuildEventCardHtml();
+
+        Assert.Contains("id=\"qm-invite-status\"", html);
+        Assert.Contains("aria-live=\"assertive\"", html);
+        // Sanity: the response buttons are still present for a REQUEST.
+        Assert.Contains("quickmail:ics-accept", html);
+    }
+
+    [Fact]
+    public void EventCard_NoInvite_IsEmpty()
+    {
+        var vm = MakeVm();
+        Assert.Equal(string.Empty, vm.BuildEventCardHtml());
+    }
+
+    [Fact]
+    public async Task Rsvp_WhenInviteDataMissing_RaisesActionableCardStatus()
+    {
+        // The #297 cache-reconstruction race: the card is shown but CalendarInvite is null. Pressing
+        // Accept must say something actionable through the card, not return silently (#329).
+        var vm = MakeVm();
+        vm.MessageDetail = new MailMessageDetail
+        {
+            AccountId = Guid.NewGuid(),
+            MessageId = "m1",
+            FolderName = "INBOX",
+            // No CalendarInvite.
+        };
+
+        string? cardStatus = null;
+        vm.OpenInviteCardStatus += s => cardStatus = s;
+
+        await vm.AcceptInviteCommand.ExecuteAsync(null);
+
+        Assert.NotNull(cardStatus);
+        Assert.Contains("can't be answered", cardStatus);
+    }
+}

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -6550,9 +6550,11 @@ public partial class MainViewModel : ObservableObject, IDisposable
             var eventTitle = invite.Summary ?? "calendar event";
             Announce($"Calendar response sent: {actionLabel} \u2014 {eventTitle}.", AnnouncementCategory.Result);
 
-            // Say what actually happened: accepting/tentative also adds the event to the calendar
-            // (the upsert below); declining only sends the reply. This is the reliable, in-document
-            // confirmation the reporter was missing (#329).
+            // Say what actually happened. The event is upserted to the calendar for every response
+            // (the block below runs regardless of partStat, so the calendar reflects the reply), but
+            // the decline MESSAGE omits the calendar line — telling someone who declined "it's on your
+            // calendar" would read oddly. This is the reliable, in-document confirmation the reporter
+            // was missing (#329).
             CardStatus(partStat == "DECLINED"
                 ? $"You {actionLabel} this meeting. Your reply was sent to the organizer."
                 : $"You {actionLabel} this meeting. It's been added to your calendar, and your reply was sent to the organizer.");

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -224,10 +224,10 @@ public partial class MainViewModel : ObservableObject, IDisposable
         DisplayName = "Calendar"
     };
 
-    // Per-source calendar children under the Calendar node: " Calendar:{guid}" for one
+    // Per-source calendar children under the Calendar node: "\u0000Calendar:{guid}" for one
     // account, "local" for locally-authored appointments, "all" for the merged view, and
     // "{guid}|{escapedCalId}" for a single specific calendar of that account.
-    internal const string CalendarSourcePrefix = " Calendar:";
+    internal const string CalendarSourcePrefix = "\u0000Calendar:";
 
     /// <summary>True for the Calendar node or any of its per-source children.</summary>
     internal static bool IsCalendarFolderName(string? fullName) =>
@@ -6308,6 +6308,14 @@ public partial class MainViewModel : ObservableObject, IDisposable
     /// Builds an accessible HTML event card for display in the WebView2 reading pane.
     /// The card is prepended to the message body HTML by the View.
     /// </summary>
+    /// <summary>
+    /// Raised to update the open invite card's in-document <c>aria-live</c> status region (issue #329).
+    /// Host-window announcements are unreliable while focus is inside the reading-pane WebView2, so a
+    /// reading-pane RSVP's sending / success / failure feedback is delivered here, inside the document
+    /// the screen reader is already reading. The View injects the text via <c>ExecuteScriptAsync</c>.
+    /// </summary>
+    public event Action<string>? OpenInviteCardStatus;
+
     public string BuildEventCardHtml()
     {
         var invite = MessageDetail?.CalendarInvite;
@@ -6403,6 +6411,12 @@ public partial class MainViewModel : ObservableObject, IDisposable
             AppendButton("quickmail:ics-decline", "Decline invitation", "Decline",
                 Color("error", "#B3261E"), Color("errorBackground", "#FBEAE9"), last: true);
             sb.Append("</div>");
+
+            // Live status region for RSVP feedback (issue #329), updated in place via
+            // ExecuteScriptAsync so the result is announced from inside the document — a host-window
+            // notification is dropped while focus is in the WebView2. Empty until the user responds.
+            sb.Append("<div id=\"qm-invite-status\" aria-live=\"assertive\" aria-atomic=\"true\" " +
+                      "style=\"margin-top:8px;font-weight:600;\"></div>");
         }
 
         sb.Append("</div>");
@@ -6430,7 +6444,16 @@ public partial class MainViewModel : ObservableObject, IDisposable
     private async Task SendIcsReply(string partStat, string actionLabel)
     {
         var invite = MessageDetail?.CalendarInvite;
-        if (invite == null) return;
+        if (invite == null)
+        {
+            // The card is shown but the invite data isn't available (e.g. a cache-served reopen before
+            // reconstruction). Say so instead of returning silently (#329). The card is what's focused,
+            // so route it through the card's live region as well as the host announce.
+            const string msg = "This invitation can't be answered right now. Open it again from the message list and try once it has loaded.";
+            OpenInviteCardStatus?.Invoke(msg);
+            Announce(msg, AnnouncementCategory.Result);
+            return;
+        }
 
         var account = Accounts.FirstOrDefault(a => a.Id == MessageDetail!.AccountId);
         if (account == null)
@@ -6503,6 +6526,18 @@ public partial class MainViewModel : ObservableObject, IDisposable
     private async Task SendIcsReplyForAsync(IcsModel invite, AccountModel account, string partStat,
         string actionLabel, string sourceMessageId, string sourceFolder)
     {
+        // Feedback for a reading-pane RSVP goes through the card's in-document live region (#329), but
+        // only while the reading pane still shows THIS invite \u2014 if the user navigated away during the
+        // send, or this reply came from the calendar list, we must not write into a different card.
+        void CardStatus(string text)
+        {
+            if (MessageDetail?.CalendarInvite is { } open &&
+                string.Equals(open.Uid, invite.Uid, StringComparison.Ordinal))
+                OpenInviteCardStatus?.Invoke(text);
+        }
+
+        CardStatus("Sending your reply\u2026");
+
         try
         {
             var attendeeName = account.SenderDisplayName;
@@ -6514,6 +6549,13 @@ public partial class MainViewModel : ObservableObject, IDisposable
 
             var eventTitle = invite.Summary ?? "calendar event";
             Announce($"Calendar response sent: {actionLabel} \u2014 {eventTitle}.", AnnouncementCategory.Result);
+
+            // Say what actually happened: accepting/tentative also adds the event to the calendar
+            // (the upsert below); declining only sends the reply. This is the reliable, in-document
+            // confirmation the reporter was missing (#329).
+            CardStatus(partStat == "DECLINED"
+                ? $"You {actionLabel} this meeting. Your reply was sent to the organizer."
+                : $"You {actionLabel} this meeting. It's been added to your calendar, and your reply was sent to the organizer.");
 
             // Update the calendar event's response status so the calendar pane reflects the reply.
             if (_calendarService != null && !string.IsNullOrEmpty(invite.Uid))
@@ -6559,6 +6601,9 @@ public partial class MainViewModel : ObservableObject, IDisposable
         {
             LogService.Log($"SendIcsReply ({partStat})", ex);
             Announce($"Failed to send calendar response: {ex.Message}", AnnouncementCategory.Result);
+            // A failed send would otherwise be silent in the reading pane too (host announce dropped),
+            // and the buttons remain so the user can retry.
+            CardStatus("Couldn't send your reply. You can try again.");
         }
     }
 

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -313,6 +313,7 @@ public partial class MainWindow : Window
         vm.MessageListFocusRequested += ReturnFocusToMessageList;
         vm.AnnouncementRequested += (_, args) =>
             AccessibilityHelper.Announce(this, args.Text, interrupt: true, category: args.Category);
+        vm.OpenInviteCardStatus += OnOpenInviteCardStatus;
         vm.SearchRequested += (_, _) => OpenSearch();
         vm.SaveViewRequested    += (_, _) => OpenViewManager(createMode: true);
         vm.ManageViewsRequested += (_, _) => OpenViewManager(createMode: false);
@@ -3196,6 +3197,20 @@ public partial class MainWindow : Window
     }
 
     /// <summary>Handles quickmail: pseudo-URIs from the event card buttons.</summary>
+    // Update the open invite card's aria-live status region in place (#329). Because the region lives
+    // in the document the screen reader is already reading, updating its text is announced reliably —
+    // unlike a host-window notification, which is dropped while focus is inside the WebView2. The
+    // reading-pane document persists across the RSVP because the quickmail: navigation is cancelled.
+    private async void OnOpenInviteCardStatus(string text)
+    {
+        if (!_webViewReady || MessageBody.CoreWebView2 is null) return;
+        // JsonSerializer yields a safe, quoted JS string literal; textContent prevents HTML injection.
+        var js = "(function(){var s=document.getElementById('qm-invite-status');" +
+                 "if(s){s.textContent=" + System.Text.Json.JsonSerializer.Serialize(text) + ";}})();";
+        try { await MessageBody.CoreWebView2.ExecuteScriptAsync(js); }
+        catch (Exception ex) { LogService.Log("OnOpenInviteCardStatus", ex); }
+    }
+
     private void HandleQuickMailUri(string uri)
     {
         if (uri.StartsWith("quickmail:ics-accept", StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
Pressing Accept/Tentative/Decline on a reading-pane invite gave no reliable feedback: the confirmation was a **host-window** UIA notification raised while focus is inside the out-of-process WebView2 document, where such notifications get dropped. Reworked from the reverted #342 approach (which only handled the success moment and still used the host channel for the interim/failure states).

## Approach -- decided with the maintainer
Keep the **inline buttons** exactly where they are (their in-context locality is a deliberate value-add), and deliver **all three states through an `aria-live` region inside the card** -- the document the screen reader is already reading -- so nothing depends on the host-window channel. Explicitly **not** moving focus to force an announcement (rejected as an anti-pattern).

- **On press:** "Sending your reply..."
- **On success:** "You accepted this meeting. It's been added to your calendar, and your reply was sent to the organizer." (declining omits the calendar line). Answers the reporter's actual questions -- *added to my calendar? organizer notified?* -- both of which the code already does (`UpsertEventAsync` + the SMTP reply).
- **On failure:** "Couldn't send your reply. You can try again." -- buttons stay for retry (a failed send was previously silent in the reading pane too).
- The silent **null-invite** path (#297 cache-reconstruction race) now speaks.

Written via `ExecuteScriptAsync` with `JsonSerializer` escaping + `textContent` (no HTML injection). Fires only while the reading pane still shows that exact invite (Uid match), so a stale card is never touched. Host announcements kept as belt-and-suspenders for the calendar-list path (focus in WPF, where they work).

## Also
Converts two raw NUL bytes in `MainViewModel.cs` (a Write-tool artifact -- one in a comment, one in the `CalendarSourcePrefix` literal) to unicode escapes: semantically identical, and it makes the file normally editable again (the NULs were silently breaking the editor).

## Verification
- Build clean (0/0); full suite **1557 passed, 0 failed**, incl. new `InviteCardTests` (aria-live region present, empty-card case, null-invite raises an actionable status).
- **The one thing that needs a real screen reader:** whether an `aria-live` update inside the reading-pane WebView2 is actually spoken. That's the crux of this approach and can't be unit-tested -- needs a manual pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
