### PR TITLE
WireMock.Net REST fakes for Google Calendar and Graph — Phase 4 of #304

### DIFF
--- a/QuickMail.IntegrationTests/GoogleCalendarApiTests.cs
+++ b/QuickMail.IntegrationTests/GoogleCalendarApiTests.cs
@@ -1,0 +1,143 @@
+using System.Net.Http;
+using QuickMail.Services;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
+
+namespace QuickMail.IntegrationTests;
+
+/// <summary>
+/// Google Calendar REST client against an in-process WireMock fake (live-content testing plan
+/// Tier 2 / §5). No external server: WireMock listens on an ephemeral localhost port and the
+/// client's base URL points at it. The headline coverage is <b>issue #293's literal bug
+/// shape</b>: writes hardcoded to <c>calendars/primary</c> — asserted here by inspecting the
+/// exact request lines the client emits when targeting a secondary calendar.
+/// </summary>
+public sealed class GoogleCalendarApiTests : IDisposable
+{
+    private readonly WireMockServer _server;
+    private readonly GoogleCalendarClient _client;
+
+    public GoogleCalendarApiTests()
+    {
+        _server = WireMockServer.Start();
+        _client = new GoogleCalendarClient(new FakeGoogleOAuthService(), baseUrl: _server.Urls[0]);
+    }
+
+    public void Dispose()
+    {
+        _client.Dispose();
+        _server.Stop();
+        _server.Dispose();
+    }
+
+    private static GoogleEventWriteBody Body(string summary) => new() { Summary = summary };
+
+    [Fact]
+    public async Task CreateEvent_TargetsTheGivenCalendar_NotPrimary()
+    {
+        _server.Given(Request.Create().WithPath("/calendars/team-cal/events").UsingPost())
+               .RespondWith(Response.Create().WithStatusCode(200)
+                   .WithBodyAsJson(new { id = "created-1", summary = "Standup" }));
+
+        var created = await _client.CreateEventAsync(
+            "user@gmail.test", Body("Standup"), calendarId: "team-cal",
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal("created-1", created.Id);
+        var request = Assert.Single(_server.LogEntries).RequestMessage!;
+        // The #293 regression: this path was hardcoded to calendars/primary regardless of the
+        // calendar the event belonged to, 404ing every secondary-calendar write.
+        Assert.Equal("/calendars/team-cal/events", request.Path);
+        Assert.DoesNotContain("primary", request.Path);
+        Assert.Equal("Bearer fake-token", Assert.Contains("Authorization", request.Headers!)[0]);
+    }
+
+    [Fact]
+    public async Task UpdateEvent_TargetsTheGivenCalendarAndEventId()
+    {
+        _server.Given(Request.Create().WithPath("/calendars/team-cal/events/evt-42").UsingPatch())
+               .RespondWith(Response.Create().WithStatusCode(200)
+                   .WithBodyAsJson(new { id = "evt-42", summary = "Renamed" }));
+
+        var updated = await _client.UpdateEventAsync(
+            "user@gmail.test", "evt-42", Body("Renamed"), calendarId: "team-cal",
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal("evt-42", updated.Id);
+        var request = Assert.Single(_server.LogEntries).RequestMessage!;
+        Assert.Equal("/calendars/team-cal/events/evt-42", request.Path);
+        Assert.Equal("PATCH", request.Method);
+    }
+
+    [Fact]
+    public async Task DeleteEvent_TargetsTheGivenCalendarAndEventId()
+    {
+        _server.Given(Request.Create().WithPath("/calendars/team-cal/events/evt-42").UsingDelete())
+               .RespondWith(Response.Create().WithStatusCode(204));
+
+        await _client.DeleteEventAsync(
+            "user@gmail.test", "evt-42", calendarId: "team-cal",
+            TestContext.Current.CancellationToken);
+
+        var request = Assert.Single(_server.LogEntries).RequestMessage!;
+        Assert.Equal("/calendars/team-cal/events/evt-42", request.Path);
+        Assert.Equal("DELETE", request.Method);
+    }
+
+    [Fact]
+    public async Task GetCalendarList_FollowsNextPageToken_UntilExhausted()
+    {
+        _server.Given(Request.Create().WithPath("/users/me/calendarList").UsingGet()
+                   .WithParam("pageToken", "page2"))
+               .RespondWith(Response.Create().WithStatusCode(200)
+                   .WithBodyAsJson(new { items = new[] { new { id = "cal-b", summary = "Work" } } }));
+        _server.Given(Request.Create().WithPath("/users/me/calendarList").UsingGet())
+               .AtPriority(10) // fallback: first page (no pageToken param)
+               .RespondWith(Response.Create().WithStatusCode(200)
+                   .WithBodyAsJson(new
+                   {
+                       items = new[] { new { id = "cal-a", summary = "Home", primary = true } },
+                       nextPageToken = "page2",
+                   }));
+
+        var calendars = await _client.GetCalendarListAsync(
+            "user@gmail.test", TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, calendars.Count);
+        Assert.Contains(calendars, c => c.Id == "cal-a" && c.Primary);
+        Assert.Contains(calendars, c => c.Id == "cal-b");
+        Assert.Equal(2, _server.LogEntries.Count); // exactly two pages fetched
+    }
+
+    [Fact]
+    public async Task WriteFailure_SurfacesStatusAndServerBody()
+    {
+        _server.Given(Request.Create().WithPath("/calendars/birthdays/events").UsingPost())
+               .RespondWith(Response.Create().WithStatusCode(403)
+                   .WithBodyAsJson(new { error = new { code = 403, message = "Cannot add events to the birthdays calendar" } }));
+
+        // The #294 family: provider-specific write rejections must surface as a diagnosable
+        // error (status + server body), never vanish into a silent no-op.
+        var ex = await Assert.ThrowsAsync<HttpRequestException>(() => _client.CreateEventAsync(
+            "user@gmail.test", Body("Party"), calendarId: "birthdays",
+            TestContext.Current.CancellationToken));
+
+        Assert.Contains("403", ex.Message);
+        Assert.Contains("birthdays calendar", ex.Message);
+    }
+}
+
+/// <summary>Returns a fixed token; these tests assert it arrives as the Bearer header.
+/// Interactive members throw — a WireMock test must never depend on interactive sign-in.</summary>
+internal sealed class FakeGoogleOAuthService : IGoogleOAuthService
+{
+    public Task<string> GetAccessTokenAsync(string username, CancellationToken ct = default) =>
+        Task.FromResult("fake-token");
+    public Task<OAuthResult> SignInInteractiveAsync(string loginHint, CancellationToken ct = default) =>
+        throw new NotSupportedException("Interactive sign-in is not available in tests.");
+    public Task<OAuthResult> AuthorizeContactsAsync(string loginHint, CancellationToken ct = default) =>
+        throw new NotSupportedException("Interactive sign-in is not available in tests.");
+    public Task SignOutAsync(string username) =>
+        throw new NotSupportedException("Sign-out is not available in tests.");
+}

--- a/QuickMail.IntegrationTests/GraphApiTests.cs
+++ b/QuickMail.IntegrationTests/GraphApiTests.cs
@@ -1,0 +1,149 @@
+using System.Net.Http;
+using QuickMail.Models;
+using QuickMail.Services;
+using QuickMail.Services.Graph;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
+
+namespace QuickMail.IntegrationTests;
+
+/// <summary>
+/// Microsoft Graph client against an in-process WireMock fake (live-content testing plan
+/// Tier 2 / §5). Pins the documenting behaviors from issue #304 item 4: calendar writes
+/// resolve by GLOBAL event id via <c>/me/events/{id}</c> (no per-calendar path needed on
+/// Graph, unlike Google), plus paging, 429 retry, and error-shape propagation.
+/// </summary>
+public sealed class GraphApiTests : IDisposable
+{
+    private sealed record TestItem(string Id, string Subject);
+
+    private readonly WireMockServer _server;
+    private readonly GraphClient _client;
+    private readonly AccountModel _account = new()
+    {
+        AccountName = "graph-test",
+        Username = "user@outlook.test",
+        AuthType = AuthType.OAuth2Microsoft,
+        BackendKind = BackendKind.MicrosoftGraph,
+    };
+
+    public GraphApiTests()
+    {
+        _server = WireMockServer.Start();
+        _client = new GraphClient(new FakeMicrosoftOAuthService(),
+            defaultRetryDelay: TimeSpan.FromMilliseconds(50), baseUrl: _server.Urls[0]);
+    }
+
+    public void Dispose()
+    {
+        _client.Dispose();
+        _server.Stop();
+        _server.Dispose();
+    }
+
+    [Fact]
+    public async Task PatchRead_ResolvesEventByGlobalId_ViaMeEvents()
+    {
+        _server.Given(Request.Create().WithPath("/me/events/AAMkAGlobalId42").UsingPatch())
+               .RespondWith(Response.Create().WithStatusCode(200)
+                   .WithBodyAsJson(new { id = "AAMkAGlobalId42", subject = "Renamed" }));
+
+        var updated = await _client.PatchReadAsync<TestItem>(
+            _account, "/me/events/AAMkAGlobalId42", new { subject = "Renamed" },
+            scopes: null, silentOnly: false, headers: null, TestContext.Current.CancellationToken);
+
+        Assert.Equal("AAMkAGlobalId42", updated!.Id);
+        var request = Assert.Single(_server.LogEntries).RequestMessage!;
+        // Graph's documented contract (issue #304 item 4): the write resolves by the event's
+        // GLOBAL id — no calendar-scoped path required, unlike Google's calendars/{id}/events.
+        Assert.Equal("/me/events/AAMkAGlobalId42", request.Path);
+        Assert.Equal("Bearer fake-graph-token", Assert.Contains("Authorization", request.Headers!)[0]);
+    }
+
+    [Fact]
+    public async Task GetAllPages_FollowsODataNextLink_UntilExhausted()
+    {
+        // Raw JSON bodies: the "@odata.nextLink" property name is not expressible as an
+        // anonymous-object member. The nextLink is absolute, exactly as Graph returns it —
+        // the client must follow it as-is.
+        _server.Given(Request.Create().WithPath("/me/messages").UsingGet())
+               .RespondWith(Response.Create().WithStatusCode(200)
+                   .WithHeader("Content-Type", "application/json")
+                   .WithBody($$"""
+                       { "value": [ { "id": "m1", "subject": "one" } ],
+                         "@odata.nextLink": "{{_server.Urls[0]}}/me/messages-page2" }
+                       """));
+        _server.Given(Request.Create().WithPath("/me/messages-page2").UsingGet())
+               .RespondWith(Response.Create().WithStatusCode(200)
+                   .WithHeader("Content-Type", "application/json")
+                   .WithBody("""{ "value": [ { "id": "m2", "subject": "two" } ] }"""));
+
+        var items = await _client.GetAllPagesAsync<TestItem>(
+            _account, "/me/messages", TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, items.Count);
+        Assert.Equal(["m1", "m2"], items.Select(i => i.Id));
+    }
+
+    [Fact]
+    public async Task Throttled429_IsRetried_ThenSucceeds()
+    {
+        _server.Given(Request.Create().WithPath("/me/events/throttled").UsingPatch())
+               .InScenario("throttle")
+               .WillSetStateTo("retried")
+               .RespondWith(Response.Create().WithStatusCode(429));
+        _server.Given(Request.Create().WithPath("/me/events/throttled").UsingPatch())
+               .InScenario("throttle")
+               .WhenStateIs("retried")
+               .RespondWith(Response.Create().WithStatusCode(200)
+                   .WithBodyAsJson(new { id = "throttled", subject = "ok" }));
+
+        var result = await _client.PatchReadAsync<TestItem>(
+            _account, "/me/events/throttled", new { subject = "ok" },
+            scopes: null, silentOnly: false, headers: null, TestContext.Current.CancellationToken);
+
+        Assert.Equal("throttled", result!.Id);
+        Assert.Equal(2, _server.LogEntries.Count); // one 429 + one retry
+    }
+
+    [Fact]
+    public async Task Failure_CarriesStatusCode_OnTheException()
+    {
+        _server.Given(Request.Create().WithPath("/me/events/gone").UsingPatch())
+               .RespondWith(Response.Create().WithStatusCode(404)
+                   .WithBodyAsJson(new { error = new { code = "ErrorItemNotFound", message = "The specified object was not found." } }));
+
+        var ex = await Assert.ThrowsAsync<HttpRequestException>(() => _client.PatchReadAsync<TestItem>(
+            _account, "/me/events/gone", new { subject = "x" },
+            scopes: null, silentOnly: false, headers: null, TestContext.Current.CancellationToken));
+
+        // The status must ride on the typed property (callers branch on it — e.g. server rules
+        // mapping 403 to a consent-required exception), not only in the message text.
+        Assert.Equal(System.Net.HttpStatusCode.NotFound, ex.StatusCode);
+        Assert.Contains("ErrorItemNotFound", ex.Message);
+    }
+}
+
+/// <summary>Silent-token members return a fixed token; interactive members throw.</summary>
+internal sealed class FakeMicrosoftOAuthService : IOAuthService
+{
+    public Task<string> GetAccessTokenAsync(AccountModel account, CancellationToken ct = default) =>
+        Task.FromResult("fake-graph-token");
+    public Task<string> GetAccessTokenAsync(AccountModel account, string[] scopes, CancellationToken ct = default) =>
+        Task.FromResult("fake-graph-token");
+    public Task<string> GetAccessTokenSilentAsync(AccountModel account, string[] scopes, CancellationToken ct = default) =>
+        Task.FromResult("fake-graph-token");
+    public Task EnsureSilentTokenAsync(AccountModel account, CancellationToken ct = default) =>
+        Task.CompletedTask;
+    public Task<OAuthResult> SignInInteractiveAsync(AccountModel account, CancellationToken ct = default) =>
+        throw new NotSupportedException("Interactive sign-in is not available in tests.");
+    public Task<OAuthResult> SignInInteractiveWithContactsAsync(AccountModel account, CancellationToken ct = default) =>
+        throw new NotSupportedException("Interactive sign-in is not available in tests.");
+    public Task RequestContactsConsentAsync(AccountModel account, CancellationToken ct = default) =>
+        throw new NotSupportedException("Consent flows are not available in tests.");
+    public Task RequestCalendarConsentAsync(AccountModel account, CancellationToken ct = default) =>
+        throw new NotSupportedException("Consent flows are not available in tests.");
+    public Task SignOutAsync(AccountModel account) =>
+        throw new NotSupportedException("Sign-out is not available in tests.");
+}

--- a/QuickMail.IntegrationTests/QuickMail.IntegrationTests.csproj
+++ b/QuickMail.IntegrationTests/QuickMail.IntegrationTests.csproj
@@ -21,6 +21,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="WireMock.Net" Version="2.13.0" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>

--- a/QuickMail/QuickMail.csproj
+++ b/QuickMail/QuickMail.csproj
@@ -89,6 +89,7 @@
          OAuthService.DefaultScopesFor, MainViewModel.AccountsNeedingConnect) can be unit-tested
          without widening the public API. -->
     <InternalsVisibleTo Include="QuickMail.Tests" />
+    <InternalsVisibleTo Include="QuickMail.IntegrationTests" />
   </ItemGroup>
 
 </Project>

--- a/QuickMail/Services/Google/GoogleCalendarClient.cs
+++ b/QuickMail/Services/Google/GoogleCalendarClient.cs
@@ -23,7 +23,9 @@ namespace QuickMail.Services;
 /// </summary>
 public sealed class GoogleCalendarClient : IDisposable
 {
-    private const string BaseUrl = "https://www.googleapis.com/calendar/v3";
+    // Production default; overridable so tests can point the client at an in-process fake
+    // (WireMock) HTTP server — see live-content testing plan (issue #304), Tier 2.
+    private readonly string _baseUrl;
     private static readonly JsonSerializerOptions JsonOpts = new() { PropertyNameCaseInsensitive = true };
 
     // Write bodies omit null fields entirely: Google PATCH treats an explicit null as "clear this
@@ -38,9 +40,10 @@ public sealed class GoogleCalendarClient : IDisposable
     private readonly HttpClient _http;
     private readonly bool _ownsHttp;
 
-    public GoogleCalendarClient(IGoogleOAuthService oauth, HttpClient? http = null)
+    public GoogleCalendarClient(IGoogleOAuthService oauth, HttpClient? http = null, string? baseUrl = null)
     {
         _oauth    = oauth;
+        _baseUrl  = baseUrl ?? "https://www.googleapis.com/calendar/v3";
         _http     = http ?? new HttpClient();
         _ownsHttp = http is null;
     }
@@ -58,7 +61,7 @@ public sealed class GoogleCalendarClient : IDisposable
         do
         {
             var token = await _oauth.GetAccessTokenAsync(username, ct);
-            var url = $"{BaseUrl}/users/me/calendarList?maxResults=250" +
+            var url = $"{_baseUrl}/users/me/calendarList?maxResults=250" +
                       (string.IsNullOrEmpty(pageToken) ? string.Empty : $"&pageToken={Uri.EscapeDataString(pageToken)}");
 
             using var req = new HttpRequestMessage(HttpMethod.Get, url);
@@ -100,7 +103,7 @@ public sealed class GoogleCalendarClient : IDisposable
         do
         {
             var token = await _oauth.GetAccessTokenAsync(username, ct);
-            var url = $"{BaseUrl}/{basePath}" +
+            var url = $"{_baseUrl}/{basePath}" +
                       (string.IsNullOrEmpty(pageToken) ? string.Empty : $"&pageToken={Uri.EscapeDataString(pageToken)}");
 
             using var req = new HttpRequestMessage(HttpMethod.Get, url);
@@ -150,7 +153,7 @@ public sealed class GoogleCalendarClient : IDisposable
         var token = await _oauth.GetAccessTokenAsync(username, ct);
         using var req = new HttpRequestMessage(
             HttpMethod.Delete,
-            $"{BaseUrl}/calendars/{Uri.EscapeDataString(calendarId)}/events/{Uri.EscapeDataString(eventId)}");
+            $"{_baseUrl}/calendars/{Uri.EscapeDataString(calendarId)}/events/{Uri.EscapeDataString(eventId)}");
         req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
         using var resp = await _http.SendAsync(req, ct);
@@ -167,7 +170,7 @@ public sealed class GoogleCalendarClient : IDisposable
         string username, HttpMethod method, string path, GoogleEventWriteBody body, CancellationToken ct)
     {
         var token = await _oauth.GetAccessTokenAsync(username, ct);
-        using var req = new HttpRequestMessage(method, $"{BaseUrl}/{path}");
+        using var req = new HttpRequestMessage(method, $"{_baseUrl}/{path}");
         req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
         req.Content = JsonContent.Create(body, options: WriteJsonOpts);
 

--- a/QuickMail/Services/Google/GooglePeopleClient.cs
+++ b/QuickMail/Services/Google/GooglePeopleClient.cs
@@ -19,16 +19,19 @@ namespace QuickMail.Services;
 /// </summary>
 public sealed class GooglePeopleClient : IDisposable
 {
-    private const string BaseUrl = "https://people.googleapis.com/v1";
+    // Production default; overridable so tests can point the client at an in-process fake
+    // (WireMock) HTTP server — see live-content testing plan (issue #304), Tier 2.
+    private readonly string _baseUrl;
     private static readonly JsonSerializerOptions JsonOpts = new() { PropertyNameCaseInsensitive = true };
 
     private readonly IGoogleOAuthService _oauth;
     private readonly HttpClient _http;
     private readonly bool _ownsHttp;
 
-    public GooglePeopleClient(IGoogleOAuthService oauth, HttpClient? http = null)
+    public GooglePeopleClient(IGoogleOAuthService oauth, HttpClient? http = null, string? baseUrl = null)
     {
         _oauth    = oauth;
+        _baseUrl  = baseUrl ?? "https://people.googleapis.com/v1";
         _http     = http ?? new HttpClient();
         _ownsHttp = http is null;
     }
@@ -50,7 +53,7 @@ public sealed class GooglePeopleClient : IDisposable
         do
         {
             var token = await _oauth.GetAccessTokenAsync(username, ct);
-            var url = $"{BaseUrl}/{path}" +
+            var url = $"{_baseUrl}/{path}" +
                       (string.IsNullOrEmpty(pageToken) ? string.Empty : $"&pageToken={Uri.EscapeDataString(pageToken)}");
 
             using var req = new HttpRequestMessage(HttpMethod.Get, url);

--- a/QuickMail/Services/Graph/GraphClient.cs
+++ b/QuickMail/Services/Graph/GraphClient.cs
@@ -20,7 +20,9 @@ namespace QuickMail.Services.Graph;
 /// </summary>
 public sealed class GraphClient : IDisposable
 {
-    private const string BaseUrl = "https://graph.microsoft.com/v1.0";
+    // Production default; overridable so tests can point the client at an in-process fake
+    // (WireMock) HTTP server — see live-content testing plan (issue #304), Tier 2.
+    private readonly string _baseUrl;
     private static readonly JsonSerializerOptions JsonOpts = new() { PropertyNameCaseInsensitive = true };
 
     private readonly IOAuthService _oauth;
@@ -28,9 +30,10 @@ public sealed class GraphClient : IDisposable
     private readonly bool _ownsHttp;
     private readonly TimeSpan _retryDelayWhenNoHeader;
 
-    public GraphClient(IOAuthService oauth, HttpClient? http = null, TimeSpan? defaultRetryDelay = null)
+    public GraphClient(IOAuthService oauth, HttpClient? http = null, TimeSpan? defaultRetryDelay = null, string? baseUrl = null)
     {
         _oauth = oauth;
+        _baseUrl = baseUrl ?? "https://graph.microsoft.com/v1.0";
         _http = http ?? new HttpClient();
         _ownsHttp = http is null;
         // Used only when a 429 response omits a Retry-After header. Injectable so tests don't wait.
@@ -197,7 +200,7 @@ public sealed class GraphClient : IDisposable
         AccountModel account, HttpMethod method, string pathOrUrl, Func<HttpContent>? contentFactory, string[]? scopes, bool silentOnly,
         IReadOnlyDictionary<string, string>? headers, CancellationToken ct)
     {
-        var url = pathOrUrl.StartsWith("http", StringComparison.OrdinalIgnoreCase) ? pathOrUrl : BaseUrl + pathOrUrl;
+        var url = pathOrUrl.StartsWith("http", StringComparison.OrdinalIgnoreCase) ? pathOrUrl : _baseUrl + pathOrUrl;
 
         // Up to 3 attempts to ride out HTTP 429 throttling.
         for (int attempt = 0; ; attempt++)


### PR DESCRIPTION
## Summary

Phase 4 of the [live-content testing plan](https://github.com/kellylford/QuickMail/blob/main/docs/planning/live-content-testing-plan.md) (#304): Tier 2 — in-process HTTP fakes for the REST providers we cannot run locally. **This is the phase that pins #293 itself.**

### Seams (production behavior unchanged)
- `GoogleCalendarClient`, `GooglePeopleClient`, `GraphClient`: optional `baseUrl` constructor parameter defaulting to the real endpoints (byte-identical to the deleted consts — a missed usage would be a compile error). All four production call sites verified unaffected. One-line `InternalsVisibleTo` addition.

### `GoogleCalendarApiTests` (5) — asserts *exact request lines*
- **#293's literal bug shape**: create/patch/delete target `calendars/{calendarId}/events…`, explicitly `DoesNotContain("primary")`.
- `calendarList` paging to exhaustion (request count pinned); 403 write rejection (#294 family) surfaces status + server body.

### `GraphApiTests` (4)
- Writes resolve by GLOBAL event id via `/me/events/{id}` (issue #304 item 4's documenting behavior); `@odata.nextLink` followed as-is; 429 retried (injectable delay); status carried on `HttpRequestException.StatusCode`.

### Validation
- WireMock tests 9/9 (in-process, no server, no gating); full integration suite 26 pass / 1 documented skip vs live GreenMail + Radicale; unit suite 1551/1551; app builds clean under `-warnaserror` incl. NuGet audit.
- Independent review verdict: **APPROVE** (seams verified structurally; tests verified non-vacuous).

Part of #304. Phase 5 (live smoke) follows in a stacked PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)