### PR TITLE
Bump version to 0.8.36

### DIFF
--- a/QuickMail/QuickMail.csproj
+++ b/QuickMail/QuickMail.csproj
@@ -15,9 +15,9 @@
          System.Windows(.Media) types this codebase uses unqualified (Point, Size, Color, Brush,
          Application, MessageBox, ...). -->
     <UseWindowsForms>true</UseWindowsForms>
-    <Version>0.8.35</Version>
-    <AssemblyVersion>0.8.35</AssemblyVersion>
-    <FileVersion>0.8.35</FileVersion>
+    <Version>0.8.36</Version>
+    <AssemblyVersion>0.8.36</AssemblyVersion>
+    <FileVersion>0.8.36</FileVersion>
     <!-- Velopack needs a hand-written Main that runs VelopackApp.Build().Run() before WPF
          initializes (install/update/uninstall hooks run and may exit the process). App.xaml
          therefore compiles as Page (no generated Main) and the entry point is declared here. -->


### PR DESCRIPTION
Bumps `<Version>`/`<AssemblyVersion>`/`<FileVersion>` from 0.8.35 to 0.8.36 so the Build Installer workflow packs a 0.8.36 installer. Release notes already on main (docs/release-notes-v0.8.36.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)