### PR TITLE
Implement #175: debug-only screenshot capture (Wave 3a of #421)

### DIFF
--- a/QuickMail.Tests/ScreenshotCaptureServiceTests.cs
+++ b/QuickMail.Tests/ScreenshotCaptureServiceTests.cs
@@ -123,7 +123,7 @@ public class ScreenshotCaptureServiceTests : IDisposable
     {
         using var svc = NewService();
         var grabs = 0;
-        svc.PixelGrabber = _ => { grabs++; return null; };
+        svc.PixelGrabber = _ => { grabs++; return TinyFrame(); };   // successful grabs consume the cap
         svc.Enabled = true;
         var window = new Window();
 
@@ -131,6 +131,24 @@ public class ScreenshotCaptureServiceTests : IDisposable
             svc.Capture(window, $"Window{i}");   // distinct labels bypass the debounce
 
         Assert.Equal(500, grabs);
+    }
+
+    [StaFact]
+    public void Capture_FailedGrabs_DoNotConsumeTheCapOrNumbering()
+    {
+        var svc = NewService();
+        var calls = 0;
+        // First grab fails, second succeeds — the file must still be 0001.
+        svc.PixelGrabber = _ => ++calls == 1 ? null : TinyFrame();
+        svc.Enabled = true;
+        var window = new Window();
+
+        svc.Capture(window, "First");
+        svc.Capture(window, "Second");
+        svc.Dispose();
+
+        var file = Assert.Single(Directory.GetFiles(svc.SessionFolder, "*.png"));
+        Assert.Equal("0001-Second.png", Path.GetFileName(file));
     }
 
     [StaFact]
@@ -163,32 +181,72 @@ public class ScreenshotCaptureServiceTests : IDisposable
     [StaFact]
     public void TitleSuffix_AppliedAndRemoved_OnStaticTitles()
     {
+        using var svc = NewService();
         var window = new Window { Title = "Address Book" };
 
-        ScreenshotCaptureService.ApplyTitleSuffix(window, enabled: true);
+        svc.ApplyTitleSuffix(window, enabled: true);
         Assert.Equal("Address Book" + IScreenshotCaptureService.TitleSuffix, window.Title);
 
         // Idempotent — applying twice must not double the suffix.
-        ScreenshotCaptureService.ApplyTitleSuffix(window, enabled: true);
+        svc.ApplyTitleSuffix(window, enabled: true);
         Assert.Equal("Address Book" + IScreenshotCaptureService.TitleSuffix, window.Title);
 
-        ScreenshotCaptureService.ApplyTitleSuffix(window, enabled: false);
+        svc.ApplyTitleSuffix(window, enabled: false);
         Assert.Equal("Address Book", window.Title);
     }
 
     [StaFact]
-    public void TitleSuffix_NeverTouchesDataBoundTitles()
+    public void TitleSuffix_OverlaysBoundTitles_WithoutDetachingTheBinding()
     {
-        // MainWindow's Title binds to MainViewModel.WindowTitle, which appends
-        // the suffix itself; a direct assignment would detach that binding.
-        var window = new Window { DataContext = new { Name = "Inbox - QuickMail" } };
+        // Compose, MessageWindow, and friends bind Title to a VM property. The
+        // suffix must appear there too (the safety warning covers real mail
+        // content), and the binding must survive so later VM updates land.
+        using var svc = NewService();
+        svc.Enabled = true;
+        var window = new Window { DataContext = new { Name = "Re: hello - QuickMail" } };
         BindingOperations.SetBinding(window, Window.TitleProperty, new Binding("Name"));
-        Assert.Equal("Inbox - QuickMail", window.Title);
 
-        ScreenshotCaptureService.ApplyTitleSuffix(window, enabled: true);
-
-        Assert.Equal("Inbox - QuickMail", window.Title);
+        svc.ApplyTitleSuffix(window, enabled: true);
+        Assert.Equal("Re: hello - QuickMail" + IScreenshotCaptureService.TitleSuffix, window.Title);
         Assert.NotNull(BindingOperations.GetBindingExpression(window, Window.TitleProperty));
+
+        // A binding push (VM title recompute) must get the suffix re-applied.
+        window.DataContext = new { Name = "Fwd: other - QuickMail" };
+        Assert.Equal("Fwd: other - QuickMail" + IScreenshotCaptureService.TitleSuffix, window.Title);
+
+        svc.ApplyTitleSuffix(window, enabled: false);
+        Assert.Equal("Fwd: other - QuickMail", window.Title);
+        Assert.NotNull(BindingOperations.GetBindingExpression(window, Window.TitleProperty));
+    }
+
+    [StaFact]
+    public void OnWindowLoaded_AppliesSuffix_AndCapturesAtIdle()
+    {
+        using var svc = NewService();
+        var grabs = 0;
+        svc.PixelGrabber = _ => { grabs++; return null; };
+        svc.Enabled = true;
+        var window = new Window { Title = "Rules Manager" };
+
+        svc.OnWindowLoaded(window);
+
+        Assert.EndsWith(IScreenshotCaptureService.TitleSuffix, window.Title, StringComparison.Ordinal);
+        Assert.Equal(0, grabs);      // capture is deferred, not synchronous
+
+        DrainDispatcherToIdle();
+        Assert.Equal(1, grabs);
+    }
+
+    /// <summary>Runs the STA dispatcher queue down past ApplicationIdle priority.</summary>
+    private static void DrainDispatcherToIdle()
+    {
+        // SystemIdle is the lowest priority, so this sentinel runs only after
+        // every ApplicationIdle callback already has.
+        var frame = new System.Windows.Threading.DispatcherFrame();
+        System.Windows.Threading.Dispatcher.CurrentDispatcher.BeginInvoke(
+            System.Windows.Threading.DispatcherPriority.SystemIdle,
+            new Action(() => frame.Continue = false));
+        System.Windows.Threading.Dispatcher.PushFrame(frame);
     }
 
     // ── MainViewModel title integration ───────────────────────────────────────

--- a/QuickMail.Tests/ScreenshotCaptureServiceTests.cs
+++ b/QuickMail.Tests/ScreenshotCaptureServiceTests.cs
@@ -1,0 +1,282 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Windows;
+using System.Windows.Data;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using QuickMail.Services;
+using QuickMail.ViewModels;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// Screenshot capture engine (#175). The Win32 pixel grab sits behind the
+/// PixelGrabber seam so none of these tests need a real HWND; what is under
+/// test is the session policy — foldering, slugs, debounce, the cap, and the
+/// off-by-default safety story.
+/// </summary>
+public class ScreenshotCaptureServiceTests : IDisposable
+{
+    private readonly string _profileDir =
+        Path.Combine(Path.GetTempPath(), $"QM-ShotTests-{Guid.NewGuid():N}");
+
+    private ScreenshotCaptureService NewService() =>
+        new(new ProfileContext(_profileDir));
+
+    private static BitmapSource TinyFrame()
+    {
+        // 2×2 with two colors so the frame never trips single-color detection.
+        var pixels = new byte[] { 0, 0, 0, 255, 255, 255, 255, 255, 0, 0, 0, 255, 255, 255, 255, 255 };
+        return BitmapSource.Create(2, 2, 96, 96, PixelFormats.Bgra32, null, pixels, 8);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_profileDir, recursive: true); } catch { /* temp cleanup */ }
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public void SessionFolder_LivesUnderProfileDebugScreenshots()
+    {
+        using var svc = NewService();
+        Assert.StartsWith(Path.Combine(_profileDir, "debug-screenshots"), svc.SessionFolder, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Enable_CreatesTheSessionFolder_AndRaisesEnabledChanged()
+    {
+        using var svc = NewService();
+        var raised = 0;
+        svc.EnabledChanged += (_, _) => raised++;
+
+        svc.Enabled = true;
+
+        Assert.True(svc.Enabled);
+        Assert.True(Directory.Exists(svc.SessionFolder));
+        Assert.Equal(1, raised);
+
+        svc.Enabled = false;
+        Assert.Equal(2, raised);
+    }
+
+    [Theory]
+    [InlineData("MainWindow", "MainWindow")]
+    [InlineData("Reading Pane: Re/Fwd?", "Reading-Pane--Re-Fwd")]
+    [InlineData("  ", "window")]
+    [InlineData("", "window")]
+    public void Slug_IsFilesystemSafe(string label, string expected)
+    {
+        Assert.Equal(expected, ScreenshotCaptureService.Slug(label));
+        Assert.DoesNotContain(ScreenshotCaptureService.Slug(label),
+            s => Path.GetInvalidFileNameChars().Contains(s));
+    }
+
+    [StaFact]
+    public void Capture_WhenDisabled_NeverGrabsPixels()
+    {
+        using var svc = NewService();
+        var grabs = 0;
+        svc.PixelGrabber = _ => { grabs++; return TinyFrame(); };
+
+        svc.Capture(new Window(), "AnyWindow");
+
+        Assert.Equal(0, grabs);
+        Assert.False(Directory.Exists(Path.Combine(_profileDir, "debug-screenshots")));
+    }
+
+    [StaFact]
+    public void Capture_WritesOneLabeledPng()
+    {
+        var svc = NewService();
+        svc.PixelGrabber = _ => TinyFrame();
+        svc.Enabled = true;
+
+        svc.Capture(new Window(), "ComposeWindow");
+        svc.Dispose();   // flushes the background save
+
+        var files = Directory.GetFiles(svc.SessionFolder, "*.png");
+        var file = Assert.Single(files);
+        Assert.Equal("0001-ComposeWindow.png", Path.GetFileName(file));
+    }
+
+    [StaFact]
+    public void Capture_DebouncesRepeatsOfTheSameLabel_ButNotOtherLabels()
+    {
+        using var svc = NewService();
+        var grabs = 0;
+        svc.PixelGrabber = _ => { grabs++; return null; };
+        svc.Enabled = true;
+        var window = new Window();
+
+        svc.Capture(window, "ReadingPane");
+        svc.Capture(window, "ReadingPane");   // < 750 ms later — suppressed
+        svc.Capture(window, "MessageWindow"); // different label — captured
+
+        Assert.Equal(2, grabs);
+    }
+
+    [StaFact]
+    public void Capture_StopsAtTheSessionCap()
+    {
+        using var svc = NewService();
+        var grabs = 0;
+        svc.PixelGrabber = _ => { grabs++; return null; };
+        svc.Enabled = true;
+        var window = new Window();
+
+        for (var i = 0; i < 520; i++)
+            svc.Capture(window, $"Window{i}");   // distinct labels bypass the debounce
+
+        Assert.Equal(500, grabs);
+    }
+
+    [StaFact]
+    public void Capture_AfterDispose_IsANoOp()
+    {
+        var svc = NewService();
+        var grabs = 0;
+        svc.PixelGrabber = _ => { grabs++; return TinyFrame(); };
+        svc.Enabled = true;
+        svc.Dispose();
+
+        svc.Capture(new Window(), "Late");
+
+        Assert.Equal(0, grabs);
+    }
+
+    [Fact]
+    public void IsSingleColor_DetectsFlatFrames_AndPassesMixedOnes()
+    {
+        var flat = new byte[4 * 4];
+        for (var i = 0; i < flat.Length; i += 4) { flat[i + 3] = 255; }
+        var flatFrame = BitmapSource.Create(2, 2, 96, 96, PixelFormats.Bgra32, null, flat, 8);
+
+        Assert.True(ScreenshotCaptureService.IsSingleColor(flatFrame));
+        Assert.False(ScreenshotCaptureService.IsSingleColor(TinyFrame()));
+    }
+
+    // ── Title suffix ──────────────────────────────────────────────────────────
+
+    [StaFact]
+    public void TitleSuffix_AppliedAndRemoved_OnStaticTitles()
+    {
+        var window = new Window { Title = "Address Book" };
+
+        ScreenshotCaptureService.ApplyTitleSuffix(window, enabled: true);
+        Assert.Equal("Address Book" + IScreenshotCaptureService.TitleSuffix, window.Title);
+
+        // Idempotent — applying twice must not double the suffix.
+        ScreenshotCaptureService.ApplyTitleSuffix(window, enabled: true);
+        Assert.Equal("Address Book" + IScreenshotCaptureService.TitleSuffix, window.Title);
+
+        ScreenshotCaptureService.ApplyTitleSuffix(window, enabled: false);
+        Assert.Equal("Address Book", window.Title);
+    }
+
+    [StaFact]
+    public void TitleSuffix_NeverTouchesDataBoundTitles()
+    {
+        // MainWindow's Title binds to MainViewModel.WindowTitle, which appends
+        // the suffix itself; a direct assignment would detach that binding.
+        var window = new Window { DataContext = new { Name = "Inbox - QuickMail" } };
+        BindingOperations.SetBinding(window, Window.TitleProperty, new Binding("Name"));
+        Assert.Equal("Inbox - QuickMail", window.Title);
+
+        ScreenshotCaptureService.ApplyTitleSuffix(window, enabled: true);
+
+        Assert.Equal("Inbox - QuickMail", window.Title);
+        Assert.NotNull(BindingOperations.GetBindingExpression(window, Window.TitleProperty));
+    }
+
+    // ── MainViewModel title integration ───────────────────────────────────────
+
+    [Fact]
+    public void MainViewModel_WindowTitle_CarriesSuffixOnlyWhileEnabled()
+    {
+        using var svc = NewService();
+        var vm = new MainViewModel(
+            new StubImapMailService(), new StubAccountService(), new StubCredentialService(),
+            new StubLocalStoreService(), new StubOAuthService(), new StubSyncService(),
+            new StubConfigService(), new StubCommandRegistry(), new StubViewService(),
+            new StubRuleService(), new StubSmtpService(), screenshotCapture: svc);
+
+        var titleChanges = 0;
+        vm.PropertyChanged += (_, e) => { if (e.PropertyName == nameof(vm.WindowTitle)) titleChanges++; };
+
+        Assert.False(vm.WindowTitle.EndsWith(IScreenshotCaptureService.TitleSuffix, StringComparison.Ordinal));
+
+        svc.Enabled = true;
+        Assert.EndsWith(IScreenshotCaptureService.TitleSuffix, vm.WindowTitle, StringComparison.Ordinal);
+        Assert.Equal(1, titleChanges);
+
+        svc.Enabled = false;
+        Assert.False(vm.WindowTitle.EndsWith(IScreenshotCaptureService.TitleSuffix, StringComparison.Ordinal));
+        Assert.Equal(2, titleChanges);
+
+        vm.Dispose();
+    }
+
+    // ── Settings behavior ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void Settings_TogglingForwardsToTheService_AndAnnouncesTheMetaChange()
+    {
+        using var svc = NewService();
+        var vm = new SettingsViewModel(new StubConfigService(), new StubCommandRegistry(),
+            screenshotCapture: svc);
+        var announcements = new System.Collections.Generic.List<string>();
+        vm.DiagnosticsAnnouncementRequested += announcements.Add;
+
+        vm.ScreenshotCaptureEnabled = true;
+        Assert.True(svc.Enabled);
+        vm.ScreenshotCaptureEnabled = false;
+        Assert.False(svc.Enabled);
+
+        Assert.Equal(2, announcements.Count);
+        Assert.Contains("on", announcements[0], StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("off", announcements[1], StringComparison.OrdinalIgnoreCase);
+
+        // Non-persistence is deliberate: no ConfigModel member exists for this
+        // toggle, so nothing can reach config.ini (see spec Decision D).
+        Assert.DoesNotContain(typeof(QuickMail.Models.ConfigModel).GetProperties(),
+            p => p.Name.Contains("Screenshot", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Settings_DiagnosticsRow_HiddenOutsideDebugMode()
+    {
+        using var svc = NewService();
+        var withService = new SettingsViewModel(new StubConfigService(), new StubCommandRegistry(),
+            screenshotCapture: svc);
+        var withoutService = new SettingsViewModel(new StubConfigService(), new StubCommandRegistry());
+
+        var originalDebugMode = LogService.DebugMode;
+        try
+        {
+            LogService.DebugMode = false;
+            Assert.False(withService.IsDebugDiagnosticsVisible);
+
+            LogService.DebugMode = true;
+            Assert.True(withService.IsDebugDiagnosticsVisible);
+            Assert.False(withoutService.IsDebugDiagnosticsVisible);
+        }
+        finally
+        {
+            LogService.DebugMode = originalDebugMode;
+        }
+    }
+
+    [Fact]
+    public void NullService_IsInertEverywhere()
+    {
+        using var svc = new NullScreenshotCaptureService();
+        svc.Enabled = true;                      // ignored
+        Assert.False(svc.Enabled);
+        Assert.Equal(string.Empty, svc.SessionFolder);
+        svc.Capture(null!, "anything");          // must not throw
+        svc.OpenFolder();
+    }
+}

--- a/QuickMail/App.xaml.cs
+++ b/QuickMail/App.xaml.cs
@@ -11,6 +11,14 @@ namespace QuickMail;
 [SuppressMessage("Design", "CA1001", Justification = "Disposable fields are disposed in OnExit; WPF Application does not support IDisposable.")]
 public partial class App : Application
 {
+    /// <summary>
+    /// Debug screenshot capture (#175). Exposed so view code-behind (Settings
+    /// composition, reading-pane render-complete) can reach the session service
+    /// without threading it through every constructor; NullScreenshotCaptureService
+    /// outside /debug.
+    /// </summary>
+    public IScreenshotCaptureService? ScreenshotCapture { get; private set; }
+
     // Held so OnExit can dispose them.
     private GraphSendMailService? _graphSendMail;
     private ContactService? _contactService;
@@ -181,6 +189,18 @@ public partial class App : Application
         if (onlineMode)
             LogService.Log("Online mode enabled — SQLite cache bypassed.");
 
+        // Debug screenshot capture (#175): the real engine exists only under /debug;
+        // otherwise a null object keeps the feature structurally unreachable. One
+        // class handler covers all Window subclasses — no per-window edits.
+        ScreenshotCapture = LogService.DebugMode
+            ? new ScreenshotCaptureService(profile)
+            : new NullScreenshotCaptureService();
+        EventManager.RegisterClassHandler(typeof(Window), FrameworkElement.LoadedEvent,
+            new RoutedEventHandler((s, _) =>
+            {
+                if (s is Window w) ScreenshotCapture?.OnWindowLoaded(w);
+            }));
+
         // Install global exception handlers BEFORE anything else so an exception
         // in startup wiring or any background task is captured in the log instead
         // of disappearing with the process. (review §1.2)
@@ -328,7 +348,7 @@ public partial class App : Application
 
             var mainVm = new MainViewModel(
                 mailRouter, accountService, credentialService, localStore, oauthService, syncService, configService, commandRegistry, viewService, ruleService, smtpService,
-                onlineMode: onlineMode, flagService: flagService, calendarService: calendarService, changeNotifier: _changeNotifier, updateCheckService: _updateCheckService,
+                onlineMode: onlineMode, flagService: flagService, calendarService: calendarService, changeNotifier: _changeNotifier, updateCheckService: _updateCheckService, screenshotCapture: ScreenshotCapture,
                 themeService: themeService, notificationService: _notificationService, contactSyncService: contactSyncService,
                 graphCalendarSyncService: graphCalendarSync, truthProbe: _truthProbe);
             mainVm.RegisterAccountBackend = a => mailRouter.RegisterAccount(a.Id, BackendFor(a));
@@ -381,6 +401,7 @@ public partial class App : Application
         _notificationService?.Dispose(); // unhooks the toast-activation static event
         _autoDiscoverService?.Dispose(); // releases the autoconfig HttpClient
         _truthProbe?.Dispose();     // cancels in-flight probes before releasing their token source
+        ScreenshotCapture?.Dispose(); // flushes any in-flight PNG save (best effort, bounded)
         base.OnExit(e);
     }
 

--- a/QuickMail/Services/IScreenshotCaptureService.cs
+++ b/QuickMail/Services/IScreenshotCaptureService.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Windows;
+
+namespace QuickMail.Services;
+
+/// <summary>
+/// Debug-only screenshot capture (issue #175): saves a PNG of each new window
+/// (and explicitly-captured surfaces like the rendered reading pane) so an
+/// external AI can review the UI visually. Exists only when /debug is active;
+/// the toggle is session-only and never persisted. See
+/// docs/planning/debug-screenshot-capture-pm-dev-spec.md.
+/// </summary>
+public interface IScreenshotCaptureService : IDisposable
+{
+    /// <summary>
+    /// Title-bar warning appended to every open window while capture is on —
+    /// the standing signal that pixels are being written to disk.
+    /// </summary>
+    public const string TitleSuffix = " — ⚠ SCREENSHOTS ON";
+
+    /// <summary>Session-only; every launch starts false. Never written to config.</summary>
+    bool Enabled { get; set; }
+
+    /// <summary>Raised on toggle so bound titles (MainViewModel.WindowTitle) can refresh.</summary>
+    event EventHandler? EnabledChanged;
+
+    /// <summary>The folder receiving this session's PNGs (created on first enable).</summary>
+    string SessionFolder { get; }
+
+    /// <summary>
+    /// Central entry point for the Window.Loaded class handler: applies the
+    /// title suffix and schedules an idle-priority capture of the window.
+    /// </summary>
+    void OnWindowLoaded(Window window);
+
+    /// <summary>Captures one labeled frame of the window, if enabled. Silent; never moves focus.</summary>
+    void Capture(Window window, string label);
+
+    /// <summary>Opens the session folder in File Explorer.</summary>
+    void OpenFolder();
+}

--- a/QuickMail/Services/NullScreenshotCaptureService.cs
+++ b/QuickMail/Services/NullScreenshotCaptureService.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Windows;
+
+namespace QuickMail.Services;
+
+/// <summary>
+/// Wired at the DI root when /debug is absent: capture is structurally
+/// unreachable in normal builds — no folder, no toggle effect, no title
+/// suffix, zero overhead.
+/// </summary>
+public sealed class NullScreenshotCaptureService : IScreenshotCaptureService
+{
+    public bool Enabled { get => false; set { } }
+
+    public event EventHandler? EnabledChanged { add { } remove { } }
+
+    public string SessionFolder => string.Empty;
+
+    public void OnWindowLoaded(Window window) { }
+
+    public void Capture(Window window, string label) { }
+
+    public void OpenFolder() { }
+
+    public void Dispose() { }
+}

--- a/QuickMail/Services/ScreenshotCaptureService.cs
+++ b/QuickMail/Services/ScreenshotCaptureService.cs
@@ -103,11 +103,13 @@ public class ScreenshotCaptureService : IScreenshotCaptureService
 
         lock (_gate)
         {
+            // Cap first: once capped, new labels must not keep growing the
+            // debounce map for the rest of the session.
+            if (IsAtSessionCap()) return;
             var now = Environment.TickCount64;
             if (_lastCaptureByLabel.TryGetValue(label, out var last) && now - last < DebounceMs)
                 return;
             _lastCaptureByLabel[label] = now;
-            if (IsAtSessionCap()) return;
         }
 
         BitmapSource? frame = null;

--- a/QuickMail/Services/ScreenshotCaptureService.cs
+++ b/QuickMail/Services/ScreenshotCaptureService.cs
@@ -1,0 +1,349 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Data;
+using System.Windows.Interop;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Threading;
+
+namespace QuickMail.Services;
+
+/// <summary>
+/// Real capture engine (issue #175), constructed only when /debug is active.
+///
+/// Pixel path: Win32 PrintWindow with PW_RENDERFULLCONTENT so the out-of-process
+/// WebView2 reading pane is included — RenderTargetBitmap renders it blank, and
+/// WebView2 fidelity is the feature's reason to exist. If PrintWindow returns a
+/// single-color frame (some GPU-composited surfaces), fall back to BitBlt from
+/// the screen at the window rect: a freshly shown window is on top, so occlusion
+/// is rare at capture time. Encoding/saving happens off the UI thread; only the
+/// fast pixel grab runs on it. Deliberately no System.Drawing dependency — GDI
+/// interop plus WPF's PngBitmapEncoder covers everything.
+/// </summary>
+public class ScreenshotCaptureService : IScreenshotCaptureService
+{
+    private const int MaxImagesPerSession = 500;
+    private const long DebounceMs = 750;
+
+    private readonly string _rootFolder;
+    private readonly object _gate = new();
+    private readonly Dictionary<string, long> _lastCaptureByLabel = new(StringComparer.OrdinalIgnoreCase);
+    private readonly List<Task> _pendingSaves = new();
+    private string? _sessionFolder;
+    private int _counter;
+    private bool _capReported;
+    private bool _enabled;
+    private bool _disposed;
+
+    /// <summary>Test seam: replaces the Win32 pixel grab so tests never need a real HWND.</summary>
+    internal Func<Window, BitmapSource?>? PixelGrabber { get; set; }
+
+    public ScreenshotCaptureService(ProfileContext profile)
+    {
+        _rootFolder = Path.Combine(profile.ProfileDir, "debug-screenshots");
+    }
+
+    public event EventHandler? EnabledChanged;
+
+    public string SessionFolder
+    {
+        get
+        {
+            lock (_gate)
+            {
+                _sessionFolder ??= Path.Combine(_rootFolder, DateTime.Now.ToString("yyyyMMdd-HHmmss"));
+                return _sessionFolder;
+            }
+        }
+    }
+
+    public bool Enabled
+    {
+        get => _enabled;
+        set
+        {
+            if (_enabled == value || _disposed) return;
+            if (value)
+            {
+                try
+                {
+                    Directory.CreateDirectory(SessionFolder);
+                }
+                catch (Exception ex)
+                {
+                    LogService.Log($"Screenshot capture not enabled — folder creation failed: {ex.Message}");
+                    return;
+                }
+            }
+            _enabled = value;
+            UpdateAllTitleSuffixes(value);
+            EnabledChanged?.Invoke(this, EventArgs.Empty);
+        }
+    }
+
+    public void OnWindowLoaded(Window window)
+    {
+        if (!_enabled) return;
+        ApplyTitleSuffix(window, enabled: true);
+        // ContentRendered cannot be class-handled; idle-after-Loaded is the
+        // central equivalent that lets layout and first paint complete.
+        window.Dispatcher.BeginInvoke(DispatcherPriority.ApplicationIdle,
+            () => Capture(window, window.GetType().Name));
+    }
+
+    public void Capture(Window window, string label)
+    {
+        if (!_enabled || _disposed) return;
+
+        int frameNumber;
+        lock (_gate)
+        {
+            var now = Environment.TickCount64;
+            if (_lastCaptureByLabel.TryGetValue(label, out var last) && now - last < DebounceMs)
+                return;
+            _lastCaptureByLabel[label] = now;
+
+            if (_counter >= MaxImagesPerSession)
+            {
+                if (!_capReported)
+                {
+                    LogService.Debug($"Screenshot session cap ({MaxImagesPerSession}) reached; capture stopped for this session.");
+                    _capReported = true;
+                }
+                return;
+            }
+            frameNumber = ++_counter;
+        }
+
+        BitmapSource? frame = null;
+        try
+        {
+            frame = (PixelGrabber ?? GrabWindowPixels)(window);
+        }
+        catch (Exception ex)
+        {
+            LogService.Debug($"Screenshot grab failed for {label}: {ex.Message}");
+        }
+        if (frame is null) return;
+        frame.Freeze();
+
+        var path = Path.Combine(SessionFolder, $"{frameNumber:D4}-{Slug(label)}.png");
+        var save = Task.Run(() => SavePng(frame, path));
+        lock (_gate)
+        {
+            _pendingSaves.RemoveAll(t => t.IsCompleted);
+            _pendingSaves.Add(save);
+        }
+    }
+
+    public void OpenFolder()
+    {
+        try
+        {
+            Directory.CreateDirectory(SessionFolder);
+            Process.Start(new ProcessStartInfo("explorer.exe", $"\"{SessionFolder}\"") { UseShellExecute = true });
+        }
+        catch (Exception ex)
+        {
+            LogService.Log($"Could not open screenshots folder: {ex.Message}");
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        _enabled = false;
+        Task[] pending;
+        lock (_gate) pending = _pendingSaves.ToArray();
+        try
+        {
+            // Best-effort flush so a capture taken just before exit isn't truncated.
+            Task.WaitAll(pending, TimeSpan.FromSeconds(3));
+        }
+        catch
+        {
+            // Individual save failures already logged in SavePng.
+        }
+        GC.SuppressFinalize(this);
+    }
+
+    // ── Title suffix ──────────────────────────────────────────────────────────
+
+    private static void UpdateAllTitleSuffixes(bool enabled)
+    {
+        if (Application.Current is null) return;
+        foreach (Window w in Application.Current.Windows)
+            ApplyTitleSuffix(w, enabled);
+    }
+
+    internal static void ApplyTitleSuffix(Window window, bool enabled)
+    {
+        // A data-bound Title (MainWindow → MainViewModel.WindowTitle) incorporates
+        // the suffix in its own getter; assigning here would detach the binding.
+        if (BindingOperations.GetBindingExpression(window, Window.TitleProperty) != null)
+            return;
+        var title = window.Title ?? string.Empty;
+        var has = title.EndsWith(IScreenshotCaptureService.TitleSuffix, StringComparison.Ordinal);
+        if (enabled && !has)
+            window.Title = title + IScreenshotCaptureService.TitleSuffix;
+        else if (!enabled && has)
+            window.Title = title[..^IScreenshotCaptureService.TitleSuffix.Length];
+    }
+
+    // ── Filename slug ─────────────────────────────────────────────────────────
+
+    internal static string Slug(string label)
+    {
+        if (string.IsNullOrWhiteSpace(label)) return "window";
+        Span<char> buffer = stackalloc char[Math.Min(label.Length, 60)];
+        var n = 0;
+        foreach (var c in label)
+        {
+            if (n == buffer.Length) break;
+            buffer[n++] = char.IsLetterOrDigit(c) || c is '-' or '_' ? c : '-';
+        }
+        var slug = new string(buffer[..n]).Trim('-');
+        return slug.Length == 0 ? "window" : slug;
+    }
+
+    // ── Pixel grab (UI thread) ────────────────────────────────────────────────
+
+    private static BitmapSource? GrabWindowPixels(Window window)
+    {
+        var hwnd = new WindowInteropHelper(window).Handle;
+        if (hwnd == IntPtr.Zero) return null;
+        if (!GetWindowRect(hwnd, out var rect)) return null;
+        int width = rect.Right - rect.Left, height = rect.Bottom - rect.Top;
+        if (width <= 0 || height <= 0) return null;
+
+        var screenDc = GetDC(IntPtr.Zero);
+        if (screenDc == IntPtr.Zero) return null;
+        var memDc = CreateCompatibleDC(screenDc);
+        var hBitmap = CreateCompatibleBitmap(screenDc, width, height);
+        var previous = SelectObject(memDc, hBitmap);
+        try
+        {
+            PrintWindow(hwnd, memDc, PW_RENDERFULLCONTENT);
+            SelectObject(memDc, previous);          // deselect before reading pixels
+            var source = FromHBitmap(hBitmap);
+
+            if (source is null || IsSingleColor(source))
+            {
+                SelectObject(memDc, hBitmap);
+                BitBlt(memDc, 0, 0, width, height, screenDc, rect.Left, rect.Top, SRCCOPY | CAPTUREBLT);
+                SelectObject(memDc, previous);
+                source = FromHBitmap(hBitmap);
+            }
+            return source;
+        }
+        finally
+        {
+            DeleteObject(hBitmap);
+            DeleteDC(memDc);
+            _ = ReleaseDC(IntPtr.Zero, screenDc); // 0 return = DC wasn't released; nothing actionable at teardown
+        }
+    }
+
+    private static BitmapSource? FromHBitmap(IntPtr hBitmap)
+    {
+        try
+        {
+            return Imaging.CreateBitmapSourceFromHBitmap(
+                hBitmap, IntPtr.Zero, Int32Rect.Empty, BitmapSizeOptions.FromEmptyOptions());
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Samples an 8×8 grid; a frame that is one flat color is treated as a
+    /// failed PrintWindow (typical for GPU surfaces) and triggers the BitBlt
+    /// fallback. Internal for tests.
+    /// </summary>
+    internal static bool IsSingleColor(BitmapSource source)
+    {
+        BitmapSource converted = source.Format == PixelFormats.Bgra32
+            ? source
+            : new FormatConvertedBitmap(source, PixelFormats.Bgra32, null, 0);
+        int w = converted.PixelWidth, h = converted.PixelHeight;
+        if (w == 0 || h == 0) return true;
+
+        var pixel = new byte[4];
+        uint? first = null;
+        for (var gy = 0; gy < 8; gy++)
+        {
+            for (var gx = 0; gx < 8; gx++)
+            {
+                int x = Math.Min(w - 1, gx * w / 8), y = Math.Min(h - 1, gy * h / 8);
+                converted.CopyPixels(new Int32Rect(x, y, 1, 1), pixel, 4, 0);
+                var value = BitConverter.ToUInt32(pixel, 0);
+                first ??= value;
+                if (value != first) return false;
+            }
+        }
+        return true;
+    }
+
+    private static void SavePng(BitmapSource frame, string path)
+    {
+        try
+        {
+            var encoder = new PngBitmapEncoder();
+            encoder.Frames.Add(BitmapFrame.Create(frame));
+            using var stream = File.Create(path);
+            encoder.Save(stream);
+        }
+        catch (Exception ex)
+        {
+            LogService.Debug($"Screenshot save failed for {Path.GetFileName(path)}: {ex.Message}");
+        }
+    }
+
+    // ── Win32 interop ─────────────────────────────────────────────────────────
+
+    private const uint PW_RENDERFULLCONTENT = 0x00000002;
+    private const uint SRCCOPY = 0x00CC0020;
+    private const uint CAPTUREBLT = 0x40000000;
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct RECT { public int Left, Top, Right, Bottom; }
+
+    [DllImport("user32.dll")]
+    private static extern bool GetWindowRect(IntPtr hWnd, out RECT lpRect);
+
+    [DllImport("user32.dll")]
+    private static extern IntPtr GetDC(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
+    private static extern int ReleaseDC(IntPtr hWnd, IntPtr hDC);
+
+    [DllImport("user32.dll")]
+    private static extern bool PrintWindow(IntPtr hWnd, IntPtr hdcBlt, uint nFlags);
+
+    [DllImport("gdi32.dll")]
+    private static extern IntPtr CreateCompatibleDC(IntPtr hdc);
+
+    [DllImport("gdi32.dll")]
+    private static extern bool DeleteDC(IntPtr hdc);
+
+    [DllImport("gdi32.dll")]
+    private static extern IntPtr CreateCompatibleBitmap(IntPtr hdc, int width, int height);
+
+    [DllImport("gdi32.dll")]
+    private static extern IntPtr SelectObject(IntPtr hdc, IntPtr hObject);
+
+    [DllImport("gdi32.dll")]
+    private static extern bool DeleteObject(IntPtr hObject);
+
+    [DllImport("gdi32.dll")]
+    private static extern bool BitBlt(IntPtr hdcDest, int x, int y, int cx, int cy,
+        IntPtr hdcSrc, int x1, int y1, uint rop);
+}

--- a/QuickMail/Services/ScreenshotCaptureService.cs
+++ b/QuickMail/Services/ScreenshotCaptureService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using System.Windows;
@@ -100,24 +101,13 @@ public class ScreenshotCaptureService : IScreenshotCaptureService
     {
         if (!_enabled || _disposed) return;
 
-        int frameNumber;
         lock (_gate)
         {
             var now = Environment.TickCount64;
             if (_lastCaptureByLabel.TryGetValue(label, out var last) && now - last < DebounceMs)
                 return;
             _lastCaptureByLabel[label] = now;
-
-            if (_counter >= MaxImagesPerSession)
-            {
-                if (!_capReported)
-                {
-                    LogService.Debug($"Screenshot session cap ({MaxImagesPerSession}) reached; capture stopped for this session.");
-                    _capReported = true;
-                }
-                return;
-            }
-            frameNumber = ++_counter;
+            if (IsAtSessionCap()) return;
         }
 
         BitmapSource? frame = null;
@@ -132,6 +122,15 @@ public class ScreenshotCaptureService : IScreenshotCaptureService
         if (frame is null) return;
         frame.Freeze();
 
+        // The counter is consumed only by a successful grab, so failed grabs
+        // neither burn the session cap nor leave gaps in the numbering.
+        int frameNumber;
+        lock (_gate)
+        {
+            if (IsAtSessionCap()) return;
+            frameNumber = ++_counter;
+        }
+
         var path = Path.Combine(SessionFolder, $"{frameNumber:D4}-{Slug(label)}.png");
         var save = Task.Run(() => SavePng(frame, path));
         lock (_gate)
@@ -139,6 +138,18 @@ public class ScreenshotCaptureService : IScreenshotCaptureService
             _pendingSaves.RemoveAll(t => t.IsCompleted);
             _pendingSaves.Add(save);
         }
+    }
+
+    /// <summary>Callers must hold <see cref="_gate"/>.</summary>
+    private bool IsAtSessionCap()
+    {
+        if (_counter < MaxImagesPerSession) return false;
+        if (!_capReported)
+        {
+            LogService.Debug($"Screenshot session cap ({MaxImagesPerSession}) reached; capture stopped for this session.");
+            _capReported = true;
+        }
+        return true;
     }
 
     public void OpenFolder()
@@ -159,6 +170,8 @@ public class ScreenshotCaptureService : IScreenshotCaptureService
         if (_disposed) return;
         _disposed = true;
         _enabled = false;
+        foreach (var window in _titleKeepers.Keys.ToList())
+            DetachTitleKeeper(window, refreshFromBinding: false);
         Task[] pending;
         lock (_gate) pending = _pendingSaves.ToArray();
         try
@@ -175,25 +188,72 @@ public class ScreenshotCaptureService : IScreenshotCaptureService
 
     // ── Title suffix ──────────────────────────────────────────────────────────
 
-    private static void UpdateAllTitleSuffixes(bool enabled)
+    private static readonly System.ComponentModel.DependencyPropertyDescriptor TitleDescriptor =
+        System.ComponentModel.DependencyPropertyDescriptor.FromProperty(Window.TitleProperty, typeof(Window));
+
+    private readonly Dictionary<Window, EventHandler> _titleKeepers = new();
+
+    private void UpdateAllTitleSuffixes(bool enabled)
     {
         if (Application.Current is null) return;
         foreach (Window w in Application.Current.Windows)
             ApplyTitleSuffix(w, enabled);
     }
 
-    internal static void ApplyTitleSuffix(Window window, bool enabled)
+    internal void ApplyTitleSuffix(Window window, bool enabled)
     {
-        // A data-bound Title (MainWindow → MainViewModel.WindowTitle) incorporates
-        // the suffix in its own getter; assigning here would detach the binding.
-        if (BindingOperations.GetBindingExpression(window, Window.TitleProperty) != null)
+        if (BindingOperations.GetBindingExpression(window, Window.TitleProperty) is null)
+        {
+            // Static title: direct, idempotent assignment.
+            var title = window.Title ?? string.Empty;
+            var has = title.EndsWith(IScreenshotCaptureService.TitleSuffix, StringComparison.Ordinal);
+            if (enabled && !has)
+                window.Title = title + IScreenshotCaptureService.TitleSuffix;
+            else if (!enabled && has)
+                window.Title = title[..^IScreenshotCaptureService.TitleSuffix.Length];
             return;
+        }
+
+        // Data-bound title (MainWindow, Compose, MessageWindow, …): assignment
+        // would detach the binding, so overlay via SetCurrentValue and re-apply
+        // whenever the binding pushes a fresh base title.
+        if (enabled) AttachTitleKeeper(window);
+        else DetachTitleKeeper(window, refreshFromBinding: true);
+    }
+
+    private void AttachTitleKeeper(Window window)
+    {
+        if (_titleKeepers.ContainsKey(window)) return;
+        EventHandler onTitleChanged = (_, _) => EnsureBoundTitleSuffix(window);
+        TitleDescriptor.AddValueChanged(window, onTitleChanged);
+        _titleKeepers[window] = onTitleChanged;
+        window.Closed += OnKeeperWindowClosed;   // paired -= in DetachTitleKeeper
+        EnsureBoundTitleSuffix(window);
+    }
+
+    private void EnsureBoundTitleSuffix(Window window)
+    {
+        if (!_enabled) return;
         var title = window.Title ?? string.Empty;
-        var has = title.EndsWith(IScreenshotCaptureService.TitleSuffix, StringComparison.Ordinal);
-        if (enabled && !has)
-            window.Title = title + IScreenshotCaptureService.TitleSuffix;
-        else if (!enabled && has)
-            window.Title = title[..^IScreenshotCaptureService.TitleSuffix.Length];
+        // Re-entrancy guard: our own SetCurrentValue fires the change handler once
+        // more with the suffix already present.
+        if (title.EndsWith(IScreenshotCaptureService.TitleSuffix, StringComparison.Ordinal)) return;
+        window.SetCurrentValue(Window.TitleProperty, title + IScreenshotCaptureService.TitleSuffix);
+    }
+
+    private void DetachTitleKeeper(Window window, bool refreshFromBinding)
+    {
+        if (!_titleKeepers.Remove(window, out var onTitleChanged)) return;
+        TitleDescriptor.RemoveValueChanged(window, onTitleChanged);
+        window.Closed -= OnKeeperWindowClosed;
+        if (refreshFromBinding)
+            BindingOperations.GetBindingExpression(window, Window.TitleProperty)?.UpdateTarget();
+    }
+
+    private void OnKeeperWindowClosed(object? sender, EventArgs e)
+    {
+        if (sender is Window window)
+            DetachTitleKeeper(window, refreshFromBinding: false);
     }
 
     // ── Filename slug ─────────────────────────────────────────────────────────
@@ -229,9 +289,9 @@ public class ScreenshotCaptureService : IScreenshotCaptureService
         var previous = SelectObject(memDc, hBitmap);
         try
         {
-            PrintWindow(hwnd, memDc, PW_RENDERFULLCONTENT);
+            var printed = PrintWindow(hwnd, memDc, PW_RENDERFULLCONTENT);
             SelectObject(memDc, previous);          // deselect before reading pixels
-            var source = FromHBitmap(hBitmap);
+            var source = printed ? FromHBitmap(hBitmap) : null;
 
             if (source is null || IsSingleColor(source))
             {

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -25,6 +25,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
     // Verifies, independently of the app's own connection state, whether an account shown as
     // disconnected really is. Optional so tests and the stub-service constructors are unaffected.
     private readonly ConnectionTruthProbe? _truthProbe;
+    private readonly IScreenshotCaptureService? _screenshotCapture;
     private readonly IAccountService _accountService;
     private readonly ICredentialService _credentials;
     private readonly ILocalStoreService _localStore;
@@ -109,8 +110,13 @@ public partial class MainViewModel : ObservableObject, IDisposable
     /// background work (sync, prefetch, message loads) unwinds via OperationCanceledException
     /// instead of being killed with the process, then releases the CTS handles and timer.
     /// </summary>
+    private void OnScreenshotCaptureEnabledChanged(object? sender, EventArgs e) =>
+        OnPropertyChanged(nameof(WindowTitle));
+
     public void Dispose()
     {
+        if (_screenshotCapture != null)
+            _screenshotCapture.EnabledChanged -= OnScreenshotCaptureEnabledChanged;
         DrainCts(ref _connectCts);
         DrainCts(ref _folderCts);
         DrainCts(ref _messageLoadCts);
@@ -769,6 +775,17 @@ public partial class MainViewModel : ObservableObject, IDisposable
     {
         get
         {
+            // The suffix lives in the getter (not applied externally) so any
+            // WindowTitle recompute keeps the capture warning while enabled.
+            var title = ComputeWindowTitle();
+            return _screenshotCapture?.Enabled == true
+                ? title + IScreenshotCaptureService.TitleSuffix
+                : title;
+        }
+    }
+
+    private string ComputeWindowTitle()
+    {
             if (IsMessageOpen && !string.IsNullOrWhiteSpace(MessageDetail?.Subject))
                 return $"{MessageDetail.Subject} - QuickMail";
             if (ActiveView != null)
@@ -796,7 +813,6 @@ public partial class MainViewModel : ObservableObject, IDisposable
                 return $"{folderPart}{suffix} - QuickMail";
             }
             return "QuickMail";
-        }
     }
 
     // ── Tab & Window Management (Phase 6) ────────────────────────────────────────
@@ -1054,9 +1070,13 @@ public partial class MainViewModel : ObservableObject, IDisposable
         INotificationService? notificationService = null,
         IContactSyncService? contactSyncService = null,
         IGraphCalendarSyncService? graphCalendarSyncService = null,
-        ConnectionTruthProbe? truthProbe = null)
+        ConnectionTruthProbe? truthProbe = null,
+        IScreenshotCaptureService? screenshotCapture = null)
     {
         _truthProbe = truthProbe;
+        _screenshotCapture = screenshotCapture;
+        if (_screenshotCapture != null)
+            _screenshotCapture.EnabledChanged += OnScreenshotCaptureEnabledChanged;
         _imap            = imap;
         _ui              = uiDispatcher ?? new WpfUiDispatcher();
         _changeNotifier  = changeNotifier;

--- a/QuickMail/ViewModels/SettingsViewModel.cs
+++ b/QuickMail/ViewModels/SettingsViewModel.cs
@@ -149,10 +149,16 @@ public partial class SettingsViewModel : ObservableObject
         {
             if (_screenshotCapture is null || _screenshotCapture.Enabled == value) return;
             _screenshotCapture.Enabled = value;
+            // Announce what actually happened, not what was requested — the
+            // service refuses to enable if its folder cannot be created.
+            var actual = _screenshotCapture.Enabled;
             OnPropertyChanged(nameof(ScreenshotCaptureEnabled));
-            DiagnosticsAnnouncementRequested?.Invoke(value
-                ? "Screenshot capture on. QuickMail is saving screen images to disk this session."
-                : "Screenshot capture off.");
+            DiagnosticsAnnouncementRequested?.Invoke(
+                actual != value
+                    ? "Screenshot capture could not be turned on. Check the log for details."
+                    : actual
+                        ? "Screenshot capture on. QuickMail is saving screen images to disk this session."
+                        : "Screenshot capture off.");
         }
     }
 

--- a/QuickMail/ViewModels/SettingsViewModel.cs
+++ b/QuickMail/ViewModels/SettingsViewModel.cs
@@ -126,6 +126,39 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty]
     private bool _googleSignIn;
 
+    // ── Diagnostics (debug-only, #175) ─────────────────────────────────────────────
+    // Deliberately NOT [ObservableProperty] over a field: the value lives on the
+    // session service, never in ConfigModel/config.ini — non-persistence is the
+    // safety story. The row is collapsed entirely outside /debug.
+
+    private readonly IScreenshotCaptureService? _screenshotCapture;
+
+    public bool IsDebugDiagnosticsVisible => LogService.DebugMode && _screenshotCapture != null;
+
+    /// <summary>
+    /// Meta-announcement about the diagnostic mode. The View forwards it to
+    /// AccessibilityHelper.Announce with force:true (like the custom-announcements
+    /// toggle, it must be heard regardless of announcement preferences).
+    /// </summary>
+    public event System.Action<string>? DiagnosticsAnnouncementRequested;
+
+    public bool ScreenshotCaptureEnabled
+    {
+        get => _screenshotCapture?.Enabled == true;
+        set
+        {
+            if (_screenshotCapture is null || _screenshotCapture.Enabled == value) return;
+            _screenshotCapture.Enabled = value;
+            OnPropertyChanged(nameof(ScreenshotCaptureEnabled));
+            DiagnosticsAnnouncementRequested?.Invoke(value
+                ? "Screenshot capture on. QuickMail is saving screen images to disk this session."
+                : "Screenshot capture off.");
+        }
+    }
+
+    [RelayCommand]
+    private void OpenScreenshotsFolder() => _screenshotCapture?.OpenFolder();
+
     /// <summary>Reads a [features] flag, treating anything unparseable or absent as the default.</summary>
     private static bool ReadFeature(ConfigModel cfg, FeatureFlag flag, bool fallback) =>
         cfg.Features.TryGetValue(flag.ToString(), out var raw) && bool.TryParse(raw, out var parsed)
@@ -253,9 +286,11 @@ public partial class SettingsViewModel : ObservableObject
         IConfigService configService,
         ICommandRegistry registry,
         IThemeService? themeService = null,
-        System.Collections.Generic.IEnumerable<string>? fontFamilies = null)
+        System.Collections.Generic.IEnumerable<string>? fontFamilies = null,
+        IScreenshotCaptureService? screenshotCapture = null)
     {
         _configService = configService;
+        _screenshotCapture = screenshotCapture;
         var cfg = configService.Load();
 
         // Appearance: themes from the service; installed fonts from the View

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -3072,6 +3072,11 @@ public partial class MainWindow : Window
         if (renderVersion != _messageBodyRenderVersion)
             return;
 
+        // Debug screenshot capture (#175): the rendered reading pane is the surface
+        // PrintWindow exists for — capture after navigation completes so the HTML
+        // body is in the frame. No-op unless /debug and the session toggle are on.
+        (Application.Current as App)?.ScreenshotCapture?.Capture(this, "ReadingPane");
+
         await FocusMessageBodyAsync(renderVersion, detail.Subject);
     }
 
@@ -5579,7 +5584,8 @@ public partial class MainWindow : Window
             .Select(f => f.Source)
             .OrderBy(n => n, StringComparer.CurrentCultureIgnoreCase)
             .ToList();
-        var vm = new SettingsViewModel(_configService, _registry, _themeService, fontNames);
+        var vm = new SettingsViewModel(_configService, _registry, _themeService, fontNames,
+            (Application.Current as App)?.ScreenshotCapture);
         var dialog = new SettingsDialog(vm) { Owner = this };
         if (dialog.ShowDialog() == true)
         {

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -3073,9 +3073,13 @@ public partial class MainWindow : Window
             return;
 
         // Debug screenshot capture (#175): the rendered reading pane is the surface
-        // PrintWindow exists for — capture after navigation completes so the HTML
-        // body is in the frame. No-op unless /debug and the session toggle are on.
-        (Application.Current as App)?.ScreenshotCapture?.Capture(this, "ReadingPane");
+        // PrintWindow exists for. Deferred to ApplicationIdle because WebView2
+        // presents its frame after NavigationCompleted — a synchronous capture can
+        // still show the previous document. Skipped on timeout: the page may never
+        // have rendered. No-op unless /debug and the session toggle are on.
+        if (completed)
+            _ = Dispatcher.BeginInvoke(DispatcherPriority.ApplicationIdle, () =>
+                (Application.Current as App)?.ScreenshotCapture?.Capture(this, $"ReadingPane-{detail.Subject}"));
 
         await FocusMessageBodyAsync(renderVersion, detail.Subject);
     }

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -3079,7 +3079,12 @@ public partial class MainWindow : Window
         // have rendered. No-op unless /debug and the session toggle are on.
         if (completed)
             _ = Dispatcher.BeginInvoke(DispatcherPriority.ApplicationIdle, () =>
-                (Application.Current as App)?.ScreenshotCapture?.Capture(this, $"ReadingPane-{detail.Subject}"));
+            {
+                // A newer render may have started before idle — skip rather than
+                // save the next message's pixels under this message's label.
+                if (renderVersion != _messageBodyRenderVersion) return;
+                (Application.Current as App)?.ScreenshotCapture?.Capture(this, $"ReadingPane-{detail.Subject}");
+            });
 
         await FocusMessageBodyAsync(renderVersion, detail.Subject);
     }

--- a/QuickMail/Views/MessageWindow.xaml.cs
+++ b/QuickMail/Views/MessageWindow.xaml.cs
@@ -358,6 +358,9 @@ public partial class MessageWindow : Window
 
         if (version != _renderVersion) return;
 
+        // Debug screenshot capture (#175): rendered body in frame (no-op unless enabled).
+        (Application.Current as App)?.ScreenshotCapture?.Capture(this, "MessageWindow-Rendered");
+
         await FocusMessageBodyAsync(version, detail.Subject);
     }
 

--- a/QuickMail/Views/MessageWindow.xaml.cs
+++ b/QuickMail/Views/MessageWindow.xaml.cs
@@ -362,7 +362,12 @@ public partial class MessageWindow : Window
         // has presented the frame; skipped on timeout (page may never have rendered).
         if (completed)
             _ = Dispatcher.BeginInvoke(DispatcherPriority.ApplicationIdle, () =>
-                (Application.Current as App)?.ScreenshotCapture?.Capture(this, $"MessageWindow-{detail.Subject}"));
+            {
+                // A newer render may have started before idle — skip rather than
+                // save the next message's pixels under this message's label.
+                if (version != _renderVersion) return;
+                (Application.Current as App)?.ScreenshotCapture?.Capture(this, $"MessageWindow-{detail.Subject}");
+            });
 
         await FocusMessageBodyAsync(version, detail.Subject);
     }

--- a/QuickMail/Views/MessageWindow.xaml.cs
+++ b/QuickMail/Views/MessageWindow.xaml.cs
@@ -358,8 +358,11 @@ public partial class MessageWindow : Window
 
         if (version != _renderVersion) return;
 
-        // Debug screenshot capture (#175): rendered body in frame (no-op unless enabled).
-        (Application.Current as App)?.ScreenshotCapture?.Capture(this, "MessageWindow-Rendered");
+        // Debug screenshot capture (#175): deferred to ApplicationIdle so WebView2
+        // has presented the frame; skipped on timeout (page may never have rendered).
+        if (completed)
+            _ = Dispatcher.BeginInvoke(DispatcherPriority.ApplicationIdle, () =>
+                (Application.Current as App)?.ScreenshotCapture?.Capture(this, $"MessageWindow-{detail.Subject}"));
 
         await FocusMessageBodyAsync(version, detail.Subject);
     }

--- a/QuickMail/Views/SettingsDialog.xaml
+++ b/QuickMail/Views/SettingsDialog.xaml
@@ -442,6 +442,24 @@
                                            FontFamily="{DynamicResource Theme.FontFamilyMono}"/>
                             </StackPanel>
                         </GroupBox>
+
+                        <!-- Diagnostics (debug builds only, #175). The toggle is session-only
+                             and never written to config.ini. -->
+                        <GroupBox Header="_Diagnostics (debug)" Padding="10" Margin="0,0,0,15"
+                                  AutomationProperties.Name="Diagnostics settings"
+                                  Visibility="{Binding IsDebugDiagnosticsVisible, Converter={StaticResource BoolToVisibilityConverter}}">
+                            <StackPanel>
+                                <CheckBox Content="Capture _screenshots of new windows"
+                                          IsChecked="{Binding ScreenshotCaptureEnabled, Mode=TwoWay}"
+                                          AutomationProperties.Name="Capture screenshots of new windows"/>
+                                <TextBlock Text="Saves a picture of each window you open, for visual review. This session only — it turns itself off when QuickMail closes, and every window's title bar warns while it is on. Images stay on this computer."
+                                           Foreground="{DynamicResource Theme.TextSecondary}" FontSize="{DynamicResource Theme.FontSizeSmall}" Margin="0,3,0,8" TextWrapping="Wrap"/>
+                                <Button Content="_Open screenshots folder"
+                                        Command="{Binding OpenScreenshotsFolderCommand}"
+                                        HorizontalAlignment="Left"
+                                        AutomationProperties.Name="Open screenshots folder"/>
+                            </StackPanel>
+                        </GroupBox>
                     </StackPanel>
                 </ScrollViewer>
             </TabItem>

--- a/QuickMail/Views/SettingsDialog.xaml.cs
+++ b/QuickMail/Views/SettingsDialog.xaml.cs
@@ -20,7 +20,14 @@ public partial class SettingsDialog : Window
         _vm = vm;
         InitializeComponent();
         DataContext = vm;
+        vm.DiagnosticsAnnouncementRequested += OnDiagnosticsAnnouncement;
+        Closed += (_, _) => vm.DiagnosticsAnnouncementRequested -= OnDiagnosticsAnnouncement;
     }
+
+    // Meta-announcement about screenshot capture (#175): force bypasses the
+    // user's announcement preferences, matching the custom-announcements toggle.
+    private void OnDiagnosticsAnnouncement(string text) =>
+        AccessibilityHelper.Announce(this, text, interrupt: false, AnnouncementCategory.Status, force: true);
 
     private void Window_Loaded(object sender, RoutedEventArgs e)
     {


### PR DESCRIPTION
Implements #175 (all three spec phases) — part of the #421 visual-quality plan, Wave 3. This is the capture engine that #180's automated visual-verification harness builds on.

## What it does

With `/debug`, a session-only Settings toggle ("Diagnostics (debug)" group on the Advanced tab) turns on silent screenshot capture: every window that opens gets one labeled PNG at `<profile>\debug-screenshots\<session>\`, plus explicit captures of the rendered reading pane and MessageWindow body after WebView2 finishes presenting. While on, every window title carries " — ⚠ SCREENSHOTS ON" and toggling force-announces regardless of announcement preferences. The toggle never persists — every launch starts off — and without `/debug` the DI root wires a null service, so the feature is structurally unreachable in normal builds.

## Design notes (per spec)

- **Pixels:** Win32 `PrintWindow(PW_RENDERFULLCONTENT)` so the out-of-process WebView2 is included; BitBlt-from-screen fallback when PrintWindow fails or returns a flat frame. Pure Win32 + WPF `PngBitmapEncoder` — no System.Drawing dependency.
- **One hook:** a single `Window.Loaded` class handler in App covers all window types; capture is scheduled at ApplicationIdle. No per-window edits.
- **Bound titles:** windows that bind `Title` (Main, Compose, MessageWindow, …) get the warning via a per-window value-changed keeper using `SetCurrentValue`, so the binding survives and every VM title recompute re-acquires the suffix. MainViewModel additionally bakes the suffix into `WindowTitle`.
- **Safety valves:** 750 ms per-label debounce, 500-image session cap, background saves flushed (bounded) on exit.
- **Spec deviation, deliberate:** no separate tab-open capture site — tab content renders through the same reading-pane `NavigationCompleted` site that is instrumented.

## Review process

Reviewed by an independent agent before this PR: 5 findings (missing warning on bound-title windows; captures firing before WebView2 presented; announcing "on" when enabling failed; PrintWindow return ignored / cap consumed by failed grabs; label + test gaps) — all fixed. A second independent verification pass confirmed the fixes and surfaced 2 more (stale-render idle captures mislabeled; debounce map growth after cap) — also fixed.

## Verification

- 18 new tests in `ScreenshotCaptureServiceTests` (foldering, slug safety, debounce, cap, failed-grab numbering, single-color detection, suffix idempotence, bound-title overlay/restore, `OnWindowLoaded` idle path, WindowTitle integration, settings forwarding + actual-state announcement, ConfigModel non-persistence guard, null-service inertness).
- Full suite green twice consecutively: 2255 passed / 0 failed / 3 skipped, with `--blame-hang`. (One earlier run flaked on `ComposeWindowFromAccountAnnouncementTests`; it passes on this branch and on a clean main baseline worktree — the known windowed-test flake, not a regression.)
- Smoke-launched with `/debug --profileDir <scratch>`: starts clean with the class handler registered.

## For your live /debug pass (the spec's highest-risk acceptance steps)

1. Enable the toggle, open a real HTML-heavy message: the reading-pane PNG must show the rendered body, not a blank rectangle (§8 scenario 1 step 4).
2. Quit and relaunch with `/debug`: the checkbox must be off again (§8 non-persistence).
3. With capture on, open Compose: title bar should end with the warning suffix (bound-title path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
