### PR TITLE
Fix end-of-day new-event defaults and make LogServiceTests parallel-safe (#378, #377)

### DIFF
--- a/QuickMail.Tests/EventEditorViewModelTests.cs
+++ b/QuickMail.Tests/EventEditorViewModelTests.cs
@@ -11,6 +11,14 @@ namespace QuickMail.Tests;
 /// </summary>
 public class EventEditorViewModelTests
 {
+    /// <summary>
+    /// Fixed seed for tests that only need "some valid start time". Seeding these from
+    /// <c>DateTime.Now</c> made them fail for anyone running the suite late in the evening — the
+    /// default end rolls past midnight — so the time of day is pinned here instead. Tests that are
+    /// specifically about a time of day pass their own value. (#378)
+    /// </summary>
+    private static readonly DateTime FixedStart = new(2026, 7, 16, 9, 3, 0);
+
     [Fact]
     public void NewEditor_DefaultsToLocalAccountAndHalfHourSlot()
     {
@@ -28,10 +36,36 @@ public class EventEditorViewModelTests
         Assert.Equal(TimeSpan.FromMinutes(30), end - start);
     }
 
+    [Theory]
+    [InlineData(23, 38)]   // rounds to 23:45; end 00:15 the next day
+    [InlineData(23, 50)]   // start itself rounds over midnight to 00:00
+    [InlineData(23, 31)]
+    [InlineData(0, 0)]     // start of day, for contrast
+    public void NewEditor_LateInTheDay_DefaultsToAValidRange(int hour, int minute)
+    {
+        var vm = new EventEditorViewModel(new DateTime(2026, 7, 16, hour, minute, 0)) { Title = "Late" };
+
+        Assert.True(vm.TryBuildEvent(out var evt, out var error), error);
+        var start = new DateTime(evt.StartTimeTicks!.Value, DateTimeKind.Utc).ToLocalTime();
+        var end = new DateTime(evt.EndTimeTicks!.Value, DateTimeKind.Utc).ToLocalTime();
+        Assert.Equal(TimeSpan.FromMinutes(30), end - start);
+    }
+
+    [Fact]
+    public void NewEditor_WhenDefaultEndRollsPastMidnight_EndDateAdvancesADay()
+    {
+        // 23:38 rounds up to 23:45; the default half-hour lands at 00:15 the following day, so the
+        // end date must advance with it rather than staying on the start's date. (#378)
+        var vm = new EventEditorViewModel(new DateTime(2026, 7, 16, 23, 38, 0));
+
+        Assert.Equal(new DateTime(2026, 7, 16), vm.StartDate);
+        Assert.Equal(new DateTime(2026, 7, 17), vm.EndDate);
+    }
+
     [Fact]
     public void MissingTitle_FailsValidation()
     {
-        var vm = new EventEditorViewModel(DateTime.Now) { Title = "   " };
+        var vm = new EventEditorViewModel(FixedStart) { Title = "   " };
         Assert.False(vm.TryBuildEvent(out _, out var error));
         Assert.Contains("Title", error);
     }
@@ -54,10 +88,10 @@ public class EventEditorViewModelTests
     [Fact]
     public void InvalidStartTime_FailsWithFriendlyMessage()
     {
-        var vm = new EventEditorViewModel(DateTime.Now)
+        var vm = new EventEditorViewModel(FixedStart)
         {
             Title = "Bad time",
-            StartDate = DateTime.Today,
+            StartDate = FixedStart.Date,
             StartTime = "not a time",
         };
         Assert.False(vm.TryBuildEvent(out _, out var error));
@@ -116,7 +150,7 @@ public class EventEditorViewModelTests
     [Fact]
     public void AllDay_EndDateBeforeStart_FailsValidation()
     {
-        var vm = new EventEditorViewModel(DateTime.Now)
+        var vm = new EventEditorViewModel(FixedStart)
         {
             Title = "Bad range",
             IsAllDay = true,
@@ -130,7 +164,7 @@ public class EventEditorViewModelTests
     [Fact]
     public void Repeat_None_ProducesNoRecurrence()
     {
-        var vm = new EventEditorViewModel(DateTime.Now) { Title = "One-off", RepeatIndex = 0 };
+        var vm = new EventEditorViewModel(FixedStart) { Title = "One-off", RepeatIndex = 0 };
         Assert.False(vm.HasRepeat);
         Assert.True(vm.TryBuildEvent(out var evt, out _));
         Assert.Null(evt.RecurrenceRule);
@@ -178,10 +212,11 @@ public class EventEditorViewModelTests
     [Fact]
     public void Repeat_WeeklyNoDaysChecked_OmitsByDay()
     {
-        var vm = new EventEditorViewModel(DateTime.Now)
+        var vm = new EventEditorViewModel(FixedStart)
         {
             Title = "Simple weekly",
-            StartDate = DateTime.Today,
+            StartDate = FixedStart.Date,
+            EndDate = FixedStart.Date,
             StartTime = "9:00 AM",
             EndTime = "9:30 AM",
             RepeatIndex = 2,
@@ -193,10 +228,11 @@ public class EventEditorViewModelTests
     [Fact]
     public void Repeat_DayCheckboxesIgnored_WhenNotWeekly()
     {
-        var vm = new EventEditorViewModel(DateTime.Now)
+        var vm = new EventEditorViewModel(FixedStart)
         {
             Title = "Daily thing",
-            StartDate = DateTime.Today,
+            StartDate = FixedStart.Date,
+            EndDate = FixedStart.Date,
             StartTime = "9:00 AM",
             EndTime = "9:30 AM",
             RepeatIndex = 1,          // Daily
@@ -229,7 +265,7 @@ public class EventEditorViewModelTests
     [Fact]
     public void Repeat_UntilBeforeStart_FailsValidation()
     {
-        var vm = new EventEditorViewModel(DateTime.Now)
+        var vm = new EventEditorViewModel(FixedStart)
         {
             Title = "Bad repeat",
             StartDate = new DateTime(2026, 7, 14),
@@ -263,7 +299,7 @@ public class EventEditorViewModelTests
     [Fact]
     public void Save_RaisesSavedWithBuiltEvent()
     {
-        var vm = new EventEditorViewModel(DateTime.Now) { Title = "Lunch" };
+        var vm = new EventEditorViewModel(FixedStart) { Title = "Lunch" };
         CalendarEvent? captured = null;
         vm.Saved += e => captured = e;
 
@@ -276,7 +312,7 @@ public class EventEditorViewModelTests
     [Fact]
     public void Save_WithInvalidData_AnnouncesInsteadOfRaisingSaved()
     {
-        var vm = new EventEditorViewModel(DateTime.Now) { Title = "" };
+        var vm = new EventEditorViewModel(FixedStart) { Title = "" };
         var saved = false;
         string? announced = null;
         vm.Saved += _ => saved = true;
@@ -348,7 +384,7 @@ public class EventEditorViewModelTests
     [Fact]
     public void SaveTargets_NoAccounts_PickerHidden()
     {
-        var vm = new EventEditorViewModel(DateTime.Now);
+        var vm = new EventEditorViewModel(FixedStart);
         Assert.False(vm.ShowSaveTarget);
         Assert.Single(vm.SaveTargetLabels);
     }

--- a/QuickMail.Tests/LogServiceTests.cs
+++ b/QuickMail.Tests/LogServiceTests.cs
@@ -44,20 +44,33 @@ public sealed class LogServiceTests : IDisposable
 
     private string LogFile => Path.Combine(_tempDir, "quickmail.log");
 
+    /// <summary>
+    /// A marker unique to this test instance. LogService's target directory is static, so while
+    /// these tests point it at their own temp dir, any other test running in parallel that happens
+    /// to log (44 production files call LogService) writes into that same file. Asserting on bare
+    /// file existence therefore fails intermittently — roughly 2 runs in 7 — for reasons that have
+    /// nothing to do with the behaviour under test. Asserting on this marker instead tests the
+    /// actual contract ("did *our* message get written?") and is immune to the interference. (#377)
+    /// </summary>
+    private readonly string _marker = $"marker-{Guid.NewGuid():N}";
+
+    private bool LogContainsMarker() =>
+        File.Exists(LogFile) && File.ReadAllText(LogFile).Contains(_marker, StringComparison.Ordinal);
+
     [Fact]
     public void Log_WhenEnabled_WritesFile()
     {
         LogService.Enabled = true;
-        LogService.Log("hello");
-        Assert.True(File.Exists(LogFile));
+        LogService.Log(_marker);
+        Assert.True(LogContainsMarker());
     }
 
     [Fact]
     public void Log_WhenDisabled_DoesNotWriteFile()
     {
         LogService.Enabled = false;
-        LogService.Log("hello");
-        Assert.False(File.Exists(LogFile));
+        LogService.Log(_marker);
+        Assert.False(LogContainsMarker());
     }
 
     [Fact]
@@ -65,32 +78,36 @@ public sealed class LogServiceTests : IDisposable
     {
         LogService.Enabled   = false;
         LogService.DebugMode = true;
-        LogService.Log("hello");
-        Assert.True(File.Exists(LogFile));
+        LogService.Log(_marker);
+        Assert.True(LogContainsMarker());
     }
 
     [Fact]
     public void Log_ContainsMessage()
     {
-        LogService.Log("sync complete");
-        Assert.Contains("sync complete", File.ReadAllText(LogFile));
+        LogService.Log($"sync complete {_marker}");
+        Assert.Contains($"sync complete {_marker}", File.ReadAllText(LogFile), StringComparison.Ordinal);
     }
 
     [Fact]
     public void DeleteLog_RemovesExistingFile()
     {
-        LogService.Log("seed");
-        Assert.True(File.Exists(LogFile));
+        LogService.Log(_marker);
+        Assert.True(LogContainsMarker());
 
         LogService.DeleteLog();
 
-        Assert.False(File.Exists(LogFile));
+        // A parallel test may recreate the file immediately; what must be gone is our content.
+        Assert.False(LogContainsMarker());
     }
 
     [Fact]
     public void DeleteLog_WhenFileAbsent_DoesNotThrow()
     {
-        Assert.False(File.Exists(LogFile));
+        // Delete first so the second call is genuinely the file-absent case. The old version
+        // asserted the file did not exist up front, which a parallel test's write could falsify.
+        LogService.DeleteLog();
+
         var ex = Record.Exception(LogService.DeleteLog);
         Assert.Null(ex);
     }
@@ -98,12 +115,12 @@ public sealed class LogServiceTests : IDisposable
     [Fact]
     public void Log_AfterDelete_RecreatesFile()
     {
-        LogService.Log("first");
+        LogService.Log($"first {_marker}");
         LogService.DeleteLog();
 
-        LogService.Log("second");
+        LogService.Log($"second {_marker}");
 
         Assert.True(File.Exists(LogFile));
-        Assert.Contains("second", File.ReadAllText(LogFile));
+        Assert.Contains($"second {_marker}", File.ReadAllText(LogFile), StringComparison.Ordinal);
     }
 }

--- a/QuickMail/ViewModels/EventEditorViewModel.cs
+++ b/QuickMail/ViewModels/EventEditorViewModel.cs
@@ -180,10 +180,15 @@ public partial class EventEditorViewModel : ObservableObject
         _saveTargets = BuildSaveTargets(accountTargets);
         SaveTargetLabels = _saveTargets.ConvertAll(t => t.Label);
         var start = RoundUpToQuarterHour(defaultStart);
+        // Derive EndDate from the end instant, not from start.Date: the default half-hour can roll
+        // past midnight (23:45 + 30min), and pinning the end to the start's date then puts the end
+        // before the start, so TryBuildEvent rejects the untouched default. Mirrors the existing-
+        // event constructor below. (#378)
+        var end = start.AddMinutes(30);
         StartDate = start.Date;
         StartTime = start.ToString("t");
-        EndDate = start.Date;
-        EndTime = start.AddMinutes(30).ToString("t");
+        EndDate = end.Date;
+        EndTime = end.ToString("t");
     }
 
     private static List<CalendarSaveTarget> BuildSaveTargets(IReadOnlyList<CalendarSaveTarget>? accountTargets)


### PR DESCRIPTION
Two independent fixes, both surfaced while verifying the #333 stack. Kept as separate commits so either can be reverted alone.

## #378 — creating an event after ~11:30 PM fails to save

`EventEditorViewModel`'s new-appointment constructor pinned `EndDate` to the **start's** date while `EndTime` was start + 30 minutes. After roughly 23:30 that half-hour crosses midnight, so the end instant lands *before* the start and `TryBuildEvent` rejects the untouched default — the user has to correct the date by hand before they can save.

Fix derives `EndDate` from the end instant, mirroring what the existing-event constructor 45 lines below already does. Reported by @CityDweller with an accurate diagnosis and the right suggested fix.

**Regression cover:** a theory over 23:31 / 23:38 / 23:50 / 00:00 plus an explicit `EndDate`-advances-a-day assertion. **Three of the five cases fail without the production change.** 23:50 passes either way — there the *start* itself rounds over midnight, so `start.Date` was already tomorrow and the old code was accidentally correct. That's why this hid for so long.

Also seeded `EventEditorViewModelTests` from a fixed `DateTime` instead of `DateTime.Now`/`Today`. Two tests that override `StartDate` were implicitly relying on the constructor to seed a matching `EndDate`, so they now set both explicitly.

## #377 — LogServiceTests flaked ~2 runs in 7

`LogService`'s target directory is static. While those tests point it at their own temp dir, any parallel test that logs (44 production files call `LogService`) writes into that same file, so assertions on bare file existence failed for reasons unrelated to the behaviour under test.

Now asserts on a per-instance marker — "did *our* message get written?" — which is the actual contract and immune to the interference. **No production change; `LogService` itself is correct.**

## Verification

- Release build clean.
- **1651 tests pass.**
- Ran the full suite **22 consecutive times**: `LogServiceTests` did not fail once (≈2 in 7 beforehand).

## Found while testing, not addressed here

Those same 22 runs surfaced a **separate** flake cluster in the address-book focus tests — `AddressBookTypeAheadTests` (four failing together in a single run) and `GroupsTabFocusTests`. Different root cause, different area, from the recent #371/#372 work. Filing separately rather than widening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)