### PR TITLE
Move the bin/obj exclusion to Directory.Build.props (#382)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,30 @@
+<Project>
+
+  <!--
+    Keep bin/ and obj/ out of every project's default source globs.
+
+    This has to live here rather than in a .csproj: the SDK computes its default Compile items in
+    props that are imported at the TOP of an SDK-style project, so a DefaultItemExcludes set in the
+    project body is evaluated too late to affect them. Directory.Build.props is imported before
+    those props, so the exclusion actually applies. (Tried it in QuickMail.csproj first — #386 —
+    and Dependabot's log showed no change.)
+
+    Why it matters: WPF compiles XAML through a generated temporary project
+    (QuickMail_<hash>_wpftmp.csproj) that has its OWN BaseIntermediateOutputPath, so the SDK's
+    implicit "exclude my own obj" rule never covers QuickMail's obj. Every generated .g.cs there is
+    then picked up a second time by the default glob and the build fails with
+
+        error NETSDK1022: Duplicate 'Compile' items were included.
+
+    Ordinary local and CI builds survive this; Dependabot's clean-clone design-time build does not,
+    so dependency determination failed and NuGet version updates silently stopped being proposed
+    for six packages. See #382.
+
+    Forward slashes are deliberate — Dependabot builds on Linux, where a bin\** pattern matches
+    nothing. That is why the first attempt (#383) had no effect either.
+  -->
+  <PropertyGroup>
+    <DefaultItemExcludes>$(DefaultItemExcludes);bin/**;obj/**</DefaultItemExcludes>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
#386 set `DefaultItemExcludes` in `QuickMail.csproj` and Dependabot's log did not change — still 6x `NETSDK1022`, the generated `.g.cs` files still double-counted.

The reason is placement: the SDK computes its default `Compile` items in props imported at the **top** of an SDK-style project, so a `DefaultItemExcludes` set in the project body is evaluated too late to affect them. `Directory.Build.props` is imported before those props, which is the documented place for this. The repo had no `Directory.Build.props`; this adds one containing only that property.

## Verified locally

- Release build clean; **1651 tests pass**.
- `dotnet publish` -> self-contained single-file win-x64 exe, 280 MB, unchanged.
- `build.bat installer` -> Setup.exe, MSI and update packages.

## This is my last attempt before handing back

Five rounds in, each one narrowing the error but not closing it:

| | Change | Dependabot's log after |
|---|---|---|
| #383 | `DefaultItemExcludes`, backslashes, in csproj | No change (12 failures) |
| #384 | `AppendRuntimeIdentifierToOutputPath=false` | Path lost `win-x64`; still 12 |
| #385 | `AppendTargetFrameworkToOutputPath=false` | Path flat; **CS0101 gone**, 6 left, error became NETSDK1022 |
| #386 | Same exclusion, forward slashes, in csproj | No change (6 NETSDK1022) |
| this | Same exclusion, in Directory.Build.props | — |

Every change is verified inert for build, test, publish and packaging, so the cost of the misses is churn rather than risk. But if this one also misses, the next step should be a considered decision rather than another round from me — most likely `EnableDefaultCompileItems=false` with explicit items, or raising it with dependabot-core, since the underlying interaction is an SDK/WPF one rather than anything wrong with this repo.