### PR TITLE
Fix CA1859 breaking the installer workflow build

### DIFF
--- a/QuickMail/ViewModels/UnifiedRulesViewModel.cs
+++ b/QuickMail/ViewModels/UnifiedRulesViewModel.cs
@@ -499,7 +499,7 @@ public partial class UnifiedRulesViewModel : ObservableObject
     /// complete and write into a window that's gone.</summary>
     public void CancelPendingLoad() => _refreshCts?.Cancel();
 
-    private static string BuildStatus(IReadOnlyList<UnifiedRuleRow> rows, IReadOnlyList<string> failures)
+    private static string BuildStatus(List<UnifiedRuleRow> rows, List<string> failures)
     {
         if (failures.Count > 0)
         {
@@ -509,7 +509,7 @@ public partial class UnifiedRulesViewModel : ObservableObject
         }
         return rows.Count == 0 ? "No rules for this account." : Counts(rows);
 
-        static string Counts(IReadOnlyList<UnifiedRuleRow> r)
+        static string Counts(List<UnifiedRuleRow> r)
         {
             var server = r.Count(x => x.RunsWhere == RuleRunsWhere.Server);
             var client = r.Count(x => x.RunsWhere == RuleRunsWhere.Client);


### PR DESCRIPTION
The **Build Installer (on demand)** workflow ([run #20](https://github.com/kellylford/QuickMail/actions/runs/30540298801)) fails because its Publish step builds with `-warnaserror`, and `BuildStatus` in `UnifiedRulesViewModel.cs` (added with the unified rules manager, #412) trips CA1859: its `rows` and `failures` parameters are declared `IReadOnlyList<>` but callers only ever pass `List<>`.

## Change
- Tighten `BuildStatus` parameters to `List<UnifiedRuleRow>` / `List<string>`.
- Same for the `Counts` local function, which would have been the next CA1859 hit once `rows` became a `List`.

## Verification
- `dotnet build QuickMail/QuickMail.csproj -c Release -warnaserror` — clean, 0 warnings.
- Full test suite with `--blame-hang`: 2201 passed, 0 failed, 3 skipped (gated input tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)