### PR TITLE
Apply client mail rules to live-arriving mail, not just the full sync

### DIFF
--- a/QuickMail.Tests/FlagServiceTests.cs
+++ b/QuickMail.Tests/FlagServiceTests.cs
@@ -145,6 +145,7 @@ sealed class RecordingFlagStore : ILocalStoreService
     public Task<MailMessageDetail?> LoadDetailAsync(Guid accountId, string folderName, string messageId) => Task.FromResult<MailMessageDetail?>(null);
     public Task<string> GetMaxMessageKeyAsync(Guid accountId, string folderName) => Task.FromResult("0");
     public Task<HashSet<string>> GetAllMessageIdsAsync(Guid accountId, string folderName) => Task.FromResult(new HashSet<string>());
+    public Task<HashSet<string>> GetExistingMessageIdsAsync(Guid accountId, string folderName, IEnumerable<string> messageIds) => Task.FromResult(new HashSet<string>());
     public Task<int> CountSummariesAsync(Guid accountId) => Task.FromResult(0);
     public Task<DateTimeOffset?> GetOldestMessageDateAsync(Guid accountId) => Task.FromResult<DateTimeOffset?>(null);
     public Task UpdateFlagIdAsync(Guid accountId, string folderName, string messageId, string? flagId)

--- a/QuickMail.Tests/MainViewModelFlagTests.cs
+++ b/QuickMail.Tests/MainViewModelFlagTests.cs
@@ -228,6 +228,7 @@ sealed class FilterableStoreForFlags : ILocalStoreService
     public Task<MailMessageDetail?> LoadDetailAsync(Guid accountId, string folderName, string messageId) => Task.FromResult<MailMessageDetail?>(null);
     public Task<string> GetMaxMessageKeyAsync(Guid accountId, string folderName) => Task.FromResult("0");
     public Task<HashSet<string>> GetAllMessageIdsAsync(Guid accountId, string folderName) => Task.FromResult(new HashSet<string>());
+    public Task<HashSet<string>> GetExistingMessageIdsAsync(Guid accountId, string folderName, IEnumerable<string> messageIds) => Task.FromResult(new HashSet<string>());
     public Task<int> CountSummariesAsync(Guid accountId) => Task.FromResult(0);
     public Task<DateTimeOffset?> GetOldestMessageDateAsync(Guid accountId) => Task.FromResult<DateTimeOffset?>(null);
     public Task UpdateFlagIdAsync(Guid accountId, string folderName, string messageId, string? flagId) => Task.CompletedTask;

--- a/QuickMail.Tests/MarkReadOnOpenTests.cs
+++ b/QuickMail.Tests/MarkReadOnOpenTests.cs
@@ -138,6 +138,7 @@ public class MarkReadOnOpenTests
         public Task UpsertDetailAsync(MailMessageDetail detail) => Task.CompletedTask;
         public Task<string> GetMaxMessageKeyAsync(Guid accountId, string folderName) => Task.FromResult("0");
         public Task<HashSet<string>> GetAllMessageIdsAsync(Guid accountId, string folderName) => Task.FromResult(new HashSet<string>());
+        public Task<HashSet<string>> GetExistingMessageIdsAsync(Guid accountId, string folderName, IEnumerable<string> messageIds) => Task.FromResult(new HashSet<string>());
         public Task<int> CountSummariesAsync(Guid accountId) => Task.FromResult(0);
         public Task<DateTimeOffset?> GetOldestMessageDateAsync(Guid accountId) => Task.FromResult<DateTimeOffset?>(null);
         public Task UpdateFlagIdAsync(Guid accountId, string folderName, string messageId, string? flagId) => Task.CompletedTask;

--- a/QuickMail.Tests/MessageFilterTests.cs
+++ b/QuickMail.Tests/MessageFilterTests.cs
@@ -42,6 +42,7 @@ public class MessageFilterTests
         public Task<MailMessageDetail?> LoadDetailAsync(Guid accountId, string folderName, string messageId) => Task.FromResult<MailMessageDetail?>(null);
         public Task<string> GetMaxMessageKeyAsync(Guid accountId, string folderName) => Task.FromResult("0");
         public Task<HashSet<string>> GetAllMessageIdsAsync(Guid accountId, string folderName) => Task.FromResult(new HashSet<string>());
+        public Task<HashSet<string>> GetExistingMessageIdsAsync(Guid accountId, string folderName, IEnumerable<string> messageIds) => Task.FromResult(new HashSet<string>());
         public Task<int> CountSummariesAsync(Guid accountId) => Task.FromResult(0);
         public Task<DateTimeOffset?> GetOldestMessageDateAsync(Guid accountId) => Task.FromResult<DateTimeOffset?>(null);
         public Task UpdateFlagIdAsync(Guid accountId, string folderName, string messageId, string? flagId) => Task.CompletedTask;

--- a/QuickMail.Tests/SavedViewsTests.cs
+++ b/QuickMail.Tests/SavedViewsTests.cs
@@ -835,6 +835,7 @@ public class SavedViewsMainViewModelTests
         public Task<MailMessageDetail?> LoadDetailAsync(Guid accountId, string folderName, string messageId) => Task.FromResult<MailMessageDetail?>(null);
         public Task<string> GetMaxMessageKeyAsync(Guid accountId, string folderName) => Task.FromResult("0");
         public Task<HashSet<string>> GetAllMessageIdsAsync(Guid accountId, string folderName) => Task.FromResult(new HashSet<string>());
+        public Task<HashSet<string>> GetExistingMessageIdsAsync(Guid accountId, string folderName, IEnumerable<string> messageIds) => Task.FromResult(new HashSet<string>());
         public Task<int> CountSummariesAsync(Guid accountId) => Task.FromResult(0);
         public Task<DateTimeOffset?> GetOldestMessageDateAsync(Guid accountId) => Task.FromResult<DateTimeOffset?>(null);
         public Task UpdateFlagIdAsync(Guid accountId, string folderName, string messageId, string? flagId) => Task.CompletedTask;

--- a/QuickMail.Tests/SessionFeaturesTests.cs
+++ b/QuickMail.Tests/SessionFeaturesTests.cs
@@ -102,6 +102,7 @@ public class PreviewSuppressionTests
         public Task<MailMessageDetail?> LoadDetailAsync(Guid accountId, string folderName, string messageId) => Task.FromResult<MailMessageDetail?>(null);
         public Task<string> GetMaxMessageKeyAsync(Guid accountId, string folderName) => Task.FromResult("0");
         public Task<HashSet<string>> GetAllMessageIdsAsync(Guid accountId, string folderName) => Task.FromResult(new HashSet<string>());
+        public Task<HashSet<string>> GetExistingMessageIdsAsync(Guid accountId, string folderName, IEnumerable<string> messageIds) => Task.FromResult(new HashSet<string>());
         public Task<int> CountSummariesAsync(Guid accountId) => Task.FromResult(0);
         public Task<DateTimeOffset?> GetOldestMessageDateAsync(Guid accountId) => Task.FromResult<DateTimeOffset?>(null);
         public Task UpdateFlagIdAsync(Guid accountId, string folderName, string messageId, string? flagId) => Task.CompletedTask;

--- a/QuickMail.Tests/StubServices.cs
+++ b/QuickMail.Tests/StubServices.cs
@@ -207,6 +207,7 @@ sealed class StubLocalStoreService : ILocalStoreService
     public Task<MailMessageDetail?> LoadDetailAsync(Guid accountId, string folderName, string messageId) => Task.FromResult(SeededDetail);
     public Task<string> GetMaxMessageKeyAsync(Guid accountId, string folderName) => Task.FromResult("0");
     public Task<HashSet<string>> GetAllMessageIdsAsync(Guid accountId, string folderName) => Task.FromResult(new HashSet<string>());
+    public Task<HashSet<string>> GetExistingMessageIdsAsync(Guid accountId, string folderName, IEnumerable<string> messageIds) => Task.FromResult(new HashSet<string>());
     public Task<int> CountSummariesAsync(Guid accountId) => Task.FromResult(0);
     public Task<DateTimeOffset?> GetOldestMessageDateAsync(Guid accountId) => Task.FromResult<DateTimeOffset?>(null);
     public Task UpdateFlagIdAsync(Guid accountId, string folderName, string messageId, string? flagId) => Task.CompletedTask;

--- a/QuickMail.Tests/SyncServiceRuleApplicationTests.cs
+++ b/QuickMail.Tests/SyncServiceRuleApplicationTests.cs
@@ -1,0 +1,193 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using QuickMail.Models;
+using QuickMail.Services;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// Pins the fix for the "client rules never ran on live-arriving mail" bug: mail that arrives while
+/// QuickMail is running comes in through the IDLE / change-notifier path
+/// (<see cref="SyncService.SyncOneFolderAsync"/> / <see cref="SyncService.SyncOneFolderOnlineAsync"/>),
+/// which previously stored and displayed the message but never invoked the rule engine. Only the
+/// full sync applied rules, so a message first seen live slipped past every client rule permanently.
+/// <para>
+/// The fix routes all sync paths through one rule-application chokepoint. These tests drive the two
+/// live paths directly and assert the rule engine is invoked exactly once per genuinely-new message,
+/// and never on a message already known to the store or already processed this session.
+/// </para>
+/// </summary>
+public class SyncServiceRuleApplicationTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly LocalStoreService _store;
+    private readonly Guid _accountId = Guid.NewGuid();
+    private readonly MailFolderModel _inbox = new() { FullName = "INBOX", DisplayName = "Inbox" };
+
+    public SyncServiceRuleApplicationTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"qm-sync-rules-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        _store = new LocalStoreService(new ProfileContext(_tempDir));
+        _store.Initialize();
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); } catch { }
+        GC.SuppressFinalize(this);
+    }
+
+    private AccountModel Account() => new() { Id = _accountId, AccountName = "Test", ImapHost = "host" };
+
+    private MailMessageSummary Message(string id, bool read = true) => new()
+    {
+        MessageId = id,
+        AccountId = _accountId,
+        FolderName = "INBOX",
+        From = "Tim Spaulding <tim.spaulding@bits-acb.org>",
+        To = "me@example.com",
+        Subject = "hello",
+        IsRead = read,
+    };
+
+    // ── IRuleService that records every batch handed to the engine ───────────────
+    private sealed class CapturingRuleService : IRuleService
+    {
+        public List<List<MailMessageSummary>> Calls { get; } = [];
+
+        public Task<(int MatchedCount, List<MailMessageSummary> RemovedMessages)> ApplyRulesAsync(
+            List<MailMessageSummary> incoming, Guid accountId, CancellationToken ct)
+        {
+            Calls.Add(incoming.ToList());
+            // Simulate a mark-as-unread rule firing on every message (local-only, no removals).
+            foreach (var m in incoming) m.IsRead = false;
+            return Task.FromResult((incoming.Count, new List<MailMessageSummary>()));
+        }
+
+        public List<MailRule> LoadRules() => [];
+        public void SaveRules(List<MailRule> rules) { }
+        public List<MailMessageSummary> TestRule(MailRule rule, IEnumerable<MailMessageSummary> messages) => [];
+        public Task<List<MailMessageSummary>> ApplyRulesToExistingAsync(ILocalStoreService store, CancellationToken ct)
+            => Task.FromResult(new List<MailMessageSummary>());
+    }
+
+    // ── IMailService that returns a scripted batch from GetMessagesSinceAsync ─────
+    private sealed class FetchStubMailService : IMailService
+    {
+        private readonly List<MailMessageSummary> _batch;
+        public FetchStubMailService(List<MailMessageSummary> batch) => _batch = batch;
+
+        // The only method the IDLE paths call to fetch.
+        public Task<List<MailMessageSummary>> GetMessagesSinceAsync(Guid a, string f, string sinceId, int count, CancellationToken ct = default)
+            => Task.FromResult(_batch.Select(Clone).ToList());
+
+        private static MailMessageSummary Clone(MailMessageSummary m) => new()
+        {
+            MessageId = m.MessageId, AccountId = m.AccountId, FolderName = m.FolderName,
+            From = m.From, To = m.To, Subject = m.Subject, IsRead = m.IsRead, Preview = m.Preview,
+        };
+
+        // ── Everything else: inert ───────────────────────────────────────────────
+        public Task ConnectAsync(AccountModel account, string? password = null, CancellationToken ct = default) => Task.CompletedTask;
+        public Task DisconnectAsync(Guid accountId, CancellationToken ct = default) => Task.CompletedTask;
+        public bool IsConnected(Guid accountId) => true;
+        public Task<List<MailFolderModel>> GetFoldersAsync(Guid a, CancellationToken ct = default) => Task.FromResult(new List<MailFolderModel>());
+        public Task<List<MailMessageSummary>> GetMessageSummariesAsync(Guid a, string f, int max, CancellationToken ct = default) => Task.FromResult(new List<MailMessageSummary>());
+        public Task<List<MailMessageSummary>> GetMessagesSinceDateAsync(Guid a, string f, DateTime since, CancellationToken ct = default) => Task.FromResult(new List<MailMessageSummary>());
+        public Task<MailMessageDetail> GetMessageDetailAsync(Guid a, string f, string id, CancellationToken ct = default) => Task.FromResult(new MailMessageDetail());
+        public Task<MailMessageDetail> PrefetchMessageDetailAsync(Guid a, string f, string id, CancellationToken ct = default) => Task.FromResult(new MailMessageDetail());
+        public Task MarkReadAsync(Guid a, string f, string id, CancellationToken ct = default) => Task.CompletedTask;
+        public Task MarkReadBatchAsync(Guid a, string f, IList<string> ids, CancellationToken ct = default) => Task.CompletedTask;
+        public Task SetMessageFlaggedAsync(Guid a, string f, string id, bool flagged, CancellationToken ct = default) => Task.CompletedTask;
+        public Task MoveToTrashAsync(Guid a, string f, string id, CancellationToken ct = default) => Task.CompletedTask;
+        public Task MoveToTrashBatchAsync(Guid a, string f, IList<string> ids, CancellationToken ct = default) => Task.CompletedTask;
+        public Task PermanentlyDeleteBatchAsync(Guid a, string f, IList<string> ids, CancellationToken ct = default) => Task.CompletedTask;
+        public Task NoOpAsync(Guid a, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<int> CountTrashMessagesAsync(Guid a, CancellationToken ct = default) => Task.FromResult(0);
+        public Task<int> EmptyTrashAsync(Guid a, CancellationToken ct = default) => Task.FromResult(0);
+        public Task<IList<string>> GetFolderMessageIdsAsync(Guid a, string f, CancellationToken ct = default) => Task.FromResult<IList<string>>([]);
+        public Task<IReadOnlyDictionary<string, string>> FetchPreviewsAsync(Guid a, string f, IList<string> ids, int maxLines, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyDictionary<string, string>>(new Dictionary<string, string>());
+        public Task<int> PollAsync(Guid a, string f, CancellationToken ct = default) => Task.FromResult(0);
+        public Task<(int Total, int Unread)> GetInboxStatusAsync(Guid a, CancellationToken ct = default) => Task.FromResult((0, 0));
+        public Task<string?> FindDraftsFolderNameAsync(Guid a, CancellationToken ct = default) => Task.FromResult<string?>(null);
+        public Task<string> AppendDraftAsync(Guid a, ComposeModel draft, string? replaceId, CancellationToken ct = default) => Task.FromResult(string.Empty);
+        public Task AppendToSentAsync(Guid a, ComposeModel sent, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<byte[]> DownloadAttachmentAsync(Guid a, string f, string id, string part, CancellationToken ct = default) => Task.FromResult(Array.Empty<byte>());
+        public Task CopyMessagesAsync(Guid a, string f, IList<string> ids, string dest, CancellationToken ct = default) => Task.CompletedTask;
+        public Task MoveMessagesAsync(Guid a, string f, IList<string> ids, string dest, CancellationToken ct = default) => Task.CompletedTask;
+        public Task CreateFolderAsync(Guid a, string? parent, string name, CancellationToken ct = default) => Task.CompletedTask;
+        public Task DeleteFolderAsync(Guid a, string f, CancellationToken ct = default) => Task.CompletedTask;
+        public Task RenameFolderAsync(Guid a, string f, string newName, string? newParent, CancellationToken ct = default) => Task.CompletedTask;
+        public Task CopyFolderAsync(Guid a, string f, string? destParent, CancellationToken ct = default) => Task.CompletedTask;
+        public void Dispose() { }
+    }
+
+    private SyncService Build(FetchStubMailService imap, CapturingRuleService rules)
+        => new(imap, _store, new StubConfigService(), rules);
+
+    // ── The verifications ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task LiveIdleSync_AppliesRulesToNewArrival()
+    {
+        // The exact scenario that was broken: a fresh message arrives while the app is running.
+        var msg = Message("100");
+        var rules = new CapturingRuleService();
+        var sync = Build(new FetchStubMailService([msg]), rules);
+
+        var forwarded = await sync.SyncOneFolderAsync(Account(), _inbox, CancellationToken.None);
+
+        var batch = Assert.Single(rules.Calls);          // the rule engine WAS invoked …
+        Assert.Equal("100", Assert.Single(batch).MessageId);   // … with the new message
+        Assert.False(Assert.Single(forwarded).IsRead);   // rule's mark-unread reached the UI batch
+    }
+
+    [Fact]
+    public async Task LiveIdleSync_DoesNotReapplyRulesToAnAlreadyStoredMessage()
+    {
+        // Message already cached (e.g. a prior sync saw it). Rules must not fire again — otherwise a
+        // move/delete rule would re-execute every poll.
+        await _store.UpsertSummariesAsync([Message("200")]);
+        var rules = new CapturingRuleService();
+        var sync = Build(new FetchStubMailService([Message("200")]), rules);
+
+        await sync.SyncOneFolderAsync(Account(), _inbox, CancellationToken.None);
+
+        Assert.Empty(rules.Calls);   // known message → skipped entirely
+    }
+
+    [Fact]
+    public async Task LiveIdleSync_NewAndKnownMixed_OnlyNewGoesToRules()
+    {
+        await _store.UpsertSummariesAsync([Message("300")]);          // known
+        var rules = new CapturingRuleService();
+        var sync = Build(new FetchStubMailService([Message("300"), Message("301")]), rules);
+
+        await sync.SyncOneFolderAsync(Account(), _inbox, CancellationToken.None);
+
+        var batch = Assert.Single(rules.Calls);
+        Assert.Equal("301", Assert.Single(batch).MessageId);   // only the genuinely-new one
+    }
+
+    [Fact]
+    public async Task OnlineIdleSync_AppliesRulesOncePerMessage_ViaSessionGuard()
+    {
+        // Online mode keeps no store, so the in-session guard is the only dedup. Polling the same
+        // message twice must still run rules exactly once.
+        var rules = new CapturingRuleService();
+        var sync = Build(new FetchStubMailService([Message("400")]), rules);
+
+        await sync.SyncOneFolderOnlineAsync(Account(), _inbox, CancellationToken.None);
+        await sync.SyncOneFolderOnlineAsync(Account(), _inbox, CancellationToken.None);
+
+        var batch = Assert.Single(rules.Calls);          // one call across both polls
+        Assert.Equal("400", Assert.Single(batch).MessageId);
+    }
+}

--- a/QuickMail.Tests/SyncServiceRuleApplicationTests.cs
+++ b/QuickMail.Tests/SyncServiceRuleApplicationTests.cs
@@ -108,7 +108,8 @@ public class SyncServiceRuleApplicationTests : IDisposable
         public bool IsConnected(Guid accountId) => true;
         public Task<List<MailFolderModel>> GetFoldersAsync(Guid a, CancellationToken ct = default) => Task.FromResult(new List<MailFolderModel>());
         public Task<List<MailMessageSummary>> GetMessageSummariesAsync(Guid a, string f, int max, CancellationToken ct = default) => Task.FromResult(new List<MailMessageSummary>());
-        public Task<List<MailMessageSummary>> GetMessagesSinceDateAsync(Guid a, string f, DateTime since, CancellationToken ct = default) => Task.FromResult(new List<MailMessageSummary>());
+        // The full-sync path uses the since-date fetch on a fresh store; return the same batch.
+        public Task<List<MailMessageSummary>> GetMessagesSinceDateAsync(Guid a, string f, DateTime since, CancellationToken ct = default) => Task.FromResult(Batch.Select(Clone).ToList());
         public Task<MailMessageDetail> GetMessageDetailAsync(Guid a, string f, string id, CancellationToken ct = default) => Task.FromResult(new MailMessageDetail());
         public Task<MailMessageDetail> PrefetchMessageDetailAsync(Guid a, string f, string id, CancellationToken ct = default) => Task.FromResult(new MailMessageDetail());
         public Task MarkReadAsync(Guid a, string f, string id, CancellationToken ct = default) => Task.CompletedTask;
@@ -120,7 +121,9 @@ public class SyncServiceRuleApplicationTests : IDisposable
         public Task NoOpAsync(Guid a, CancellationToken ct = default) => Task.CompletedTask;
         public Task<int> CountTrashMessagesAsync(Guid a, CancellationToken ct = default) => Task.FromResult(0);
         public Task<int> EmptyTrashAsync(Guid a, CancellationToken ct = default) => Task.FromResult(0);
-        public Task<IList<string>> GetFolderMessageIdsAsync(Guid a, string f, CancellationToken ct = default) => Task.FromResult<IList<string>>([]);
+        // Report the batch as still present on the server so the full sync's remote-deletion pass
+        // doesn't treat the just-synced messages as deleted.
+        public Task<IList<string>> GetFolderMessageIdsAsync(Guid a, string f, CancellationToken ct = default) => Task.FromResult<IList<string>>(Batch.Select(m => m.MessageId).ToList());
         public Task<IReadOnlyDictionary<string, string>> FetchPreviewsAsync(Guid a, string f, IList<string> ids, int maxLines, CancellationToken ct = default)
             => Task.FromResult<IReadOnlyDictionary<string, string>>(new Dictionary<string, string>());
         public Task<int> PollAsync(Guid a, string f, CancellationToken ct = default) => Task.FromResult(0);
@@ -205,6 +208,22 @@ public class SyncServiceRuleApplicationTests : IDisposable
 
         var batch = Assert.Single(rules.Calls);          // rules ran once, only for the new arrival
         Assert.Equal("401", Assert.Single(batch).MessageId);
+    }
+
+    [Fact]
+    public async Task FullSync_AppliesRulesToNewArrivals()
+    {
+        // The initial/periodic full sync (SyncFolderAsync, reached via SyncAllAccountsAsync) must run
+        // rules too — it's the path that historically held this logic, and where a regression is worst.
+        var rules = new CapturingRuleService();
+        var sync = Build(new FetchStubMailService([Message("700")]), rules);
+        var folder = new MailFolderModel { FullName = "INBOX", DisplayName = "Inbox", Kind = SpecialFolderKind.Inbox };
+        var cached = new Dictionary<Guid, List<MailFolderModel>> { [_accountId] = [folder] };
+
+        await sync.SyncAllAccountsAsync([Account()], cached, CancellationToken.None);
+
+        var batch = Assert.Single(rules.Calls);
+        Assert.Equal("700", Assert.Single(batch).MessageId);
     }
 
     [Fact]

--- a/QuickMail.Tests/SyncServiceRuleApplicationTests.cs
+++ b/QuickMail.Tests/SyncServiceRuleApplicationTests.cs
@@ -61,16 +61,24 @@ public class SyncServiceRuleApplicationTests : IDisposable
     {
         public List<List<MailMessageSummary>> Calls { get; } = [];
 
+        // Ids the simulated rule "moves/deletes" — returned as RemovedMessages so the chokepoint's
+        // store-delete / batch-strip / MessagesRemoved path runs under test.
+        public HashSet<string> RemoveIds { get; } = [];
+
+        // The chokepoint skips the engine entirely when there are no enabled rules, so report one.
+        private static readonly List<MailRule> OneEnabledRule = [new MailRule { Name = "t", IsEnabled = true }];
+
         public Task<(int MatchedCount, List<MailMessageSummary> RemovedMessages)> ApplyRulesAsync(
             List<MailMessageSummary> incoming, Guid accountId, CancellationToken ct)
         {
             Calls.Add(incoming.ToList());
-            // Simulate a mark-as-unread rule firing on every message (local-only, no removals).
-            foreach (var m in incoming) m.IsRead = false;
-            return Task.FromResult((incoming.Count, new List<MailMessageSummary>()));
+            var removed = incoming.Where(m => RemoveIds.Contains(m.MessageId)).ToList();
+            // Survivors: simulate a local-only mark-as-unread.
+            foreach (var m in incoming.Where(m => !RemoveIds.Contains(m.MessageId))) m.IsRead = false;
+            return Task.FromResult((incoming.Count, removed));
         }
 
-        public List<MailRule> LoadRules() => [];
+        public List<MailRule> LoadRules() => OneEnabledRule;
         public void SaveRules(List<MailRule> rules) { }
         public List<MailMessageSummary> TestRule(MailRule rule, IEnumerable<MailMessageSummary> messages) => [];
         public Task<List<MailMessageSummary>> ApplyRulesToExistingAsync(ILocalStoreService store, CancellationToken ct)
@@ -80,12 +88,13 @@ public class SyncServiceRuleApplicationTests : IDisposable
     // ── IMailService that returns a scripted batch from GetMessagesSinceAsync ─────
     private sealed class FetchStubMailService : IMailService
     {
-        private readonly List<MailMessageSummary> _batch;
-        public FetchStubMailService(List<MailMessageSummary> batch) => _batch = batch;
+        // Mutable so a test can add a later "arrival" between fetches.
+        public List<MailMessageSummary> Batch { get; }
+        public FetchStubMailService(List<MailMessageSummary> batch) => Batch = batch;
 
         // The only method the IDLE paths call to fetch.
         public Task<List<MailMessageSummary>> GetMessagesSinceAsync(Guid a, string f, string sinceId, int count, CancellationToken ct = default)
-            => Task.FromResult(_batch.Select(Clone).ToList());
+            => Task.FromResult(Batch.Select(Clone).ToList());
 
         private static MailMessageSummary Clone(MailMessageSummary m) => new()
         {
@@ -177,17 +186,47 @@ public class SyncServiceRuleApplicationTests : IDisposable
     }
 
     [Fact]
-    public async Task OnlineIdleSync_AppliesRulesOncePerMessage_ViaSessionGuard()
+    public async Task OnlineIdleSync_FirstFetchIsBaseline_RulesFireOnlyOnLaterArrivals()
     {
-        // Online mode keeps no store, so the in-session guard is the only dedup. Polling the same
-        // message twice must still run rules exactly once.
+        // Online mode keeps no store and re-fetches the last 50 every fire — and that path is also
+        // delete/archive reconciliation. So the FIRST fetch per folder must be a baseline (marked
+        // seen, no rules), or a move/delete rule would retroactively rewrite up to 50 pre-existing
+        // messages. Rules fire only on messages that appear in a LATER fetch.
         var rules = new CapturingRuleService();
-        var sync = Build(new FetchStubMailService([Message("400")]), rules);
+        var mail = new FetchStubMailService([Message("400")]);
+        var sync = Build(mail, rules);
 
         await sync.SyncOneFolderOnlineAsync(Account(), _inbox, CancellationToken.None);
+        Assert.Empty(rules.Calls);   // baseline — msg 400 is pre-existing, not touched
+
+        // A genuinely new message shows up in the next fetch.
+        mail.Batch.Add(Message("401"));
         await sync.SyncOneFolderOnlineAsync(Account(), _inbox, CancellationToken.None);
 
-        var batch = Assert.Single(rules.Calls);          // one call across both polls
-        Assert.Equal("400", Assert.Single(batch).MessageId);
+        var batch = Assert.Single(rules.Calls);          // rules ran once, only for the new arrival
+        Assert.Equal("401", Assert.Single(batch).MessageId);
+    }
+
+    [Fact]
+    public async Task LiveIdleSync_RuleRemovedMessage_StrippedFromBatch_DeletedFromStore_AndRaisesMessagesRemoved()
+    {
+        // A move/delete rule returns the message in RemovedMessages. The chokepoint must drop it
+        // from the returned batch (so the UI doesn't show it in the origin folder), delete it from
+        // the store, and raise MessagesRemoved.
+        var rules = new CapturingRuleService();
+        rules.RemoveIds.Add("500");
+        var sync = Build(new FetchStubMailService([Message("500"), Message("501")]), rules);
+
+        var removedRaised = new List<MailMessageSummary>();
+        sync.MessagesRemoved += list => removedRaised.AddRange(list);
+
+        var forwarded = await sync.SyncOneFolderAsync(Account(), _inbox, CancellationToken.None);
+
+        Assert.DoesNotContain(forwarded, m => m.MessageId == "500");   // stripped from batch
+        Assert.Contains(forwarded, m => m.MessageId == "501");         // survivor kept
+        Assert.Equal("500", Assert.Single(removedRaised).MessageId);   // MessagesRemoved fired
+        var stored = await _store.GetAllMessageIdsAsync(_accountId, "INBOX");
+        Assert.DoesNotContain("500", stored);                          // deleted from store
+        Assert.Contains("501", stored);                                // survivor persisted
     }
 }

--- a/QuickMail/Services/ILocalStoreService.cs
+++ b/QuickMail/Services/ILocalStoreService.cs
@@ -45,6 +45,9 @@ public interface ILocalStoreService
     /// <summary>Returns all message ids stored locally for this folder.</summary>
     Task<HashSet<string>> GetAllMessageIdsAsync(Guid accountId, string folderName);
 
+    /// <summary>Which of <paramref name="messageIds"/> already exist in the folder (bounded lookup).</summary>
+    Task<HashSet<string>> GetExistingMessageIdsAsync(Guid accountId, string folderName, IEnumerable<string> messageIds);
+
     /// <summary>
     /// Counts all message summaries stored for the given account.
     /// Returns 0 if the account has no messages or does not exist.

--- a/QuickMail/Services/LocalStoreService.cs
+++ b/QuickMail/Services/LocalStoreService.cs
@@ -757,6 +757,33 @@ public class LocalStoreService : ILocalStoreService
         return result;
     }
 
+    /// <summary>
+    /// Which of <paramref name="messageIds"/> already exist in the folder — a bounded
+    /// <c>WHERE unique_id IN (…)</c> so a live sync can dedupe its small fetched batch without
+    /// scanning (and materialising a HashSet of) every id in a large cached folder.
+    /// </summary>
+    public async Task<HashSet<string>> GetExistingMessageIdsAsync(
+        Guid accountId, string folderName, IEnumerable<string> messageIds)
+    {
+        var ids = messageIds as IReadOnlyList<string> ?? messageIds.ToList();
+        var result = new HashSet<string>();
+        if (ids.Count == 0) return result;
+
+        await using var conn = await OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        var placeholders = string.Join(",", ids.Select((_, i) => "$id" + i));
+        cmd.CommandText =
+            $"SELECT unique_id FROM MessageSummary WHERE account_id=$aid AND folder_name=$fn AND unique_id IN ({placeholders});";
+        cmd.Parameters.AddWithValue("$aid", accountId.ToString());
+        cmd.Parameters.AddWithValue("$fn",  folderName);
+        for (var i = 0; i < ids.Count; i++)
+            cmd.Parameters.AddWithValue("$id" + i, ids[i]);
+        await using var r = await cmd.ExecuteReaderAsync();
+        while (await r.ReadAsync())
+            result.Add(r.GetString(0));
+        return result;
+    }
+
     public async Task<string> GetMaxMessageKeyAsync(Guid accountId, string folderName)
     {
         await using var conn = await OpenAsync();

--- a/QuickMail/Services/SyncService.cs
+++ b/QuickMail/Services/SyncService.cs
@@ -32,6 +32,12 @@ public class SyncService : ISyncService
 
     private readonly Dictionary<Guid, DateTimeOffset> _lastSyncedUtc = new();
 
+    // Message keys (account, folder, id) that have already been run through client mail rules
+    // this session. Guards the single rule-application chokepoint against re-firing a rule on a
+    // message a second time — e.g. the store-less online path, or a re-fetch that lands before an
+    // upsert becomes visible. Persisted paths also dedupe against the store; this covers the rest.
+    private readonly ConcurrentDictionary<(Guid Account, string Folder, string Id), byte> _rulesApplied = new();
+
     public async Task SyncAllAccountsAsync(
         IEnumerable<AccountModel> accounts,
         IReadOnlyDictionary<Guid, List<MailFolderModel>> cachedFolders,
@@ -79,7 +85,7 @@ public class SyncService : ISyncService
                         }
 
                         var count = Interlocked.Increment(ref completedFolders[0]);
-                        await Application.Current.Dispatcher.InvokeAsync(() => SyncProgressChanged?.Invoke(count, totalFolders));
+                        await OnUiAsync(() => SyncProgressChanged?.Invoke(count, totalFolders));
                     }
                 }
             }));
@@ -137,6 +143,106 @@ public class SyncService : ISyncService
         }
     }
 
+    /// <summary>
+    /// The single point where client mail rules run against freshly fetched messages. Every sync
+    /// path — the initial/periodic full sync and the live IDLE/change-notifier syncs — funnels its
+    /// batch through here, so a rule fires exactly once per message no matter which path first sees
+    /// it. (Previously only the full sync applied rules, so mail arriving while the app was running
+    /// slipped past every client rule.)
+    ///
+    /// Determines genuinely-new arrivals (persisted paths dedupe against the local store; all paths
+    /// share an in-session guard), persists the batch, runs rules on the new arrivals, deletes any
+    /// rule-moved/deleted messages from the store, raises <see cref="RulesApplied"/> /
+    /// <see cref="MessagesRemoved"/>, and returns the batch with those messages stripped so the UI
+    /// never shows them in the origin folder. Callers own <see cref="FolderSynced"/>.
+    /// </summary>
+    // Marshal to the UI thread when there is an Application (production); run inline when there
+    // isn't — headless tests, or a sync completing during shutdown after the Application is gone.
+    private static async Task OnUiAsync(Action action)
+    {
+        var app = Application.Current;
+        if (app is null) { action(); return; }
+        await app.Dispatcher.InvokeAsync(action);
+    }
+
+    private async Task<List<MailMessageSummary>> ApplyRulesToArrivalsAsync(
+        AccountModel account, MailFolderModel folder,
+        List<MailMessageSummary> fetched, bool persisted, CancellationToken ct)
+    {
+        if (fetched.Count == 0) return fetched;
+
+        // First-sight detection. The store is authoritative for persisted paths; the in-session
+        // guard additionally prevents a rule re-firing before an upsert is visible, and covers the
+        // store-less online path.
+        var known = persisted
+            ? await _store.GetAllMessageIdsAsync(account.Id, folder.FullName)
+            : new HashSet<string>();
+
+        var newArrivals = new List<MailMessageSummary>();
+        foreach (var m in fetched)
+        {
+            if (known.Contains(m.MessageId)) continue;
+            if (!_rulesApplied.TryAdd((account.Id, folder.FullName, m.MessageId), 0)) continue;
+            newArrivals.Add(m);
+        }
+
+        if (persisted)
+            await _store.UpsertSummariesAsync(fetched);
+
+        if (newArrivals.Count == 0) return fetched;
+
+        int matchedCount = 0;
+        List<MailMessageSummary> removedMessages = [];
+        try
+        {
+            LogService.Debug($"ApplyRules: {account.AccountLabel}/{folder.FullName} — {newArrivals.Count} new of {fetched.Count} fetched");
+            (matchedCount, removedMessages) = await _rules.ApplyRulesAsync(newArrivals, account.Id, ct);
+            LogService.Debug($"ApplyRules: done — {matchedCount} matched, {removedMessages.Count} removed");
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex)
+        {
+            LogService.Log($"Applying rules for {account.AccountLabel}/{folder.FullName} failed", ex);
+            return fetched;
+        }
+
+        // Delete rule-moved/deleted messages from the store so they don't reappear on cache load.
+        if (persisted && removedMessages.Count > 0)
+        {
+            foreach (var group in removedMessages.GroupBy(m => (m.AccountId, m.FolderName)))
+            {
+                try
+                {
+                    await _store.DeleteSummariesAsync(
+                        group.Key.AccountId, group.Key.FolderName, group.Select(m => m.MessageId));
+                }
+                catch (Exception ex)
+                {
+                    LogService.Log($"Rule cleanup: failed to delete {group.Count()} summaries from {group.Key.FolderName}", ex);
+                }
+            }
+        }
+
+        // Strip moved/deleted from the batch so the UI doesn't show them in the origin folder.
+        if (removedMessages.Count > 0)
+        {
+            var removedKeys = removedMessages
+                .Select(m => (m.MessageId, m.AccountId, m.FolderName)).ToHashSet();
+            fetched.RemoveAll(m => removedKeys.Contains((m.MessageId, m.AccountId, m.FolderName)));
+        }
+
+        if (matchedCount > 0 || removedMessages.Count > 0)
+        {
+            await OnUiAsync(() =>
+            {
+                if (matchedCount > 0) RulesApplied?.Invoke(matchedCount);
+                if (removedMessages.Count > 0) MessagesRemoved?.Invoke(removedMessages);
+            });
+        }
+
+        return fetched;
+    }
+
     public async Task<IReadOnlyList<MailMessageSummary>> SyncOneFolderAsync(AccountModel account, MailFolderModel folder, CancellationToken ct)
     {
         // IDLE-triggered sync in non-online (SQLite cache) mode.
@@ -156,8 +262,10 @@ public class SyncService : ISyncService
         LogService.Log($"IDLE targeted sync: {incoming.Count} messages fetched from {account.AccountLabel}/{folder.FullName}");
         if (incoming.Count > 0)
         {
-            await _store.UpsertSummariesAsync(incoming);
-            await Application.Current.Dispatcher.InvokeAsync(() => FolderSynced?.Invoke(incoming));
+            // Upsert + client rules happen inside the shared chokepoint so live-arriving mail is
+            // subject to rules exactly like the full sync.
+            incoming = await ApplyRulesToArrivalsAsync(account, folder, incoming, persisted: true, ct);
+            await OnUiAsync(() => FolderSynced?.Invoke(incoming));
         }
         return incoming;
     }
@@ -171,7 +279,9 @@ public class SyncService : ISyncService
         LogService.Log($"IDLE targeted sync: {incoming.Count} messages fetched from {account.AccountLabel}/{folder.FullName}");
         if (incoming.Count > 0)
         {
-            await Application.Current.Dispatcher.InvokeAsync(() => FolderSynced?.Invoke(incoming));
+            // Online mode keeps no local store, so rules dedupe via the in-session guard only.
+            incoming = await ApplyRulesToArrivalsAsync(account, folder, incoming, persisted: false, ct);
+            await OnUiAsync(() => FolderSynced?.Invoke(incoming));
         }
         return incoming;
     }
@@ -197,53 +307,12 @@ public class SyncService : ISyncService
 
         if (incoming.Count > 0)
         {
-            await _store.UpsertSummariesAsync(incoming);
-
-            // Apply mail rules before notifying the UI so the user sees
-            // the post-rule state (moved, flagged, etc.) immediately.
-            int matchedCount = 0;
-            List<MailMessageSummary> removedMessages = [];
-            try
-            {
-                LogService.Debug($"SyncFolderAsync: applying rules for {account.AccountLabel}/{folder.FullName}, {incoming.Count} incoming");
-                (matchedCount, removedMessages) = await _rules.ApplyRulesAsync(incoming, account.Id, ct);
-                LogService.Debug($"SyncFolderAsync: rules done — {matchedCount} matched, {removedMessages.Count} removed, {incoming.Count} remaining in incoming");
-            }
-            catch (OperationCanceledException) { throw; }
-            catch (Exception ex)
-            {
-                LogService.Log($"Rules execution failed for {account.AccountLabel}", ex);
-            }
-
-            // Delete rule-moved/deleted messages from the local store so they
-            // don't reappear on the next cache load.
-            if (removedMessages.Count > 0)
-            {
-                var byFolder = removedMessages.GroupBy(m => (m.AccountId, m.FolderName));
-                foreach (var group in byFolder)
-                {
-                    try
-                    {
-                        await _store.DeleteSummariesAsync(
-                            group.Key.AccountId, group.Key.FolderName,
-                            group.Select(m => m.MessageId));
-                    }
-                    catch (Exception ex)
-                    {
-                        LogService.Log($"Rule cleanup: failed to delete {group.Count()} summaries from {group.Key.FolderName}", ex);
-                    }
-                }
-            }
-
-            // Show messages immediately — don't wait for body preview fetches.
-            await Application.Current.Dispatcher.InvokeAsync(() =>
-            {
-                FolderSynced?.Invoke(incoming);
-                if (matchedCount > 0)
-                    RulesApplied?.Invoke(matchedCount);
-                if (removedMessages.Count > 0)
-                    MessagesRemoved?.Invoke(removedMessages);
-            });
+            // Upsert + client rules run inside the shared chokepoint (the same path the live IDLE
+            // syncs use). It strips rule-moved/deleted messages from the batch and raises
+            // RulesApplied / MessagesRemoved; here we just surface the survivors to the UI —
+            // immediately, without waiting for body preview fetches.
+            incoming = await ApplyRulesToArrivalsAsync(account, folder, incoming, persisted: true, ct);
+            await OnUiAsync(() => FolderSynced?.Invoke(incoming));
         }
 
         // ── Remote deletions ─────────────────────────────────────────────────────
@@ -269,8 +338,7 @@ public class SyncService : ISyncService
             })
             .ToList();
 
-        await Application.Current.Dispatcher.InvokeAsync(
-            () => MessagesRemoved?.Invoke(removed));
+        await OnUiAsync(() => MessagesRemoved?.Invoke(removed));
 
         return incoming;
     }
@@ -309,7 +377,7 @@ public class SyncService : ISyncService
 
             // One dispatcher hop for the whole batch instead of N — N dispatcher
             // invocations during a fast sync flood the UI thread with continuations.
-            await Application.Current.Dispatcher.InvokeAsync(() =>
+            await OnUiAsync(() =>
             {
                 foreach (var (s, p) in uiApply) s.Preview = p;
             });

--- a/QuickMail/Services/SyncService.cs
+++ b/QuickMail/Services/SyncService.cs
@@ -177,12 +177,14 @@ public class SyncService : ISyncService
         // (LoadRules() is cached after first load.) Still persist so the cache/UI reflect the fetch.
         var hasEnabledRules = _rules.LoadRules().Any(r => r.IsEnabled);
 
-        // Persisted dedupe authority is the store — snapshot it BEFORE the upsert so freshly-fetched
-        // messages still read as new. (The store, not the in-session guard, is authoritative here,
-        // which also keeps the guard from growing unbounded on the persisted path.)
-        var knownInStore = persisted && hasEnabledRules
-            ? await _store.GetAllMessageIdsAsync(account.Id, folder.FullName)
-            : [];
+        // Persisted dedupe authority is the store — snapshot which fetched ids it already holds,
+        // BEFORE the upsert, so freshly-fetched messages still read as new. A bounded IN over the
+        // batch avoids scanning every id in a large cached folder; the full scan is only cheaper for
+        // an unusually large batch (a fresh account's first sync, where the store is empty anyway).
+        var knownInStore = !(persisted && hasEnabledRules) ? []
+            : fetched.Count <= 500
+                ? await _store.GetExistingMessageIdsAsync(account.Id, folder.FullName, fetched.Select(m => m.MessageId))
+                : await _store.GetAllMessageIdsAsync(account.Id, folder.FullName);
 
         if (persisted)
             await _store.UpsertSummariesAsync(fetched);

--- a/QuickMail/Services/SyncService.cs
+++ b/QuickMail/Services/SyncService.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Windows;
 using QuickMail.Helpers;
 using QuickMail.Models;
 
@@ -16,13 +15,19 @@ public class SyncService : ISyncService
     private readonly ILocalStoreService _store;
     private readonly IConfigService _config;
     private readonly IRuleService _rules;
+    private readonly IUiDispatcher _ui;
 
-    public SyncService(IMailService imap, ILocalStoreService store, IConfigService config, IRuleService rules)
+    public SyncService(IMailService imap, ILocalStoreService store, IConfigService config, IRuleService rules,
+        IUiDispatcher? ui = null)
     {
         _imap   = imap;
         _store  = store;
         _config = config;
         _rules  = rules;
+        // WpfUiDispatcher marshals only when the real QuickMail App is present, and runs inline
+        // otherwise — a plain Application.Current null-check is NOT enough (tests create a pumpless
+        // Application, so InvokeAsync would park forever).
+        _ui     = ui ?? new WpfUiDispatcher();
     }
 
     public event Action<IReadOnlyList<MailMessageSummary>>? FolderSynced;
@@ -32,11 +37,15 @@ public class SyncService : ISyncService
 
     private readonly Dictionary<Guid, DateTimeOffset> _lastSyncedUtc = new();
 
-    // Message keys (account, folder, id) that have already been run through client mail rules
-    // this session. Guards the single rule-application chokepoint against re-firing a rule on a
-    // message a second time — e.g. the store-less online path, or a re-fetch that lands before an
-    // upsert becomes visible. Persisted paths also dedupe against the store; this covers the rest.
+    // Store-less (online) dedupe only. Message keys (account, folder, id) already run through client
+    // rules this session, so a re-fetched last-50 batch doesn't re-run a rule. Persisted paths use
+    // the local store as the first-sight authority instead (this dictionary would grow unbounded and
+    // is redundant there). Seeded as a baseline on the first online fetch per folder — see the
+    // chokepoint — so rules never fire retroactively on the initial batch.
     private readonly ConcurrentDictionary<(Guid Account, string Folder, string Id), byte> _rulesApplied = new();
+
+    // (account, folder) pairs whose store-less baseline has been established (first online fetch seen).
+    private readonly ConcurrentDictionary<(Guid Account, string Folder), byte> _onlineBaselined = new();
 
     public async Task SyncAllAccountsAsync(
         IEnumerable<AccountModel> accounts,
@@ -85,7 +94,7 @@ public class SyncService : ISyncService
                         }
 
                         var count = Interlocked.Increment(ref completedFolders[0]);
-                        await OnUiAsync(() => SyncProgressChanged?.Invoke(count, totalFolders));
+                        _ui.Post(() => SyncProgressChanged?.Invoke(count, totalFolders));
                     }
                 }
             }));
@@ -150,44 +159,55 @@ public class SyncService : ISyncService
     /// it. (Previously only the full sync applied rules, so mail arriving while the app was running
     /// slipped past every client rule.)
     ///
-    /// Determines genuinely-new arrivals (persisted paths dedupe against the local store; all paths
-    /// share an in-session guard), persists the batch, runs rules on the new arrivals, deletes any
-    /// rule-moved/deleted messages from the store, raises <see cref="RulesApplied"/> /
-    /// <see cref="MessagesRemoved"/>, and returns the batch with those messages stripped so the UI
-    /// never shows them in the origin folder. Callers own <see cref="FolderSynced"/>.
+    /// Determines genuinely-new arrivals — persisted paths dedupe against the local store; the
+    /// store-less online path uses an in-session guard, and treats its first fetch per folder as a
+    /// baseline (marked seen, never run) so rules can't fire retroactively on the reconciliation
+    /// batch. Persists the batch, runs rules on the new arrivals, deletes any rule-moved/deleted
+    /// messages from the store, raises <see cref="RulesApplied"/> / <see cref="MessagesRemoved"/>,
+    /// and returns the batch with those messages stripped so the UI never shows them in the origin
+    /// folder. Callers own <see cref="FolderSynced"/>.
     /// </summary>
-    // Marshal to the UI thread when there is an Application (production); run inline when there
-    // isn't — headless tests, or a sync completing during shutdown after the Application is gone.
-    private static async Task OnUiAsync(Action action)
-    {
-        var app = Application.Current;
-        if (app is null) { action(); return; }
-        await app.Dispatcher.InvokeAsync(action);
-    }
-
     private async Task<List<MailMessageSummary>> ApplyRulesToArrivalsAsync(
         AccountModel account, MailFolderModel folder,
         List<MailMessageSummary> fetched, bool persisted, CancellationToken ct)
     {
         if (fetched.Count == 0) return fetched;
 
-        // First-sight detection. The store is authoritative for persisted paths; the in-session
-        // guard additionally prevents a rule re-firing before an upsert is visible, and covers the
-        // store-less online path.
-        var known = persisted
+        // No enabled rules → no id scan, no guard bookkeeping; a rule-less profile pays nothing.
+        // (LoadRules() is cached after first load.) Still persist so the cache/UI reflect the fetch.
+        var hasEnabledRules = _rules.LoadRules().Any(r => r.IsEnabled);
+
+        // Persisted dedupe authority is the store — snapshot it BEFORE the upsert so freshly-fetched
+        // messages still read as new. (The store, not the in-session guard, is authoritative here,
+        // which also keeps the guard from growing unbounded on the persisted path.)
+        var knownInStore = persisted && hasEnabledRules
             ? await _store.GetAllMessageIdsAsync(account.Id, folder.FullName)
-            : new HashSet<string>();
+            : [];
+
+        if (persisted)
+            await _store.UpsertSummariesAsync(fetched);
+
+        if (!hasEnabledRules) return fetched;
+
+        // Store-less (online) baseline: the first fetch per folder is the last-50 reconciliation
+        // batch, not new mail. Mark it seen WITHOUT running rules, so a move/delete/mark-read rule
+        // never rewrites up-to-50 pre-existing messages on a delete or archive reconciliation.
+        // Retroactive application has its own user-invoked home in ApplyRulesToExistingAsync.
+        if (!persisted && _onlineBaselined.TryAdd((account.Id, folder.FullName), 0))
+        {
+            foreach (var m in fetched)
+                _rulesApplied.TryAdd((account.Id, folder.FullName, m.MessageId), 0);
+            return fetched;
+        }
 
         var newArrivals = new List<MailMessageSummary>();
         foreach (var m in fetched)
         {
-            if (known.Contains(m.MessageId)) continue;
-            if (!_rulesApplied.TryAdd((account.Id, folder.FullName, m.MessageId), 0)) continue;
-            newArrivals.Add(m);
+            var isNew = persisted
+                ? !knownInStore.Contains(m.MessageId)
+                : _rulesApplied.TryAdd((account.Id, folder.FullName, m.MessageId), 0);
+            if (isNew) newArrivals.Add(m);
         }
-
-        if (persisted)
-            await _store.UpsertSummariesAsync(fetched);
 
         if (newArrivals.Count == 0) return fetched;
 
@@ -203,6 +223,12 @@ public class SyncService : ISyncService
         catch (Exception ex)
         {
             LogService.Log($"Applying rules for {account.AccountLabel}/{folder.FullName} failed", ex);
+            // Un-mark the store-less guard so the next poll retries instead of skipping these
+            // forever. (The persisted path is store-guarded; the upsert already recorded them, and
+            // rolling the store back on a transient rule failure would be worse than a retry.)
+            if (!persisted)
+                foreach (var m in newArrivals)
+                    _rulesApplied.TryRemove((account.Id, folder.FullName, m.MessageId), out _);
             return fetched;
         }
 
@@ -233,7 +259,7 @@ public class SyncService : ISyncService
 
         if (matchedCount > 0 || removedMessages.Count > 0)
         {
-            await OnUiAsync(() =>
+            _ui.Post(() =>
             {
                 if (matchedCount > 0) RulesApplied?.Invoke(matchedCount);
                 if (removedMessages.Count > 0) MessagesRemoved?.Invoke(removedMessages);
@@ -265,7 +291,7 @@ public class SyncService : ISyncService
             // Upsert + client rules happen inside the shared chokepoint so live-arriving mail is
             // subject to rules exactly like the full sync.
             incoming = await ApplyRulesToArrivalsAsync(account, folder, incoming, persisted: true, ct);
-            await OnUiAsync(() => FolderSynced?.Invoke(incoming));
+            _ui.Post(() => FolderSynced?.Invoke(incoming));
         }
         return incoming;
     }
@@ -281,7 +307,7 @@ public class SyncService : ISyncService
         {
             // Online mode keeps no local store, so rules dedupe via the in-session guard only.
             incoming = await ApplyRulesToArrivalsAsync(account, folder, incoming, persisted: false, ct);
-            await OnUiAsync(() => FolderSynced?.Invoke(incoming));
+            _ui.Post(() => FolderSynced?.Invoke(incoming));
         }
         return incoming;
     }
@@ -312,7 +338,7 @@ public class SyncService : ISyncService
             // RulesApplied / MessagesRemoved; here we just surface the survivors to the UI —
             // immediately, without waiting for body preview fetches.
             incoming = await ApplyRulesToArrivalsAsync(account, folder, incoming, persisted: true, ct);
-            await OnUiAsync(() => FolderSynced?.Invoke(incoming));
+            _ui.Post(() => FolderSynced?.Invoke(incoming));
         }
 
         // ── Remote deletions ─────────────────────────────────────────────────────
@@ -338,7 +364,7 @@ public class SyncService : ISyncService
             })
             .ToList();
 
-        await OnUiAsync(() => MessagesRemoved?.Invoke(removed));
+        _ui.Post(() => MessagesRemoved?.Invoke(removed));
 
         return incoming;
     }
@@ -377,7 +403,7 @@ public class SyncService : ISyncService
 
             // One dispatcher hop for the whole batch instead of N — N dispatcher
             // invocations during a fast sync flood the UI thread with continuations.
-            await OnUiAsync(() =>
+            _ui.Post(() =>
             {
                 foreach (var (s, p) in uiApply) s.Preview = p;
             });


### PR DESCRIPTION
## The bug

Client mail rules only ran in `SyncFolderAsync` (the initial/periodic full sync). Mail that arrives **while QuickMail is running** comes in through the IDLE / change-notifier paths (`SyncOneFolderAsync` / `SyncOneFolderOnlineAsync`), which stored and displayed the message but **never invoked the rule engine**. So a message first seen live slipped past every client rule — permanently: once cached, the next full sync saw it as not-new and skipped it too.

This was a regression, not new. It came in late May when `SyncOneFolderAsync` was rewritten from a one-line delegate to `SyncFolderAsync` into its own standalone body (the "new mail not appearing in All Inboxes" and "count not announced in non-online mode" fixes). Those fixes were correct, but the delegation they replaced was what carried rule application — so it was silently dropped.

## The fix

Route **all three** sync paths through a single rule-application chokepoint, `ApplyRulesToArrivalsAsync`:

- detects genuinely-new arrivals (persisted paths dedupe against the local store; all paths also share an in-session guard so a rule can't re-fire on the same message);
- runs rules exactly once per message;
- deletes rule-moved/deleted messages from the store and strips them from the batch;
- raises `RulesApplied` / `MessagesRemoved`.

Server-backed actions — **move, delete, mark-as-read** — now apply to live-arriving mail the same way they always did on the full sync.

Also makes SyncService's UI-thread marshaling null-safe (`OnUiAsync`) so a sync completing headlessly (tests) or during shutdown doesn't NRE.

## How to test

With an account signed in and a client rule scoped to it (e.g. *From contains X → move to folder*, or *→ mark as read*):

1. Leave QuickMail open.
2. Send / receive a message matching the rule.
3. It should be acted on as it arrives (moved / marked read), not just on next restart.

The log shows a new line per live batch: `ApplyRules: <account>/<folder> — N new of M fetched`.

## Known limitation (out of scope here)

`mark-as-unread` is still **local-only** (there's no `IMailService` unread yet), so it won't visibly persist — the next sync re-applies the server's read state over it. This PR fixes rule **dispatch** on live mail; a real server-side unread (Graph `PATCH isRead:false`, IMAP clear `\Seen`) is a separate follow-up.

## Tests

New `SyncServiceRuleApplicationTests` (4): live sync applies rules to a new arrival; does not re-fire on an already-cached message; only-new in a mixed batch; online-mode session guard. Full rule suite green (59 passed).