### PR TITLE
Download-numbers article: name QuickMail and publish the real data

### DIFF
--- a/docs/github-release-download-numbers.md
+++ b/docs/github-release-download-numbers.md
@@ -88,9 +88,16 @@ why it is the easier route on a machine you do not control.
 
 If you would rather read this in a window than a terminal,
 [GHManage](https://github.com/kellylford/GHManage) is a keyboard-driven,
-screen-reader-friendly desktop app whose Releases view shows a downloads column
-per release, a repo-wide total, and a per-file breakdown when you press Enter on
-a release.
+screen-reader-friendly desktop app for browsing GitHub repositories. Its
+Releases view shows a downloads column per release and a repo-wide total in the
+status bar; pressing Enter on a release drills into its individual files, ordered
+most-downloaded first, and the details panel breaks a release down file by file
+without leaving the list.
+
+Download it from the [v0.2.1 release](https://github.com/kellylford/GHManage/releases/tag/v0.2.1)
+(a standalone `.exe`, no install required — it needs the `gh` CLI authenticated),
+or read the source at [github.com/kellylford/GHManage](https://github.com/kellylford/GHManage).
+Every number in the case study below was read out of it.
 
 ---
 
@@ -162,22 +169,7 @@ number you have. An installer download tells you someone took a copy. An
 **updater** download tells you a copy was still installed and still running when
 you shipped the next version. That is retention, measured directly.
 
-Watch it across consecutive releases. A real example from a small Windows app
-using an auto-updater:
-
-| Release | Delta package | Full package |
-|---------|--------------:|-------------:|
-| 0.8.31  | 11 | 8 |
-| 0.8.32  | 11 | 8 |
-| 0.8.33  | 13 | 5 |
-| 0.8.34  | 13 | 4 |
-| 0.8.35  | 14 | 12 |
-| 0.8.36  | 18 | 12 |
-
-That steadiness is the finding. It is the same population showing up six
-releases running, growing slowly. Meanwhile the installer count for those same
-releases bounced between 5 and 41 — noisier, and measuring something else
-entirely.
+Watch it across consecutive releases. The full worked example is below.
 
 Treat the updater figure as a **floor**, not a total. Portable users and people
 who reinstall manually never appear in it.
@@ -188,16 +180,10 @@ A useful heuristic. If a bot is crawling your release page and grabbing
 everything, all your assets show roughly the same count. Real users produce a
 jagged profile, because each one fetches exactly the file they need.
 
-From the same release: the update-feed metadata file had 110 downloads, the
-installer 27, the delta package 18, the portable build 11 — while a stale
-package from the previous version had 1 and one metadata file had 0. That spread
-is the signature of software behaving like software. Uniformity across every
-asset would be the warning sign.
-
-Apply the same suspicion to spikes. In that project's history, two releases
-scored 258 and 234 when their neighbours sat between 30 and 40. A jump of that
-shape, out of pattern with everything around it, is much more likely to be
-automated traffic than a sudden burst of humans.
+Uniformity across every asset is the warning sign. Apply the same suspicion to
+spikes: a release that scores five or ten times its neighbours, with nothing in
+its content to explain it, is far more likely to be automated traffic than a
+sudden burst of humans.
 
 ### Things that quietly are not counted
 
@@ -223,36 +209,133 @@ automated traffic than a sudden burst of humans.
 
 ---
 
-## A worked reading
+## A worked example, with real numbers
 
-Suppose one release shows:
+Abstract advice is easy to nod along to and hard to apply, so here is an entire
+repository's history with nothing withheld.
 
-```
-installer.msi          27
-app-delta.nupkg        18
-app-full.nupkg         12
-portable.exe           11
-update-feed.json      110
-```
+[QuickMail](https://github.com/kellylford/QuickMail) is a keyboard and screen
+reader friendly email client for Windows. It is a personal project with no
+marketing, no announcement channel, and no press. Discovery is word of mouth.
+These are all of its numbers as of 29 July 2026.
 
-The wrong read: "somewhere between 12 and 27 users."
+### What its releases contain
 
-The right read:
+Understanding the files is a prerequisite for reading the counts, and this is
+true of any project — you cannot interpret a number until you know which
+population produces it.
 
-- 18 + 12 = **30 existing installs updated themselves.** Both nupkg files are
-  fetched only by the updater; the full package is what it falls back to when a
-  delta will not apply. Different machines, so they add.
-- 27 installer + 11 portable = **38 fresh acquisitions**, of which an unknown
-  share are bots, repeat downloads, or people who tried it once.
-- 110 feed checks is **not** 110 users — it is cumulative polls, and one install
-  polling daily for a week is seven of them.
-- Ceiling on machines that obtained this version: about 68. Floor on machines
-  demonstrably running it: about 30. The truth is in between and closer to the
-  floor.
+| File | Who fetches it |
+|------|----------------|
+| `QuickMail-win.msi` / `-setup.exe` | A person installing it. New users, reinstalls, manual updaters. |
+| `QuickMail.exe` | A person who wants the portable build and no installer. Never auto-updates. |
+| `QuickMail-<v>-delta.nupkg` | An **installed, running** copy patching itself from the previous version. |
+| `QuickMail-<v>-full.nupkg` | The same updater, taking the whole package because a delta would not apply. |
+| `releases.win.json` | The updater checking whether a new version exists. |
+| `RELEASES`, `assets.win.json` | Legacy or unused feed metadata. |
 
-And the honest limit: none of this distinguishes someone who downloaded and kept
-using it from someone who downloaded and deleted it ten minutes later. Downloads
-measure acquisition. They can never measure whether anyone stayed.
+The last three are machine traffic by definition. The updater arrived in v0.8.0
+on 8 July 2026; before that there was no auto-update at all, which is why the
+nupkg columns are empty earlier in the history.
+
+### The whole history
+
+| Release | Date | Installer | Portable | Delta | Full | Feed |
+|---------|------|----------:|---------:|------:|-----:|-----:|
+| v0.8.36 | 07-24 | 27 | 11 | **18** | 12 | 110 |
+| v0.8.35 | 07-23 | 9 | 9 | **14** | 12 | 172 |
+| v0.8.34 | 07-22 | 37 | 15 | **13** | 4 | 256 |
+| v0.8.33 | 07-20 | 15 | 8 | **13** | 5 | 331 |
+| v0.8.32 | 07-15 | 16 | 13 | **11** | 8 | 476 |
+| v0.8.31 | 07-14 | 5 | 2 | **11** | 8 | 516 |
+| v0.8.3 | 07-13 | 8 | 5 | **9** | 11 | 565 |
+| v0.8.2 | 07-12 | 10 | 8 | **9** | 11 | 640 |
+| v0.8.1 | 07-09 | 41 | 29 | 0 | 9 | 712 |
+| v0.8.0 | 07-08 | 14 | 12 | 0 | 3 | 744 |
+| v0.7.9.1 | 07-03 | 57 | 35 | — | — | — |
+| v0.7.4 | 06-17 | **234** | 9 | — | — | — |
+| v0.7.2 | 06-12 | **258** | 5 | — | — | — |
+| v0.6.6 | 05-28 | 0 | **164** | — | — | — |
+| v0.5.1 | 05-12 | 0 | **149** | — | — | — |
+| *(29 more)* | | | | | | |
+| **Lifetime** | | **1,091** | **771** | **98** | **83** | **4,522** |
+
+Lifetime downloads across every asset of every release: **6,571**. Lifetime
+downloads of things a human would deliberately choose — installers and the
+portable build — **1,862**.
+
+### Reading it
+
+**1,862 is not a user count, and neither is 6,571.** The larger figure is mostly
+the updater talking to itself. The smaller one counts acquisitions over three
+months, including bots, repeat downloads, and everyone who tried it once and
+deleted it.
+
+**The delta column is the honest one.** Look at it in isolation: 9, 9, 11, 11,
+13, 13, 14, 18. Eight consecutive releases, each number earned only by a copy of
+QuickMail that was still installed and still running when the next version
+shipped. It is not noisy, it does not spike, and it grows slowly. That is the
+same group of people showing up again and again.
+
+Compare the installer column over exactly the same releases: 10, 8, 5, 16, 15,
+37, 9, 27. Same period, triple the volatility, and measuring something else
+entirely — arrival, not retention.
+
+**So how many people actually use QuickMail?** The defensible answer is
+**roughly 15 to 20 regular users**, with a plausible ceiling around 30 to 35.
+
+The reasoning, in full:
+
+- **18** installs auto-updated into the most recent release. That is a hard
+  floor — each one is a running installation.
+- Add the **12** that took the full package instead. Some of those are the same
+  kind of user on a machine where the delta failed; some skipped a version.
+  Call the updating population **20 to 30**.
+- Portable users are **invisible** to this. They never auto-update, so they never
+  appear in any nupkg count. Roughly 11 people took the portable build of the
+  latest release, but there is no way to know how many still run it.
+- Anyone who updates by re-running the installer is invisible too, mixed
+  indistinguishably into the installer column with genuinely new users.
+- The feed count of 110 is **not** 110 people. It is cumulative update checks,
+  and one install checking daily for a week contributes seven.
+
+**Two spikes do not belong.** v0.7.2 at 258 and v0.7.4 at 234 sit among
+neighbours in the 30 to 40 range, with nothing in either release to explain a
+sevenfold jump. The same shape appears in the portable column at v0.6.6 (164)
+and v0.5.1 (149). These are almost certainly automated. Excluding them removes
+roughly 800 from the lifetime total — which is to say, **nearly half of that
+1,862 is probably not human at all.**
+
+**One thing I genuinely cannot explain.** The feed column declines steadily as
+releases get newer — 744 at v0.8.0 down to 110 at v0.8.36. Older releases have
+had longer to accumulate checks, which accounts for some of it, but not cleanly.
+I do not know exactly how the updater distributes those requests across
+releases, and rather than invent a mechanism I will say so. It is a reminder
+that not every number in this data has a confident interpretation, and the
+temptation to supply one is exactly the failure mode this article is about.
+
+### What the numbers do and do not say
+
+They say roughly 15 to 20 people run this software regularly, and that the
+figure is growing slowly and steadily.
+
+They do **not** say the software is good or bad. QuickMail has had no
+distribution whatsoever, and a project with no distribution gets a number like
+this regardless of quality. For contrast, a comparable Windows accessibility
+project in the same niche recorded roughly 3,000 downloads in two months — it
+has an organisation behind it and a 36-episode onboarding podcast, which is a
+marketing budget wearing a disguise. Nothing in either dataset speaks to which
+program is better. They measure reach.
+
+And they never, under any circumstance, distinguish a person who downloaded and
+still uses it from a person who downloaded and deleted it ten minutes later.
+Downloads measure acquisition. Only an updater measures retention, and only
+approximately.
+
+That is the whole point of publishing these figures rather than a tidy
+hypothetical. Small numbers are the normal case for independent software, they
+are worth reading accurately, and reading them accurately is more useful than
+either inflating them or being embarrassed by them.
 
 ---
 


### PR DESCRIPTION
Follow-up to #404. Replaces the anonymised examples in the article with QuickMail's actual release history, in full.

**What is now published:** every release's installer, portable, delta, full-package and feed counts; lifetime totals (1,091 installer / 771 portable / 6,571 across all assets); and the reasoning that gets from those to *roughly 15–20 regular users, plausibly 30–35*.

**Including the unflattering parts**, because a worked example that only shows tidy data teaches nothing:
- Two releases (v0.7.2 at 258, v0.7.4 at 234) sit ~7× their neighbours and are almost certainly automated — excluding them removes roughly 800 downloads, close to half the lifetime human-facing total.
- The feed column declines monotonically as releases get newer and I cannot cleanly explain the distribution. The article says so rather than inventing a mechanism, and names that temptation as the failure mode the whole piece is about.
- It states plainly that the numbers measure reach, not quality, and notes a comparable project in the same niche doing ~3,000 downloads in two months with an organisation and a marketing budget behind it.

Also adds links to the [GHManage v0.2.1 release](https://github.com/kellylford/GHManage/releases/tag/v0.2.1) and repo — the tool these numbers were read from, whose release-download feature shipped alongside this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)