### PR TITLE
Also stop appending the TFM to bin/obj paths (#382)

### DIFF
--- a/QuickMail/QuickMail.csproj
+++ b/QuickMail/QuickMail.csproj
@@ -49,6 +49,11 @@
          -o directory, and the RID itself still applies (still self-contained win-x64). Only the
          intermediate/bin layout loses its redundant win-x64 segment. -->
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+    <!-- Same reason, other half. Removing only the RID left obj/Debug/<TFM>/<TFM>/ — confirmed
+         from the Dependabot log after #384 — because the temp project re-appends the TFM too.
+         Both appends have to be off for the path to stop doubling. Nothing in build.bat, the
+         workflows or installer/ keys off a bin/obj path containing the TFM. -->
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Follow-on to #384. That one removed the RID from the output path and it genuinely helped — the Dependabot log afterwards showed the path had gone from

    obj/Debug/<TFM>/win-x64/<TFM>/win-x64/

to

    obj/Debug/<TFM>/<TFM>/

so the RID doubling was fixed but the **target framework** still doubles: the generated XAML temp project re-appends the TFM as well. Dependency determination still fails, so NuGet updates are still not being proposed. Both appends have to be off.

Nothing in `build.bat`, either publishing workflow, or `installer/` keys off a bin/obj path containing the TFM or the RID — only the intermediate layout changes.

## Verified locally

- Release build clean; **1651 tests pass** (one run hit the known #380 address-book flake, three consecutive clean runs after).
- `dotnet publish` -> self-contained single-file win-x64 `QuickMail.exe`, 280 MB, same output shape.
- `build.bat installer` -> `vpk pack` succeeded: portable, `QuickMail-win-Setup.exe`, `QuickMail-win.msi` and update packages for 0.8.37.

## Confidence

Higher than the previous two attempts, because this is no longer a guess about the mechanism — #384 changed the observed path in exactly the predicted way, and `<TFM>/<TFM>` is the only doubling left. Confirming the same way regardless: merge, press **Check for updates**, read the log.