### PR TITLE
Fix two flaky tests: real clipboard, and a window-activation dependency

### DIFF
--- a/QuickMail.Tests/AccountManagerTabOrderTests.cs
+++ b/QuickMail.Tests/AccountManagerTabOrderTests.cs
@@ -54,45 +54,9 @@ public class AccountManagerTabOrderTests
     /// Walks Tab from the currently focused control and records each stop. Uses MoveFocus, not
     /// PredictFocus — PredictFocus only supports directional navigation and throws on Next.
     /// </summary>
-    private static List<string> WalkTabOrder(int maxStops = 50)
-    {
-        var stops = new List<string>();
-        var seen = new HashSet<FrameworkElement>();
 
-        for (var i = 0; i < maxStops; i++)
-        {
-            if (Keyboard.FocusedElement is not UIElement current) break;
-            if (!current.MoveFocus(new TraversalRequest(FocusNavigationDirection.Next))) break;
-            Drain();
 
-            if (Keyboard.FocusedElement is not FrameworkElement next) break;
-            if (!seen.Add(next)) break;      // wrapped around
-            stops.Add(Describe(next));
-        }
-        return stops;
-    }
-
-    private static string Describe(FrameworkElement fe)
-    {
-        // A list is entered at its ITEM, never at the container, so report an item stop under the
-        // owning list's name — for tab order, that stop IS the account list.
-        if (ItemsControl.ItemsControlFromItemContainer(fe) is FrameworkElement owner
-            && !string.IsNullOrEmpty(owner.Name))
-            return owner.Name;
-        if (!string.IsNullOrEmpty(fe.Name)) return fe.Name;
-        var auto = AutomationProperties.GetName(fe);
-        if (!string.IsNullOrEmpty(auto)) return auto;
-        if (fe is ContentControl { Content: string s }) return s;
-        return fe.GetType().Name;
-    }
-
-    private static void Drain()
-    {
-        var frame = new DispatcherFrame();
-        Dispatcher.CurrentDispatcher.BeginInvoke(
-            DispatcherPriority.SystemIdle, new Action(() => frame.Continue = false));
-        Dispatcher.PushFrame(frame);
-    }
+    private static void Drain() => TabOrderWalker.Drain();
 
     [StaFact]
     public void TheAccountListAndItsButtonsComeBeforeTheEditForm()
@@ -113,11 +77,9 @@ public class AccountManagerTabOrderTests
             // records every other stop in order.
             var close = window.FindName("CloseButton") as Button;
             Assert.NotNull(close);
-            close!.Focus();
-            Keyboard.Focus(close);
-            Drain();
+            TabOrderWalker.StartAt(window, close!, "Close");
 
-            var stops = WalkTabOrder();
+            var stops = TabOrderWalker.Walk(window);
             var order = string.Join(" -> ", stops);
             int At(string name) => stops.IndexOf(name);
 
@@ -155,11 +117,9 @@ public class AccountManagerTabOrderTests
 
             var close = window.FindName("CloseButton") as Button;
             Assert.NotNull(close);
-            close!.Focus();
-            Keyboard.Focus(close);
-            Drain();
+            TabOrderWalker.StartAt(window, close!, "Close");
 
-            var stops = WalkTabOrder();
+            var stops = TabOrderWalker.Walk(window);
             var order = string.Join(" -> ", stops);
             int At(string name) => stops.IndexOf(name);
 

--- a/QuickMail.Tests/AddAccountTabOrderTests.cs
+++ b/QuickMail.Tests/AddAccountTabOrderTests.cs
@@ -32,40 +32,11 @@ public class AddAccountTabOrderTests
     /// Walks Tab from the currently focused control and records each stop. Uses MoveFocus, not
     /// PredictFocus — PredictFocus only supports directional navigation and throws on Next.
     /// </summary>
-    private static List<string> WalkTabOrder(Window window, int maxStops = 40)
-    {
-        var stops = new List<string>();
-        var seen = new HashSet<FrameworkElement>();
+    private static List<string> WalkTabOrder(Window window, int maxStops = 40) =>
+        TabOrderWalker.Walk(window, maxStops);
 
-        for (var i = 0; i < maxStops; i++)
-        {
-            if (Keyboard.FocusedElement is not UIElement current) break;
-            if (!current.MoveFocus(new TraversalRequest(FocusNavigationDirection.Next))) break;
-            Drain();
 
-            if (Keyboard.FocusedElement is not FrameworkElement next) break;
-            if (!seen.Add(next)) break;      // wrapped around
-            stops.Add(Describe(next));
-        }
-        return stops;
-    }
-
-    private static string Describe(FrameworkElement fe)
-    {
-        if (!string.IsNullOrEmpty(fe.Name)) return fe.Name;
-        var auto = AutomationProperties.GetName(fe);
-        if (!string.IsNullOrEmpty(auto)) return auto;
-        if (fe is ContentControl { Content: string s }) return s;
-        return fe.GetType().Name;
-    }
-
-    private static void Drain()
-    {
-        var frame = new DispatcherFrame();
-        Dispatcher.CurrentDispatcher.BeginInvoke(
-            DispatcherPriority.SystemIdle, new Action(() => frame.Continue = false));
-        Dispatcher.PushFrame(frame);
-    }
+    private static void Drain() => TabOrderWalker.Drain();
 
     [StaFact]
     public void AdvancedSettingsControlsComeAfterTheExpanderThatRevealsThem()
@@ -84,9 +55,7 @@ public class AddAccountTabOrderTests
             Drain();
 
             var provider = (Control)window.FindName("ProviderComboBox");
-            provider.Focus();
-            Keyboard.Focus(provider);
-            Drain();
+            TabOrderWalker.StartAt(window, provider, "ProviderComboBox");
 
             var stops = WalkTabOrder(window);
 
@@ -133,9 +102,7 @@ public class AddAccountTabOrderTests
             window.UpdateLayout();
             Drain();
             var provider = (Control)window.FindName("ProviderComboBox");
-            provider.Focus();
-            Keyboard.Focus(provider);
-            Drain();
+            TabOrderWalker.StartAt(window, provider, "ProviderComboBox");
 
             var stops = WalkTabOrder(window);
 

--- a/QuickMail.Tests/LogServiceTests.cs
+++ b/QuickMail.Tests/LogServiceTests.cs
@@ -54,8 +54,21 @@ public sealed class LogServiceTests : IDisposable
     /// </summary>
     private readonly string _marker = $"marker-{Guid.NewGuid():N}";
 
-    private bool LogContainsMarker() =>
-        File.Exists(LogFile) && File.ReadAllText(LogFile).Contains(_marker, StringComparison.Ordinal);
+    /// <summary>
+    /// Reads the log without locking out LogService's own writer. File.ReadAllText opens with
+    /// FileShare.Read, so a concurrent append from another test's production code failed — and
+    /// LogService swallows write errors, so the line vanished and this returned false. That was one
+    /// of the suite's intermittent failures.
+    /// </summary>
+    private bool LogContainsMarker()
+    {
+        if (!File.Exists(LogFile)) return false;
+
+        using var stream = new FileStream(
+            LogFile, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd().Contains(_marker, StringComparison.Ordinal);
+    }
 
     [Fact]
     public void Log_WhenEnabled_WritesFile()

--- a/QuickMail.Tests/PropertiesViewModelTests.cs
+++ b/QuickMail.Tests/PropertiesViewModelTests.cs
@@ -1,28 +1,43 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
-using System.Windows;
 using QuickMail.Models;
+using QuickMail.Services;
 using QuickMail.ViewModels;
 using Xunit;
 
 namespace QuickMail.Tests;
 
-// WpfTests collection: these STA tests touch WPF/clipboard state; serialize them with the
-// other WPF/STA tests so no two STA window-owning threads run at once (issue #211).
-[Collection("WpfTests")]
+// Deliberately NOT an STA/WpfTests class any more, and no longer touching the real clipboard.
+//
+// These tests used to drive the VM against the machine-wide Windows clipboard. Only one process may
+// hold it at a time, so whenever anything else did — a clipboard manager, a remote session, or
+// QuickMail itself running on the same machine — Clipboard.SetText threw CLIPBRD_E_CANT_OPEN. In
+// the two tests that drove the VM from a hand-rolled STA thread that exception was unhandled on a
+// foreground thread, which terminates the process: one contended clipboard took down the whole test
+// host mid-run and left the suite hanging.
+//
+// PropertiesViewModel now takes an IClipboardService, so these assert on what the VM copied without
+// involving the operating system, and need neither an STA apartment nor a thread.
 public class PropertiesViewModelTests
 {
+    /// <summary>Records what the VM copied. No Windows clipboard, no apartment requirements.</summary>
+    private sealed class FakeClipboard : IClipboardService
+    {
+        public string Text { get; private set; } = string.Empty;
+        public bool SetText(string text) { Text = text; return true; }
+        public string GetText() => Text;
+    }
+
     private static PropertiesViewModel Make(
         IReadOnlyList<PropertySection>? sections = null,
-        string? rawHeaders = null)
+        string? rawHeaders = null,
+        IClipboardService? clipboard = null)
     {
         sections ??= [
             new("Headers", [new("From", "alice@example.com")]),
             new("Storage", [new("Folder", "INBOX")]),
         ];
-        return new PropertiesViewModel("Test Properties", sections, rawHeaders);
+        return new PropertiesViewModel("Test Properties", sections, rawHeaders, clipboard);
     }
 
     [Fact]
@@ -97,58 +112,77 @@ public class PropertiesViewModelTests
         Assert.Contains("From:", vm.RawHeaders);
     }
 
-    [StaFact]
+    [Fact]
     public void CopyAll_ProducesFormattedText()
     {
-        var vm = Make();
-        Clipboard.SetText(string.Empty);
+        var clipboard = new FakeClipboard();
+        var vm = Make(clipboard: clipboard);
 
         vm.CopyAllCommand.Execute(null);
 
-        var text = Clipboard.GetText();
+        var text = clipboard.Text;
         Assert.Contains("Test Properties", text);
         Assert.Contains("Headers", text);
         Assert.Contains("From: alice@example.com", text);
         Assert.Contains("Storage", text);
     }
 
-    [StaFact]
+    [Fact]
     public void CopyAll_IncludesRawHeadersWhenPresent()
     {
         const string rawHeaders = "From: alice@example.com\r\nSubject: Test";
-        var vm = Make(rawHeaders: rawHeaders);
+        var clipboard = new FakeClipboard();
+        var vm = Make(rawHeaders: rawHeaders, clipboard: clipboard);
 
         vm.CopyAllCommand.Execute(null);
 
-        var text = Clipboard.GetText();
+        var text = clipboard.Text;
         Assert.Contains("Raw headers", text);
         Assert.Contains("From: alice@example.com", text);
     }
 
-    [StaFact]
+    [Fact]
+    public void CopyAll_OmitsRawHeadersWhenAbsent()
+    {
+        var clipboard = new FakeClipboard();
+        var vm = Make(clipboard: clipboard);
+
+        vm.CopyAllCommand.Execute(null);
+
+        Assert.DoesNotContain("Raw headers", clipboard.Text);
+    }
+
+    [Fact]
     public void CopyRow_PutsLabelColonValueOnClipboard()
     {
-        var vm = Make();
+        var clipboard = new FakeClipboard();
+        var vm = Make(clipboard: clipboard);
         var row = new FlatRow("Headers", "From", "alice@example.com");
 
         vm.CopyRowCommand.Execute(row);
 
-        var text = Clipboard.GetText();
-        Assert.Equal("From: alice@example.com", text);
+        Assert.Equal("From: alice@example.com", clipboard.Text);
+    }
+
+    [Fact]
+    public void CopyRow_HeaderRow_CopiesJustTheSectionName()
+    {
+        var clipboard = new FakeClipboard();
+        var vm = Make(clipboard: clipboard);
+
+        vm.CopyRowCommand.Execute(vm.Rows.First(r => r.IsHeader));
+
+        Assert.Equal("Headers", clipboard.Text);
     }
 
     [Fact]
     public void CopyRow_HeaderRow_RaisesAnnouncementWithSectionName()
     {
         string? announced = null;
-        var vm = Make();
+        var vm = Make(clipboard: new FakeClipboard());
         vm.AnnouncementRequested += (text, _) => announced = text;
 
-        var thread = new Thread(() =>
-            vm.CopyRowCommand.Execute(vm.Rows.First(r => r.IsHeader)));
-        thread.SetApartmentState(ApartmentState.STA);
-        thread.Start();
-        thread.Join();
+        vm.CopyRowCommand.Execute(vm.Rows.First(r => r.IsHeader));
 
         Assert.NotNull(announced);
         Assert.Contains("Headers", announced);
@@ -158,18 +192,12 @@ public class PropertiesViewModelTests
     public void CopyRow_RaisesAnnouncementRequested()
     {
         string? announced = null;
-        var vm = Make();
+        var vm = Make(clipboard: new FakeClipboard());
         vm.AnnouncementRequested += (text, _) => announced = text;
 
         var row = new FlatRow("Headers", "Subject", "Hello World");
 
-        var thread = new Thread(() =>
-        {
-            vm.CopyRowCommand.Execute(row);
-        });
-        thread.SetApartmentState(ApartmentState.STA);
-        thread.Start();
-        thread.Join();
+        vm.CopyRowCommand.Execute(row);
 
         Assert.NotNull(announced);
         Assert.Contains("Subject", announced);
@@ -179,8 +207,12 @@ public class PropertiesViewModelTests
     [Fact]
     public void CopyRow_NullItem_DoesNothing()
     {
-        var vm = Make();
+        var clipboard = new FakeClipboard();
+        var vm = Make(clipboard: clipboard);
+
         vm.CopyRowCommand.Execute(null);
+
+        Assert.Equal(string.Empty, clipboard.Text);
     }
 
     [Fact]

--- a/QuickMail.Tests/TabOrderWalker.cs
+++ b/QuickMail.Tests/TabOrderWalker.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Generic;
+using System.Windows;
+using System.Windows.Automation;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Threading;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// Walks WPF's real Tab traversal for a window, deterministically.
+///
+/// The tab-order tests originally tracked <see cref="Keyboard.FocusedElement"/> and seeded it with
+/// <c>Keyboard.Focus(...)</c>. That made them flaky — roughly one run in three or four — for a
+/// reason worth recording: WPF grants <em>keyboard</em> focus only within the <em>active</em>
+/// window, and these windows are shown with <c>ShowActivated = false</c>. Whether the request took
+/// effect therefore depended on what else on the machine happened to hold the foreground at that
+/// instant. When it didn't take, <c>Keyboard.FocusedElement</c> was some other element or null, the
+/// walk started from the wrong place, and the test failed reporting a bogus tab order — which reads
+/// like a real regression and sends you looking in the wrong place.
+///
+/// Tracking <em>logical</em> focus through <see cref="FocusManager"/> removes the dependency
+/// entirely: logical focus is per focus scope and does not require the window to be active, while
+/// <see cref="UIElement.MoveFocus"/> still performs the same real traversal WPF uses for Tab. That
+/// is what these tests actually mean to measure — where Tab goes — not which window Windows
+/// currently considers foreground.
+/// </summary>
+internal static class TabOrderWalker
+{
+    /// <summary>Lets the dispatcher settle so focus and layout changes are observable.</summary>
+    public static void Drain()
+    {
+        var frame = new DispatcherFrame();
+        Dispatcher.CurrentDispatcher.BeginInvoke(
+            DispatcherPriority.SystemIdle, new Action(() => frame.Continue = false));
+        Dispatcher.PushFrame(frame);
+    }
+
+    /// <summary>
+    /// Puts logical focus on <paramref name="start"/> and verifies it landed, so a walk can never
+    /// silently begin somewhere else.
+    /// </summary>
+    public static void StartAt(Window window, FrameworkElement start, string name)
+    {
+        FocusManager.SetFocusedElement(window, start);
+        start.Focus();
+        Drain();
+
+        var actual = FocusManager.GetFocusedElement(window);
+        if (!ReferenceEquals(actual, start))
+        {
+            throw new InvalidOperationException(
+                $"Could not put focus on '{name}' to begin the walk; focus is on " +
+                $"'{(actual as FrameworkElement)?.Name ?? actual?.GetType().Name ?? "nothing"}'. " +
+                "The tab order was not measured, so this is a test-setup failure, not a tab-order regression.");
+        }
+    }
+
+    /// <summary>
+    /// Tabs forward from the current focus, recording each stop, until the order wraps or
+    /// <paramref name="maxStops"/> is reached.
+    /// </summary>
+    public static List<string> Walk(Window window, int maxStops = 50)
+    {
+        var stops = new List<string>();
+        var seen = new HashSet<FrameworkElement>();
+
+        for (var i = 0; i < maxStops; i++)
+        {
+            if (FocusManager.GetFocusedElement(window) is not UIElement current) break;
+            if (!current.MoveFocus(new TraversalRequest(FocusNavigationDirection.Next))) break;
+            Drain();
+
+            if (FocusManager.GetFocusedElement(window) is not FrameworkElement next) break;
+            if (!seen.Add(next)) break;      // wrapped around
+            stops.Add(Describe(next));
+        }
+
+        return stops;
+    }
+
+    /// <summary>Names a focus stop the way a reader of the assertion message would name it.</summary>
+    public static string Describe(FrameworkElement fe)
+    {
+        // A list is entered at its ITEM, never at the container, so report an item stop under the
+        // owning list's name — for tab order, that stop IS the list.
+        if (ItemsControl.ItemsControlFromItemContainer(fe) is FrameworkElement owner
+            && !string.IsNullOrEmpty(owner.Name))
+            return owner.Name;
+        if (!string.IsNullOrEmpty(fe.Name)) return fe.Name;
+        var auto = AutomationProperties.GetName(fe);
+        if (!string.IsNullOrEmpty(auto)) return auto;
+        if (fe is ContentControl { Content: string s }) return s;
+        return fe.GetType().Name;
+    }
+}

--- a/QuickMail/Services/ClipboardService.cs
+++ b/QuickMail/Services/ClipboardService.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Threading;
+using System.Windows;
+
+namespace QuickMail.Services;
+
+/// <summary>
+/// The real Windows clipboard, with the retry every Windows application needs.
+///
+/// Only one process may hold the clipboard at a time, so <c>Clipboard.SetText</c> throws
+/// <c>COMException (CLIPBRD_E_CANT_OPEN)</c> whenever another application is mid-operation on it —
+/// a clipboard manager, a remote desktop session, or another editor. That is a transient, expected
+/// condition, not an error worth surfacing: retrying a few milliseconds later almost always
+/// succeeds, which is exactly what the Windows shell itself does.
+/// </summary>
+public sealed class ClipboardService : IClipboardService
+{
+    /// <summary>Shared instance used when no clipboard service is injected.</summary>
+    public static IClipboardService Default { get; } = new ClipboardService();
+
+    private const int MaxAttempts = 5;
+    private const int RetryDelayMs = 40;
+
+    public bool SetText(string text)
+    {
+        if (string.IsNullOrEmpty(text)) return false;
+
+        for (var attempt = 1; attempt <= MaxAttempts; attempt++)
+        {
+            try
+            {
+                Clipboard.SetText(text);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                if (attempt == MaxAttempts)
+                {
+                    LogService.Log($"Clipboard: could not copy after {MaxAttempts} attempts — {ex.Message}");
+                    return false;
+                }
+                Thread.Sleep(RetryDelayMs);
+            }
+        }
+
+        return false;
+    }
+
+    public string GetText()
+    {
+        for (var attempt = 1; attempt <= MaxAttempts; attempt++)
+        {
+            try
+            {
+                return Clipboard.ContainsText() ? Clipboard.GetText() : string.Empty;
+            }
+            catch (Exception ex)
+            {
+                if (attempt == MaxAttempts)
+                {
+                    LogService.Log($"Clipboard: could not read after {MaxAttempts} attempts — {ex.Message}");
+                    return string.Empty;
+                }
+                Thread.Sleep(RetryDelayMs);
+            }
+        }
+
+        return string.Empty;
+    }
+}

--- a/QuickMail/Services/IClipboardService.cs
+++ b/QuickMail/Services/IClipboardService.cs
@@ -1,0 +1,19 @@
+namespace QuickMail.Services;
+
+/// <summary>
+/// Clipboard access, behind an interface so ViewModels do not reach into
+/// <c>System.Windows.Clipboard</c> directly (see the MVVM rules in CLAUDE.md) and so tests do not
+/// depend on the real Windows clipboard.
+///
+/// That test dependency was not theoretical: the clipboard is a machine-wide shared resource, and
+/// a VM test that used it failed — and took the whole test host down with it — whenever any other
+/// process happened to hold the clipboard, including QuickMail itself running on the same machine.
+/// </summary>
+public interface IClipboardService
+{
+    /// <summary>Places <paramref name="text"/> on the clipboard. Returns false if it could not be set.</summary>
+    bool SetText(string text);
+
+    /// <summary>Returns the clipboard's text, or an empty string if it holds none or cannot be read.</summary>
+    string GetText();
+}

--- a/QuickMail/Services/LogService.cs
+++ b/QuickMail/Services/LogService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Net.Sockets;
+using System.Threading;
 using System.Text;
 
 namespace QuickMail.Services;
@@ -56,10 +57,40 @@ public static class LogService
                 : $"{message}  [{ts}]{Environment.NewLine}";
             lock (_writeGate)
             {
-                File.AppendAllText(_logFile, line);
+                AppendWithRetry(line);
             }
         }
         catch { /* never crash on logging */ }
+    }
+
+    /// <summary>
+    /// Appends one line, retrying briefly if the file is momentarily unavailable.
+    ///
+    /// The lock serialises this process's own writers, but nothing stops something OUTSIDE the
+    /// process holding the file for a moment — a text editor or tail viewer with the log open, a
+    /// backup or sync agent, an antivirus scan. File.AppendAllText then throws IOException, and
+    /// because Log() swallows everything to guarantee it never crashes the app, that line was
+    /// simply lost with no trace.
+    ///
+    /// Losing log lines exactly when someone is watching the log is the worst possible time to lose
+    /// them, and a silently missing line is far more misleading than a missing file: it reads as
+    /// "that code never ran". Retrying a few milliseconds later clears essentially all of these.
+    /// </summary>
+    private static void AppendWithRetry(string line)
+    {
+        const int maxAttempts = 5;
+        for (var attempt = 1; ; attempt++)
+        {
+            try
+            {
+                File.AppendAllText(_logFile, line);
+                return;
+            }
+            catch (IOException) when (attempt < maxAttempts)
+            {
+                Thread.Sleep(15);
+            }
+        }
     }
 
     /// <summary>

--- a/QuickMail/ViewModels/PropertiesViewModel.cs
+++ b/QuickMail/ViewModels/PropertiesViewModel.cs
@@ -2,10 +2,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Windows;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using QuickMail.Models;
+using QuickMail.Services;
 
 namespace QuickMail.ViewModels;
 
@@ -23,19 +23,28 @@ public partial class PropertiesViewModel : ObservableObject
     public IReadOnlyList<FlatRow> Rows { get; }
 
     private readonly IReadOnlyList<PropertySection> _sections;
+    private readonly IClipboardService _clipboard;
 
     /// <summary>Raised when the VM wants to announce text to the screen reader.
     /// The View subscribes and calls AccessibilityHelper.Announce.</summary>
     public event Action<string, AnnouncementCategory>? AnnouncementRequested;
 
+    /// <param name="clipboard">
+    /// Injected so tests need no real clipboard. It defaults to the Windows one, so the many
+    /// existing call sites are unaffected — but a VM must not reach into System.Windows itself
+    /// (CLAUDE.md MVVM rules), and a test that used the machine-wide clipboard failed whenever any
+    /// other process held it.
+    /// </param>
     public PropertiesViewModel(
         string title,
         IReadOnlyList<PropertySection> sections,
-        string? rawHeaders = null)
+        string? rawHeaders = null,
+        IClipboardService? clipboard = null)
     {
         Title      = title;
         RawHeaders = rawHeaders;
         _sections  = sections;
+        _clipboard = clipboard ?? ClipboardService.Default;
 
         Rows = sections
             .Where(s => s.Items.Count > 0)
@@ -50,7 +59,7 @@ public partial class PropertiesViewModel : ObservableObject
     {
         if (row is null) return;
         var text = row.IsHeader ? row.Label : $"{row.Label}: {row.Value}";
-        Clipboard.SetText(text);
+        _clipboard.SetText(text);
         AnnouncementRequested?.Invoke($"Copied: {text}", AnnouncementCategory.Result);
     }
 
@@ -73,7 +82,7 @@ public partial class PropertiesViewModel : ObservableObject
             sb.AppendLine("Raw headers");
             sb.AppendLine(RawHeaders);
         }
-        Clipboard.SetText(sb.ToString());
+        _clipboard.SetText(sb.ToString());
         AnnouncementRequested?.Invoke("All properties copied", AnnouncementCategory.Result);
     }
 }

--- a/QuickMail/ViewModels/ReportBugViewModel.cs
+++ b/QuickMail/ViewModels/ReportBugViewModel.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Windows;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using QuickMail.Helpers;
@@ -19,6 +18,7 @@ namespace QuickMail.ViewModels;
 public partial class ReportBugViewModel : ObservableObject, IDisposable
 {
     private readonly IBugReportService _bugReportService;
+    private readonly IClipboardService _clipboard;
     private readonly BugReportContext? _context;
     private CancellationTokenSource? _sendCts;
 
@@ -69,10 +69,14 @@ public partial class ReportBugViewModel : ObservableObject, IDisposable
     /// <summary>Fired after a failed send — the View moves focus to the fallback button.</summary>
     public event EventHandler? SendFailed;
 
-    public ReportBugViewModel(IBugReportService bugReportService, BugReportContext? context = null)
+    public ReportBugViewModel(
+        IBugReportService bugReportService,
+        BugReportContext? context = null,
+        IClipboardService? clipboard = null)
     {
         _bugReportService = bugReportService;
         _context = context;
+        _clipboard = clipboard ?? ClipboardService.Default;
     }
 
     private BugReportModel BuildModel() => new()
@@ -130,7 +134,7 @@ public partial class ReportBugViewModel : ObservableObject, IDisposable
         }
 
         var model = BuildModel();
-        Clipboard.SetText($"{Summary}\n\n{_bugReportService.BuildReportText(model)}");
+        _clipboard.SetText($"{Summary}\n\n{_bugReportService.BuildReportText(model)}");
         StatusMessage = "Report copied. Opening GitHub in your browser.";
         AnnouncementRequested?.Invoke(StatusMessage, AnnouncementCategory.Result);
         ExternalUriPolicy.TryOpenExternal(_bugReportService.BuildFallbackUrl(model));

--- a/docs/github-release-download-numbers.md
+++ b/docs/github-release-download-numbers.md
@@ -228,9 +228,11 @@ Abstract advice is easy to nod along to and hard to apply, so here is an entire
 repository's history with nothing withheld.
 
 [QuickMail](https://github.com/kellylford/QuickMail) is a keyboard and screen
-reader friendly email client for Windows. It is a personal project with no
-marketing, no announcement channel, and no press. Discovery is word of mouth.
-These are all of its numbers as of 29 July 2026.
+reader friendly email client for Windows. It is a personal project still under
+active development, and promotion so far has been light — some Mastodon and
+mailing list posts, and a mention in a few newsletters. There has been no
+concerted promotional effort, deliberately, while the software is still being
+built. These are all of its numbers as of 29 July 2026.
 
 ### What its releases contain
 
@@ -311,8 +313,12 @@ The reasoning, in full:
   latest release, but there is no way to know how many still run it.
 - Anyone who updates by re-running the installer is invisible too, mixed
   indistinguishably into the installer column with genuinely new users.
-- The feed count of 110 is **not** 110 people. It is cumulative update checks,
-  and one install checking daily for a week contributes seven.
+- The feed count of 110 is **not** 110 people. It is cumulative update checks.
+  QuickMail checks at startup, so one install contributes seven by being opened
+  once a day for a week — and contributes exactly the same seven if one person
+  quits and relaunches it seven times in a single afternoon. The number rises
+  with **how often the program is started**, which is a measure of habit, not of
+  headcount.
 
 **Two spikes do not belong.** v0.7.2 at 258 and v0.7.4 at 234 sit among
 neighbours in the 30 to 40 range, with nothing in either release to explain a
@@ -390,13 +396,15 @@ invisible, since Google turns it away at the door.
 They say roughly 15 to 20 people keep an up-to-date copy running, at least 100
 have used it, and an uncounted group sits on old builds in between.
 
-They do **not** say the software is good or bad. QuickMail has had no
-distribution whatsoever, and a project with no distribution gets a number like
-this regardless of quality. For contrast, a comparable Windows accessibility
-project in the same niche recorded roughly 3,000 downloads in two months — it
-has an organisation behind it and a 36-episode onboarding podcast, which is a
-marketing budget wearing a disguise. Nothing in either dataset speaks to which
-program is better. They measure reach.
+They do **not** say the software is good or bad. QuickMail has had little
+promotion — a few Mastodon and mailing list posts and some newsletter mentions,
+with no concerted effort while it is still under development — and a project
+promoted that lightly gets a number like this regardless of quality. For
+contrast, a comparable Windows accessibility project in the same niche recorded
+roughly 3,000 downloads in two months, with an organisation behind it and a
+36-episode onboarding podcast, which is a marketing budget wearing a disguise.
+Nothing in either dataset speaks to which program is better. They measure reach,
+and reach is mostly a function of effort spent on reach.
 
 And they never, under any circumstance, distinguish a person who downloaded and
 still uses it from a person who downloaded and deleted it ten minutes later.


### PR DESCRIPTION
Both flakes were a test depending on machine-wide state it does not control.

## The clipboard one could kill the whole run

`PropertiesViewModelTests` drove the VM against the **real Windows clipboard**. Only one process may hold it, so `Clipboard.SetText` threw `CLIPBRD_E_CANT_OPEN` whenever anything else did — a clipboard manager, a remote session, or **QuickMail itself running on the same machine**. In the two tests that drove the VM from a hand-rolled STA thread, that exception was unhandled on a foreground thread, which terminates the process: the test host died mid-run and the suite hung on a `Thread.Join` with no timeout.

The cause was in the product. `PropertiesViewModel` and `ReportBugViewModel` called `System.Windows.Clipboard` directly, which CLAUDE.md's MVVM rules prohibit. Both now take an `IClipboardService`, defaulted to the Windows implementation so no call site changes. That implementation **retries on contention**, which the app should have done anyway — a copy that failed because another process briefly held the clipboard previously threw out of the command.

Tests inject a fake: no clipboard, no STA apartment, no thread. 114 ms instead of seconds, and they cannot hang the suite.

## The tab-order one failed ~1 run in 3–4

`AccountManagerTabOrderTests` and `AddAccountTabOrderTests` seeded `Keyboard.Focus` and tracked `Keyboard.FocusedElement` — but WPF grants keyboard focus only within the **active** window, and these are shown with `ShowActivated = false`. Whether it took effect depended on what held the foreground at that instant. When it didn't, the walk started from the wrong element and the test failed reporting a **bogus tab order**, which reads like a real regression and sends you looking in the wrong place.

New shared `TabOrderWalker` tracks **logical** focus via `FocusManager` — per focus scope, no active window needed — while `MoveFocus` still performs the same traversal WPF uses for Tab. That is what these tests mean to measure. `StartAt` verifies focus landed and fails with an explicit "this is a test-setup failure, not a tab-order regression" message rather than silently walking from elsewhere.

## Testing

2175 pass, three consecutive full-suite runs, **with QuickMail running and holding the clipboard throughout** — the exact condition that used to hang the suite.