### PR TITLE
Bump Microsoft.NET.Test.Sdk to 18.8.1

### DIFF
--- a/QuickMail.IntegrationTests/QuickMail.IntegrationTests.csproj
+++ b/QuickMail.IntegrationTests/QuickMail.IntegrationTests.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="WireMock.Net" Version="2.13.0" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/QuickMail.Tests/QuickMail.Tests.csproj
+++ b/QuickMail.Tests/QuickMail.Tests.csproj
@@ -26,7 +26,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="10.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
     <!-- STA-thread fact attribute for WPF tests -->


### PR DESCRIPTION
Test-only dependency bump. Dependabot proposed the 18.7.0 step in #161, auto-closed it, and has not proposed the next one — see the dependency findings below.

**Verification is direct:** the 1651-test suite executes on this runner. Release build clean; ran the full suite 12 times. Two runs failed with one test each, then nine consecutive clean runs. I did not capture the names on those two, so I can't prove it — but the rate and the burst pattern match #380, and a broken test runner would fail consistently rather than 2-in-12.

## Why only this one

Five other packages are behind. I applied all six together and they build clean and pass 1651 tests — but passing unit tests is not the same as verifying them:

| Package | Current → Latest | Why not here |
|---|---|---|
| `Microsoft.Web.WebView2` | 1.0.4022.49 → 1.0.4078.44 | Reading pane and compose rendering have no test coverage; needs the running app |
| `Microsoft.Identity.Client` (+ `.Desktop`, `.Extensions.Msal`) | 4.85.2 → 4.87.0 | OAuth can't be tested here — **and #369 is an open OAuth failure**, so changing MSAL now would confound that diagnosis |
| `SQLitePCLRaw.bundle_e_sqlite3` | 2.1.12 → **3.0.5** | Major version. `LocalStoreServiceTests` do exercise real SQLite round-trips and passed, so this is the best-covered of the five — but not against a real populated `mail.db` with migrations |
| `System.Drawing.Common` | 4.7.2 → **10.0.10** | Used only by `TrayIconManager` for the tray icon (`TrayIconManager.cs:51`). Small blast radius, but needs the app running to confirm the icon still loads |

All six install cleanly at the pinned `net8.0-windows10.0.17763.0`, so **the TFM is not what's holding them back.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
