### PR TITLE
Address book: first-letter (type-ahead) navigation in the contact and group lists (#371)

### DIFF
--- a/QuickMail.Tests/AddressBookTypeAheadTests.cs
+++ b/QuickMail.Tests/AddressBookTypeAheadTests.cs
@@ -1,0 +1,279 @@
+// Regression tests for first-letter (type-ahead) navigation in the Address Book
+// lists — issue #371.
+//
+// The contact list uses an ItemTemplate whose root is a Grid, so WPF's TextSearch
+// has no text to match unless the list declares TextSearch.TextPath explicitly.
+// Without it, typing a letter with focus on the list does nothing at all. These
+// tests drive real TextInput events through the WPF input pipeline so a regression
+// (a removed TextPath, or a renamed source property) fails here rather than in the
+// running app.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+using QuickMail.Models;
+using QuickMail.Services;
+using QuickMail.ViewModels;
+using QuickMail.Views;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+[Collection("WpfTests")]
+public class AddressBookTypeAheadTests
+{
+    private static string TempDir() =>
+        Path.Combine(Path.GetTempPath(), $"QM-TypeAheadTests-{Guid.NewGuid():N}");
+
+    [StaFact]
+    public void ContactList_TypingFirstLetter_SelectsMatchingContact()
+    {
+        EnsureApplication();
+        var (_, window, dir) = BuildWindowWithContacts();
+        try
+        {
+            var list = window.FindName("ContactList") as ListView;
+            Assert.NotNull(list);
+            list!.Focus();
+            DoEvents();
+
+            SendText(list, "b");
+            DoEvents();
+
+            var selected = list.SelectedItem as ContactModel;
+            Assert.NotNull(selected);
+            Assert.Equal("Bob Baker", selected!.DisplayName);
+        }
+        finally
+        {
+            window.Close();
+            DeleteDir(dir);
+        }
+    }
+
+    [StaFact]
+    public void ContactList_RepeatingSameLetter_CyclesThroughMatches()
+    {
+        // Two contacts start with "B". Pressing B twice should land on the second
+        // one — WPF treats a repeat of the same character as "next match", not as
+        // a two-character prefix.
+        EnsureApplication();
+        var (_, window, dir) = BuildWindowWithContacts();
+        try
+        {
+            var list = window.FindName("ContactList") as ListView;
+            Assert.NotNull(list);
+            list!.Focus();
+            DoEvents();
+
+            SendText(list, "b");
+            DoEvents();
+            SendText(list, "b");
+            DoEvents();
+
+            var selected = list.SelectedItem as ContactModel;
+            Assert.NotNull(selected);
+            Assert.Equal("Brenda Cole", selected!.DisplayName);
+        }
+        finally
+        {
+            window.Close();
+            DeleteDir(dir);
+        }
+    }
+
+    [StaFact]
+    public void ContactList_TypingMultipleLetters_MatchesLongerPrefix()
+    {
+        // Typed characters accumulate within the type-ahead timeout, so "br"
+        // should skip past "Bob Baker" and land on "Brenda Cole".
+        EnsureApplication();
+        var (_, window, dir) = BuildWindowWithContacts();
+        try
+        {
+            var list = window.FindName("ContactList") as ListView;
+            Assert.NotNull(list);
+            list!.Focus();
+            DoEvents();
+
+            SendText(list, "b");
+            SendText(list, "r");
+            DoEvents();
+
+            var selected = list.SelectedItem as ContactModel;
+            Assert.NotNull(selected);
+            Assert.Equal("Brenda Cole", selected!.DisplayName);
+        }
+        finally
+        {
+            window.Close();
+            DeleteDir(dir);
+        }
+    }
+
+    [StaFact]
+    public void ContactList_NamelessContact_IsReachableByAddress()
+    {
+        // Prior-recipient contacts often have no display name. TypeAheadText falls
+        // back to the address so they are still reachable by typing.
+        EnsureApplication();
+        var (_, window, dir) = BuildWindowWithContacts();
+        try
+        {
+            var list = window.FindName("ContactList") as ListView;
+            Assert.NotNull(list);
+            list!.Focus();
+            DoEvents();
+
+            SendText(list, "z");
+            DoEvents();
+
+            var selected = list.SelectedItem as ContactModel;
+            Assert.NotNull(selected);
+            Assert.Equal("zeta@example.com", selected!.EmailAddress);
+            Assert.Equal(string.Empty, selected.DisplayName);
+        }
+        finally
+        {
+            window.Close();
+            DeleteDir(dir);
+        }
+    }
+
+    [StaFact]
+    public void GroupsList_TypingFirstLetter_SelectsMatchingGroup()
+    {
+        EnsureApplication();
+        var (_, window, dir) = BuildWindowWithContacts();
+        try
+        {
+            var tabs = FindFirstVisualChild<TabControl>(window);
+            Assert.NotNull(tabs);
+            tabs!.SelectedIndex = 1;
+            DoEvents();
+            window.UpdateLayout();
+
+            var list = window.FindName("GroupsList") as ListView;
+            Assert.NotNull(list);
+            list!.Focus();
+            DoEvents();
+
+            SendText(list, "w");
+            DoEvents();
+
+            var selected = list.SelectedItem as GroupModel;
+            Assert.NotNull(selected);
+            Assert.Equal("Work", selected!.Name);
+        }
+        finally
+        {
+            window.Close();
+            DeleteDir(dir);
+        }
+    }
+
+    [Fact]
+    public void TypeAheadText_PrefersName_FallsBackToAddress()
+    {
+        Assert.Equal("Bob Baker",
+            new ContactModel { DisplayName = "Bob Baker", EmailAddress = "bob@example.com" }.TypeAheadText);
+        Assert.Equal("zeta@example.com",
+            new ContactModel { DisplayName = "", EmailAddress = "zeta@example.com" }.TypeAheadText);
+        Assert.Equal("zeta@example.com",
+            new ContactModel { DisplayName = "   ", EmailAddress = "zeta@example.com" }.TypeAheadText);
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private static (AddressBookViewModel vm, AddressBookWindow window, string dir) BuildWindowWithContacts()
+    {
+        var dir     = TempDir();
+        var profile = new ProfileContext(dir);
+        var svc     = new ContactService(profile);
+
+        // Insertion order is deliberately not alphabetical: type-ahead must find the
+        // match wherever it sits in the list, not just when the list happens to be sorted.
+        foreach (var (name, email) in new[]
+                 {
+                     ("Alice Adams",  "alice@example.com"),
+                     ("Bob Baker",    "bob@example.com"),
+                     ("Brenda Cole",  "brenda@example.com"),
+                     ("",             "zeta@example.com"),
+                 })
+        {
+            svc.UpsertContactAsync(new ContactModel { DisplayName = name, EmailAddress = email })
+               .GetAwaiter().GetResult();
+        }
+        svc.CreateGroupAsync("Family").GetAwaiter().GetResult();
+        svc.CreateGroupAsync("Work").GetAwaiter().GetResult();
+
+        var vm     = new AddressBookViewModel(svc);
+        var window = new AddressBookWindow(vm);
+        vm.LoadAsync().GetAwaiter().GetResult();
+        window.Show();
+        window.UpdateLayout();
+        DoEvents();
+        return (vm, window, dir);
+    }
+
+    /// <summary>
+    /// Raises a real TextInput event on the list, which is what a keystroke produces
+    /// once WPF has translated it — the same event ItemsControl's class handler uses
+    /// to drive TextSearch.
+    /// </summary>
+    private static void SendText(UIElement target, string text)
+    {
+        var composition = new TextComposition(InputManager.Current, target, text);
+        target.RaiseEvent(new TextCompositionEventArgs(
+            InputManager.Current.PrimaryKeyboardDevice, composition)
+        {
+            RoutedEvent = UIElement.TextInputEvent,
+        });
+    }
+
+    private static void DeleteDir(string dir)
+    {
+        try { if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true); } catch { }
+    }
+
+    private static T? FindFirstVisualChild<T>(DependencyObject root) where T : DependencyObject
+    {
+        var queue = new Queue<DependencyObject>();
+        queue.Enqueue(root);
+        while (queue.Count > 0)
+        {
+            var d = queue.Dequeue();
+            if (d is T match) return match;
+            int n = VisualTreeHelper.GetChildrenCount(d);
+            for (int i = 0; i < n; i++)
+                queue.Enqueue(VisualTreeHelper.GetChild(d, i));
+        }
+        return null;
+    }
+
+    private static void DoEvents()
+    {
+        var frame = new System.Windows.Threading.DispatcherFrame();
+        System.Windows.Threading.Dispatcher.CurrentDispatcher.BeginInvoke(
+            System.Windows.Threading.DispatcherPriority.Background,
+            new Action(() => frame.Continue = false));
+        System.Windows.Threading.Dispatcher.PushFrame(frame);
+    }
+
+    private static void EnsureApplication()
+    {
+        lock (typeof(Application))
+        {
+            if (Application.Current == null)
+                new Application { ShutdownMode = ShutdownMode.OnExplicitShutdown };
+            const string stylesUri = "pack://application:,,,/QuickMail;component/Styles/AccessibleStyles.xaml";
+            var uri = new Uri(stylesUri, UriKind.Absolute);
+            if (Application.Current!.Resources.MergedDictionaries.All(d => d.Source != uri))
+                Application.Current.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = uri });
+        }
+    }
+}

--- a/QuickMail/Models/ContactModel.cs
+++ b/QuickMail/Models/ContactModel.cs
@@ -68,4 +68,16 @@ public class ContactModel
     public string Display => string.IsNullOrWhiteSpace(DisplayName)
         ? EmailAddress
         : $"{DisplayName} <{EmailAddress}>";
+
+    /// <summary>
+    /// Text WPF's <c>TextSearch</c> matches when the user types in a contact list
+    /// (issue #371). The name is what the user thinks of the contact as, so it comes
+    /// first; contacts stored with only an address (prior recipients) fall back to the
+    /// address so they are still reachable by typing. Must be a single value — a
+    /// <c>TextSearch.TextPath</c> binds to exactly one property.
+    /// </summary>
+    [JsonIgnore]
+    public string TypeAheadText => string.IsNullOrWhiteSpace(DisplayName)
+        ? EmailAddress
+        : DisplayName;
 }

--- a/QuickMail/Views/AddressBookWindow.xaml
+++ b/QuickMail/Views/AddressBookWindow.xaml
@@ -181,10 +181,18 @@
                     </Grid>
 
                     <!-- Contact list -->
+                    <!-- IsTextSearchEnabled + TextSearch.TextPath give the list first-letter
+                         (type-ahead) navigation: WPF matches typed characters against
+                         TypeAheadText, accumulating within the system type-ahead timeout and
+                         cycling through same-letter matches on repeats (issue #371). Without
+                         an explicit TextPath the item template's Grid supplies no text and
+                         typing does nothing. -->
                     <ListView x:Name="ContactList"
                               ItemsSource="{Binding FilteredContacts}"
                               SelectedItem="{Binding SelectedContact}"
                               AutomationProperties.Name="Contacts"
+                              IsTextSearchEnabled="True"
+                              TextSearch.TextPath="TypeAheadText"
                               TabIndex="4"
                               Grid.IsSharedSizeScope="True"
                               KeyboardNavigation.TabNavigation="Once"
@@ -244,6 +252,8 @@
                                   ItemsSource="{Binding Groups}"
                                   SelectedItem="{Binding SelectedGroup, Mode=TwoWay}"
                                   AutomationProperties.Name="Groups"
+                                  IsTextSearchEnabled="True"
+                                  TextSearch.TextPath="Name"
                                   TabIndex="20"
                                   KeyboardNavigation.TabNavigation="Once"
                                   PreviewKeyDown="GroupsList_PreviewKeyDown">
@@ -297,6 +307,8 @@
                         <ListView x:Name="GroupMembersList"
                                   ItemsSource="{Binding SelectedGroupMembers}"
                                   AutomationProperties.Name="Group members"
+                                  IsTextSearchEnabled="True"
+                                  TextSearch.TextPath="TypeAheadText"
                                   TabIndex="21"
                                   KeyboardNavigation.TabNavigation="Once"
                                   PreviewKeyDown="GroupMembersList_PreviewKeyDown">

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -550,6 +550,10 @@ Press **Ctrl+Shift+B** to open the address book.
 
 The address book lists everyone you have sent mail to or explicitly added, plus — if you turn on contact sync — the contacts stored in your Microsoft and Google accounts. You can search by name or address, edit contact details, and organize contacts into groups. An **Account** column shows where each contact came from: **Local address book** for the ones you added yourself, or the account name for synced ones.
 
+### Jumping to a Contact by Typing
+
+With focus on the contact list, type the first letter of a contact's name to jump straight to it. Type more letters quickly to match a longer beginning ("br" goes to Brenda rather than Bob), or press the same letter again to move to the next contact starting with that letter. Contacts stored without a name are matched on their address instead. The same typing shortcut works in the **Groups** list and the **Group members** list.
+
 ### Syncing Contacts from Your Accounts
 
 QuickMail can fill the address book from the contacts already stored in your Microsoft, Google, and iCloud accounts, so the people your account knows are available for autocomplete when you address a message.

--- a/docs/release-notes-v0.8.37.md
+++ b/docs/release-notes-v0.8.37.md
@@ -1,0 +1,30 @@
+# QuickMail v0.8.37 Release Notes
+
+## Download
+
+Two options are available for v0.8.37:
+
+| Download | When to use |
+|----------|-------------|
+| **`QuickMail-win.msi`** — Windows installer | Recommended for most users. A standard setup wizard with license agreement; installs per-user with no elevation required, adds the WebView2 Runtime if missing, and enables automatic updates. |
+| **`QuickMail.exe`** — standalone portable executable | No installation required. Copy it anywhere and run. |
+
+Both downloads include the .NET 8 runtime — you do not need to install .NET separately.
+
+---
+
+## Fixed: typing a letter jumps to a contact in the address book
+
+With focus on the address book's contact list, typing a letter did nothing. Now it jumps to the first contact starting with that letter, the same way lists behave elsewhere in Windows. Type several letters quickly to match a longer beginning ("br" goes to Brenda rather than Bob), or press the same letter again to move to the next contact starting with it. Contacts saved without a name are matched on their address. The **Groups** and **Group members** lists work the same way. (#371)
+
+---
+
+## Reporting Issues
+
+Found a problem or have a suggestion? There are three ways to reach us — pick the one that fits:
+
+1. **Report a Bug → Send** (Help menu, inside QuickMail). Files the report for you anonymously — it includes no email address or other identifying information, so there is no way to follow up with you. **Best when you don't want any follow-up.**
+2. **Report a Bug → Copy report and open GitHub** (Help menu). Opens a pre-filled issue that you submit under your own GitHub account, so your GitHub contact information is attached. **Best when you have a GitHub account and want automatic filing plus direct contact.**
+3. **Email** [quickmailissues@theideaplace.net](mailto:quickmailissues@theideaplace.net). **Best when you don't mind sending email and want a personal follow-up.**
+
+Full details, including exactly what a report contains (and what it never contains), are in the [Reporting Issues section of the User Guide](https://kellylford.github.io/QuickMail/reporting-issues.html).


### PR DESCRIPTION
Fixes #371.

## The bug

With focus on the address book's contact list, typing a letter did nothing. The list renders each row through an `ItemTemplate` whose root is a `Grid`, so WPF's `TextSearch` had no text to match — and with no `TextSearch.TextPath` declared, type-ahead was silently a no-op.

## The fix

- `ContactList`, `GroupsList`, and `GroupMembersList` now declare `IsTextSearchEnabled="True"` plus a `TextSearch.TextPath`.
- Contacts match on a new `ContactModel.TypeAheadText`: the display name, falling back to the email address for prior-recipient contacts stored without a name. A `TextPath` binds to exactly one property, so that fallback has to live on the model. Groups match on `Name`.

WPF's built-in behavior then gives what the issue asks for: letters accumulate within the system type-ahead timeout ("br" lands on Brenda, not Bob), and repeating the same letter cycles through the contacts starting with it.

## Tests

`QuickMail.Tests/AddressBookTypeAheadTests.cs` raises real `TextInput` events through the WPF input pipeline (not just asserting the XAML attribute), covering:

- first letter selects the matching contact
- repeating a letter cycles to the next match
- multiple letters match a longer prefix
- a contact with no name is reachable by its address
- the groups list matches on group name

All 6 pass locally; full suite run as well.

## Notes

- Docs: user guide gets a "Jumping to a Contact by Typing" subsection; release notes entry added to `docs/release-notes-v0.8.37.md` (new file — this work ships in 0.8.37).
- Out of scope: the standalone Group Manager dialog (Manage… / `Ctrl+Shift+M`) has its own lists that were not touched here. Worth a follow-up if the same typing behavior is wanted there.