### PR TITLE
Mail breadth + Radicale CalDAV/CardDAV suite — Phase 3 of #304

### DIFF
--- a/QuickMail.IntegrationTests/CalDavTests.cs
+++ b/QuickMail.IntegrationTests/CalDavTests.cs
@@ -1,0 +1,121 @@
+using QuickMail.Models;
+using QuickMail.Services;
+
+namespace QuickMail.IntegrationTests;
+
+/// <summary>
+/// CalDAV protocol tests against a local Radicale server (live-content testing plan §4.3):
+/// discovery, multi-calendar enumeration, event sync round-trip, and — the #293 bug shape at
+/// the DAV level — write targeting: a create/edit/delete must land in the calendar it was
+/// aimed at, and only there.
+/// </summary>
+[Collection(RadicaleCollection.Name)]
+public sealed class CalDavTests
+{
+    private readonly RadicaleFixture _radicale;
+
+    // Fetch window covering every event these tests seed (all in Sep 2026).
+    private static readonly DateTime RangeStart = new(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime RangeEnd   = new(2027, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    public CalDavTests(RadicaleFixture radicale) => _radicale = radicale;
+
+    private static string MakeIcs(string uid, string summary) => string.Join("\r\n",
+        "BEGIN:VCALENDAR",
+        "VERSION:2.0",
+        "PRODID:-//QuickMail Integration Tests//EN",
+        "BEGIN:VEVENT",
+        $"UID:{uid}",
+        $"SUMMARY:{summary}",
+        "DTSTART:20260910T100000Z",
+        "DTEND:20260910T110000Z",
+        "END:VEVENT",
+        "END:VCALENDAR");
+
+    [Fact]
+    public async Task Discovery_EnumeratesAllOfTheUsersCalendars()
+    {
+        _radicale.RequireServer();
+        var ct = TestContext.Current.CancellationToken;
+        var user = RadicaleFixture.CreateUser("discover");
+        var work = await _radicale.CreateCalendarAsync(user, "work", ct);
+        var home = await _radicale.CreateCalendarAsync(user, "home", ct);
+
+        using var client = new CalDavCalendarClient();
+        var calendars = await client.DiscoverCalendarsAsync(
+            RadicaleFixture.ServerUrl, user, RadicaleFixture.Password, ct);
+
+        Assert.Equal(2, calendars.Count);
+        Assert.Contains(calendars, c => new Uri(work).AbsolutePath == new Uri(c.Url).AbsolutePath);
+        Assert.Contains(calendars, c => new Uri(home).AbsolutePath == new Uri(c.Url).AbsolutePath);
+    }
+
+    [Fact]
+    public async Task FetchEvents_RoundTripsSeededEvent()
+    {
+        _radicale.RequireServer();
+        var ct = TestContext.Current.CancellationToken;
+        var user = RadicaleFixture.CreateUser("fetch");
+        var calendar = await _radicale.CreateCalendarAsync(user, "cal", ct);
+        await _radicale.PutResourceAsync($"{calendar}seeded-1.ics",
+            MakeIcs("seeded-1@quickmail.test", "Seeded Event"), "text/calendar", user, ct);
+
+        using var client = new CalDavCalendarClient();
+        var events = await client.FetchEventIcsAsync(calendar, user, RadicaleFixture.Password, RangeStart, RangeEnd, ct);
+
+        var (href, ics) = Assert.Single(events);
+        Assert.EndsWith("seeded-1.ics", href);
+        var parsed = IcsModel.Parse(ics);
+        Assert.NotNull(parsed);
+        Assert.Equal("seeded-1@quickmail.test", parsed!.Uid);
+        Assert.Equal("Seeded Event", parsed.Summary);
+    }
+
+    [Fact]
+    public async Task PutEvent_LandsOnlyInTheTargetedCalendar()
+    {
+        _radicale.RequireServer();
+        var ct = TestContext.Current.CancellationToken;
+        var user = RadicaleFixture.CreateUser("target");
+        var primary   = await _radicale.CreateCalendarAsync(user, "primary", ct);
+        var secondary = await _radicale.CreateCalendarAsync(user, "secondary", ct);
+
+        // The #293 bug shape: the write went to the hardcoded primary calendar regardless of
+        // target. Aim the client's write at the SECONDARY calendar and assert it landed there
+        // and only there.
+        const string uid = "targeted-1@quickmail.test";
+        using var client = new CalDavCalendarClient();
+        var resourceUrl = CalDavCalendarClient.EventResourceUrl(secondary, uid);
+        await client.PutEventAsync(resourceUrl, MakeIcs(uid, "Targeted Event"),
+            user, RadicaleFixture.Password, ifNoneMatch: true, ct);
+
+        var inSecondary = await client.FetchEventIcsAsync(secondary, user, RadicaleFixture.Password, RangeStart, RangeEnd, ct);
+        var inPrimary   = await client.FetchEventIcsAsync(primary, user, RadicaleFixture.Password, RangeStart, RangeEnd, ct);
+        Assert.Single(inSecondary);
+        Assert.Empty(inPrimary);
+
+        // Delete must also hit the targeted calendar's resource.
+        await client.DeleteEventAsync(resourceUrl, user, RadicaleFixture.Password, ct);
+        var afterDelete = await client.FetchEventIcsAsync(secondary, user, RadicaleFixture.Password, RangeStart, RangeEnd, ct);
+        Assert.Empty(afterDelete);
+    }
+
+    [Fact]
+    public async Task PutEvent_EditRoundTrip_UpdatesInPlace()
+    {
+        _radicale.RequireServer();
+        var ct = TestContext.Current.CancellationToken;
+        var user = RadicaleFixture.CreateUser("edit");
+        var calendar = await _radicale.CreateCalendarAsync(user, "cal", ct);
+
+        const string uid = "edit-1@quickmail.test";
+        using var client = new CalDavCalendarClient();
+        var resourceUrl = CalDavCalendarClient.EventResourceUrl(calendar, uid);
+        await client.PutEventAsync(resourceUrl, MakeIcs(uid, "Before"), user, RadicaleFixture.Password, ifNoneMatch: true, ct);
+        await client.PutEventAsync(resourceUrl, MakeIcs(uid, "After"), user, RadicaleFixture.Password, ifNoneMatch: false, ct);
+
+        var events = await client.FetchEventIcsAsync(calendar, user, RadicaleFixture.Password, RangeStart, RangeEnd, ct);
+        var (_, ics) = Assert.Single(events); // updated in place, not duplicated
+        Assert.Equal("After", IcsModel.Parse(ics)!.Summary);
+    }
+}

--- a/QuickMail.IntegrationTests/CardDavTests.cs
+++ b/QuickMail.IntegrationTests/CardDavTests.cs
@@ -1,0 +1,58 @@
+using QuickMail.Services;
+
+namespace QuickMail.IntegrationTests;
+
+/// <summary>
+/// CardDAV protocol tests against local Radicale (live-content testing plan §4.3):
+/// addressbook discovery and contact sync round-trip, without touching iCloud.
+/// </summary>
+[Collection(RadicaleCollection.Name)]
+public sealed class CardDavTests
+{
+    private readonly RadicaleFixture _radicale;
+
+    public CardDavTests(RadicaleFixture radicale) => _radicale = radicale;
+
+    private static string MakeVCard(string uid, string fullName, string email) => string.Join("\r\n",
+        "BEGIN:VCARD",
+        "VERSION:3.0",
+        $"UID:{uid}",
+        $"FN:{fullName}",
+        $"EMAIL:{email}",
+        "END:VCARD");
+
+    [Fact]
+    public async Task DiscoverAddressbook_FindsTheUsersAddressbook()
+    {
+        _radicale.RequireServer();
+        var ct = TestContext.Current.CancellationToken;
+        var user = RadicaleFixture.CreateUser("abdiscover");
+        var addressbook = await _radicale.CreateAddressbookAsync(user, "contacts", ct);
+
+        using var client = new CardDavContactClient();
+        var info = await client.DiscoverAddressbookAsync(
+            RadicaleFixture.ServerUrl, user, RadicaleFixture.Password, ct);
+
+        Assert.Equal(new Uri(addressbook).AbsolutePath, new Uri(info.Url).AbsolutePath);
+    }
+
+    [Fact]
+    public async Task FetchVCards_RoundTripsSeededContacts()
+    {
+        _radicale.RequireServer();
+        var ct = TestContext.Current.CancellationToken;
+        var user = RadicaleFixture.CreateUser("abfetch");
+        var addressbook = await _radicale.CreateAddressbookAsync(user, "contacts", ct);
+        await _radicale.PutResourceAsync($"{addressbook}alice.vcf",
+            MakeVCard("alice-1@quickmail.test", "Alice Tester", "alice@example.test"), "text/vcard", user, ct);
+        await _radicale.PutResourceAsync($"{addressbook}bob.vcf",
+            MakeVCard("bob-1@quickmail.test", "Bob Tester", "bob@example.test"), "text/vcard", user, ct);
+
+        using var client = new CardDavContactClient();
+        var vcards = await client.FetchVCardsAsync(addressbook, user, RadicaleFixture.Password, ct);
+
+        Assert.Equal(2, vcards.Count);
+        Assert.Contains(vcards, v => v.Contains("Alice Tester") && v.Contains("alice@example.test"));
+        Assert.Contains(vcards, v => v.Contains("Bob Tester") && v.Contains("bob@example.test"));
+    }
+}

--- a/QuickMail.IntegrationTests/MailBreadthTests.cs
+++ b/QuickMail.IntegrationTests/MailBreadthTests.cs
@@ -1,0 +1,208 @@
+using System.Diagnostics;
+using MimeKit;
+using QuickMail.Models;
+using QuickMail.Services;
+
+namespace QuickMail.IntegrationTests;
+
+/// <summary>
+/// Mail-operation breadth against live GreenMail (live-content testing plan §4.5): flags and
+/// \Seen state, folder operations, real SMTP send end-to-end, and — exercising #296 — ICS
+/// invite-reply routing: the Accept/Decline reply must leave via the SMTP settings of the
+/// account that received the invite and reach the organizer's mailbox.
+/// </summary>
+[Collection(GreenMailCollection.Name)]
+public sealed class MailBreadthTests
+{
+    private readonly GreenMailFixture _greenMail;
+
+    public MailBreadthTests(GreenMailFixture greenMail) => _greenMail = greenMail;
+
+    [Fact]
+    public async Task FlagAndMarkRead_RoundTripThroughServer()
+    {
+        _greenMail.RequireServers();
+        var ct = TestContext.Current.CancellationToken;
+        var account = _greenMail.CreateAccount("flags");
+        await SeedPlainAsync(account.Username, "flag me", ct);
+
+        using var imap = new ImapMailService(new NoOpOAuthService());
+        await imap.ConnectAsync(account, "pw", ct);
+        try
+        {
+            var summary = await WaitForMessageAsync(imap, account.Id, ct);
+            Assert.False(summary.IsRead);
+            Assert.False(summary.IsServerFlagged);
+
+            await imap.SetMessageFlaggedAsync(account.Id, "INBOX", summary.MessageId, flagged: true, ct);
+            await imap.MarkReadAsync(account.Id, "INBOX", summary.MessageId, ct);
+
+            var after = (await imap.GetMessageSummariesAsync(account.Id, "INBOX", 10, ct))[0];
+            Assert.True(after.IsRead, "\\Seen must round-trip through the server.");
+            Assert.True(after.IsServerFlagged, "\\Flagged must round-trip through the server.");
+
+            await imap.SetMessageFlaggedAsync(account.Id, "INBOX", summary.MessageId, flagged: false, ct);
+            var cleared = (await imap.GetMessageSummariesAsync(account.Id, "INBOX", 10, ct))[0];
+            Assert.False(cleared.IsServerFlagged);
+        }
+        finally
+        {
+            await imap.DisconnectAsync(account.Id, ct);
+        }
+    }
+
+    [Fact]
+    public async Task Folders_CreateListMoveAcross()
+    {
+        _greenMail.RequireServers();
+        var ct = TestContext.Current.CancellationToken;
+        var account = _greenMail.CreateAccount("folders");
+        await SeedPlainAsync(account.Username, "move me", ct);
+
+        using var imap = new ImapMailService(new NoOpOAuthService());
+        await imap.ConnectAsync(account, "pw", ct);
+        try
+        {
+            var summary = await WaitForMessageAsync(imap, account.Id, ct);
+
+            await imap.CreateFolderAsync(account.Id, null, "Projects", ct);
+            var folders = await imap.GetFoldersAsync(account.Id, ct);
+            Assert.Contains(folders, f => f.FullName == "Projects");
+
+            await imap.MoveMessagesAsync(account.Id, "INBOX", [summary.MessageId], "Projects", ct);
+
+            var inboxAfter = await imap.GetMessageSummariesAsync(account.Id, "INBOX", 10, ct);
+            var projectsAfter = await imap.GetMessageSummariesAsync(account.Id, "Projects", 10, ct);
+            Assert.Empty(inboxAfter);
+            var moved = Assert.Single(projectsAfter);
+            Assert.Equal("connection test", moved.Subject);
+        }
+        finally
+        {
+            await imap.DisconnectAsync(account.Id, ct);
+        }
+    }
+
+    [Fact]
+    public async Task SmtpSend_DeliversEndToEnd()
+    {
+        _greenMail.RequireServers();
+        var ct = TestContext.Current.CancellationToken;
+        var sender = _greenMail.CreateAccount("sender");
+        var recipient = _greenMail.CreateAccount("recipient");
+
+        var smtp = new SmtpService(new NoOpOAuthService(), new NoOpGraphSendService());
+        var compose = new ComposeModel
+        {
+            AccountId = sender.Id,
+            To = recipient.Username,
+            Subject = "Real SMTP send",
+            Body = "Sent through SmtpService against live GreenMail.",
+        };
+        await smtp.SendAsync(compose, sender, "pw", ct);
+
+        using var imap = new ImapMailService(new NoOpOAuthService());
+        await imap.ConnectAsync(recipient, "pw", ct);
+        try
+        {
+            var received = await WaitForMessageAsync(imap, recipient.Id, ct);
+            Assert.Equal("Real SMTP send", received.Subject);
+
+            var detail = await imap.GetMessageDetailAsync(recipient.Id, "INBOX", received.MessageId, ct);
+            Assert.Contains("Sent through SmtpService", detail.PlainTextBody);
+            Assert.Contains(sender.Username, detail.From);
+        }
+        finally
+        {
+            await imap.DisconnectAsync(recipient.Id, ct);
+        }
+    }
+
+    [Fact]
+    public async Task IcsReply_RoutesFromReceivingAccount_ToOrganizer()
+    {
+        _greenMail.RequireServers();
+        var ct = TestContext.Current.CancellationToken;
+        // #296 shape: an invite lands in ONE of the user's accounts; the Accept reply must go
+        // out through THAT account's SMTP identity and reach the organizer.
+        var invitee   = _greenMail.CreateAccount("invitee296");
+        var organizer = _greenMail.CreateAccount("organizer296");
+
+        var replyIcs = string.Join("\r\n",
+            "BEGIN:VCALENDAR",
+            "VERSION:2.0",
+            "METHOD:REPLY",
+            "BEGIN:VEVENT",
+            "UID:route-296@quickmail.test",
+            $"ORGANIZER:mailto:{organizer.Username}",
+            $"ATTENDEE;PARTSTAT=ACCEPTED:mailto:{invitee.Username}",
+            "SUMMARY:Routed Meeting",
+            "DTSTART:20260915T140000Z",
+            "END:VEVENT",
+            "END:VCALENDAR");
+
+        var smtp = new SmtpService(new NoOpOAuthService(), new NoOpGraphSendService());
+        await smtp.SendIcsReplyAsync(replyIcs, invitee, "pw", organizer.Username, ct);
+
+        using var imap = new ImapMailService(new NoOpOAuthService());
+        await imap.ConnectAsync(organizer, "pw", ct);
+        try
+        {
+            var received = await WaitForMessageAsync(imap, organizer.Id, ct);
+            // The summary's From renders the display name (the invitee account's AccountName),
+            // not the address — asserting it proves the reply left under the invitee account's
+            // identity, not the organizer's or a default account's.
+            Assert.Contains("invitee296", received.From);
+            Assert.DoesNotContain("organizer296", received.From);
+
+            var detail = await imap.GetMessageDetailAsync(organizer.Id, "INBOX", received.MessageId, ct);
+            Assert.NotNull(detail.CalendarInvite);
+            Assert.Equal("REPLY", detail.CalendarInvite!.Method);
+            Assert.Equal("route-296@quickmail.test", detail.CalendarInvite.Uid);
+        }
+        finally
+        {
+            await imap.DisconnectAsync(organizer.Id, ct);
+        }
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────────
+
+    private static async Task<MailMessageSummary> WaitForMessageAsync(
+        ImapMailService imap, Guid accountId, CancellationToken ct)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        while (stopwatch.Elapsed < TimeSpan.FromSeconds(15))
+        {
+            var summaries = await imap.GetMessageSummariesAsync(accountId, "INBOX", 10, ct);
+            if (summaries.Count > 0)
+                return summaries[0];
+            await Task.Delay(250, ct);
+        }
+        throw new TimeoutException("Expected message never appeared in the GreenMail INBOX.");
+    }
+
+    private static async Task SeedPlainAsync(string recipient, string body, CancellationToken ct)
+    {
+        var message = new MimeMessage();
+        message.From.Add(new MailboxAddress("Sender", "sender@example.test"));
+        message.To.Add(MailboxAddress.Parse(recipient));
+        message.Subject = "connection test";
+        message.Body = new TextPart("plain") { Text = body };
+
+        using var smtp = new MailKit.Net.Smtp.SmtpClient();
+        await smtp.ConnectAsync(GreenMailFixture.Host, GreenMailFixture.SmtpPort, MailKit.Security.SecureSocketOptions.None, ct);
+        await smtp.SendAsync(message, ct);
+        await smtp.DisconnectAsync(quit: true, ct);
+    }
+}
+
+/// <summary>Graph send-backend stub: IMAP accounts never route here; any call is a bug.</summary>
+internal sealed class NoOpGraphSendService : ISendMailService
+{
+    public Task SendAsync(ComposeModel compose, AccountModel account, string? password, CancellationToken ct = default) =>
+        throw new NotSupportedException("Graph send is not available in integration tests.");
+    public Task SendIcsReplyAsync(string icsReplyContent, AccountModel account, string? password,
+        string organizerEmail, CancellationToken ct = default) =>
+        throw new NotSupportedException("Graph send is not available in integration tests.");
+}

--- a/QuickMail.IntegrationTests/RadicaleFixture.cs
+++ b/QuickMail.IntegrationTests/RadicaleFixture.cs
@@ -1,0 +1,118 @@
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Sockets;
+using System.Text;
+
+namespace QuickMail.IntegrationTests;
+
+/// <summary>
+/// Shared fixture for tests that talk to a local Radicale server (CalDAV + CardDAV, port 5232).
+/// Same lifecycle contract as <see cref="GreenMailFixture"/>: the server is an external process
+/// (scripts/start-test-servers.ps1 or the CI integration job); absent server means dynamic skip
+/// locally and hard failure under QUICKMAIL_IT_SERVERS=1.
+///
+/// Radicale runs with auth-type 'none': any username/password authenticates, and each user owns
+/// the /&lt;user&gt;/ hierarchy, so tests invent unique per-run users. Collections are created
+/// explicitly (MKCALENDAR / extended MKCOL) via <see cref="CreateCalendarAsync"/> and
+/// <see cref="CreateAddressbookAsync"/>.
+/// </summary>
+public sealed class RadicaleFixture : IDisposable
+{
+    public const string Host = "127.0.0.1";
+    public const int Port = 5232;
+    public static string ServerUrl => $"http://{Host}:{Port}/";
+
+    /// <summary>Password for test users — arbitrary, since Radicale auth is 'none'.</summary>
+    public const string Password = "test";
+
+    private readonly bool _serverAvailable;
+    private readonly HttpClient _http = new();
+
+    public RadicaleFixture()
+    {
+        _serverAvailable = IsPortOpen(Host, Port);
+    }
+
+    public void RequireServer()
+    {
+        if (_serverAvailable)
+            return;
+
+        if (Environment.GetEnvironmentVariable("QUICKMAIL_IT_SERVERS") == "1")
+            throw new InvalidOperationException(
+                $"QUICKMAIL_IT_SERVERS=1 but Radicale is not reachable on {Host}:{Port}. " +
+                "The CI harness failed to start; see the radicale log artifact.");
+
+        Assert.Skip(
+            $"Radicale is not running on {Host}:{Port}. " +
+            "Start it with scripts/start-test-servers.ps1 (see docs/TESTING-INTEGRATION.md).");
+    }
+
+    /// <summary>Unique per-run username; owns the /{user}/ collection hierarchy.</summary>
+    public static string CreateUser(string prefix) => $"{prefix}-{Guid.NewGuid():N}";
+
+    /// <summary>Creates a calendar collection at /{user}/{name}/ and returns its URL.</summary>
+    public async Task<string> CreateCalendarAsync(string user, string name, CancellationToken ct)
+    {
+        var url = $"{ServerUrl}{user}/{name}/";
+        using var request = new HttpRequestMessage(new HttpMethod("MKCALENDAR"), url);
+        Authorize(request, user);
+        using var response = await _http.SendAsync(request, ct);
+        Assert.True(response.IsSuccessStatusCode, $"MKCALENDAR {url} failed: {(int)response.StatusCode}");
+        return url;
+    }
+
+    /// <summary>Creates an addressbook collection at /{user}/{name}/ (extended MKCOL) and returns its URL.</summary>
+    public async Task<string> CreateAddressbookAsync(string user, string name, CancellationToken ct)
+    {
+        var url = $"{ServerUrl}{user}/{name}/";
+        using var request = new HttpRequestMessage(new HttpMethod("MKCOL"), url);
+        Authorize(request, user);
+        request.Content = new StringContent("""
+            <?xml version="1.0" encoding="utf-8"?>
+            <D:mkcol xmlns:D="DAV:" xmlns:CR="urn:ietf:params:xml:ns:carddav">
+              <D:set><D:prop>
+                <D:resourcetype><D:collection/><CR:addressbook/></D:resourcetype>
+              </D:prop></D:set>
+            </D:mkcol>
+            """, Encoding.UTF8, "application/xml");
+        using var response = await _http.SendAsync(request, ct);
+        Assert.True(response.IsSuccessStatusCode, $"MKCOL (addressbook) {url} failed: {(int)response.StatusCode}");
+        return url;
+    }
+
+    /// <summary>PUTs a raw resource (ics/vcf body) into a collection.</summary>
+    public async Task PutResourceAsync(string resourceUrl, string body, string mediaType, string user, CancellationToken ct)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Put, resourceUrl);
+        Authorize(request, user);
+        request.Content = new StringContent(body, Encoding.UTF8, mediaType);
+        using var response = await _http.SendAsync(request, ct);
+        Assert.True(response.IsSuccessStatusCode, $"PUT {resourceUrl} failed: {(int)response.StatusCode}");
+    }
+
+    private static void Authorize(HttpRequestMessage request, string user) =>
+        request.Headers.Authorization = new AuthenticationHeaderValue(
+            "Basic", Convert.ToBase64String(Encoding.ASCII.GetBytes($"{user}:{Password}")));
+
+    private static bool IsPortOpen(string host, int port)
+    {
+        try
+        {
+            using var client = new TcpClient();
+            return client.ConnectAsync(host, port).Wait(TimeSpan.FromSeconds(2));
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    public void Dispose() => _http.Dispose();
+}
+
+[CollectionDefinition(Name)]
+public class RadicaleCollection : ICollectionFixture<RadicaleFixture>
+{
+    public const string Name = "Radicale";
+}

--- a/docs/TESTING-INTEGRATION.md
+++ b/docs/TESTING-INTEGRATION.md
@@ -12,11 +12,14 @@ message, so running `dotnet test` on the whole solution stays green on any machi
 
 - **Java 11+** (any JRE — Temurin recommended). The server script finds it via `JAVA_HOME`,
   `PATH`, or an explicit `-JavaExe` argument.
+- **Python 3 with pip** — for Radicale (CalDAV/CardDAV). The script pip-installs the pinned
+  Radicale version on first run.
 
 ## Running locally
 
 ```powershell
 # one-time per session: start GreenMail (IMAP 127.0.0.1:3143, SMTP 127.0.0.1:3025)
+# and Radicale (CalDAV/CardDAV 127.0.0.1:5232)
 .\scripts\start-test-servers.ps1
 
 # run the integration suite
@@ -32,6 +35,14 @@ The script downloads the pinned GreenMail standalone jar from Maven Central once
 GreenMail runs with **auth disabled**: any username/password authenticates and mailboxes are
 created on first use. Tests create unique per-run users (`<prefix>-<guid>@greenmail.test`), so
 no server-side user configuration exists and tests never collide.
+
+Radicale runs with **auth-type `none`** (same idea: any credentials work; each user owns the
+`/<user>/` collection hierarchy) and is launched through `scripts/radicale-launcher.py`, which
+works around a Radicale-on-Windows startup crash: its symlink-support probe catches only
+`PermissionError`, but an unprivileged Windows `os.symlink` raises `OSError` (WinError 1314).
+The shim makes the probe fail soft (symlink support is an optional storage optimization).
+Tests create collections explicitly via `RadicaleFixture.CreateCalendarAsync` /
+`CreateAddressbookAsync` and seed events/contacts with raw `PUT`s.
 
 ## CI
 

--- a/scripts/radicale-launcher.py
+++ b/scripts/radicale-launcher.py
@@ -1,0 +1,31 @@
+"""Launcher shim for Radicale on Windows (integration test harness).
+
+Radicale's startup probe `pathutils.path_supports_symlink` catches only
+PermissionError, but on Windows without the symlink privilege (any non-admin,
+non-developer-mode session) `os.symlink` raises OSError (WinError 1314,
+ERROR_PRIVILEGE_NOT_HELD), which escapes the probe and crashes server startup.
+Symlink support is an optional storage optimization, so the correct degraded
+answer is simply "no". This shim wraps the probe to fail soft, then hands off
+to Radicale's normal CLI entry point (arguments pass through unchanged).
+
+Used by scripts/start-test-servers.ps1; harmless on systems where the
+privilege is held (the original probe result is returned).
+"""
+
+import radicale.pathutils as pathutils
+
+_original_probe = pathutils.path_supports_symlink
+
+
+def _path_supports_symlink_failsoft(path):
+    try:
+        return _original_probe(path)
+    except OSError:
+        return False
+
+
+pathutils.path_supports_symlink = _path_supports_symlink_failsoft
+
+from radicale.__main__ import run  # noqa: E402  (import after patch is the point)
+
+run()

--- a/scripts/start-test-servers.ps1
+++ b/scripts/start-test-servers.ps1
@@ -1,14 +1,18 @@
 # Starts (or stops) the local protocol servers used by QuickMail.IntegrationTests.
 #
-# Currently: GreenMail (IMAP on 3143, SMTP on 3025, bound to 127.0.0.1, auth disabled so any
-# user/password works and mailboxes auto-create). Radicale (CalDAV/CardDAV) is added in a later
-# phase of the live-content testing plan.
+# - GreenMail: IMAP on 3143, SMTP on 3025, bound to 127.0.0.1, auth disabled so any
+#   user/password works and mailboxes auto-create.
+# - Radicale (CalDAV + CardDAV): port 5232, auth 'none' (any credentials accepted; each user
+#   owns /<user>/ collections), filesystem storage under .testservers\radicale-storage.
+#   Launched via scripts/radicale-launcher.py, which works around Radicale's Windows
+#   symlink-probe startup crash (WinError 1314 escapes its PermissionError handler).
 #
-# Requirements: Java 11+ on PATH, in JAVA_HOME, or passed via -JavaExe.
-# The GreenMail jar is downloaded once from Maven Central into .testservers\ (gitignored).
+# Requirements: Java 11+ (PATH, JAVA_HOME, or -JavaExe) and Python 3 with pip.
+# The GreenMail jar is downloaded once from Maven Central into .testservers\ (gitignored);
+# Radicale is pip-installed once (pinned version).
 #
 # Usage:
-#   .\scripts\start-test-servers.ps1              # download if needed, start, wait until ready
+#   .\scripts\start-test-servers.ps1              # install/download if needed, start, wait until ready
 #   .\scripts\start-test-servers.ps1 -Stop        # stop servers started by this script
 #
 # See docs/TESTING-INTEGRATION.md for the full local workflow.
@@ -17,6 +21,7 @@
 param(
     [switch]$Stop,
     [string]$GreenMailVersion = "2.1.11",
+    [string]$RadicaleVersion = "3.7.7",
     [string]$JavaExe = ""
 )
 
@@ -25,24 +30,32 @@ $ErrorActionPreference = "Stop"
 if ($PSVersionTable.PSVersion.Major -lt 6) {
     [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
 }
-$repoRoot   = Split-Path -Parent $PSScriptRoot
-$serversDir = Join-Path $repoRoot ".testservers"
-$pidFile    = Join-Path $serversDir "greenmail.pid"
-$logFile    = Join-Path $serversDir "greenmail.log"
+$repoRoot        = Split-Path -Parent $PSScriptRoot
+$serversDir      = Join-Path $repoRoot ".testservers"
+$pidFile         = Join-Path $serversDir "greenmail.pid"
+$logFile         = Join-Path $serversDir "greenmail.log"
+$radicalePidFile = Join-Path $serversDir "radicale.pid"
+$radicaleLog     = Join-Path $serversDir "radicale.log"
+$radicaleStorage = Join-Path $serversDir "radicale-storage"
 
-if ($Stop) {
-    if (Test-Path $pidFile) {
-        $procId = Get-Content $pidFile
+function Stop-ByPidFile([string]$file, [string]$name) {
+    if (Test-Path $file) {
+        $procId = Get-Content $file
         try {
             Stop-Process -Id $procId -Force -Confirm:$false -ErrorAction Stop
-            Write-Host "Stopped GreenMail (pid $procId)."
+            Write-Host "Stopped $name (pid $procId)."
         } catch {
-            Write-Host "GreenMail (pid $procId) was not running."
+            Write-Host "$name (pid $procId) was not running."
         }
-        Remove-Item $pidFile -Force
+        Remove-Item $file -Force
     } else {
-        Write-Host "No pid file at $pidFile - nothing to stop."
+        Write-Host "No pid file at $file - $name not started by this script."
     }
+}
+
+if ($Stop) {
+    Stop-ByPidFile $pidFile "GreenMail"
+    Stop-ByPidFile $radicalePidFile "Radicale"
     exit 0
 }
 
@@ -86,45 +99,103 @@ if ($knownJarHashes.ContainsKey($GreenMailVersion)) {
     Write-Warning "No pinned SHA-256 for GreenMail $GreenMailVersion - skipping integrity check."
 }
 
-# ── Start ──────────────────────────────────────────────────────────────────────
+# ── Start GreenMail ────────────────────────────────────────────────────────────
+$gmAlreadyRunning = $false
 if (Test-Path $pidFile) {
     $existing = Get-Content $pidFile
     if (Get-Process -Id $existing -ErrorAction SilentlyContinue) {
         Write-Host "GreenMail already running (pid $existing)."
-        exit 0
+        $gmAlreadyRunning = $true
+    } else {
+        Remove-Item $pidFile -Force
     }
-    Remove-Item $pidFile -Force
 }
 
-# greenmail.setup.test.smtp / .imap bind 127.0.0.1 at the test-profile ports (3025 / 3143).
-# greenmail.auth.disabled accepts any credentials and auto-creates mailboxes, so tests can
-# invent per-run users without any server-side user list.
-$gmArgs = @(
-    "-Dgreenmail.setup.test.smtp",
-    "-Dgreenmail.setup.test.imap",
-    "-Dgreenmail.auth.disabled",
-    "-Dgreenmail.verbose",
-    "-jar", $jar
-)
-$proc = Start-Process -FilePath $JavaExe -ArgumentList $gmArgs -PassThru -WindowStyle Hidden `
-    -RedirectStandardOutput $logFile -RedirectStandardError "$logFile.err"
-Set-Content $pidFile $proc.Id
+if (-not $gmAlreadyRunning) {
+    # greenmail.setup.test.smtp / .imap bind 127.0.0.1 at the test-profile ports (3025 / 3143).
+    # greenmail.auth.disabled accepts any credentials and auto-creates mailboxes, so tests can
+    # invent per-run users without any server-side user list.
+    $gmArgs = @(
+        "-Dgreenmail.setup.test.smtp",
+        "-Dgreenmail.setup.test.imap",
+        "-Dgreenmail.auth.disabled",
+        "-Dgreenmail.verbose",
+        "-jar", $jar
+    )
+    $proc = Start-Process -FilePath $JavaExe -ArgumentList $gmArgs -PassThru -WindowStyle Hidden `
+        -RedirectStandardOutput $logFile -RedirectStandardError "$logFile.err"
+    Set-Content $pidFile $proc.Id
 
-# ── Wait until ready ───────────────────────────────────────────────────────────
-$deadline = (Get-Date).AddSeconds(60)
-$ready = $false
-while ((Get-Date) -lt $deadline) {
-    if ($proc.HasExited) {
-        Write-Error ("GreenMail exited immediately (code $($proc.ExitCode)). See $logFile / $logFile.err")
+    $deadline = (Get-Date).AddSeconds(60)
+    $ready = $false
+    while ((Get-Date) -lt $deadline) {
+        if ($proc.HasExited) {
+            Write-Error ("GreenMail exited immediately (code $($proc.ExitCode)). See $logFile / $logFile.err")
+        }
+        $smtpOk = (Test-NetConnection 127.0.0.1 -Port 3025 -WarningAction SilentlyContinue).TcpTestSucceeded
+        $imapOk = (Test-NetConnection 127.0.0.1 -Port 3143 -WarningAction SilentlyContinue).TcpTestSucceeded
+        if ($smtpOk -and $imapOk) { $ready = $true; break }
+        Start-Sleep -Milliseconds 500
     }
-    $smtpOk = (Test-NetConnection 127.0.0.1 -Port 3025 -WarningAction SilentlyContinue).TcpTestSucceeded
-    $imapOk = (Test-NetConnection 127.0.0.1 -Port 3143 -WarningAction SilentlyContinue).TcpTestSucceeded
-    if ($smtpOk -and $imapOk) { $ready = $true; break }
-    Start-Sleep -Milliseconds 500
+
+    if (-not $ready) {
+        Write-Error "GreenMail did not open ports 3025/3143 within 60s. See $logFile / $logFile.err"
+    }
+    Write-Host "GreenMail ready: SMTP 127.0.0.1:3025, IMAP 127.0.0.1:3143 (pid $($proc.Id))."
 }
 
-if (-not $ready) {
-    Write-Error "GreenMail did not open ports 3025/3143 within 60s. See $logFile / $logFile.err"
+# ── Radicale (CalDAV + CardDAV) ────────────────────────────────────────────────
+$python = (Get-Command python -ErrorAction SilentlyContinue)
+if (-not $python) {
+    Write-Error "Python not found on PATH. Install Python 3 (needed for Radicale). See docs/TESTING-INTEGRATION.md."
 }
-Write-Host "GreenMail ready: SMTP 127.0.0.1:3025, IMAP 127.0.0.1:3143 (pid $($proc.Id))."
+
+$installed = & python -c "import radicale; print(radicale.VERSION)" 2>$null
+if ($LASTEXITCODE -ne 0 -or $installed -ne $RadicaleVersion) {
+    Write-Host "Installing Radicale $RadicaleVersion via pip..."
+    & python -m pip install --user --quiet "radicale==$RadicaleVersion"
+    if ($LASTEXITCODE -ne 0) { Write-Error "pip install radicale==$RadicaleVersion failed." }
+}
+
+$alreadyRunning = $false
+if (Test-Path $radicalePidFile) {
+    $existing = Get-Content $radicalePidFile
+    if (Get-Process -Id $existing -ErrorAction SilentlyContinue) {
+        Write-Host "Radicale already running (pid $existing)."
+        $alreadyRunning = $true
+    } else {
+        Remove-Item $radicalePidFile -Force
+    }
+}
+
+if (-not $alreadyRunning) {
+    # auth-type none: any username/password authenticates; each user owns /<user>/ collections,
+    # so tests invent per-run users just like they do against GreenMail. The launcher shim works
+    # around Radicale's Windows symlink-probe crash (see scripts/radicale-launcher.py).
+    New-Item -ItemType Directory -Force $radicaleStorage | Out-Null
+    $radArgs = @(
+        (Join-Path $PSScriptRoot "radicale-launcher.py"),
+        "--server-hosts", "127.0.0.1:5232",
+        "--auth-type", "none",
+        "--storage-filesystem-folder", $radicaleStorage
+    )
+    $radProc = Start-Process -FilePath python -ArgumentList $radArgs -PassThru -WindowStyle Hidden `
+        -RedirectStandardOutput $radicaleLog -RedirectStandardError "$radicaleLog.err"
+    Set-Content $radicalePidFile $radProc.Id
+
+    $deadline = (Get-Date).AddSeconds(60)
+    $ready = $false
+    while ((Get-Date) -lt $deadline) {
+        if ($radProc.HasExited) {
+            Write-Error ("Radicale exited immediately (code $($radProc.ExitCode)). See $radicaleLog / $radicaleLog.err")
+        }
+        if ((Test-NetConnection 127.0.0.1 -Port 5232 -WarningAction SilentlyContinue).TcpTestSucceeded) { $ready = $true; break }
+        Start-Sleep -Milliseconds 500
+    }
+    if (-not $ready) {
+        Write-Error "Radicale did not open port 5232 within 60s. See $radicaleLog / $radicaleLog.err"
+    }
+    Write-Host "Radicale ready: CalDAV/CardDAV 127.0.0.1:5232 (pid $($radProc.Id))."
+}
+
 Write-Host "Stop with: .\scripts\start-test-servers.ps1 -Stop"

--- a/scripts/start-test-servers.ps1
+++ b/scripts/start-test-servers.ps1
@@ -150,12 +150,22 @@ if (-not $python) {
     Write-Error "Python not found on PATH. Install Python 3 (needed for Radicale). See docs/TESTING-INTEGRATION.md."
 }
 
+# EAP guard: under Windows PowerShell 5.1, EAP=Stop turns a native command's redirected
+# stderr into a terminating NativeCommandError — the probe's ModuleNotFoundError traceback
+# would kill the script HERE, before the pip install it exists to trigger. pip likewise
+# writes warnings to stderr, so both run under Continue; $LASTEXITCODE still decides.
+$prevEap = $ErrorActionPreference
+$ErrorActionPreference = "Continue"
 $installed = & python -c "import radicale; print(radicale.VERSION)" 2>$null
 if ($LASTEXITCODE -ne 0 -or $installed -ne $RadicaleVersion) {
     Write-Host "Installing Radicale $RadicaleVersion via pip..."
     & python -m pip install --user --quiet "radicale==$RadicaleVersion"
-    if ($LASTEXITCODE -ne 0) { Write-Error "pip install radicale==$RadicaleVersion failed." }
+    if ($LASTEXITCODE -ne 0) {
+        $ErrorActionPreference = $prevEap
+        Write-Error "pip install radicale==$RadicaleVersion failed."
+    }
 }
+$ErrorActionPreference = $prevEap
 
 $alreadyRunning = $false
 if (Test-Path $radicalePidFile) {


### PR DESCRIPTION
## Summary

Phase 3 of the [live-content testing plan](https://github.com/kellylford/QuickMail/blob/main/docs/planning/live-content-testing-plan.md) (#304): the rest of the §4.5 mail coverage matrix plus the Radicale CalDAV/CardDAV tier.

### Mail breadth (`MailBreadthTests`, GreenMail)
- **Flags & state** — `\Flagged` and `\Seen` round-trip through the real server; unflag clears.
- **Folder ops** — create, list, move-across end-to-end.
- **Real SMTP send** — `SmtpService.SendAsync` account A → account B through GreenMail, fetched back over IMAP with body + sender identity asserted.
- **#296 ICS reply routing** — `SendIcsReplyAsync` sends from the account that *received* the invite; the `METHOD:REPLY` message arrives in the organizer's mailbox under the invitee account's identity (asserted positively and negatively).

### Radicale tier (`CalDavTests` / `CardDavTests`, port 5232)
- Discovery enumerates **all** of a user's calendars (multi-calendar enumeration).
- Event fetch round-trips seeded ICS through the real `CalDavCalendarClient`.
- **Write targeting — the #293 bug shape at the DAV level**: `PutEventAsync` aimed at a *secondary* calendar lands there and **only** there (primary asserted empty); delete hits the same target; edits update in place without duplicating.
- CardDAV: addressbook discovery + vCard fetch round-trip.

### Harness
- `start-test-servers.ps1` now pip-installs (pinned 3.7.7) and starts Radicale alongside GreenMail; `-Stop` stops both. **No CI workflow change needed** — the script does everything and Python is preinstalled on `windows-latest`; the existing artifact glob picks up `radicale.log`.
- `scripts/radicale-launcher.py`: a small shim working around a **Radicale-on-Windows startup crash** — its symlink-support probe catches only `PermissionError`, but unprivileged Windows `os.symlink` raises `OSError` (WinError 1314), killing the server. The shim makes the probe fail soft (symlink support is an optional storage optimization). Documented in `docs/TESTING-INTEGRATION.md`.

### Test results
- Integration suite: **17 pass / 1 documented skip**, two consecutive green local runs (~35s).
- No app-code changes — pure test/harness additions.

Part of #304. Next: Phase 4 (WireMock.Net REST fakes for Google/Graph write targeting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)