### PR TITLE
Connection-fault integration suite — Phase 2 of #304

### DIFF
--- a/QuickMail.IntegrationTests/ConnectionRecoveryTests.cs
+++ b/QuickMail.IntegrationTests/ConnectionRecoveryTests.cs
@@ -56,7 +56,7 @@ public sealed class ConnectionRecoveryTests : IDisposable
             // Sever the pooled connection the way a server-side drop does. The next operation
             // rents a dead-on-arrival client (younger than the pool's stale-probe threshold, so
             // it is NOT probed) — exactly the #311 scenario.
-            _relay.KillActiveConnections();
+            Assert.True(_relay.KillActiveConnections() >= 1, "Kill hit no connections — nothing to recover from.");
 
             // Must not throw: ExecuteWithReconnectAsync retries once on a fresh connection.
             await imap.PermanentlyDeleteBatchAsync(account.Id, "INBOX", [summary.MessageId], ct);
@@ -88,19 +88,19 @@ public sealed class ConnectionRecoveryTests : IDisposable
             // client may fail — the guarantee under test is recovery: the dead client is
             // discarded when its lease returns, so a subsequent attempt gets a fresh
             // connection and succeeds (#268/#278/#313: recover, don't stay stuck/stale).
-            _relay.KillActiveConnections();
+            Assert.True(_relay.KillActiveConnections() >= 1, "Kill hit no connections — nothing to recover from.");
             var summaries = await RetryOnceAsync(
                 () => imap.GetMessageSummariesAsync(account.Id, "INBOX", 10, ct));
             Assert.Single(summaries);
             Assert.Equal(summary.MessageId, summaries[0].MessageId);
 
-            _relay.KillActiveConnections();
+            Assert.True(_relay.KillActiveConnections() >= 1, "Kill hit no connections — nothing to recover from.");
             var (total, unread) = await RetryOnceAsync(
                 () => imap.GetInboxStatusAsync(account.Id, ct));
             Assert.Equal(1, total);
             Assert.Equal(1, unread);
 
-            _relay.KillActiveConnections();
+            Assert.True(_relay.KillActiveConnections() >= 1, "Kill hit no connections — nothing to recover from.");
             var detail = await RetryOnceAsync(
                 () => imap.GetMessageDetailAsync(account.Id, "INBOX", summary.MessageId, ct));
             Assert.Contains("survives drops", detail.PlainTextBody);

--- a/QuickMail.IntegrationTests/ConnectionRecoveryTests.cs
+++ b/QuickMail.IntegrationTests/ConnectionRecoveryTests.cs
@@ -1,0 +1,163 @@
+using System.Diagnostics;
+using MailKit.Net.Smtp;
+using MailKit.Security;
+using MimeKit;
+using QuickMail.Models;
+using QuickMail.Services;
+
+namespace QuickMail.IntegrationTests;
+
+/// <summary>
+/// Connection-fault regression tests (live-content testing plan §4.4). Each test routes IMAP
+/// through a <see cref="TcpRelay"/> so a "server-side" connection drop can be injected
+/// mid-session, then asserts the service recovers instead of surfacing the failure:
+/// <list type="bullet">
+/// <item>#311 — delete after a silent drop must transparently reconnect and complete, never
+/// surface "Delete may not have completed".</item>
+/// <item>#268/#278/#313 — fetch and folder-count operations must recover after a drop rather
+/// than staying stuck on an error or stale state.</item>
+/// </list>
+/// </summary>
+[Collection(GreenMailCollection.Name)]
+public sealed class ConnectionRecoveryTests : IDisposable
+{
+    private readonly GreenMailFixture _greenMail;
+    private readonly TcpRelay _relay;
+
+    public ConnectionRecoveryTests(GreenMailFixture greenMail)
+    {
+        _greenMail = greenMail;
+        _relay = new TcpRelay(GreenMailFixture.Host, GreenMailFixture.ImapPort);
+    }
+
+    public void Dispose() => _relay.Dispose();
+
+    private AccountModel CreateRelayedAccount(string prefix)
+    {
+        var account = _greenMail.CreateAccount(prefix);
+        account.ImapPort = _relay.Port; // IMAP through the fault-injecting relay; SMTP direct
+        return account;
+    }
+
+    [Fact]
+    public async Task Delete_AfterKilledConnection_ReconnectsAndCompletes()
+    {
+        _greenMail.RequireServers();
+        var ct = TestContext.Current.CancellationToken;
+        var account = CreateRelayedAccount("del-retry");
+        await SeedAsync(account.Username, "to be deleted", ct);
+
+        using var imap = new ImapMailService(new NoOpOAuthService());
+        await imap.ConnectAsync(account, "pw", ct);
+        try
+        {
+            var summary = await WaitForMessageAsync(imap, account.Id, ct);
+
+            // Sever the pooled connection the way a server-side drop does. The next operation
+            // rents a dead-on-arrival client (younger than the pool's stale-probe threshold, so
+            // it is NOT probed) — exactly the #311 scenario.
+            _relay.KillActiveConnections();
+
+            // Must not throw: ExecuteWithReconnectAsync retries once on a fresh connection.
+            await imap.PermanentlyDeleteBatchAsync(account.Id, "INBOX", [summary.MessageId], ct);
+
+            var after = await imap.GetMessageSummariesAsync(account.Id, "INBOX", 10, ct);
+            Assert.Empty(after);
+        }
+        finally
+        {
+            await imap.DisconnectAsync(account.Id, ct);
+        }
+    }
+
+    [Fact]
+    public async Task FetchAndStatus_AfterKilledConnection_RecoverOnRetry()
+    {
+        _greenMail.RequireServers();
+        var ct = TestContext.Current.CancellationToken;
+        var account = CreateRelayedAccount("fetch-recover");
+        await SeedAsync(account.Username, "survives drops", ct);
+
+        using var imap = new ImapMailService(new NoOpOAuthService());
+        await imap.ConnectAsync(account, "pw", ct);
+        try
+        {
+            var summary = await WaitForMessageAsync(imap, account.Id, ct);
+
+            // Plain fetches have no retry wrapper, so the FIRST attempt on the dead pooled
+            // client may fail — the guarantee under test is recovery: the dead client is
+            // discarded when its lease returns, so a subsequent attempt gets a fresh
+            // connection and succeeds (#268/#278/#313: recover, don't stay stuck/stale).
+            _relay.KillActiveConnections();
+            var summaries = await RetryOnceAsync(
+                () => imap.GetMessageSummariesAsync(account.Id, "INBOX", 10, ct));
+            Assert.Single(summaries);
+            Assert.Equal(summary.MessageId, summaries[0].MessageId);
+
+            _relay.KillActiveConnections();
+            var (total, unread) = await RetryOnceAsync(
+                () => imap.GetInboxStatusAsync(account.Id, ct));
+            Assert.Equal(1, total);
+            Assert.Equal(1, unread);
+
+            _relay.KillActiveConnections();
+            var detail = await RetryOnceAsync(
+                () => imap.GetMessageDetailAsync(account.Id, "INBOX", summary.MessageId, ct));
+            Assert.Contains("survives drops", detail.PlainTextBody);
+        }
+        finally
+        {
+            await imap.DisconnectAsync(account.Id, ct);
+        }
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// One attempt is allowed to fail with a connection error (no retry wrapper on reads);
+    /// the second must succeed. A second failure fails the test — that is the regression.
+    /// </summary>
+    private static async Task<T> RetryOnceAsync<T>(Func<Task<T>> op)
+    {
+        try { return await op(); }
+        catch (Exception first) when (first is not OperationCanceledException)
+        {
+            try { return await op(); }
+            catch (Exception second) when (second is not OperationCanceledException)
+            {
+                throw new InvalidOperationException(
+                    $"Operation failed twice after a connection drop — no recovery. " +
+                    $"First: {first.GetType().Name}: {first.Message}; " +
+                    $"Second: {second.GetType().Name}: {second.Message}", second);
+            }
+        }
+    }
+
+    private static async Task<MailMessageSummary> WaitForMessageAsync(
+        ImapMailService imap, Guid accountId, CancellationToken ct)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        while (stopwatch.Elapsed < TimeSpan.FromSeconds(15))
+        {
+            var summaries = await imap.GetMessageSummariesAsync(accountId, "INBOX", 10, ct);
+            if (summaries.Count > 0)
+                return summaries[0];
+            await Task.Delay(250, ct);
+        }
+        throw new TimeoutException("Seeded message never appeared in the GreenMail INBOX.");
+    }
+
+    private static async Task SeedAsync(string recipient, string body, CancellationToken ct)
+    {
+        var message = new MimeMessage();
+        message.From.Add(new MailboxAddress("Sender", "sender@example.test"));
+        message.To.Add(MailboxAddress.Parse(recipient));
+        message.Subject = "connection test";
+        message.Body = new TextPart("plain") { Text = body };
+
+        using var smtp = new SmtpClient();
+        await smtp.ConnectAsync(GreenMailFixture.Host, GreenMailFixture.SmtpPort, SecureSocketOptions.None, ct);
+        await smtp.SendAsync(message, ct);
+        await smtp.DisconnectAsync(quit: true, ct);
+    }
+}

--- a/QuickMail.IntegrationTests/TcpRelay.cs
+++ b/QuickMail.IntegrationTests/TcpRelay.cs
@@ -44,17 +44,24 @@ public sealed class TcpRelay : IDisposable
     public int LiveConnectionCount => _live.Count;
 
     /// <summary>
-    /// Abruptly closes both sides of every in-flight connection. The listener stays up, so
-    /// clients can reconnect — this simulates a server-side drop, not an outage.
+    /// Abruptly closes both sides of every in-flight connection and returns how many pairs
+    /// were killed. The listener stays up, so clients can reconnect — this simulates a
+    /// server-side drop, not an outage. Callers should assert the count is at least 1: a kill
+    /// that hit nothing means the connection under test was already gone, and the "recovery"
+    /// being asserted would silently degrade into a happy-path test.
     /// </summary>
-    public void KillActiveConnections()
+    public int KillActiveConnections()
     {
+        var killed = 0;
         foreach (var (id, pair) in _live.ToArray())
         {
-            _live.TryRemove(id, out _);
+            if (!_live.TryRemove(id, out _))
+                continue;
+            killed++;
             try { pair.Client.Close(); } catch { }
             try { pair.Server.Close(); } catch { }
         }
+        return killed;
     }
 
     private async Task AcceptLoopAsync()
@@ -78,8 +85,11 @@ public sealed class TcpRelay : IDisposable
         var server = new TcpClient();
         try
         {
-            await server.ConnectAsync(_targetHost, _targetPort, _cts.Token);
+            // Register BEFORE the target connect so a kill issued the instant a connection is
+            // counted in TotalAccepted can't slip through the accept→connect window. Closing a
+            // not-yet-connected TcpClient is safe.
             _live[id] = (client, server);
+            await server.ConnectAsync(_targetHost, _targetPort, _cts.Token);
 
             var upstream   = PumpAsync(client, server);
             var downstream = PumpAsync(server, client);
@@ -109,11 +119,16 @@ public sealed class TcpRelay : IDisposable
         catch { /* closed/killed — RelayAsync's finally tears the pair down */ }
     }
 
+    private bool _disposed;
+
     public void Dispose()
     {
+        if (_disposed) return;
+        _disposed = true;
         _cts.Cancel();
         try { _listener.Stop(); } catch { }
         KillActiveConnections();
         _cts.Dispose();
+        GC.SuppressFinalize(this);
     }
 }

--- a/QuickMail.IntegrationTests/TcpRelay.cs
+++ b/QuickMail.IntegrationTests/TcpRelay.cs
@@ -1,0 +1,119 @@
+using System.Collections.Concurrent;
+using System.Net;
+using System.Net.Sockets;
+
+namespace QuickMail.IntegrationTests;
+
+/// <summary>
+/// Fault-injecting TCP relay for connection-handling tests (live-content testing plan §4.4).
+/// Listens on an ephemeral 127.0.0.1 port and forwards byte streams to a target (GreenMail).
+/// Point an account's ImapPort at <see cref="Port"/>, then use <see cref="KillActiveConnections"/>
+/// to sever every in-flight connection mid-session — the deterministic stand-in for a server
+/// dropping a pooled or IDLE connection, which is the trigger for the #311/#268/#278/#313/#314
+/// family of regressions. <see cref="TotalAccepted"/> counts every connection ever accepted, so a
+/// test can also assert that connections were NOT re-established (the #126 watcher-stability
+/// property).
+/// </summary>
+public sealed class TcpRelay : IDisposable
+{
+    private readonly TcpListener _listener;
+    private readonly string _targetHost;
+    private readonly int _targetPort;
+    private readonly CancellationTokenSource _cts = new();
+    private readonly ConcurrentDictionary<int, (TcpClient Client, TcpClient Server)> _live = new();
+    private int _nextId;
+    private int _totalAccepted;
+
+    public TcpRelay(string targetHost, int targetPort)
+    {
+        _targetHost = targetHost;
+        _targetPort = targetPort;
+        _listener = new TcpListener(IPAddress.Loopback, 0);
+        _listener.Start();
+        Port = ((IPEndPoint)_listener.LocalEndpoint).Port;
+        _ = AcceptLoopAsync();
+    }
+
+    /// <summary>The ephemeral local port tests point their account's ImapPort at.</summary>
+    public int Port { get; }
+
+    /// <summary>Connections accepted over the relay's lifetime (never decremented).</summary>
+    public int TotalAccepted => Volatile.Read(ref _totalAccepted);
+
+    /// <summary>Connections currently being relayed.</summary>
+    public int LiveConnectionCount => _live.Count;
+
+    /// <summary>
+    /// Abruptly closes both sides of every in-flight connection. The listener stays up, so
+    /// clients can reconnect — this simulates a server-side drop, not an outage.
+    /// </summary>
+    public void KillActiveConnections()
+    {
+        foreach (var (id, pair) in _live.ToArray())
+        {
+            _live.TryRemove(id, out _);
+            try { pair.Client.Close(); } catch { }
+            try { pair.Server.Close(); } catch { }
+        }
+    }
+
+    private async Task AcceptLoopAsync()
+    {
+        try
+        {
+            while (!_cts.IsCancellationRequested)
+            {
+                var client = await _listener.AcceptTcpClientAsync(_cts.Token);
+                Interlocked.Increment(ref _totalAccepted);
+                _ = RelayAsync(client);
+            }
+        }
+        catch (OperationCanceledException) { }
+        catch (ObjectDisposedException) { }
+    }
+
+    private async Task RelayAsync(TcpClient client)
+    {
+        var id = Interlocked.Increment(ref _nextId);
+        var server = new TcpClient();
+        try
+        {
+            await server.ConnectAsync(_targetHost, _targetPort, _cts.Token);
+            _live[id] = (client, server);
+
+            var upstream   = PumpAsync(client, server);
+            var downstream = PumpAsync(server, client);
+            await Task.WhenAny(upstream, downstream);
+        }
+        catch { /* torn-down connections are the point of this class */ }
+        finally
+        {
+            _live.TryRemove(id, out _);
+            try { client.Close(); } catch { }
+            try { server.Close(); } catch { }
+        }
+    }
+
+    private async Task PumpAsync(TcpClient from, TcpClient to)
+    {
+        var buffer = new byte[8192];
+        try
+        {
+            while (true)
+            {
+                var read = await from.GetStream().ReadAsync(buffer, _cts.Token);
+                if (read == 0) return;
+                await to.GetStream().WriteAsync(buffer.AsMemory(0, read), _cts.Token);
+            }
+        }
+        catch { /* closed/killed — RelayAsync's finally tears the pair down */ }
+    }
+
+    public void Dispose()
+    {
+        _cts.Cancel();
+        try { _listener.Stop(); } catch { }
+        KillActiveConnections();
+        _cts.Dispose();
+    }
+}

--- a/QuickMail.IntegrationTests/WatcherTests.cs
+++ b/QuickMail.IntegrationTests/WatcherTests.cs
@@ -62,7 +62,7 @@ public sealed class WatcherTests : IDisposable
 
             imap.StartWatchers([a1, a2], ct);
             await WaitUntilAsync(() => r1.TotalAccepted == pool1 + 1 && r2.TotalAccepted == pool2 + 1,
-                TimeSpan.FromSeconds(15), "watchers for accounts 1 and 2 never connected");
+                TimeSpan.FromSeconds(15), "watchers for accounts 1 and 2 never connected", ct);
             var watched1 = r1.TotalAccepted;
             var watched2 = r2.TotalAccepted;
 
@@ -73,7 +73,7 @@ public sealed class WatcherTests : IDisposable
             var pool3 = r3.TotalAccepted;
             imap.StartWatchers([a1, a2, a3], ct);
             await WaitUntilAsync(() => r3.TotalAccepted == pool3 + 1,
-                TimeSpan.FromSeconds(15), "watcher for account 3 never connected");
+                TimeSpan.FromSeconds(15), "watcher for account 3 never connected", ct);
 
             // Settle window: a restart of watchers 1/2 would show up as extra accepts.
             await Task.Delay(TimeSpan.FromSeconds(2), ct);
@@ -106,7 +106,7 @@ public sealed class WatcherTests : IDisposable
             var pool = relay.TotalAccepted;
             imap.StartWatchers([account], ct);
             await WaitUntilAsync(() => relay.TotalAccepted == pool + 1,
-                TimeSpan.FromSeconds(15), "watcher never connected");
+                TimeSpan.FromSeconds(15), "watcher never connected", ct);
             // Brief grace so the watcher is inside IdleAsync before mail arrives.
             await Task.Delay(TimeSpan.FromSeconds(1), ct);
 
@@ -147,12 +147,12 @@ public sealed class WatcherTests : IDisposable
             var pool = relay.TotalAccepted;
             imap.StartWatchers([account], ct);
             await WaitUntilAsync(() => relay.TotalAccepted == pool + 1,
-                TimeSpan.FromSeconds(15), "watcher never connected");
+                TimeSpan.FromSeconds(15), "watcher never connected", ct);
             await Task.Delay(TimeSpan.FromSeconds(1), ct);
 
             // Drop the watcher's socket: IdleAsync faults, the first retry marks the account
             // unreachable (#314 — the UI 'connected' state must track real socket outcomes).
-            relay.KillActiveConnections();
+            Assert.True(relay.KillActiveConnections() >= 1, "Kill hit no connections — nothing to recover from.");
             var downWinner = await Task.WhenAny(gotDown.Task, Task.Delay(TimeSpan.FromSeconds(15), ct));
             Assert.True(downWinner == gotDown.Task, "No unreachable event after the watcher socket was severed.");
 
@@ -179,13 +179,13 @@ public sealed class WatcherTests : IDisposable
 
     // ── Helpers ──────────────────────────────────────────────────────────────────
 
-    private static async Task WaitUntilAsync(Func<bool> condition, TimeSpan timeout, string failure)
+    private static async Task WaitUntilAsync(Func<bool> condition, TimeSpan timeout, string failure, CancellationToken ct)
     {
         var stopwatch = Stopwatch.StartNew();
         while (stopwatch.Elapsed < timeout)
         {
             if (condition()) return;
-            await Task.Delay(100);
+            await Task.Delay(100, ct);
         }
         throw new TimeoutException(failure);
     }

--- a/QuickMail.IntegrationTests/WatcherTests.cs
+++ b/QuickMail.IntegrationTests/WatcherTests.cs
@@ -1,0 +1,206 @@
+using System.Diagnostics;
+using MailKit.Net.Smtp;
+using MailKit.Security;
+using MimeKit;
+using QuickMail.Models;
+using QuickMail.Services;
+
+namespace QuickMail.IntegrationTests;
+
+/// <summary>
+/// IDLE-watcher behavior against a real server (live-content testing plan §4.4):
+/// <list type="bullet">
+/// <item>#126 — connecting an additional account must NOT drop/restart the existing accounts'
+/// IDLE connections (end-to-end half; the pure-logic half is WatcherReconcilerTests).</item>
+/// <item>IDLE fidelity — GreenMail pushes EXISTS on new mail and the watcher surfaces it as
+/// InboxNewMailDetected (the Phase-2 acceptance check from the plan).</item>
+/// <item>#314 — AccountReachabilityChanged tracks real socket outcomes: unreachable on drop,
+/// reachable again once the watcher reconnects.</item>
+/// </list>
+/// Each account gets its own <see cref="TcpRelay"/> so connection counts and kills are
+/// per-account observable.
+/// </summary>
+[Collection(GreenMailCollection.Name)]
+public sealed class WatcherTests : IDisposable
+{
+    private readonly GreenMailFixture _greenMail;
+    private readonly List<TcpRelay> _relays = new();
+
+    public WatcherTests(GreenMailFixture greenMail) => _greenMail = greenMail;
+
+    public void Dispose()
+    {
+        foreach (var relay in _relays)
+            relay.Dispose();
+    }
+
+    private (AccountModel Account, TcpRelay Relay) CreateRelayedAccount(string prefix)
+    {
+        var relay = new TcpRelay(GreenMailFixture.Host, GreenMailFixture.ImapPort);
+        _relays.Add(relay);
+        var account = _greenMail.CreateAccount(prefix);
+        account.ImapPort = relay.Port;
+        return (account, relay);
+    }
+
+    [Fact]
+    public async Task StartWatchers_AddingThirdAccount_DoesNotRestartExistingWatchers()
+    {
+        _greenMail.RequireServers();
+        var ct = TestContext.Current.CancellationToken;
+        var (a1, r1) = CreateRelayedAccount("watch1");
+        var (a2, r2) = CreateRelayedAccount("watch2");
+        var (a3, r3) = CreateRelayedAccount("watch3");
+
+        using var imap = new ImapMailService(new NoOpOAuthService());
+        try
+        {
+            await imap.ConnectAsync(a1, "pw", ct);
+            await imap.ConnectAsync(a2, "pw", ct);
+            var pool1 = r1.TotalAccepted;
+            var pool2 = r2.TotalAccepted;
+
+            imap.StartWatchers([a1, a2], ct);
+            await WaitUntilAsync(() => r1.TotalAccepted == pool1 + 1 && r2.TotalAccepted == pool2 + 1,
+                TimeSpan.FromSeconds(15), "watchers for accounts 1 and 2 never connected");
+            var watched1 = r1.TotalAccepted;
+            var watched2 = r2.TotalAccepted;
+
+            // The #126 regression: reconciling the watcher set for a third account restarted
+            // every watcher, dropping accounts 1 and 2 mid-IDLE. Adding account 3 must open
+            // exactly one new connection — on relay 3 — and none on relays 1 and 2.
+            await imap.ConnectAsync(a3, "pw", ct);
+            var pool3 = r3.TotalAccepted;
+            imap.StartWatchers([a1, a2, a3], ct);
+            await WaitUntilAsync(() => r3.TotalAccepted == pool3 + 1,
+                TimeSpan.FromSeconds(15), "watcher for account 3 never connected");
+
+            // Settle window: a restart of watchers 1/2 would show up as extra accepts.
+            await Task.Delay(TimeSpan.FromSeconds(2), ct);
+            Assert.Equal(watched1, r1.TotalAccepted);
+            Assert.Equal(watched2, r2.TotalAccepted);
+        }
+        finally
+        {
+            imap.StopWatchers();
+            await imap.DisconnectAsync(a1.Id, ct);
+            await imap.DisconnectAsync(a2.Id, ct);
+            await imap.DisconnectAsync(a3.Id, ct);
+        }
+    }
+
+    [Fact]
+    public async Task IdleWatcher_SurfacesNewMail_AsInboxNewMailDetected()
+    {
+        _greenMail.RequireServers();
+        var ct = TestContext.Current.CancellationToken;
+        var (account, relay) = CreateRelayedAccount("idle-push");
+
+        using var imap = new ImapMailService(new NoOpOAuthService());
+        var detected = new TaskCompletionSource<Guid>(TaskCreationOptions.RunContinuationsAsynchronously);
+        imap.InboxNewMailDetected += id => detected.TrySetResult(id);
+
+        try
+        {
+            await imap.ConnectAsync(account, "pw", ct);
+            var pool = relay.TotalAccepted;
+            imap.StartWatchers([account], ct);
+            await WaitUntilAsync(() => relay.TotalAccepted == pool + 1,
+                TimeSpan.FromSeconds(15), "watcher never connected");
+            // Brief grace so the watcher is inside IdleAsync before mail arrives.
+            await Task.Delay(TimeSpan.FromSeconds(1), ct);
+
+            await SeedAsync(account.Username, ct);
+
+            var winner = await Task.WhenAny(detected.Task, Task.Delay(TimeSpan.FromSeconds(15), ct));
+            Assert.True(winner == detected.Task, "IDLE watcher never surfaced the new message.");
+            Assert.Equal(account.Id, await detected.Task);
+        }
+        finally
+        {
+            imap.StopWatchers();
+            await imap.DisconnectAsync(account.Id, ct);
+        }
+    }
+
+    [Fact]
+    public async Task Reachability_TracksSocketOutcomes_DownOnDropUpOnReconnect()
+    {
+        _greenMail.RequireServers();
+        var ct = TestContext.Current.CancellationToken;
+        var (account, relay) = CreateRelayedAccount("reach");
+
+        using var imap = new ImapMailService(new NoOpOAuthService());
+        var events = new List<(Guid Id, bool Reachable)>();
+        var gotDown = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var gotUp   = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        imap.AccountReachabilityChanged += (id, reachable) =>
+        {
+            lock (events) events.Add((id, reachable));
+            if (!reachable) gotDown.TrySetResult();
+            else gotUp.TrySetResult();
+        };
+
+        try
+        {
+            await imap.ConnectAsync(account, "pw", ct);
+            var pool = relay.TotalAccepted;
+            imap.StartWatchers([account], ct);
+            await WaitUntilAsync(() => relay.TotalAccepted == pool + 1,
+                TimeSpan.FromSeconds(15), "watcher never connected");
+            await Task.Delay(TimeSpan.FromSeconds(1), ct);
+
+            // Drop the watcher's socket: IdleAsync faults, the first retry marks the account
+            // unreachable (#314 — the UI 'connected' state must track real socket outcomes).
+            relay.KillActiveConnections();
+            var downWinner = await Task.WhenAny(gotDown.Task, Task.Delay(TimeSpan.FromSeconds(15), ct));
+            Assert.True(downWinner == gotDown.Task, "No unreachable event after the watcher socket was severed.");
+
+            // The watcher's first retry is scheduled at 30s ±30% jitter; when it reconnects
+            // (the relay listener stayed up) it must flip the account back to reachable.
+            // This wait dominates the test's runtime — that's the price of asserting the
+            // recovery half of #314 for real.
+            var upWinner = await Task.WhenAny(gotUp.Task, Task.Delay(TimeSpan.FromSeconds(75), ct));
+            Assert.True(upWinner == gotUp.Task, "No reachable event after the watcher reconnected.");
+
+            lock (events)
+            {
+                Assert.Equal(account.Id, events[0].Id);
+                Assert.False(events[0].Reachable);
+                Assert.Contains(events, e => e.Reachable);
+            }
+        }
+        finally
+        {
+            imap.StopWatchers();
+            await imap.DisconnectAsync(account.Id, ct);
+        }
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────────
+
+    private static async Task WaitUntilAsync(Func<bool> condition, TimeSpan timeout, string failure)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        while (stopwatch.Elapsed < timeout)
+        {
+            if (condition()) return;
+            await Task.Delay(100);
+        }
+        throw new TimeoutException(failure);
+    }
+
+    private static async Task SeedAsync(string recipient, CancellationToken ct)
+    {
+        var message = new MimeMessage();
+        message.From.Add(new MailboxAddress("Sender", "sender@example.test"));
+        message.To.Add(MailboxAddress.Parse(recipient));
+        message.Subject = "idle push test";
+        message.Body = new TextPart("plain") { Text = "new mail for the idle watcher" };
+
+        using var smtp = new SmtpClient();
+        await smtp.ConnectAsync(GreenMailFixture.Host, GreenMailFixture.SmtpPort, SecureSocketOptions.None, ct);
+        await smtp.SendAsync(message, ct);
+        await smtp.DisconnectAsync(quit: true, ct);
+    }
+}


### PR DESCRIPTION
## Summary

Phase 2 of the [live-content testing plan](https://github.com/kellylford/QuickMail/blob/main/docs/planning/live-content-testing-plan.md) (#304): the connection-handling regression suite from the issue's #312-review comment, built on a fault-injecting TCP relay.

### What's in it

- **`TcpRelay`** — ~120-line in-test relay (ephemeral 127.0.0.1 port → GreenMail IMAP). `KillActiveConnections()` severs every in-flight connection mid-session, deterministically simulating a server-side drop; `TotalAccepted` lets tests assert connections were *not* re-established.
- **`ConnectionRecoveryTests`** (IMAP routed through the relay):
  - **#311** — delete after a silent drop transparently reconnects and completes (`ExecuteWithReconnectAsync` path); never surfaces "Delete may not have completed".
  - **#268/#278/#313** — summaries, inbox status, and detail fetches recover on the attempt after a drop (dead pooled client discarded on lease return) rather than staying stuck or stale. The helper fails the test if recovery takes more than the one allowed failure.
- **`WatcherTests`** (one relay per account):
  - **#126 end-to-end** — adding a third account's watcher opens exactly one new connection; existing accounts' IDLE connections are untouched (complements the pure-logic `WatcherReconcilerTests`).
  - **IDLE fidelity** — the plan's Phase-2 gate: GreenMail 2.1.11 advertises IDLE (verified via raw CAPABILITY) and pushes EXISTS on new mail; the watcher surfaces it as `InboxNewMailDetected` within seconds.
  - **#314** — `AccountReachabilityChanged` tracks real socket outcomes: unreachable on drop, reachable after the watcher's backoff reconnect. The ~30s backoff wait dominates the suite's runtime by design — it asserts the *recovery* half of #314 for real.

### Test results

- Integration suite: **7 pass / 1 documented skip** (the Phase-1 GreenMail multipart limitation), **3 consecutive green runs** locally (27–43s).
- No app-code changes in this PR — pure test/harness additions, so no unit-suite impact.

Part of #304. Next: Phase 3 (mail breadth + Radicale CalDAV/CardDAV).

🤖 Generated with [Claude Code](https://claude.com/claude-code)