### PR TITLE
Wave 4a (#421): Theme Manager scroll at large scales, probe review notes, visual rules in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -379,7 +379,7 @@ collects labeled PNGs. Review the run folder with the checklist in
   windows: captures come out white, and focus/clipboard-dependent tests flake. The
   driver exits 4 and the script refuses to run when locked. (Also check
   `Get-Process LogonUI` before blaming code for white captures or rotating test flakes.)
-- Every WPF control type used in Views must have an implicit style in
+- Every WPF control type used in Views/ and Controls/ must have an implicit style in
   `Styles/ThemedControls.xaml` or a reviewed exemption — enforced by
   `ThemedControlCoverageTests`. WPF default chrome ignores theming; the unstyled ToolBar
   shipped washed-out for months and passed every sighted spot-check.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -345,6 +345,45 @@ Before a feature branch is committed:
 5. **Test in `--online` mode** for any feature that calls `LocalStoreService`. Run with `--online` and verify the feature works correctly from IMAP alone. Features that only pass in normal mode are incomplete.
 6. **If the feature affects startup state, verify it activates before the user sees content.** Any feature that influences what the user sees or hears at launch (default view, folder selection, announcement text, connection status, etc.) must be applied in `InitialLoadAsync`, not deferred to the end of `StartBackgroundSyncAsync`. Deferring to post-sync means the user sees a different state for 20–40 seconds before the feature takes effect.
 
+## Visual Quality — Enforced
+
+QuickMail is built screen-reader-first by a developer who cannot see the screen. The
+visual channel is covered by measurement and tooling, never by assumption.
+
+### Grounding rules for any visual claim
+
+- **No screenshot, no claim.** A statement about how the UI looks must cite a specific
+  captured image. Reviews written from memory or general knowledge of "how WPF looks"
+  are speculation, and speculation is not a work item.
+- **Contrast is computed, never eyeballed.** Use the WCAG math in `BuiltInThemeTests`
+  against the theme token JSON. (History: an external review claimed text-contrast
+  problems that measured 7:1–15:1, and missed real border/focus failures that
+  measurement caught in minutes.)
+- **Hedged language is a rejection signal.** "Can/may/likely/risks being" describes a
+  color family, not this app. Findings state what is visible, in which image.
+
+### The visual verification harness (#175/#180)
+
+```bat
+powershell -File scripts\ui-probe.ps1
+```
+
+Seeds a deterministic fixture profile (Tools/QuickMail.Fixtures), launches the real exe
+offline once per (surface × theme × scale) entry in `scripts/ui-probe-plan.json`, and
+collects labeled PNGs. Review the run folder with the checklist in
+`scripts/ui-review-prompt.md`. Notes:
+
+- **Run it after any change to `Views/`, `Styles/`, or `Themes/`** — at minimum the
+  affected surfaces in parchment + dark.
+- **The desktop session must be unlocked.** On a locked session DWM never composites new
+  windows: captures come out white, and focus/clipboard-dependent tests flake. The
+  driver exits 4 and the script refuses to run when locked. (Also check
+  `Get-Process LogonUI` before blaming code for white captures or rotating test flakes.)
+- Every WPF control type used in Views must have an implicit style in
+  `Styles/ThemedControls.xaml` or a reviewed exemption — enforced by
+  `ThemedControlCoverageTests`. WPF default chrome ignores theming; the unstyled ToolBar
+  shipped washed-out for months and passed every sighted spot-check.
+
 ## Spec Writing Requirements
 
 When AI generates a spec from a conceptual directive, the spec is not ready for implementation until it includes all three of these sections.

--- a/QuickMail/Views/ThemeManagerWindow.xaml
+++ b/QuickMail/Views/ThemeManagerWindow.xaml
@@ -59,9 +59,15 @@
             </ListBox.ItemTemplate>
         </ListBox>
 
-        <!-- Action buttons — F6 stop 2 -->
+        <!-- Action buttons — F6 stop 2. The ScrollViewer keeps every button
+             reachable when large text scales outgrow the fixed window height
+             (at 150% the column clipped the Import button — sweep finding,
+             #421); keyboard focus scrolls the focused button into view. -->
+        <ScrollViewer Grid.Row="0" Grid.Column="1"
+                      VerticalScrollBarVisibility="Auto"
+                      HorizontalScrollBarVisibility="Disabled"
+                      Focusable="False">
         <StackPanel x:Name="ButtonColumn"
-                    Grid.Row="0" Grid.Column="1"
                     Margin="10,0,0,0"
                     KeyboardNavigation.TabNavigation="Continue">
             <Button Content="_Apply"
@@ -100,6 +106,7 @@
                     MinWidth="140" Margin="0,12,0,0"
                     AutomationProperties.Name="Open themes folder"/>
         </StackPanel>
+        </ScrollViewer>
 
         <!-- Theme description — a read-only account of the selected theme's colors
              and where they are used, for users who cannot see the swatches.

--- a/scripts/ui-review-prompt.md
+++ b/scripts/ui-review-prompt.md
@@ -35,6 +35,12 @@ Ground rules — these are non-negotiable:
    Reading pane: rendered HTML body text. Address book: seeded contacts. Rules: one rule.
    Calendar: seeded events. Theme manager: theme list with a description.)
 
+Expected probe-mode state (do NOT flag as errors): the account shows "Disconnected",
+and the status bar reads "9 messages (cached — syncing…)  Never synced  Connecting…  Rules:
+1 active…". The probe runs fully offline against a cache, so these strings are the app's
+normal never-connected state and are identical in every run. A red error banner or an
+exception dialog is still check 6.
+
 ## Output
 
 For each image, emit one JSON object (all of them wrapped in a top-level array):


### PR DESCRIPTION
Part of #421 (Wave 4 + a sweep finding).

- **Theme Manager**: the action-button column scrolls when large text scales outgrow the fixed window height — at 150% the Import button was clipped and unreachable (found by the ui-probe sweep). Keyboard focus scrolls buttons into view; verified by a 150% probe shot showing the scrollbar and reachable column, plus the F6/keyboard flow check in review.
- **scripts/ui-review-prompt.md**: documents the expected probe-mode status strings (Disconnected / cached — syncing… / Connecting…) so a reviewer doesn't flag the app's normal never-connected offline state as an error. All strings verified as exact code matches and run-invariant, so the #421 "suppress status text" item needed documentation, not code.
- **CLAUDE.md**: new "Visual Quality — Enforced" section — grounding rules for visual claims, how/when to run the harness, the locked-desktop caveat, the ThemedControlCoverageTests contract.

Also on this branch's timeline: the #180 §10 planted-defect acceptance test was run and passed (throwaway toolbar sabotage → probe → checklist FAIL naming the region → reverted; evidence on #421).

Verification: full suite green (2281/0 on rerun; one windowed flake during a run that overlapped live probe launches), XAML parse + coverage + regression guards green, independent agent review: no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)