### PR TITLE
Server rules: full editing, account picker, and classifier foundation in the Rules Manager (#333)

### DIFF
--- a/QuickMail.Tests/GraphServerRuleServiceTests.cs
+++ b/QuickMail.Tests/GraphServerRuleServiceTests.cs
@@ -422,20 +422,30 @@ public class GraphServerRuleServiceTests
     }
 
     [Fact]
-    public async Task Reorder_AssignsSequentialPositions()
+    public async Task Reorder_PatchesOnlyChangedRules_LeavingUntouchedRulesAlone()
     {
-        var handler = new RecordingHandler(Json("{}"), Json("{}"), Json("{}"));
+        // Rules a=1, b=2, c=3. Swap the first two → [b, a, c]. Only b and a change position;
+        // c keeps sequence 3 and must NOT be PATCHed. This is what stops a server-protected rule
+        // elsewhere in the list (which 400s on any PATCH) from poisoning an unrelated move.
+        var a = new ServerRuleModel { Id = "a", Sequence = 1 };
+        var b = new ServerRuleModel { Id = "b", Sequence = 2 };
+        var c = new ServerRuleModel { Id = "c", Sequence = 3 };
+        var handler = new RecordingHandler(Json("{}"), Json("{}"));
 
-        await Service(handler).ReorderAsync(_accountId, ["c", "a", "b"]);
+        await Service(handler).ReorderAsync(_accountId, new[] { b, a, c });
 
-        Assert.Equal(3, handler.Urls.Count);
+        Assert.Equal(2, handler.Urls.Count);
         Assert.All(handler.Methods, m => Assert.Equal("PATCH", m));
-        Assert.EndsWith("/messageRules/c", handler.Urls[0]);
+        Assert.EndsWith("/messageRules/b", handler.Urls[0]);
         Assert.Contains("\"sequence\":1", handler.Bodies[0]!);
         Assert.EndsWith("/messageRules/a", handler.Urls[1]);
         Assert.Contains("\"sequence\":2", handler.Bodies[1]!);
-        Assert.EndsWith("/messageRules/b", handler.Urls[2]);
-        Assert.Contains("\"sequence\":3", handler.Bodies[2]!);
+        Assert.DoesNotContain(handler.Urls, u => u.EndsWith("/messageRules/c"));
+
+        // Local models reflect the sequence values the server was told.
+        Assert.Equal(1, b.Sequence);
+        Assert.Equal(2, a.Sequence);
+        Assert.Equal(3, c.Sequence);
     }
 
     [Fact]

--- a/QuickMail.Tests/GraphServerRuleServiceTests.cs
+++ b/QuickMail.Tests/GraphServerRuleServiceTests.cs
@@ -134,14 +134,65 @@ public class GraphServerRuleServiceTests
         var handler = new RecordingHandler(Json(Collection(
             """
             { "id": "r1", "displayName": "Complex", "sequence": 1, "isEnabled": true,
-              "conditions": { "subjectContains": ["x"], "bodyContains": ["secret"] },
+              "conditions": { "subjectContains": ["x"], "headerContains": ["X-Spam"] },
               "actions": { "markAsRead": true } }
             """)));
 
         var rule = (await Service(handler).ListAsync(_accountId)).Single();
 
         Assert.False(rule.IsFullyEditable);
-        Assert.Contains("body contains", rule.UnsupportedFields);
+        Assert.Contains("header contains", rule.UnsupportedFields);
+    }
+
+    [Fact]
+    public async Task List_BodyContainsAndSentToAddresses_AreEditable_AndRoundTrip()
+    {
+        // #333: these two conditions were added to the supported subset (they cover every rule that
+        // was previously flagged on a real O365 mailbox). Read them, and prove Create writes them
+        // back so an edit can't drop them.
+        var handler = new RecordingHandler(
+            Json(Collection(
+                """
+                { "id": "r1", "displayName": "Boards", "sequence": 1, "isEnabled": true,
+                  "conditions": { "subjectContains": ["Agenda"], "bodyContains": ["PTAC"],
+                                  "sentToAddresses": [ { "emailAddress": { "address": "board@contoso.com" } } ] },
+                  "actions": { "moveToFolder": "F", "stopProcessingRules": true } }
+                """)),
+            Json("""{ "id": "new", "displayName": "Boards" }"""));
+        var svc = Service(handler);
+
+        var rule = (await svc.ListAsync(_accountId)).Single();
+        Assert.True(rule.IsFullyEditable);                       // no longer flagged
+        Assert.Empty(rule.UnsupportedFields);
+        Assert.Equal("PTAC", rule.BodyContains);
+        Assert.Equal("board@contoso.com", Assert.Single(rule.SentToAddresses));
+
+        await svc.CreateAsync(_accountId, rule);
+        var body = handler.Bodies.Last()!;
+        Assert.Contains("bodyContains", body);
+        Assert.Contains("sentToAddresses", body);
+        Assert.Contains("board@contoso.com", body);
+    }
+
+    [Fact]
+    public async Task List_CopyToFolder_IsEditable_AndRoundTrips()
+    {
+        var handler = new RecordingHandler(
+            Json(Collection(
+                """
+                { "id": "r1", "displayName": "Archive copy", "sequence": 1, "isEnabled": true,
+                  "conditions": { "subjectContains": ["x"] },
+                  "actions": { "copyToFolder": "FolderZ" } }
+                """)),
+            Json("""{ "id": "new" }"""));
+        var svc = Service(handler);
+
+        var rule = (await svc.ListAsync(_accountId)).Single();
+        Assert.True(rule.IsFullyEditable);
+        Assert.Equal("FolderZ", rule.CopyToFolderId);
+
+        await svc.CreateAsync(_accountId, rule);
+        Assert.Contains("copyToFolder", handler.Bodies.Last()!);
     }
 
     [Fact]
@@ -163,6 +214,7 @@ public class GraphServerRuleServiceTests
     [Theory]
     [InlineData("subjectContains")]
     [InlineData("senderContains")]
+    [InlineData("bodyContains")]
     [InlineData("bodyOrSubjectContains")]
     public async Task List_MultiValueStringPredicate_IsViewOnly(string predicate)
     {
@@ -442,6 +494,16 @@ public class GraphServerRuleServiceTests
         Assert.Contains("subject contains 'digest'", text);
         Assert.Contains("move to Archive", text);
         Assert.DoesNotContain("ServerRuleModel", text);  // never the type name
+    }
+
+    [Fact]
+    public void ToString_MarksNotEditableRules_SoTheListRowAnnouncesIt()
+    {
+        var editable = new ServerRuleModel { DisplayName = "Simple", SubjectContains = "x", MarkAsRead = true };
+        var notEditable = new ServerRuleModel { DisplayName = "Complex", IsFullyEditable = false, UnsupportedFields = ["body contains"] };
+
+        Assert.DoesNotContain("not editable", editable.ToString(), StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("not editable in QuickMail", notEditable.ToString(), StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/QuickMail.Tests/ServerRulesViewModelTests.cs
+++ b/QuickMail.Tests/ServerRulesViewModelTests.cs
@@ -317,6 +317,36 @@ public class ServerRulesViewModelTests
     }
 
     [Fact]
+    public async Task Refresh_ResolvesMoveAndCopyFolderNames_FromCachedFolders()
+    {
+        var rule = new ServerRuleModel
+        {
+            Id = "r1", DisplayName = "Filer",
+            MoveToFolderId = "graph-id-move",
+            CopyToFolderId = "graph-id-copy",
+            SubjectContains = "x",
+        };
+        var svc = new FakeServerRuleService { Stored = [rule] };
+        var folders = new Dictionary<Guid, List<MailFolderModel>>
+        {
+            [_accountId] =
+            [
+                new MailFolderModel { FullName = "graph-id-move", DisplayName = "Archive" },
+                new MailFolderModel { FullName = "graph-id-copy", DisplayName = "Backups" },
+            ],
+        };
+        var vm = new ServerRulesViewModel(svc, [GraphAccount()], folders);
+
+        await vm.RefreshCommand.ExecuteAsync(null);
+
+        var loaded = vm.Rules.Single();
+        Assert.Equal("Archive", loaded.MoveToFolderName);
+        Assert.Equal("Backups", loaded.CopyToFolderName);
+        Assert.Contains("move to Archive", loaded.OneLineSummary());
+        Assert.Contains("copy to Backups", loaded.OneLineSummary());
+    }
+
+    [Fact]
     public void HasGraphAccount_FalseWithoutAGraphAccount()
     {
         var imap = new AccountModel { Id = Guid.NewGuid(), BackendKind = BackendKind.ImapSmtp, Username = "u@e.com" };

--- a/QuickMail.Tests/ServerRulesViewModelTests.cs
+++ b/QuickMail.Tests/ServerRulesViewModelTests.cs
@@ -62,10 +62,10 @@ public class ServerRulesViewModelTests
             return Task.CompletedTask;
         }
 
-        public Task ReorderAsync(Guid accountId, IReadOnlyList<string> ruleIdsInOrder, CancellationToken ct = default)
+        public Task ReorderAsync(Guid accountId, IReadOnlyList<ServerRuleModel> rulesInOrder, CancellationToken ct = default)
         {
             Calls.Add("reorder");
-            LastReorder = ruleIdsInOrder;
+            LastReorder = rulesInOrder.Select(r => r.Id).ToList();
             if (ThrowOnWrite is not null) throw ThrowOnWrite;
             return Task.CompletedTask;
         }
@@ -88,6 +88,21 @@ public class ServerRulesViewModelTests
 
     private ServerRulesViewModel Vm(FakeServerRuleService svc, params AccountModel[] accounts)
         => new(svc, accounts.Length > 0 ? accounts : [GraphAccount()]);
+
+    [Fact]
+    public void Ctor_DefaultsToPreferredAccount_WhenProvided()
+    {
+        var first = new AccountModel { Id = Guid.NewGuid(), BackendKind = BackendKind.MicrosoftGraph, Username = "a@x.com", AccountName = "A" };
+        var second = new AccountModel { Id = Guid.NewGuid(), BackendKind = BackendKind.MicrosoftGraph, Username = "b@x.com", AccountName = "B" };
+
+        // Opening from the second account's inbox should land on the second account, not the first.
+        var vm = new ServerRulesViewModel(new FakeServerRuleService(), [first, second], null, second.Id);
+        Assert.Equal(second.Id, vm.SelectedAccount?.Id);
+
+        // No current-account context (e.g. an aggregate view) → fall back to the first account.
+        var fallback = new ServerRulesViewModel(new FakeServerRuleService(), [first, second], null, null);
+        Assert.Equal(first.Id, fallback.SelectedAccount?.Id);
+    }
 
     private static ServerRuleModel Rule(string id, string name, bool enabled = true,
         bool editable = true, bool readOnly = false) => new()
@@ -162,19 +177,32 @@ public class ServerRulesViewModelTests
     }
 
     [Fact]
-    public async Task EditRule_OnNonEditableRule_DoesNotOpenEditor_AndExplainsWhy()
+    public async Task EditRule_OnNonEditableRule_IsDisabled_AndDoesNotOpenEditor()
     {
         var svc = new FakeServerRuleService { Stored = [Rule("a", "Complex", editable: false)] };
         var vm = Vm(svc);
         await vm.RefreshCommand.ExecuteAsync(null);
 
+        // Edit is disabled (not pressable) for a rule we can't fully represent — the user runs with
+        // announcements off, so a disabled control is clearer than a pressable one that silently fails.
+        Assert.False(vm.EditRuleCommand.CanExecute(null));
+
         var opened = false;
         vm.EditorRequested += _ => opened = true;
-
-        vm.EditRuleCommand.Execute(null);
-
+        vm.EditRuleCommand.Execute(null);   // force-invoke: the defensive guard still blocks it
         Assert.False(opened);
-        Assert.Contains("Outlook", vm.StatusText);
+    }
+
+    [Fact]
+    public async Task ToggleAndDelete_AreDisabled_ForServerReadOnlyRule()
+    {
+        var svc = new FakeServerRuleService { Stored = [Rule("ro", "Protected", readOnly: true)] };
+        var vm = Vm(svc);
+        await vm.RefreshCommand.ExecuteAsync(null);
+
+        Assert.False(vm.ToggleEnabledCommand.CanExecute(null));
+        Assert.False(vm.DeleteRuleCommand.CanExecute(null));
+        Assert.False(vm.EditRuleCommand.CanExecute(null));
     }
 
     [Fact]
@@ -209,6 +237,28 @@ public class ServerRulesViewModelTests
         Assert.Equal(string.Empty, editor.Name);
     }
 
+    [Fact]
+    public async Task CreateRule_OnEmptyAccount_AssignsSequence1_NotZero()
+    {
+        // Graph rejects sequence 0 with MessageRuleValidationError; a new rule must get a 1-based
+        // sequence. On an account with no rules yet, the first new rule is sequence 1.
+        var svc = new FakeServerRuleService();
+        var vm = Vm(svc);
+        await vm.RefreshCommand.ExecuteAsync(null);
+
+        ServerRuleEditorViewModel? editor = null;
+        vm.EditorRequested += e => editor = e;
+        vm.CreateRuleCommand.Execute(null);
+
+        editor!.Name = "First rule";
+        editor.MarkAsRead = true;
+        await editor.SaveCommand.ExecuteAsync(null);
+
+        Assert.Contains("create", svc.Calls);
+        Assert.Single(vm.Rules);
+        Assert.Equal(1, vm.Rules[0].Sequence);
+    }
+
     // ── Toggle / delete / reorder ───────────────────────────────────────────────
 
     [Fact]
@@ -225,26 +275,27 @@ public class ServerRulesViewModelTests
     }
 
     [Fact]
-    public async Task ToggleEnabled_RaisesCollectionChange_SoTheRowTextRefreshes()
+    public async Task ToggleEnabled_UpdatesRowText_InPlace_ViaNotification()
     {
-        // A row's announced text comes from ServerRuleModel.ToString(), which a ListView evaluates
-        // once per container. The model raises no change notification, so without re-assigning the
-        // slot the row would keep announcing "enabled" after the user disabled it.
+        // The row's accessible name is bound to ServerRuleModel.RowText, which change-notifies when
+        // IsEnabled flips. So a toggle re-announces the new state WITHOUT re-inserting the row (which
+        // would disturb a screen reader's focus). Re-assigning the same object into the collection
+        // was a no-op for the WPF generator, which is why the row didn't refresh before.
         var svc = new FakeServerRuleService { Stored = [Rule("a", "Alpha", enabled: true)] };
         var vm = Vm(svc);
         await vm.RefreshCommand.ExecuteAsync(null);
 
-        var replaced = false;
-        vm.Rules.CollectionChanged += (_, e) =>
-        {
-            if (e.Action == System.Collections.Specialized.NotifyCollectionChangedAction.Replace) replaced = true;
-        };
+        var rule = vm.Rules[0];
+        var rowTextChanged = false;
+        rule.PropertyChanged += (_, e) => { if (e.PropertyName == nameof(ServerRuleModel.RowText)) rowTextChanged = true; };
 
         await vm.ToggleEnabledCommand.ExecuteAsync(null);
 
-        Assert.True(replaced);
-        Assert.Contains("disabled", vm.Rules[0].ToString());
-        Assert.Same(vm.Rules[0], vm.SelectedRule);   // selection survives the replace
+        Assert.False(rule.IsEnabled);
+        Assert.True(rowTextChanged);                     // UIA gets the change the screen reader needs
+        Assert.Contains("disabled", rule.RowText);
+        Assert.Same(vm.Rules[0], vm.SelectedRule);       // no re-insert; selection undisturbed
+        Assert.Equal("Enable", vm.ToggleEnabledLabel);   // button now offers the opposite action
     }
 
     [Fact]
@@ -290,6 +341,50 @@ public class ServerRulesViewModelTests
     }
 
     [Fact]
+    public async Task MoveUpDown_AreDisabled_AtTheEnds()
+    {
+        var svc = new FakeServerRuleService { Stored = [Rule("a", "Alpha"), Rule("b", "Beta"), Rule("c", "Gamma")] };
+        var vm = Vm(svc);
+        await vm.RefreshCommand.ExecuteAsync(null);
+
+        // First rule selected: can't move up.
+        Assert.False(vm.CanMoveUp);
+        Assert.True(vm.CanMoveDown);
+        Assert.False(vm.MoveUpCommand.CanExecute(null));
+        Assert.True(vm.MoveDownCommand.CanExecute(null));
+
+        // Last rule selected: can't move down.
+        vm.SelectedRule = vm.Rules[2];
+        Assert.True(vm.CanMoveUp);
+        Assert.False(vm.CanMoveDown);
+        Assert.False(vm.MoveDownCommand.CanExecute(null));
+
+        // Middle: both.
+        vm.SelectedRule = vm.Rules[1];
+        Assert.True(vm.CanMoveUp);
+        Assert.True(vm.CanMoveDown);
+    }
+
+    [Fact]
+    public async Task MoveUpDown_AreDisabled_ForServerReadOnlyRule()
+    {
+        // A read-only rule (e.g. "Delete Pokémon messages") can't be re-sequenced by the API; Move
+        // must be gated like Edit/Delete even when it's in the middle of the list.
+        var svc = new FakeServerRuleService
+        {
+            Stored = [Rule("a", "Alpha"), Rule("ro", "Protected", readOnly: true), Rule("c", "Gamma")],
+        };
+        var vm = Vm(svc);
+        await vm.RefreshCommand.ExecuteAsync(null);
+
+        vm.SelectedRule = vm.Rules[1];   // the read-only rule, mid-list
+        Assert.False(vm.CanMoveUp);
+        Assert.False(vm.CanMoveDown);
+        Assert.False(vm.MoveUpCommand.CanExecute(null));
+        Assert.False(vm.MoveDownCommand.CanExecute(null));
+    }
+
+    [Fact]
     public async Task MoveDown_ReordersAndSendsNewOrder()
     {
         var svc = new FakeServerRuleService { Stored = [Rule("a", "Alpha"), Rule("b", "Beta")] };
@@ -300,7 +395,8 @@ public class ServerRulesViewModelTests
 
         Assert.Equal(["b", "a"], vm.Rules.Select(r => r.Id));
         Assert.Equal(["b", "a"], svc.LastReorder);
-        Assert.Equal([1, 2], vm.Rules.Select(r => r.Sequence));
+        // Sequence-value reassignment is the service's job (verified in GraphServerRuleServiceTests);
+        // the VM only owns the visible order and the service call.
     }
 
     [Fact]
@@ -391,7 +487,7 @@ public class ServerRulesViewModelTests
     }
 
     [Fact]
-    public void Editor_Save_RaisesSavedWithAssembledRule_AndCloses()
+    public async Task Editor_Save_RaisesSavedWithAssembledRule_AndCloses()
     {
         var editor = ServerRuleEditorViewModel.ForNew();
         editor.Name = "  Newsletters  ";
@@ -401,10 +497,10 @@ public class ServerRulesViewModelTests
 
         ServerRuleModel? saved = null;
         var closed = false;
-        editor.Saved += r => saved = r;
+        editor.Saved += r => { saved = r; return Task.FromResult<string?>(null); };   // null = success
         editor.CloseRequested += () => closed = true;
 
-        editor.SaveCommand.Execute(null);
+        await editor.SaveCommand.ExecuteAsync(null);
 
         Assert.NotNull(saved);
         Assert.Equal("Newsletters", saved!.DisplayName);      // trimmed
@@ -412,6 +508,23 @@ public class ServerRulesViewModelTests
         Assert.Equal(["a@b.com", "c@d.com", "e@f.com"], saved.ForwardTo);
         Assert.True(saved.IsFullyEditable);
         Assert.True(closed);
+    }
+
+    [Fact]
+    public async Task Editor_Save_WhenOwnerReportsError_StaysOpen_AndShowsError()
+    {
+        var editor = ServerRuleEditorViewModel.ForNew();
+        editor.Name = "Nope";
+        editor.MarkAsRead = true;
+
+        var closed = false;
+        editor.Saved += _ => Task.FromResult<string?>("Graph rejected the rule.");   // non-null = failure
+        editor.CloseRequested += () => closed = true;
+
+        await editor.SaveCommand.ExecuteAsync(null);
+
+        Assert.False(closed);                                   // editor stays open on failure
+        Assert.Equal("Graph rejected the rule.", editor.SaveError);
     }
 
     [Fact]
@@ -454,6 +567,29 @@ public class ServerRulesViewModelTests
         Assert.Equal("folder-1", result.MoveToFolderId);
         Assert.Equal("folder-2", result.CopyToFolderId);
         Assert.True(result.StopProcessingRules);
+    }
+
+    [Fact]
+    public void Editor_ForNew_LeavesAdvancedCollapsed()
+        => Assert.False(ServerRuleEditorViewModel.ForNew().IsAdvancedExpanded);
+
+    [Fact]
+    public void Editor_ForEdit_ExpandsAdvanced_WhenRuleUsesAnAdvancedField()
+    {
+        // "Sender contains" lives in the Advanced section; editing a rule that uses it must open
+        // Advanced so the populated field isn't hidden.
+        var withAdvanced = ServerRuleEditorViewModel.ForEdit(new ServerRuleModel
+        {
+            Id = "r1", DisplayName = "Alpha", SenderContains = "boss", MarkAsRead = true,
+        });
+        Assert.True(withAdvanced.IsAdvancedExpanded);
+
+        // A rule using only common fields keeps Advanced collapsed.
+        var commonOnly = ServerRuleEditorViewModel.ForEdit(new ServerRuleModel
+        {
+            Id = "r2", DisplayName = "Beta", SubjectContains = "invoice", MarkAsRead = true,
+        });
+        Assert.False(commonOnly.IsAdvancedExpanded);
     }
 
     [Fact]

--- a/QuickMail.Tests/ServerRulesViewModelTests.cs
+++ b/QuickMail.Tests/ServerRulesViewModelTests.cs
@@ -569,6 +569,146 @@ public class ServerRulesViewModelTests
         Assert.True(result.StopProcessingRules);
     }
 
+    // ── Classification: server vs client (spec §20.3) ───────────────────────
+
+    [Fact]
+    public void Classify_SimpleRuleOnGraphAccount_IsServerRule()
+    {
+        var e = ServerRuleEditorViewModel.ForNew();
+        e.Name = "Move digests";
+        e.SubjectContains = "digest";
+        e.MoveToFolder = true; e.MoveToFolderId = "f1";
+
+        var result = e.Classify(accountSupportsServerRules: true);
+
+        Assert.Equal(RuleRunsWhere.Server, result.Kind);
+        Assert.False(result.IsConflict);
+    }
+
+    [Fact]
+    public void Classify_MarkAsUnreadOnGraphAccount_IsClientRule_WithReason()
+    {
+        var e = ServerRuleEditorViewModel.ForNew();
+        e.Name = "Keep unread";
+        e.SubjectContains = "later";
+        e.MarkAsUnread = true;   // the only client-only action today
+
+        var result = e.Classify(accountSupportsServerRules: true);
+
+        Assert.Equal(RuleRunsWhere.Client, result.Kind);
+        Assert.Contains("Mark as unread", result.ClientReason);
+    }
+
+    [Fact]
+    public void Classify_SimpleRuleOnNonGraphAccount_IsClientRule()
+    {
+        var e = ServerRuleEditorViewModel.ForNew();
+        e.Name = "IMAP rule";
+        e.SubjectContains = "news";
+        e.MarkAsRead = true;
+
+        var result = e.Classify(accountSupportsServerRules: false);
+
+        Assert.Equal(RuleRunsWhere.Client, result.Kind);
+        Assert.Contains("server-side", result.ClientReason);
+    }
+
+    [Fact]
+    public void Classify_ClientOnlyActionPlusServerOnlyCondition_IsConflict()
+    {
+        var e = ServerRuleEditorViewModel.ForNew();
+        e.Name = "Impossible";
+        e.MarkAsUnread = true;                 // client-only action
+        e.SelectedImportance = ServerRuleEditorViewModel.ImportanceOptions.First(o => o.Value == "high"); // server-only condition
+
+        var result = e.Classify(accountSupportsServerRules: true);
+
+        Assert.Null(result.Kind);
+        Assert.True(result.IsConflict);
+        Assert.Contains("Mark as unread", result.ConflictError);
+        Assert.Contains("importance", result.ConflictError);
+    }
+
+    [Fact]
+    public void Classify_ServerOnlyActionOnNonGraphAccount_IsConflict()
+    {
+        var e = ServerRuleEditorViewModel.ForNew();
+        e.Name = "Copy on IMAP";
+        e.CopyToFolder = true; e.CopyToFolderId = "f2";   // server-only action, no client equivalent
+
+        var result = e.Classify(accountSupportsServerRules: false);
+
+        Assert.True(result.IsConflict);
+        Assert.Contains("Copy to folder", result.ConflictError);
+    }
+
+    [Fact]
+    public void Classify_MultipleActionsWithoutClientOnly_StaysServer()
+    {
+        // Several actions is fine for a server rule; only a client-only capability forces client.
+        var e = ServerRuleEditorViewModel.ForNew();
+        e.Name = "Multi";
+        e.SubjectContains = "x";
+        e.MarkAsRead = true;
+        e.MoveToFolder = true; e.MoveToFolderId = "f1";
+
+        Assert.Equal(RuleRunsWhere.Server, e.Classify(accountSupportsServerRules: true).Kind);
+    }
+
+    // ── Client-rule conversion (spec §20.4) ─────────────────────────────────
+
+    [Fact]
+    public void ToClientRule_MapsConditionsAndMoveAction()
+    {
+        var accountId = Guid.NewGuid();
+        var e = ServerRuleEditorViewModel.ForNew();
+        e.Name = "  From Bob  ";
+        e.SenderContains = "bob@x.com";
+        e.SubjectContains = "report";
+        e.HasAttachments = true;
+        e.MoveToFolder = true; e.MoveToFolderId = "Inbox/Reports";
+
+        var rule = e.ToClientRule(accountId);
+
+        Assert.Equal("From Bob", rule.Name);   // trimmed
+        Assert.Equal(accountId, rule.AccountId);
+        Assert.True(rule.UseFromCondition);
+        Assert.Equal("bob@x.com", rule.FromContains);
+        Assert.True(rule.UseSubjectCondition);
+        Assert.Equal("report", rule.SubjectContains);
+        Assert.False(rule.UseToCondition);
+        Assert.True(rule.MustHaveAttachments);
+        Assert.Equal(RuleAction.MoveToFolder, rule.Action);
+        Assert.Equal("Inbox/Reports", rule.TargetFolder);
+    }
+
+    [Theory]
+    [InlineData(true, false, false, RuleAction.MarkAsUnread)]
+    [InlineData(false, true, false, RuleAction.Delete)]
+    [InlineData(false, false, true, RuleAction.MarkAsRead)]
+    public void ToClientRule_MapsTheSingleAction(bool unread, bool delete, bool read, RuleAction expected)
+    {
+        var e = ServerRuleEditorViewModel.ForNew();
+        e.Name = "Act";
+        e.SubjectContains = "x";
+        e.MarkAsUnread = unread; e.Delete = delete; e.MarkAsRead = read;
+
+        Assert.Equal(expected, e.ToClientRule(Guid.NewGuid()).Action);
+    }
+
+    [Fact]
+    public void ToClientRule_SingleFromAddress_BecomesFromContains()
+    {
+        var e = ServerRuleEditorViewModel.ForNew();
+        e.Name = "One sender";
+        e.FromAddresses = "alice@x.com";
+        e.MarkAsRead = true;
+
+        var rule = e.ToClientRule(Guid.NewGuid());
+        Assert.True(rule.UseFromCondition);
+        Assert.Equal("alice@x.com", rule.FromContains);
+    }
+
     [Fact]
     public void Editor_ForNew_LeavesAdvancedCollapsed()
         => Assert.False(ServerRuleEditorViewModel.ForNew().IsAdvancedExpanded);

--- a/QuickMail.Tests/ServerRulesViewModelTests.cs
+++ b/QuickMail.Tests/ServerRulesViewModelTests.cs
@@ -415,8 +415,10 @@ public class ServerRulesViewModelTests
     }
 
     [Fact]
-    public void Editor_ForEdit_RoundTripsFields()
+    public void Editor_ForEdit_RoundTripsFields_IncludingBodyContainsSentToAndCopy()
     {
+        // Covers the fields added in #333 (bodyContains, sentToAddresses, copyToFolder) — an edit
+        // must carry them through, not drop them (the §16 data-loss trap).
         var original = new ServerRuleModel
         {
             Id = "r1",
@@ -425,26 +427,44 @@ public class ServerRulesViewModelTests
             IsEnabled = false,
             SenderContains = "boss",
             SubjectContains = "urgent",
+            BodyContains = "invoice",
+            SentToAddresses = ["team@contoso.com", "ops@contoso.com"],
             SentOnlyToMe = true,
             Importance = "high",
             MoveToFolderId = "folder-1",
             MoveToFolderName = "Priority",
+            CopyToFolderId = "folder-2",
+            CopyToFolderName = "Backups",
             StopProcessingRules = true,
             IsFullyEditable = true,
         };
 
-        var editor = ServerRuleEditorViewModel.ForEdit(original);
-        var result = editor.ToModel();
+        var result = ServerRuleEditorViewModel.ForEdit(original).ToModel();
 
         Assert.Equal("r1", result.Id);
         Assert.Equal(3, result.Sequence);
         Assert.Equal("Alpha", result.DisplayName);
         Assert.False(result.IsEnabled);
         Assert.Equal("boss", result.SenderContains);
+        Assert.Equal("urgent", result.SubjectContains);
+        Assert.Equal("invoice", result.BodyContains);
+        Assert.Equal(["team@contoso.com", "ops@contoso.com"], result.SentToAddresses);
         Assert.True(result.SentOnlyToMe);
         Assert.Equal("high", result.Importance);
         Assert.Equal("folder-1", result.MoveToFolderId);
+        Assert.Equal("folder-2", result.CopyToFolderId);
         Assert.True(result.StopProcessingRules);
+    }
+
+    [Fact]
+    public void Editor_CopyToFolderWithoutAFolder_IsInvalid()
+    {
+        var editor = ServerRuleEditorViewModel.ForNew();
+        editor.Name = "Copier";
+        editor.CopyToFolder = true;   // checked, but no folder picked
+
+        Assert.False(editor.Validate());
+        Assert.Contains("folder", editor.FolderError, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/QuickMail.Tests/UnifiedRuleRowTests.cs
+++ b/QuickMail.Tests/UnifiedRuleRowTests.cs
@@ -1,0 +1,63 @@
+using QuickMail.Models;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+public class UnifiedRuleRowTests
+{
+    [Fact]
+    public void ServerRow_ReadsFromServerRule_AndMarksOnServer()
+    {
+        var row = UnifiedRuleRow.ForServer(new ServerRuleModel
+        {
+            DisplayName = "Move digests",
+            IsEnabled = true,
+            SubjectContains = "digest",
+            MoveToFolderId = "f1",
+            MoveToFolderName = "Archive",
+        });
+
+        Assert.Equal(RuleRunsWhere.Server, row.RunsWhere);
+        Assert.Equal("Move digests", row.Name);
+        Assert.True(row.IsEnabled);
+        Assert.Contains("on server", row.RowText);
+        Assert.Contains("enabled", row.RowText);
+        Assert.Contains("Archive", row.RowText);           // from the server summary
+        Assert.Equal(row.RowText, row.ToString());          // screen reader reads ToString()
+    }
+
+    [Fact]
+    public void ClientRow_ReadsFromMailRule_AndMarksInQuickMail()
+    {
+        var row = UnifiedRuleRow.ForClient(new MailRule
+        {
+            Name = "Keep unread",
+            IsEnabled = false,
+            UseSubjectCondition = true,
+            SubjectContains = "later",
+            Action = RuleAction.MarkAsUnread,
+        });
+
+        Assert.Equal(RuleRunsWhere.Client, row.RunsWhere);
+        Assert.Equal("Keep unread", row.Name);
+        Assert.False(row.IsEnabled);
+        Assert.Contains("in QuickMail", row.RowText);
+        Assert.Contains("disabled", row.RowText);
+        Assert.Contains("subject contains 'later'", row.RowText);
+        Assert.Contains("mark as unread", row.RowText);
+    }
+
+    [Fact]
+    public void ClientRow_NoConditions_ReadsAllMessages()
+    {
+        var row = UnifiedRuleRow.ForClient(new MailRule
+        {
+            Name = "Catch-all",
+            Action = RuleAction.MoveToFolder,
+            TargetFolder = "INBOX/Sorted",
+        });
+
+        Assert.Contains("All messages", row.RowText);
+        Assert.Contains("move to INBOX/Sorted", row.RowText);
+    }
+}

--- a/QuickMail.Tests/UnitTest1.cs
+++ b/QuickMail.Tests/UnitTest1.cs
@@ -341,6 +341,18 @@ public class XamlParseTests
     }
 
     [StaFact]
+    public void ServerRuleEditorWindow_XamlParsesWithoutException()
+    {
+        EnsureApplication();
+        var window = new ServerRuleEditorWindow(
+            ServerRuleEditorViewModel.ForNew(),
+            new List<AccountModel>(),
+            new Dictionary<Guid, List<MailFolderModel>>());
+        Assert.NotNull(window);
+        window.Close();
+    }
+
+    [StaFact]
     public void GroupManagerWindow_XamlParsesWithoutException()
     {
         EnsureApplication();

--- a/QuickMail/App.xaml.cs
+++ b/QuickMail/App.xaml.cs
@@ -230,6 +230,9 @@ public partial class App : Application
             var templateService = _templateService;
             // accountService drives the one-time "All accounts" → per-account rule migration (#333 D1).
             var ruleService = new RuleService(mailRouter, localStore, profile.ProfileDir, accountService);
+            // Server-side (Exchange/Graph) Inbox rules — read/manage a Graph account's messageRules.
+            // Reuses the shared GraphClient (no own disposables), so no disposal wiring needed.
+            var serverRuleService = new GraphServerRuleService(accountService, graphBackend.Client);
             var syncService = new SyncService(mailRouter, localStore, configService, ruleService);
 
             // Contact sync (issue #256): Graph source reuses the Graph backend's client; Google source
@@ -295,7 +298,7 @@ public partial class App : Application
             mainVm.RegisterAccountBackend = a => mailRouter.RegisterAccount(a.Id, BackendFor(a));
             mainVm.LoadAccountList(accounts);
 
-            var mainWindow = new MainWindow(mainVm, smtpService, accountService, credentialService, mailRouter, oauthService, commandRegistry, contactService, configService, localStore, viewService, ruleService, templateService, featureGate, flagService, customDictionary, themeService, _bugReportService, _notificationService, contactSyncService, graphCalendarSync);
+            var mainWindow = new MainWindow(mainVm, smtpService, accountService, credentialService, mailRouter, oauthService, commandRegistry, contactService, configService, localStore, viewService, ruleService, templateService, featureGate, flagService, customDictionary, themeService, _bugReportService, _notificationService, contactSyncService, graphCalendarSync, serverRuleService);
 
             // Clicking a new-mail toast brings QuickMail to the foreground and opens the referenced
             // message. OnActivated may fire on a background thread, so marshal to the UI thread first.

--- a/QuickMail/Models/FeatureFlag.cs
+++ b/QuickMail/Models/FeatureFlag.cs
@@ -18,4 +18,13 @@ public enum FeatureFlag
     /// Default: true. Disable in config.ini with GoogleAuth=false under [features].
     /// </summary>
     GoogleAuth,
+
+    /// <summary>
+    /// Shows server-side (Exchange/Graph) Inbox rules in the Rules Manager for Microsoft 365
+    /// accounts (#333). Default: false while the feature is built out — enable at launch with
+    /// --feature ServerRules or in config.ini with ServerRules=true under [features]. Flip the
+    /// default to true via a joint-decision PR once create/edit/delete and the unified per-account
+    /// window are complete.
+    /// </summary>
+    ServerRules,
 }

--- a/QuickMail/Models/ServerRuleModel.cs
+++ b/QuickMail/Models/ServerRuleModel.cs
@@ -38,8 +38,16 @@ public sealed class ServerRuleModel
 
     public string? SenderContains { get; set; }
     public List<string> FromAddresses { get; set; } = [];
+
+    /// <summary>Recipients the message was sent to (Graph <c>sentToAddresses</c>).</summary>
+    public List<string> SentToAddresses { get; set; } = [];
+
     public string? SubjectContains { get; set; }
     public string? BodyOrSubjectContains { get; set; }
+
+    /// <summary>Text matched against the message body (Graph <c>bodyContains</c>).</summary>
+    public string? BodyContains { get; set; }
+
     public bool SentToMe { get; set; }
     public bool SentOnlyToMe { get; set; }
     public bool HasAttachments { get; set; }
@@ -54,6 +62,12 @@ public sealed class ServerRuleModel
 
     /// <summary>Display name for <see cref="MoveToFolderId"/>, resolved for prose. Not sent to Graph.</summary>
     public string? MoveToFolderName { get; set; }
+
+    /// <summary>Graph folder ID for a copy action (copyToFolder).</summary>
+    public string? CopyToFolderId { get; set; }
+
+    /// <summary>Display name for <see cref="CopyToFolderId"/>, resolved for prose. Not sent to Graph.</summary>
+    public string? CopyToFolderName { get; set; }
 
     public bool MarkAsRead { get; set; }
 
@@ -99,6 +113,9 @@ public sealed class ServerRuleModel
         var parts = new List<string> { name, IsEnabled ? "enabled" : "disabled" };
         if (IsReadOnly) parts.Add("read-only");
         if (HasError) parts.Add("error");
+        // Announced per row so a user arrowing the list hears which rules QuickMail can't fully edit
+        // (they use conditions/actions outside the editable subset). Read-only rules already say so.
+        if (!IsFullyEditable && !IsReadOnly) parts.Add("not editable in QuickMail");
 
         var summary = OneLineSummary();
         var head = string.Join(", ", parts);
@@ -125,33 +142,47 @@ public sealed class ServerRuleModel
     public string DetailText()
     {
         var sb = new StringBuilder();
-        sb.Append(string.IsNullOrWhiteSpace(DisplayName) ? "Unnamed rule" : DisplayName);
-        sb.Append(IsEnabled ? " (enabled)" : " (disabled)");
-        sb.AppendLine();
+        var name = string.IsNullOrWhiteSpace(DisplayName) ? "Unnamed rule" : DisplayName;
+        sb.AppendLine($"{name} ({(IsEnabled ? "enabled" : "disabled")})");
 
-        var conditions = DescribeConditions();
-        sb.AppendLine(conditions.Count == 0
-            ? "Applies to: all messages."
-            : "Applies when: " + string.Join("; ", conditions) + ".");
+        // Each condition / action on its own line under a header, so it's easy to read line by line
+        // with a screen reader.
+        AppendSection(sb, "Applies when:", DescribeConditions(), "all messages");
+        AppendSection(sb, "Does:", DescribeActions(), "nothing");
 
-        var actions = DescribeActions();
-        sb.AppendLine(actions.Count == 0
-            ? "Does: nothing."
-            : "Does: " + string.Join("; ", actions) + ".");
-
-        if (IsReadOnly) sb.AppendLine("This rule is read-only on the server and cannot be changed.");
-        if (HasError) sb.AppendLine("This rule is in an error state on the server.");
-
+        var reasons = new List<string>();
+        if (IsReadOnly) reasons.Add("This rule is read-only on the server and cannot be changed.");
+        if (HasError) reasons.Add("This rule is in an error state on the server.");
         if (!IsFullyEditable)
+            reasons.Add(UnsupportedFields.Count > 0
+                ? $"This rule uses conditions or actions QuickMail can't edit yet ({string.Join(", ", UnsupportedFields)}). You can enable, disable, or delete it here, or edit it in Outlook."
+                : "This rule uses conditions or actions QuickMail can't edit yet. You can enable, disable, or delete it here, or edit it in Outlook.");
+
+        if (reasons.Count > 0)
         {
-            sb.Append("This rule uses ");
-            sb.Append(UnsupportedFields.Count > 0
-                ? "conditions or actions QuickMail can't edit yet (" + string.Join(", ", UnsupportedFields) + ")"
-                : "conditions or actions QuickMail can't edit yet");
-            sb.AppendLine(". You can enable, disable, or delete it here, or edit it in Outlook.");
+            sb.AppendLine("Reason for block:");
+            foreach (var r in reasons) sb.AppendLine(r);
         }
 
         return sb.ToString().TrimEnd();
+    }
+
+    /// <summary>
+    /// Appends a titled section with one item per line. Non-empty: the header on its own line, then
+    /// each item on its own line separated by ";" (no trailing ";" on the last). Empty: the header
+    /// and the empty text on one line ("Applies when: all messages").
+    /// </summary>
+    private static void AppendSection(StringBuilder sb, string header, List<string> items, string emptyText)
+    {
+        if (items.Count == 0)
+        {
+            sb.AppendLine($"{header} {emptyText}");
+            return;
+        }
+
+        sb.AppendLine(header);
+        for (var i = 0; i < items.Count; i++)
+            sb.AppendLine(i < items.Count - 1 ? $"{items[i]};" : items[i]);
     }
 
     private List<string> DescribeConditions()
@@ -159,8 +190,10 @@ public sealed class ServerRuleModel
         var c = new List<string>();
         if (!string.IsNullOrWhiteSpace(SenderContains)) c.Add($"sender contains '{SenderContains}'");
         if (FromAddresses.Count > 0) c.Add($"from {string.Join(" or ", FromAddresses)}");
+        if (SentToAddresses.Count > 0) c.Add($"sent to {string.Join(" or ", SentToAddresses)}");
         if (!string.IsNullOrWhiteSpace(SubjectContains)) c.Add($"subject contains '{SubjectContains}'");
         if (!string.IsNullOrWhiteSpace(BodyOrSubjectContains)) c.Add($"subject or body contains '{BodyOrSubjectContains}'");
+        if (!string.IsNullOrWhiteSpace(BodyContains)) c.Add($"body contains '{BodyContains}'");
         if (SentToMe) c.Add("sent to me");
         if (SentOnlyToMe) c.Add("sent only to me");
         if (HasAttachments) c.Add("has attachments");
@@ -173,6 +206,8 @@ public sealed class ServerRuleModel
         var a = new List<string>();
         if (!string.IsNullOrWhiteSpace(MoveToFolderId))
             a.Add($"move to {(string.IsNullOrWhiteSpace(MoveToFolderName) ? "another folder" : MoveToFolderName)}");
+        if (!string.IsNullOrWhiteSpace(CopyToFolderId))
+            a.Add($"copy to {(string.IsNullOrWhiteSpace(CopyToFolderName) ? "another folder" : CopyToFolderName)}");
         if (MarkAsRead) a.Add("mark as read");
         if (!string.IsNullOrWhiteSpace(MarkImportance)) a.Add($"set importance to {MarkImportance}");
         if (Delete) a.Add("move to Deleted Items");

--- a/QuickMail/Models/ServerRuleModel.cs
+++ b/QuickMail/Models/ServerRuleModel.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Text.Json;
+using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace QuickMail.Models;
 
@@ -18,7 +19,7 @@ namespace QuickMail.Models;
 /// in Outlook (spec §16, the central correctness risk).
 /// </para>
 /// </summary>
-public sealed class ServerRuleModel
+public sealed partial class ServerRuleModel : ObservableObject
 {
     public string Id { get; set; } = string.Empty;
     public string DisplayName { get; set; } = string.Empty;
@@ -26,7 +27,18 @@ public sealed class ServerRuleModel
     /// <summary>Execution order on the server. Lower runs first.</summary>
     public int Sequence { get; set; }
 
-    public bool IsEnabled { get; set; } = true;
+    /// <summary>
+    /// Observable so a list row's announced text updates in place when the rule is toggled — without
+    /// re-inserting the item (which would disturb a screen reader's focus). <see cref="RowText"/> is
+    /// what the list binds its accessible name to; notifying it fires the UIA change the reader needs.
+    /// </summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(RowText))]
+    private bool _isEnabled = true;
+
+    /// <summary>The list row's accessible/display text (same as <see cref="ToString"/>), as a
+    /// change-notifying property so a toggle re-announces the new state.</summary>
+    public string RowText => ToString();
 
     /// <summary>Server-set: the rule cannot be modified (edit/delete blocked).</summary>
     public bool IsReadOnly { get; set; }

--- a/QuickMail/Models/UnifiedRuleRow.cs
+++ b/QuickMail/Models/UnifiedRuleRow.cs
@@ -1,0 +1,82 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace QuickMail.Models;
+
+/// <summary>Where a rule executes: on the Microsoft 365 server, or inside QuickMail.</summary>
+public enum RuleRunsWhere { Server, Client }
+
+/// <summary>
+/// One row in the unified per-account rules list (spec §20.7). Wraps exactly one of a server
+/// (<see cref="ServerRuleModel"/>) or client (<see cref="MailRule"/>) rule and presents a single,
+/// consistent accessible line that also states where the rule runs. The list is per-account, so the
+/// row carries no account label.
+/// </summary>
+public sealed class UnifiedRuleRow
+{
+    private UnifiedRuleRow(RuleRunsWhere runsWhere, ServerRuleModel? server, MailRule? client)
+    {
+        RunsWhere = runsWhere;
+        Server = server;
+        Client = client;
+    }
+
+    public static UnifiedRuleRow ForServer(ServerRuleModel rule) => new(RuleRunsWhere.Server, rule, null);
+    public static UnifiedRuleRow ForClient(MailRule rule) => new(RuleRunsWhere.Client, null, rule);
+
+    public RuleRunsWhere RunsWhere { get; }
+
+    /// <summary>The wrapped server rule, or null for a client row.</summary>
+    public ServerRuleModel? Server { get; }
+
+    /// <summary>The wrapped client rule, or null for a server row.</summary>
+    public MailRule? Client { get; }
+
+    public string Name => RunsWhere == RuleRunsWhere.Server ? Server!.DisplayName : Client!.Name;
+
+    public bool IsEnabled => RunsWhere == RuleRunsWhere.Server ? Server!.IsEnabled : Client!.IsEnabled;
+
+    /// <summary>
+    /// The list row's accessible/display text: name, where it runs, enabled state, and a one-line
+    /// summary. A screen reader reads a Selector item's name from <see cref="ToString"/>, so that
+    /// forwards here (see CLAUDE.md).
+    /// </summary>
+    public string RowText
+    {
+        get
+        {
+            var name = string.IsNullOrWhiteSpace(Name) ? "Unnamed rule" : Name;
+            var where = RunsWhere == RuleRunsWhere.Server ? "on server" : "in QuickMail";
+            var state = IsEnabled ? "enabled" : "disabled";
+            var head = $"{name}, {where}, {state}";
+            var summary = RunsWhere == RuleRunsWhere.Server ? Server!.OneLineSummary() : ClientSummary(Client!);
+            return string.IsNullOrEmpty(summary) ? head : $"{head}. {summary}";
+        }
+    }
+
+    public override string ToString() => RowText;
+
+    /// <summary>"If subject contains 'x' → move to Archive" for a client rule — mirrors
+    /// <see cref="ServerRuleModel.OneLineSummary"/> so both kinds read the same way.</summary>
+    private static string ClientSummary(MailRule r)
+    {
+        var conditions = new List<string>();
+        if (r.UseFromCondition && !string.IsNullOrWhiteSpace(r.FromContains)) conditions.Add($"from contains '{r.FromContains}'");
+        if (r.UseToCondition && !string.IsNullOrWhiteSpace(r.ToContains)) conditions.Add($"to contains '{r.ToContains}'");
+        if (r.UseSubjectCondition && !string.IsNullOrWhiteSpace(r.SubjectContains)) conditions.Add($"subject contains '{r.SubjectContains}'");
+        if (r.UseBodyCondition && !string.IsNullOrWhiteSpace(r.BodyContains)) conditions.Add($"body contains '{r.BodyContains}'");
+        if (r.MustHaveAttachments) conditions.Add("has attachments");
+
+        var action = r.Action switch
+        {
+            RuleAction.MarkAsRead => "mark as read",
+            RuleAction.MarkAsUnread => "mark as unread",
+            RuleAction.MoveToFolder => $"move to {(string.IsNullOrWhiteSpace(r.TargetFolder) ? "a folder" : r.TargetFolder)}",
+            RuleAction.Delete => "move to Trash",
+            _ => r.Action.ToString(),
+        };
+
+        var lhs = conditions.Count == 0 ? "All messages" : "If " + string.Join(" and ", conditions);
+        return $"{lhs} → {action}";
+    }
+}

--- a/QuickMail/Services/ConfigFeatureGate.cs
+++ b/QuickMail/Services/ConfigFeatureGate.cs
@@ -17,6 +17,7 @@ public class ConfigFeatureGate : IFeatureGate
     {
         [FeatureFlag.GraphBackend] = true,
         [FeatureFlag.GoogleAuth]   = true,
+        [FeatureFlag.ServerRules]  = false,   // off until server-rule editing + unified window ship (#333)
     };
 
     private readonly Dictionary<string, string> _configFlags;

--- a/QuickMail/Services/Graph/ServerRuleMapper.cs
+++ b/QuickMail/Services/Graph/ServerRuleMapper.cs
@@ -24,14 +24,14 @@ internal static class ServerRuleMapper
     /// <summary>Condition predicates QuickMail can represent and therefore safely rewrite.</summary>
     internal static readonly HashSet<string> SupportedConditions = new(StringComparer.OrdinalIgnoreCase)
     {
-        "senderContains", "fromAddresses", "subjectContains", "bodyOrSubjectContains",
-        "sentToMe", "sentOnlyToMe", "hasAttachments", "importance",
+        "senderContains", "fromAddresses", "sentToAddresses", "subjectContains", "bodyContains",
+        "bodyOrSubjectContains", "sentToMe", "sentOnlyToMe", "hasAttachments", "importance",
     };
 
     /// <summary>Actions QuickMail can represent and therefore safely rewrite.</summary>
     internal static readonly HashSet<string> SupportedActions = new(StringComparer.OrdinalIgnoreCase)
     {
-        "moveToFolder", "markAsRead", "markImportance", "delete", "forwardTo", "stopProcessingRules",
+        "moveToFolder", "copyToFolder", "markAsRead", "markImportance", "delete", "forwardTo", "stopProcessingRules",
     };
 
     /// <summary>
@@ -47,16 +47,14 @@ internal static class ServerRuleMapper
     /// </summary>
     private static readonly HashSet<string> SingleValueStringPredicates = new(StringComparer.OrdinalIgnoreCase)
     {
-        "senderContains", "subjectContains", "bodyOrSubjectContains",
+        "senderContains", "subjectContains", "bodyContains", "bodyOrSubjectContains",
     };
 
     /// <summary>Friendlier labels for the predicates/actions we don't support yet.</summary>
     private static readonly Dictionary<string, string> FriendlyNames = new(StringComparer.OrdinalIgnoreCase)
     {
-        ["bodyContains"] = "body contains",
         ["headerContains"] = "header contains",
         ["recipientContains"] = "recipient contains",
-        ["sentToAddresses"] = "sent to specific addresses",
         ["sentCcMe"] = "sent CC to me",
         ["sentToOrCcMe"] = "sent to or CC me",
         ["notSentToMe"] = "not sent to me",
@@ -75,7 +73,6 @@ internal static class ServerRuleMapper
         ["isApprovalRequest"] = "approval request",
         ["isAutomaticReply"] = "automatic reply",
         ["isNonDeliveryReport"] = "non-delivery report",
-        ["copyToFolder"] = "copy to folder",
         ["forwardAsAttachmentTo"] = "forward as attachment",
         ["redirectTo"] = "redirect to",
         ["assignCategories"] = "assign categories",
@@ -122,8 +119,10 @@ internal static class ServerRuleMapper
                 {
                     case "sendercontains": m.SenderContains = FirstString(p.Value); break;
                     case "subjectcontains": m.SubjectContains = FirstString(p.Value); break;
+                    case "bodycontains": m.BodyContains = FirstString(p.Value); break;
                     case "bodyorsubjectcontains": m.BodyOrSubjectContains = FirstString(p.Value); break;
                     case "fromaddresses": m.FromAddresses = Recipients(p.Value); break;
+                    case "senttoaddresses": m.SentToAddresses = Recipients(p.Value); break;
                     case "senttome": m.SentToMe = p.Value.ValueKind == JsonValueKind.True; break;
                     case "sentonlytome": m.SentOnlyToMe = p.Value.ValueKind == JsonValueKind.True; break;
                     case "hasattachments": m.HasAttachments = p.Value.ValueKind == JsonValueKind.True; break;
@@ -142,6 +141,7 @@ internal static class ServerRuleMapper
                 switch (p.Name.ToLowerInvariant())
                 {
                     case "movetofolder": m.MoveToFolderId = p.Value.GetString(); break;
+                    case "copytofolder": m.CopyToFolderId = p.Value.GetString(); break;
                     case "markasread": m.MarkAsRead = p.Value.ValueKind == JsonValueKind.True; break;
                     case "markimportance": m.MarkImportance = p.Value.GetString(); break;
                     case "delete": m.Delete = p.Value.ValueKind == JsonValueKind.True; break;
@@ -177,8 +177,10 @@ internal static class ServerRuleMapper
         var conditions = new Dictionary<string, object?>();
         if (!string.IsNullOrWhiteSpace(rule.SenderContains)) conditions["senderContains"] = new[] { rule.SenderContains };
         if (!string.IsNullOrWhiteSpace(rule.SubjectContains)) conditions["subjectContains"] = new[] { rule.SubjectContains };
+        if (!string.IsNullOrWhiteSpace(rule.BodyContains)) conditions["bodyContains"] = new[] { rule.BodyContains };
         if (!string.IsNullOrWhiteSpace(rule.BodyOrSubjectContains)) conditions["bodyOrSubjectContains"] = new[] { rule.BodyOrSubjectContains };
         if (rule.FromAddresses.Count > 0) conditions["fromAddresses"] = rule.FromAddresses.Select(ToRecipient).ToArray();
+        if (rule.SentToAddresses.Count > 0) conditions["sentToAddresses"] = rule.SentToAddresses.Select(ToRecipient).ToArray();
         if (rule.SentToMe) conditions["sentToMe"] = true;
         if (rule.SentOnlyToMe) conditions["sentOnlyToMe"] = true;
         if (rule.HasAttachments) conditions["hasAttachments"] = true;
@@ -186,6 +188,7 @@ internal static class ServerRuleMapper
 
         var actions = new Dictionary<string, object?>();
         if (!string.IsNullOrWhiteSpace(rule.MoveToFolderId)) actions["moveToFolder"] = rule.MoveToFolderId;
+        if (!string.IsNullOrWhiteSpace(rule.CopyToFolderId)) actions["copyToFolder"] = rule.CopyToFolderId;
         if (rule.MarkAsRead) actions["markAsRead"] = true;
         if (!string.IsNullOrWhiteSpace(rule.MarkImportance)) actions["markImportance"] = rule.MarkImportance;
         if (rule.Delete) actions["delete"] = true;

--- a/QuickMail/Services/GraphServerRuleService.cs
+++ b/QuickMail/Services/GraphServerRuleService.cs
@@ -50,6 +50,11 @@ public sealed class GraphServerRuleService : IServerRuleService
                         .ToList();
         LogService.Debug($"ServerRules: listed {rules.Count} rule(s) for {account.Username} " +
                          $"({rules.Count(r => !r.IsFullyEditable)} not fully editable)");
+        // Diagnostic (/debug only): name the specific unsupported field(s) per flagged rule so a
+        // gap in the supported subset can be identified. Field NAMES only — not the raw predicate
+        // values, which would put mail subjects/addresses in the log.
+        foreach (var r in rules.Where(x => !x.IsFullyEditable))
+            LogService.Debug($"ServerRules: not-editable '{r.DisplayName}' unsupported=[{string.Join(", ", r.UnsupportedFields)}]");
         return rules;
     }
 

--- a/QuickMail/Services/GraphServerRuleService.cs
+++ b/QuickMail/Services/GraphServerRuleService.cs
@@ -55,6 +55,14 @@ public sealed class GraphServerRuleService : IServerRuleService
         // values, which would put mail subjects/addresses in the log.
         foreach (var r in rules.Where(x => !x.IsFullyEditable))
             LogService.Debug($"ServerRules: not-editable '{r.DisplayName}' unsupported=[{string.Join(", ", r.UnsupportedFields)}]");
+        var disabled = rules.Where(r => !r.IsEnabled).Select(r => r.DisplayName).ToList();
+        if (disabled.Count > 0)
+            LogService.Debug($"ServerRules: disabled rules: {string.Join("; ", disabled)}");
+        // Server read-only rules are the ones the API refuses to move/edit/delete
+        // (ErrorNotSupportedMessageRule). Name them so a reorder/edit failure is easy to trace back.
+        var readOnly = rules.Where(r => r.IsReadOnly).Select(r => r.DisplayName).ToList();
+        if (readOnly.Count > 0)
+            LogService.Debug($"ServerRules: read-only rules: {string.Join("; ", readOnly)}");
         return rules;
     }
 
@@ -101,28 +109,37 @@ public sealed class GraphServerRuleService : IServerRuleService
         LogService.Log($"ServerRules: {(enabled ? "enabled" : "disabled")} rule {ruleId} for {account.Username}");
     }
 
-    public async Task ReorderAsync(Guid accountId, IReadOnlyList<string> ruleIdsInOrder, CancellationToken ct = default)
+    public async Task ReorderAsync(Guid accountId, IReadOnlyList<ServerRuleModel> rulesInOrder, CancellationToken ct = default)
     {
         var account = Account(accountId);
 
-        // Sequence is 1-based on the server; assign positions in the given order. Only `sequence` is
-        // sent, so the rest of each rule is untouched.
+        // Reassign which rule holds which sequence value, in the new order — WITHOUT renumbering the
+        // whole list. We keep the existing set of server sequence values and only PATCH the rules
+        // whose value actually changes. This is critical: a mailbox commonly contains a rule the
+        // server refuses to modify ("ErrorNotSupportedMessageRule"). A full 1..N re-sequence PATCHes
+        // every rule and 400s the moment it reaches that one — poisoning an otherwise valid move of
+        // an unrelated rule. By touching only the rules whose position changed (two, for a single
+        // Move up/down), a protected rule elsewhere is never sent a PATCH.
         //
-        // NOT ATOMIC, and it can't be: Graph exposes no batch/transactional reorder, so this is N
-        // sequential PATCHes. A failure partway leaves the server partially reordered, and duplicate
-        // sequence values exist transiently mid-loop (Graph tolerates this — it resolves ordering on
-        // read). The caller rolls back its LOCAL order on failure, which does not undo PATCHes
-        // already applied server-side; the next refresh shows the server's true order. Accepted for
-        // v1: the blast radius is rule ordering, not rule content.
-        for (var i = 0; i < ruleIdsInOrder.Count; i++)
+        // Still not atomic (Graph has no batch reorder) and a transient duplicate sequence can exist
+        // mid-loop — Graph tolerates that and resolves ordering on read. If a PATCH fails, the caller
+        // rolls back its LOCAL order; the next refresh reflects the server's true state.
+        var sortedSequences = rulesInOrder.Select(r => r.Sequence).OrderBy(s => s).ToList();
+        var patched = 0;
+        for (var i = 0; i < rulesInOrder.Count; i++)
         {
             ct.ThrowIfCancellationRequested();
-            var body = new Dictionary<string, object?> { ["sequence"] = i + 1 };
-            var id = ruleIdsInOrder[i];
-            await GuardAsync(() => _client.PatchAsync(account, $"{RulesPath}/{Uri.EscapeDataString(id)}", body, ct));
+            var rule = rulesInOrder[i];
+            var target = sortedSequences[i];
+            if (rule.Sequence == target) continue;   // unchanged position → don't touch this rule
+
+            var body = new Dictionary<string, object?> { ["sequence"] = target };
+            await GuardAsync(() => _client.PatchAsync(account, $"{RulesPath}/{Uri.EscapeDataString(rule.Id)}", body, ct));
+            rule.Sequence = target;   // keep the local model in sync with what the server was told
+            patched++;
         }
 
-        LogService.Log($"ServerRules: reordered {ruleIdsInOrder.Count} rule(s) for {account.Username}");
+        LogService.Log($"ServerRules: reordered {rulesInOrder.Count} rule(s), {patched} PATCHed, for {account.Username}");
     }
 
     public async Task DeleteAsync(Guid accountId, string ruleId, CancellationToken ct = default)

--- a/QuickMail/Services/IServerRuleService.cs
+++ b/QuickMail/Services/IServerRuleService.cs
@@ -38,8 +38,12 @@ public interface IServerRuleService
     /// <summary>Enables or disables a rule. Safe even for rules outside the editable subset.</summary>
     Task SetEnabledAsync(Guid accountId, string ruleId, bool enabled, CancellationToken ct = default);
 
-    /// <summary>Rewrites execution order; the given ids are assigned sequences 1..n in order.</summary>
-    Task ReorderAsync(Guid accountId, IReadOnlyList<string> ruleIdsInOrder, CancellationToken ct = default);
+    /// <summary>
+    /// Applies the given rule order by reassigning the existing server sequence values in that order,
+    /// PATCHing only the rules whose sequence actually changes (so a server-protected rule elsewhere
+    /// in the list is never touched). Each model carries its current <see cref="ServerRuleModel.Sequence"/>.
+    /// </summary>
+    Task ReorderAsync(Guid accountId, IReadOnlyList<ServerRuleModel> rulesInOrder, CancellationToken ct = default);
 
     Task DeleteAsync(Guid accountId, string ruleId, CancellationToken ct = default);
 }

--- a/QuickMail/ViewModels/ServerRuleEditorViewModel.cs
+++ b/QuickMail/ViewModels/ServerRuleEditorViewModel.cs
@@ -59,8 +59,10 @@ public partial class ServerRuleEditorViewModel : ObservableObject
 
             SenderContains = rule.SenderContains ?? string.Empty,
             FromAddresses = string.Join(", ", rule.FromAddresses),
+            SentToAddresses = string.Join(", ", rule.SentToAddresses),
             SubjectContains = rule.SubjectContains ?? string.Empty,
             BodyOrSubjectContains = rule.BodyOrSubjectContains ?? string.Empty,
+            BodyContains = rule.BodyContains ?? string.Empty,
             SentToMe = rule.SentToMe,
             SentOnlyToMe = rule.SentOnlyToMe,
             HasAttachments = rule.HasAttachments,
@@ -68,6 +70,9 @@ public partial class ServerRuleEditorViewModel : ObservableObject
             MoveToFolder = !string.IsNullOrWhiteSpace(rule.MoveToFolderId),
             MoveToFolderId = rule.MoveToFolderId,
             MoveToFolderName = rule.MoveToFolderName,
+            CopyToFolder = !string.IsNullOrWhiteSpace(rule.CopyToFolderId),
+            CopyToFolderId = rule.CopyToFolderId,
+            CopyToFolderName = rule.CopyToFolderName,
             MarkAsRead = rule.MarkAsRead,
             Delete = rule.Delete,
             ForwardTo = string.Join(", ", rule.ForwardTo),
@@ -89,8 +94,10 @@ public partial class ServerRuleEditorViewModel : ObservableObject
     // Conditions
     [ObservableProperty] private string _senderContains = string.Empty;
     [ObservableProperty] private string _fromAddresses = string.Empty;
+    [ObservableProperty] private string _sentToAddresses = string.Empty;
     [ObservableProperty] private string _subjectContains = string.Empty;
     [ObservableProperty] private string _bodyOrSubjectContains = string.Empty;
+    [ObservableProperty] private string _bodyContains = string.Empty;
     [ObservableProperty] private bool _sentToMe;
     [ObservableProperty] private bool _sentOnlyToMe;
     [ObservableProperty] private bool _hasAttachments;
@@ -102,6 +109,11 @@ public partial class ServerRuleEditorViewModel : ObservableObject
     private bool _moveToFolder;
     [ObservableProperty] private string? _moveToFolderId;
     [ObservableProperty] private string? _moveToFolderName;
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsCopyToFolderSelected))]
+    private bool _copyToFolder;
+    [ObservableProperty] private string? _copyToFolderId;
+    [ObservableProperty] private string? _copyToFolderName;
     [ObservableProperty] private bool _markAsRead;
     [ObservableProperty] private ImportanceOption _selectedMarkImportance = ImportanceOptions[0];
     [ObservableProperty] private bool _delete;
@@ -109,6 +121,7 @@ public partial class ServerRuleEditorViewModel : ObservableObject
     [ObservableProperty] private bool _stopProcessingRules;
 
     public bool IsMoveToFolderSelected => MoveToFolder;
+    public bool IsCopyToFolderSelected => CopyToFolder;
 
     // Validation surfaces
     [ObservableProperty] private string _nameError = string.Empty;
@@ -137,6 +150,16 @@ public partial class ServerRuleEditorViewModel : ObservableObject
     }
 
     [RelayCommand]
+    private void PickCopyFolder()
+    {
+        if (PickFolderRequested?.Invoke() is not { } picked) return;
+        CopyToFolderId = picked.Id;
+        CopyToFolderName = picked.Name;
+        CopyToFolder = true;
+        FolderError = string.Empty;
+    }
+
+    [RelayCommand]
     private void Save()
     {
         if (!Validate()) return;
@@ -158,8 +181,10 @@ public partial class ServerRuleEditorViewModel : ObservableObject
 
         SenderContains = Blank(SenderContains),
         FromAddresses = SplitAddresses(FromAddresses),
+        SentToAddresses = SplitAddresses(SentToAddresses),
         SubjectContains = Blank(SubjectContains),
         BodyOrSubjectContains = Blank(BodyOrSubjectContains),
+        BodyContains = Blank(BodyContains),
         SentToMe = SentToMe,
         SentOnlyToMe = SentOnlyToMe,
         HasAttachments = HasAttachments,
@@ -167,6 +192,8 @@ public partial class ServerRuleEditorViewModel : ObservableObject
 
         MoveToFolderId = MoveToFolder ? MoveToFolderId : null,
         MoveToFolderName = MoveToFolder ? MoveToFolderName : null,
+        CopyToFolderId = CopyToFolder ? CopyToFolderId : null,
+        CopyToFolderName = CopyToFolder ? CopyToFolderName : null,
         MarkAsRead = MarkAsRead,
         MarkImportance = SelectedMarkImportance?.Value,
         Delete = Delete,
@@ -198,6 +225,12 @@ public partial class ServerRuleEditorViewModel : ObservableObject
             valid = false;
         }
 
+        if (CopyToFolder && string.IsNullOrWhiteSpace(CopyToFolderId))
+        {
+            FolderError = "Choose a folder for the Copy to folder action.";
+            valid = false;
+        }
+
         if (!HasAnyAction())
         {
             ActionsError = "Choose at least one action.";
@@ -215,6 +248,7 @@ public partial class ServerRuleEditorViewModel : ObservableObject
 
     private bool HasAnyAction()
         => (MoveToFolder && !string.IsNullOrWhiteSpace(MoveToFolderId))
+           || (CopyToFolder && !string.IsNullOrWhiteSpace(CopyToFolderId))
            || MarkAsRead
            || Delete
            || StopProcessingRules

--- a/QuickMail/ViewModels/ServerRuleEditorViewModel.cs
+++ b/QuickMail/ViewModels/ServerRuleEditorViewModel.cs
@@ -32,8 +32,12 @@ public partial class ServerRuleEditorViewModel : ObservableObject
     /// <summary>Ask the View to open the folder picker; returns the chosen folder id (or null).</summary>
     public event Func<(string Id, string Name)?>? PickFolderRequested;
 
-    /// <summary>Raised on a successful Save with the assembled rule. The owner persists it.</summary>
-    public event Action<ServerRuleModel>? Saved;
+    /// <summary>
+    /// Raised on Save with the assembled rule; the owner persists it and returns an error message on
+    /// failure (null on success). The editor stays open and shows the error when non-null, so a
+    /// rejected save never silently loses the form.
+    /// </summary>
+    public event Func<ServerRuleModel, Task<string?>>? Saved;
 
     /// <summary>Raised when the editor window should close (Save or Cancel).</summary>
     public event Action? CloseRequested;
@@ -83,6 +87,9 @@ public partial class ServerRuleEditorViewModel : ObservableObject
             string.Equals(o.Value, rule.Importance, StringComparison.OrdinalIgnoreCase)) ?? ImportanceOptions[0];
         vm.SelectedMarkImportance = ImportanceOptions.FirstOrDefault(o =>
             string.Equals(o.Value, rule.MarkImportance, StringComparison.OrdinalIgnoreCase)) ?? ImportanceOptions[0];
+        // If the rule already uses any advanced field, open the Advanced section so editing never
+        // hides a populated field. A brand-new rule leaves it collapsed.
+        vm.IsAdvancedExpanded = vm.HasAdvancedContent();
         return vm;
     }
 
@@ -90,6 +97,12 @@ public partial class ServerRuleEditorViewModel : ObservableObject
 
     [ObservableProperty] private string _name = string.Empty;
     [ObservableProperty] private bool _isEnabled = true;
+
+    /// <summary>
+    /// Whether the Advanced conditions/actions section is expanded. Collapsed for a new rule; opened
+    /// automatically when editing a rule that already uses an advanced field (see <see cref="ForEdit"/>).
+    /// </summary>
+    [ObservableProperty] private bool _isAdvancedExpanded;
 
     // Conditions
     [ObservableProperty] private string _senderContains = string.Empty;
@@ -127,6 +140,8 @@ public partial class ServerRuleEditorViewModel : ObservableObject
     [ObservableProperty] private string _nameError = string.Empty;
     [ObservableProperty] private string _folderError = string.Empty;
     [ObservableProperty] private string _actionsError = string.Empty;
+    /// <summary>A server-side save failure (e.g. Graph rejected the rule), shown on the form.</summary>
+    [ObservableProperty] private string _saveError = string.Empty;
 
     /// <summary>Importance choices for both the condition and the action ComboBoxes.</summary>
     public static List<ImportanceOption> ImportanceOptions { get; } =
@@ -160,11 +175,22 @@ public partial class ServerRuleEditorViewModel : ObservableObject
     }
 
     [RelayCommand]
-    private void Save()
+    private async Task Save()
     {
         if (!Validate()) return;
-        Saved?.Invoke(ToModel());
-        CloseRequested?.Invoke();
+        SaveError = string.Empty;
+
+        // The owner persists and returns null on success, or an error to display. Close only on
+        // success — a failed save keeps the form (and the user's input) and shows why.
+        var error = Saved is null ? null : await Saved.Invoke(ToModel());
+        if (string.IsNullOrEmpty(error))
+        {
+            CloseRequested?.Invoke();
+            return;
+        }
+
+        SaveError = error;
+        AnnouncementRequested?.Invoke(error, AnnouncementCategory.Result);
     }
 
     [RelayCommand]
@@ -245,6 +271,21 @@ public partial class ServerRuleEditorViewModel : ObservableObject
 
         return valid;
     }
+
+    /// <summary>
+    /// True when any field that lives in the Advanced section is set — used to auto-expand it when
+    /// editing. Keep this list in sync with the Advanced group in ServerRuleEditorWindow.xaml.
+    /// </summary>
+    private bool HasAdvancedContent()
+        => !string.IsNullOrWhiteSpace(SenderContains)
+           || !string.IsNullOrWhiteSpace(SentToAddresses)
+           || !string.IsNullOrWhiteSpace(BodyOrSubjectContains)
+           || !string.IsNullOrWhiteSpace(BodyContains)
+           || SentToMe || SentOnlyToMe || HasAttachments
+           || !string.IsNullOrWhiteSpace(SelectedImportance?.Value)
+           || CopyToFolder
+           || !string.IsNullOrWhiteSpace(SelectedMarkImportance?.Value)
+           || !string.IsNullOrWhiteSpace(ForwardTo);
 
     private bool HasAnyAction()
         => (MoveToFolder && !string.IsNullOrWhiteSpace(MoveToFolderId))

--- a/QuickMail/ViewModels/ServerRuleEditorViewModel.cs
+++ b/QuickMail/ViewModels/ServerRuleEditorViewModel.cs
@@ -128,6 +128,8 @@ public partial class ServerRuleEditorViewModel : ObservableObject
     [ObservableProperty] private string? _copyToFolderId;
     [ObservableProperty] private string? _copyToFolderName;
     [ObservableProperty] private bool _markAsRead;
+    /// <summary>Client-only action — Microsoft 365 server rules have no "mark as unread" (spec §20.2).</summary>
+    [ObservableProperty] private bool _markAsUnread;
     [ObservableProperty] private ImportanceOption _selectedMarkImportance = ImportanceOptions[0];
     [ObservableProperty] private bool _delete;
     [ObservableProperty] private string _forwardTo = string.Empty;
@@ -234,6 +236,49 @@ public partial class ServerRuleEditorViewModel : ObservableObject
         RawExceptions = _rawExceptions,
     };
 
+    /// <summary>
+    /// Assembles a client-side <see cref="MailRule"/> from the client-representable subset of the
+    /// form (spec §20.4). Only valid when <see cref="IsClientRepresentable"/> holds — the caller
+    /// guarantees a single From/To value and exactly one action, so the mapping is lossless. The
+    /// client engine treats a condition as active only when its flag is set AND it has a value, so
+    /// empty conditions are simply switched off.
+    /// </summary>
+    public MailRule ToClientRule(Guid accountId)
+    {
+        var fromAddrs = SplitAddresses(FromAddresses);
+        var from = !string.IsNullOrWhiteSpace(SenderContains) ? SenderContains.Trim()
+                 : fromAddrs.Count == 1 ? fromAddrs[0]
+                 : null;
+        var to = SplitAddresses(SentToAddresses) is { Count: 1 } toList ? toList[0] : null;
+        var subject = Blank(SubjectContains);
+        var body = Blank(BodyContains);
+
+        return new MailRule
+        {
+            Name = Name.Trim(),
+            IsEnabled = IsEnabled,
+            AccountId = accountId,
+
+            UseFromCondition = from is not null, FromContains = from,
+            UseToCondition = to is not null, ToContains = to,
+            UseSubjectCondition = subject is not null, SubjectContains = subject,
+            UseBodyCondition = body is not null, BodyContains = body,
+            MustHaveAttachments = HasAttachments,
+
+            Action = ClientAction(),
+            TargetFolder = MoveToFolder ? MoveToFolderId : null,
+        };
+    }
+
+    /// <summary>The single client action in use (IsClientRepresentable guarantees exactly one).</summary>
+    private RuleAction ClientAction()
+    {
+        if (MoveToFolder) return RuleAction.MoveToFolder;
+        if (Delete) return RuleAction.Delete;
+        if (MarkAsUnread) return RuleAction.MarkAsUnread;
+        return RuleAction.MarkAsRead;
+    }
+
     public bool Validate()
     {
         NameError = FolderError = ActionsError = string.Empty;
@@ -272,6 +317,104 @@ public partial class ServerRuleEditorViewModel : ObservableObject
         return valid;
     }
 
+    // ── Classification: server vs client (spec §20.3) ───────────────────────
+
+    /// <summary>
+    /// Decides where the rule runs. A Graph account gets a server rule unless the rule uses a
+    /// client-only capability; otherwise (or on a non-Graph account) it's a client rule, with a
+    /// reason for the save dialog. A rule that fits neither — a client-only action combined with a
+    /// server-only condition/action — is a conflict the user must resolve. Assumes the rule already
+    /// passed <see cref="Validate"/> (so it has at least one action).
+    /// </summary>
+    public RuleClassification Classify(bool accountSupportsServerRules)
+    {
+        if (accountSupportsServerRules && IsServerRepresentable)
+            return new RuleClassification { Kind = RuleRunsWhere.Server };
+
+        if (IsClientRepresentable)
+        {
+            var reason = accountSupportsServerRules
+                ? $"it uses {Join(ClientOnlyFeaturesUsed())}, which Microsoft 365 server rules don't support"
+                : "this account doesn't support server-side rules";
+            return new RuleClassification { Kind = RuleRunsWhere.Client, ClientReason = reason };
+        }
+
+        // Representable by neither: a client-only action combined with a server-only condition/action,
+        // or a server-only feature on a non-Graph account.
+        var serverOnly = ServerOnlyFeaturesUsed();
+        var clientOnly = ClientOnlyFeaturesUsed();
+        var conflict = accountSupportsServerRules && clientOnly.Count > 0
+            ? $"{Join(clientOnly)} only works in a QuickMail rule, but {Join(serverOnly)} only works in a server rule. Remove one to save."
+            : $"This account only supports QuickMail rules, but {Join(serverOnly)} isn't available in a QuickMail rule. Remove it to save.";
+        return new RuleClassification { ConflictError = conflict };
+    }
+
+    /// <summary>True when the rule uses no client-only capability, so the server can express it.</summary>
+    public bool IsServerRepresentable => ClientOnlyFeaturesUsed().Count == 0;
+
+    /// <summary>
+    /// True when every condition and action fits the client rule model (a near-subset of the server
+    /// model): no server-only condition/action, single From/To value, exactly one action.
+    /// </summary>
+    public bool IsClientRepresentable
+        => ServerOnlyFeaturesUsed().Count == 0 && ClientEligibleActionCount() == 1;
+
+    /// <summary>Client-only capabilities in use — the server has no equivalent (spec §20.2). Extend
+    /// as more client-only options are added (play sound, notify, …).</summary>
+    private List<string> ClientOnlyFeaturesUsed()
+    {
+        var f = new List<string>();
+        if (MarkAsUnread) f.Add("Mark as unread");
+        return f;
+    }
+
+    /// <summary>
+    /// Features only a server rule can express, so any of them blocks representing the rule as a
+    /// client rule: conditions with no client equivalent, the client's single-value From/To limits,
+    /// server-only actions, and the client's one-action limit.
+    /// </summary>
+    private List<string> ServerOnlyFeaturesUsed()
+    {
+        var f = new List<string>();
+
+        // Conditions with no client equivalent.
+        if (!string.IsNullOrWhiteSpace(BodyOrSubjectContains)) f.Add("the subject-or-body condition");
+        if (SentToMe) f.Add("the “sent to me” condition");
+        if (SentOnlyToMe) f.Add("the “sent only to me” condition");
+        if (SelectedImportance?.Value is not null) f.Add("the importance condition");
+
+        // A client rule has a single From and a single To field.
+        var fromAddrs = SplitAddresses(FromAddresses);
+        if (fromAddrs.Count > 1) f.Add("multiple From addresses");
+        if (!string.IsNullOrWhiteSpace(SenderContains) && fromAddrs.Count > 0)
+            f.Add("both Sender-contains and From-addresses");
+        if (SplitAddresses(SentToAddresses).Count > 1) f.Add("multiple Sent-to addresses");
+
+        // Actions with no client equivalent.
+        if (CopyToFolder) f.Add("Copy to folder");
+        if (SelectedMarkImportance?.Value is not null) f.Add("Set importance");
+        if (SplitAddresses(ForwardTo).Count > 0) f.Add("Forward");
+        if (StopProcessingRules) f.Add("Stop processing more rules");
+
+        // A client rule performs exactly one action.
+        if (ClientEligibleActionCount() > 1) f.Add("more than one action");
+
+        return f;
+    }
+
+    /// <summary>Count of actions that a client rule could carry (it allows exactly one).</summary>
+    private int ClientEligibleActionCount()
+    {
+        var n = 0;
+        if (MarkAsRead) n++;
+        if (MarkAsUnread) n++;
+        if (MoveToFolder) n++;
+        if (Delete) n++;
+        return n;
+    }
+
+    private static string Join(List<string> items) => string.Join(", ", items);
+
     /// <summary>
     /// True when any field that lives in the Advanced section is set — used to auto-expand it when
     /// editing. Keep this list in sync with the Advanced group in ServerRuleEditorWindow.xaml.
@@ -291,6 +434,7 @@ public partial class ServerRuleEditorViewModel : ObservableObject
         => (MoveToFolder && !string.IsNullOrWhiteSpace(MoveToFolderId))
            || (CopyToFolder && !string.IsNullOrWhiteSpace(CopyToFolderId))
            || MarkAsRead
+           || MarkAsUnread
            || Delete
            || StopProcessingRules
            || !string.IsNullOrWhiteSpace(SelectedMarkImportance?.Value)
@@ -305,6 +449,22 @@ public partial class ServerRuleEditorViewModel : ObservableObject
             : text.Split([',', ';'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
                   .Where(s => s.Length > 0)
                   .ToList();
+}
+
+/// <summary>Where a rule executes: on the Microsoft 365 server, or inside QuickMail.</summary>
+public enum RuleRunsWhere { Server, Client }
+
+/// <summary>
+/// Result of classifying a rule (spec §20.3). Exactly one of these holds: <see cref="Kind"/> is
+/// Server; <see cref="Kind"/> is Client with a <see cref="ClientReason"/> for the save dialog; or
+/// <see cref="ConflictError"/> is set (the rule fits neither and must be changed before saving).
+/// </summary>
+public sealed record RuleClassification
+{
+    public RuleRunsWhere? Kind { get; init; }
+    public string? ClientReason { get; init; }
+    public string? ConflictError { get; init; }
+    public bool IsConflict => ConflictError is not null;
 }
 
 /// <summary>

--- a/QuickMail/ViewModels/ServerRuleEditorViewModel.cs
+++ b/QuickMail/ViewModels/ServerRuleEditorViewModel.cs
@@ -451,9 +451,6 @@ public partial class ServerRuleEditorViewModel : ObservableObject
                   .ToList();
 }
 
-/// <summary>Where a rule executes: on the Microsoft 365 server, or inside QuickMail.</summary>
-public enum RuleRunsWhere { Server, Client }
-
 /// <summary>
 /// Result of classifying a rule (spec §20.3). Exactly one of these holds: <see cref="Kind"/> is
 /// Server; <see cref="Kind"/> is Client with a <see cref="ClientReason"/> for the save dialog; or

--- a/QuickMail/ViewModels/ServerRulesViewModel.cs
+++ b/QuickMail/ViewModels/ServerRulesViewModel.cs
@@ -41,9 +41,15 @@ public partial class ServerRulesViewModel : ObservableObject
 
     // ── Construction ────────────────────────────────────────────────────────
 
-    public ServerRulesViewModel(IServerRuleService service, IEnumerable<AccountModel> graphAccounts)
+    private readonly IReadOnlyDictionary<Guid, List<MailFolderModel>>? _foldersByAccount;
+
+    public ServerRulesViewModel(
+        IServerRuleService service,
+        IEnumerable<AccountModel> graphAccounts,
+        IReadOnlyDictionary<Guid, List<MailFolderModel>>? foldersByAccount = null)
     {
         _service = service;
+        _foldersByAccount = foldersByAccount;
 
         AccountOptions = graphAccounts
             .Where(a => a.BackendKind == BackendKind.MicrosoftGraph)
@@ -51,6 +57,23 @@ public partial class ServerRulesViewModel : ObservableObject
             .ToList();
 
         _selectedAccount = AccountOptions.FirstOrDefault();
+    }
+
+    /// <summary>
+    /// Fills in the display names for a rule's move/copy target folders. Graph rules carry only the
+    /// opaque folder ID; the cached folder list maps that ID (stored as <c>FullName</c>) to a
+    /// readable name. Best-effort — a target not in the cached set (e.g. a rarely-synced subfolder)
+    /// falls back to "another folder".
+    /// </summary>
+    private void ResolveFolderNames(ServerRuleModel rule)
+    {
+        if (SelectedAccount?.Id is not Guid accountId) return;
+        if (_foldersByAccount is null || !_foldersByAccount.TryGetValue(accountId, out var folders)) return;
+
+        if (!string.IsNullOrWhiteSpace(rule.MoveToFolderId))
+            rule.MoveToFolderName = folders.FirstOrDefault(f => f.FullName == rule.MoveToFolderId)?.DisplayName;
+        if (!string.IsNullOrWhiteSpace(rule.CopyToFolderId))
+            rule.CopyToFolderName = folders.FirstOrDefault(f => f.FullName == rule.CopyToFolderId)?.DisplayName;
     }
 
     // ── State ───────────────────────────────────────────────────────────────
@@ -112,14 +135,22 @@ public partial class ServerRulesViewModel : ObservableObject
 
             var previouslySelected = SelectedRule?.Id;
             Rules.Clear();
-            foreach (var r in rules) Rules.Add(r);
+            foreach (var r in rules)
+            {
+                ResolveFolderNames(r);
+                Rules.Add(r);
+            }
 
             SelectedRule = Rules.FirstOrDefault(r => r.Id == previouslySelected) ?? Rules.FirstOrDefault();
 
             var disabled = Rules.Count(r => !r.IsEnabled);
+            var notEditable = Rules.Count(r => !r.IsFullyEditable);
             StatusText = Rules.Count == 0
                 ? "No server rules."
-                : $"{Rules.Count} rule{(Rules.Count == 1 ? "" : "s")}" + (disabled > 0 ? $", {disabled} disabled." : ".");
+                : $"{Rules.Count} rule{(Rules.Count == 1 ? "" : "s")}"
+                  + (disabled > 0 ? $", {disabled} disabled" : "")
+                  + (notEditable > 0 ? $", {notEditable} not editable in QuickMail" : "")
+                  + ".";
             Announce(StatusText, AnnouncementCategory.Status);
         }
         catch (ServerRuleConsentRequiredException ex)

--- a/QuickMail/ViewModels/ServerRulesViewModel.cs
+++ b/QuickMail/ViewModels/ServerRulesViewModel.cs
@@ -39,6 +39,13 @@ public partial class ServerRulesViewModel : ObservableObject
     /// <summary>The View should open the rule editor (modeless) for this prepared editor VM.</summary>
     public event Action<ServerRuleEditorViewModel>? EditorRequested;
 
+    /// <summary>
+    /// After an action that changed a rule in place (toggle, move, delete), the View should return
+    /// keyboard focus to the selected rule in the list — so the user isn't stranded on a button, and
+    /// (for toggle) the screen reader re-announces the updated row when focus lands back on it.
+    /// </summary>
+    public event Action? FocusSelectedRuleRequested;
+
     // ── Construction ────────────────────────────────────────────────────────
 
     private readonly IReadOnlyDictionary<Guid, List<MailFolderModel>>? _foldersByAccount;
@@ -46,7 +53,8 @@ public partial class ServerRulesViewModel : ObservableObject
     public ServerRulesViewModel(
         IServerRuleService service,
         IEnumerable<AccountModel> graphAccounts,
-        IReadOnlyDictionary<Guid, List<MailFolderModel>>? foldersByAccount = null)
+        IReadOnlyDictionary<Guid, List<MailFolderModel>>? foldersByAccount = null,
+        Guid? preferredAccountId = null)
     {
         _service = service;
         _foldersByAccount = foldersByAccount;
@@ -56,7 +64,12 @@ public partial class ServerRulesViewModel : ObservableObject
             .Select(a => new AccountOption { Id = a.Id, DisplayName = a.AccountLabel })
             .ToList();
 
-        _selectedAccount = AccountOptions.FirstOrDefault();
+        // Land on the account the user is currently in (the inbox they opened the Rules Manager from)
+        // rather than always the first Graph account — otherwise opening from the Guest inbox would
+        // show icanbrew's rules. Falls back to the first account when there's no current-account
+        // context (e.g. an aggregate/unified view at the top of the tree).
+        _selectedAccount = AccountOptions.FirstOrDefault(o => o.Id == preferredAccountId)
+                           ?? AccountOptions.FirstOrDefault();
     }
 
     /// <summary>
@@ -93,7 +106,23 @@ public partial class ServerRulesViewModel : ObservableObject
     [NotifyPropertyChangedFor(nameof(CanEditSelected))]
     [NotifyPropertyChangedFor(nameof(CanModifySelected))]
     [NotifyPropertyChangedFor(nameof(DetailText))]
+    [NotifyPropertyChangedFor(nameof(ToggleEnabledLabel))]
+    [NotifyCanExecuteChangedFor(nameof(MoveUpCommand))]
+    [NotifyCanExecuteChangedFor(nameof(MoveDownCommand))]
+    [NotifyCanExecuteChangedFor(nameof(EditRuleCommand))]
+    [NotifyCanExecuteChangedFor(nameof(ToggleEnabledCommand))]
+    [NotifyCanExecuteChangedFor(nameof(DeleteRuleCommand))]
     private ServerRuleModel? _selectedRule;
+
+    /// <summary>Enable/Disable button text: "Enable" for a disabled rule, "Disable" for an enabled one.</summary>
+    public string ToggleEnabledLabel => SelectedRule?.IsEnabled == true ? "Disable" : "Enable";
+
+    /// <summary>Move Up is invalid for the first rule, a server read-only rule, or none selected.
+    /// A read-only rule can't be re-sequenced (Graph refuses the PATCH), so gate it like Edit/Delete.</summary>
+    public bool CanMoveUp => SelectedRule is { IsReadOnly: false } r && Rules.IndexOf(r) > 0;
+
+    /// <summary>Move Down is invalid for the last rule, a server read-only rule, or none selected.</summary>
+    public bool CanMoveDown => SelectedRule is { IsReadOnly: false } r && Rules.IndexOf(r) is var i && i >= 0 && i < Rules.Count - 1;
 
     [ObservableProperty] private AccountOption? _selectedAccount;
     [ObservableProperty] private string _statusText = string.Empty;
@@ -104,16 +133,20 @@ public partial class ServerRulesViewModel : ObservableObject
     /// represent — saving those would replace the server's richer object with our narrower one and
     /// silently drop the user's other predicates (spec §16).
     /// <para>
-    /// <b>Deliberately NOT wired to the commands' <c>CanExecute</c>.</b> A disabled control is
-    /// announced only as unavailable, which tells a screen-reader user nothing about <i>why</i> a
-    /// rule on their own mailbox can't be edited. Instead the commands stay executable and explain
-    /// the reason when invoked (see <see cref="EditRule"/>), which is the accessible behaviour. XAML
-    /// may still bind visual affordances to this property.
+    /// Wired to <c>EditRuleCommand.CanExecute</c> so the Edit button and context-menu item are
+    /// <b>disabled</b> for these rules. (Tim's call, 2026-07-25, reversing the earlier
+    /// keep-enabled-and-explain design: he runs with announcements off, so an explain-on-invoke is
+    /// inaudible — a pressable item that silently fails is worse than a disabled one. The list row
+    /// already states "read-only" / "not editable in QuickMail", so the reason is still conveyed.)
     /// </para>
     /// </summary>
     public bool CanEditSelected => SelectedRule is { IsFullyEditable: true, IsReadOnly: false };
 
-    /// <summary>Toggle/reorder/delete only need the rule to be writable, not fully representable.</summary>
+    /// <summary>
+    /// Toggle/reorder/delete only need the rule to be writable, not fully representable. Wired to
+    /// those commands' <c>CanExecute</c> so they're disabled for read-only rules (see
+    /// <see cref="CanEditSelected"/> for the rationale).
+    /// </summary>
     public bool CanModifySelected => SelectedRule is { IsReadOnly: false };
 
     /// <summary>Full prose for the detail region, including parts QuickMail can't edit.</summary>
@@ -176,61 +209,53 @@ public partial class ServerRulesViewModel : ObservableObject
         if (SelectedAccount?.Id is not Guid accountId) return;
 
         var editor = ServerRuleEditorViewModel.ForNew();
-        editor.Saved += async rule => await SaveNewAsync(accountId, rule);
+        editor.Saved += rule => SaveNewAsync(accountId, rule);
         EditorRequested?.Invoke(editor);
     }
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(CanEditSelected))]
     private void EditRule()
     {
         if (SelectedAccount?.Id is not Guid accountId) return;
         if (SelectedRule is not { } rule) return;
-
-        if (!CanEditSelected)
-        {
-            var why = rule.IsReadOnly
-                ? "This rule is read-only on the server and can't be changed here."
-                : "This rule uses conditions or actions QuickMail can't edit yet. You can enable, disable, or delete it here, or edit it in Outlook.";
-            StatusText = why;
-            Announce(why, AnnouncementCategory.Hint);
-            return;
-        }
+        if (!CanEditSelected) return;   // defensive; the command is disabled for these rules
 
         var editor = ServerRuleEditorViewModel.ForEdit(rule);
-        editor.Saved += async updated => await SaveExistingAsync(accountId, updated);
+        editor.Saved += updated => SaveExistingAsync(accountId, updated);
         EditorRequested?.Invoke(editor);
     }
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(CanModifySelected))]
     private async Task ToggleEnabledAsync(CancellationToken ct)
     {
         if (SelectedAccount?.Id is not Guid accountId) return;
         if (SelectedRule is not { } rule) return;
-        if (!CanModifySelected) return;
+        if (!CanModifySelected) return;   // defensive; the command is disabled for read-only rules
 
         var target = !rule.IsEnabled;
         await RunWriteAsync(async () =>
         {
             await _service.SetEnabledAsync(accountId, rule.Id, target, ct);
-            rule.IsEnabled = target;
-            RefreshRow(rule);
+            rule.IsEnabled = target;                   // observable → the row's RowText updates in place
             OnPropertyChanged(nameof(DetailText));
+            OnPropertyChanged(nameof(ToggleEnabledLabel));
             Announce(target ? "Rule enabled." : "Rule disabled.", AnnouncementCategory.Result);
+            // Focus returns to the row (so the new state is read) via RunWriteAsync's finally.
         });
     }
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(CanMoveUp))]
     private Task MoveUpAsync(CancellationToken ct) => MoveAsync(-1, ct);
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(CanMoveDown))]
     private Task MoveDownAsync(CancellationToken ct) => MoveAsync(+1, ct);
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(CanModifySelected))]
     private async Task DeleteRuleAsync(CancellationToken ct)
     {
         if (SelectedAccount?.Id is not Guid accountId) return;
         if (SelectedRule is not { } rule) return;
-        if (!CanModifySelected) return;
+        if (!CanModifySelected) return;   // defensive; the command is disabled for read-only rules
 
         var confirmed = ConfirmDeleteRequested?.Invoke(
             $"Delete server rule '{rule.DisplayName}'? It will stop running on the server.",
@@ -247,33 +272,11 @@ public partial class ServerRulesViewModel : ObservableObject
             SelectedRule = Rules.Count == 0 ? null : Rules[Math.Min(index, Rules.Count - 1)];
 
             Announce("Rule deleted.", AnnouncementCategory.Result);
+            // Focus moves to the newly-selected neighbour via RunWriteAsync's finally.
         });
     }
 
     // ── Internals ───────────────────────────────────────────────────────────
-
-    /// <summary>
-    /// Forces the list row to re-render after the rule was mutated in place.
-    /// <para>
-    /// A row's displayed <i>and announced</i> text comes from <see cref="ServerRuleModel.ToString()"/>,
-    /// which a <c>ListView</c> evaluates when it realises the container. <see cref="ServerRuleModel"/>
-    /// is a plain model (like <see cref="MailRule"/>) and raises no change notification, so mutating
-    /// <c>IsEnabled</c> alone would leave the row still reading "enabled" after the user disabled it.
-    /// Re-assigning the slot raises a Replace notification, which regenerates that one container.
-    /// </para>
-    /// <para>
-    /// Chosen over making the model observable because <c>ToString()</c> composes several properties;
-    /// per-property notification would not cause WPF to re-evaluate it anyway.
-    /// </para>
-    /// </summary>
-    private void RefreshRow(ServerRuleModel rule)
-    {
-        var index = Rules.IndexOf(rule);
-        if (index < 0) return;
-
-        Rules[index] = rule;
-        SelectedRule = rule;   // Replace clears selection; put it back so focus doesn't jump
-    }
 
     private async Task MoveAsync(int delta, CancellationToken ct)
     {
@@ -289,30 +292,46 @@ public partial class ServerRulesViewModel : ObservableObject
 
         await RunWriteAsync(async () =>
         {
-            await _service.ReorderAsync(accountId, Rules.Select(r => r.Id).ToList(), ct);
-
-            // Keep local sequence numbers consistent with what the server was just told.
-            for (var i = 0; i < Rules.Count; i++) Rules[i].Sequence = i + 1;
+            // Pass the models (each carries its current server Sequence). The service reassigns only
+            // the changed sequence values, so a server-protected rule elsewhere isn't PATCHed and
+            // can't 400 this move.
+            await _service.ReorderAsync(accountId, Rules.ToList(), ct);
 
             Announce($"Moved {(delta < 0 ? "up" : "down")}. Now {to + 1} of {Rules.Count}.",
                 AnnouncementCategory.Status);
+            // The rule's position changed → Move Up/Down availability may have flipped (now at an end).
+            MoveUpCommand.NotifyCanExecuteChanged();
+            MoveDownCommand.NotifyCanExecuteChanged();
+            OnPropertyChanged(nameof(CanMoveUp));
+            OnPropertyChanged(nameof(CanMoveDown));
+            // Focus follows the rule to its new position via RunWriteAsync's finally.
         }, onFailure: () => Rules.Move(to, from));   // put it back if the server refused
     }
 
-    private async Task SaveNewAsync(Guid accountId, ServerRuleModel rule)
+    /// <summary>Persists a new rule. Returns null on success, or an error message for the editor.</summary>
+    private async Task<string?> SaveNewAsync(Guid accountId, ServerRuleModel rule)
     {
-        await RunWriteAsync(async () =>
+        // Graph rejects sequence 0 (must be 1-based); a new rule goes to the end of the list.
+        rule.Sequence = Rules.Count + 1;
+
+        // focusSelectedAfter:false — the editor is still open during the write; don't pull focus to
+        // the list. On success we focus the new rule *after* the editor closes (below).
+        var error = await RunWriteAsync(async () =>
         {
             var created = await _service.CreateAsync(accountId, rule);
             Rules.Add(created);
             SelectedRule = created;
             Announce("Rule created.", AnnouncementCategory.Result);
-        });
+        }, focusSelectedAfter: false);
+
+        if (error is null) FocusSelectedRuleRequested?.Invoke();   // land on the new rule once the editor closes
+        return error;
     }
 
-    private async Task SaveExistingAsync(Guid accountId, ServerRuleModel rule)
+    /// <summary>Persists an edited rule. Returns null on success, or an error message for the editor.</summary>
+    private async Task<string?> SaveExistingAsync(Guid accountId, ServerRuleModel rule)
     {
-        await RunWriteAsync(async () =>
+        var error = await RunWriteAsync(async () =>
         {
             await _service.UpdateAsync(accountId, rule);
 
@@ -321,35 +340,55 @@ public partial class ServerRulesViewModel : ObservableObject
             SelectedRule = rule;
 
             Announce("Rule updated.", AnnouncementCategory.Result);
-        });
+        }, focusSelectedAfter: false);
+
+        if (error is null) FocusSelectedRuleRequested?.Invoke();
+        return error;
     }
 
     /// <summary>
     /// Runs a write, translating a permission refusal into the admin-directed path and never
-    /// swallowing other failures into a silent no-op.
+    /// swallowing other failures into a silent no-op. Returns null on success, or a user-facing
+    /// error message (which the editor shows when the write came from a Save).
     /// </summary>
-    private async Task RunWriteAsync(Func<Task> write, Action? onFailure = null)
+    /// <param name="focusSelectedAfter">
+    /// When true (the in-list actions: toggle/move/delete), focus returns to the selected rule so the
+    /// user isn't stranded on a button. Save paths pass false — the editor is still open during the
+    /// write and manages its own focus (staying on the error, or focusing the list after it closes).
+    /// </param>
+    private async Task<string?> RunWriteAsync(Func<Task> write, Action? onFailure = null, bool focusSelectedAfter = true)
     {
         IsBusy = true;
         try
         {
             await write();
+            return null;
         }
         catch (ServerRuleConsentRequiredException ex)
         {
             onFailure?.Invoke();
             HandlePermissionRefusal(ex);
+            return StatusText;
         }
         catch (Exception ex)
         {
             onFailure?.Invoke();
-            StatusText = ex.Message;
+            // Some rules (typically created by Outlook) can't be modified through the Graph API at
+            // all — the server returns ErrorNotSupportedMessageRule. Translate that into a plain,
+            // actionable message instead of surfacing raw HTTP/JSON.
+            StatusText = ex.Message.Contains("ErrorNotSupportedMessageRule", StringComparison.OrdinalIgnoreCase)
+                ? $"'{SelectedRule?.DisplayName}' can't be changed from QuickMail — edit it in Outlook."
+                : ex.Message;
             Announce(StatusText, AnnouncementCategory.Result);
             LogService.Log("ServerRules: write failed", ex);
+            return StatusText;
         }
         finally
         {
             IsBusy = false;
+            // Put keyboard focus back on the selected rule so the user isn't stranded on a button
+            // (and, after a failed move, so arrow keys stay in the list). Suppressed for Save paths.
+            if (focusSelectedAfter && SelectedRule is not null) FocusSelectedRuleRequested?.Invoke();
         }
     }
 

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -3431,7 +3431,13 @@ public partial class MainWindow : Window
     {
         LogService.Debug($"[FOCUS] Activated lastPane={_paneIndexBeforeDeactivation} {FocusInfo()}");
         if (_paneIndexBeforeDeactivation == 3 || _paneIndexBeforeDeactivation == 4)
-            Dispatcher.InvokeAsync(ReturnFocusToMessageList, DispatcherPriority.Input);
+            // Re-check IsActive at callback time: a transient activation (e.g. a modeless child of the
+            // Rules Manager closing and briefly bouncing foreground through here) must NOT pull focus
+            // into this window's message list when another window ends up active. Otherwise this
+            // unconditionally steals focus from the Rules Manager's rule list. (#333)
+            Dispatcher.InvokeAsync(
+                () => { if (IsActive) ReturnFocusToMessageList(); },
+                DispatcherPriority.Input);
     }
 
     // Routes focus to whichever message panel is currently visible.
@@ -5855,7 +5861,11 @@ public partial class MainWindow : Window
         if (_serverRuleService != null
             && _featureGate.IsEnabled(FeatureFlag.ServerRules)
             && accounts.Any(a => a.BackendKind == BackendKind.MicrosoftGraph))
-            serverRulesVm = new ServerRulesViewModel(_serverRuleService, accounts, _vm.CachedFolders);
+            // Seed the picker with the account the user is currently in, so the Rules Manager opens
+            // on that account's rules rather than always the first Graph account (#333). Null on
+            // aggregate views → VM falls back to the first account.
+            serverRulesVm = new ServerRulesViewModel(
+                _serverRuleService, accounts, _vm.CachedFolders, _vm.SelectedAccount?.Id);
 
         var dialog = new RulesManagerWindow(rulesVm, accounts, _vm.CachedFolders, serverRulesVm);
         _rulesWindow = dialog;

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -195,6 +195,7 @@ public partial class MainWindow : Window
     private readonly ILocalStoreService _localStore;
     private readonly IViewService _viewService;
     private readonly IRuleService _ruleService;
+    private readonly IServerRuleService? _serverRuleService;
     private readonly ITemplateService _templateService;
     private readonly IFlagService? _flagService;
     private readonly ICustomDictionaryService? _customDictionary;
@@ -258,7 +259,8 @@ public partial class MainWindow : Window
         IBugReportService? bugReportService = null,
         INotificationService? notificationService = null,
         IContactSyncService? contactSyncService = null,
-        IGraphCalendarSyncService? graphCalendarSyncService = null)
+        IGraphCalendarSyncService? graphCalendarSyncService = null,
+        IServerRuleService? serverRuleService = null)
     {
         _vm = vm;
         _notificationService = notificationService;
@@ -271,6 +273,7 @@ public partial class MainWindow : Window
         _contactService = contactService;
         _contactSyncService = contactSyncService;
         _graphCalendarSyncService = graphCalendarSyncService;
+        _serverRuleService = serverRuleService;
         _configService = configService;
         _localStore = localStore;
         _viewService = viewService;
@@ -5846,7 +5849,13 @@ public partial class MainWindow : Window
         // Manager". Leaving it unowned makes it an independent peer that reads its own title — the
         // same fix compose and standalone message windows use. Unowned windows aren't auto-closed
         // with the main window, so it's tracked in _rulesWindow and closed in OnClosed.
-        var dialog = new RulesManagerWindow(rulesVm, accounts, _vm.CachedFolders);
+        // Read-only server-rules peek (#333): when a Graph account exists, surface its Exchange
+        // messageRules in the Rules Manager so the user can see them. Editing lands in a follow-up.
+        ServerRulesViewModel? serverRulesVm = null;
+        if (_serverRuleService != null && accounts.Any(a => a.BackendKind == BackendKind.MicrosoftGraph))
+            serverRulesVm = new ServerRulesViewModel(_serverRuleService, accounts, _vm.CachedFolders);
+
+        var dialog = new RulesManagerWindow(rulesVm, accounts, _vm.CachedFolders, serverRulesVm);
         _rulesWindow = dialog;
 
         // Modeless (.Show, NOT .ShowDialog). Opening this window modally over MainWindow's

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -5852,7 +5852,9 @@ public partial class MainWindow : Window
         // Read-only server-rules peek (#333): when a Graph account exists, surface its Exchange
         // messageRules in the Rules Manager so the user can see them. Editing lands in a follow-up.
         ServerRulesViewModel? serverRulesVm = null;
-        if (_serverRuleService != null && accounts.Any(a => a.BackendKind == BackendKind.MicrosoftGraph))
+        if (_serverRuleService != null
+            && _featureGate.IsEnabled(FeatureFlag.ServerRules)
+            && accounts.Any(a => a.BackendKind == BackendKind.MicrosoftGraph))
             serverRulesVm = new ServerRulesViewModel(_serverRuleService, accounts, _vm.CachedFolders);
 
         var dialog = new RulesManagerWindow(rulesVm, accounts, _vm.CachedFolders, serverRulesVm);

--- a/QuickMail/Views/RulesManagerWindow.xaml
+++ b/QuickMail/Views/RulesManagerWindow.xaml
@@ -286,14 +286,43 @@
                 Margin="0,10,0,0" Padding="8" BorderThickness="1"
                 BorderBrush="{DynamicResource Theme.Border}">
             <StackPanel>
-                <TextBlock Text="Server rules (run on Microsoft 365, even when QuickMail is closed) — read-only for now"
+                <TextBlock Text="Server rules (run on Microsoft 365, even when QuickMail is closed)"
                            FontWeight="SemiBold" TextWrapping="Wrap" Margin="0,0,0,6"/>
+
+                <!-- Account picker: which Microsoft 365 account's rules are shown/created. Seeded to
+                     the account the user is currently in (see ServerRulesViewModel ctor). Shown only
+                     when there's more than one Graph account (a single account needs no choice). -->
+                <StackPanel x:Name="ServerAccountPicker" Margin="0,0,0,6"
+                            Visibility="{Binding ShowAccountSelector, Converter={StaticResource BoolToVisibilityConverter}}">
+                    <TextBlock Text="Account"/>
+                    <ComboBox x:Name="ServerAccountCombo"
+                              ItemsSource="{Binding AccountOptions}"
+                              SelectedItem="{Binding SelectedAccount}"
+                              Margin="0,2,0,0" AutomationProperties.Name="Account for server rules"/>
+                </StackPanel>
+
                 <!-- Focusable (F6 ring) so a screen-reader user can move to it and re-read the count
                      on demand; IsTabStop=False keeps it out of the Tab order. -->
                 <TextBlock x:Name="ServerRulesStatusText" Text="{Binding StatusText}" Margin="0,0,0,6"
                            Focusable="True" KeyboardNavigation.IsTabStop="False"
                            AutomationProperties.Name="{Binding StatusText}"
                            AutomationProperties.LiveSetting="Polite"/>
+
+                <WrapPanel Orientation="Horizontal" Margin="0,0,0,6">
+                    <Button Content="New" Command="{Binding CreateRuleCommand}"
+                            Height="26" Padding="10,0" Margin="0,0,6,4" AutomationProperties.Name="New server rule"/>
+                    <Button Content="Edit" Command="{Binding EditRuleCommand}"
+                            Height="26" Padding="10,0" Margin="0,0,6,4" AutomationProperties.Name="Edit selected server rule"/>
+                    <Button Content="Delete" Command="{Binding DeleteRuleCommand}"
+                            Height="26" Padding="10,0" Margin="0,0,6,4" AutomationProperties.Name="Delete selected server rule"/>
+                    <Button Content="{Binding ToggleEnabledLabel}" Command="{Binding ToggleEnabledCommand}"
+                            Height="26" Padding="10,0" Margin="0,0,6,4"
+                            AutomationProperties.Name="{Binding ToggleEnabledLabel, StringFormat={}{0} selected server rule}"/>
+                    <Button Content="Move Up" Command="{Binding MoveUpCommand}"
+                            Height="26" Padding="10,0" Margin="0,0,6,4" AutomationProperties.Name="Move selected server rule up"/>
+                    <Button Content="Move Down" Command="{Binding MoveDownCommand}"
+                            Height="26" Padding="10,0" Margin="0,0,0,4" AutomationProperties.Name="Move selected server rule down"/>
+                </WrapPanel>
                 <Grid>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="260"/>
@@ -305,14 +334,30 @@
                              MaxHeight="150"
                              ItemsSource="{Binding Rules}"
                              SelectedItem="{Binding SelectedRule}"
-                             AutomationProperties.Name="Server rules list">
+                             AutomationProperties.Name="Server rules list"
+                             KeyDown="ServerRulesListBox_KeyDown"
+                             VirtualizingPanel.IsVirtualizing="False">
                         <ListBox.ItemContainerStyle>
                             <Style TargetType="ListBoxItem">
                                 <Setter Property="Padding" Value="6,4"/>
-                                <!-- Row announced from ServerRuleModel.ToString() (name, state, where, summary). -->
-                                <Setter Property="AutomationProperties.Name" Value="{Binding}"/>
+                                <!-- Bound to RowText (a change-notifying alias of ToString) so a toggle
+                                     re-announces the new enabled/disabled state without re-inserting the row. -->
+                                <Setter Property="AutomationProperties.Name" Value="{Binding RowText}"/>
                             </Style>
                         </ListBox.ItemContainerStyle>
+                        <ListBox.ContextMenu>
+                            <!-- A ContextMenu lives in its own popup tree, so it doesn't inherit the
+                                 ListBox's DataContext; point it at the ListBox (its PlacementTarget). -->
+                            <ContextMenu DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
+                                <MenuItem Header="New rule" Command="{Binding CreateRuleCommand}"/>
+                                <MenuItem Header="Edit" Command="{Binding EditRuleCommand}"/>
+                                <MenuItem Header="{Binding ToggleEnabledLabel}" Command="{Binding ToggleEnabledCommand}"/>
+                                <MenuItem Header="Move up" Command="{Binding MoveUpCommand}"/>
+                                <MenuItem Header="Move down" Command="{Binding MoveDownCommand}"/>
+                                <Separator/>
+                                <MenuItem Header="Delete" Command="{Binding DeleteRuleCommand}"/>
+                            </ContextMenu>
+                        </ListBox.ContextMenu>
                     </ListBox>
 
                     <!-- Read-only detail for the selected server rule (full prose, incl. any not-editable

--- a/QuickMail/Views/RulesManagerWindow.xaml
+++ b/QuickMail/Views/RulesManagerWindow.xaml
@@ -36,6 +36,7 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
         <Grid Grid.Row="0">
@@ -278,10 +279,62 @@
             </ScrollViewer>
         </Grid>
 
+        <!-- Read-only server-rules peek (#333). Its DataContext is set to a ServerRulesViewModel in
+             code-behind, so bindings here resolve against THAT, not the client-rules VM. Collapsed
+             unless the account has server rules; editing/creating lands in a follow-up. -->
+        <Border x:Name="ServerRulesSection" Grid.Row="1" Visibility="Collapsed"
+                Margin="0,10,0,0" Padding="8" BorderThickness="1"
+                BorderBrush="{DynamicResource Theme.Border}">
+            <StackPanel>
+                <TextBlock Text="Server rules (run on Microsoft 365, even when QuickMail is closed) — read-only for now"
+                           FontWeight="SemiBold" TextWrapping="Wrap" Margin="0,0,0,6"/>
+                <!-- Focusable (F6 ring) so a screen-reader user can move to it and re-read the count
+                     on demand; IsTabStop=False keeps it out of the Tab order. -->
+                <TextBlock x:Name="ServerRulesStatusText" Text="{Binding StatusText}" Margin="0,0,0,6"
+                           Focusable="True" KeyboardNavigation.IsTabStop="False"
+                           AutomationProperties.Name="{Binding StatusText}"
+                           AutomationProperties.LiveSetting="Polite"/>
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="260"/>
+                        <ColumnDefinition Width="10"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+
+                    <ListBox Grid.Column="0" x:Name="ServerRulesListBox"
+                             MaxHeight="150"
+                             ItemsSource="{Binding Rules}"
+                             SelectedItem="{Binding SelectedRule}"
+                             AutomationProperties.Name="Server rules list">
+                        <ListBox.ItemContainerStyle>
+                            <Style TargetType="ListBoxItem">
+                                <Setter Property="Padding" Value="6,4"/>
+                                <!-- Row announced from ServerRuleModel.ToString() (name, state, where, summary). -->
+                                <Setter Property="AutomationProperties.Name" Value="{Binding}"/>
+                            </Style>
+                        </ListBox.ItemContainerStyle>
+                    </ListBox>
+
+                    <!-- Read-only detail for the selected server rule (full prose, incl. any not-editable
+                         note). AcceptsReturn makes it a MULTI-LINE text control so a screen reader can
+                         arrow through every line, not just the first. -->
+                    <TextBox Grid.Column="2" x:Name="ServerRulesDetailBox"
+                             Text="{Binding DetailText, Mode=OneWay}"
+                             IsReadOnly="True" IsReadOnlyCaretVisible="True"
+                             AcceptsReturn="True" TextWrapping="Wrap"
+                             VerticalScrollBarVisibility="Auto" MaxHeight="150"
+                             Background="Transparent" BorderThickness="0"
+                             AutomationProperties.Name="Selected server rule details"/>
+                </Grid>
+            </StackPanel>
+        </Border>
+
         <!-- Status bar -->
-        <StatusBar Grid.Row="1" Margin="0,8,0,0">
+        <StatusBar Grid.Row="2" Margin="0,8,0,0">
             <StatusBarItem>
-                <TextBlock Text="{Binding StatusText}"
+                <TextBlock x:Name="MainStatusText" Text="{Binding StatusText}"
+                           Focusable="True" KeyboardNavigation.IsTabStop="False"
+                           AutomationProperties.Name="{Binding StatusText}"
                            AutomationProperties.LiveSetting="Polite"/>
             </StatusBarItem>
         </StatusBar>

--- a/QuickMail/Views/RulesManagerWindow.xaml.cs
+++ b/QuickMail/Views/RulesManagerWindow.xaml.cs
@@ -6,6 +6,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
 using System.Windows.Input;
+using System.Windows.Media;
 using QuickMail.Models;
 using QuickMail.ViewModels;
 
@@ -27,15 +28,19 @@ public partial class RulesManagerWindow : Window
     private readonly IEnumerable<AccountModel> _accounts;
     private readonly IReadOnlyDictionary<Guid, List<MailFolderModel>> _cachedFolders;
 
+    private readonly ServerRulesViewModel? _serverRulesVm;
+
     public RulesManagerWindow(
         RulesManagerViewModel vm,
         IEnumerable<AccountModel> accounts,
-        IReadOnlyDictionary<Guid, List<MailFolderModel>> cachedFolders)
+        IReadOnlyDictionary<Guid, List<MailFolderModel>> cachedFolders,
+        ServerRulesViewModel? serverRulesVm = null)
     {
         InitializeComponent();
         _vm = vm;
         _accounts = accounts;
         _cachedFolders = cachedFolders;
+        _serverRulesVm = serverRulesVm;
         DataContext = vm;
 
         // Wire VM events
@@ -44,10 +49,78 @@ public partial class RulesManagerWindow : Window
         vm.AnnouncementRequested += OnAnnouncementRequested;
         vm.PickFolderRequested += OnPickFolderRequested;
 
-        // Focus the first rule in the list on open (issue #348). Focusing the ListBox alone does
-        // not reliably move keyboard focus onto an item for some screen readers, so focus the
-        // first item's container directly.
-        Loaded += (_, _) => FocusFirstRule();
+        // Read-only server-rules section (#333): a distinct sub-tree with its own DataContext so its
+        // bindings resolve against the ServerRulesViewModel rather than the client-rules VM. Hidden
+        // entirely when there's no Graph account.
+        if (_serverRulesVm is not null)
+        {
+            ServerRulesSection.DataContext = _serverRulesVm;
+            ServerRulesSection.Visibility = Visibility.Visible;
+            _serverRulesVm.AnnouncementRequested += OnAnnouncementRequested;
+            _serverRulesVm.WriteBlockedByPermission += OnServerRulesPermissionMessage;
+            // Load the account's server rules, THEN decide focus — landing focus on the list that
+            // actually holds the user's rules (they may have only server rules, no client rules).
+            Loaded += async (_, _) =>
+            {
+                await _serverRulesVm.RefreshCommand.ExecuteAsync(null);
+                FocusInitialList();
+            };
+        }
+        else
+        {
+            // No server rules in play: original behaviour — focus the client rule list on open (#348).
+            Loaded += (_, _) => FocusFirstRule();
+        }
+    }
+
+    /// <summary>
+    /// Lands focus on whichever list has content. A Graph account with no client rules would
+    /// otherwise open onto the empty client list and sound empty while the user's (server) rules sit
+    /// in the section below.
+    /// </summary>
+    private void FocusInitialList()
+    {
+        if (RuleListBox.Items.Count > 0 || ServerRulesListBox.Items.Count == 0)
+        {
+            FocusFirstRule();
+            return;
+        }
+
+        ServerRulesListBox.SelectedIndex = 0;
+        ServerRulesListBox.UpdateLayout();
+        if (ServerRulesListBox.ItemContainerGenerator.ContainerFromIndex(0) is ListBoxItem item)
+            item.Focus();
+        else
+            ServerRulesListBox.Focus();
+    }
+
+    private void OnServerRulesPermissionMessage(string message)
+        => AccessibilityHelper.Announce(this, message, category: AnnouncementCategory.Hint);
+
+    /// <summary>Moves keyboard focus to the next (or previous) window pane for F6 / Shift+F6.</summary>
+    private void CyclePane(bool forward)
+    {
+        // Only include panes that are actually present/visible.
+        var stops = new List<UIElement> { RuleListBox };
+        if (_serverRulesVm is not null && ServerRulesSection.Visibility == Visibility.Visible)
+        {
+            stops.Add(ServerRulesListBox);
+            stops.Add(ServerRulesDetailBox);
+            stops.Add(ServerRulesStatusText);
+        }
+        stops.Add(MainStatusText);
+
+        // Find where focus currently sits (walk up from the focused element to a known pane).
+        var current = -1;
+        for (var node = Keyboard.FocusedElement as DependencyObject; node is not null; node = VisualTreeHelper.GetParent(node))
+        {
+            if (node is UIElement el && (current = stops.IndexOf(el)) >= 0) break;
+        }
+
+        var next = current < 0
+            ? 0
+            : (current + (forward ? 1 : stops.Count - 1)) % stops.Count;
+        stops[next].Focus();
     }
 
     private void FocusFirstRule()
@@ -133,6 +206,16 @@ public partial class RulesManagerWindow : Window
         // so the Close button's IsCancel="True" no longer closes it on Escape — wire that
         // explicitly here. Step aside when an open combo dropdown needs Escape to dismiss
         // itself, so we don't steal it (matches ComposeWindow's guard).
+        // F6 / Shift+F6 cycle between the window's panes (New Window Checklist). Stops are the client
+        // rule list, the server-rules list and detail (when shown), and the status line — so a
+        // keyboard/screen-reader user can reach every region, including the status to re-read counts.
+        if (e.Key == Key.F6)
+        {
+            CyclePane(forward: (Keyboard.Modifiers & ModifierKeys.Shift) == 0);
+            e.Handled = true;
+            return;
+        }
+
         if (e.Key == Key.Escape)
         {
             if (AccountScopeCombo.IsDropDownOpen || ActionCombo.IsDropDownOpen)
@@ -149,6 +232,11 @@ public partial class RulesManagerWindow : Window
         _vm.ConfirmDeleteRequested -= OnConfirmDeleteRequested;
         _vm.AnnouncementRequested -= OnAnnouncementRequested;
         _vm.PickFolderRequested -= OnPickFolderRequested;
+        if (_serverRulesVm is not null)
+        {
+            _serverRulesVm.AnnouncementRequested -= OnAnnouncementRequested;
+            _serverRulesVm.WriteBlockedByPermission -= OnServerRulesPermissionMessage;
+        }
         base.OnClosed(e);
     }
 }

--- a/QuickMail/Views/RulesManagerWindow.xaml.cs
+++ b/QuickMail/Views/RulesManagerWindow.xaml.cs
@@ -7,7 +7,9 @@ using System.Windows.Controls;
 using System.Windows.Data;
 using System.Windows.Input;
 using System.Windows.Media;
+using System.Windows.Threading;
 using QuickMail.Models;
+using QuickMail.Services;
 using QuickMail.ViewModels;
 
 namespace QuickMail.Views;
@@ -58,6 +60,9 @@ public partial class RulesManagerWindow : Window
             ServerRulesSection.Visibility = Visibility.Visible;
             _serverRulesVm.AnnouncementRequested += OnAnnouncementRequested;
             _serverRulesVm.WriteBlockedByPermission += OnServerRulesPermissionMessage;
+            _serverRulesVm.EditorRequested += OnServerRuleEditorRequested;
+            _serverRulesVm.ConfirmDeleteRequested += OnServerRuleConfirmDelete;
+            _serverRulesVm.FocusSelectedRuleRequested += OnFocusSelectedServerRule;
             // Load the account's server rules, THEN decide focus — landing focus on the list that
             // actually holds the user's rules (they may have only server rules, no client rules).
             Loaded += async (_, _) =>
@@ -97,6 +102,81 @@ public partial class RulesManagerWindow : Window
     private void OnServerRulesPermissionMessage(string message)
         => AccessibilityHelper.Announce(this, message, category: AnnouncementCategory.Hint);
 
+    // Server-rule create/edit: open the modeless editor. Persistence is already wired by the list VM
+    // (it hooked the editor's Saved event before raising this), so the window only shows the form.
+    // Modeless (not ShowDialog) is deliberate — a modal editor with editable text over the live
+    // WebView2 reading pane is the GrabAddresses freeze scenario (spec §10.4). Activate() foregrounds
+    // it and its Loaded handler focuses the Name field, so keyboard focus lands in the editor
+    // immediately without the user tabbing to it.
+    private void OnServerRuleEditorRequested(ServerRuleEditorViewModel editorVm)
+    {
+        var editor = new ServerRuleEditorWindow(editorVm, _accounts, _cachedFolders) { Owner = this };
+        editor.Show();
+        editor.Activate();
+    }
+
+    // Return keyboard focus to the selected server rule after a toggle/move/delete, so the user isn't
+    // left on a button and the screen reader re-reads the row (with its updated state/position).
+    private void OnFocusSelectedServerRule()
+        // Deferred to Input priority so it runs AFTER the context menu has fully closed (which itself
+        // restores focus) and after any layout from a move. Otherwise focus can land before the
+        // container is realized and end up on the bare ListBox — where arrow keys escape to sibling
+        // controls instead of navigating items.
+        => Dispatcher.BeginInvoke(new Action(FocusSelectedServerRuleNow), DispatcherPriority.Input);
+
+    private void FocusSelectedServerRuleNow()
+    {
+        if (_serverRulesVm?.SelectedRule is not { } rule) return;
+        var index = ServerRulesListBox.Items.IndexOf(rule);
+        if (index < 0) return;
+
+        ServerRulesListBox.ScrollIntoView(rule);
+        ServerRulesListBox.UpdateLayout();
+        // Focus the actual item container — never the bare ListBox (arrow keys escape from there).
+        if (ServerRulesListBox.ItemContainerGenerator.ContainerFromIndex(index) is ListBoxItem item)
+        {
+            item.Focus();
+            Keyboard.Focus(item);
+        }
+    }
+
+    private bool OnServerRuleConfirmDelete(string message, string title)
+        => MessageBox.Show(this, message, title, MessageBoxButton.YesNo, MessageBoxImage.Warning) == MessageBoxResult.Yes;
+
+    // List-local keys for the server rules list (window-scoped, same pattern as Enter-to-edit; these
+    // are not Command Palette / CommandRegistry shortcuts):
+    //   Enter  → edit the selected rule (default action)
+    //   Space  → enable/disable the selected rule
+    //   Delete → delete the selected rule
+    // The commands carry their own read-only/representability guards, so these no-op on rules that
+    // can't take the action.
+    private void ServerRulesListBox_KeyDown(object sender, KeyEventArgs e)
+    {
+        if (_serverRulesVm is null) return;
+        switch (e.Key)
+        {
+            case Key.Enter:
+                Invoke(_serverRulesVm.EditRuleCommand);
+                e.Handled = true;
+                break;
+            case Key.Space:
+                Invoke(_serverRulesVm.ToggleEnabledCommand);
+                e.Handled = true;
+                break;
+            case Key.Delete:
+                Invoke(_serverRulesVm.DeleteRuleCommand);
+                e.Handled = true;
+                break;
+        }
+
+        // Respect the command's CanExecute so a key does nothing on a rule where the button/menu item
+        // is disabled (e.g. Delete/Space on a read-only rule) — Execute() alone bypasses CanExecute.
+        static void Invoke(System.Windows.Input.ICommand cmd)
+        {
+            if (cmd.CanExecute(null)) cmd.Execute(null);
+        }
+    }
+
     /// <summary>Moves keyboard focus to the next (or previous) window pane for F6 / Shift+F6.</summary>
     private void CyclePane(bool forward)
     {
@@ -104,6 +184,8 @@ public partial class RulesManagerWindow : Window
         var stops = new List<UIElement> { RuleListBox };
         if (_serverRulesVm is not null && ServerRulesSection.Visibility == Visibility.Visible)
         {
+            if (ServerAccountPicker.Visibility == Visibility.Visible)
+                stops.Add(ServerAccountCombo);   // only present when there's >1 Graph account
             stops.Add(ServerRulesListBox);
             stops.Add(ServerRulesDetailBox);
             stops.Add(ServerRulesStatusText);
@@ -236,6 +318,9 @@ public partial class RulesManagerWindow : Window
         {
             _serverRulesVm.AnnouncementRequested -= OnAnnouncementRequested;
             _serverRulesVm.WriteBlockedByPermission -= OnServerRulesPermissionMessage;
+            _serverRulesVm.EditorRequested -= OnServerRuleEditorRequested;
+            _serverRulesVm.ConfirmDeleteRequested -= OnServerRuleConfirmDelete;
+            _serverRulesVm.FocusSelectedRuleRequested -= OnFocusSelectedServerRule;
         }
         base.OnClosed(e);
     }

--- a/QuickMail/Views/ServerRuleEditorWindow.xaml
+++ b/QuickMail/Views/ServerRuleEditorWindow.xaml
@@ -1,0 +1,155 @@
+<Window x:Class="QuickMail.Views.ServerRuleEditorWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="{Binding Title}"
+        AutomationProperties.Name="{Binding Title}"
+        Width="520" Height="620"
+        MinWidth="440" MinHeight="480"
+        WindowStartupLocation="CenterScreen"
+        ResizeMode="CanResizeWithGrip"
+        WindowStyle="SingleBorderWindow"
+        Background="{DynamicResource Theme.WindowBackground}"
+        Foreground="{DynamicResource Theme.TextPrimary}"
+        FontFamily="{DynamicResource Theme.FontFamily}"
+        FontSize="{DynamicResource Theme.FontSizeBase}">
+
+    <Window.Resources>
+        <Style TargetType="TextBox" x:Key="EditorTextBox" BasedOn="{StaticResource {x:Type TextBox}}">
+            <Setter Property="Margin" Value="0,2,0,8"/>
+            <Setter Property="Padding" Value="4,3"/>
+        </Style>
+        <Style TargetType="ComboBox" x:Key="EditorComboBox" BasedOn="{StaticResource {x:Type ComboBox}}">
+            <Setter Property="Margin" Value="0,2,0,8"/>
+        </Style>
+        <Style TargetType="CheckBox" x:Key="EditorCheckBox" BasedOn="{StaticResource {x:Type CheckBox}}">
+            <Setter Property="Margin" Value="0,4"/>
+        </Style>
+        <Style TargetType="TextBlock" x:Key="SectionHeader">
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="Margin" Value="0,12,0,4"/>
+        </Style>
+    </Window.Resources>
+
+    <Grid Margin="14">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <ScrollViewer Grid.Row="0" VerticalScrollBarVisibility="Auto"
+                      Focusable="False" KeyboardNavigation.TabNavigation="Continue">
+            <StackPanel x:Name="FieldsPanel">
+                <TextBlock Text="Rule name" Style="{StaticResource SectionHeader}" Margin="0,0,0,4"/>
+                <TextBox x:Name="NameBox" Text="{Binding Name, UpdateSourceTrigger=PropertyChanged}"
+                         Style="{StaticResource EditorTextBox}" AutomationProperties.Name="Rule name"/>
+                <TextBlock Text="{Binding NameError}" Foreground="{DynamicResource Theme.Error}"
+                           TextWrapping="Wrap" KeyboardNavigation.IsTabStop="False"/>
+
+                <CheckBox Content="Enabled" IsChecked="{Binding IsEnabled}"
+                          Style="{StaticResource EditorCheckBox}" AutomationProperties.Name="Rule enabled"/>
+
+                <!-- Common conditions -->
+                <TextBlock Text="Apply when a message matches" Style="{StaticResource SectionHeader}"/>
+                <Separator/>
+
+                <TextBlock Text="From addresses (comma-separated)"/>
+                <TextBox Text="{Binding FromAddresses, UpdateSourceTrigger=PropertyChanged}"
+                         Style="{StaticResource EditorTextBox}" AutomationProperties.Name="From addresses"/>
+
+                <TextBlock Text="Subject contains"/>
+                <TextBox Text="{Binding SubjectContains, UpdateSourceTrigger=PropertyChanged}"
+                         Style="{StaticResource EditorTextBox}" AutomationProperties.Name="Subject contains"/>
+
+                <!-- Common actions -->
+                <TextBlock Text="Then do this" Style="{StaticResource SectionHeader}"/>
+                <Separator/>
+
+                <CheckBox Content="Move to folder" IsChecked="{Binding MoveToFolder}"
+                          Style="{StaticResource EditorCheckBox}" AutomationProperties.Name="Move to folder"/>
+                <Button Content="{Binding MoveToFolderName, TargetNullValue=Choose folder…, FallbackValue=Choose folder…}"
+                        Command="{Binding PickFolderCommand}" HorizontalAlignment="Left"
+                        Padding="8,3" Margin="0,0,0,8" AutomationProperties.Name="Choose move-to folder"/>
+
+                <CheckBox Content="Mark as read" IsChecked="{Binding MarkAsRead}"
+                          Style="{StaticResource EditorCheckBox}" AutomationProperties.Name="Mark as read"/>
+
+                <CheckBox Content="Delete (move to Deleted Items)" IsChecked="{Binding Delete}"
+                          Style="{StaticResource EditorCheckBox}" AutomationProperties.Name="Delete"/>
+
+                <CheckBox Content="Stop processing more rules" IsChecked="{Binding StopProcessingRules}"
+                          Style="{StaticResource EditorCheckBox}" AutomationProperties.Name="Stop processing more rules"/>
+
+                <!-- Advanced: less-common conditions/actions. Collapsed for a new rule; auto-expanded
+                     when editing a rule that already uses any field inside (VM.IsAdvancedExpanded). -->
+                <Expander Header="Advanced conditions &amp; actions" Margin="0,14,0,0"
+                          IsExpanded="{Binding IsAdvancedExpanded}"
+                          AutomationProperties.Name="Advanced conditions and actions">
+                    <StackPanel Margin="0,6,0,0">
+                        <TextBlock Text="More conditions" Style="{StaticResource SectionHeader}" Margin="0,0,0,4"/>
+
+                        <TextBlock Text="Sender contains (substring match on sender)"/>
+                        <TextBox Text="{Binding SenderContains, UpdateSourceTrigger=PropertyChanged}"
+                                 Style="{StaticResource EditorTextBox}" AutomationProperties.Name="Sender contains"/>
+
+                        <TextBlock Text="Sent to addresses (comma-separated)"/>
+                        <TextBox Text="{Binding SentToAddresses, UpdateSourceTrigger=PropertyChanged}"
+                                 Style="{StaticResource EditorTextBox}" AutomationProperties.Name="Sent to addresses"/>
+
+                        <TextBlock Text="Subject or body contains"/>
+                        <TextBox Text="{Binding BodyOrSubjectContains, UpdateSourceTrigger=PropertyChanged}"
+                                 Style="{StaticResource EditorTextBox}" AutomationProperties.Name="Subject or body contains"/>
+
+                        <TextBlock Text="Body contains"/>
+                        <TextBox Text="{Binding BodyContains, UpdateSourceTrigger=PropertyChanged}"
+                                 Style="{StaticResource EditorTextBox}" AutomationProperties.Name="Body contains"/>
+
+                        <CheckBox Content="Sent to me" IsChecked="{Binding SentToMe}"
+                                  Style="{StaticResource EditorCheckBox}" AutomationProperties.Name="Sent to me"/>
+                        <CheckBox Content="Sent only to me" IsChecked="{Binding SentOnlyToMe}"
+                                  Style="{StaticResource EditorCheckBox}" AutomationProperties.Name="Sent only to me"/>
+                        <CheckBox Content="Has attachments" IsChecked="{Binding HasAttachments}"
+                                  Style="{StaticResource EditorCheckBox}" AutomationProperties.Name="Has attachments"/>
+
+                        <TextBlock Text="Importance is"/>
+                        <ComboBox ItemsSource="{Binding ImportanceOptions}"
+                                  SelectedItem="{Binding SelectedImportance}"
+                                  Style="{StaticResource EditorComboBox}" AutomationProperties.Name="Importance condition"/>
+
+                        <TextBlock Text="More actions" Style="{StaticResource SectionHeader}"/>
+
+                        <CheckBox Content="Copy to folder" IsChecked="{Binding CopyToFolder}"
+                                  Style="{StaticResource EditorCheckBox}" AutomationProperties.Name="Copy to folder"/>
+                        <Button Content="{Binding CopyToFolderName, TargetNullValue=Choose folder…, FallbackValue=Choose folder…}"
+                                Command="{Binding PickCopyFolderCommand}" HorizontalAlignment="Left"
+                                Padding="8,3" Margin="0,0,0,8" AutomationProperties.Name="Choose copy-to folder"/>
+
+                        <TextBlock Text="Set importance to"/>
+                        <ComboBox ItemsSource="{Binding ImportanceOptions}"
+                                  SelectedItem="{Binding SelectedMarkImportance}"
+                                  Style="{StaticResource EditorComboBox}" AutomationProperties.Name="Set importance action"/>
+
+                        <TextBlock Text="Forward to (comma-separated)"/>
+                        <TextBox Text="{Binding ForwardTo, UpdateSourceTrigger=PropertyChanged}"
+                                 Style="{StaticResource EditorTextBox}" AutomationProperties.Name="Forward to"/>
+                    </StackPanel>
+                </Expander>
+
+                <TextBlock Text="{Binding FolderError}" Foreground="{DynamicResource Theme.Error}"
+                           TextWrapping="Wrap" Margin="0,8,0,0" KeyboardNavigation.IsTabStop="False"/>
+                <TextBlock Text="{Binding ActionsError}" Foreground="{DynamicResource Theme.Error}"
+                           TextWrapping="Wrap" KeyboardNavigation.IsTabStop="False"/>
+            </StackPanel>
+        </ScrollViewer>
+
+        <StackPanel Grid.Row="1" Margin="0,12,0,0">
+            <TextBlock Text="{Binding SaveError}" Foreground="{DynamicResource Theme.Error}"
+                       TextWrapping="Wrap" Margin="0,0,0,6" KeyboardNavigation.IsTabStop="False"/>
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                <Button Content="Save" Command="{Binding SaveCommand}" IsDefault="True"
+                        Width="80" Height="28" Margin="0,0,8,0" AutomationProperties.Name="Save rule"/>
+                <Button Content="Cancel" Command="{Binding CancelCommand}" IsCancel="True"
+                        Width="80" Height="28" AutomationProperties.Name="Cancel"/>
+            </StackPanel>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/QuickMail/Views/ServerRuleEditorWindow.xaml.cs
+++ b/QuickMail/Views/ServerRuleEditorWindow.xaml.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using System.Windows;
+using System.Windows.Input;
+using QuickMail.Models;
+using QuickMail.ViewModels;
+
+namespace QuickMail.Views;
+
+/// <summary>
+/// Create/edit form for a server (Exchange/Graph) rule. Modeless (CLAUDE.md: editable text over the
+/// live WebView2 reading pane must not run under a nested modal loop), so Escape/Cancel close it
+/// explicitly. The owning <see cref="ServerRuleEditorViewModel"/> raises the save/close/folder-pick
+/// requests as events; persistence is wired by the list VM that created the editor.
+/// </summary>
+public partial class ServerRuleEditorWindow : Window
+{
+    private readonly ServerRuleEditorViewModel _vm;
+    private readonly IEnumerable<AccountModel> _accounts;
+    private readonly IReadOnlyDictionary<Guid, List<MailFolderModel>> _cachedFolders;
+
+    public ServerRuleEditorWindow(
+        ServerRuleEditorViewModel vm,
+        IEnumerable<AccountModel> accounts,
+        IReadOnlyDictionary<Guid, List<MailFolderModel>> cachedFolders)
+    {
+        _vm = vm;
+        _accounts = accounts;
+        _cachedFolders = cachedFolders;
+        InitializeComponent();
+        DataContext = vm;
+
+        vm.PickFolderRequested += OnPickFolderRequested;
+        vm.CloseRequested += OnCloseRequested;
+        vm.AnnouncementRequested += OnAnnouncementRequested;
+
+        Loaded += (_, _) =>
+        {
+            NameBox.Focus();
+            Keyboard.Focus(NameBox);
+        };
+    }
+
+    private (string Id, string Name)? OnPickFolderRequested()
+    {
+        var picker = new FolderPickerWindow(_accounts, _cachedFolders, title: "Choose Folder") { Owner = this };
+        if (picker.ShowDialog() == true && picker.SelectedFolder is MailFolderModel folder)
+            return (folder.FullName, folder.DisplayName);
+        return null;
+    }
+
+    private void OnCloseRequested() => Close();
+
+    private void OnAnnouncementRequested(string text, AnnouncementCategory category)
+        => AccessibilityHelper.Announce(this, text, category: category);
+
+    protected override void OnPreviewKeyDown(KeyEventArgs e)
+    {
+        base.OnPreviewKeyDown(e);
+        if (e.Handled) return;
+
+        // Modeless window: no DialogResult, so IsCancel doesn't auto-close on Escape. Wire it, but
+        // step aside when a ComboBox dropdown is open so it can consume Escape itself.
+        if (e.Key == Key.Escape && Keyboard.FocusedElement is not System.Windows.Controls.ComboBox { IsDropDownOpen: true })
+        {
+            Close();
+            e.Handled = true;
+        }
+    }
+
+    protected override void OnClosed(EventArgs e)
+    {
+        _vm.PickFolderRequested -= OnPickFolderRequested;
+        _vm.CloseRequested -= OnCloseRequested;
+        _vm.AnnouncementRequested -= OnAnnouncementRequested;
+
+        // Hand foreground back to the Rules Manager (our owner), not the main window. This window is
+        // the active foreground window as it closes, so it may pass foreground to its owner — a
+        // background window calling Activate() on itself would hit Windows' foreground lock and fail.
+        // Without this the main window grabs activation and Tab operates there instead of the list.
+        Owner?.Activate();
+
+        base.OnClosed(e);
+    }
+}

--- a/docs/planning/server-rules-pm-dev-spec.md
+++ b/docs/planning/server-rules-pm-dev-spec.md
@@ -487,3 +487,99 @@ This is the single most important correctness decision; reviewers should confirm
 3. ~~**Converting the existing window to modeless:**~~ **Resolved 2026-07-23 (maintainer sign-off).** `RulesManagerWindow` **is converted to modeless** as part of this work. Launching the new modeless editor from a `ShowDialog()` parent, over the live WebView2 reading pane, is the exact nested-message-loop shape behind the GrabAddresses lockup, and CLAUDE.md already codifies modeless-with-editable-text as the required pattern. The Escape / `IsCancel` rewiring is well understood (compose already does it), and accepting the modal-parent risk to avoid that rewiring was judged a bad trade. Implementation must wire Cancel and a guarded `PreviewKeyDown` Escape handler to `Close()` — the guard so Escape isn't stolen from an open ComboBox dropdown.
 4. **Toggle on read-only rules:** does Graph permit `isEnabled` PATCH on an `isReadOnly` rule? Confirm against a live mailbox before enabling that path.
 5. **Reorder UX:** Move Up/Down (recommended, simplest for keyboard) vs. an explicit sequence editor.
+
+---
+
+## 20. Unified New/Create — one button, auto-classify (2026-07-25)
+
+Supersedes the two-entry-point interim (separate client "New Rule" + server
+"New"). Decision by Tim 2026-07-25: **one "New rule" button**; the app decides
+server vs client automatically. Full auto-classify chosen (not
+account-decides) because **more client-only capabilities are coming**
+(play a sound / desktop notification / etc.), so the classifier must generalise
+beyond today's single client-only action.
+
+### 20.1 Layout (the landing experience)
+
+- **Account picker is the first focusable control** in the Rules Manager — Tim's
+  ask: "the first place a person lands." It governs everything below.
+- **One rules list** for the selected account: server + client rules together,
+  each row marked where it runs ("on server" / "in QuickMail") per §10.3.
+- **One "New rule" button** + Edit / Delete / Enable-Disable / Move. Edit/Delete/
+  toggle/move route to the correct service by the row's actual kind.
+- Account capability: a **Microsoft 365 (Graph)** account can hold server *and*
+  client rules; an **IMAP** account, client rules only.
+
+### 20.2 Capability facts (why the classifier is shaped this way)
+
+A client rule (`MailRule`) is **almost a strict subset** of a server rule:
+- Client conditions: From / To / Subject / Body **contains** (single substring
+  each), Has attachments. All are server-expressible too.
+- Client actions: Mark read, **Mark _unread_**, Move, Delete — **exactly one**.
+- The **only** thing a client rule does that a server rule cannot: **Mark as
+  unread** (today). Server additionally has address lists, sent-to/only-to-me,
+  importance, subject-or-body, copy, forward, set-importance, stop, and
+  **multiple** actions.
+
+### 20.3 Classification algorithm (on Save)
+
+Let `serverOk` = account supports server rules (Graph). Compute two flags from
+the editor's field values:
+
+- **ServerRepresentable** = uses **no client-only feature**. Client-only feature
+  set (extensible): `MarkAsUnread` (+ future: play sound, notify, …). Conditions
+  never block server (server ⊇ client conditions).
+- **ClientRepresentable** = every used condition AND action is client-expressible:
+  - No server-only **condition**: subject-or-body, sent-to-me, sent-only-to-me,
+    importance-is ⇒ not client-representable.
+  - "From" collapses to one field: at most one of {Sender contains, From
+    addresses}, and From-addresses has ≤1 entry. Sent-to-addresses ≤1 entry.
+  - Exactly **one** action, from {Mark read, Mark unread, Move, Delete}. Any of
+    copy / forward / set-importance / stop, or >1 action ⇒ not client-representable.
+
+Decision:
+1. `serverOk && ServerRepresentable` → **server rule** (silent; the expected path).
+2. else if `ClientRepresentable` → **client rule**. Show an **informational
+   dialog on save** (Tim's requirement): e.g. *"Saved as a QuickMail rule (runs
+   only while QuickMail is open) because it uses Mark as unread, which Microsoft
+   365 server rules don't support."* For an IMAP account the reason is *"this
+   account has no server-side rules."*
+3. else → **conflict** (representable by neither): a **validation error**, not a
+   silent choice — e.g. *"Mark as unread only works in a QuickMail rule, but the
+   'importance' condition only works in a server rule. Remove one to save."*
+   (This happens only when a server-only condition is combined with a client-only
+   action.)
+
+### 20.4 Editor & conversions
+
+- The editor becomes the **unified rule editor** (rename `ServerRuleEditor*` →
+  `RuleEditor*` when convenient; not required for correctness). It exposes the
+  server field set (§ existing Common/Advanced) **plus** client-only actions,
+  starting with **Mark as unread** (Advanced → actions). Future client-only
+  options slot in beside it and register in the client-only feature set (20.3).
+- `ToServerModel()` (exists) builds the `ServerRuleModel`. New `ToClientRule(Guid
+  accountId)` builds a `MailRule` from the client-representable subset (map From→
+  FromContains, Sent-to→ToContains, Subject→SubjectContains, Body→BodyContains,
+  Has-attachments→MustHaveAttachments, the single action→RuleAction, Move target→
+  TargetFolder). Only ever called when ClientRepresentable holds, so no lossy
+  conversion.
+- Save routes by classification: server → `GraphServerRuleService`; client →
+  `RuleService`.
+
+### 20.5 Build phases (each independently safe; feature stays gated)
+
+1. **Classifier engine** — pure, unit-tested: ServerRepresentable /
+   ClientRepresentable / conflict, from editor field values. No UI change. Add
+   `MarkAsUnread` to the editor VM (not yet in XAML).
+2. **ToClientRule conversion** + unit tests (round-trip the client subset).
+3. **Save routing + client-save dialog + conflict validation** wired into the
+   unified editor; add Mark-as-unread to the editor XAML (Advanced actions).
+4. **Layout unification** — account picker as first landing control; single
+   merged list (server + client rows, "runs where" marker); single New button;
+   Edit/Delete/toggle/move route by row kind; retire the two-section split and
+   the cross-labeled client "New Rule" / server "New" buttons.
+
+### 20.6 Out of scope (unchanged, reaffirmed)
+
+No copy/convert between server and client, no sync between the two sets (§18).
+Auto-classify picks a kind at creation; it never migrates an existing rule.

--- a/docs/planning/server-rules-pm-dev-spec.md
+++ b/docs/planning/server-rules-pm-dev-spec.md
@@ -583,3 +583,58 @@ Decision:
 
 No copy/convert between server and client, no sync between the two sets (§18).
 Auto-classify picks a kind at creation; it never migrates an existing rule.
+
+---
+
+## 20.7 Phase 4 implementation notes — the unified list (2026-07-25)
+
+The refactor that merges the two-section Rules Manager into one account-scoped
+list. Touches shipped client-rule UI, so build it behind `FeatureFlag.ServerRules`
+(unified path only when on; old two-section path stays until the flag flips).
+
+### Row model
+`UnifiedRuleRow` wraps exactly one of `ServerRuleModel` / `MailRule`:
+- `RunsWhere` (Server | Client), `Name`, `IsEnabled`.
+- `RowText` (accessible name, also `ToString`): `"{Name}, {on server|in QuickMail}, {enabled|disabled}. {summary}"`.
+  Server summary reuses `ServerRuleModel.OneLineSummary()`; client summary is a
+  small formatter over the `MailRule` conditions/action.
+- The list is per-account, so the row carries no account label.
+
+### ViewModel
+`UnifiedRulesViewModel` owns the account picker and one `ObservableCollection<UnifiedRuleRow> Rules`.
+- Ctor takes `IRuleService` (client), `IServerRuleService?` (server; null when no
+  Graph account exists), accounts, cached folders.
+- `AccountOptions` = ALL accounts (Graph + IMAP). `SelectedAccount` seeded to the
+  current account (as the server picker already does).
+- On account change: load client rules for the account (RuleService) + server
+  rules if the account is Graph (GraphServerRuleService); merge into `Rules`
+  (server first by sequence, then client), each wrapped in a `UnifiedRuleRow`.
+- `AccountSupportsServerRules` = selected account is Graph → drives the New
+  classifier and gates server-only affordances.
+- CRUD routes by `SelectedRow.RunsWhere`:
+  - New → open the editor; on Save, `Classify(AccountSupportsServerRules)` →
+    server (GraphServerRuleService) or client (RuleService, + the "saved as a
+    QuickMail rule" dialog), or block on conflict. (This is where Phase 3 lands.)
+  - Edit/Delete/Enable-Disable → the matching service for the row's kind.
+  - Move (reorder) → **server rows only** (client rules have no ordering); gate
+    Move for client rows the way read-only rows are gated.
+
+### Window
+- Retire the two `Border` sections; one account picker (first focusable control,
+  first F6 stop) + one list + one button row (New/Edit/Delete/Enable-Disable/
+  Move Up/Move Down) + the detail pane.
+- Editor is a **single** F6 region (resolves Kelly's review item 4 for the
+  merged world).
+- **One** status-announcement mechanism (resolves Kelly's item 3): keep the
+  focusable status line for F6 re-read, drive updates through a single path — do
+  not pair `LiveSetting="Polite"` with an explicit `Announce` on the same text.
+  Confirm by listening once the unified line exists.
+- Retire the cross-labeled client "New Rule" / server "New"; the client
+  New-Rule focus bug disappears with the single New button.
+
+### Migration / base
+- Depends on #364's per-account client-rule scoping. Land order stays: #364 →
+  retarget #367 to `main` (no rebase). Main's address-book work touched
+  MainViewModel/MainWindow — expect conflicts to resolve at retarget.
+- Keep everything behind the flag; the unified list ships only when §20 is
+  complete and the flag flips.


### PR DESCRIPTION
Server-rule support for #333, grown well past the original read-only peek. Validated end-to-end against a live **68-rule** M365 mailbox (create → the server rule fires) and by a screen-reader user throughout. `FeatureFlag.ServerRules` stays **off** — the two-section layout here is explicitly transitional and ships to nobody until the unified list (§20) lands.

> ⚠️ **Stacked on #364** (base = `feat/rules-per-account-migration-333`); also builds on the merged service (#335) and VMs (#337). Per review: once #364 lands, this **retargets to `main`** (no rebase — stays a clean descendant).

## What's in it
- **Read-only view** of a Graph account's Exchange `messageRules` in the Rules Manager (the original slice).
- **Full editing** via a new **modeless** `ServerRuleEditorWindow` — create / edit / delete / enable-disable / reorder. Modeless per the editable-text-over-WebView2 rule. Editor is laid out **Common + collapsible Advanced**, and Advanced auto-expands when editing a rule that already uses an advanced field.
- **Subset expansion:** `bodyContains`, `sentToAddresses`, `copyToFolder` — every rule on the test mailbox is representable (0 flagged). Read + write, with the multi-value guard.
- **Minimal-diff reorder:** only PATCH the rules whose sequence changes, so an unrelated server-read-only rule (e.g. an Outlook-created one) no longer 400s and poisons a valid move.
- **Read-only rules disable** Edit/Delete/Enable-Disable/Move (CanExecute, buttons *and* context menu) — clearer than pressable-but-silent for a screen-reader user with announcements off.
- **Keys:** Space = enable/disable, Delete = delete, Enter = edit on the server list.
- **Account picker** in the server section, seeded to the account you're currently in.
- **Save round-trip correctness:** valid 1-based sequence on create (Graph rejects 0); the editor stays open and shows the error on a failed save instead of closing and losing the form; focus returns to the new rule; and a guard so a transient main-window activation can't steal focus back to the message list as the editor closes.
- **Classifier foundation (§20 Phases 1–2):** `Classify(accountSupportsServerRules)` + `ToClientRule` — pure, unit-tested logic that decides server vs client vs conflict. Not yet wired to UI; it's the engine for the unified New button.

## Accessibility
One-per-line `DetailText` under "Applies when:" / "Does:" / "Reason for block:" headers; caret-navigable read-only detail pane; per-row not-editable/read-only markers; status line reports counts and is focusable; F6 / Shift+F6 pane cycling (which the window lacked entirely before).

## Still to come (§20, this PR's successor work)
The **single per-account combined list** with the account picker as first focusable control and **one auto-classifying New button** — replaces this interim two-section layout. Design in `docs/planning/server-rules-pm-dev-spec.md` §20.

## Tests
Full suite **1597 passed** (lone red is the known `OpenClipboard` clipboard flake, passes in isolation). Server-rule/classifier coverage: reorder minimal-diff, read-only gating, sequence-on-create, save-failure keeps editor open, classifier server/client/conflict, client-rule conversion, and the earlier subset round-trips.

## Filed while testing (separate)
- **#365** — move/copy to a *different account* (client-rule-only).
- **#366** — Graph mail delete/move reappearing from stale mutable message IDs (our backend).
