### PR TITLE
Stop putting the RID in bin/obj paths so Dependabot can read dependencies (#382)

### DIFF
--- a/QuickMail/QuickMail.csproj
+++ b/QuickMail/QuickMail.csproj
@@ -36,15 +36,19 @@
     <PublishReadyToRun>true</PublishReadyToRun>
     <SelfContained>true</SelfContained>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
-    <!-- Keep bin/ and obj/ out of the default source globs. WPF compiles XAML through a generated
-         temporary project (QuickMail_<hash>_wpftmp.csproj) that inherits these properties but has
-         its OWN BaseIntermediateOutputPath — so the SDK's built-in "exclude my own obj" rule no
-         longer covers THIS project's obj, and the .g.cs files already generated there get globbed
-         in as ordinary sources. Every XAML-generated type is then defined twice (CS0101 / CS0111 /
-         CS0102 / CS0579 on GeneratedInternalTypeHelper, App, TokenizedAddressBox, ...).
-         A normal build doesn't trip this, but Dependabot's clean-clone design-time build does: it
-         failed dependency determination, so NuGet updates silently stopped arriving (#382). -->
-    <DefaultItemExcludes>$(DefaultItemExcludes);bin\**;obj\**</DefaultItemExcludes>
+    <!-- Do NOT put the RID in the bin/obj paths. Setting RuntimeIdentifier on a WPF project makes
+         the SDK's generated XAML temp project (QuickMail_<hash>_wpftmp.csproj) re-append the
+         TFM and RID to an intermediate path that already ends in them, producing
+         obj/Debug/<TFM>/<RID>/<TFM>/<RID>/ — the generated .g.cs files then exist at two depths
+         and every XAML-generated type is compiled twice (CS0101/CS0111/CS0102/CS0579 on
+         GeneratedInternalTypeHelper, App, TokenizedAddressBox, ...).
+         Local and CI builds happen to survive this; Dependabot's clean-clone design-time build
+         does not — it failed dependency determination, so NuGet updates silently stopped
+         arriving for six packages (#382). This is the documented workaround.
+         Publish output is unaffected: build.bat and both publishing workflows pass an explicit
+         -o directory, and the RID itself still applies (still self-contained win-x64). Only the
+         intermediate/bin layout loses its redundant win-x64 segment. -->
+    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Stop putting the RID in bin/obj paths so Dependabot can read dependencies (#382)

Replaces the DefaultItemExcludes attempt from #383, which I merged and then
confirmed did nothing: I triggered a Dependabot run against it and got the
identical CS0101 wall at the identical doubled path.

Real cause. Setting RuntimeIdentifier on a WPF project makes the SDK's
generated XAML temp project (QuickMail_<hash>_wpftmp.csproj) re-append TFM and
RID to an intermediate path that already ends in them:

  obj/Debug/net8.0-windows10.0.17763.0/win-x64/net8.0-windows10.0.17763.0/win-x64/

The XAML-generated .g.cs files then exist at two depths and every generated
type is compiled twice — CS0101/CS0111/CS0102/CS0579 on GeneratedInternalType-
Helper, App, TokenizedAddressBox and the rest. Excluding obj from the source
globs could not help, because the duplication is in the temp project's own
output layout, not in what the default glob picks up.

AppendRuntimeIdentifierToOutputPath=false removes the redundant RID segment,
so the path cannot double.

Publish is unaffected: build.bat and both publishing workflows pass an explicit
-o directory, the RID still applies, and nothing in build.bat, the workflows or
installer/ keys off a bin path containing win-x64.

Verified locally, the whole chain:
- Release build clean; 1651 tests pass.
- dotnet publish -> self-contained single-file win-x64 QuickMail.exe, 280 MB,
  same output shape as before.
- build.bat installer -> vpk pack succeeded: portable, QuickMail-win-Setup.exe,
  QuickMail-win.msi and update packages for 0.8.37.

Still to confirm after merge: press "Check for updates" on the nuget row and
read the job log, the same way #383 was disproved.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
