### PR TITLE
Address book: find mail from or to a contact (#370)

### DIFF
--- a/QuickMail.Tests/ContactMailSearchTests.cs
+++ b/QuickMail.Tests/ContactMailSearchTests.cs
@@ -160,6 +160,40 @@ public class ContactMailSearchTests
         Assert.Equal("1", vm.Messages[0].MessageId);
     }
 
+    [Theory]
+    // Whole-address hits, in every shape a header puts them in.
+    [InlineData("Bob Baker <bob@example.com>",            "bob@example.com", true)]
+    [InlineData("bob@example.com",                        "bob@example.com", true)]
+    [InlineData("BOB@EXAMPLE.COM",                        "bob@example.com", true)]
+    [InlineData("ann@x.com, bob@example.com, cy@x.com",   "bob@example.com", true)]
+    [InlineData("\"Baker, Bob\" <bob@example.com>",       "bob@example.com", true)]
+    // Partial hits that a plain substring test would wrongly report.
+    [InlineData("notbob@example.com",                     "bob@example.com", false)]
+    [InlineData("bob@example.com.au",                     "bob@example.com", false)]
+    [InlineData("bob@example.common",                     "bob@example.com", false)]
+    [InlineData("ann@x.com",                              "bob@example.com", false)]
+    [InlineData("",                                       "bob@example.com", false)]
+    public void HeaderNamesAddress_MatchesWholeAddressesOnly(string header, string address, bool expected)
+        => Assert.Equal(expected, MainViewModel.HeaderNamesAddress(header, address));
+
+    [Fact]
+    public async Task ShowContactMail_DoesNotMatchALongerAddress()
+    {
+        var messages = new[]
+        {
+            Msg("1", "Impostor <notbob@example.com>", "kelly@example.com"),
+            Msg("2", "Bob <bob@example.com.au>",      "kelly@example.com"),
+            Msg("3", "Bob <bob@example.com>",         "kelly@example.com"),
+        };
+        var vm = MakeVm(messages);
+        await vm.InitialLoadAsync();
+
+        await vm.ShowContactMailAsync("bob@example.com", MainViewModel.ContactMailDirection.From);
+
+        Assert.Single(vm.Messages);
+        Assert.Equal("3", vm.Messages[0].MessageId);
+    }
+
     // ── Address book side ────────────────────────────────────────────────────
 
     [Fact]

--- a/QuickMail.Tests/ContactMailSearchTests.cs
+++ b/QuickMail.Tests/ContactMailSearchTests.cs
@@ -1,0 +1,231 @@
+// Tests for "find mail from / to this contact" — issue #370.
+//
+// The address book hands the main window a contact; the main window opens a virtual
+// folder whose sentinel carries the address and the direction, and the fetch filters
+// every cached message across all accounts and folders on the From or To header.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using QuickMail.Models;
+using QuickMail.Services;
+using QuickMail.ViewModels;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+public class ContactMailSearchTests
+{
+    private static MailMessageSummary Msg(string id, string from, string to, int daysAgo = 0) => new()
+    {
+        MessageId  = id,
+        AccountId  = Guid.NewGuid(),
+        FolderName = "INBOX",
+        From       = from,
+        To         = to,
+        Subject    = $"Subject {id}",
+        Date       = DateTimeOffset.Now.AddDays(-daysAgo),
+    };
+
+    private static readonly MailMessageSummary[] Corpus =
+    [
+        Msg("1", "Bob Baker <bob@example.com>", "kelly@example.com",                       daysAgo: 2),
+        Msg("2", "Kelly <kelly@example.com>",   "Bob Baker <bob@example.com>, ann@x.com",  daysAgo: 1),
+        Msg("3", "Ann <ann@x.com>",             "kelly@example.com",                       daysAgo: 3),
+        Msg("4", "BOB@EXAMPLE.COM",             "kelly@example.com",                       daysAgo: 0),
+    ];
+
+    private static MainViewModel MakeVm(IEnumerable<MailMessageSummary>? messages = null)
+    {
+        ILocalStoreService store = messages != null
+            ? new FilterableStoreForFlags(messages)
+            : new StubLocalStoreService();
+        return new MainViewModel(
+            new StubImapMailService(), new StubAccountService(), new StubCredentialService(),
+            store, new StubOAuthService(), new StubSyncService(), new StubConfigService(),
+            new StubCommandRegistry(), new StubViewService(), new StubRuleService(), new StubSmtpService());
+    }
+
+    [Fact]
+    public async Task ShowContactMail_From_ReturnsOnlyMessagesTheContactSent()
+    {
+        var vm = MakeVm(Corpus);
+        await vm.InitialLoadAsync();
+
+        await vm.ShowContactMailAsync("bob@example.com", MainViewModel.ContactMailDirection.From, "Bob Baker");
+
+        Assert.Equal(new[] { "4", "1" }, vm.Messages.Select(m => m.MessageId).ToArray());
+    }
+
+    [Fact]
+    public async Task ShowContactMail_To_ReturnsOnlyMessagesAddressedToTheContact()
+    {
+        var vm = MakeVm(Corpus);
+        await vm.InitialLoadAsync();
+
+        await vm.ShowContactMailAsync("bob@example.com", MainViewModel.ContactMailDirection.To, "Bob Baker");
+
+        Assert.Single(vm.Messages);
+        Assert.Equal("2", vm.Messages[0].MessageId);
+    }
+
+    [Fact]
+    public async Task ShowContactMail_UsesContactNameInTheFolderTitle()
+    {
+        var vm = MakeVm(Corpus);
+        await vm.InitialLoadAsync();
+
+        await vm.ShowContactMailAsync("bob@example.com", MainViewModel.ContactMailDirection.From, "Bob Baker");
+
+        Assert.Equal("Mail from Bob Baker", vm.SelectedFolder?.DisplayName);
+        Assert.Contains("2 messages from bob@example.com", vm.StatusText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ShowContactMail_NoName_TitlesWithTheAddress()
+    {
+        var vm = MakeVm(Corpus);
+        await vm.InitialLoadAsync();
+
+        await vm.ShowContactMailAsync("bob@example.com", MainViewModel.ContactMailDirection.To);
+
+        Assert.Equal("Mail to bob@example.com", vm.SelectedFolder?.DisplayName);
+    }
+
+    [Fact]
+    public async Task ShowContactMail_NoMatches_ClearsListAndSaysSo()
+    {
+        var vm = MakeVm(Corpus);
+        await vm.InitialLoadAsync();
+
+        await vm.ShowContactMailAsync("nobody@example.com", MainViewModel.ContactMailDirection.From);
+
+        Assert.Empty(vm.Messages);
+        Assert.Equal("No messages from nobody@example.com.", vm.StatusText);
+    }
+
+    [Fact]
+    public async Task ShowContactMail_BlankAddress_DoesNothing()
+    {
+        var vm = MakeVm(Corpus);
+        await vm.InitialLoadAsync();
+        var before = vm.SelectedFolder;
+
+        await vm.ShowContactMailAsync("   ", MainViewModel.ContactMailDirection.From);
+
+        Assert.Same(before, vm.SelectedFolder);
+    }
+
+    [Fact]
+    public async Task ShowContactMail_ClearsAnyActiveFilterAndSearch()
+    {
+        // The results view is a fresh start, exactly like navigating to any other folder:
+        // a leftover unread filter or search text must not silently hide matches.
+        var vm = MakeVm(Corpus);
+        await vm.InitialLoadAsync();
+        await vm.SetFilterCommand.ExecuteAsync("unread");
+        vm.IsSearchActive = true;
+        vm.SearchText     = "zzz";
+
+        await vm.ShowContactMailAsync("bob@example.com", MainViewModel.ContactMailDirection.From);
+
+        Assert.Equal(MessageFilter.All, vm.ActiveFilter);
+        Assert.Equal(string.Empty, vm.SearchText);
+        Assert.False(vm.IsSearchActive);
+        Assert.Equal(2, vm.Messages.Count);
+    }
+
+    [Fact]
+    public async Task SelectingTheSentinelFolder_RunsTheSameSearch()
+    {
+        // Refresh, sync-days changes, and any other re-fetch go back through the sentinel,
+        // so the folder name has to round-trip the address (including characters that
+        // percent-escape) and the direction.
+        var messages = new[]
+        {
+            Msg("1", "Bob <bob+news@example.com>", "kelly@example.com"),
+            Msg("2", "Ann <ann@x.com>",            "kelly@example.com"),
+        };
+        var vm = MakeVm(messages);
+        await vm.InitialLoadAsync();
+
+        var folder = MainViewModel.CreateContactMailVirtualFolder(
+            "bob+news@example.com", MainViewModel.ContactMailDirection.From, "Bob");
+        Assert.DoesNotContain("+", folder.FullName, StringComparison.Ordinal);
+
+        await vm.SelectFolderCommand.ExecuteAsync(folder);
+
+        Assert.Single(vm.Messages);
+        Assert.Equal("1", vm.Messages[0].MessageId);
+    }
+
+    // ── Address book side ────────────────────────────────────────────────────
+
+    [Fact]
+    public void AddressBook_WithoutSearchActions_HidesTheFindMailActions()
+    {
+        var vm = new AddressBookViewModel(new StubContactService())
+        {
+            SelectedContact = new ContactModel { DisplayName = "Bob", EmailAddress = "bob@example.com" },
+        };
+
+        Assert.False(vm.HasSearchActions);
+        Assert.False(vm.CanFindMailForContact);
+        // Invoking anyway must not throw — the command is registered in the palette.
+        vm.FindMailFromContactCommand.Execute(null);
+    }
+
+    [Fact]
+    public void AddressBook_FindMailCommands_ReportTheSelectedContact()
+    {
+        ContactModel? fromArg = null;
+        ContactModel? toArg   = null;
+        var vm = new AddressBookViewModel(new StubContactService());
+        vm.SetSearchActions(c => fromArg = c, c => toArg = c);
+
+        var bob = new ContactModel { DisplayName = "Bob", EmailAddress = "bob@example.com" };
+        vm.SelectedContact = bob;
+
+        Assert.True(vm.CanFindMailForContact);
+        vm.FindMailFromContactCommand.Execute(null);
+        vm.FindMailToContactCommand.Execute(null);
+
+        Assert.Same(bob, fromArg);
+        Assert.Same(bob, toArg);
+    }
+
+    [Fact]
+    public void AddressBook_ContactWithNoAddress_CannotBeSearchedFor()
+    {
+        var invoked = false;
+        var vm = new AddressBookViewModel(new StubContactService());
+        vm.SetSearchActions(_ => invoked = true, _ => invoked = true);
+
+        vm.SelectedContact = new ContactModel { DisplayName = "No Address", EmailAddress = string.Empty };
+
+        Assert.False(vm.CanFindMailForContact);
+        vm.FindMailFromContactCommand.Execute(null);
+        vm.FindMailToContactCommand.Execute(null);
+        Assert.False(invoked);
+    }
+
+    [Fact]
+    public void AddressBook_CanFindMail_TracksSelection()
+    {
+        var vm = new AddressBookViewModel(new StubContactService());
+        vm.SetSearchActions(_ => { }, _ => { });
+        var raised = 0;
+        vm.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(AddressBookViewModel.CanFindMailForContact)) raised++;
+        };
+
+        vm.SelectedContact = new ContactModel { DisplayName = "Bob", EmailAddress = "bob@example.com" };
+        Assert.True(vm.CanFindMailForContact);
+
+        vm.SelectedContact = null;
+        Assert.False(vm.CanFindMailForContact);
+        Assert.Equal(2, raised);
+    }
+}

--- a/QuickMail/ViewModels/AddressBookViewModel.cs
+++ b/QuickMail/ViewModels/AddressBookViewModel.cs
@@ -28,6 +28,9 @@ public partial class AddressBookViewModel : ObservableObject
     private Action<ContactModel>? _ccInsertAction;
     private Action<ContactModel>? _bccInsertAction;
 
+    private Action<ContactModel>? _searchFromAction;
+    private Action<ContactModel>? _searchToAction;
+
     /// <summary>
     /// Raised by destructive operations (e.g. delete group) so the View can
     /// show a MessageBox and return the user's choice. The VM never touches
@@ -57,6 +60,26 @@ public partial class AddressBookViewModel : ObservableObject
         _ccInsertAction = ccAction;
         _bccInsertAction = bccAction;
         OnPropertyChanged(nameof(HasInsertActions));
+    }
+
+    /// <summary>
+    /// True when the host window can show mail for a contact (issue #370). Only the main
+    /// window sets these — the address book opened from a compose window has no message list
+    /// to show results in, so it hides the two "Find mail…" actions entirely.
+    /// </summary>
+    public bool HasSearchActions => _searchFromAction != null && _searchToAction != null;
+
+    /// <summary>
+    /// Supplies the "find mail from / to this contact" actions. The host decides what a search
+    /// means and when to run it — the address book only reports which contact was chosen.
+    /// </summary>
+    public void SetSearchActions(
+        Action<ContactModel> searchFromAction,
+        Action<ContactModel> searchToAction)
+    {
+        _searchFromAction = searchFromAction;
+        _searchToAction   = searchToAction;
+        OnPropertyChanged(nameof(HasSearchActions));
     }
 
     public AddressBookViewModel(
@@ -109,6 +132,7 @@ public partial class AddressBookViewModel : ObservableObject
     [NotifyPropertyChangedFor(nameof(HasSelectedContact))]
     [NotifyPropertyChangedFor(nameof(CanEditContact))]
     [NotifyPropertyChangedFor(nameof(CanDeleteContact))]
+    [NotifyPropertyChangedFor(nameof(CanFindMailForContact))]
     private ContactModel? _selectedContact;
 
     public bool HasSelectedContact => SelectedContact != null;
@@ -326,6 +350,31 @@ public partial class AddressBookViewModel : ObservableObject
 
     [RelayCommand]
     private void AddToBcc() { if (SelectedContact is { } c) _bccInsertAction?.Invoke(c); }
+
+    // ── Find mail for a contact (issue #370) ─────────────────────────────────
+    // A contact with no address cannot be searched for, so both commands no-op on one
+    // rather than handing the host an empty string to search with.
+
+    [RelayCommand]
+    private void FindMailFromContact()
+    {
+        if (SelectedContact is { } c && !string.IsNullOrWhiteSpace(c.EmailAddress))
+            _searchFromAction?.Invoke(c);
+    }
+
+    [RelayCommand]
+    private void FindMailToContact()
+    {
+        if (SelectedContact is { } c && !string.IsNullOrWhiteSpace(c.EmailAddress))
+            _searchToAction?.Invoke(c);
+    }
+
+    /// <summary>
+    /// True when the two "Find mail…" actions are usable: the host wired them up and the
+    /// selected contact has an address to search for.
+    /// </summary>
+    public bool CanFindMailForContact =>
+        HasSearchActions && SelectedContact is { } c && !string.IsNullOrWhiteSpace(c.EmailAddress);
 
     // ── Group commands ───────────────────────────────────────────────────────
 

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -342,14 +342,46 @@ public partial class MainViewModel : ObservableObject, IDisposable
     }
 
     /// <summary>
-    /// True when the message's From (or To) header mentions the address. Substring matching is
-    /// deliberate: both headers carry a display name alongside the address, and To holds a list.
+    /// True when the message's From (or To) header names this address. The headers are display
+    /// strings — a name plus an address, and a whole list of them for To — so the address is
+    /// looked for inside them rather than compared whole.
     /// </summary>
     private static bool MatchesContactAddress(
         MailMessageSummary msg, string address, ContactMailDirection direction) =>
-        direction == ContactMailDirection.From
-            ? msg.From.Contains(address, StringComparison.OrdinalIgnoreCase)
-            : msg.To.Contains(address, StringComparison.OrdinalIgnoreCase);
+        HeaderNamesAddress(
+            direction == ContactMailDirection.From ? msg.From : msg.To,
+            address);
+
+    /// <summary>
+    /// True when <paramref name="header"/> contains <paramref name="address"/> as a whole address
+    /// rather than as part of a longer one. A plain substring test would report a match for
+    /// "bob@example.com" in both "notbob@example.com" and "bob@example.com.au", so each hit has to
+    /// sit on an address boundary — anything but an address character on either side, which is what
+    /// the surrounding "&lt;", "&gt;", quotes, commas, and spaces in a header supply.
+    /// </summary>
+    internal static bool HeaderNamesAddress(string header, string address)
+    {
+        if (string.IsNullOrEmpty(header) || string.IsNullOrEmpty(address)) return false;
+
+        var i = header.IndexOf(address, StringComparison.OrdinalIgnoreCase);
+        while (i >= 0)
+        {
+            var end = i + address.Length;
+            if ((i == 0 || !IsAddressChar(header[i - 1])) &&
+                (end >= header.Length || !IsAddressChar(header[end])))
+                return true;
+            if (i + 1 >= header.Length) break;
+            i = header.IndexOf(address, i + 1, StringComparison.OrdinalIgnoreCase);
+        }
+        return false;
+    }
+
+    // Characters that can appear inside an address (RFC 5322 atext plus '.' and '@'). Seeing one
+    // immediately before or after a hit means the hit is only part of a longer address.
+    private static bool IsAddressChar(char c) =>
+        char.IsLetterOrDigit(c) ||
+        c is '.' or '@' or '-' or '_' or '+' or '%' or '!' or '#' or '$' or '&' or '\''
+          or '*' or '/' or '=' or '?' or '^' or '`' or '{' or '|' or '}' or '~';
 
     private static bool TryGetViewIdFromSentinel(string? fullName, out Guid viewId)
     {

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -287,6 +287,70 @@ public partial class MainViewModel : ObservableObject, IDisposable
     internal const string ViewPrefix    = "\u0000View:";
     internal const string ViewAllPrefix = "\u0000ViewAll:";
 
+    // Sentinel prefix for the "mail from / to this contact" results view launched from the
+    // address book (issue #370), e.g. ContactMailPrefix + "from|bob%40example.com". The address
+    // is percent-escaped so a '|' inside it can never be mistaken for the field separator.
+    internal const string ContactMailPrefix = "\u0000ContactMail:";
+
+    /// <summary>Which header the contact-mail results view matches an address against.</summary>
+    public enum ContactMailDirection
+    {
+        /// <summary>Mail the contact sent (matches the From header).</summary>
+        From,
+        /// <summary>Mail addressed to the contact (matches the To header).</summary>
+        To,
+    }
+
+    /// <summary>
+    /// Builds the virtual folder that shows every cached message from (or to) one address.
+    /// <paramref name="label"/> is the contact's display name when there is one; it appears in
+    /// the window title and status bar, while the sentinel always carries the raw address.
+    /// </summary>
+    public static MailFolderModel CreateContactMailVirtualFolder(
+        string address, ContactMailDirection direction, string? label = null)
+    {
+        var who  = string.IsNullOrWhiteSpace(label) ? address : label!.Trim();
+        var kind = direction == ContactMailDirection.From ? "from" : "to";
+        return new MailFolderModel
+        {
+            FullName    = $"{ContactMailPrefix}{kind}|{Uri.EscapeDataString(address)}",
+            DisplayName = $"Mail {kind} {who}",
+        };
+    }
+
+    /// <summary>
+    /// Extracts the address and direction from a contact-mail sentinel. Returns false for any
+    /// other folder name, so callers can use it as the branch test for this view.
+    /// </summary>
+    private static bool TryGetContactMailFromSentinel(
+        string? fullName, out string address, out ContactMailDirection direction)
+    {
+        address   = string.Empty;
+        direction = ContactMailDirection.From;
+        if (fullName == null || !fullName.StartsWith(ContactMailPrefix, StringComparison.Ordinal))
+            return false;
+
+        var tail = fullName[ContactMailPrefix.Length..];
+        var sep  = tail.IndexOf('|', StringComparison.Ordinal);
+        if (sep <= 0) return false;
+
+        direction = tail[..sep].Equals("to", StringComparison.Ordinal)
+            ? ContactMailDirection.To
+            : ContactMailDirection.From;
+        address = Uri.UnescapeDataString(tail[(sep + 1)..]);
+        return address.Length > 0;
+    }
+
+    /// <summary>
+    /// True when the message's From (or To) header mentions the address. Substring matching is
+    /// deliberate: both headers carry a display name alongside the address, and To holds a list.
+    /// </summary>
+    private static bool MatchesContactAddress(
+        MailMessageSummary msg, string address, ContactMailDirection direction) =>
+        direction == ContactMailDirection.From
+            ? msg.From.Contains(address, StringComparison.OrdinalIgnoreCase)
+            : msg.To.Contains(address, StringComparison.OrdinalIgnoreCase);
+
     private static bool TryGetViewIdFromSentinel(string? fullName, out Guid viewId)
     {
         if (fullName != null &&
@@ -343,6 +407,9 @@ public partial class MainViewModel : ObservableObject, IDisposable
         // Saved-view sentinels.
         if (TryGetViewIdFromSentinel(folder.FullName, out _))    return true;
         if (TryGetViewAllIdFromSentinel(folder.FullName, out _)) return true;
+
+        // Address-book "mail from / to this contact" results (#370).
+        if (TryGetContactMailFromSentinel(folder.FullName, out _, out _)) return true;
 
         if (folder.AccountId != Guid.Empty) return false;
 
@@ -2123,6 +2190,11 @@ public partial class MainViewModel : ObservableObject, IDisposable
                     .Select(f => (kvp.Key, f.FullName.ToUpperInvariant()))));
             relevant = incoming.Where(m =>
                 matchingFolderKeys.Contains((m.AccountId, m.FolderName.ToUpperInvariant())));
+        }
+        else if (TryGetContactMailFromSentinel(selected.FullName, out var contactAddress, out var contactDirection))
+        {
+            // Contact mail results (#370) — only accept messages that still match the address.
+            relevant = incoming.Where(m => MatchesContactAddress(m, contactAddress, contactDirection));
         }
         else if (!selected.IsHeader && selected.AccountId != Guid.Empty)
         {
@@ -3962,6 +4034,8 @@ public partial class MainViewModel : ObservableObject, IDisposable
         if (folder.FullName == AllTrashFolder.FullName)   return FetchVirtualFolderAsync(SpecialFolderKind.Trash,  "All Trash");
         if (folder.FullName == AllFlaggedFolder.FullName) return FetchAllFlaggedAsync();
         if (TryGetAccountIdFromSentinel(folder.FullName, out var accountId)) return FetchAccountAllMailAsync(accountId);
+        if (TryGetContactMailFromSentinel(folder.FullName, out var contactAddress, out var contactDirection))
+            return FetchContactMailAsync(contactAddress, contactDirection);
 
         // Saved-view sentinels — re-fetch without resetting mode/filter/sort
         if (TryGetViewIdFromSentinel(folder.FullName, out var viewId) ||
@@ -4036,6 +4110,94 @@ public partial class MainViewModel : ObservableObject, IDisposable
         {
             LogService.Log("FetchAllFlagged failed", ex);
             StatusText = "Could not load flagged messages.";
+        }
+        finally
+        {
+            if (loadVersion == _folderLoadVersion)
+                IsBusy = false;
+        }
+    }
+
+    /// <summary>
+    /// Opens the "mail from / to this contact" results view for an address (issue #370): every
+    /// message in the local cache whose From (or To) header mentions it, across all accounts and
+    /// folders. Called from the address book; also the entry point for any future caller.
+    /// Reuses <see cref="SelectFolderAsync"/> so filter/search/view state is reset exactly the
+    /// same way navigating to any other folder resets it.
+    /// </summary>
+    public Task ShowContactMailAsync(string address, ContactMailDirection direction, string? label = null)
+    {
+        if (string.IsNullOrWhiteSpace(address)) return Task.CompletedTask;
+        return SelectFolderAsync(
+            CreateContactMailVirtualFolder(address.Trim(), direction, label));
+    }
+
+    private async Task FetchContactMailAsync(string address, ContactMailDirection direction)
+    {
+        var loadVersion    = Interlocked.Increment(ref _folderLoadVersion);
+        var expectedFolder = SelectedFolder;
+        var kind           = direction == ContactMailDirection.From ? "from" : "to";
+        Messages.Clear();
+        StatusText = $"Searching for mail {kind} {address}…";
+        IsBusy = true;
+
+        _folderCts?.Cancel();
+        ReplaceCts(ref _folderCts, out var ct);
+
+        try
+        {
+            List<MailMessageSummary> all;
+            if (OnlineMode)
+            {
+                // In --online mode there is no cache to search, so sweep every non-excluded
+                // folder across all accounts and match client-side — same shape as All Flagged.
+                all = new List<MailMessageSummary>();
+                foreach (var account in Accounts)
+                {
+                    if (!_cachedFolders.TryGetValue(account.Id, out var folders)) continue;
+                    foreach (var folder in folders)
+                    {
+                        if (folder.ExcludeFromAllMail) continue;
+                        ct.ThrowIfCancellationRequested();
+                        try
+                        {
+                            var msgs = _syncDays > 0
+                                ? await _imap.GetMessagesSinceDateAsync(
+                                    account.Id, folder.FullName, DateTime.UtcNow.AddDays(-_syncDays), ct)
+                                : await _imap.GetMessageSummariesAsync(account.Id, folder.FullName, 50000, ct);
+                            all.AddRange(msgs.Where(m => MatchesContactAddress(m, address, direction)));
+                        }
+                        catch (OperationCanceledException) { throw; }
+                        catch (Exception ex)
+                        {
+                            LogService.Log($"FetchContactMail online {account.DisplayName}/{folder.DisplayName}", ex);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                all = await _localStore.LoadAllSummariesAsync();
+            }
+            if (!IsCurrentFolderLoad(loadVersion, expectedFolder)) return;
+
+            var matches = all.Where(m => MatchesContactAddress(m, address, direction)).ToList();
+            await ResolveFlagNamesAsync(matches);
+            SetMessages(matches.OrderByDescending(m => m.Date).ToList());
+            var n = Messages.Count;
+            StatusText = n == 0
+                ? $"No messages {kind} {address}."
+                : $"{n} {(n == 1 ? "message" : "messages")} {kind} {address}.";
+        }
+        catch (OperationCanceledException)
+        {
+            if (loadVersion == _folderLoadVersion)
+                StatusText = "Contact mail search cancelled.";
+        }
+        catch (Exception ex)
+        {
+            LogService.Log("FetchContactMail failed", ex);
+            StatusText = $"Could not search for mail {kind} {address}.";
         }
         finally
         {

--- a/QuickMail/Views/AddressBookWindow.xaml
+++ b/QuickMail/Views/AddressBookWindow.xaml
@@ -192,7 +192,10 @@
                               PreviewKeyDown="ContactList_PreviewKeyDown"
                               ContextMenuOpening="ContactList_ContextMenuOpening">
                         <ListView.ContextMenu>
-                            <ContextMenu AutomationProperties.Name="Add to group"/>
+                            <!-- Items are built in ContactList_ContextMenuOpening: the two
+                                 "Find mail…" actions (when the host can show results) then
+                                 one "Add to group" item per group. -->
+                            <ContextMenu AutomationProperties.Name="Contact actions"/>
                         </ListView.ContextMenu>
                         <ListView.ItemContainerStyle>
                             <Style TargetType="ListViewItem" BasedOn="{StaticResource {x:Type ListViewItem}}">

--- a/QuickMail/Views/AddressBookWindow.xaml.cs
+++ b/QuickMail/Views/AddressBookWindow.xaml.cs
@@ -92,6 +92,21 @@ public partial class AddressBookWindow : Window
             execute: () => _vm.CancelEditCommand.Execute(null),
             isAvailable: () => MainTabs.SelectedIndex == 0 && _vm.IsEditingContact));
 
+        // Find mail from / to the selected contact (issue #370). No default key — the actions
+        // live on the contact list's context menu (Shift+F10) and in the palette, and can be
+        // given a shortcut from Settings → Keyboard like any other registered command.
+        _registry.Register(new CommandDefinition(
+            id: "contacts.findMailFrom", category: "Contacts", title: "Find Mail From Contact",
+            defaultKey: Key.None, defaultModifiers: ModifierKeys.None,
+            execute: () => _vm.FindMailFromContactCommand.Execute(null),
+            isAvailable: () => MainTabs.SelectedIndex == 0 && _vm.CanFindMailForContact));
+
+        _registry.Register(new CommandDefinition(
+            id: "contacts.findMailTo", category: "Contacts", title: "Find Mail To Contact",
+            defaultKey: Key.None, defaultModifiers: ModifierKeys.None,
+            execute: () => _vm.FindMailToContactCommand.Execute(null),
+            isAvailable: () => MainTabs.SelectedIndex == 0 && _vm.CanFindMailForContact));
+
         // ── Groups tab commands ──────────────────────────────────────────────
 
         // Ctrl+Shift+N: switch to Groups tab and show the name entry area in create mode.
@@ -275,6 +290,21 @@ public partial class AddressBookWindow : Window
 
         var menu = ContactList.ContextMenu!;
         menu.Items.Clear();
+
+        // Find mail from / to this contact (issue #370). Present only when the host window
+        // can actually show results — the address book opened from Compose cannot.
+        if (_vm.CanFindMailForContact)
+        {
+            var fromItem = new System.Windows.Controls.MenuItem { Header = "Find mail _from this contact" };
+            fromItem.Click += (_, _) => _vm.FindMailFromContactCommand.Execute(null);
+            menu.Items.Add(fromItem);
+
+            var toItem = new System.Windows.Controls.MenuItem { Header = "Find mail _to this contact" };
+            toItem.Click += (_, _) => _vm.FindMailToContactCommand.Execute(null);
+            menu.Items.Add(toItem);
+
+            menu.Items.Add(new Separator());
+        }
 
         if (_vm.Groups.Count == 0)
         {

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -5518,8 +5518,8 @@ public partial class MainWindow : Window
 
     /// <summary>
     /// Loads the "mail from / to this contact" results view, moves focus to the message list,
-    /// and announces the count. Fire-and-forget from <see cref="OpenAddressBook"/>, so it
-    /// swallows nothing silently — a failure is logged and surfaced in the status bar by the VM.
+    /// and announces the count. Fire-and-forget from <see cref="OpenAddressBook"/>: a failure
+    /// is logged and announced rather than left as a silently empty list.
     /// </summary>
     private async Task ShowContactMailAsync(ContactModel contact, MainViewModel.ContactMailDirection direction)
     {

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -5487,8 +5487,63 @@ public partial class MainWindow : Window
             ccAction:  c => GetOrOpenCompose().AddCcAddress(c.DisplayName ?? string.Empty, c.EmailAddress),
             bccAction: c => GetOrOpenCompose().AddBccAddress(c.DisplayName ?? string.Empty, c.EmailAddress));
 
-        var win = new AddressBookWindow(vm) { Owner = this };
+        // "Find mail from / to this contact" (issue #370). The results replace this window's
+        // message list, which must not be touched while the address book's modal message loop
+        // is still running (see the modal-dialog rules in CLAUDE.md). So the action only
+        // records the request and closes the address book; the search runs below, once
+        // ShowDialog has returned and the nested loop is gone.
+        ContactModel? searchContact = null;
+        var searchDirection = MainViewModel.ContactMailDirection.From;
+        AddressBookWindow? win = null;
+        vm.SetSearchActions(
+            searchFromAction: c =>
+            {
+                searchContact   = c;
+                searchDirection = MainViewModel.ContactMailDirection.From;
+                win?.Close();
+            },
+            searchToAction: c =>
+            {
+                searchContact   = c;
+                searchDirection = MainViewModel.ContactMailDirection.To;
+                win?.Close();
+            });
+
+        win = new AddressBookWindow(vm) { Owner = this };
         win.ShowDialog();
+
+        if (searchContact is { } contact && !string.IsNullOrWhiteSpace(contact.EmailAddress))
+            _ = ShowContactMailAsync(contact, searchDirection);
+    }
+
+    /// <summary>
+    /// Loads the "mail from / to this contact" results view, moves focus to the message list,
+    /// and announces the count. Fire-and-forget from <see cref="OpenAddressBook"/>, so it
+    /// swallows nothing silently — a failure is logged and surfaced in the status bar by the VM.
+    /// </summary>
+    private async Task ShowContactMailAsync(ContactModel contact, MainViewModel.ContactMailDirection direction)
+    {
+        var label = string.IsNullOrWhiteSpace(contact.DisplayName)
+            ? contact.EmailAddress
+            : contact.DisplayName;
+        var kind = direction == MainViewModel.ContactMailDirection.From ? "from" : "to";
+        try
+        {
+            await _vm.ShowContactMailAsync(contact.EmailAddress, direction, label);
+            ReturnFocusToMessageList();
+            var n = _vm.Messages.Count;
+            AccessibilityHelper.Announce(this,
+                n == 0
+                    ? $"No messages {kind} {label}."
+                    : $"{n} {(n == 1 ? "message" : "messages")} {kind} {label}.",
+                interrupt: true, category: AnnouncementCategory.Result);
+        }
+        catch (Exception ex)
+        {
+            LogService.Log($"ShowContactMail {kind}", ex);
+            AccessibilityHelper.Announce(this, $"Could not search for mail {kind} {label}.",
+                interrupt: true, category: AnnouncementCategory.Result);
+        }
     }
 
     private void MenuPlainText_Click(object sender, RoutedEventArgs e) => TogglePlainTextView();

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -5513,7 +5513,7 @@ public partial class MainWindow : Window
         win.ShowDialog();
 
         if (searchContact is { } contact && !string.IsNullOrWhiteSpace(contact.EmailAddress))
-            _ = ShowContactMailAsync(contact, searchDirection);
+            ShowContactMailAsync(contact, searchDirection).LogFaults("contact mail search");
     }
 
     /// <summary>

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -560,7 +560,7 @@ From the contact list, you can pull up everything a person sent you, or everythi
 
 Both actions are also in the address book's Command Palette (**Ctrl+Shift+P**) as **Find Mail From Contact** and **Find Mail To Contact**, and you can assign them a keyboard shortcut in Settings → Keyboard.
 
-The search covers every account and folder QuickMail has cached — not just the folder you were in. Mail older than your sync range is not stored locally, so it is not included. To leave the results, select any folder in the folder tree.
+The search covers every account and folder QuickMail has cached — not just the folder you were in. Mail older than your sync range is not stored locally, so it is not included. **Find mail to this contact** matches the To line, so a message where the person was only in Cc does not appear. To leave the results, select any folder in the folder tree.
 
 ### Syncing Contacts from Your Accounts
 

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -550,6 +550,18 @@ Press **Ctrl+Shift+B** to open the address book.
 
 The address book lists everyone you have sent mail to or explicitly added, plus — if you turn on contact sync — the contacts stored in your Microsoft and Google accounts. You can search by name or address, edit contact details, and organize contacts into groups. An **Account** column shows where each contact came from: **Local address book** for the ones you added yourself, or the account name for synced ones.
 
+### Finding Mail From or To a Contact
+
+From the contact list, you can pull up everything a person sent you, or everything you addressed to them.
+
+1. Select the contact and press **Shift+F10** (or the Applications key) to open the context menu.
+2. Choose **Find mail from this contact** or **Find mail to this contact**.
+3. The address book closes and the message list fills with the matches, newest first. Focus moves to the message list and the count is announced — for example, "12 messages from Bob Baker." The window title shows **Mail from Bob Baker** so you can tell the results apart from a folder.
+
+Both actions are also in the address book's Command Palette (**Ctrl+Shift+P**) as **Find Mail From Contact** and **Find Mail To Contact**, and you can assign them a keyboard shortcut in Settings → Keyboard.
+
+The search covers every account and folder QuickMail has cached — not just the folder you were in. Mail older than your sync range is not stored locally, so it is not included. To leave the results, select any folder in the folder tree.
+
 ### Syncing Contacts from Your Accounts
 
 QuickMail can fill the address book from the contacts already stored in your Microsoft, Google, and iCloud accounts, so the people your account knows are available for autocomplete when you address a message.

--- a/docs/release-notes-v0.8.37.md
+++ b/docs/release-notes-v0.8.37.md
@@ -1,0 +1,32 @@
+# QuickMail v0.8.37 Release Notes
+
+## Download
+
+Two options are available for v0.8.37:
+
+| Download | When to use |
+|----------|-------------|
+| **`QuickMail-win.msi`** — Windows installer | Recommended for most users. A standard setup wizard with license agreement; installs per-user with no elevation required, adds the WebView2 Runtime if missing, and enables automatic updates. |
+| **`QuickMail.exe`** — standalone portable executable | No installation required. Copy it anywhere and run. |
+
+Both downloads include the .NET 8 runtime — you do not need to install .NET separately.
+
+---
+
+## New: find a contact's mail from the address book
+
+Select someone in the address book, press **Shift+F10**, and choose **Find mail from this contact** or **Find mail to this contact**. The address book closes and the message list fills with the matches, newest first, drawn from every account and folder QuickMail has cached — not just the folder you were in. Focus lands on the message list and the count is announced ("12 messages from Bob Baker."), and the window title reads **Mail from Bob Baker** so the results are easy to tell apart from a folder.
+
+Both actions are also in the address book's Command Palette (**Ctrl+Shift+P**) as **Find Mail From Contact** and **Find Mail To Contact**, so you can give them a keyboard shortcut in Settings → Keyboard. (#370)
+
+---
+
+## Reporting Issues
+
+Found a problem or have a suggestion? There are three ways to reach us — pick the one that fits:
+
+1. **Report a Bug → Send** (Help menu, inside QuickMail). Files the report for you anonymously — it includes no email address or other identifying information, so there is no way to follow up with you. **Best when you don't want any follow-up.**
+2. **Report a Bug → Copy report and open GitHub** (Help menu). Opens a pre-filled issue that you submit under your own GitHub account, so your GitHub contact information is attached. **Best when you have a GitHub account and want automatic filing plus direct contact.**
+3. **Email** [quickmailissues@theideaplace.net](mailto:quickmailissues@theideaplace.net). **Best when you don't mind sending email and want a personal follow-up.**
+
+Full details, including exactly what a report contains (and what it never contains), are in the [Reporting Issues section of the User Guide](https://kellylford.github.io/QuickMail/reporting-issues.html).


### PR DESCRIPTION
Fixes #370.

## What it does

Select a contact in the address book, press **Shift+F10**, and choose **Find mail from this contact** or **Find mail to this contact**. The address book closes, the message list fills with the matches (newest first), focus lands on the message list, and the count is announced — "12 messages from Bob Baker." The window title reads **Mail from Bob Baker** so the results are distinguishable from a folder.

Both actions are also registered in the address book's own `CommandRegistry`, so they appear in its palette (`Ctrl+Shift+P`) as **Find Mail From Contact** / **Find Mail To Contact** and can be given a shortcut. No default key is claimed.

## How it works

- **Results are a virtual folder**, the same mechanism All Flagged uses. The sentinel `\u0000ContactMail:{from|to}|{escaped address}` carries direction and address, so `FetchVirtualAsync`, refresh, sync-range changes, and the `OnFolderSynced` merge all route back through the same search instead of leaving a stale list behind.
- **Matching** is a case-insensitive substring test against the `From` or `To` header — both hold display name plus address, and `To` holds a list.
- **Source of messages** is the local cache (`LoadAllSummariesAsync`), i.e. every account and folder, subject to the sync range. `--online` mode has no cache, so it sweeps the non-excluded folders directly, mirroring `FetchAllFlaggedAsync`.
- **Entry point** `MainViewModel.ShowContactMailAsync` delegates to `SelectFolderAsync`, so filter / search / saved-view state is reset exactly as it is when navigating to any other folder.

## Modal-dialog safety

The address book is shown with `ShowDialog()` over a window with a live WebView2. Running the search while that nested message loop is alive is the crash pattern CLAUDE.md documents, so the context-menu action only **records** the request and closes the address book; the search runs in `OpenAddressBook` after `ShowDialog()` returns.

## Scope

- The two items appear only when the host supplied search actions — the address book opened from a compose window (`Ctrl+Shift+B` while composing) has no message list to show results in, so they are hidden there and the palette entries are unavailable.
- A contact with no email address can't be searched for; `CanFindMailForContact` gates both the menu items and the palette commands.
- The contact list's `ContextMenu` automation name changed from "Add to group" to "Contact actions" — it is no longer only about groups. Group items are unchanged, below a separator.

## Tests

`QuickMail.Tests/ContactMailSearchTests.cs` (12 tests): from/to filtering, newest-first order, case-insensitive match, title with and without a display name, empty-result message, blank address no-op, filter/search reset, sentinel round-trip through `SelectFolderCommand` (including an address that percent-escapes), and the address-book VM side (hidden without search actions, commands report the selected contact, no-address contact is not searchable, `CanFindMailForContact` change notification).

Full suite: 1582 passed.

## Docs

User guide gets a "Finding Mail From or To a Contact" subsection; release-notes entry in `docs/release-notes-v0.8.37.md`.