### PR TITLE
Account Manager: read-only Provider value is invisible to screen readers

### DIFF
--- a/QuickMail/Views/AccountManagerDialog.xaml
+++ b/QuickMail/Views/AccountManagerDialog.xaml
@@ -84,21 +84,18 @@
 
                 <!-- Provider is read-only here: it is fixed when the account is created, the same way
                      BackendKind is. Changing it means deleting and re-adding the account. -->
-                <!-- No AutomationProperties.Name here: an explicit Name OVERRIDES a TextBlock's
-                     automatic name (its own text), so setting it to "Provider" would make a screen
-                     reader say "Provider" for the label and "Provider" again for the value — the
-                     actual provider would never be spoken. LabeledBy supplies the label; the text
-                     supplies the value. -->
                 <Label x:Name="LblProvider" Content="Provider:" Target="{Binding ElementName=ProviderText}" Padding="0" Margin="0,0,0,2"/>
-                <!-- Focusable so a keyboard user reaches the provider at all: it is read-only, and a
-                     TextBlock is not in the tab order by default. TabIndex puts it with the fields
-                     it belongs to rather than at the very end. -->
-                <TextBlock x:Name="ProviderText"
-                           Text="{Binding SelectedProvider.DisplayName, Mode=OneWay}"
-                           AutomationProperties.LabeledBy="{Binding ElementName=LblProvider}"
-                           Focusable="True"
-                           KeyboardNavigation.TabIndex="4"
-                           Margin="0,0,0,4"/>
+                <!-- A read-only TextBox, NOT a TextBlock: a TextBox has a value the screen reader reads
+                     in addition to its LabeledBy name, so it announces "Provider: <value>" and the text
+                     can be read/arrowed. A bare TextBlock has no value pattern, so LabeledBy overrode
+                     its name with just "Provider" and the actual provider was never spoken at all. It
+                     also matches the other read-only-looking fields in this dialog. -->
+                <TextBox x:Name="ProviderText"
+                         Text="{Binding SelectedProvider.DisplayName, Mode=OneWay}"
+                         IsReadOnly="True"
+                         AutomationProperties.LabeledBy="{Binding ElementName=LblProvider}"
+                         TabIndex="4"
+                         Margin="0,0,0,4"/>
 
                 <!-- Account Name -->
                 <Label x:Name="LblAccountName" Content="Account _name:" Target="{Binding ElementName=AccountNameBox}" Padding="0" Margin="0,8,0,2"/>


### PR DESCRIPTION
The read-only **Provider** field in Account Manager (added in #393) reads as empty to a screen reader — you hear "Provider" and nothing else, with no value to read. Found by a screen-reader user.

**Cause:** it's a focusable `TextBlock` with `AutomationProperties.LabeledBy` pointing at the "Provider:" label. A TextBlock has no value the reader falls back to, so `LabeledBy` overrode its accessible name with just "Provider" — the actual provider (`Outlook.com / Microsoft 365`) was never spoken.

**Fix:** make it a **read-only `TextBox`**. A TextBox exposes its `Text` as a value the reader announces alongside the `LabeledBy` label, so it reads "Provider: Outlook.com / Microsoft 365" and the text can be read/arrowed — while staying read-only (the provider is fixed at account creation). Consistent with the dialog's other fields. Verified with a screen reader.

XAML parse tests green.
