### PR TITLE
Contact mail results: close them and go back (#370 follow-up)

### DIFF
--- a/QuickMail.Tests/ContactMailSearchTests.cs
+++ b/QuickMail.Tests/ContactMailSearchTests.cs
@@ -160,6 +160,65 @@ public class ContactMailSearchTests
         Assert.Equal("1", vm.Messages[0].MessageId);
     }
 
+    // ── Closing the results ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ShowContactMail_MarksTheViewAsContactMail()
+    {
+        var vm = MakeVm(Corpus);
+        await vm.InitialLoadAsync();
+        Assert.False(vm.IsContactMailView);
+
+        await vm.ShowContactMailAsync("bob@example.com", MainViewModel.ContactMailDirection.From);
+
+        Assert.True(vm.IsContactMailView);
+    }
+
+    [Fact]
+    public async Task CloseContactMail_ReturnsToTheFolderTheSearchStartedFrom()
+    {
+        var vm = MakeVm(Corpus);
+        await vm.InitialLoadAsync();
+        var startedIn = vm.SelectedFolder;
+        Assert.NotNull(startedIn);
+
+        await vm.ShowContactMailAsync("bob@example.com", MainViewModel.ContactMailDirection.From);
+        await vm.CloseContactMailCommand.ExecuteAsync(null);
+
+        Assert.False(vm.IsContactMailView);
+        Assert.Equal(startedIn!.FullName, vm.SelectedFolder?.FullName);
+        Assert.Equal(Corpus.Length, vm.Messages.Count);
+    }
+
+    [Fact]
+    public async Task CloseContactMail_AfterASecondSearch_StillReturnsToTheOriginalFolder()
+    {
+        // Searching again from inside a results view must not make the previous search the
+        // place we go back to — one close always lands back in real mail.
+        var vm = MakeVm(Corpus);
+        await vm.InitialLoadAsync();
+        var startedIn = vm.SelectedFolder;
+
+        await vm.ShowContactMailAsync("bob@example.com", MainViewModel.ContactMailDirection.From);
+        await vm.ShowContactMailAsync("ann@x.com", MainViewModel.ContactMailDirection.From);
+        await vm.CloseContactMailCommand.ExecuteAsync(null);
+
+        Assert.False(vm.IsContactMailView);
+        Assert.Equal(startedIn?.FullName, vm.SelectedFolder?.FullName);
+    }
+
+    [Fact]
+    public async Task CloseContactMail_OutsideTheResultsView_DoesNothing()
+    {
+        var vm = MakeVm(Corpus);
+        await vm.InitialLoadAsync();
+        var before = vm.SelectedFolder;
+
+        await vm.CloseContactMailCommand.ExecuteAsync(null);
+
+        Assert.Same(before, vm.SelectedFolder);
+    }
+
     [Theory]
     // Whole-address hits, in every shape a header puts them in.
     [InlineData("Bob Baker <bob@example.com>",            "bob@example.com", true)]

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -501,6 +501,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
     [NotifyPropertyChangedFor(nameof(HasSelectedFolder))]
     [NotifyPropertyChangedFor(nameof(WindowTitle))]
     [NotifyPropertyChangedFor(nameof(IsCalendarView))]
+    [NotifyPropertyChangedFor(nameof(IsContactMailView))]
     private MailFolderModel? _selectedFolder;
 
     [ObservableProperty]
@@ -4160,8 +4161,33 @@ public partial class MainViewModel : ObservableObject, IDisposable
     public Task ShowContactMailAsync(string address, ContactMailDirection direction, string? label = null)
     {
         if (string.IsNullOrWhiteSpace(address)) return Task.CompletedTask;
+        // Remember where to go back to when the results are closed. Searching again from
+        // inside a results view keeps the original folder as the destination, so one Escape
+        // always lands back in real mail rather than in the previous search.
+        if (!IsContactMailView) _contactMailReturnFolder = SelectedFolder;
         return SelectFolderAsync(
             CreateContactMailVirtualFolder(address.Trim(), direction, label));
+    }
+
+    /// <summary>True while the message list is showing contact-mail results (issue #370).</summary>
+    public bool IsContactMailView =>
+        SelectedFolder != null && TryGetContactMailFromSentinel(SelectedFolder.FullName, out _, out _);
+
+    // The folder the user was in when the contact-mail search started; null when the search
+    // began before any folder was open (a fresh profile), in which case closing goes to All Mail.
+    private MailFolderModel? _contactMailReturnFolder;
+
+    /// <summary>
+    /// Closes the contact-mail results and returns to the folder the search started from
+    /// (All Mail if there wasn't one), re-fetching it exactly as selecting it would.
+    /// </summary>
+    [RelayCommand]
+    public async Task CloseContactMailAsync()
+    {
+        if (!IsContactMailView) return;
+        var back = _contactMailReturnFolder ?? AllMailFolder;
+        _contactMailReturnFolder = null;
+        await SelectFolderAsync(back);
     }
 
     private async Task FetchContactMailAsync(string address, ContactMailDirection direction)

--- a/QuickMail/Views/MainWindow.xaml
+++ b/QuickMail/Views/MainWindow.xaml
@@ -1115,6 +1115,32 @@
                                Background="{DynamicResource Theme.ChromeBackground}"
                                AutomationProperties.Name="Current folder"/>
 
+                    <!-- Contact-mail results bar (#370) — visible only while the message list is
+                         showing "mail from / to a contact". Mirrors the search bar below: the
+                         match count plus a Close that returns to the folder the search started
+                         from, so the results are never a dead end. Escape does the same. -->
+                    <Border DockPanel.Dock="Top"
+                            Padding="6,4"
+                            BorderThickness="0,0,0,1"
+                            BorderBrush="{DynamicResource Theme.Border}"
+                            Visibility="{Binding IsContactMailView, Converter={StaticResource BoolToVisibilityConverter}}">
+                        <DockPanel>
+                            <!-- Click rather than a direct command binding: closing also moves
+                                 focus to the message list and announces the result, both View
+                                 concerns the VM must not reach into. -->
+                            <Button DockPanel.Dock="Right"
+                                    Content="Close"
+                                    Click="CloseContactMailResults_Click"
+                                    AutomationProperties.Name="Close search results"
+                                    ToolTip="Close these results and go back (Escape)"
+                                    IsTabStop="True"/>
+                            <TextBlock VerticalAlignment="Center"
+                                       Margin="0,0,6,0"
+                                       Focusable="False"
+                                       Text="{Binding Messages.Count, StringFormat='{}{0} found'}"/>
+                        </DockPanel>
+                    </Border>
+
                     <!-- Search bar — visible only while IsSearchActive -->
                     <Border DockPanel.Dock="Top"
                             Padding="6,4"

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -1148,6 +1148,19 @@ public partial class MainWindow : Window
             defaultKey: Key.A, defaultModifiers: ModifierKeys.Alt,
             isAvailable: () => _vm.IsMessageOpen));
 
+        // Close the contact-mail results (#370) and return to the folder the search started
+        // from, the way Escape leaves any other search. Registered rather than hardcoded so it
+        // reaches the palette and can be rebound. It is unavailable while the search box has
+        // focus, so Escape there still clears the text search first; and the Escape cases
+        // earlier in OnWindowKeyDown (open message, calendar) run before the registry, so
+        // Escape keeps its existing meanings and only falls through to this one when nothing
+        // else claims it.
+        _registry.Register(new CommandDefinition(
+            id: "view.closeContactMail", category: "View", title: "Close Contact Mail Results",
+            execute: () => CloseContactMailResultsAsync().LogFaults("close contact mail results"),
+            defaultKey: Key.Escape, defaultModifiers: ModifierKeys.None,
+            isAvailable: () => _vm.IsContactMailView && !SearchBox.IsKeyboardFocusWithin));
+
         // ── Tab & Window Management commands ─────────────────────────────────────
         _registry.Register(new CommandDefinition(
             id: "tabs.next", category: "View", title: "Next Tab",
@@ -5544,6 +5557,26 @@ public partial class MainWindow : Window
             AccessibilityHelper.Announce(this, $"Could not search for mail {kind} {label}.",
                 interrupt: true, category: AnnouncementCategory.Result);
         }
+    }
+
+    private void CloseContactMailResults_Click(object sender, RoutedEventArgs e)
+        => CloseContactMailResultsAsync().LogFaults("close contact mail results");
+
+    /// <summary>
+    /// Leaves the contact-mail results view: back to the folder the search started from, focus
+    /// to the message list, and the destination announced with its count — the same shape as
+    /// clearing a message search.
+    /// </summary>
+    private async Task CloseContactMailResultsAsync()
+    {
+        if (!_vm.IsContactMailView) return;
+        await _vm.CloseContactMailCommand.ExecuteAsync(null);
+        ReturnFocusToMessageList();
+        var n     = _vm.Messages.Count;
+        var where = _vm.SelectedFolder?.DisplayName ?? "Mail";
+        AccessibilityHelper.Announce(this,
+            $"Search closed. {where}, {n} {(n == 1 ? "message" : "messages")}.",
+            interrupt: true, category: AnnouncementCategory.Result);
     }
 
     private void MenuPlainText_Click(object sender, RoutedEventArgs e) => TogglePlainTextView();

--- a/docs/KEYBOARD-SHORTCUTS.md
+++ b/docs/KEYBOARD-SHORTCUTS.md
@@ -15,6 +15,7 @@
 | Ctrl+Alt+3 | `view.focusMessages` | Focus Message List (always) |
 | F6 / Shift+F6 | *(hardcoded)* | Cycle panes |
 | Escape | *(hardcoded)* | Close reading pane |
+| Escape | `view.closeContactMail` | Close Contact Mail Results — dispatched only when no earlier Escape case claims the key (reading pane, calendar, tab mode) and the search box does not have focus |
 | Ctrl+Shift+P | *(hardcoded)* | Command Palette |
 | Ctrl+N | `mail.new` | New Message |
 | Ctrl+R | `mail.reply` | Reply |

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -564,7 +564,9 @@ From the contact list, you can pull up everything a person sent you, or everythi
 
 Both actions are also in the address book's Command Palette (**Ctrl+Shift+P**) as **Find Mail From Contact** and **Find Mail To Contact**, and you can assign them a keyboard shortcut in Settings → Keyboard.
 
-The search covers every account and folder QuickMail has cached — not just the folder you were in. Mail older than your sync range is not stored locally, so it is not included. **Find mail to this contact** matches the To line, so a message where the person was only in Cc does not appear. To leave the results, select any folder in the folder tree.
+Press **Escape** with focus in the message list to close the results and go back to the folder you started from; the folder name and its message count are announced. A **Close** button at the top of the results does the same, and **Close Contact Mail Results** is in the Command Palette. Selecting any folder in the folder tree also leaves the results.
+
+The search covers every account and folder QuickMail has cached — not just the folder you were in. Mail older than your sync range is not stored locally, so it is not included. **Find mail to this contact** matches the To line, so a message where the person was only in Cc does not appear.
 
 ### Syncing Contacts from Your Accounts
 
@@ -1133,6 +1135,7 @@ Every announcement is optional and controlled by the settings above. No custom s
 | `F1` | User Guide |
 | `Shift+,` | First message in group |
 | `Shift+.` | Last message in group |
+| `Escape` | Close contact mail results (message list focus) |
 
 **Move to Folder…** and **Copy to Folder…** are available from the context menu (Shift+F10) or the command palette; they have no default keyboard shortcut. **Manage Themes**, **Next Theme**, **Previous Theme**, and **Report a Bug** are likewise command-palette-only unless you assign a shortcut yourself in Settings → Keyboard.
 

--- a/docs/release-notes-v0.8.37.md
+++ b/docs/release-notes-v0.8.37.md
@@ -17,6 +17,8 @@ Both downloads include the .NET 8 runtime — you do not need to install .NET se
 
 Select someone in the address book, press **Shift+F10**, and choose **Find mail from this contact** or **Find mail to this contact**. The address book closes and the message list fills with the matches, newest first, drawn from every account and folder QuickMail has cached — not just the folder you were in. Focus lands on the message list and the count is announced ("12 messages from Bob Baker."), and the window title reads **Mail from Bob Baker** so the results are easy to tell apart from a folder.
 
+Press **Escape** in the message list to close the results and return to the folder you started from — the destination and its message count are announced. There is also a **Close** button above the results, and **Close Contact Mail Results** in the Command Palette.
+
 Both actions are also in the address book's Command Palette (**Ctrl+Shift+P**) as **Find Mail From Contact** and **Find Mail To Contact**, so you can give them a keyboard shortcut in Settings → Keyboard.
 
 Two things to know about the results: mail older than your sync range is not stored locally, so it is not searched, and **Find mail to this contact** matches the To line — a message where the person was only in Cc does not appear. (#370)


### PR DESCRIPTION
Follow-up to #370, reported by Kelly: after searching for a contact's mail there was no way back — the results view had to be left by picking a folder in the tree, and it did not behave like the app's other searches.

## What changed

- **Escape** with focus anywhere but the search box closes the results and returns to the folder the search started from (All Mail if there wasn't one). The destination and its message count are announced as a Result: "Search closed. Inbox, 47 messages."
- A **Close** button sits above the results next to the match count, mirroring the search bar's Clear.
- **Close Contact Mail Results** is in the Command Palette and rebindable.

Escape stays two-stage where it already had meaning: an open reading pane, the calendar, and tab mode all claim Escape earlier in `OnWindowKeyDown`, and the command is unavailable while the search box has focus so Escape there still clears the text search first.

Searching again from inside a results view keeps the *original* folder as the return target, so one Escape always lands back in real mail rather than in the previous search.

## Tests

Four added to `ContactMailSearchTests` (27 total in the file): the view reports itself as contact-mail, closing returns to the starting folder and reloads it, a second search does not move the return target, and closing outside the results view is a no-op. Full suite: 1603 passed.

## Docs

User guide (Address Book section + main-window shortcut table), release notes for 0.8.37, and the `Escape` row in `docs/KEYBOARD-SHORTCUTS.md`.