### PR TITLE
Exclude bin/obj from the default Compile glob, with forward slashes (#382)

### DIFF
--- a/QuickMail/QuickMail.csproj
+++ b/QuickMail/QuickMail.csproj
@@ -54,6 +54,13 @@
          Both appends have to be off for the path to stop doubling. Nothing in build.bat, the
          workflows or installer/ keys off a bin/obj path containing the TFM. -->
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <!-- Keep generated XAML sources out of the default Compile glob. The WPF temp project has its
+         own BaseIntermediateOutputPath, so the SDK's implicit "exclude my own obj" rule does not
+         cover THIS project's obj — every obj/Debug/**/*.g.cs is then included a second time and
+         the build dies with NETSDK1022 (Duplicate 'Compile' items).
+         FORWARD slashes matter: Dependabot builds on Linux, where a `bin\**` style pattern does
+         not match, which is why the first attempt at this (#383) had no effect. -->
+    <DefaultItemExcludes>$(DefaultItemExcludes);bin/**;obj/**</DefaultItemExcludes>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
After #385 the Dependabot log stopped showing CS0101 and named the real error outright:

    error NETSDK1022: Duplicate 'Compile' items were included ...
    The duplicate items were: obj/Debug/Controls/TokenizedAddressBox.g.cs;
    obj/Debug/Views/AboutDialog.g.cs; ... [QuickMail_y33rkr3f_wpftmp.csproj]

The WPF temp project has its own `BaseIntermediateOutputPath`, so the SDK's implicit "exclude my own obj" rule never covers this project's `obj`, and every generated `.g.cs` gets included a second time by the default glob.

**#383 tried exactly this and did nothing — because I wrote the patterns with backslashes.** Dependabot builds on Linux, where `obj\**` matches nothing. With forward slashes the exclusion actually applies. That was my error, and it cost two extra rounds.

## Where the four attempts landed

| | Change | Result in Dependabot's log |
|---|---|---|
| #383 | `DefaultItemExcludes` with backslashes | No effect — 12 failures, unchanged path |
| #384 | `AppendRuntimeIdentifierToOutputPath=false` | Path lost `win-x64`; still 12 failures |
| #385 | `AppendTargetFrameworkToOutputPath=false` | Path fully flat; **CS0101 gone**, 6 failures, error changed to NETSDK1022 |
| this | Same exclusion, forward slashes | — |

The two path properties from #384/#385 are what turned an opaque duplicate-symbol wall into a precise, self-describing SDK error. They may be removable now; worth a follow-up rather than another round here.

## Verified locally

- Release build clean; **1651 tests pass**.
- `dotnet publish` -> self-contained single-file win-x64 `QuickMail.exe`, 280 MB, unchanged shape.
- `build.bat installer` -> `vpk pack` succeeded: Setup.exe, MSI and update packages for 0.8.37.

Confirming against Dependabot the same way as the others.