### PR TITLE
Bump to 0.8.37 and start its release notes

### DIFF
--- a/QuickMail/QuickMail.csproj
+++ b/QuickMail/QuickMail.csproj
@@ -15,9 +15,9 @@
          System.Windows(.Media) types this codebase uses unqualified (Point, Size, Color, Brush,
          Application, MessageBox, ...). -->
     <UseWindowsForms>true</UseWindowsForms>
-    <Version>0.8.36</Version>
-    <AssemblyVersion>0.8.36</AssemblyVersion>
-    <FileVersion>0.8.36</FileVersion>
+    <Version>0.8.37</Version>
+    <AssemblyVersion>0.8.37</AssemblyVersion>
+    <FileVersion>0.8.37</FileVersion>
     <!-- Velopack needs a hand-written Main that runs VelopackApp.Build().Run() before WPF
          initializes (install/update/uninstall hooks run and may exit the process). App.xaml
          therefore compiles as Page (no generated Main) and the entry point is declared here. -->

--- a/docs/release-notes-v0.8.37.md
+++ b/docs/release-notes-v0.8.37.md
@@ -17,7 +17,9 @@ Both downloads include the .NET 8 runtime — you do not need to install .NET se
 
 Select someone in the address book, press **Shift+F10**, and choose **Find mail from this contact** or **Find mail to this contact**. The address book closes and the message list fills with the matches, newest first, drawn from every account and folder QuickMail has cached — not just the folder you were in. Focus lands on the message list and the count is announced ("12 messages from Bob Baker."), and the window title reads **Mail from Bob Baker** so the results are easy to tell apart from a folder.
 
-Both actions are also in the address book's Command Palette (**Ctrl+Shift+P**) as **Find Mail From Contact** and **Find Mail To Contact**, so you can give them a keyboard shortcut in Settings → Keyboard. (#370)
+Both actions are also in the address book's Command Palette (**Ctrl+Shift+P**) as **Find Mail From Contact** and **Find Mail To Contact**, so you can give them a keyboard shortcut in Settings → Keyboard.
+
+Two things to know about the results: mail older than your sync range is not stored locally, so it is not searched, and **Find mail to this contact** matches the To line — a message where the person was only in Cc does not appear. (#370)
 
 ## Fixed: typing a letter jumps to a contact in the address book
 


### PR DESCRIPTION
Follows the usual "bump and start the notes" step for a new version.

- `QuickMail.csproj`: 0.8.36 → **0.8.37** (Version / AssemblyVersion / FileVersion). The version has to stay ahead of the shipped 0.8.36 for auto-update to offer the build.
- `docs/release-notes-v0.8.37.md`: already carried the two address book entries from #372 and #373; this adds the search-scope caveats to the #370 entry — mail outside the sync range is not cached and therefore not searched, and **Find mail to this contact** matches the To line, so Cc-only messages do not appear.

The user guide was updated alongside each change (a "Jumping to a Contact by Typing" subsection and a "Finding Mail From or To a Contact" subsection under Address Book), so nothing further is needed there for what has landed so far.

The **Thank You to Contributors** section is added when the release is cut, once the full contents of 0.8.37 are known — the per-account Rules work (#364/#367) is still open and expected in this version.