### PR TITLE
Reach attachments in window mode + Alt+A focus command; report open mode (#350)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ installer/velopack/license.txt
 # Test result artifacts
 *.trx
 QuickMail.Tests/TestResults/
+
+# Local test mail servers (GreenMail jars, logs)
+.testservers/

--- a/QuickMail.Tests/BugReportServiceTests.cs
+++ b/QuickMail.Tests/BugReportServiceTests.cs
@@ -196,6 +196,7 @@ public class BugReportServiceTests
             Theme = "Parchment",
             View  = "Unread (Conversations)",
             Sort  = "Newest First",
+            MessageOpenMode = "Window",
         };
 
         var text = service.BuildReportText(report);
@@ -203,6 +204,25 @@ public class BugReportServiceTests
         Assert.Contains("Theme: Parchment", text);
         Assert.Contains("View: Unread (Conversations)", text);
         Assert.Contains("Sort: Newest First", text);
+        Assert.Contains("Message open mode: Window", text);
+    }
+
+    [Fact]
+    public void BuildReportText_OmitsMessageOpenMode_WhenContextValueEmpty()
+    {
+        var service = MakeService(_ => new HttpResponseMessage(HttpStatusCode.OK), out _);
+        var report = SampleReport();
+        report.Context = new BugReportContext
+        {
+            Theme = "Parchment",
+            View  = "All (Messages)",
+            Sort  = "Newest First",
+            // MessageOpenMode stays empty
+        };
+
+        var text = service.BuildReportText(report);
+
+        Assert.DoesNotContain("Message open mode:", text);
     }
 
     [Fact]

--- a/QuickMail/Models/BugReportModel.cs
+++ b/QuickMail/Models/BugReportModel.cs
@@ -26,4 +26,11 @@ public sealed class BugReportContext
     public string Theme { get; set; } = string.Empty;
     public string View { get; set; } = string.Empty;
     public string Sort { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Where messages open (Reading pane / Tab / Window) — the Windowing "Message Open Mode"
+    /// setting. Included because it has no PII and is often central to reproducing a report
+    /// (e.g. attachment behaviour differs by mode; see issue #350).
+    /// </summary>
+    public string MessageOpenMode { get; set; } = string.Empty;
 }

--- a/QuickMail/Services/BugReportService.cs
+++ b/QuickMail/Services/BugReportService.cs
@@ -141,6 +141,8 @@ public partial class BugReportService : IBugReportService, IDisposable
             sb.AppendLine($"- Theme: {ctx.Theme}");
             sb.AppendLine($"- View: {ctx.View}");
             sb.AppendLine($"- Sort: {ctx.Sort}");
+            if (!string.IsNullOrWhiteSpace(ctx.MessageOpenMode))
+                sb.AppendLine($"- Message open mode: {ctx.MessageOpenMode}");
         }
 
         return sb.ToString();

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -547,6 +547,13 @@ public partial class MainViewModel : ObservableObject, IDisposable
             MessageSort.FlaggedFirst    => "Flagged First",
             _                           => ActiveSort.ToString(),
         },
+        MessageOpenMode = MessageOpenMode switch
+        {
+            Models.MessageOpenMode.ReadingPane => "Reading pane",
+            Models.MessageOpenMode.Tab         => "Tab",
+            Models.MessageOpenMode.Window      => "Window",
+            _                                  => MessageOpenMode.ToString(),
+        },
     };
 
     private string ViewModeName => ViewMode switch

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -1137,6 +1137,17 @@ public partial class MainWindow : Window
             defaultKey: Key.T, defaultModifiers: ModifierKeys.Control | ModifierKeys.Shift,
             isAvailable: () => _vm.ShowTabStrip));
 
+        // Focus Attachment List (Alt+A, issue #350) — jumps straight to the reading-pane/tab
+        // attachment list of the open message, so attachments are reachable without Tabbing
+        // through the header fields (or, for window mode, MessageWindow's own copy of this command).
+        // Available only when the open message actually has attachments; announces otherwise so
+        // the keypress is never silently ignored.
+        _registry.Register(new CommandDefinition(
+            id: "view.focusAttachments", category: "View", title: "Focus Attachment List",
+            execute: FocusAttachmentList,
+            defaultKey: Key.A, defaultModifiers: ModifierKeys.Alt,
+            isAvailable: () => _vm.IsMessageOpen));
+
         // ── Tab & Window Management commands ─────────────────────────────────────
         _registry.Register(new CommandDefinition(
             id: "tabs.next", category: "View", title: "Next Tab",
@@ -2922,6 +2933,7 @@ public partial class MainWindow : Window
                 +"else if(e.key==='F6'){window.chrome.webview.postMessage(e.shiftKey?'shift-f6':'f6');e.preventDefault();}"
                 +"else if(e.ctrlKey&&(e.key==='2'||e.key==='y'||e.key==='Y')){window.chrome.webview.postMessage('focus-folders');e.preventDefault();}"
                 +"else if(e.key==='Tab'&&e.shiftKey){window.chrome.webview.postMessage('shift-tab');e.preventDefault();}"
+                +"else if(e.altKey&&(e.key==='a'||e.key==='A')){window.chrome.webview.postMessage('focus-attachments');e.preventDefault();}"
                 +"else if(e.ctrlKey&&e.key==='w'){window.chrome.webview.postMessage('ctrl-w');e.preventDefault();}"
                 +"});");
 
@@ -2938,6 +2950,8 @@ public partial class MainWindow : Window
                     Dispatcher.InvokeAsync(FocusFolderTree, DispatcherPriority.Input);
                 else if (msg == "shift-tab")
                     Dispatcher.InvokeAsync(FocusLastHeaderField, DispatcherPriority.Input);
+                else if (msg == "focus-attachments")
+                    Dispatcher.InvokeAsync(FocusAttachmentList, DispatcherPriority.Input);
                 else if (msg == "ctrl-w")
                     Dispatcher.InvokeAsync(
                         () => _registry.FindByGesture(Key.W, ModifierKeys.Control)?.Execute(),
@@ -3240,6 +3254,24 @@ public partial class MainWindow : Window
             {
                 LogService.Log("MessageBody_GotKeyboardFocus", ex);
             }
+        }
+    }
+
+    // Alt+A (view.focusAttachments, issue #350): move focus to the open message's attachment
+    // list. GotKeyboardFocus selects the first item so the screen reader lands on an attachment,
+    // not the empty list shell. When the message has none, announce it rather than moving focus
+    // to a collapsed control the user can't see.
+    private void FocusAttachmentList()
+    {
+        if (ReadingPaneAttachmentList.Visibility == Visibility.Visible
+            && ReadingPaneAttachmentList.Items.Count > 0)
+        {
+            ReadingPaneAttachmentList.Focus();
+        }
+        else
+        {
+            AccessibilityHelper.Announce(this, "No attachments.",
+                interrupt: true, category: AnnouncementCategory.Result);
         }
     }
 

--- a/QuickMail/Views/MessageWindow.xaml.cs
+++ b/QuickMail/Views/MessageWindow.xaml.cs
@@ -130,6 +130,11 @@ public partial class MessageWindow : Window
             isAvailable: () => _vm.CanNavigateNext));
 
         _localRegistry.Register(new CommandDefinition(
+            id: "window.focusAttachments", category: "View", title: "Focus Attachment List",
+            execute: FocusAttachmentList,
+            defaultKey: Key.A, defaultModifiers: ModifierKeys.Alt));
+
+        _localRegistry.Register(new CommandDefinition(
             id: "window.moveToMainWindow", category: "View", title: "Move to Main Window",
             execute: () => _vm.MoveToMainWindowCommand.Execute(null)));
 
@@ -164,6 +169,7 @@ public partial class MessageWindow : Window
                 "else if(e.key==='Tab'&&e.shiftKey){window.chrome.webview.postMessage('shift-tab');e.preventDefault();}" +
                 "else if(e.key==='F6'&&!e.shiftKey){window.chrome.webview.postMessage('f6');e.preventDefault();}" +
                 "else if(e.key==='F6'&&e.shiftKey){window.chrome.webview.postMessage('shift-f6');e.preventDefault();}" +
+                "else if(e.altKey&&(e.key==='a'||e.key==='A')){window.chrome.webview.postMessage('focus-attachments');e.preventDefault();}" +
                 "else if(e.ctrlKey&&e.key==='w'){window.chrome.webview.postMessage('ctrl-w');e.preventDefault();}" +
                 "});");
 
@@ -175,6 +181,7 @@ public partial class MessageWindow : Window
                     case "escape":     Dispatcher.InvokeAsync(Close,                DispatcherPriority.Input); break;
                     case "ctrl-w":     Dispatcher.InvokeAsync(Close,                DispatcherPriority.Input); break;
                     case "shift-tab":  Dispatcher.InvokeAsync(FocusLastHeaderField,  DispatcherPriority.Input); break;
+                    case "focus-attachments": Dispatcher.InvokeAsync(FocusAttachmentList, DispatcherPriority.Input); break;
                     case "f6":         Dispatcher.InvokeAsync(() => CycleFocus(true),  DispatcherPriority.Input); break;
                     case "shift-f6":   Dispatcher.InvokeAsync(() => CycleFocus(false), DispatcherPriority.Input); break;
                 }
@@ -522,6 +529,11 @@ public partial class MessageWindow : Window
             TogglePlainTextView();
             e.Handled = true;
         }
+        else if (key == Key.A && mod == ModifierKeys.Alt)
+        {
+            FocusAttachmentList();
+            e.Handled = true;
+        }
         else if (key == Key.P && mod == (ModifierKeys.Control | ModifierKeys.Shift))
         {
             OpenCommandPalette();
@@ -604,7 +616,34 @@ public partial class MessageWindow : Window
         }
     }
 
-    private void FocusLastHeaderField() => SubjectField.Focus();
+    // Alt+A (window.focusAttachments, issue #350): move focus to this message's attachment list.
+    // GotKeyboardFocus selects the first item so the screen reader lands on an attachment rather
+    // than the empty list shell. When the message has none, announce it instead of moving focus
+    // to a collapsed control.
+    private void FocusAttachmentList()
+    {
+        if (AttachmentList.Visibility == Visibility.Visible && AttachmentList.Items.Count > 0)
+        {
+            AttachmentList.Focus();
+        }
+        else
+        {
+            AccessibilityHelper.Announce(this, "No attachments.",
+                interrupt: true, category: AnnouncementCategory.Result);
+        }
+    }
+
+    // Shift+Tab from the WebView2 body lands on the last visible header stop: the attachment
+    // list when the message has attachments (issue #350), otherwise the Date field. Previously
+    // this always jumped to Subject (the first field), leaving attachments unreachable by
+    // Shift+Tab in window mode.
+    private void FocusLastHeaderField()
+    {
+        if (AttachmentList.Visibility == Visibility.Visible && AttachmentList.Items.Count > 0)
+            AttachmentList.Focus();
+        else
+            DateField.Focus();
+    }
 
     private void OnMoveToMainWindowRequested(MessageWindowViewModel vm)
     {

--- a/docs/KEYBOARD-SHORTCUTS.md
+++ b/docs/KEYBOARD-SHORTCUTS.md
@@ -43,6 +43,7 @@
 | *(unassigned)* | `mail.tentativeInvite` | Tentatively Accept Invitation |
 | *(unassigned)* | `help.keyboardTutorial` | Keyboard Tutorial |
 | Ctrl+Shift+T | `view.focusTabs` | Focus Tab Strip |
+| Alt+A | `view.focusAttachments` | Focus Attachment List (of the open message) |
 | Alt+Enter | `view.showProperties` | View Properties |
 | Ctrl+Tab | `tabs.next` | Next Tab |
 | Ctrl+Shift+Tab | `tabs.previous` | Previous Tab |

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -343,8 +343,26 @@ When Reading Mode is set to **Window**, messages open in a separate window. Each
 | `Ctrl+Shift+M` | Move to Archive |
 | `Ctrl+Q` | Mark as Read |
 | `Ctrl+Shift+G` | Grab Addresses |
+| `Alt+A` | Focus the attachment list |
 
 Deleting a message from its window closes the window and returns focus to the originating position in the message list.
+
+### Attachments on a Received Message
+
+When a message has attachments, they appear in an **attachments list** just below the header fields (Subject, From, To, Date). This works the same way in all three reading modes — reading pane, tab, and window.
+
+Reach the attachment list in either of two ways:
+
+- Press **Alt+A** to jump straight to it from anywhere in the open message. If the message has no attachments, QuickMail announces "No attachments."
+- Press **Shift+Tab** from the message body to step back into the header area; when the message has attachments, focus lands on the attachment list.
+
+Once focus is on the list, arrow between attachments and use:
+
+| Shortcut | Action |
+|----------|--------|
+| `Enter` | Open the selected attachment |
+| `Alt+Enter` | Show the attachment's properties |
+| `Shift+F10` (or the Menu key) | Open the context menu: **Save…**, **Save All…**, **Open** |
 
 ### Message Properties
 
@@ -903,7 +921,7 @@ Choose this option when you **don't mind sending an email** and want a **persona
 
 ### What's included in a report — and what's never included
 
-Alongside what you type, an in-app report (options 1 and 2) adds a short **Environment** section so a problem can be reproduced in the right context: the QuickMail version, your Windows version, the .NET runtime version, the active color theme, the current view, and the current sort order.
+Alongside what you type, an in-app report (options 1 and 2) adds a short **Environment** section so a problem can be reproduced in the right context: the QuickMail version, your Windows version, the .NET runtime version, the active color theme, the current view, the current sort order, and the message open mode (reading pane, tab, or window).
 
 **No message content, email addresses, account settings, passwords, or log file content is ever collected or sent.** The Preview shows the full report verbatim, so you always see exactly what is included before it leaves your computer.
 


### PR DESCRIPTION
Fixes #350 — attachments were unreachable when a message opens in its own window, and screen readers couldn't find them.

## 1. Focus Attachment List command (Alt+A)

- New command registered in all three reading modes:
  - `view.focusAttachments` (MainWindow — reading pane and tab)
  - `window.focusAttachments` (MessageWindow — window mode)
- **Alt+A** jumps straight to the open message's attachment list from anywhere in the message, including from inside the WebView2 body (relayed via `postMessage`). If the message has no attachments it announces "No attachments." rather than silently doing nothing.
- Discoverable in the **Command Palette** and **keyboard customizations** (no Alt+A conflicts — no menu mnemonic or existing binding uses it).
- **Shift+Tab from the body** now reaches attachments in window mode too: `MessageWindow.FocusLastHeaderField` lands on the attachment list (or Date) instead of always jumping to Subject, matching the reading pane's existing behavior.

## 2. Bug reports include the Message Open Mode

The reporter's window mode was the crux of this bug but wasn't in the report. `BugReportContext` now carries the reading-pane/tab/window setting (no PII), and the **Environment** section prints `Message open mode: <value>`.

## Docs
- `USER-GUIDE.md` — new "Attachments on a Received Message" section (Alt+A, Shift+Tab, Enter/Alt+Enter/context menu) and the bug-report environment list now mentions message open mode.
- `KEYBOARD-SHORTCUTS.md` — Alt+A row.

## Tests
- `BugReportServiceTests` — asserts the new environment line appears when set and is omitted when unset.
- Full existing suite for BugReport / CommandRegistry / ViewModelConstruction passes; project builds clean (0 warnings/errors).

## Manual verification still recommended
Per the repo's feature checklist, a keyboard-only walkthrough with a screen reader across all three modes (reading pane, tab, window) — reaching attachments via both Alt+A and Shift+Tab, then Enter/Save — is the authoritative check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)