### PR TITLE
Live-smoke tier: weekly real-account smoke workflow — Phase 5 of #304

### DIFF
--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -1,0 +1,125 @@
+# Tier 3 of the live-content testing plan (issue #304): a small smoke suite against a REAL
+# mail account on a Kelly-owned domain. Runs weekly and on demand — never on PRs, never a
+# required check (real servers bring rate limits and flakiness; GreenMail covers the per-PR
+# regression surface). Skips cleanly when the LIVE_* secrets are absent (e.g. forks).
+#
+# Required repository secrets (see docs/TESTING-INTEGRATION.md):
+#   LIVE_IMAP_HOST   IMAP server hostname
+#   LIVE_USER        full account/login (also the self-send address)
+#   LIVE_PASSWORD    account password or app password
+# Optional (with defaults): LIVE_IMAP_PORT (993), LIVE_IMAP_SSL (1),
+#   LIVE_SMTP_HOST (=LIVE_IMAP_HOST), LIVE_SMTP_PORT (587), LIVE_SMTP_SSL (0 = STARTTLS).
+name: Live Smoke
+
+on:
+  schedule:
+    - cron: '0 11 * * 1'   # Mondays 11:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write   # failure reporting (see last step)
+
+# One run at a time: two concurrent runs would race in the same real mailbox.
+concurrency:
+  group: live-smoke
+  cancel-in-progress: false
+
+jobs:
+  smoke:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: '8.0.x'
+
+      # The gitignored credential partial classes are required to compile QuickMail.csproj.
+      - name: Write Google OAuth credentials
+        shell: pwsh
+        env:
+          GOOGLE_CLIENT_ID:     ${{ secrets.GOOGLE_CLIENT_ID }}
+          GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+        run: |
+          @"
+          namespace QuickMail.Services;
+          public partial class GoogleOAuthService
+          {
+              private const string ClientId     = "$env:GOOGLE_CLIENT_ID";
+              private const string ClientSecret = "$env:GOOGLE_CLIENT_SECRET";
+          }
+          "@ | Set-Content -Path "QuickMail/Services/GoogleOAuthService.Credentials.cs" -Encoding UTF8
+
+      - name: Write bug-report credentials
+        shell: pwsh
+        env:
+          BUG_REPORT_TOKEN: ${{ secrets.BUG_REPORT_TOKEN }}
+        run: |
+          @"
+          namespace QuickMail.Services;
+          public partial class BugReportService
+          {
+              private const string AppOwnedToken = "$env:BUG_REPORT_TOKEN";
+          }
+          "@ | Set-Content -Path "QuickMail/Services/BugReportService.Credentials.cs" -Encoding UTF8
+
+      - name: Run live smoke tests
+        shell: pwsh
+        env:
+          LIVE_IMAP_HOST: ${{ secrets.LIVE_IMAP_HOST }}
+          LIVE_IMAP_PORT: ${{ secrets.LIVE_IMAP_PORT }}
+          LIVE_IMAP_SSL:  ${{ secrets.LIVE_IMAP_SSL }}
+          LIVE_SMTP_HOST: ${{ secrets.LIVE_SMTP_HOST }}
+          LIVE_SMTP_PORT: ${{ secrets.LIVE_SMTP_PORT }}
+          LIVE_SMTP_SSL:  ${{ secrets.LIVE_SMTP_SSL }}
+          LIVE_USER:      ${{ secrets.LIVE_USER }}
+          LIVE_PASSWORD:  ${{ secrets.LIVE_PASSWORD }}
+          QUICKMAIL_LIVE_RUN_ID: ${{ github.run_id }}
+        run: |
+          if (-not $env:LIVE_IMAP_HOST) {
+            Write-Host "LIVE_* secrets not configured - nothing to smoke-test. Exiting green."
+            exit 0
+          }
+          dotnet test QuickMail.IntegrationTests/QuickMail.IntegrationTests.csproj -c Release `
+            --filter "Category=LiveSmoke" `
+            --logger "trx;LogFileName=live-smoke.trx"
+          $testExit = $LASTEXITCODE
+          $trx = "QuickMail.IntegrationTests/TestResults/live-smoke.trx"
+          if (-not (Test-Path $trx)) { Write-Error "No trx produced (exit=$testExit)."; exit 1 }
+          [xml]$doc = Get-Content $trx
+          $c = $doc.TestRun.ResultSummary.Counters
+          Write-Host "trx counters: total=$($c.total) passed=$($c.passed) failed=$($c.failed) error=$($c.error)"
+          # Secrets are set, so the suite must actually RUN — all-skipped means the env
+          # plumbing broke, which must not look like a healthy smoke pass.
+          if ([int]$c.passed -le 0) { Write-Error "No live smoke tests passed (all skipped/failed)."; exit 1 }
+          exit $testExit
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: live-smoke-results
+          path: QuickMail.IntegrationTests/TestResults/live-smoke.trx
+          if-no-files-found: ignore
+          retention-days: 30
+
+      # Drift is only useful if someone sees it: on failure, comment on (or create) the
+      # tracking issue instead of relying on anyone watching the Actions tab.
+      - name: Report failure on tracking issue
+        if: failure()
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $title = "Live smoke failing"
+          $runUrl = "$env:GITHUB_SERVER_URL/$env:GITHUB_REPOSITORY/actions/runs/$env:GITHUB_RUN_ID"
+          $existing = gh issue list --state open --search "in:title `"$title`"" --json number --jq ".[0].number"
+          $body = "Live smoke run failed: $runUrl (see the live-smoke-results artifact)."
+          if ($existing) {
+            gh issue comment $existing --body $body
+          } else {
+            gh issue create --title $title --label bug `
+              --body "The scheduled live-account smoke test is failing. Latest: $body`n`nThis issue is updated by .github/workflows/live-smoke.yml; close it when the smoke run is green again."
+          }

--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -120,6 +120,8 @@ jobs:
           if ($existing) {
             gh issue comment $existing --body $body
           } else {
-            gh issue create --title $title --label bug `
+            # No --label: a deleted label would make issue creation itself fail, silently
+            # degrading the one reporting path this workflow exists to provide.
+            gh issue create --title $title `
               --body "The scheduled live-account smoke test is failing. Latest: $body`n`nThis issue is updated by .github/workflows/live-smoke.yml; close it when the smoke run is green again."
           }

--- a/QuickMail.IntegrationTests/GoogleCalendarApiTests.cs
+++ b/QuickMail.IntegrationTests/GoogleCalendarApiTests.cs
@@ -1,0 +1,143 @@
+using System.Net.Http;
+using QuickMail.Services;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
+
+namespace QuickMail.IntegrationTests;
+
+/// <summary>
+/// Google Calendar REST client against an in-process WireMock fake (live-content testing plan
+/// Tier 2 / §5). No external server: WireMock listens on an ephemeral localhost port and the
+/// client's base URL points at it. The headline coverage is <b>issue #293's literal bug
+/// shape</b>: writes hardcoded to <c>calendars/primary</c> — asserted here by inspecting the
+/// exact request lines the client emits when targeting a secondary calendar.
+/// </summary>
+public sealed class GoogleCalendarApiTests : IDisposable
+{
+    private readonly WireMockServer _server;
+    private readonly GoogleCalendarClient _client;
+
+    public GoogleCalendarApiTests()
+    {
+        _server = WireMockServer.Start();
+        _client = new GoogleCalendarClient(new FakeGoogleOAuthService(), baseUrl: _server.Urls[0]);
+    }
+
+    public void Dispose()
+    {
+        _client.Dispose();
+        _server.Stop();
+        _server.Dispose();
+    }
+
+    private static GoogleEventWriteBody Body(string summary) => new() { Summary = summary };
+
+    [Fact]
+    public async Task CreateEvent_TargetsTheGivenCalendar_NotPrimary()
+    {
+        _server.Given(Request.Create().WithPath("/calendars/team-cal/events").UsingPost())
+               .RespondWith(Response.Create().WithStatusCode(200)
+                   .WithBodyAsJson(new { id = "created-1", summary = "Standup" }));
+
+        var created = await _client.CreateEventAsync(
+            "user@gmail.test", Body("Standup"), calendarId: "team-cal",
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal("created-1", created.Id);
+        var request = Assert.Single(_server.LogEntries).RequestMessage!;
+        // The #293 regression: this path was hardcoded to calendars/primary regardless of the
+        // calendar the event belonged to, 404ing every secondary-calendar write.
+        Assert.Equal("/calendars/team-cal/events", request.Path);
+        Assert.DoesNotContain("primary", request.Path);
+        Assert.Equal("Bearer fake-token", Assert.Contains("Authorization", request.Headers!)[0]);
+    }
+
+    [Fact]
+    public async Task UpdateEvent_TargetsTheGivenCalendarAndEventId()
+    {
+        _server.Given(Request.Create().WithPath("/calendars/team-cal/events/evt-42").UsingPatch())
+               .RespondWith(Response.Create().WithStatusCode(200)
+                   .WithBodyAsJson(new { id = "evt-42", summary = "Renamed" }));
+
+        var updated = await _client.UpdateEventAsync(
+            "user@gmail.test", "evt-42", Body("Renamed"), calendarId: "team-cal",
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal("evt-42", updated.Id);
+        var request = Assert.Single(_server.LogEntries).RequestMessage!;
+        Assert.Equal("/calendars/team-cal/events/evt-42", request.Path);
+        Assert.Equal("PATCH", request.Method);
+    }
+
+    [Fact]
+    public async Task DeleteEvent_TargetsTheGivenCalendarAndEventId()
+    {
+        _server.Given(Request.Create().WithPath("/calendars/team-cal/events/evt-42").UsingDelete())
+               .RespondWith(Response.Create().WithStatusCode(204));
+
+        await _client.DeleteEventAsync(
+            "user@gmail.test", "evt-42", calendarId: "team-cal",
+            TestContext.Current.CancellationToken);
+
+        var request = Assert.Single(_server.LogEntries).RequestMessage!;
+        Assert.Equal("/calendars/team-cal/events/evt-42", request.Path);
+        Assert.Equal("DELETE", request.Method);
+    }
+
+    [Fact]
+    public async Task GetCalendarList_FollowsNextPageToken_UntilExhausted()
+    {
+        _server.Given(Request.Create().WithPath("/users/me/calendarList").UsingGet()
+                   .WithParam("pageToken", "page2"))
+               .RespondWith(Response.Create().WithStatusCode(200)
+                   .WithBodyAsJson(new { items = new[] { new { id = "cal-b", summary = "Work" } } }));
+        _server.Given(Request.Create().WithPath("/users/me/calendarList").UsingGet())
+               .AtPriority(10) // fallback: first page (no pageToken param)
+               .RespondWith(Response.Create().WithStatusCode(200)
+                   .WithBodyAsJson(new
+                   {
+                       items = new[] { new { id = "cal-a", summary = "Home", primary = true } },
+                       nextPageToken = "page2",
+                   }));
+
+        var calendars = await _client.GetCalendarListAsync(
+            "user@gmail.test", TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, calendars.Count);
+        Assert.Contains(calendars, c => c.Id == "cal-a" && c.Primary);
+        Assert.Contains(calendars, c => c.Id == "cal-b");
+        Assert.Equal(2, _server.LogEntries.Count); // exactly two pages fetched
+    }
+
+    [Fact]
+    public async Task WriteFailure_SurfacesStatusAndServerBody()
+    {
+        _server.Given(Request.Create().WithPath("/calendars/birthdays/events").UsingPost())
+               .RespondWith(Response.Create().WithStatusCode(403)
+                   .WithBodyAsJson(new { error = new { code = 403, message = "Cannot add events to the birthdays calendar" } }));
+
+        // The #294 family: provider-specific write rejections must surface as a diagnosable
+        // error (status + server body), never vanish into a silent no-op.
+        var ex = await Assert.ThrowsAsync<HttpRequestException>(() => _client.CreateEventAsync(
+            "user@gmail.test", Body("Party"), calendarId: "birthdays",
+            TestContext.Current.CancellationToken));
+
+        Assert.Contains("403", ex.Message);
+        Assert.Contains("birthdays calendar", ex.Message);
+    }
+}
+
+/// <summary>Returns a fixed token; these tests assert it arrives as the Bearer header.
+/// Interactive members throw — a WireMock test must never depend on interactive sign-in.</summary>
+internal sealed class FakeGoogleOAuthService : IGoogleOAuthService
+{
+    public Task<string> GetAccessTokenAsync(string username, CancellationToken ct = default) =>
+        Task.FromResult("fake-token");
+    public Task<OAuthResult> SignInInteractiveAsync(string loginHint, CancellationToken ct = default) =>
+        throw new NotSupportedException("Interactive sign-in is not available in tests.");
+    public Task<OAuthResult> AuthorizeContactsAsync(string loginHint, CancellationToken ct = default) =>
+        throw new NotSupportedException("Interactive sign-in is not available in tests.");
+    public Task SignOutAsync(string username) =>
+        throw new NotSupportedException("Sign-out is not available in tests.");
+}

--- a/QuickMail.IntegrationTests/GraphApiTests.cs
+++ b/QuickMail.IntegrationTests/GraphApiTests.cs
@@ -1,0 +1,149 @@
+using System.Net.Http;
+using QuickMail.Models;
+using QuickMail.Services;
+using QuickMail.Services.Graph;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
+
+namespace QuickMail.IntegrationTests;
+
+/// <summary>
+/// Microsoft Graph client against an in-process WireMock fake (live-content testing plan
+/// Tier 2 / §5). Pins the documenting behaviors from issue #304 item 4: calendar writes
+/// resolve by GLOBAL event id via <c>/me/events/{id}</c> (no per-calendar path needed on
+/// Graph, unlike Google), plus paging, 429 retry, and error-shape propagation.
+/// </summary>
+public sealed class GraphApiTests : IDisposable
+{
+    private sealed record TestItem(string Id, string Subject);
+
+    private readonly WireMockServer _server;
+    private readonly GraphClient _client;
+    private readonly AccountModel _account = new()
+    {
+        AccountName = "graph-test",
+        Username = "user@outlook.test",
+        AuthType = AuthType.OAuth2Microsoft,
+        BackendKind = BackendKind.MicrosoftGraph,
+    };
+
+    public GraphApiTests()
+    {
+        _server = WireMockServer.Start();
+        _client = new GraphClient(new FakeMicrosoftOAuthService(),
+            defaultRetryDelay: TimeSpan.FromMilliseconds(50), baseUrl: _server.Urls[0]);
+    }
+
+    public void Dispose()
+    {
+        _client.Dispose();
+        _server.Stop();
+        _server.Dispose();
+    }
+
+    [Fact]
+    public async Task PatchRead_ResolvesEventByGlobalId_ViaMeEvents()
+    {
+        _server.Given(Request.Create().WithPath("/me/events/AAMkAGlobalId42").UsingPatch())
+               .RespondWith(Response.Create().WithStatusCode(200)
+                   .WithBodyAsJson(new { id = "AAMkAGlobalId42", subject = "Renamed" }));
+
+        var updated = await _client.PatchReadAsync<TestItem>(
+            _account, "/me/events/AAMkAGlobalId42", new { subject = "Renamed" },
+            scopes: null, silentOnly: false, headers: null, TestContext.Current.CancellationToken);
+
+        Assert.Equal("AAMkAGlobalId42", updated!.Id);
+        var request = Assert.Single(_server.LogEntries).RequestMessage!;
+        // Graph's documented contract (issue #304 item 4): the write resolves by the event's
+        // GLOBAL id — no calendar-scoped path required, unlike Google's calendars/{id}/events.
+        Assert.Equal("/me/events/AAMkAGlobalId42", request.Path);
+        Assert.Equal("Bearer fake-graph-token", Assert.Contains("Authorization", request.Headers!)[0]);
+    }
+
+    [Fact]
+    public async Task GetAllPages_FollowsODataNextLink_UntilExhausted()
+    {
+        // Raw JSON bodies: the "@odata.nextLink" property name is not expressible as an
+        // anonymous-object member. The nextLink is absolute, exactly as Graph returns it —
+        // the client must follow it as-is.
+        _server.Given(Request.Create().WithPath("/me/messages").UsingGet())
+               .RespondWith(Response.Create().WithStatusCode(200)
+                   .WithHeader("Content-Type", "application/json")
+                   .WithBody($$"""
+                       { "value": [ { "id": "m1", "subject": "one" } ],
+                         "@odata.nextLink": "{{_server.Urls[0]}}/me/messages-page2" }
+                       """));
+        _server.Given(Request.Create().WithPath("/me/messages-page2").UsingGet())
+               .RespondWith(Response.Create().WithStatusCode(200)
+                   .WithHeader("Content-Type", "application/json")
+                   .WithBody("""{ "value": [ { "id": "m2", "subject": "two" } ] }"""));
+
+        var items = await _client.GetAllPagesAsync<TestItem>(
+            _account, "/me/messages", TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, items.Count);
+        Assert.Equal(["m1", "m2"], items.Select(i => i.Id));
+    }
+
+    [Fact]
+    public async Task Throttled429_IsRetried_ThenSucceeds()
+    {
+        _server.Given(Request.Create().WithPath("/me/events/throttled").UsingPatch())
+               .InScenario("throttle")
+               .WillSetStateTo("retried")
+               .RespondWith(Response.Create().WithStatusCode(429));
+        _server.Given(Request.Create().WithPath("/me/events/throttled").UsingPatch())
+               .InScenario("throttle")
+               .WhenStateIs("retried")
+               .RespondWith(Response.Create().WithStatusCode(200)
+                   .WithBodyAsJson(new { id = "throttled", subject = "ok" }));
+
+        var result = await _client.PatchReadAsync<TestItem>(
+            _account, "/me/events/throttled", new { subject = "ok" },
+            scopes: null, silentOnly: false, headers: null, TestContext.Current.CancellationToken);
+
+        Assert.Equal("throttled", result!.Id);
+        Assert.Equal(2, _server.LogEntries.Count); // one 429 + one retry
+    }
+
+    [Fact]
+    public async Task Failure_CarriesStatusCode_OnTheException()
+    {
+        _server.Given(Request.Create().WithPath("/me/events/gone").UsingPatch())
+               .RespondWith(Response.Create().WithStatusCode(404)
+                   .WithBodyAsJson(new { error = new { code = "ErrorItemNotFound", message = "The specified object was not found." } }));
+
+        var ex = await Assert.ThrowsAsync<HttpRequestException>(() => _client.PatchReadAsync<TestItem>(
+            _account, "/me/events/gone", new { subject = "x" },
+            scopes: null, silentOnly: false, headers: null, TestContext.Current.CancellationToken));
+
+        // The status must ride on the typed property (callers branch on it — e.g. server rules
+        // mapping 403 to a consent-required exception), not only in the message text.
+        Assert.Equal(System.Net.HttpStatusCode.NotFound, ex.StatusCode);
+        Assert.Contains("ErrorItemNotFound", ex.Message);
+    }
+}
+
+/// <summary>Silent-token members return a fixed token; interactive members throw.</summary>
+internal sealed class FakeMicrosoftOAuthService : IOAuthService
+{
+    public Task<string> GetAccessTokenAsync(AccountModel account, CancellationToken ct = default) =>
+        Task.FromResult("fake-graph-token");
+    public Task<string> GetAccessTokenAsync(AccountModel account, string[] scopes, CancellationToken ct = default) =>
+        Task.FromResult("fake-graph-token");
+    public Task<string> GetAccessTokenSilentAsync(AccountModel account, string[] scopes, CancellationToken ct = default) =>
+        Task.FromResult("fake-graph-token");
+    public Task EnsureSilentTokenAsync(AccountModel account, CancellationToken ct = default) =>
+        Task.CompletedTask;
+    public Task<OAuthResult> SignInInteractiveAsync(AccountModel account, CancellationToken ct = default) =>
+        throw new NotSupportedException("Interactive sign-in is not available in tests.");
+    public Task<OAuthResult> SignInInteractiveWithContactsAsync(AccountModel account, CancellationToken ct = default) =>
+        throw new NotSupportedException("Interactive sign-in is not available in tests.");
+    public Task RequestContactsConsentAsync(AccountModel account, CancellationToken ct = default) =>
+        throw new NotSupportedException("Consent flows are not available in tests.");
+    public Task RequestCalendarConsentAsync(AccountModel account, CancellationToken ct = default) =>
+        throw new NotSupportedException("Consent flows are not available in tests.");
+    public Task SignOutAsync(AccountModel account) =>
+        throw new NotSupportedException("Sign-out is not available in tests.");
+}

--- a/QuickMail.IntegrationTests/LiveSmokeTests.cs
+++ b/QuickMail.IntegrationTests/LiveSmokeTests.cs
@@ -62,6 +62,15 @@ public sealed class LiveSmokeTests
         await imap.ConnectAsync(account, password, ct);
         try
         {
+            // Best-effort sweep of leftovers from earlier runs (a message that arrived after a
+            // previous run's poll window lingers otherwise — inert, but no reason to keep it).
+            var stale = (await imap.GetMessageSummariesAsync(account.Id, "INBOX", 50, ct))
+                .Where(s => s.Subject.StartsWith("[quickmail-live-smoke", StringComparison.Ordinal))
+                .Select(s => s.MessageId)
+                .ToList();
+            if (stale.Count > 0)
+                await imap.PermanentlyDeleteBatchAsync(account.Id, "INBOX", stale, ct);
+
             // Real servers deliver in seconds-to-a-minute; poll generously but boundedly.
             var messageId = await PollForSubjectAsync(imap, account.Id, subject, ct);
             Assert.NotNull(messageId);
@@ -130,6 +139,8 @@ public sealed class LiveSmokeTests
     private static async Task<string?> FindSubjectOnceAsync(
         ImapMailService imap, Guid accountId, string subject, CancellationToken ct)
     {
+        // Scans only the newest 50 summaries — fine for the DEDICATED smoke mailbox this tier
+        // assumes; a busy shared mailbox could push our message past the window and flake.
         var summaries = await imap.GetMessageSummariesAsync(accountId, "INBOX", 50, ct);
         return summaries.FirstOrDefault(s => s.Subject.Contains(subject, StringComparison.Ordinal))?.MessageId;
     }

--- a/QuickMail.IntegrationTests/LiveSmokeTests.cs
+++ b/QuickMail.IntegrationTests/LiveSmokeTests.cs
@@ -1,0 +1,136 @@
+using System.Diagnostics;
+using QuickMail.Models;
+using QuickMail.Services;
+
+namespace QuickMail.IntegrationTests;
+
+/// <summary>
+/// Tier 3 of the live-content testing plan (issue #304): a thin smoke slice against a REAL
+/// mail account on an owned domain. Never gates PRs — it runs on a weekly schedule and manual
+/// dispatch (.github/workflows/live-smoke.yml), and skips everywhere the LIVE_* environment
+/// variables are absent. This is the only tier that sees real TLS/auth negotiation and
+/// provider behavior; keep it small on purpose — minutes, not comprehensive.
+///
+/// Hygiene rules: every message this class sends carries a run-scoped marker in the subject,
+/// and each test deletes what it created before finishing, so repeated runs never pollute the
+/// mailbox or each other (the workflow's concurrency group serializes runs besides).
+/// </summary>
+public sealed class LiveSmokeTests
+{
+    [Fact]
+    [Trait("Category", "LiveSmoke")]
+    public async Task Connect_AndListFolders()
+    {
+        var (account, password) = RequireLiveAccount();
+        var ct = TestContext.Current.CancellationToken;
+
+        using var imap = new ImapMailService(new NoOpOAuthService());
+        await imap.ConnectAsync(account, password, ct);
+        try
+        {
+            var folders = await imap.GetFoldersAsync(account.Id, ct);
+            Assert.Contains(folders, f => f.FullName.Equals("INBOX", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            await imap.DisconnectAsync(account.Id, ct);
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "LiveSmoke")]
+    public async Task SendToSelf_RoundTrips_ThenCleansUp()
+    {
+        var (account, password) = RequireLiveAccount();
+        var ct = TestContext.Current.CancellationToken;
+
+        // Namespaced subject: unique per run AND per test invocation, so polling can never
+        // match a leftover from a previous (crashed) run, and cleanup targets only our mail.
+        var runId = Environment.GetEnvironmentVariable("QUICKMAIL_LIVE_RUN_ID") ?? "local";
+        var subject = $"[quickmail-live-smoke {runId} {Guid.NewGuid():N}]";
+
+        var smtp = new SmtpService(new NoOpOAuthService(), new NoOpGraphSendService());
+        await smtp.SendAsync(new ComposeModel
+        {
+            AccountId = account.Id,
+            To = account.Username,
+            Subject = subject,
+            Body = "Automated live smoke round-trip. Deleted by the test that sent it.",
+        }, account, password, ct);
+
+        using var imap = new ImapMailService(new NoOpOAuthService());
+        await imap.ConnectAsync(account, password, ct);
+        try
+        {
+            // Real servers deliver in seconds-to-a-minute; poll generously but boundedly.
+            var messageId = await PollForSubjectAsync(imap, account.Id, subject, ct);
+            Assert.NotNull(messageId);
+
+            await imap.PermanentlyDeleteBatchAsync(account.Id, "INBOX", [messageId!], ct);
+
+            var stillThere = await FindSubjectOnceAsync(imap, account.Id, subject, ct);
+            Assert.Null(stillThere);
+        }
+        finally
+        {
+            await imap.DisconnectAsync(account.Id, ct);
+        }
+    }
+
+    // ── Environment plumbing ─────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Builds the account from LIVE_* environment variables (populated from repository
+    /// secrets by the workflow). Skips the test when they are absent — locally and on every
+    /// PR run, this suite is a no-op by design.
+    /// </summary>
+    private static (AccountModel Account, string Password) RequireLiveAccount()
+    {
+        var host = Environment.GetEnvironmentVariable("LIVE_IMAP_HOST");
+        var user = Environment.GetEnvironmentVariable("LIVE_USER");
+        var password = Environment.GetEnvironmentVariable("LIVE_PASSWORD");
+        Assert.SkipWhen(
+            string.IsNullOrEmpty(host) || string.IsNullOrEmpty(user) || string.IsNullOrEmpty(password),
+            "LIVE_* environment variables not configured — live smoke runs only from live-smoke.yml with repository secrets.");
+
+        var account = new AccountModel
+        {
+            AccountName = "live-smoke",
+            Username    = user!,
+            AuthType    = AuthType.Password,
+            ImapHost    = host!,
+            ImapPort    = ParseOr("LIVE_IMAP_PORT", 993),
+            ImapUseSsl  = ParseOr("LIVE_IMAP_SSL", 1) == 1,
+            SmtpHost    = Environment.GetEnvironmentVariable("LIVE_SMTP_HOST") ?? host!,
+            SmtpPort    = ParseOr("LIVE_SMTP_PORT", 587),
+            SmtpUseSsl  = ParseOr("LIVE_SMTP_SSL", 0) == 1, // 0 = STARTTLS on 587 (the default posture)
+        };
+        return (account, password!);
+    }
+
+    private static int ParseOr(string name, int fallback) =>
+        int.TryParse(Environment.GetEnvironmentVariable(name), out var value) ? value : fallback;
+
+    // ── Polling helpers ──────────────────────────────────────────────────────────
+
+    private static async Task<string?> PollForSubjectAsync(
+        ImapMailService imap, Guid accountId, string subject, CancellationToken ct)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        while (stopwatch.Elapsed < TimeSpan.FromSeconds(90))
+        {
+            var found = await FindSubjectOnceAsync(imap, accountId, subject, ct);
+            if (found != null)
+                return found;
+            await Task.Delay(TimeSpan.FromSeconds(3), ct);
+        }
+        return null;
+    }
+
+    private static async Task<string?> FindSubjectOnceAsync(
+        ImapMailService imap, Guid accountId, string subject, CancellationToken ct)
+    {
+        var summaries = await imap.GetMessageSummariesAsync(accountId, "INBOX", 50, ct);
+        return summaries.FirstOrDefault(s => s.Subject.Contains(subject, StringComparison.Ordinal))?.MessageId;
+    }
+}

--- a/QuickMail.IntegrationTests/QuickMail.IntegrationTests.csproj
+++ b/QuickMail.IntegrationTests/QuickMail.IntegrationTests.csproj
@@ -21,6 +21,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="WireMock.Net" Version="2.13.0" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>

--- a/QuickMail/QuickMail.csproj
+++ b/QuickMail/QuickMail.csproj
@@ -89,6 +89,7 @@
          OAuthService.DefaultScopesFor, MainViewModel.AccountsNeedingConnect) can be unit-tested
          without widening the public API. -->
     <InternalsVisibleTo Include="QuickMail.Tests" />
+    <InternalsVisibleTo Include="QuickMail.IntegrationTests" />
   </ItemGroup>
 
 </Project>

--- a/QuickMail/Services/Google/GoogleCalendarClient.cs
+++ b/QuickMail/Services/Google/GoogleCalendarClient.cs
@@ -23,7 +23,9 @@ namespace QuickMail.Services;
 /// </summary>
 public sealed class GoogleCalendarClient : IDisposable
 {
-    private const string BaseUrl = "https://www.googleapis.com/calendar/v3";
+    // Production default; overridable so tests can point the client at an in-process fake
+    // (WireMock) HTTP server — see live-content testing plan (issue #304), Tier 2.
+    private readonly string _baseUrl;
     private static readonly JsonSerializerOptions JsonOpts = new() { PropertyNameCaseInsensitive = true };
 
     // Write bodies omit null fields entirely: Google PATCH treats an explicit null as "clear this
@@ -38,9 +40,10 @@ public sealed class GoogleCalendarClient : IDisposable
     private readonly HttpClient _http;
     private readonly bool _ownsHttp;
 
-    public GoogleCalendarClient(IGoogleOAuthService oauth, HttpClient? http = null)
+    public GoogleCalendarClient(IGoogleOAuthService oauth, HttpClient? http = null, string? baseUrl = null)
     {
         _oauth    = oauth;
+        _baseUrl  = baseUrl ?? "https://www.googleapis.com/calendar/v3";
         _http     = http ?? new HttpClient();
         _ownsHttp = http is null;
     }
@@ -58,7 +61,7 @@ public sealed class GoogleCalendarClient : IDisposable
         do
         {
             var token = await _oauth.GetAccessTokenAsync(username, ct);
-            var url = $"{BaseUrl}/users/me/calendarList?maxResults=250" +
+            var url = $"{_baseUrl}/users/me/calendarList?maxResults=250" +
                       (string.IsNullOrEmpty(pageToken) ? string.Empty : $"&pageToken={Uri.EscapeDataString(pageToken)}");
 
             using var req = new HttpRequestMessage(HttpMethod.Get, url);
@@ -100,7 +103,7 @@ public sealed class GoogleCalendarClient : IDisposable
         do
         {
             var token = await _oauth.GetAccessTokenAsync(username, ct);
-            var url = $"{BaseUrl}/{basePath}" +
+            var url = $"{_baseUrl}/{basePath}" +
                       (string.IsNullOrEmpty(pageToken) ? string.Empty : $"&pageToken={Uri.EscapeDataString(pageToken)}");
 
             using var req = new HttpRequestMessage(HttpMethod.Get, url);
@@ -150,7 +153,7 @@ public sealed class GoogleCalendarClient : IDisposable
         var token = await _oauth.GetAccessTokenAsync(username, ct);
         using var req = new HttpRequestMessage(
             HttpMethod.Delete,
-            $"{BaseUrl}/calendars/{Uri.EscapeDataString(calendarId)}/events/{Uri.EscapeDataString(eventId)}");
+            $"{_baseUrl}/calendars/{Uri.EscapeDataString(calendarId)}/events/{Uri.EscapeDataString(eventId)}");
         req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
         using var resp = await _http.SendAsync(req, ct);
@@ -167,7 +170,7 @@ public sealed class GoogleCalendarClient : IDisposable
         string username, HttpMethod method, string path, GoogleEventWriteBody body, CancellationToken ct)
     {
         var token = await _oauth.GetAccessTokenAsync(username, ct);
-        using var req = new HttpRequestMessage(method, $"{BaseUrl}/{path}");
+        using var req = new HttpRequestMessage(method, $"{_baseUrl}/{path}");
         req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
         req.Content = JsonContent.Create(body, options: WriteJsonOpts);
 

--- a/QuickMail/Services/Google/GooglePeopleClient.cs
+++ b/QuickMail/Services/Google/GooglePeopleClient.cs
@@ -19,16 +19,19 @@ namespace QuickMail.Services;
 /// </summary>
 public sealed class GooglePeopleClient : IDisposable
 {
-    private const string BaseUrl = "https://people.googleapis.com/v1";
+    // Production default; overridable so tests can point the client at an in-process fake
+    // (WireMock) HTTP server — see live-content testing plan (issue #304), Tier 2.
+    private readonly string _baseUrl;
     private static readonly JsonSerializerOptions JsonOpts = new() { PropertyNameCaseInsensitive = true };
 
     private readonly IGoogleOAuthService _oauth;
     private readonly HttpClient _http;
     private readonly bool _ownsHttp;
 
-    public GooglePeopleClient(IGoogleOAuthService oauth, HttpClient? http = null)
+    public GooglePeopleClient(IGoogleOAuthService oauth, HttpClient? http = null, string? baseUrl = null)
     {
         _oauth    = oauth;
+        _baseUrl  = baseUrl ?? "https://people.googleapis.com/v1";
         _http     = http ?? new HttpClient();
         _ownsHttp = http is null;
     }
@@ -50,7 +53,7 @@ public sealed class GooglePeopleClient : IDisposable
         do
         {
             var token = await _oauth.GetAccessTokenAsync(username, ct);
-            var url = $"{BaseUrl}/{path}" +
+            var url = $"{_baseUrl}/{path}" +
                       (string.IsNullOrEmpty(pageToken) ? string.Empty : $"&pageToken={Uri.EscapeDataString(pageToken)}");
 
             using var req = new HttpRequestMessage(HttpMethod.Get, url);

--- a/QuickMail/Services/Graph/GraphClient.cs
+++ b/QuickMail/Services/Graph/GraphClient.cs
@@ -20,7 +20,9 @@ namespace QuickMail.Services.Graph;
 /// </summary>
 public sealed class GraphClient : IDisposable
 {
-    private const string BaseUrl = "https://graph.microsoft.com/v1.0";
+    // Production default; overridable so tests can point the client at an in-process fake
+    // (WireMock) HTTP server — see live-content testing plan (issue #304), Tier 2.
+    private readonly string _baseUrl;
     private static readonly JsonSerializerOptions JsonOpts = new() { PropertyNameCaseInsensitive = true };
 
     private readonly IOAuthService _oauth;
@@ -28,9 +30,10 @@ public sealed class GraphClient : IDisposable
     private readonly bool _ownsHttp;
     private readonly TimeSpan _retryDelayWhenNoHeader;
 
-    public GraphClient(IOAuthService oauth, HttpClient? http = null, TimeSpan? defaultRetryDelay = null)
+    public GraphClient(IOAuthService oauth, HttpClient? http = null, TimeSpan? defaultRetryDelay = null, string? baseUrl = null)
     {
         _oauth = oauth;
+        _baseUrl = baseUrl ?? "https://graph.microsoft.com/v1.0";
         _http = http ?? new HttpClient();
         _ownsHttp = http is null;
         // Used only when a 429 response omits a Retry-After header. Injectable so tests don't wait.
@@ -197,7 +200,7 @@ public sealed class GraphClient : IDisposable
         AccountModel account, HttpMethod method, string pathOrUrl, Func<HttpContent>? contentFactory, string[]? scopes, bool silentOnly,
         IReadOnlyDictionary<string, string>? headers, CancellationToken ct)
     {
-        var url = pathOrUrl.StartsWith("http", StringComparison.OrdinalIgnoreCase) ? pathOrUrl : BaseUrl + pathOrUrl;
+        var url = pathOrUrl.StartsWith("http", StringComparison.OrdinalIgnoreCase) ? pathOrUrl : _baseUrl + pathOrUrl;
 
         // Up to 3 attempts to ride out HTTP 429 throttling.
         for (int attempt = 0; ; attempt++)

--- a/docs/TESTING-INTEGRATION.md
+++ b/docs/TESTING-INTEGRATION.md
@@ -86,6 +86,10 @@ Setup (repository secrets): `LIVE_IMAP_HOST`, `LIVE_USER`, `LIVE_PASSWORD` requi
 — the suite writes to and deletes from the real INBOX. On failure the workflow comments on (or
 creates) a "Live smoke failing" issue.
 
+Privacy note: the uploaded trx artifact can embed the IMAP **hostname** in connect-failure
+messages (GitHub's secret masking does not reach inside artifacts). Passwords never appear,
+but pick a smoke host you don't mind naming in a downloadable artifact.
+
 ## Writing integration tests
 
 - Join the collection: `[Collection(GreenMailCollection.Name)]`, take `GreenMailFixture` in the

--- a/docs/TESTING-INTEGRATION.md
+++ b/docs/TESTING-INTEGRATION.md
@@ -72,6 +72,20 @@ Consequences for this suite:
 - Multipart-heavy coverage belongs to a future tier (recorded IMAP fixtures or a
   spec-compliant server), tracked in the live-content testing plan.
 
+## Live smoke tier (real account, scheduled)
+
+`LiveSmokeTests` (trait `Category=LiveSmoke`) runs a minimal slice — connect/list, and a
+send-to-self round-trip that deletes what it sent — against a **real** mail account, driven by
+`.github/workflows/live-smoke.yml` (weekly cron + manual dispatch; never a PR gate). The tests
+skip everywhere the `LIVE_*` environment variables are absent, so they are a no-op locally and
+in the per-PR integration job.
+
+Setup (repository secrets): `LIVE_IMAP_HOST`, `LIVE_USER`, `LIVE_PASSWORD` required;
+`LIVE_IMAP_PORT` (993), `LIVE_IMAP_SSL` (1), `LIVE_SMTP_HOST` (=IMAP host), `LIVE_SMTP_PORT`
+(587), `LIVE_SMTP_SSL` (0 = STARTTLS) optional. Use a **dedicated mailbox on an owned domain**
+— the suite writes to and deletes from the real INBOX. On failure the workflow comments on (or
+creates) a "Live smoke failing" issue.
+
 ## Writing integration tests
 
 - Join the collection: `[Collection(GreenMailCollection.Name)]`, take `GreenMailFixture` in the


### PR DESCRIPTION
## Summary

Phase 5 (final phase) of the [live-content testing plan](https://github.com/kellylford/QuickMail/blob/main/docs/planning/live-content-testing-plan.md) (#304): the Tier 3 scheduled live smoke. **Stacked on #362** — merges after it; the diff reduces to the Phase 5 delta once #362 lands.

### `live-smoke.yml`
- Weekly cron (Mon 11:00 UTC) + `workflow_dispatch`; **never on PRs, never a required check**.
- Exits green with a notice when `LIVE_*` secrets are absent (forks / not yet configured); when secrets ARE set, an all-skipped run **fails** — broken env plumbing must not look healthy.
- `concurrency` group serializes runs (one real mailbox); trx uploaded (30-day retention).
- On failure: comments on (or creates) a **"Live smoke failing"** tracking issue — drift is visible without watching the Actions tab.

### `LiveSmokeTests` (`Category=LiveSmoke`)
- Connect + list folders; send-to-self round-trip that deletes what it sent, with run-scoped subject markers and a best-effort sweeper for leftovers from crashed runs.
- Env-var driven (`LIVE_IMAP_HOST`/`LIVE_USER`/`LIVE_PASSWORD` + optional port/SSL overrides); skips everywhere they're absent — verified a no-op locally and in the per-PR integration job (env-based skip, independent of the `QUICKMAIL_IT_SERVERS` fail-hard logic).

### Activation (the one human step)
Create repository secrets for a **dedicated mailbox on an owned domain** — `LIVE_IMAP_HOST`, `LIVE_USER`, `LIVE_PASSWORD` (optional: `LIVE_IMAP_PORT`, `LIVE_IMAP_SSL`, `LIVE_SMTP_HOST`, `LIVE_SMTP_PORT`, `LIVE_SMTP_SSL`) — then run **Actions → Live Smoke → Run workflow** once to validate. Details + privacy note in `docs/TESTING-INTEGRATION.md`.

### Validation
- Independent review verdict: **APPROVE-WITH-NITS**; all four nits applied (sweeper, label-free issue creation, dedicated-mailbox comment, artifact-privacy doc note).
- Suite behavior verified: 2 LiveSmoke tests skip cleanly without env everywhere, including under `QUICKMAIL_IT_SERVERS=1` with live servers (26 pass / 3 expected skips).

Closes the implementation phases of #304.

🤖 Generated with [Claude Code](https://claude.com/claude-code)