### PR TITLE
Fix #433: capture service cross-thread crash in parallel test runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ QuickMail.Tests/TestResults/
 
 # Local integration-test servers (GreenMail jar cache, logs, pids)
 .testservers/
+*_wpftmp.csproj

--- a/QuickMail.Tests/ScreenshotCaptureServiceTests.cs
+++ b/QuickMail.Tests/ScreenshotCaptureServiceTests.cs
@@ -16,7 +16,13 @@ namespace QuickMail.Tests;
 /// PixelGrabber seam so none of these tests need a real HWND; what is under
 /// test is the session policy — foldering, slugs, debounce, the cap, and the
 /// off-by-default safety story.
+///
+/// In the WpfTests collection because these tests create Window objects and
+/// toggle Enabled (which walks Application.Current.Windows): running them in
+/// parallel with the windowed test classes intermittently crashed the CI test
+/// process with a cross-thread InvalidOperationException (#433).
 /// </summary>
+[Collection("WpfTests")]
 public class ScreenshotCaptureServiceTests : IDisposable
 {
     private readonly string _profileDir =

--- a/QuickMail/Services/ProbeOfflineServices.cs
+++ b/QuickMail/Services/ProbeOfflineServices.cs
@@ -52,7 +52,7 @@ public sealed class ProbeOfflineMailService : IMailService
 
 public sealed class ProbeOfflineSendMailService : ISendMailService
 {
-    private static Exception Refused() =>
+    private static InvalidOperationException Refused() =>
         new InvalidOperationException("Network is disabled in --ui-probe mode; sending is forbidden.");
 
     public Task SendAsync(ComposeModel compose, AccountModel account, string? password, CancellationToken ct = default) => Task.FromException(Refused());
@@ -62,7 +62,7 @@ public sealed class ProbeOfflineSendMailService : ISendMailService
 
 public sealed class ProbeOfflineOAuthService : IOAuthService
 {
-    private static Exception Refused() =>
+    private static InvalidOperationException Refused() =>
         new InvalidOperationException("Network is disabled in --ui-probe mode; sign-in is forbidden.");
 
     public Task<string> GetAccessTokenAsync(AccountModel account, CancellationToken ct = default) => Task.FromException<string>(Refused());

--- a/QuickMail/Services/ScreenshotCaptureService.cs
+++ b/QuickMail/Services/ScreenshotCaptureService.cs
@@ -224,9 +224,22 @@ public class ScreenshotCaptureService : IScreenshotCaptureService
 
     private void UpdateAllTitleSuffixes(bool enabled)
     {
-        if (Application.Current is null) return;
-        foreach (Window w in Application.Current.Windows)
+        // Windows are thread-affine. Production always toggles Enabled on the UI
+        // thread (the Settings checkbox), but under parallel test runs another
+        // test collection can own a live Application on a different thread —
+        // touching its windows from here throws InvalidOperationException, and a
+        // title keeper attached cross-thread can later crash the whole process
+        // from WPF plumbing with no handler (#433). Never walk windows we don't
+        // own the dispatcher for.
+        var app = Application.Current;
+        if (app is null || !app.Dispatcher.CheckAccess()) return;
+        foreach (Window w in app.Windows)
+        {
+            // Application.Windows can hold windows created on other threads
+            // (leaked by parallel tests); skip any we don't own.
+            if (!w.CheckAccess()) continue;
             ApplyTitleSuffix(w, enabled);
+        }
     }
 
     internal void ApplyTitleSuffix(Window window, bool enabled)


### PR DESCRIPTION
Fixes #433.

Root cause and fix are in the commit message. Two layers: the service now refuses to walk or touch windows whose dispatcher it doesn't own (defends the contract instead of assuming it), and the test class joins the WpfTests collection so it serializes with the windowed classes it was racing.

Independent review confirmed: no production path toggles Enabled off the UI thread (the only writer is the Settings checkbox binding), remaining service paths (OnWindowLoaded, keeper callbacks, Dispose) all run on owning threads, and the per-window CheckAccess closes the last theoretical residue the reviewer found.

Verification plan per Kelly: local stress (4x full suite green) plus repeated runs of the actual CI workflow on this PR, since GitHub Actions is where the interleaving reproduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)