### PR TITLE
Exclude bin/obj from default source globs so Dependabot can read dependencies (#382)

### DIFF
--- a/QuickMail/QuickMail.csproj
+++ b/QuickMail/QuickMail.csproj
@@ -36,6 +36,15 @@
     <PublishReadyToRun>true</PublishReadyToRun>
     <SelfContained>true</SelfContained>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <!-- Keep bin/ and obj/ out of the default source globs. WPF compiles XAML through a generated
+         temporary project (QuickMail_<hash>_wpftmp.csproj) that inherits these properties but has
+         its OWN BaseIntermediateOutputPath — so the SDK's built-in "exclude my own obj" rule no
+         longer covers THIS project's obj, and the .g.cs files already generated there get globbed
+         in as ordinary sources. Every XAML-generated type is then defined twice (CS0101 / CS0111 /
+         CS0102 / CS0579 on GeneratedInternalTypeHelper, App, TokenizedAddressBox, ...).
+         A normal build doesn't trip this, but Dependabot's clean-clone design-time build does: it
+         failed dependency determination, so NuGet updates silently stopped arriving (#382). -->
+    <DefaultItemExcludes>$(DefaultItemExcludes);bin\**;obj\**</DefaultItemExcludes>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Targeted mitigation for #382 — Dependabot's NuGet updater has proposed nothing since 2026-07-13 while six packages drifted behind, because its dependency determination fails on a duplicate-symbol build error.

## The change

One property on `QuickMail/QuickMail.csproj`:

```xml
<DefaultItemExcludes>$(DefaultItemExcludes);bin\**;obj\**</DefaultItemExcludes>
```

WPF compiles XAML through a generated temporary project (`QuickMail_<hash>_wpftmp.csproj`). In Dependabot's build that project's intermediate path picks up TFM and RID **twice** — `obj/Debug/net8.0-windows10.0.17763.0/win-x64/net8.0-windows10.0.17763.0/win-x64/` — so the outer `obj/` falls outside the SDK's implicit "exclude my own obj" rule and its `.g.cs` files are globbed in as ordinary sources. Every XAML-generated type is then defined twice, producing ~100 `CS0101` / `CS0111` / `CS0102` / `CS0579` errors.

## What I verified

- **The property propagates into the generated temp project.** I captured a live `_wpftmp.csproj` mid-build; it carries the inherited `DefaultItemExcludes`. So the exclusion does apply where the duplicates come from — that was the main thing worth checking.
- **Inert for normal builds:** Release build clean, **1651 tests pass**, and `dotnet publish` still produces the self-contained single-file win-x64 `QuickMail.exe` with an unchanged output shape. No change to any of the four publish call sites.

## What I could NOT verify — read this before merging

**I could not reproduce the failure locally.** I planted duplicate `GeneratedInternalTypeHelper.g.cs` and `App.g.cs` at the doubled path and built: it still succeeded. The captured temp project shows why — here its `BaseIntermediateOutputPath` is plain `obj\`, which the SDK already excludes. The doubled path appears only in Dependabot's environment (Linux, their SDK, their invocation).

**So there is a real possibility this change is a no-op.** It is well-founded and costless, but it is a hypothesis, not a demonstrated fix.

## How to actually confirm it

Merging is the only way to test, because Dependabot runs against the default branch. The loop is fast:

1. Merge this.
2. Press **"Check for updates"** on the nuget row at `/network/updates` — no need to wait for the Monday schedule.
3. Read the new job log.

**Success** = the log determines dependencies without the CS0101 wall, and PRs appear for the six outdated packages (`Microsoft.Identity.Client` ×3, `Microsoft.Web.WebView2`, `SQLitePCLRaw.bundle_e_sqlite3`, `System.Drawing.Common`).

**Failure** = the same duplicate-symbol errors. In that case revert this (it changes nothing else) and escalate to the larger fix: making `RuntimeIdentifier` / `SelfContained` publish-only, which then requires adding `-r win-x64 --self-contained` to `build.bat`'s `publish` and `installer` targets and to both workflows that publish — a change that can silently break Velopack packaging, which is why it is not the first thing to try.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
