### PR TITLE
Rules: retire "All accounts" — per-account migration + scoping (#333 D1)

### DIFF
--- a/QuickMail.Tests/RuleMigrationTests.cs
+++ b/QuickMail.Tests/RuleMigrationTests.cs
@@ -144,6 +144,20 @@ public class RuleMigrationTests : IDisposable
     }
 
     [Fact]
+    public void EmptyAccountList_SkipsMigration_KeepsUnscopedRule()
+    {
+        // An empty account read can be transient; migrating would drop every unscoped rule. So with
+        // an account service present but returning no accounts, the migration defers (rule kept, not
+        // dropped) rather than treating "no accounts" like a Graph-only profile. (Review of #364.)
+        SeedRules(Unscoped("Global"));
+
+        var rules = ServiceWith().LoadRules();   // FixedAccountService with zero accounts
+
+        var rule = Assert.Single(rules);
+        Assert.Null(rule.AccountId);
+    }
+
+    [Fact]
     public void NoAccountService_LeavesUnscopedRulesUntouched()
     {
         // The test-only path: without an account context there's nothing to migrate against, so an

--- a/QuickMail.Tests/RuleMigrationTests.cs
+++ b/QuickMail.Tests/RuleMigrationTests.cs
@@ -1,0 +1,174 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using QuickMail.Models;
+using QuickMail.Services;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// The D1 "All accounts" → per-account rule migration (#333): each unscoped (null-AccountId) rule is
+/// duplicated into one rule per NON-Graph account, Graph accounts get none, and for a Graph-only
+/// profile the unscoped rule is dropped. Runs once in <see cref="RuleService.LoadRules"/>, is
+/// idempotent, and persists atomically.
+/// </summary>
+public class RuleMigrationTests : IDisposable
+{
+    private readonly string _dir;
+
+    public RuleMigrationTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), $"qm-rule-migrate-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_dir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { }
+        GC.SuppressFinalize(this);
+    }
+
+    private sealed class FixedAccountService : IAccountService
+    {
+        private readonly List<AccountModel> _accounts;
+        public FixedAccountService(params AccountModel[] accounts) => _accounts = [.. accounts];
+        public List<AccountModel> LoadAccounts() => _accounts;
+        public void SaveAccounts(List<AccountModel> accounts) { }
+        public void SetDefaultAccount(Guid accountId) { }
+    }
+
+    private static AccountModel Imap(string name = "IMAP") => new() { Id = Guid.NewGuid(), AccountName = name, BackendKind = BackendKind.ImapSmtp };
+    private static AccountModel Graph(string name = "M365") => new() { Id = Guid.NewGuid(), AccountName = name, BackendKind = BackendKind.MicrosoftGraph };
+
+    /// <summary>Writes an initial rules.json via a plain RuleService (no account service = no migration).</summary>
+    private void SeedRules(params MailRule[] rules)
+        => new RuleService(new StubImapMailService(), new StubLocalStoreService(), _dir).SaveRules([.. rules]);
+
+    private RuleService ServiceWith(params AccountModel[] accounts)
+        => new(new StubImapMailService(), new StubLocalStoreService(), _dir, new FixedAccountService(accounts));
+
+    private static MailRule Unscoped(string name) => new() { Name = name, AccountId = null, SubjectContains = "x", Action = RuleAction.MarkAsRead };
+    private static MailRule Scoped(string name, Guid accountId) => new() { Name = name, AccountId = accountId, SubjectContains = "y", Action = RuleAction.MarkAsRead };
+
+    // ── The migration ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Unscoped_DuplicatedIntoEachNonGraphAccount_WithFreshIds()
+    {
+        var a = Imap("A");
+        var b = Imap("B");
+        SeedRules(Unscoped("Newsletters"));
+
+        var rules = ServiceWith(a, b).LoadRules();
+
+        Assert.Equal(2, rules.Count);
+        Assert.All(rules, r => Assert.Equal("Newsletters", r.Name));
+        Assert.Contains(rules, r => r.AccountId == a.Id);
+        Assert.Contains(rules, r => r.AccountId == b.Id);
+        Assert.Equal(2, rules.Select(r => r.Id).Distinct().Count());   // fresh, distinct ids
+        Assert.DoesNotContain(rules, r => r.AccountId is null);
+    }
+
+    [Fact]
+    public void GraphAccounts_GetNoCopies()
+    {
+        var imap = Imap("Home");
+        var graph = Graph("Work");
+        SeedRules(Unscoped("Global"));
+
+        var rules = ServiceWith(imap, graph).LoadRules();
+
+        var rule = Assert.Single(rules);
+        Assert.Equal(imap.Id, rule.AccountId);   // only the IMAP account, never the Graph one
+    }
+
+    [Fact]
+    public void GraphOnlyProfile_UnscopedRuleIsDropped()
+    {
+        var graph = Graph("Work");
+        SeedRules(Unscoped("Legacy global"), Scoped("Kept", graph.Id));
+
+        var rules = ServiceWith(graph).LoadRules();
+
+        // The unscoped rule has no non-Graph target and is dropped; the already-scoped one survives.
+        var kept = Assert.Single(rules);
+        Assert.Equal("Kept", kept.Name);
+        Assert.DoesNotContain(rules, r => r.AccountId is null);
+    }
+
+    [Fact]
+    public void AlreadyScopedRules_AreLeftUntouched()
+    {
+        var a = Imap("A");
+        SeedRules(Scoped("Existing", a.Id));
+
+        var rules = ServiceWith(a, Imap("B")).LoadRules();
+
+        var rule = Assert.Single(rules);
+        Assert.Equal("Existing", rule.Name);
+        Assert.Equal(a.Id, rule.AccountId);
+    }
+
+    [Fact]
+    public void Migration_IsIdempotent_SecondLoadDoesNotDuplicateAgain()
+    {
+        var a = Imap("A");
+        var b = Imap("B");
+        SeedRules(Unscoped("Global"));
+
+        // First service migrates: 1 unscoped → 2 scoped, persisted to disk.
+        var first = ServiceWith(a, b).LoadRules();
+        Assert.Equal(2, first.Count);
+
+        // A brand-new service reads the migrated file — must not duplicate the already-scoped rules.
+        var second = ServiceWith(a, b).LoadRules();
+        Assert.Equal(2, second.Count);
+        Assert.DoesNotContain(second, r => r.AccountId is null);
+    }
+
+    [Fact]
+    public void Migration_PersistsToDisk()
+    {
+        var a = Imap("A");
+        SeedRules(Unscoped("Global"));
+
+        ServiceWith(a, Imap("B")).LoadRules();   // migrates + saves
+
+        // A plain service (no account service, so no migration) reads the file straight back;
+        // if the migration hadn't persisted, it would still see the null-AccountId rule.
+        var reloaded = new RuleService(new StubImapMailService(), new StubLocalStoreService(), _dir).LoadRules();
+        Assert.Equal(2, reloaded.Count);
+        Assert.DoesNotContain(reloaded, r => r.AccountId is null);
+    }
+
+    [Fact]
+    public void NoAccountService_LeavesUnscopedRulesUntouched()
+    {
+        // The test-only path: without an account context there's nothing to migrate against, so an
+        // unscoped rule is preserved as-is rather than dropped.
+        SeedRules(Unscoped("Global"));
+
+        var rules = new RuleService(new StubImapMailService(), new StubLocalStoreService(), _dir).LoadRules();
+
+        var rule = Assert.Single(rules);
+        Assert.Null(rule.AccountId);
+    }
+
+    [Fact]
+    public void MixedRules_OnlyUnscopedOnesAreExpanded()
+    {
+        var a = Imap("A");
+        var b = Imap("B");
+        SeedRules(Scoped("Pinned", a.Id), Unscoped("Global"));
+
+        var rules = ServiceWith(a, b).LoadRules();
+
+        // Pinned stays as one; Global becomes two (a + b) → 3 total, none unscoped.
+        Assert.Equal(3, rules.Count);
+        Assert.Single(rules, r => r.Name == "Pinned");
+        Assert.Equal(2, rules.Count(r => r.Name == "Global"));
+        Assert.DoesNotContain(rules, r => r.AccountId is null);
+    }
+}

--- a/QuickMail.Tests/RulesManagerViewModelTests.cs
+++ b/QuickMail.Tests/RulesManagerViewModelTests.cs
@@ -484,6 +484,33 @@ public class RulesManagerViewModelTests
         Assert.Contains("IdeaPlace", vm.SelectedRule.AccessibleName);
     }
 
+    [Fact]
+    public void NewRule_PrefersTheDefaultAccount_OverTheFirst()
+    {
+        var first = new AccountModel { Id = Guid.NewGuid(), AccountName = "First", IsDefault = false };
+        var preferred = new AccountModel { Id = Guid.NewGuid(), AccountName = "Preferred", IsDefault = true };
+        var vm = new RulesManagerViewModel(new StubRuleService(), accounts: [first, preferred]);
+
+        vm.NewRuleCommand.Execute(null);
+
+        Assert.Equal(preferred.Id, vm.SelectedRule!.AccountId);   // default account, not the first
+    }
+
+    [Fact]
+    public void HasSelectedRule_FalseWithNoRules_TrueAfterNew()
+    {
+        // Drives the editor's IsEnabled so, with no rules, the per-rule fields (incl. the Account
+        // combo) are dropped from the tab order instead of presenting a blank live control.
+        var account = new AccountModel { Id = Guid.NewGuid(), AccountName = "Work" };
+        var vm = new RulesManagerViewModel(new StubRuleService(), accounts: [account]);
+
+        Assert.False(vm.HasSelectedRule);   // no rules → nothing selected
+
+        vm.NewRuleCommand.Execute(null);
+
+        Assert.True(vm.HasSelectedRule);
+    }
+
     // ── Run on existing mail (issue #346) ───────────────────────────────────────
 
     [Fact]

--- a/QuickMail.Tests/RulesManagerViewModelTests.cs
+++ b/QuickMail.Tests/RulesManagerViewModelTests.cs
@@ -416,16 +416,16 @@ public class RulesManagerViewModelTests
     }
 
     [Fact]
-    public void AccountOptions_IncludesAllAccountsFirst()
+    public void AccountOptions_ListsAccountsOnly_NoAllAccountsEntry()
     {
+        // "All accounts" was retired (#333 D1): every rule is scoped to one account, so the options
+        // are real accounts only — no null-Id entry that would let a user create an unscoped rule.
         var account = new AccountModel { Id = Guid.NewGuid(), AccountName = "Work" };
         var vm = new RulesManagerViewModel(new StubRuleService(), accounts: [account]);
 
         var options = vm.AccountOptions;
-        Assert.True(options.Count >= 2);
-        Assert.Null(options[0].Id); // "All accounts" has null Id
-        Assert.Equal("All accounts", options[0].DisplayName);
-        Assert.Equal(account.Id, options[1].Id);
+        Assert.DoesNotContain(options, o => o.Id is null);
+        Assert.Equal(account.Id, Assert.Single(options).Id);
     }
 
     // ── Account-in-row display (rule name, account) ─────────────────────────────
@@ -470,14 +470,18 @@ public class RulesManagerViewModelTests
     }
 
     [Fact]
-    public void NewRule_IsStampedWithAllAccounts()
+    public void NewRule_DefaultsToFirstAccount()
     {
-        var vm = new RulesManagerViewModel(new StubRuleService(), accounts: []);
+        // With "All accounts" retired (#333 D1), a new rule is scoped to an account immediately
+        // rather than left unscoped.
+        var account = new AccountModel { Id = Guid.NewGuid(), AccountName = "IdeaPlace" };
+        var vm = new RulesManagerViewModel(new StubRuleService(), accounts: [account]);
 
         vm.NewRuleCommand.Execute(null);
 
-        Assert.Equal("All accounts", vm.SelectedRule!.AccountDisplay);
-        Assert.Contains("All accounts", vm.SelectedRule.AccessibleName);
+        Assert.Equal(account.Id, vm.SelectedRule!.AccountId);
+        Assert.Equal("IdeaPlace", vm.SelectedRule.AccountDisplay);
+        Assert.Contains("IdeaPlace", vm.SelectedRule.AccessibleName);
     }
 
     // ── Run on existing mail (issue #346) ───────────────────────────────────────

--- a/QuickMail.Tests/RulesManagerViewModelTests.cs
+++ b/QuickMail.Tests/RulesManagerViewModelTests.cs
@@ -511,6 +511,54 @@ public class RulesManagerViewModelTests
         Assert.True(vm.HasSelectedRule);
     }
 
+    [Fact]
+    public void DeleteSaveTest_AreDisabled_UntilARuleIsSelected()
+    {
+        // With no rule selected, these commands have nothing to act on — they must be disabled so a
+        // screen-reader user isn't offered "Delete selected rule" / "Test rule" with no rule.
+        var account = new AccountModel { Id = Guid.NewGuid(), AccountName = "Work" };
+        var vm = new RulesManagerViewModel(new StubRuleService(), accounts: [account]);
+
+        Assert.False(vm.DeleteRuleCommand.CanExecute(null));
+        Assert.False(vm.SaveRuleCommand.CanExecute(null));
+        Assert.False(vm.TestRuleCommand.CanExecute(null));
+
+        vm.NewRuleCommand.Execute(null);   // now a rule is selected
+
+        Assert.True(vm.DeleteRuleCommand.CanExecute(null));
+        Assert.True(vm.SaveRuleCommand.CanExecute(null));
+        Assert.True(vm.TestRuleCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public void RunOnExisting_IsDisabled_WhenThereAreNoRules()
+    {
+        var account = new AccountModel { Id = Guid.NewGuid(), AccountName = "Work" };
+        var vm = new RulesManagerViewModel(new StubRuleService(), accounts: [account]);
+
+        Assert.False(vm.RunOnExistingCommand.CanExecute(null));   // nothing to run
+
+        vm.NewRuleCommand.Execute(null);
+
+        Assert.True(vm.RunOnExistingCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public void DeletingTheLastRule_DisablesRunOnExistingAgain()
+    {
+        var account = new AccountModel { Id = Guid.NewGuid(), AccountName = "Work" };
+        var stub = new StubRuleService { LoadedRules = [new MailRule { Name = "Only", AccountId = account.Id }] };
+        var vm = new RulesManagerViewModel(stub, accounts: [account]);
+        vm.ConfirmDeleteRequested += (_, _) => true;
+
+        Assert.True(vm.RunOnExistingCommand.CanExecute(null));
+
+        vm.DeleteRuleCommand.Execute(null);
+
+        Assert.False(vm.RunOnExistingCommand.CanExecute(null));   // list is empty again
+        Assert.False(vm.DeleteRuleCommand.CanExecute(null));
+    }
+
     // ── Run on existing mail (issue #346) ───────────────────────────────────────
 
     [Fact]

--- a/QuickMail/App.xaml.cs
+++ b/QuickMail/App.xaml.cs
@@ -228,7 +228,8 @@ public partial class App : Application
             var contactService = _contactService;
             _templateService = new TemplateService(profile);
             var templateService = _templateService;
-            var ruleService = new RuleService(mailRouter, localStore, profile.ProfileDir);
+            // accountService drives the one-time "All accounts" → per-account rule migration (#333 D1).
+            var ruleService = new RuleService(mailRouter, localStore, profile.ProfileDir, accountService);
             var syncService = new SyncService(mailRouter, localStore, configService, ruleService);
 
             // Contact sync (issue #256): Graph source reuses the Graph backend's client; Google source

--- a/QuickMail/Services/RuleService.cs
+++ b/QuickMail/Services/RuleService.cs
@@ -14,15 +14,20 @@ public class RuleService : IRuleService
     private readonly string _filePath;
     private readonly IMailService _imap;
     private readonly ILocalStoreService _store;
+    private readonly IAccountService? _accountService;
     private List<MailRule> _cache = [];
     private bool _loaded;
 
     private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
 
-    public RuleService(IMailService imap, ILocalStoreService store, string? dataDirectory = null)
+    public RuleService(IMailService imap, ILocalStoreService store, string? dataDirectory = null,
+        IAccountService? accountService = null)
     {
         _imap = imap;
         _store = store;
+        // Optional: supplied in the app (App.xaml.cs) to drive the D1 "All accounts" → per-account
+        // migration. When absent (unit tests that don't exercise migration), no migration runs.
+        _accountService = accountService;
         var dir = dataDirectory ?? Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "QuickMail");
         _filePath = Path.Combine(dir, "rules.json");
@@ -51,8 +56,83 @@ public class RuleService : IRuleService
             _cache = [];
         }
         _loaded = true;
+        MigrateAllAccountRules();
         return _cache;
     }
+
+    /// <summary>
+    /// One-time migration (#333, D1): the "All accounts" rule scope is retired, so every rule must
+    /// belong to exactly one account. Each unscoped rule (null <see cref="MailRule.AccountId"/>) is
+    /// duplicated into one rule per <b>non-Graph</b> account; Graph accounts receive none — server
+    /// rules replace client rules there, and an all-account client rule must not silently run on a
+    /// Graph mailbox (D2).
+    /// <para>
+    /// <b>Idempotent by construction.</b> The migration is defined as "eliminate null AccountId", so
+    /// the absence of any unscoped rule <i>is</i> the completion signal — a second run finds nothing
+    /// to do. It runs here in <see cref="LoadRules"/>, before any consumer sees the list, so no caller
+    /// can observe a null AccountId. It persists once at the end via the atomic <see cref="SaveRules"/>,
+    /// so the file is either fully migrated or untouched — never half-duplicated.
+    /// </para>
+    /// </summary>
+    private void MigrateAllAccountRules()
+    {
+        if (_accountService is null) return;                    // no account context (some unit tests)
+        if (_cache.All(r => r.AccountId is not null)) return;   // already migrated / nothing unscoped
+
+        var targets = _accountService.LoadAccounts()
+            .Where(a => a.BackendKind != BackendKind.MicrosoftGraph)
+            .ToList();
+
+        var migrated = new List<MailRule>(_cache.Count);
+        int converted = 0, dropped = 0;
+
+        foreach (var rule in _cache)
+        {
+            if (rule.AccountId is not null) { migrated.Add(rule); continue; }
+
+            converted++;
+            if (targets.Count == 0)
+            {
+                // Graph-only profile: an all-account CLIENT rule has no valid target (it must not run
+                // on a Graph account, D2), so it is dropped. Destructive, hence logged per rule — the
+                // release notes call this out. Affected population: a Microsoft-only profile carrying
+                // legacy all-account client rules.
+                dropped++;
+                LogService.Log($"Rules migration: dropped all-account rule '{rule.Name}' — no non-Graph account to assign it to.");
+                continue;
+            }
+
+            foreach (var account in targets)
+                migrated.Add(CloneForAccount(rule, account.Id));
+        }
+
+        _cache = migrated;
+        SaveRules(_cache);   // atomic write; also refreshes _cache/_loaded
+        LogService.Log($"Rules migration: converted {converted} all-account rule(s) across {targets.Count} non-Graph account(s); dropped {dropped}.");
+    }
+
+    /// <summary>
+    /// Copies a rule and binds it to one account. The copy gets a <b>fresh Id</b> — reusing the
+    /// source id across N per-account copies would collide, breaking selection and delete-by-id.
+    /// </summary>
+    private static MailRule CloneForAccount(MailRule source, Guid accountId) => new()
+    {
+        Id = Guid.NewGuid(),
+        Name = source.Name,
+        IsEnabled = source.IsEnabled,
+        UseFromCondition = source.UseFromCondition,
+        FromContains = source.FromContains,
+        UseToCondition = source.UseToCondition,
+        ToContains = source.ToContains,
+        UseSubjectCondition = source.UseSubjectCondition,
+        SubjectContains = source.SubjectContains,
+        UseBodyCondition = source.UseBodyCondition,
+        BodyContains = source.BodyContains,
+        MustHaveAttachments = source.MustHaveAttachments,
+        AccountId = accountId,
+        Action = source.Action,
+        TargetFolder = source.TargetFolder,
+    };
 
     public void SaveRules(List<MailRule> rules)
     {

--- a/QuickMail/Services/RuleService.cs
+++ b/QuickMail/Services/RuleService.cs
@@ -79,9 +79,14 @@ public class RuleService : IRuleService
         if (_accountService is null) return;                    // no account context (some unit tests)
         if (_cache.All(r => r.AccountId is not null)) return;   // already migrated / nothing unscoped
 
-        var targets = _accountService.LoadAccounts()
-            .Where(a => a.BackendKind != BackendKind.MicrosoftGraph)
-            .ToList();
+        var accounts = _accountService.LoadAccounts();
+        // Never migrate against an EMPTY account list: it would drop every unscoped rule, and an empty
+        // read can be transient (startup ordering, a locked/corrupt accounts.json). Defer until
+        // accounts exist. A genuine Graph-only profile still drops below (accounts present, but none
+        // non-Graph) — the drop path only fires when there is real account context. (Review of #364.)
+        if (accounts.Count == 0) return;
+
+        var targets = accounts.Where(a => a.BackendKind != BackendKind.MicrosoftGraph).ToList();
 
         var migrated = new List<MailRule>(_cache.Count);
         int converted = 0, dropped = 0;

--- a/QuickMail/ViewModels/RulesManagerViewModel.cs
+++ b/QuickMail/ViewModels/RulesManagerViewModel.cs
@@ -63,6 +63,13 @@ public partial class RulesManagerViewModel : ObservableObject
         foreach (var r in rules) StampDisplay(r);
         Rules = new ObservableCollection<MailRule>(rules);
 
+        // "Run on Existing Mail" acts on the whole list, so it enables/disables with rule count.
+        Rules.CollectionChanged += (_, _) =>
+        {
+            OnPropertyChanged(nameof(HasRules));
+            RunOnExistingCommand.NotifyCanExecuteChanged();
+        };
+
         if (prefillTemplate != null)
         {
             StampDisplay(prefillTemplate);
@@ -83,15 +90,22 @@ public partial class RulesManagerViewModel : ObservableObject
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(HasSelectedRule))]
+    [NotifyCanExecuteChangedFor(nameof(DeleteRuleCommand))]
+    [NotifyCanExecuteChangedFor(nameof(SaveRuleCommand))]
+    [NotifyCanExecuteChangedFor(nameof(TestRuleCommand))]
     private MailRule? _selectedRule;
 
     /// <summary>
     /// True when a rule is selected. The View gates the editor panel on this so that, when there are
     /// no rules, the per-rule fields (which bind to <c>SelectedRule.*</c>) are disabled and dropped
     /// from the tab order — otherwise a screen-reader user tabs onto a live-but-blank Account combo
-    /// with nothing behind it.
+    /// with nothing behind it. Delete/Save/Test are gated on it too, so they don't offer an action
+    /// with no rule to act on.
     /// </summary>
     public bool HasSelectedRule => SelectedRule is not null;
+
+    /// <summary>True when the list has any rules — gates "Run on Existing Mail".</summary>
+    public bool HasRules => Rules.Count > 0;
 
     /// <summary>
     /// Account options for the ComboBox. Every rule belongs to exactly one account — the "All
@@ -233,7 +247,7 @@ public partial class RulesManagerViewModel : ObservableObject
         SelectedRule = rule;   // Replace clears selection; restore it
     }
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(HasSelectedRule))]
     private void DeleteRule()
     {
         if (SelectedRule == null) return;
@@ -251,7 +265,7 @@ public partial class RulesManagerViewModel : ObservableObject
         Announce($"Rule '{name}' deleted.", AnnouncementCategory.Result);
     }
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(HasSelectedRule))]
     private void SaveRule()
     {
         if (SelectedRule == null) return;
@@ -265,7 +279,7 @@ public partial class RulesManagerViewModel : ObservableObject
         Announce($"Rule '{SelectedRule.Name}' saved.", AnnouncementCategory.Result);
     }
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(HasSelectedRule))]
     private void TestRule()
     {
         if (SelectedRule == null || _selectedMessagesForTest == null)
@@ -300,7 +314,7 @@ public partial class RulesManagerViewModel : ObservableObject
     /// mailbox (issue #346). The owner performs the work (it holds the local store); the count is
     /// messages moved or deleted — actions like Mark as read still apply but aren't counted here.
     /// </summary>
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(HasRules))]
     private async Task RunOnExistingAsync()
     {
         if (RunOnExistingRequested is null) return;

--- a/QuickMail/ViewModels/RulesManagerViewModel.cs
+++ b/QuickMail/ViewModels/RulesManagerViewModel.cs
@@ -84,11 +84,13 @@ public partial class RulesManagerViewModel : ObservableObject
     [ObservableProperty]
     private MailRule? _selectedRule;
 
-    /// <summary>Account options for the ComboBox. First item is "All accounts" (null).</summary>
+    /// <summary>
+    /// Account options for the ComboBox. Every rule belongs to exactly one account — the "All
+    /// accounts" scope was retired (#333 D1), so this lists real accounts only and a new rule can no
+    /// longer be created unscoped.
+    /// </summary>
     public List<AccountOption> AccountOptions =>
-        new[] { new AccountOption { Id = null, DisplayName = "All accounts" } }
-        .Concat(_accounts.Select(a => new AccountOption { Id = a.Id, DisplayName = a.AccountLabel }))
-        .ToList();
+        _accounts.Select(a => new AccountOption { Id = a.Id, DisplayName = a.AccountLabel }).ToList();
 
     /// <summary>Action options for the ComboBox.</summary>
     public static List<ActionOption> ActionOptions => new()
@@ -161,7 +163,10 @@ public partial class RulesManagerViewModel : ObservableObject
     [RelayCommand]
     private void NewRule()
     {
-        var rule = new MailRule { Name = "New rule" };
+        // A rule must be scoped to an account now that "All accounts" is gone (#333 D1); default to
+        // the first account so the rule is valid immediately. (No accounts is a degenerate state in
+        // which rules aren't usable anyway.)
+        var rule = new MailRule { Name = "New rule", AccountId = _accounts.FirstOrDefault()?.Id };
         StampDisplay(rule);
         Rules.Add(rule);
         SelectedRule = rule;

--- a/QuickMail/ViewModels/RulesManagerViewModel.cs
+++ b/QuickMail/ViewModels/RulesManagerViewModel.cs
@@ -82,7 +82,16 @@ public partial class RulesManagerViewModel : ObservableObject
     public ObservableCollection<MailRule> Rules { get; }
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasSelectedRule))]
     private MailRule? _selectedRule;
+
+    /// <summary>
+    /// True when a rule is selected. The View gates the editor panel on this so that, when there are
+    /// no rules, the per-rule fields (which bind to <c>SelectedRule.*</c>) are disabled and dropped
+    /// from the tab order — otherwise a screen-reader user tabs onto a live-but-blank Account combo
+    /// with nothing behind it.
+    /// </summary>
+    public bool HasSelectedRule => SelectedRule is not null;
 
     /// <summary>
     /// Account options for the ComboBox. Every rule belongs to exactly one account — the "All
@@ -91,6 +100,14 @@ public partial class RulesManagerViewModel : ObservableObject
     /// </summary>
     public List<AccountOption> AccountOptions =>
         _accounts.Select(a => new AccountOption { Id = a.Id, DisplayName = a.AccountLabel }).ToList();
+
+    /// <summary>
+    /// The account a new rule is scoped to by default: the Account Manager default account, or — when
+    /// none is marked default (e.g. a single-account profile) — the first account. Null only when
+    /// there are no accounts at all.
+    /// </summary>
+    private Guid? DefaultAccountId =>
+        _accounts.FirstOrDefault(a => a.IsDefault)?.Id ?? _accounts.FirstOrDefault()?.Id;
 
     /// <summary>Action options for the ComboBox.</summary>
     public static List<ActionOption> ActionOptions => new()
@@ -164,9 +181,10 @@ public partial class RulesManagerViewModel : ObservableObject
     private void NewRule()
     {
         // A rule must be scoped to an account now that "All accounts" is gone (#333 D1); default to
-        // the first account so the rule is valid immediately. (No accounts is a degenerate state in
-        // which rules aren't usable anyway.)
-        var rule = new MailRule { Name = "New rule", AccountId = _accounts.FirstOrDefault()?.Id };
+        // the Account Manager default account (or the sole account) so the rule is valid immediately
+        // and the Account combo lands on a real selection rather than blank. (No accounts is a
+        // degenerate state in which rules aren't usable anyway.)
+        var rule = new MailRule { Name = "New rule", AccountId = DefaultAccountId };
         StampDisplay(rule);
         Rules.Add(rule);
         SelectedRule = rule;

--- a/QuickMail/Views/RulesManagerWindow.xaml
+++ b/QuickMail/Views/RulesManagerWindow.xaml
@@ -102,10 +102,13 @@
                           Focusable="False"
                           KeyboardNavigation.TabNavigation="Continue"
                           KeyboardNavigation.IsTabStop="False">
-                <!-- Disabled when no rule is selected (e.g. no rules yet): the fields bind to
-                     SelectedRule.* and would otherwise be live-but-blank, so a keyboard/screen-reader
-                     user could tab onto an empty Account combo with nothing behind it. -->
-                <StackPanel Margin="12,0,0,0" IsEnabled="{Binding HasSelectedRule}">
+                <StackPanel Margin="12,0,0,0">
+                  <!-- Fields disabled when no rule is selected (e.g. no rules yet): they bind to
+                       SelectedRule.* and would otherwise be live-but-blank, so a keyboard/screen-reader
+                       user could tab onto an empty Account combo with nothing behind it. The button row
+                       below stays OUTSIDE this so Close is always available; Test/Save gate themselves
+                       via CanExecute. -->
+                  <StackPanel IsEnabled="{Binding HasSelectedRule}">
                     <!-- Rule Name -->
                     <TextBlock Text="Rule Name" FontWeight="SemiBold" Margin="0,8,0,2"/>
                     <TextBox Text="{Binding SelectedRule.Name, UpdateSourceTrigger=PropertyChanged}"
@@ -254,6 +257,8 @@
                             </Style>
                         </TextBlock.Style>
                     </TextBlock>
+                  </StackPanel>
+                  <!-- End of the fields panel; buttons below stay enabled. -->
 
                     <!-- Buttons -->
                     <StackPanel Orientation="Horizontal" Margin="0,16,0,0">

--- a/QuickMail/Views/RulesManagerWindow.xaml
+++ b/QuickMail/Views/RulesManagerWindow.xaml
@@ -102,7 +102,10 @@
                           Focusable="False"
                           KeyboardNavigation.TabNavigation="Continue"
                           KeyboardNavigation.IsTabStop="False">
-                <StackPanel Margin="12,0,0,0">
+                <!-- Disabled when no rule is selected (e.g. no rules yet): the fields bind to
+                     SelectedRule.* and would otherwise be live-but-blank, so a keyboard/screen-reader
+                     user could tab onto an empty Account combo with nothing behind it. -->
+                <StackPanel Margin="12,0,0,0" IsEnabled="{Binding HasSelectedRule}">
                     <!-- Rule Name -->
                     <TextBlock Text="Rule Name" FontWeight="SemiBold" Margin="0,8,0,2"/>
                     <TextBox Text="{Binding SelectedRule.Name, UpdateSourceTrigger=PropertyChanged}"

--- a/docs/release-notes-v0.8.36.md
+++ b/docs/release-notes-v0.8.36.md
@@ -39,6 +39,12 @@ Several fixes to the Rules Manager (Tools → Rules…, `Ctrl+Shift+L`):
 - Screen readers now read the Rules Manager's own window title correctly. (#347)
 - Added a field-labels display option and other row-level accessibility refinements. (#344, #346, #348)
 
+**Mail rules are now per-account.** The "All accounts" rule option has been replaced by scoping each rule to a specific account. This happens automatically the first time rules load after updating:
+
+- Existing "All accounts" rules are **copied to each of your standard (IMAP/SMTP) accounts**, so they keep working exactly as before.
+- **If you use *only* Microsoft 365 accounts**, any old "All accounts" rules are **removed** — those rules run inside QuickMail, and Microsoft 365 accounts are moving to server-side rules instead. If you had such rules, recreate them scoped to the account you want. (This affects very few people; every removal is recorded in the log.)
+- New rules now ask which account they apply to (defaulting to your default account) instead of offering "All accounts". (#333)
+
 ---
 
 ## Under the Hood

--- a/docs/release-notes-v0.8.36.md
+++ b/docs/release-notes-v0.8.36.md
@@ -39,12 +39,6 @@ Several fixes to the Rules Manager (Tools → Rules…, `Ctrl+Shift+L`):
 - Screen readers now read the Rules Manager's own window title correctly. (#347)
 - Added a field-labels display option and other row-level accessibility refinements. (#344, #346, #348)
 
-**Mail rules are now per-account.** The "All accounts" rule option has been replaced by scoping each rule to a specific account. This happens automatically the first time rules load after updating:
-
-- Existing "All accounts" rules are **copied to each of your standard (IMAP/SMTP) accounts**, so they keep working exactly as before.
-- **If you use *only* Microsoft 365 accounts**, any old "All accounts" rules are **removed** — those rules run inside QuickMail, and Microsoft 365 accounts are moving to server-side rules instead. If you had such rules, recreate them scoped to the account you want. (This affects very few people; every removal is recorded in the log.)
-- New rules now ask which account they apply to (defaulting to your default account) instead of offering "All accounts". (#333)
-
 ---
 
 ## Internal

--- a/docs/release-notes-v0.8.37.md
+++ b/docs/release-notes-v0.8.37.md
@@ -13,6 +13,14 @@ Both downloads include the .NET 8 runtime — you do not need to install .NET se
 
 ---
 
+## Changed: mail rules are now per-account
+
+The "All accounts" rule option has been replaced by scoping each rule to a specific account. This happens automatically the first time rules load after updating:
+
+- Existing "All accounts" rules are **copied to each of your standard (IMAP/SMTP) accounts**, so they keep working exactly as before.
+- **If you use *only* Microsoft 365 accounts**, any old "All accounts" rules are **removed** — those rules run inside QuickMail, and Microsoft 365 accounts are moving to server-side rules instead. If you had such rules, recreate them scoped to the account you want. (This affects very few people; every removal is recorded in the log.)
+- New rules now ask which account they apply to (defaulting to your default account) instead of offering "All accounts". (#333)
+
 ## New: find a contact's mail from the address book
 
 Select someone in the address book, press **Shift+F10**, and choose **Find mail from this contact** or **Find mail to this contact**. The address book closes and the message list fills with the matches, newest first, drawn from every account and folder QuickMail has cached — not just the folder you were in. Focus lands on the message list and the count is announced ("12 messages from Bob Baker."), and the window title reads **Mail from Bob Baker** so the results are easy to tell apart from a folder.


### PR DESCRIPTION
First of two PRs for the per-account Rules Manager (spec #334, approved). **This is the data-touching half, deliberately isolated ahead of the window** so the migration is an easy-to-review, easy-to-revert diff — per your call on #334. No window/UI changes here; that's PR B.

## Migration — `RuleService.LoadRules()`
Implements D1 exactly as specced:
- Each unscoped rule (null `AccountId`) is **duplicated into one rule per non-Graph account**; Graph accounts get none (server rules replace client rules there, and an all-account client rule must not silently run on a Graph mailbox — D2).
- **Copies get fresh `Id`s** — reusing the source id across N copies would break selection and delete-by-id.
- **Graph-only profile: the unscoped rule is dropped**, with a per-rule log line (see release-note callout below).
- **Idempotent by construction** — the migration *is* "eliminate null `AccountId`", so the absence of any unscoped rule is the completion signal; a second run is a no-op. Runs in `LoadRules()` before any consumer sees the list, and persists once via the atomic `SaveRules`, so the file is fully migrated or untouched — never half-duplicated.
- Wired via an **optional `IAccountService`** on `RuleService` (supplied in `App.xaml.cs`; absent in unit tests that don't exercise migration, so existing call sites are unchanged).

## `RulesManagerViewModel`
- **"All accounts" removed** from `AccountOptions` — a user can no longer create a new unscoped rule, which would reintroduce the null the migration just eliminated.
- New rules **default to the first account**.

`ApplyRulesAsync`'s null-`AccountId` handling is intentionally left intact as defense in depth: the migration removes null from persisted data, but matching still treats a stray null as all-accounts rather than crashing.

## ⚠️ Release-notes callout required before the release that ships this
Per the spec, the Graph-only drop must be called out. It runs at startup the moment this merges (it's not behind the feature gate), so it needs to land in that version's notes. Suggested wording — tell me which version file to add it to, or I'll add it wherever you prefer:

> **Mail rules are now per-account.** The "All accounts" rule option has been replaced by scoping each rule to a specific account. Existing "all accounts" rules are automatically copied to each of your standard (IMAP/SMTP) accounts. **If you use *only* Microsoft 365 accounts**, any old "all accounts" rules are removed, because those rules run inside QuickMail and Microsoft 365 accounts use server-side rules instead — recreate them per account, or as server rules, if needed.

## Why this is safe
- **IMAP users are untouched** — their rules duplicate cleanly per account.
- **The destructive path (drop) hits only a Microsoft-only profile carrying legacy all-account *client* rules** — effectively nil, since Exchange only went default-on two days ago. Every drop is logged.

## Tests
- **+9 migration tests** (`RuleMigrationTests`): duplication per non-Graph account with fresh ids, Graph excluded, Graph-only drop, already-scoped untouched, idempotency across two loads, disk persistence, the no-account-service path, and mixed scoped/unscoped.
- Updated two `RulesManagerViewModelTests` for the retired "All accounts" option.
- **92 rule-related tests green.** Full suite **1577 passed**; the lone failure is the known `OpenClipboard Failed` clipboard flake, which passes in isolation.

## Next
PR B — the window: per-account selector, combined server+client list with "runs where" markers and group headings, the modeless conversion (your sign-off), the modeless editor, F6 ring, command palette, and `App.xaml.cs` DI wiring for `IServerRuleService`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
