### PR TITLE
Account dialogs: hide Test Connection when it can't apply (Graph / no selection)

### DIFF
--- a/QuickMail.Tests/UnitTest1.cs
+++ b/QuickMail.Tests/UnitTest1.cs
@@ -82,6 +82,31 @@ public class ViewModelConstructionTests
     }
 
     [Fact]
+    public void ShowTestConnection_OnlyWhenAnImapAccountIsSelected()
+    {
+        var (imap, accounts, creds, _, _, _, _, _, _) = MakeServices();
+        var (_, _, _, store2, _, config2, _, _, _) = MakeServices();
+        var vm = new AccountManagerViewModel(accounts, creds, imap, new StubOAuthService(), store2, config2, new StubFeatureGate());
+
+        Assert.False(vm.ShowTestConnection);   // nothing selected — nothing to test
+
+        vm.SelectedAccount = new AccountModel
+        {
+            Id = Guid.NewGuid(), BackendKind = BackendKind.ImapSmtp, Username = "u@e.com", AuthType = AuthType.Password,
+        };
+        Assert.True(vm.ShowTestConnection);    // IMAP account selected
+
+        vm.SelectedAccount = new AccountModel
+        {
+            Id = Guid.NewGuid(), BackendKind = BackendKind.MicrosoftGraph, Username = "g@e.com", AuthType = AuthType.OAuth2Microsoft,
+        };
+        Assert.False(vm.ShowTestConnection);   // Graph account — OAuth, no IMAP to test
+
+        vm.SelectedAccount = null;
+        Assert.False(vm.ShowTestConnection);   // deselected again
+    }
+
+    [Fact]
     public void GroupManagerViewModel_ConstructsWithoutException()
     {
         var (_, _, _, _, _, _, _, contacts, _) = MakeServices();

--- a/QuickMail/ViewModels/AccountManagerViewModel.cs
+++ b/QuickMail/ViewModels/AccountManagerViewModel.cs
@@ -28,9 +28,18 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
     [NotifyPropertyChangedFor(nameof(IsEditing))]
     [NotifyPropertyChangedFor(nameof(CanSyncContacts))]
     [NotifyPropertyChangedFor(nameof(CanSyncCalendar))]
+    [NotifyPropertyChangedFor(nameof(ShowTestConnection))]
     private AccountModel? _selectedAccount;
 
     public bool IsEditing => SelectedAccount != null;
+
+    /// <summary>
+    /// Test Connection tests IMAP with the current host/port, so it's shown only when an IMAP
+    /// account is actually selected — hidden when nothing is selected (nothing to test) and for
+    /// Graph accounts (OAuth, no IMAP host). In this dialog BackendKind only changes when the
+    /// selection does, so notifying on SelectedAccount covers the IsImapBackend half too.
+    /// </summary>
+    public bool ShowTestConnection => IsEditing && IsImapBackend;
 
     /// <summary>
     /// Contact sync (issue #256) is offered for Microsoft and Google (OAuth contact APIs), plus

--- a/QuickMail/Views/AccountManagerDialog.xaml
+++ b/QuickMail/Views/AccountManagerDialog.xaml
@@ -268,7 +268,7 @@
                     Content="_Test Connection"
                     Command="{Binding TestConnectionCommand}"
                     AutomationProperties.Name="Test IMAP connection with current settings"
-                    Visibility="{Binding IsImapBackend, Converter={StaticResource BoolToVisibility}}"
+                    Visibility="{Binding ShowTestConnection, Converter={StaticResource BoolToVisibility}}"
                     MinWidth="120" Margin="6,0,0,0"/>
             <Button DockPanel.Dock="Right"
                     Content="_Save"

--- a/QuickMail/Views/AddAccountDialog.xaml
+++ b/QuickMail/Views/AddAccountDialog.xaml
@@ -231,6 +231,7 @@
                     Content="_Test Connection"
                     Command="{Binding TestConnectionCommand}"
                     AutomationProperties.Name="Test IMAP connection with current settings"
+                    Visibility="{Binding IsImapBackend, Converter={StaticResource BoolToVisibility}}"
                     MinWidth="120" Margin="6,0,0,0"/>
             <Button DockPanel.Dock="Right"
                     Content="_Add Account"


### PR DESCRIPTION
Test Connection tests IMAP with the current host/port, so it shouldn't appear where there's nothing meaningful to test. Two spots showed it when it couldn't apply — reported by a screen-reader user working through the add/manage flow for a Microsoft 365 account.

## Add Account dialog
The IMAP/SMTP settings panels already hide for Graph accounts via `IsImapBackend`, but the **Test Connection** button had no visibility binding, so it stayed on screen for a Graph (OAuth) account that has no IMAP host. Bound it to `IsImapBackend`, matching what `AccountManagerDialog` already did.

## Account Manager dialog
With **no account selected**, the button was still visible. `OnSelectedAccountChanged` returns early on a null selection, so `BackendKind` stays at its default (`ImapSmtp`) and `IsImapBackend` alone kept the button showing with nothing to test. Added `ShowTestConnection = IsEditing && IsImapBackend`, so it appears only when an IMAP account is actually selected (also hides it for a selected Graph account).

## Test
`ShowTestConnection` is `false` with no selection, `true` for a selected IMAP account, and `false` for a selected Graph account.

Verified in the running app by a screen-reader user: the button no longer appears for Graph accounts or with nothing selected, and the primary action (Save / Add Account) is easy to reach.
