### PR TITLE
Implement #180 phases 1-3: fixtures, --ui-probe, orchestrator (Wave 3b of #421)

### DIFF
--- a/QuickMail.Tests/QuickMail.Tests.csproj
+++ b/QuickMail.Tests/QuickMail.Tests.csproj
@@ -35,6 +35,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\QuickMail\QuickMail.csproj" />
+    <ProjectReference Include="..\tools\QuickMail.Fixtures\QuickMail.Fixtures.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/QuickMail.Tests/QuickMail.Tests.csproj
+++ b/QuickMail.Tests/QuickMail.Tests.csproj
@@ -35,7 +35,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\QuickMail\QuickMail.csproj" />
-    <ProjectReference Include="..\tools\QuickMail.Fixtures\QuickMail.Fixtures.csproj" />
+    <ProjectReference Include="..\Tools\QuickMail.Fixtures\QuickMail.Fixtures.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/QuickMail.Tests/QuickMailFixturesTests.cs
+++ b/QuickMail.Tests/QuickMailFixturesTests.cs
@@ -1,0 +1,151 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using QuickMail.Fixtures;
+using QuickMail.Services;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// #180 Phase 1 round-trip: the fixture generator writes through the app's real
+/// persistence services, and the same services read back exactly the curated
+/// dataset. Because both sides are the shipping code, a schema migration that
+/// desyncs the fixtures fails here, not at probe time.
+/// </summary>
+public class QuickMailFixturesTests : IDisposable
+{
+    private readonly string _dir =
+        Path.Combine(Path.GetTempPath(), $"QM-FixtureTests-{Guid.NewGuid():N}");
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { /* temp cleanup */ }
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public async Task DefaultSet_RoundTripsThroughTheRealServices()
+    {
+        await DefaultFixtureSet.WriteAsync(_dir);
+        var profile = new ProfileContext(_dir);
+
+        // Account
+        var accounts = new AccountService(profile).LoadAccounts();
+        var account = Assert.Single(accounts);
+        Assert.Equal(UiProbeFixture.AccountId, account.Id);
+        Assert.True(account.IsDefault);
+        Assert.Equal("test@example.com", account.Username);
+
+        // Mail
+        var store = new LocalStoreService(profile);
+        store.Initialize();
+        var all = await store.LoadAllSummariesAsync();
+        Assert.Equal(9, all.Count);
+
+        var inbox = await store.LoadFolderSummariesAsync(UiProbeFixture.AccountId, UiProbeFixture.InboxFolder);
+        Assert.Equal(7, inbox.Count);
+        Assert.Contains(inbox, m => !m.IsRead);                       // unread rows exist
+        Assert.Contains(inbox, m => m.FlagId != null);                // the flagged row persisted a flag id
+        Assert.Contains(inbox, m => m.IsMailingList);
+        Assert.Contains(inbox, m => m.Subject.Length > 120);          // the pathological subject
+
+        // The attachment indicator comes from UpsertDetailAsync, not the summary.
+        var withAttachment = inbox.Single(m => m.MessageId == "1004");
+        Assert.True(withAttachment.HasAttachments);
+
+        // Reading-pane target: HTML body present and non-trivial.
+        var html = await store.LoadDetailAsync(UiProbeFixture.AccountId, UiProbeFixture.InboxFolder, UiProbeFixture.HtmlMessageId);
+        Assert.NotNull(html);
+        Assert.Contains("<h1>", html!.HtmlBody, StringComparison.OrdinalIgnoreCase);
+
+        // Invite: the reading pane's event card needs CalendarIcs on the detail.
+        var invite = await store.LoadDetailAsync(UiProbeFixture.AccountId, UiProbeFixture.InboxFolder, "1007");
+        Assert.NotNull(invite);
+        Assert.Contains("BEGIN:VEVENT", invite!.CalendarIcs, StringComparison.Ordinal);
+
+        // Config: first-run tutorial suppressed so probe shots show the app.
+        var cfg = new ConfigService(profile).Load();
+        Assert.True(cfg.TutorialCompleted);
+        Assert.False(cfg.CloseToTray);
+
+        // Supporting files exist and are non-empty.
+        foreach (var file in new[] { "contacts.json", "groups.json", "flags.json", "views.json", "rules.json", "templates.json" })
+            Assert.True(new FileInfo(Path.Combine(_dir, file)).Length > 0, $"{file} missing or empty");
+    }
+
+    [Fact]
+    public async Task DefaultSet_IsDeterministic_AcrossRuns()
+    {
+        var dirA = _dir + "-a";
+        var dirB = _dir + "-b";
+        try
+        {
+            await DefaultFixtureSet.WriteAsync(dirA);
+            await DefaultFixtureSet.WriteAsync(dirB);
+
+            // JSON artifacts must be byte-identical (fixed GUIDs, fixed clock).
+            // mail.db is excluded: SQLite internals (page layout) are not
+            // byte-stable, but the row content is covered by the round-trip test.
+            foreach (var file in new[] { "accounts.json", "contacts.json", "groups.json", "flags.json", "views.json", "rules.json", "templates.json" })
+            {
+                Assert.True(
+                    File.ReadAllBytes(Path.Combine(dirA, file)).SequenceEqual(File.ReadAllBytes(Path.Combine(dirB, file))),
+                    $"{file} differs between two generator runs — non-determinism crept in");
+            }
+        }
+        finally
+        {
+            try { Directory.Delete(dirA, recursive: true); } catch { }
+            try { Directory.Delete(dirB, recursive: true); } catch { }
+        }
+    }
+}
+
+/// <summary>--ui-probe flag parsing (#180 Phase 2).</summary>
+public class UiProbeOptionsTests
+{
+    [Fact]
+    public void Absent_ReturnsNullWithoutError()
+    {
+        var options = UiProbeOptions.Parse(["--profileDir", "x"], out var error);
+        Assert.Null(options);
+        Assert.Null(error);
+    }
+
+    [Fact]
+    public void FullInvocation_ParsesEveryKnob()
+    {
+        var options = UiProbeOptions.Parse(
+            ["--ui-probe", "inbox;Reading-Pane", "--theme", "dark", "--text-scale", "150",
+             "--capture-dir", @"C:\shots", "--capture-tag", "01-inbox"], out var error);
+
+        Assert.Null(error);
+        Assert.NotNull(options);
+        Assert.Equal(["inbox", "reading-pane"], options!.Surfaces);
+        Assert.Equal("dark", options.ThemeId);
+        Assert.Equal(1.5, options.TextScale);
+        Assert.Equal(@"C:\shots", options.CaptureDir);
+        Assert.Equal("01-inbox", options.CaptureTag);
+    }
+
+    [Fact]
+    public void MissingSurface_IsAHardError()
+    {
+        var options = UiProbeOptions.Parse(["--ui-probe", "--theme", "dark"], out var error);
+        Assert.Null(options);
+        Assert.NotNull(error);
+    }
+
+    [Theory]
+    [InlineData("99")]
+    [InlineData("201")]
+    [InlineData("large")]
+    public void BadScale_IsAHardError(string scale)
+    {
+        var options = UiProbeOptions.Parse(["--ui-probe", "inbox", "--text-scale", scale], out var error);
+        Assert.Null(options);
+        Assert.NotNull(error);
+    }
+}

--- a/QuickMail.sln
+++ b/QuickMail.sln
@@ -9,6 +9,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QuickMail.Tests", "QuickMai
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QuickMail.IntegrationTests", "QuickMail.IntegrationTests\QuickMail.IntegrationTests.csproj", "{24A85037-C714-49CA-8C31-84290B5DAD2C}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tools", "tools", "{07C2787E-EAC7-C090-1BA3-A61EC2A24D84}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QuickMail.Fixtures", "tools\QuickMail.Fixtures\QuickMail.Fixtures.csproj", "{325F9F3C-7A15-4DE0-A1C6-C83A35B9D125}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -55,8 +59,23 @@ Global
 		{24A85037-C714-49CA-8C31-84290B5DAD2C}.Release|x64.Build.0 = Release|Any CPU
 		{24A85037-C714-49CA-8C31-84290B5DAD2C}.Release|x86.ActiveCfg = Release|Any CPU
 		{24A85037-C714-49CA-8C31-84290B5DAD2C}.Release|x86.Build.0 = Release|Any CPU
+		{325F9F3C-7A15-4DE0-A1C6-C83A35B9D125}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{325F9F3C-7A15-4DE0-A1C6-C83A35B9D125}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{325F9F3C-7A15-4DE0-A1C6-C83A35B9D125}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{325F9F3C-7A15-4DE0-A1C6-C83A35B9D125}.Debug|x64.Build.0 = Debug|Any CPU
+		{325F9F3C-7A15-4DE0-A1C6-C83A35B9D125}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{325F9F3C-7A15-4DE0-A1C6-C83A35B9D125}.Debug|x86.Build.0 = Debug|Any CPU
+		{325F9F3C-7A15-4DE0-A1C6-C83A35B9D125}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{325F9F3C-7A15-4DE0-A1C6-C83A35B9D125}.Release|Any CPU.Build.0 = Release|Any CPU
+		{325F9F3C-7A15-4DE0-A1C6-C83A35B9D125}.Release|x64.ActiveCfg = Release|Any CPU
+		{325F9F3C-7A15-4DE0-A1C6-C83A35B9D125}.Release|x64.Build.0 = Release|Any CPU
+		{325F9F3C-7A15-4DE0-A1C6-C83A35B9D125}.Release|x86.ActiveCfg = Release|Any CPU
+		{325F9F3C-7A15-4DE0-A1C6-C83A35B9D125}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{325F9F3C-7A15-4DE0-A1C6-C83A35B9D125} = {07C2787E-EAC7-C090-1BA3-A61EC2A24D84}
 	EndGlobalSection
 EndGlobal

--- a/QuickMail.sln
+++ b/QuickMail.sln
@@ -11,7 +11,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QuickMail.IntegrationTests"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tools", "tools", "{07C2787E-EAC7-C090-1BA3-A61EC2A24D84}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QuickMail.Fixtures", "tools\QuickMail.Fixtures\QuickMail.Fixtures.csproj", "{325F9F3C-7A15-4DE0-A1C6-C83A35B9D125}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QuickMail.Fixtures", "Tools\QuickMail.Fixtures\QuickMail.Fixtures.csproj", "{325F9F3C-7A15-4DE0-A1C6-C83A35B9D125}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/QuickMail/App.xaml.cs
+++ b/QuickMail/App.xaml.cs
@@ -264,6 +264,16 @@ public partial class App : Application
             // BackendKind rather than defaulting to IMAP.
             var mailRouter = new MailServiceRouter(new IMailService[] { imapBackend, graphBackend }, BackendFor);
 
+            // ui-probe (#180 Decision D): network hard-off at the DI root. EVERY
+            // consumer of the mail/send/oauth services gets the offline no-op —
+            // including RuleService (whose rules-apply path runs when the rules
+            // window closes) and SyncService — so the probe is structurally
+            // incapable of connecting, syncing, or sending, not merely unlikely to.
+            var probeMode = UiProbe != null;
+            IMailService effectiveMail = probeMode ? new ProbeOfflineMailService() : mailRouter;
+            ISendMailService effectiveSmtp = probeMode ? new ProbeOfflineSendMailService() : smtpService;
+            IOAuthService effectiveOAuth = probeMode ? new ProbeOfflineOAuthService() : oauthService;
+
             var localStore = new LocalStoreService(profile);
             if (!onlineMode)
                 localStore.Initialize();
@@ -298,11 +308,11 @@ public partial class App : Application
             _templateService = new TemplateService(profile);
             var templateService = _templateService;
             // accountService drives the one-time "All accounts" → per-account rule migration (#333 D1).
-            var ruleService = new RuleService(mailRouter, localStore, profile.ProfileDir, accountService);
+            var ruleService = new RuleService(effectiveMail, localStore, profile.ProfileDir, accountService);
             // Server-side (Exchange/Graph) Inbox rules — read/manage a Graph account's messageRules.
             // Reuses the shared GraphClient (no own disposables), so no disposal wiring needed.
             var serverRuleService = new GraphServerRuleService(accountService, graphBackend.Client);
-            var syncService = new SyncService(mailRouter, localStore, configService, ruleService);
+            var syncService = new SyncService(effectiveMail, localStore, configService, ruleService);
 
             // Contact sync (issue #256): Graph source reuses the Graph backend's client; Google source
             // gets its own People API client (owns an HttpClient → disposed in OnExit).
@@ -343,7 +353,7 @@ public partial class App : Application
             commandRegistry.ApplyUserOverrides(startupCfg.CustomHotkeys);
 
             var viewService = new ViewService(profile);
-            var flagService = new FlagService(profile, configService, localStore, mailRouter);
+            var flagService = new FlagService(profile, configService, localStore, effectiveMail);
             var customDictionary = new CustomDictionaryService(profile);
 
             // Calendar service: harvests events from the local message cache.
@@ -373,17 +383,9 @@ public partial class App : Application
             // Through the ROUTER, not the IMAP backend: each account must be probed by the backend
             // that actually owns it. Probing a Graph account with the IMAP backend is what produced
             // the first live false alarm.
-            _truthProbe = new ConnectionTruthProbe(
+            _truthProbe = probeMode ? null : new ConnectionTruthProbe(
                 mailRouter,
                 id => accounts.FirstOrDefault(a => a.Id == id)?.AccountLabel ?? id.ToString());
-
-            // ui-probe (#180 Decision D): network hard-off at the DI root. The VM and
-            // window get offline no-op backends and null background services, so the
-            // probe is structurally incapable of connecting, syncing, or sending.
-            var probeMode = UiProbe != null;
-            IMailService effectiveMail = probeMode ? new ProbeOfflineMailService() : mailRouter;
-            ISendMailService effectiveSmtp = probeMode ? new ProbeOfflineSendMailService() : smtpService;
-            IOAuthService effectiveOAuth = probeMode ? new ProbeOfflineOAuthService() : oauthService;
 
             var mainVm = new MainViewModel(
                 effectiveMail, accountService, credentialService, localStore, effectiveOAuth, syncService, configService, commandRegistry, viewService, ruleService, effectiveSmtp,
@@ -524,6 +526,16 @@ public partial class App : Application
     {
         for (var cur = e.Exception; cur != null; cur = cur.InnerException)
             LogService.Log("Dispatcher", cur);
+
+        // ui-probe (#180): unattended — a modal error box would park the run on an
+        // invisible dialog until the orchestrator's kill timeout and destroy the
+        // diagnostic exit code. Log (done above) and exit distinctly instead.
+        if ((Current as App)?.UiProbe != null)
+        {
+            e.Handled = true;
+            Current!.Shutdown(3);
+            return;
+        }
 
         // Keep the process alive so the user isn't left staring at a vanished window.
         // The log captures the cause; the next user action will either succeed or

--- a/QuickMail/App.xaml.cs
+++ b/QuickMail/App.xaml.cs
@@ -19,6 +19,9 @@ public partial class App : Application
     /// </summary>
     public IScreenshotCaptureService? ScreenshotCapture { get; private set; }
 
+    /// <summary>Non-null only in --ui-probe automation mode (#180).</summary>
+    public UiProbeOptions? UiProbe { get; private set; }
+
     // Held so OnExit can dispose them.
     private GraphSendMailService? _graphSendMail;
     private ContactService? _contactService;
@@ -185,7 +188,27 @@ public partial class App : Application
             LogService.Log("Debug mode enabled.");
         }
 
+        // --ui-probe (#180): automation launch mode — implies /debug, forces the
+        // app offline, drives to a surface, captures, exits. Never user-reachable.
+        UiProbe = UiProbeOptions.Parse(e.Args, out var probeError);
+        if (probeError != null)
+        {
+            LogService.Log($"ui-probe: {probeError}");
+            Shutdown(64); // EX_USAGE — the orchestrator must see a hard failure
+            return;
+        }
+        if (UiProbe != null)
+        {
+            LogService.DebugMode = true;
+            LogService.Log($"ui-probe mode: surfaces=[{string.Join(";", UiProbe.Surfaces)}] theme={UiProbe.ThemeId ?? "(configured)"} scale={UiProbe.TextScale?.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? "(configured)"}");
+        }
+
         var onlineMode = e.Args.Contains("--online", StringComparer.OrdinalIgnoreCase);
+        if (onlineMode && UiProbe != null)
+        {
+            LogService.Debug("ui-probe forces offline; --online ignored.");
+            onlineMode = false;
+        }
         if (onlineMode)
             LogService.Log("Online mode enabled — SQLite cache bypassed.");
 
@@ -294,6 +317,14 @@ public partial class App : Application
             var contactSyncService  = new ContactSyncService(accountService, contactService, graphContactSource, googleContactSource, iCloudContactSource);
 
             var startupCfg = configService.Load();
+            // ui-probe (#180): theme/scale land in the loaded config BEFORE
+            // ThemeService.Initialize so the first render is already correct;
+            // ThemeService never persists, so config.ini is untouched.
+            if (UiProbe is { } probeOpts)
+            {
+                if (probeOpts.ThemeId != null) startupCfg.AppearanceThemeId = probeOpts.ThemeId;
+                if (probeOpts.TextScale != null) startupCfg.AppearanceTextScale = probeOpts.TextScale.Value;
+            }
             Views.AccessibilityHelper.Configure(startupCfg);
             LogService.Format  = startupCfg.LogFormat;
             LogService.Enabled = startupCfg.EnableLogging;
@@ -346,18 +377,31 @@ public partial class App : Application
                 mailRouter,
                 id => accounts.FirstOrDefault(a => a.Id == id)?.AccountLabel ?? id.ToString());
 
+            // ui-probe (#180 Decision D): network hard-off at the DI root. The VM and
+            // window get offline no-op backends and null background services, so the
+            // probe is structurally incapable of connecting, syncing, or sending.
+            var probeMode = UiProbe != null;
+            IMailService effectiveMail = probeMode ? new ProbeOfflineMailService() : mailRouter;
+            ISendMailService effectiveSmtp = probeMode ? new ProbeOfflineSendMailService() : smtpService;
+            IOAuthService effectiveOAuth = probeMode ? new ProbeOfflineOAuthService() : oauthService;
+
             var mainVm = new MainViewModel(
-                mailRouter, accountService, credentialService, localStore, oauthService, syncService, configService, commandRegistry, viewService, ruleService, smtpService,
-                onlineMode: onlineMode, flagService: flagService, calendarService: calendarService, changeNotifier: _changeNotifier, updateCheckService: _updateCheckService, screenshotCapture: ScreenshotCapture,
-                themeService: themeService, notificationService: _notificationService, contactSyncService: contactSyncService,
-                graphCalendarSyncService: graphCalendarSync, truthProbe: _truthProbe);
-            mainVm.RegisterAccountBackend = a => mailRouter.RegisterAccount(a.Id, BackendFor(a));
+                effectiveMail, accountService, credentialService, localStore, effectiveOAuth, syncService, configService, commandRegistry, viewService, ruleService, effectiveSmtp,
+                onlineMode: onlineMode, flagService: flagService, calendarService: calendarService,
+                changeNotifier: probeMode ? null : _changeNotifier,
+                updateCheckService: probeMode ? null : _updateCheckService,
+                screenshotCapture: ScreenshotCapture,
+                themeService: themeService, notificationService: _notificationService,
+                contactSyncService: probeMode ? null : contactSyncService,
+                graphCalendarSyncService: probeMode ? null : graphCalendarSync,
+                truthProbe: probeMode ? null : _truthProbe);
+            mainVm.RegisterAccountBackend = a => { if (!probeMode) mailRouter.RegisterAccount(a.Id, BackendFor(a)); };
             // Registers/unregisters the Help command and shows or hides the menu item, and sets
             // ConnectionJournal.Enabled — so nothing records until the user opts in.
             mainVm.ApplyConnectionDiagnosticsSetting(startupCfg.ConnectionDiagnostics);
             mainVm.LoadAccountList(accounts);
 
-            var mainWindow = new MainWindow(mainVm, smtpService, accountService, credentialService, mailRouter, oauthService, commandRegistry, contactService, configService, localStore, viewService, ruleService, templateService, featureGate, flagService, customDictionary, themeService, _bugReportService, _notificationService, contactSyncService, graphCalendarSync, serverRuleService, providerCatalog, _autoDiscoverService, _truthProbe);
+            var mainWindow = new MainWindow(mainVm, effectiveSmtp, accountService, credentialService, effectiveMail, effectiveOAuth, commandRegistry, contactService, configService, localStore, viewService, ruleService, templateService, featureGate, flagService, customDictionary, themeService, _bugReportService, _notificationService, contactSyncService, graphCalendarSync, serverRuleService, providerCatalog, _autoDiscoverService, _truthProbe);
 
             // Clicking a new-mail toast brings QuickMail to the foreground and opens the referenced
             // message. OnActivated may fire on a background thread, so marshal to the UI thread first.

--- a/QuickMail/Services/IScreenshotCaptureService.cs
+++ b/QuickMail/Services/IScreenshotCaptureService.cs
@@ -38,4 +38,13 @@ public interface IScreenshotCaptureService : IDisposable
 
     /// <summary>Opens the session folder in File Explorer.</summary>
     void OpenFolder();
+
+    /// <summary>
+    /// Programmatic capture to an exact path (the #180 probe driver's entry
+    /// point): grabs and saves synchronously, independent of <see cref="Enabled"/>
+    /// — the probe wants deterministic filenames without the session machinery
+    /// (numbering, debounce, title warning). Returns false if the grab or save
+    /// failed.
+    /// </summary>
+    bool CaptureToFile(Window window, string filePath);
 }

--- a/QuickMail/Services/NullScreenshotCaptureService.cs
+++ b/QuickMail/Services/NullScreenshotCaptureService.cs
@@ -22,5 +22,7 @@ public sealed class NullScreenshotCaptureService : IScreenshotCaptureService
 
     public void OpenFolder() { }
 
+    public bool CaptureToFile(Window window, string filePath) => false;
+
     public void Dispose() { }
 }

--- a/QuickMail/Services/ProbeOfflineServices.cs
+++ b/QuickMail/Services/ProbeOfflineServices.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using QuickMail.Models;
+
+namespace QuickMail.Services;
+
+/// <summary>
+/// Offline no-op backends wired at the DI root in --ui-probe mode (#180
+/// Decision D): the probe must be structurally incapable of touching a real
+/// mailbox. Reads return empty; connection state is always disconnected; the
+/// few operations that would leave the machine (send, sign-in) throw so a
+/// probe that somehow reaches them fails loudly instead of silently no-oping.
+/// </summary>
+public sealed class ProbeOfflineMailService : IMailService
+{
+    public Task ConnectAsync(AccountModel account, string? password = null, CancellationToken ct = default) => Task.CompletedTask;
+    public bool IsConnected(Guid accountId) => false;
+    public Task DisconnectAsync(Guid accountId, CancellationToken ct = default) => Task.CompletedTask;
+    public Task<List<MailFolderModel>> GetFoldersAsync(Guid accountId, CancellationToken ct = default) => Task.FromResult(new List<MailFolderModel>());
+    public Task<List<MailMessageSummary>> GetMessageSummariesAsync(Guid accountId, string folderName, int maxMessages, CancellationToken ct = default) => Task.FromResult(new List<MailMessageSummary>());
+    public Task<List<MailMessageSummary>> GetMessagesSinceDateAsync(Guid accountId, string folderName, DateTime since, CancellationToken ct = default) => Task.FromResult(new List<MailMessageSummary>());
+    public Task<List<MailMessageSummary>> GetMessagesSinceAsync(Guid accountId, string folderName, string sinceMessageId, int initialCount, CancellationToken ct = default) => Task.FromResult(new List<MailMessageSummary>());
+    public Task<MailMessageDetail> GetMessageDetailAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default) => Task.FromResult(new MailMessageDetail());
+    public Task<MailMessageDetail> PrefetchMessageDetailAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default) => Task.FromResult(new MailMessageDetail());
+    public Task MarkReadAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default) => Task.CompletedTask;
+    public Task MarkReadBatchAsync(Guid accountId, string folderName, IList<string> messageIds, CancellationToken ct = default) => Task.CompletedTask;
+    public Task SetMessageFlaggedAsync(Guid accountId, string folderName, string messageId, bool flagged, CancellationToken ct = default) => Task.CompletedTask;
+    public Task MoveToTrashAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default) => Task.CompletedTask;
+    public Task MoveToTrashBatchAsync(Guid accountId, string folderName, IList<string> messageIds, CancellationToken ct = default) => Task.CompletedTask;
+    public Task PermanentlyDeleteBatchAsync(Guid accountId, string folderName, IList<string> messageIds, CancellationToken ct = default) => Task.CompletedTask;
+    public Task NoOpAsync(Guid accountId, CancellationToken ct = default) => Task.CompletedTask;
+    public Task<int> CountTrashMessagesAsync(Guid accountId, CancellationToken ct = default) => Task.FromResult(0);
+    public Task<int> EmptyTrashAsync(Guid accountId, CancellationToken ct = default) => Task.FromResult(0);
+    public Task<IList<string>> GetFolderMessageIdsAsync(Guid accountId, string folderName, CancellationToken ct = default) => Task.FromResult<IList<string>>(Array.Empty<string>());
+    public Task<IReadOnlyDictionary<string, string>> FetchPreviewsAsync(Guid accountId, string folderName, IList<string> messageIds, int maxLines, CancellationToken ct = default) => Task.FromResult<IReadOnlyDictionary<string, string>>(new Dictionary<string, string>());
+    public Task<int> PollAsync(Guid accountId, string folderName, CancellationToken ct = default) => Task.FromResult(0);
+    public Task<(int Total, int Unread)> GetInboxStatusAsync(Guid accountId, CancellationToken ct = default) => Task.FromResult((0, 0));
+    public Task<string?> FindDraftsFolderNameAsync(Guid accountId, CancellationToken ct = default) => Task.FromResult<string?>(null);
+    public Task<string> AppendDraftAsync(Guid accountId, ComposeModel draft, string? replaceMessageId, CancellationToken ct = default) => Task.FromResult("0");
+    public Task AppendToSentAsync(Guid accountId, ComposeModel sent, CancellationToken ct = default) => Task.CompletedTask;
+    public Task<byte[]> DownloadAttachmentAsync(Guid accountId, string folderName, string messageId, string partSpecifier, CancellationToken ct = default) => Task.FromResult(Array.Empty<byte>());
+    public Task CopyMessagesAsync(Guid accountId, string folderName, IList<string> messageIds, string destinationFolder, CancellationToken ct = default) => Task.CompletedTask;
+    public Task MoveMessagesAsync(Guid accountId, string folderName, IList<string> messageIds, string destinationFolder, CancellationToken ct = default) => Task.CompletedTask;
+    public Task CreateFolderAsync(Guid accountId, string? parentFolderName, string name, CancellationToken ct = default) => Task.CompletedTask;
+    public Task DeleteFolderAsync(Guid accountId, string folderName, CancellationToken ct = default) => Task.CompletedTask;
+    public Task RenameFolderAsync(Guid accountId, string folderName, string newName, string? newParentFolderName, CancellationToken ct = default) => Task.CompletedTask;
+    public Task CopyFolderAsync(Guid accountId, string folderName, string? destinationParentName, CancellationToken ct = default) => Task.CompletedTask;
+    public void Dispose() { }
+}
+
+public sealed class ProbeOfflineSendMailService : ISendMailService
+{
+    private static Exception Refused() =>
+        new InvalidOperationException("Network is disabled in --ui-probe mode; sending is forbidden.");
+
+    public Task SendAsync(ComposeModel compose, AccountModel account, string? password, CancellationToken ct = default) => Task.FromException(Refused());
+    public Task SendIcsReplyAsync(string icsReplyContent, AccountModel account, string? password, string organizerEmail, CancellationToken ct = default) => Task.FromException(Refused());
+    public Task VerifyAsync(AccountModel account, string? password, CancellationToken ct = default) => Task.FromException(Refused());
+}
+
+public sealed class ProbeOfflineOAuthService : IOAuthService
+{
+    private static Exception Refused() =>
+        new InvalidOperationException("Network is disabled in --ui-probe mode; sign-in is forbidden.");
+
+    public Task<string> GetAccessTokenAsync(AccountModel account, CancellationToken ct = default) => Task.FromException<string>(Refused());
+    public Task<string> GetAccessTokenAsync(AccountModel account, string[] scopes, CancellationToken ct = default) => Task.FromException<string>(Refused());
+    public Task<string> GetAccessTokenSilentAsync(AccountModel account, string[] scopes, CancellationToken ct = default) => Task.FromException<string>(Refused());
+    public Task EnsureSilentTokenAsync(AccountModel account, CancellationToken ct = default) => Task.FromException(Refused());
+    public Task<OAuthResult> SignInInteractiveAsync(AccountModel account, CancellationToken ct = default) => Task.FromException<OAuthResult>(Refused());
+    public Task<OAuthResult> SignInInteractiveWithContactsAsync(AccountModel account, CancellationToken ct = default) => Task.FromException<OAuthResult>(Refused());
+    public Task RequestContactsConsentAsync(AccountModel account, CancellationToken ct = default) => Task.FromException(Refused());
+    public Task RequestCalendarConsentAsync(AccountModel account, CancellationToken ct = default) => Task.FromException(Refused());
+    public Task SignOutAsync(AccountModel account) => Task.FromException(Refused());
+}

--- a/QuickMail/Services/ScreenshotCaptureService.cs
+++ b/QuickMail/Services/ScreenshotCaptureService.cs
@@ -154,6 +154,33 @@ public class ScreenshotCaptureService : IScreenshotCaptureService
         return true;
     }
 
+    public bool CaptureToFile(Window window, string filePath)
+    {
+        if (_disposed) return false;
+        BitmapSource? frame = null;
+        try
+        {
+            frame = (PixelGrabber ?? GrabWindowPixels)(window);
+        }
+        catch (Exception ex)
+        {
+            LogService.Debug($"CaptureToFile grab failed for {Path.GetFileName(filePath)}: {ex.Message}");
+        }
+        if (frame is null) return false;
+        frame.Freeze();
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(filePath)!);
+        }
+        catch (Exception ex)
+        {
+            LogService.Debug($"CaptureToFile folder creation failed: {ex.Message}");
+            return false;
+        }
+        SavePng(frame, filePath);
+        return File.Exists(filePath);
+    }
+
     public void OpenFolder()
     {
         try

--- a/QuickMail/Services/UiProbeFixture.cs
+++ b/QuickMail/Services/UiProbeFixture.cs
@@ -1,0 +1,23 @@
+namespace QuickMail.Services;
+
+/// <summary>
+/// The contract between the fixture generator (tools/QuickMail.Fixtures) and the
+/// probe driver (#180): the driver selects fixture content by these identifiers,
+/// so they live in one place both sides reference. Changing a value here changes
+/// what the generator writes AND what the driver looks for — they cannot drift.
+/// </summary>
+public static class UiProbeFixture
+{
+    /// <summary>The single fixture account.</summary>
+    public static readonly System.Guid AccountId = new("11111111-1111-1111-1111-111111111111");
+
+    public const string InboxFolder = "INBOX";
+    public const string SentFolder = "Sent";
+
+    /// <summary>The HTML-bodied message the reading-pane probe renders.</summary>
+    public const string HtmlMessageId = "1002";
+    public const string HtmlMessageSubject = "Weekly digest: headings, lists, links";
+
+    /// <summary>Fixed clock: every fixture timestamp derives from this instant.</summary>
+    public static readonly System.DateTimeOffset T0 = new(2026, 1, 15, 9, 0, 0, System.TimeSpan.Zero);
+}

--- a/QuickMail/Services/UiProbeOptions.cs
+++ b/QuickMail/Services/UiProbeOptions.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace QuickMail.Services;
+
+/// <summary>
+/// Parsed <c>--ui-probe</c> launch options (#180). The flag is a developer/CI
+/// automation hook, never user-reachable: it implies /debug, forces the app
+/// offline, drives to each named surface, captures a PNG, and exits.
+/// </summary>
+public sealed class UiProbeOptions
+{
+    public IReadOnlyList<string> Surfaces { get; private init; } = [];
+
+    /// <summary>Theme id to apply before the first render (null = configured/system).</summary>
+    public string? ThemeId { get; private init; }
+
+    /// <summary>Text scale factor 1.0–2.0 (from <c>--text-scale &lt;percent&gt;</c>).</summary>
+    public double? TextScale { get; private init; }
+
+    /// <summary>Folder receiving the PNGs (default: current directory).</summary>
+    public string CaptureDir { get; private init; } = "";
+
+    /// <summary>Optional exact file-name stem for the shot (orchestrator-controlled naming).</summary>
+    public string? CaptureTag { get; private init; }
+
+    /// <summary>
+    /// Returns the parsed options, null when <c>--ui-probe</c> is absent. A
+    /// malformed invocation (missing value, bad scale) yields null with
+    /// <paramref name="error"/> set — the caller must exit non-zero, not limp on.
+    /// </summary>
+    public static UiProbeOptions? Parse(string[] args, out string? error)
+    {
+        error = null;
+
+        string? TakeValue(string flag)
+        {
+            for (var i = 0; i < args.Length - 1; i++)
+            {
+                if (string.Equals(args[i], flag, StringComparison.OrdinalIgnoreCase))
+                    return args[i + 1];
+            }
+            return null;
+        }
+
+        var hasFlag = args.Any(a => string.Equals(a, "--ui-probe", StringComparison.OrdinalIgnoreCase));
+        if (!hasFlag) return null;
+
+        var surfacesRaw = TakeValue("--ui-probe");
+        if (string.IsNullOrWhiteSpace(surfacesRaw) || surfacesRaw.StartsWith("--", StringComparison.Ordinal))
+        {
+            error = "--ui-probe requires a surface name (e.g. --ui-probe inbox).";
+            return null;
+        }
+        var surfaces = surfacesRaw
+            .Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(s => s.ToLowerInvariant())
+            .ToList();
+        if (surfaces.Count == 0)
+        {
+            error = "--ui-probe requires at least one surface name.";
+            return null;
+        }
+
+        double? scale = null;
+        var scaleRaw = TakeValue("--text-scale");
+        if (scaleRaw != null)
+        {
+            if (!int.TryParse(scaleRaw, out var pct) || pct < 100 || pct > 200)
+            {
+                error = $"--text-scale must be a percentage 100–200, got \"{scaleRaw}\".";
+                return null;
+            }
+            scale = pct / 100.0;
+        }
+
+        var captureDir = TakeValue("--capture-dir");
+        if (string.IsNullOrWhiteSpace(captureDir))
+            captureDir = Directory.GetCurrentDirectory();
+
+        return new UiProbeOptions
+        {
+            Surfaces = surfaces,
+            ThemeId = TakeValue("--theme"),
+            TextScale = scale,
+            CaptureDir = captureDir,
+            CaptureTag = TakeValue("--capture-tag"),
+        };
+    }
+}

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -1389,7 +1389,13 @@ public partial class MainWindow : Window
         if (_vm.MessageOpenMode != MessageOpenMode.Window)
             await InitReadingPaneWebViewAsync();
 
-        _ = _vm.CheckForUpdateInBackgroundAsync();
+        // ui-probe (#180): no update check, no background sync, no startup dialogs —
+        // the probe boots offline against the fixture cache, drives to its surface,
+        // captures, and exits. Everything network- or dialog-shaped is gated off.
+        var uiProbe = (Application.Current as App)?.UiProbe;
+
+        if (uiProbe is null)
+            _ = _vm.CheckForUpdateInBackgroundAsync();
 
         var firstAccount = _vm.Accounts.FirstOrDefault();
         if (firstAccount == null)
@@ -1409,6 +1415,15 @@ public partial class MainWindow : Window
         // Populate the Views menu from saved views loaded at startup.
         RebuildViewsMenu();
 
+        if (uiProbe != null)
+        {
+            // Fire-and-forget by design: the driver owns the rest of the process
+            // lifetime and exits the app with its own code when done.
+            var capture = ((App)Application.Current).ScreenshotCapture!;
+            _ = new UiProbeDriver(this, _vm, _registry, uiProbe, capture).RunAsync();
+            return;
+        }
+
         // Connect accounts and sync new mail in the background; messages trickle in via FolderSynced.
         _ = _vm.StartBackgroundSyncAsync();
 
@@ -1421,6 +1436,31 @@ public partial class MainWindow : Window
         // offer so a first-run-after-migration launch never stacks two dialogs.
         _vm.MaybeShowUpdateInstalledNotice();
     }
+
+    // ── ui-probe hooks (#180) — internal, driver-only; never user-reachable ──
+
+    /// <summary>Opens the Settings dialog exactly as the menu item would (modal).</summary>
+    internal void ShowSettingsDialogForProbe() => MenuSettings_Click(this, new RoutedEventArgs());
+
+    /// <summary>Opens the command palette exactly as Ctrl+Shift+P would (modal).</summary>
+    internal void OpenCommandPaletteForProbe() => OpenCommandPalette();
+
+    /// <summary>
+    /// Exits the app with the given code, bypassing close-to-tray (which would
+    /// otherwise turn the probe's exit into a minimize and hang the orchestrator).
+    /// </summary>
+    internal void ForceExit(int exitCode)
+    {
+        _explicitExit = true;
+        Application.Current.Shutdown(exitCode);
+    }
+
+    /// <summary>
+    /// Raised when the reading pane has finished rendering a message body —
+    /// after WebView2 NavigationCompleted and the idle turn that lets the frame
+    /// present. The probe driver's settle signal for the reading-pane surface.
+    /// </summary>
+    internal event Action? MessageBodyRendered;
 
     // WM_CONTEXTMENU hook: fires synchronously before DefWindowProc so we can ensure
     // Keyboard.FocusedElement is non-null before WPF routes ContextMenuOpening.
@@ -3084,6 +3124,7 @@ public partial class MainWindow : Window
                 // save the next message's pixels under this message's label.
                 if (renderVersion != _messageBodyRenderVersion) return;
                 (Application.Current as App)?.ScreenshotCapture?.Capture(this, $"ReadingPane-{detail.Subject}");
+                MessageBodyRendered?.Invoke();
             });
 
         await FocusMessageBodyAsync(renderVersion, detail.Subject);

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -1371,9 +1371,14 @@ public partial class MainWindow : Window
         // Create the WebView2 environment — always needed, shared with MessageWindow instances.
         try
         {
-            var userDataFolder = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                "QuickMail", "WebView2");
+            // ui-probe (#180): an isolated, throwaway user-data folder under the
+            // capture dir — the probe must never write outside its own dirs, and
+            // must not contend with a live QuickMail's shared browser instance.
+            var userDataFolder = (Application.Current as App)?.UiProbe is { } probeOptions
+                ? Path.Combine(probeOptions.CaptureDir, "webview2-data")
+                : Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                    "QuickMail", "WebView2");
             _webViewEnvironment = await CoreWebView2Environment.CreateAsync(null, userDataFolder);
         }
         catch (Exception ex)
@@ -1444,6 +1449,14 @@ public partial class MainWindow : Window
 
     /// <summary>Opens the command palette exactly as Ctrl+Shift+P would (modal).</summary>
     internal void OpenCommandPaletteForProbe() => OpenCommandPalette();
+
+    /// <summary>
+    /// Opens AND renders a message exactly as a notification activation would —
+    /// the VM command alone loads the detail but the body render lives in this
+    /// window's open path, so the probe must come through here.
+    /// </summary>
+    internal Task OpenMessageForProbeAsync(Guid accountId, string folder, string messageId) =>
+        OpenMessageByIdentityAsync(accountId, folder, messageId);
 
     /// <summary>
     /// Exits the app with the given code, bypassing close-to-tray (which would

--- a/QuickMail/Views/UiProbeDriver.cs
+++ b/QuickMail/Views/UiProbeDriver.cs
@@ -1,0 +1,336 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Threading;
+using QuickMail.Models;
+using QuickMail.Services;
+using QuickMail.ViewModels;
+
+namespace QuickMail.Views;
+
+/// <summary>
+/// Drives the app to one or more named UI surfaces, captures each as a PNG, and
+/// exits the process (#180 Decision E). Constructed only in --ui-probe mode,
+/// after InitialLoadAsync has populated the cache-first UI. Every surface is
+/// opened through the SAME command/handler the user's menu would invoke — the
+/// probe exercises real paths, never a parallel one.
+///
+/// Modal surfaces (Settings, View Manager, command palette) are opened with a
+/// fire-and-forget dispatcher invoke: their nested message loops keep pumping
+/// the dispatcher queue, so this driver's timer-based polling and captures run
+/// inside the modal loop, and closing the window unblocks it.
+/// </summary>
+internal sealed class UiProbeDriver
+{
+    private static readonly TimeSpan SurfaceTimeout = TimeSpan.FromSeconds(15);
+
+    private readonly MainWindow _window;
+    private readonly MainViewModel _vm;
+    private readonly ICommandRegistry _registry;
+    private readonly UiProbeOptions _options;
+    private readonly IScreenshotCaptureService _capture;
+
+    public UiProbeDriver(MainWindow window, MainViewModel vm, ICommandRegistry registry,
+        UiProbeOptions options, IScreenshotCaptureService capture)
+    {
+        _window = window;
+        _vm = vm;
+        _registry = registry;
+        _options = options;
+        _capture = capture;
+    }
+
+    public async Task RunAsync()
+    {
+        var exitCode = 0;
+        try
+        {
+            if (IsSessionLocked())
+            {
+                // DWM does not composite new windows on the secure desktop; every
+                // capture would be a white frame. Exit distinctly so the
+                // orchestrator can tell "environment unusable" from "surface broke".
+                LogService.Log("ui-probe: desktop session is locked; captures would be blank. Exiting 4.");
+                _window.ForceExit(4);
+                return;
+            }
+            Directory.CreateDirectory(_options.CaptureDir);
+            var index = 0;
+            foreach (var surface in _options.Surfaces)
+            {
+                index++;
+                var ok = await RunSurfaceAsync(surface, index);
+                if (!ok)
+                {
+                    LogService.Log($"ui-probe: surface \"{surface}\" FAILED.");
+                    exitCode = 2;
+                    break;
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            LogService.Log("ui-probe", ex);
+            exitCode = 3;
+        }
+        _window.ForceExit(exitCode);
+    }
+
+    private async Task<bool> RunSurfaceAsync(string surface, int index)
+    {
+        var tag = _options.CaptureTag ?? $"{index:D2}-{surface}";
+        var path = Path.Combine(_options.CaptureDir, tag + ".png");
+        LogService.Debug($"ui-probe: {surface} -> {path}");
+
+        switch (surface)
+        {
+            case "inbox":
+                await IdleAsync();
+                await IdleAsync();
+                return await CaptureSettledAsync(_window, path);
+
+            case "reading-pane":
+                return await CaptureReadingPaneAsync(path);
+
+            case "calendar":
+                ExecuteCommand("view.calendar");
+                await IdleAsync();
+                await IdleAsync();
+                return await CaptureSettledAsync(_window, path);
+
+            case "compose":
+                return await CaptureChildWindowAsync(() => ExecuteCommand("mail.new"),
+                    w => w is ComposeWindow, path);
+
+            case "theme-manager":
+                return await CaptureChildWindowAsync(() => ExecuteCommand("theme.manager.open"),
+                    w => w is ThemeManagerWindow, path);
+
+            case "address-book":
+                return await CaptureChildWindowAsync(() => ExecuteCommand("contacts.openAddressBook"),
+                    w => w is AddressBookWindow, path);
+
+            case "rules":
+                return await CaptureChildWindowAsync(() => ExecuteCommand("mail.rules"),
+                    w => w is RulesManagerWindow or UnifiedRulesWindow, path);
+
+            case "saved-views":
+                return await CaptureChildWindowAsync(() => _vm.ManageViewsCommand.Execute(null),
+                    w => w is ViewManagerWindow, path);
+
+            case "settings-appearance":
+                return await CaptureChildWindowAsync(() => _window.ShowSettingsDialogForProbe(),
+                    w => w is SettingsDialog, path,
+                    prepare: w => SelectTabByHeader((SettingsDialog)w, "ppearance"));
+
+            case "command-palette":
+                return await CaptureChildWindowAsync(() => _window.OpenCommandPaletteForProbe(),
+                    w => w is CommandPaletteWindow, path);
+
+            case "folder-picker":
+                return await CaptureChildWindowAsync(() => ExecuteCommand("view.folderPicker"),
+                    w => w is FolderPickerWindow, path);
+
+            default:
+                LogService.Log($"ui-probe: unknown surface \"{surface}\". Known: inbox, reading-pane, calendar, compose, theme-manager, address-book, rules, saved-views, settings-appearance, command-palette, folder-picker.");
+                return false;
+        }
+    }
+
+    private void ExecuteCommand(string commandId)
+    {
+        var command = _registry.FindById(commandId)
+            ?? throw new InvalidOperationException($"ui-probe: command \"{commandId}\" is not registered.");
+        command.Execute();
+    }
+
+    /// <summary>
+    /// Selects the fixture HTML message and awaits the window's render-complete
+    /// signal (WebView2 NavigationCompleted + an idle turn) — the strongest
+    /// settle signal available, per spec Decision F.
+    /// </summary>
+    private async Task<bool> CaptureReadingPaneAsync(string path)
+    {
+        var rendered = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        void OnRendered() => rendered.TrySetResult(true);
+        _window.MessageBodyRendered += OnRendered;
+        try
+        {
+            // Same stub-summary route OpenCalendarSourceMessage uses: the real
+            // SelectMessageAsync resolves the account and loads the cached detail.
+            _vm.SelectMessageCommand.Execute(new MailMessageSummary
+            {
+                MessageId = UiProbeFixture.HtmlMessageId,
+                AccountId = UiProbeFixture.AccountId,
+                FolderName = UiProbeFixture.InboxFolder,
+                Subject = UiProbeFixture.HtmlMessageSubject,
+            });
+
+            var done = await Task.WhenAny(rendered.Task, Task.Delay(SurfaceTimeout)) == rendered.Task;
+            if (!done)
+            {
+                LogService.Log("ui-probe: reading pane never reported render-complete.");
+                return false;
+            }
+            await IdleAsync();
+            return await CaptureSettledAsync(_window, path);
+        }
+        finally
+        {
+            _window.MessageBodyRendered -= OnRendered;
+        }
+    }
+
+    /// <summary>
+    /// Opens a surface that lives in its own window (modal or modeless), waits
+    /// for the window to appear and settle, captures it, and closes it.
+    /// </summary>
+    private async Task<bool> CaptureChildWindowAsync(Action open, Func<Window, bool> match,
+        string path, Action<Window>? prepare = null)
+    {
+        // Modal ShowDialog would block this method if called directly — fire it
+        // through the dispatcher and poll from within whatever loop is pumping.
+        _ = _window.Dispatcher.BeginInvoke(open);
+
+        Window? child = null;
+        var deadline = Environment.TickCount64 + (long)SurfaceTimeout.TotalMilliseconds;
+        while (child is null && Environment.TickCount64 < deadline)
+        {
+            await Task.Delay(100);
+            child = Application.Current.Windows.OfType<Window>()
+                .FirstOrDefault(w => match(w) && w.IsLoaded && w.IsVisible);
+        }
+        if (child is null)
+        {
+            LogService.Log($"ui-probe: expected window for {Path.GetFileNameWithoutExtension(path)} never appeared.");
+            return false;
+        }
+
+        await IdleAsync();
+        if (prepare != null)
+        {
+            prepare(child);
+            await IdleAsync();
+        }
+        var ok = await CaptureSettledAsync(child, path);
+        child.Close();
+        await IdleAsync();
+        return ok;
+    }
+
+    /// <summary>Selects the TabItem whose header contains the fragment (e.g. Appearance).</summary>
+    private static void SelectTabByHeader(Window window, string headerFragment)
+    {
+        var tabs = FindDescendant<TabControl>(window);
+        if (tabs is null) return;
+        for (var i = 0; i < tabs.Items.Count; i++)
+        {
+            if (tabs.Items[i] is TabItem item &&
+                item.Header?.ToString()?.Contains(headerFragment, StringComparison.OrdinalIgnoreCase) == true)
+            {
+                tabs.SelectedIndex = i;
+                return;
+            }
+        }
+    }
+
+    private static T? FindDescendant<T>(DependencyObject root) where T : DependencyObject
+    {
+        for (var i = 0; i < VisualTreeHelper.GetChildrenCount(root); i++)
+        {
+            var child = VisualTreeHelper.GetChild(root, i);
+            if (child is T typed) return typed;
+            if (FindDescendant<T>(child) is { } found) return found;
+        }
+        return null;
+    }
+
+    private async Task IdleAsync() =>
+        await _window.Dispatcher.InvokeAsync(() => { }, DispatcherPriority.ApplicationIdle);
+
+    // ── Settled capture ───────────────────────────────────────────────────────
+    // Dispatcher idle is not "pixels on screen": a freshly shown WPF window can
+    // reach ApplicationIdle before DWM has composited its first frame, and
+    // PrintWindow then returns a white client area under a painted title bar
+    // (which defeats the single-color fallback). So each capture waits for a
+    // CompositionTarget.Rendering frame plus DwmFlush, and retries while the
+    // client area still reads as one flat color. A window that is STILL blank
+    // after the retries is captured as-is — a genuinely blank surface is
+    // exactly what the AI review exists to flag, so the probe must not hide it.
+
+    private async Task<bool> CaptureSettledAsync(Window window, string path)
+    {
+        for (var attempt = 0; attempt < 5; attempt++)
+        {
+            await IdleAsync();
+            await NextCompositionFrameAsync();
+            try { _ = DwmFlush(); } catch (DllNotFoundException) { }
+            if (_capture.CaptureToFile(window, path) && !ClientAreaLooksBlank(path))
+                return true;
+            await Task.Delay(300);
+        }
+        return File.Exists(path);
+    }
+
+    private static async Task NextCompositionFrameAsync()
+    {
+        var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        EventHandler? handler = null;
+        handler = (_, _) =>
+        {
+            CompositionTarget.Rendering -= handler;
+            tcs.TrySetResult(true);
+        };
+        CompositionTarget.Rendering += handler;
+        // Rendering only fires while WPF has something to draw; don't hang if idle.
+        if (await Task.WhenAny(tcs.Task, Task.Delay(1000)) != tcs.Task)
+            CompositionTarget.Rendering -= handler;
+    }
+
+    /// <summary>True when the image below the title-bar strip is one flat color.</summary>
+    private static bool ClientAreaLooksBlank(string path)
+    {
+        try
+        {
+            var frame = BitmapFrame.Create(new Uri(path), BitmapCreateOptions.IgnoreImageCache, BitmapCacheOption.OnLoad);
+            // Inset past the title bar AND the window border: a 1px dark frame
+            // around a white void otherwise defeats the single-color check.
+            var top = Math.Min(frame.PixelHeight - 2, Math.Max(40, frame.PixelHeight / 10));
+            var margin = Math.Max(8, frame.PixelWidth / 50);
+            var width = frame.PixelWidth - 2 * margin;
+            var height = frame.PixelHeight - top - margin;
+            if (width <= 0 || height <= 0) return false;
+            var client = new CroppedBitmap(frame, new Int32Rect(margin, top, width, height));
+            return ScreenshotCaptureService.IsSingleColor(client);
+        }
+        catch (Exception)
+        {
+            return false; // unreadable file is a different failure; don't loop on it
+        }
+    }
+
+    [DllImport("dwmapi.dll")]
+    private static extern int DwmFlush();
+
+    /// <summary>True when the interactive desktop is not available (locked/secure desktop).</summary>
+    private static bool IsSessionLocked()
+    {
+        const uint DESKTOP_READOBJECTS = 0x0001;
+        var desktop = OpenInputDesktop(0, false, DESKTOP_READOBJECTS);
+        if (desktop == IntPtr.Zero) return true;
+        _ = CloseDesktop(desktop);
+        return false;
+    }
+
+    [DllImport("user32.dll", SetLastError = true)]
+    private static extern IntPtr OpenInputDesktop(uint flags, bool inherit, uint desiredAccess);
+
+    [DllImport("user32.dll")]
+    private static extern bool CloseDesktop(IntPtr hDesktop);
+}

--- a/QuickMail/Views/UiProbeDriver.cs
+++ b/QuickMail/Views/UiProbeDriver.cs
@@ -166,15 +166,10 @@ internal sealed class UiProbeDriver
         _window.MessageBodyRendered += OnRendered;
         try
         {
-            // Same stub-summary route OpenCalendarSourceMessage uses: the real
-            // SelectMessageAsync resolves the account and loads the cached detail.
-            _vm.SelectMessageCommand.Execute(new MailMessageSummary
-            {
-                MessageId = UiProbeFixture.HtmlMessageId,
-                AccountId = UiProbeFixture.AccountId,
-                FolderName = UiProbeFixture.InboxFolder,
-                Subject = UiProbeFixture.HtmlMessageSubject,
-            });
+            // Through the window's open path (the notification-activation route):
+            // the VM command alone loads the detail but never renders the body.
+            _ = _window.OpenMessageForProbeAsync(
+                UiProbeFixture.AccountId, UiProbeFixture.InboxFolder, UiProbeFixture.HtmlMessageId);
 
             var done = await Task.WhenAny(rendered.Task, Task.Delay(SurfaceTimeout)) == rendered.Task;
             if (!done)

--- a/QuickMail/Views/UiProbeDriver.cs
+++ b/QuickMail/Views/UiProbeDriver.cs
@@ -84,7 +84,11 @@ internal sealed class UiProbeDriver
 
     private async Task<bool> RunSurfaceAsync(string surface, int index)
     {
-        var tag = _options.CaptureTag ?? $"{index:D2}-{surface}";
+        // With multiple surfaces, a bare --capture-tag would make every shot
+        // overwrite the last; suffix the index so each keeps a distinct file.
+        var tag = _options.CaptureTag is { } custom
+            ? _options.Surfaces.Count > 1 ? $"{custom}-{index:D2}" : custom
+            : $"{index:D2}-{surface}";
         var path = Path.Combine(_options.CaptureDir, tag + ".png");
         LogService.Debug($"ui-probe: {surface} -> {path}");
 
@@ -212,16 +216,23 @@ internal sealed class UiProbeDriver
             return false;
         }
 
-        await IdleAsync();
-        if (prepare != null)
+        try
         {
-            prepare(child);
+            await IdleAsync();
+            if (prepare != null)
+            {
+                prepare(child);
+                await IdleAsync();
+            }
+            return await CaptureSettledAsync(child, path);
+        }
+        finally
+        {
+            // Always close: a leaked modal child would leave its nested message
+            // loop running while RunAsync tries to shut the app down.
+            try { child.Close(); } catch (Exception ex) { LogService.Debug($"ui-probe: child close failed: {ex.Message}"); }
             await IdleAsync();
         }
-        var ok = await CaptureSettledAsync(child, path);
-        child.Close();
-        await IdleAsync();
-        return ok;
     }
 
     /// <summary>Selects the TabItem whose header contains the fragment (e.g. Appearance).</summary>

--- a/Tools/QuickMail.Fixtures/DefaultFixtureSet.cs
+++ b/Tools/QuickMail.Fixtures/DefaultFixtureSet.cs
@@ -1,0 +1,278 @@
+using System.Text;
+using QuickMail.Models;
+using QuickMail.Services;
+
+namespace QuickMail.Fixtures;
+
+/// <summary>
+/// The deterministic "default" fixture set (#180 spec §6): one account, seeded
+/// Inbox/Sent mail covering every visually risky case, plus contacts, a custom
+/// flag, a saved view, a rule, a template, and calendar events. Fixed GUIDs and
+/// a fixed clock (UiProbeFixture.T0) — no Guid.NewGuid(), no DateTime.Now — so
+/// two runs produce byte-identical content and probe shots are diffable.
+/// </summary>
+public static class DefaultFixtureSet
+{
+    private static readonly Guid AccountId = UiProbeFixture.AccountId;
+    private static DateTimeOffset T0 => UiProbeFixture.T0;
+
+    public static async Task<string> WriteAsync(string profileDir)
+    {
+        var profile = new ProfileContext(profileDir);
+
+        // ── Account ──────────────────────────────────────────────────────────
+        // Hosts use example.com (outside ProviderCatalog) so AccountStartupRepair
+        // never rewrites accounts.json at boot; automation mode never contacts them.
+        var accountService = new AccountService(profile);
+        accountService.SaveAccounts(
+        [
+            new AccountModel
+            {
+                Id = AccountId,
+                AccountName = "Test",
+                DisplayName = "Test User",
+                Username = "test@example.com",
+                AuthType = AuthType.Password,
+                ImapHost = "imap.example.com", ImapPort = 993, ImapUseSsl = true,
+                SmtpHost = "smtp.example.com", SmtpPort = 587,
+                IsDefault = true,
+            },
+        ]);
+
+        // ── Config: suppress first-run UI so probe shots show the app, not a tutorial ──
+        var configService = new ConfigService(profile);
+        var cfg = configService.Load();
+        cfg.TutorialCompleted = true;
+        cfg.CloseToTray = false;   // the probe's exit must be an exit, not a minimize
+        configService.Save(cfg);
+
+        // ── Mail: through the real store so the schema is always current ─────
+        var localStore = new LocalStoreService(profile);
+        localStore.Initialize();
+
+        var inbox = new List<MailMessageSummary>
+        {
+            Summary("1001", UiProbeFixture.InboxFolder, "Ava Chen", "Quick question",
+                hoursAgo: 1, isRead: false,
+                preview: "Do you have five minutes today to look at the draft?"),
+            Summary(UiProbeFixture.HtmlMessageId, UiProbeFixture.InboxFolder, "Newsletter Weekly",
+                UiProbeFixture.HtmlMessageSubject,
+                hoursAgo: 3, isRead: true,
+                preview: "This week: headings, lists, links, and a blockquote."),
+            Summary("1003", UiProbeFixture.InboxFolder, "Ben Ortiz", "Invoice attached — please review",
+                hoursAgo: 5, isRead: false, isServerFlagged: true,
+                preview: "Flagged for follow-up before Friday."),
+            Summary("1004", UiProbeFixture.InboxFolder, "Files Team", "Q4 report",
+                hoursAgo: 8, isRead: true,
+                preview: "The quarterly report is attached as a PDF."),
+            Summary("1005", UiProbeFixture.InboxFolder,
+                "Extraordinarily Long Sender Display Name That Should Ellipsize Somewhere Sensible",
+                "This subject line is pathologically long on purpose so that truncation, wrapping, and ellipsis behavior in every theme and text scale is exercised by a single deterministic fixture row",
+                hoursAgo: 26, isRead: false,
+                preview: "Long-subject rendering check."),
+            Summary("1006", UiProbeFixture.InboxFolder, "dev-list@example.com", "[dev-list] Build 4821 is green",
+                hoursAgo: 30, isRead: true, isMailingList: true,
+                preview: "All 2,258 tests passed on the main branch."),
+            Summary("1007", UiProbeFixture.InboxFolder, "Dana Organizer", "Project X planning session",
+                hoursAgo: 2, isRead: false,
+                preview: "You are invited to the Project X planning session."),
+        };
+        var sent = new List<MailMessageSummary>
+        {
+            Summary("2001", UiProbeFixture.SentFolder, "Test User", "Re: Quick question",
+                hoursAgo: 4, isRead: true, to: "Ava Chen <ava@example.com>",
+                preview: "Sure — free after 2pm."),
+            Summary("2002", UiProbeFixture.SentFolder, "Test User", "Notes from Tuesday",
+                hoursAgo: 40, isRead: true, to: "Ben Ortiz <ben@example.com>",
+                preview: "Attaching my notes from the Tuesday sync."),
+        };
+        await localStore.UpsertSummariesAsync(inbox);
+        await localStore.UpsertSummariesAsync(sent);
+
+        await localStore.UpsertDetailAsync(Detail(inbox[0],
+            plain: "Do you have five minutes today to look at the draft?\n\nThanks,\nAva"));
+        await localStore.UpsertDetailAsync(Detail(inbox[1], html:
+            "<h1>Weekly digest</h1>" +
+            "<p>This week's items, rendered as real HTML:</p>" +
+            "<h2>Highlights</h2>" +
+            "<ul><li>First list item</li><li>Second list item with a <a href=\"https://example.com\">link</a></li><li>Third item</li></ul>" +
+            "<blockquote>A blockquote to exercise quoted styling in the reading pane.</blockquote>" +
+            "<p>Plain closing paragraph.</p>"));
+        await localStore.UpsertDetailAsync(Detail(inbox[2],
+            plain: "Please review the attached invoice before Friday.\n\n— Ben"));
+        await localStore.UpsertDetailAsync(Detail(inbox[3],
+            plain: "The quarterly report is attached as a PDF.",
+            attachments:
+            [
+                new AttachmentModel
+                {
+                    FileName = "Q4-report.pdf",
+                    ContentType = "application/pdf",
+                    FileSize = 245_760,
+                    PartSpecifier = "2",
+                },
+            ]));
+        await localStore.UpsertDetailAsync(Detail(inbox[4],
+            plain: "Body of the long-subject message."));
+        await localStore.UpsertDetailAsync(Detail(inbox[5],
+            plain: "All 2,258 tests passed on the main branch.\n\n-- \ndev-list"));
+        await localStore.UpsertDetailAsync(Detail(inbox[6],
+            plain: "You are invited to the Project X planning session.",
+            calendarIcs: InviteIcs));
+        await localStore.UpsertDetailAsync(Detail(sent[0], plain: "Sure — free after 2pm."));
+        await localStore.UpsertDetailAsync(Detail(sent[1], plain: "Attaching my notes from the Tuesday sync."));
+
+        // ── Calendar events (locally-authored; IsGraph stays false) ──────────
+        await localStore.UpsertCalendarEventAsync(new CalendarEvent
+        {
+            Uid = "fixture-event-0001@example.com",
+            AccountId = Guid.Empty,
+            Summary = "Team stand-up",
+            Location = "Room 4",
+            StartTimeTicks = T0.AddDays(1).AddHours(1).UtcTicks,
+            EndTimeTicks = T0.AddDays(1).AddHours(1.5).UtcTicks,
+        });
+        await localStore.UpsertCalendarEventAsync(new CalendarEvent
+        {
+            Uid = "fixture-event-0002@example.com",
+            AccountId = Guid.Empty,
+            Summary = "Release day",
+            IsAllDay = true,
+            StartTimeTicks = T0.AddDays(3).UtcTicks,
+            EndTimeTicks = T0.AddDays(4).UtcTicks,
+        });
+
+        // ── Supporting state, each through its real service ──────────────────
+        var contactService = new ContactService(profile);
+        foreach (var (name, email) in new[]
+        {
+            ("Ava Chen", "ava@example.com"),
+            ("Ben Ortiz", "ben@example.com"),
+            ("Dana Organizer", "dana@example.com"),
+            ("Newsletter Weekly", "news@example.com"),
+        })
+        {
+            await contactService.UpsertContactAsync(new ContactModel
+            {
+                DisplayName = name,
+                EmailAddress = email,
+                LastUsedTicks = T0.UtcTicks,
+            });
+        }
+        var groupId = await contactService.CreateGroupAsync("Project X team");
+        await contactService.AddMemberAsync(groupId, 1);   // ids are deterministic: max+1 from empty
+        await contactService.AddMemberAsync(groupId, 2);
+
+        var offlineMail = new ProbeOfflineMailService();
+        var flagService = new FlagService(profile, configService, localStore, offlineMail);
+        await flagService.SaveFlagDefinitionsAsync(
+        [
+            FlagDefinition.CreateBuiltIn(),
+            new FlagDefinition
+            {
+                Id = new Guid("22222222-2222-2222-2222-222222222222"),
+                Name = "Follow up",
+                ColorHex = "#C05621",
+                SortOrder = 1,
+            },
+        ]);
+
+        new ViewService(profile).Save(
+        [
+            new SavedView
+            {
+                Id = new Guid("33333333-3333-3333-3333-333333333333"),
+                Name = "All mail, unread",
+                VirtualFolderKey = "AllMail",
+                ViewMode = "messages",
+                Filter = "unread",
+                Sort = "dateDesc",
+            },
+        ]);
+
+        new RuleService(offlineMail, localStore, profile.ProfileDir, accountService).SaveRules(
+        [
+            new MailRule
+            {
+                Id = new Guid("44444444-4444-4444-4444-444444444444"),
+                Name = "Mark invoices read",
+                AccountId = AccountId,
+                UseSubjectCondition = true,
+                SubjectContains = "invoice",
+                Action = RuleAction.MarkAsRead,
+            },
+        ]);
+
+        await new TemplateService(profile).AddAsync(new MessageTemplate
+        {
+            Title = "Status update",
+            Subject = "Weekly status",
+            Body = "Progress this week:\n- \n\nBlockers:\n- none",
+        });
+
+        var report = new StringBuilder();
+        report.AppendLine($"Fixture profile written to {profileDir}");
+        report.AppendLine($"  account: Test User <test@example.com> ({AccountId})");
+        report.AppendLine($"  mail: {inbox.Count} inbox + {sent.Count} sent (clock T0 = {T0:u})");
+        report.AppendLine("  plus: 2 calendar events, 4 contacts + 1 group, 1 custom flag, 1 saved view, 1 rule, 1 template");
+        return report.ToString();
+    }
+
+    private static MailMessageSummary Summary(string id, string folder, string from, string subject,
+        double hoursAgo, bool isRead, string preview, string? to = null,
+        bool isServerFlagged = false, bool isMailingList = false) => new()
+    {
+        MessageId = id,
+        AccountId = AccountId,
+        FolderName = folder,
+        InternetMessageId = $"<msg-{id}@example.com>",
+        From = from,
+        To = to ?? "Test User <test@example.com>",
+        Subject = subject,
+        Date = T0.AddHours(-hoursAgo),
+        IsRead = isRead,
+        Preview = preview,
+        IsServerFlagged = isServerFlagged,
+        IsMailingList = isMailingList,
+    };
+
+    private static MailMessageDetail Detail(MailMessageSummary summary, string? plain = null,
+        string? html = null, List<AttachmentModel>? attachments = null, string calendarIcs = "")
+    {
+        var detail = new MailMessageDetail
+        {
+            MessageId = summary.MessageId,
+            AccountId = summary.AccountId,
+            FolderName = summary.FolderName,
+            InternetMessageId = summary.InternetMessageId,
+            From = summary.From,
+            To = summary.To,
+            Subject = summary.Subject,
+            Date = summary.Date,
+            IsRead = summary.IsRead,
+            PlainTextBody = plain ?? string.Empty,
+            HtmlBody = html ?? string.Empty,
+            CalendarIcs = calendarIcs,
+        };
+        if (attachments != null)
+            detail.Attachments = attachments;
+        return detail;
+    }
+
+    private const string InviteIcs =
+        "BEGIN:VCALENDAR\r\n" +
+        "VERSION:2.0\r\n" +
+        "PRODID:-//QuickMail Fixtures//EN\r\n" +
+        "METHOD:REQUEST\r\n" +
+        "BEGIN:VEVENT\r\n" +
+        "UID:fixture-invite-0001@example.com\r\n" +
+        "DTSTAMP:20260115T090000Z\r\n" +
+        "DTSTART:20260122T170000Z\r\n" +
+        "DTEND:20260122T180000Z\r\n" +
+        "SUMMARY:Project X planning session\r\n" +
+        "LOCATION:Room 4\r\n" +
+        "ORGANIZER;CN=Dana Organizer:mailto:dana@example.com\r\n" +
+        "ATTENDEE;CN=Test User;PARTSTAT=NEEDS-ACTION:mailto:test@example.com\r\n" +
+        "END:VEVENT\r\n" +
+        "END:VCALENDAR\r\n";
+}

--- a/Tools/QuickMail.Fixtures/Program.cs
+++ b/Tools/QuickMail.Fixtures/Program.cs
@@ -1,0 +1,33 @@
+using System.IO;
+using QuickMail.Fixtures;
+
+// Fixture generator CLI (#180 Phase 1):
+//   dotnet run --project tools/QuickMail.Fixtures -- --out <dir>
+// Writes a complete, deterministic QuickMail profile (accounts.json, mail.db,
+// contacts.json, flags.json, views.json, rules.json, templates.json, config.ini)
+// through the app's REAL persistence services — never hand-rolled SQL/JSON —
+// so schema migrations can never desync the fixtures (spec Decision A).
+
+string? outDir = null;
+for (var i = 0; i < args.Length - 1; i++)
+{
+    if (string.Equals(args[i], "--out", StringComparison.OrdinalIgnoreCase))
+        outDir = args[i + 1];
+}
+if (string.IsNullOrWhiteSpace(outDir))
+{
+    Console.Error.WriteLine("Usage: QuickMail.Fixtures --out <profileDir>");
+    return 64;
+}
+
+try
+{
+    var summary = await DefaultFixtureSet.WriteAsync(Path.GetFullPath(outDir));
+    Console.WriteLine(summary);
+    return 0;
+}
+catch (Exception ex)
+{
+    Console.Error.WriteLine($"Fixture generation failed: {ex}");
+    return 1;
+}

--- a/Tools/QuickMail.Fixtures/QuickMail.Fixtures.csproj
+++ b/Tools/QuickMail.Fixtures/QuickMail.Fixtures.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <!-- QuickMail.csproj is a self-contained executable; NETSDK1151 requires
+         consumers to be self-contained too. -->
+    <SelfContained>true</SelfContained>
+    <UseWPF>true</UseWPF>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <!-- Dev tooling (#180): writes deterministic fixture profiles through the
+         app's real persistence services. Never shipped. -->
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\QuickMail\QuickMail.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/scripts/ui-probe-plan.json
+++ b/scripts/ui-probe-plan.json
@@ -1,40 +1,155 @@
 {
-  "comment": "Default probe plan for scripts/ui-probe.ps1 (#180). Each entry launches QuickMail.exe --ui-probe <surface> --theme <theme> --text-scale <scale> once. Surfaces are the names UiProbeDriver understands. Per spec §13.2: all surfaces x {parchment, dark} at 100%, plus the full set at 150% in Parchment.",
+  "comment": "Default probe plan for scripts/ui-probe.ps1 (#180). Each entry launches QuickMail.exe --ui-probe <surface> --theme <theme> --text-scale <scale> once. Surfaces are the names UiProbeDriver understands. Per spec \u00a713.2: all surfaces x {parchment, dark} at 100%, plus the full set at 150% in Parchment. folder-picker is EXCLUDED offline: the folder cache only exists after an IMAP connect, so the picker's open path early-returns (documented #180 v1 limitation).",
   "entries": [
-    { "surface": "inbox",               "theme": "parchment", "scale": 100 },
-    { "surface": "reading-pane",        "theme": "parchment", "scale": 100 },
-    { "surface": "compose",             "theme": "parchment", "scale": 100 },
-    { "surface": "settings-appearance", "theme": "parchment", "scale": 100 },
-    { "surface": "theme-manager",       "theme": "parchment", "scale": 100 },
-    { "surface": "address-book",        "theme": "parchment", "scale": 100 },
-    { "surface": "rules",               "theme": "parchment", "scale": 100 },
-    { "surface": "saved-views",         "theme": "parchment", "scale": 100 },
-    { "surface": "calendar",            "theme": "parchment", "scale": 100 },
-    { "surface": "command-palette",     "theme": "parchment", "scale": 100 },
-    { "surface": "folder-picker",       "theme": "parchment", "scale": 100 },
-
-    { "surface": "inbox",               "theme": "dark", "scale": 100 },
-    { "surface": "reading-pane",        "theme": "dark", "scale": 100 },
-    { "surface": "compose",             "theme": "dark", "scale": 100 },
-    { "surface": "settings-appearance", "theme": "dark", "scale": 100 },
-    { "surface": "theme-manager",       "theme": "dark", "scale": 100 },
-    { "surface": "address-book",        "theme": "dark", "scale": 100 },
-    { "surface": "rules",               "theme": "dark", "scale": 100 },
-    { "surface": "saved-views",         "theme": "dark", "scale": 100 },
-    { "surface": "calendar",            "theme": "dark", "scale": 100 },
-    { "surface": "command-palette",     "theme": "dark", "scale": 100 },
-    { "surface": "folder-picker",       "theme": "dark", "scale": 100 },
-
-    { "surface": "inbox",               "theme": "parchment", "scale": 150 },
-    { "surface": "reading-pane",        "theme": "parchment", "scale": 150 },
-    { "surface": "compose",             "theme": "parchment", "scale": 150 },
-    { "surface": "settings-appearance", "theme": "parchment", "scale": 150 },
-    { "surface": "theme-manager",       "theme": "parchment", "scale": 150 },
-    { "surface": "address-book",        "theme": "parchment", "scale": 150 },
-    { "surface": "rules",               "theme": "parchment", "scale": 150 },
-    { "surface": "saved-views",         "theme": "parchment", "scale": 150 },
-    { "surface": "calendar",            "theme": "parchment", "scale": 150 },
-    { "surface": "command-palette",     "theme": "parchment", "scale": 150 },
-    { "surface": "folder-picker",       "theme": "parchment", "scale": 150 }
+    {
+      "surface": "inbox",
+      "theme": "parchment",
+      "scale": 100
+    },
+    {
+      "surface": "reading-pane",
+      "theme": "parchment",
+      "scale": 100
+    },
+    {
+      "surface": "compose",
+      "theme": "parchment",
+      "scale": 100
+    },
+    {
+      "surface": "settings-appearance",
+      "theme": "parchment",
+      "scale": 100
+    },
+    {
+      "surface": "theme-manager",
+      "theme": "parchment",
+      "scale": 100
+    },
+    {
+      "surface": "address-book",
+      "theme": "parchment",
+      "scale": 100
+    },
+    {
+      "surface": "rules",
+      "theme": "parchment",
+      "scale": 100
+    },
+    {
+      "surface": "saved-views",
+      "theme": "parchment",
+      "scale": 100
+    },
+    {
+      "surface": "calendar",
+      "theme": "parchment",
+      "scale": 100
+    },
+    {
+      "surface": "command-palette",
+      "theme": "parchment",
+      "scale": 100
+    },
+    {
+      "surface": "inbox",
+      "theme": "dark",
+      "scale": 100
+    },
+    {
+      "surface": "reading-pane",
+      "theme": "dark",
+      "scale": 100
+    },
+    {
+      "surface": "compose",
+      "theme": "dark",
+      "scale": 100
+    },
+    {
+      "surface": "settings-appearance",
+      "theme": "dark",
+      "scale": 100
+    },
+    {
+      "surface": "theme-manager",
+      "theme": "dark",
+      "scale": 100
+    },
+    {
+      "surface": "address-book",
+      "theme": "dark",
+      "scale": 100
+    },
+    {
+      "surface": "rules",
+      "theme": "dark",
+      "scale": 100
+    },
+    {
+      "surface": "saved-views",
+      "theme": "dark",
+      "scale": 100
+    },
+    {
+      "surface": "calendar",
+      "theme": "dark",
+      "scale": 100
+    },
+    {
+      "surface": "command-palette",
+      "theme": "dark",
+      "scale": 100
+    },
+    {
+      "surface": "inbox",
+      "theme": "parchment",
+      "scale": 150
+    },
+    {
+      "surface": "reading-pane",
+      "theme": "parchment",
+      "scale": 150
+    },
+    {
+      "surface": "compose",
+      "theme": "parchment",
+      "scale": 150
+    },
+    {
+      "surface": "settings-appearance",
+      "theme": "parchment",
+      "scale": 150
+    },
+    {
+      "surface": "theme-manager",
+      "theme": "parchment",
+      "scale": 150
+    },
+    {
+      "surface": "address-book",
+      "theme": "parchment",
+      "scale": 150
+    },
+    {
+      "surface": "rules",
+      "theme": "parchment",
+      "scale": 150
+    },
+    {
+      "surface": "saved-views",
+      "theme": "parchment",
+      "scale": 150
+    },
+    {
+      "surface": "calendar",
+      "theme": "parchment",
+      "scale": 150
+    },
+    {
+      "surface": "command-palette",
+      "theme": "parchment",
+      "scale": 150
+    }
   ]
 }

--- a/scripts/ui-probe-plan.json
+++ b/scripts/ui-probe-plan.json
@@ -1,0 +1,40 @@
+{
+  "comment": "Default probe plan for scripts/ui-probe.ps1 (#180). Each entry launches QuickMail.exe --ui-probe <surface> --theme <theme> --text-scale <scale> once. Surfaces are the names UiProbeDriver understands. Per spec §13.2: all surfaces x {parchment, dark} at 100%, plus the full set at 150% in Parchment.",
+  "entries": [
+    { "surface": "inbox",               "theme": "parchment", "scale": 100 },
+    { "surface": "reading-pane",        "theme": "parchment", "scale": 100 },
+    { "surface": "compose",             "theme": "parchment", "scale": 100 },
+    { "surface": "settings-appearance", "theme": "parchment", "scale": 100 },
+    { "surface": "theme-manager",       "theme": "parchment", "scale": 100 },
+    { "surface": "address-book",        "theme": "parchment", "scale": 100 },
+    { "surface": "rules",               "theme": "parchment", "scale": 100 },
+    { "surface": "saved-views",         "theme": "parchment", "scale": 100 },
+    { "surface": "calendar",            "theme": "parchment", "scale": 100 },
+    { "surface": "command-palette",     "theme": "parchment", "scale": 100 },
+    { "surface": "folder-picker",       "theme": "parchment", "scale": 100 },
+
+    { "surface": "inbox",               "theme": "dark", "scale": 100 },
+    { "surface": "reading-pane",        "theme": "dark", "scale": 100 },
+    { "surface": "compose",             "theme": "dark", "scale": 100 },
+    { "surface": "settings-appearance", "theme": "dark", "scale": 100 },
+    { "surface": "theme-manager",       "theme": "dark", "scale": 100 },
+    { "surface": "address-book",        "theme": "dark", "scale": 100 },
+    { "surface": "rules",               "theme": "dark", "scale": 100 },
+    { "surface": "saved-views",         "theme": "dark", "scale": 100 },
+    { "surface": "calendar",            "theme": "dark", "scale": 100 },
+    { "surface": "command-palette",     "theme": "dark", "scale": 100 },
+    { "surface": "folder-picker",       "theme": "dark", "scale": 100 },
+
+    { "surface": "inbox",               "theme": "parchment", "scale": 150 },
+    { "surface": "reading-pane",        "theme": "parchment", "scale": 150 },
+    { "surface": "compose",             "theme": "parchment", "scale": 150 },
+    { "surface": "settings-appearance", "theme": "parchment", "scale": 150 },
+    { "surface": "theme-manager",       "theme": "parchment", "scale": 150 },
+    { "surface": "address-book",        "theme": "parchment", "scale": 150 },
+    { "surface": "rules",               "theme": "parchment", "scale": 150 },
+    { "surface": "saved-views",         "theme": "parchment", "scale": 150 },
+    { "surface": "calendar",            "theme": "parchment", "scale": 150 },
+    { "surface": "command-palette",     "theme": "parchment", "scale": 150 },
+    { "surface": "folder-picker",       "theme": "parchment", "scale": 150 }
+  ]
+}

--- a/scripts/ui-probe.ps1
+++ b/scripts/ui-probe.ps1
@@ -1,0 +1,117 @@
+<#
+.SYNOPSIS
+  UI probe orchestrator (#180 Phase 3): seed a fixture profile, launch QuickMail
+  once per probe-plan entry to capture a screenshot of each surface, and collect
+  the PNGs into a run folder.
+
+.DESCRIPTION
+  Steps:
+    1. Build (unless -NoBuild) the app and the fixture generator.
+    2. Generate a deterministic fixture profile into a temp dir (or -ProfileDir).
+    3. For each (surface, theme, scale) in the plan, run
+         QuickMail.exe --ui-probe <surface> --theme <theme> --text-scale <scale>
+                       --profileDir <fixture> --capture-dir <run>
+       with a bounded timeout. A hang or non-zero exit fails that entry, not the run.
+    4. Print a summary and exit non-zero if any entry failed or produced no PNG.
+
+  AI review (#180 Phase 4) runs over the run folder afterwards using
+  scripts/ui-review-prompt.md — from Claude Code:  "review the run folder at <path>
+  with scripts/ui-review-prompt.md". This script stops at the collection step so the
+  orchestration stays deterministic and the judgment stays in the model.
+
+.PARAMETER Plan     Path to a probe plan JSON (default scripts/ui-probe-plan.json).
+.PARAMETER RunDir   Output folder for PNGs (default <temp>\qm-ui-probe\<timestamp>).
+.PARAMETER ProfileDir  Existing fixture profile to reuse (default: generate fresh).
+.PARAMETER TimeoutSeconds  Per-probe timeout (default 45).
+.PARAMETER NoBuild  Skip dotnet build (use existing Debug binaries).
+#>
+[CmdletBinding()]
+param(
+    [string]$Plan = "$PSScriptRoot\ui-probe-plan.json",
+    [string]$RunDir = "",
+    [string]$ProfileDir = "",
+    [int]$TimeoutSeconds = 45,
+    [switch]$NoBuild
+)
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = Split-Path $PSScriptRoot -Parent
+$exe      = Join-Path $repoRoot 'QuickMail\bin\Debug\QuickMail.exe'
+$fixtures = Join-Path $repoRoot 'tools\QuickMail.Fixtures\QuickMail.Fixtures.csproj'
+
+if (-not $RunDir) {
+    $RunDir = Join-Path $env:TEMP ("qm-ui-probe\" + (Get-Date -Format 'yyyyMMdd-HHmmss'))
+}
+New-Item -ItemType Directory -Force $RunDir | Out-Null
+
+if (-not $NoBuild) {
+    Write-Host "Building QuickMail (Debug) and the fixture generator..."
+    dotnet build (Join-Path $repoRoot 'QuickMail\QuickMail.csproj') -c Debug --nologo -v quiet
+    if ($LASTEXITCODE -ne 0) { throw "QuickMail build failed." }
+    dotnet build $fixtures -c Debug --nologo -v quiet
+    if ($LASTEXITCODE -ne 0) { throw "Fixture generator build failed." }
+}
+if (-not (Test-Path $exe)) { throw "Not found: $exe (build first or drop -NoBuild)" }
+
+if (-not $ProfileDir) {
+    $ProfileDir = Join-Path $RunDir 'profile'
+    Write-Host "Seeding fixture profile at $ProfileDir ..."
+    dotnet run --project $fixtures -c Debug --no-build -- --out $ProfileDir
+    if ($LASTEXITCODE -ne 0) { throw "Fixture generation failed." }
+}
+if (-not (Test-Path (Join-Path $ProfileDir 'mail.db'))) {
+    throw "Fixture profile at $ProfileDir has no mail.db."
+}
+
+# A locked session means DWM never composites new windows: every capture would
+# come out white. Fail fast with a clear message instead of a folder of blanks.
+if (Get-Process LogonUI -ErrorAction SilentlyContinue) {
+    throw "The desktop session is locked. WPF windows cannot render on the secure desktop, so probe captures would be blank. Unlock the machine (or use an unlocked/virtual desktop session) and retry."
+}
+
+$planEntries = (Get-Content $Plan -Raw | ConvertFrom-Json).entries
+Write-Host ("Probe plan: {0} entries -> {1}" -f $planEntries.Count, $RunDir)
+
+$failed = @()
+$index  = 0
+foreach ($entry in $planEntries) {
+    $index++
+    $tag = "{0:D2}-{1}-{2}-{3}" -f $index, $entry.surface, $entry.theme, $entry.scale
+    Write-Host ("[{0}/{1}] {2}" -f $index, $planEntries.Count, $tag)
+
+    $args = @(
+        '--ui-probe', $entry.surface,
+        '--theme', $entry.theme,
+        '--text-scale', "$($entry.scale)",
+        '--profileDir', $ProfileDir,
+        '--capture-dir', $RunDir,
+        '--capture-tag', $tag
+    )
+    $proc = Start-Process -FilePath $exe -ArgumentList $args -PassThru
+    $exited = $proc.WaitForExit($TimeoutSeconds * 1000)
+    if (-not $exited) {
+        try { $proc.Kill() } catch {}
+        $failed += "$tag (timeout after ${TimeoutSeconds}s)"
+        continue
+    }
+    if ($proc.ExitCode -ne 0) {
+        $failed += "$tag (exit code $($proc.ExitCode))"
+        continue
+    }
+    $png = Get-ChildItem $RunDir -Filter "$tag*.png" -ErrorAction SilentlyContinue
+    if (-not $png) {
+        $failed += "$tag (exited 0 but produced no PNG)"
+    }
+}
+
+$shots = (Get-ChildItem $RunDir -Filter '*.png').Count
+Write-Host ""
+Write-Host ("Run complete: {0}/{1} entries produced shots ({2} PNGs) in {3}" -f `
+    ($planEntries.Count - $failed.Count), $planEntries.Count, $shots, $RunDir)
+if ($failed.Count -gt 0) {
+    Write-Host "FAILED entries:"
+    $failed | ForEach-Object { Write-Host "  $_" }
+    exit 1
+}
+Write-Host "Next: AI review — run the checklist in scripts/ui-review-prompt.md over $RunDir"
+exit 0

--- a/scripts/ui-probe.ps1
+++ b/scripts/ui-probe.ps1
@@ -37,7 +37,7 @@ param(
 $ErrorActionPreference = 'Stop'
 $repoRoot = Split-Path $PSScriptRoot -Parent
 $exe      = Join-Path $repoRoot 'QuickMail\bin\Debug\QuickMail.exe'
-$fixtures = Join-Path $repoRoot 'tools\QuickMail.Fixtures\QuickMail.Fixtures.csproj'
+$fixtures = Join-Path $repoRoot 'Tools\QuickMail.Fixtures\QuickMail.Fixtures.csproj'
 
 if (-not $RunDir) {
     $RunDir = Join-Path $env:TEMP ("qm-ui-probe\" + (Get-Date -Format 'yyyyMMdd-HHmmss'))
@@ -79,12 +79,14 @@ foreach ($entry in $planEntries) {
     $tag = "{0:D2}-{1}-{2}-{3}" -f $index, $entry.surface, $entry.theme, $entry.scale
     Write-Host ("[{0}/{1}] {2}" -f $index, $planEntries.Count, $tag)
 
+    # Quote path arguments explicitly: Windows PowerShell 5.1's Start-Process
+    # joins the array without quoting, so a space in TEMP would split the args.
     $args = @(
         '--ui-probe', $entry.surface,
         '--theme', $entry.theme,
         '--text-scale', "$($entry.scale)",
-        '--profileDir', $ProfileDir,
-        '--capture-dir', $RunDir,
+        '--profileDir', ('"{0}"' -f $ProfileDir),
+        '--capture-dir', ('"{0}"' -f $RunDir),
         '--capture-tag', $tag
     )
     $proc = Start-Process -FilePath $exe -ArgumentList $args -PassThru

--- a/scripts/ui-probe.ps1
+++ b/scripts/ui-probe.ps1
@@ -15,7 +15,7 @@
     4. Print a summary and exit non-zero if any entry failed or produced no PNG.
 
   AI review (#180 Phase 4) runs over the run folder afterwards using
-  scripts/ui-review-prompt.md — from Claude Code:  "review the run folder at <path>
+  scripts/ui-review-prompt.md - from Claude Code:  "review the run folder at <path>
   with scripts/ui-review-prompt.md". This script stops at the collection step so the
   orchestration stays deterministic and the judgment stays in the model.
 
@@ -27,7 +27,9 @@
 #>
 [CmdletBinding()]
 param(
-    [string]$Plan = "$PSScriptRoot\ui-probe-plan.json",
+    # Resolved below: $PSScriptRoot is empty inside param defaults under
+    # Windows PowerShell 5.1 when invoked with -File.
+    [string]$Plan = "",
     [string]$RunDir = "",
     [string]$ProfileDir = "",
     [int]$TimeoutSeconds = 45,
@@ -35,6 +37,7 @@ param(
 )
 
 $ErrorActionPreference = 'Stop'
+if (-not $Plan) { $Plan = Join-Path $PSScriptRoot 'ui-probe-plan.json' }
 $repoRoot = Split-Path $PSScriptRoot -Parent
 $exe      = Join-Path $repoRoot 'QuickMail\bin\Debug\QuickMail.exe'
 $fixtures = Join-Path $repoRoot 'Tools\QuickMail.Fixtures\QuickMail.Fixtures.csproj'
@@ -81,7 +84,8 @@ foreach ($entry in $planEntries) {
 
     # Quote path arguments explicitly: Windows PowerShell 5.1's Start-Process
     # joins the array without quoting, so a space in TEMP would split the args.
-    $args = @(
+    # ($probeArgs, not $args - $args is a PowerShell automatic variable.)
+    $probeArgs = @(
         '--ui-probe', $entry.surface,
         '--theme', $entry.theme,
         '--text-scale', "$($entry.scale)",
@@ -89,7 +93,7 @@ foreach ($entry in $planEntries) {
         '--capture-dir', ('"{0}"' -f $RunDir),
         '--capture-tag', $tag
     )
-    $proc = Start-Process -FilePath $exe -ArgumentList $args -PassThru
+    $proc = Start-Process -FilePath $exe -ArgumentList $probeArgs -PassThru
     $exited = $proc.WaitForExit($TimeoutSeconds * 1000)
     if (-not $exited) {
         try { $proc.Kill() } catch {}
@@ -115,5 +119,5 @@ if ($failed.Count -gt 0) {
     $failed | ForEach-Object { Write-Host "  $_" }
     exit 1
 }
-Write-Host "Next: AI review — run the checklist in scripts/ui-review-prompt.md over $RunDir"
+Write-Host "Next: AI review - run the checklist in scripts/ui-review-prompt.md over $RunDir"
 exit 0

--- a/scripts/ui-review-prompt.md
+++ b/scripts/ui-review-prompt.md
@@ -1,0 +1,55 @@
+# UI Probe — AI Review Prompt (#180 §9)
+
+You are reviewing screenshots of the QuickMail desktop email client produced by the
+automated UI probe harness. Each image filename encodes `NN-<surface>-<theme>-<scale>.png`.
+The app was seeded with a fixed fixture mailbox, so expected content is known (see
+"Fixture content" below).
+
+Ground rules — these are non-negotiable:
+
+- **No screenshot, no claim.** Judge only what is visible in the image in front of you.
+- **Never guess PASS.** If you cannot tell whether a check holds, the verdict is UNSURE.
+- **Report observations, not possibilities.** "The toolbar text is unreadable against its
+  background in this image" — never "this theme may have contrast issues."
+
+## Checklist (evaluate every item, per image)
+
+1. **Blank/empty render** — is the main content area (especially the reading pane) empty,
+   white, or black where it should show content?
+2. **Missing styling** — do controls look like default/unstyled WPF (light gray Aero chrome
+   in a themed app), or is a whole region unpainted?
+3. **Theme applied** — do background/text/accent colors match the named theme in the
+   filename? parchment = warm off-white surfaces; dark = dark charcoal surfaces with light
+   text; ember = warm cream with rust accent; fjord = pale cool with teal accent;
+   heather = pale with violet accent. A `dark` shot that renders light is a FAIL.
+4. **Text legibility** — clipped text, truncation without ellipsis, overlapping text, or
+   text whose contrast against its background is visibly too low to read.
+5. **Layout integrity** — overlapping controls, controls rendered off-window or zero-sized,
+   gross misalignment, scrollbars where content should fit, a dialog missing its buttons.
+6. **Error state** — an exception dialog, "unable to load" text, a red error banner.
+7. **Text artifacts** — literal access-key underscores rendered in labels (e.g. `_Reply`),
+   mojibake, `{Binding …}` shown literally, raw `#RRGGBB` strings leaking into UI text.
+8. **Content presence** — is the expected fixture content visible for this surface?
+   (Inbox: the seeded message rows including the very-long-subject row with ellipsis, a
+   bold unread row with a 3px accent bar, a flagged row, an attachment indicator.
+   Reading pane: rendered HTML body text. Address book: seeded contacts. Rules: one rule.
+   Calendar: seeded events. Theme manager: theme list with a description.)
+
+## Output
+
+For each image, emit one JSON object (all of them wrapped in a top-level array):
+
+```json
+{
+  "image": "<filename>",
+  "surface": "<surface>",
+  "theme": "<theme>",
+  "scale": <scale>,
+  "verdict": "PASS" | "FAIL" | "UNSURE",
+  "failedChecks": [<check numbers>],
+  "note": "<one sentence citing what is visible in the image; empty for a clean PASS>"
+}
+```
+
+After the array, write a two-line summary: total images, PASS/FAIL/UNSURE counts, and the
+list of FAIL surfaces. A FAIL must always name the check number and the visible evidence.


### PR DESCRIPTION
Implements #180 phases 1–3 — Wave 3b of #421. **Stacked on #424 (#175)**: merge that first; this branch contains it.

## What this delivers

One command produces labeled screenshots of every major surface, offline, against a deterministic fake mailbox:

```
pwsh scripts/ui-probe.ps1
```

- **Phase 1 — fixture generator** (`Tools/QuickMail.Fixtures`): writes a complete profile through the app's *real* services (accounts, mail.db via LocalStoreService, contacts, flags, views, rules, templates, config) — no hand-rolled SQL/JSON, so schema migrations can't desync it. Fixed GUIDs + fixed clock; the JSON artifacts are byte-identical across runs (unit-enforced). The dataset covers the spec's risky visuals: unread/flagged/attachment rows, HTML body, pathological subject, mailing list, calendar invite with event card, and supporting state for every picker/manager surface.
- **Phase 2 — `--ui-probe <surface>` launch mode**: implies `/debug`, hard-forces offline at the DI root (offline no-op IMailService/SendMail/OAuth wired into *every* consumer including RuleService/SyncService/FlagService; watchers, update check, sync, truth probe, startup dialogs all off), applies `--theme`/`--text-scale` before first render, drives to the surface through the same commands the user's menus invoke, settles (idle + CompositionTarget.Rendering + DwmFlush; WebView2 render-complete for the reading pane; blank-frame retry), captures via #175's engine, exits with a meaningful code (0 ok / 2 surface failed / 3 exception / 4 desktop locked / 64 usage).
- **Phase 3 — orchestrator**: `scripts/ui-probe.ps1` + `ui-probe-plan.json` (11 surfaces × parchment/dark × 100% + a 150% pass) + `scripts/ui-review-prompt.md` (the fixed Phase-4 AI checklist, grounding rules included).

## Review process

Independent agent review before the PR: 6 findings — Linux path-casing (the #382 class), probe runs parking on the unhandled-exception MessageBox, RuleService still holding the real mail router (safety-by-accident, now safety-by-structure), capture-tag collisions, PS 5.1 argument quoting, missing close-on-failure — all fixed and re-verified by the same reviewer.

## Verified

- Fixture generation end-to-end; round-trip + determinism tests green (8 new tests).
- Live probe run: boots offline against the fixture, loads the seeded mail (list populated, correct title), captures, exits 0.
- Full suite: 2262 passed; one *rotating* failure among focus/menu/clipboard tests that pass in isolation and were green twice pre-lock — the desktop session locked mid-session, and those tests (like the probe itself) need an unlocked desktop. This finding is now encoded: the driver exits 4 and the orchestrator refuses to run on a locked session with a clear message.

## Remaining before closing #180 (tracked in #421)

1. **Full visual sweep on an unlocked desktop** — `pwsh scripts/ui-probe.ps1`, then eyeball/AI-review the run folder. I'll run this next unlocked session.
2. **Phase 4 wiring** — run the checklist prompt over a run folder and land the planted-defect acceptance test (break a template on a branch, confirm the review FAILs that surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
