### PR TITLE
Fix #436: Delete QuickMail logs also deletes debug screenshots

### DIFF
--- a/QuickMail.Tests/ScreenshotCaptureServiceTests.cs
+++ b/QuickMail.Tests/ScreenshotCaptureServiceTests.cs
@@ -344,11 +344,11 @@ public class ScreenshotCaptureServiceTests : IDisposable
         var window = new Window();
 
         svc.Capture(window, "BeforeDelete");
-        // Saves are async: wait for the file so no in-flight save can recreate
-        // the folder after the delete below (SavePng recreates missing dirs).
+        // Saves are async, and File.Exists turns true while the writer still
+        // holds the handle — flush so the save is fully finished before the
+        // delete, exactly as the Settings handler does.
+        svc.FlushPendingSaves(TimeSpan.FromSeconds(5));
         var before = Path.Combine(svc.SessionFolder, "0001-BeforeDelete.png");
-        for (var i = 0; i < 40 && !File.Exists(before); i++)
-            System.Threading.Thread.Sleep(50);
         Assert.True(File.Exists(before), "BeforeDelete capture never landed");
 
         // Two sessions: simulate an older leftover folder alongside the live one.

--- a/QuickMail.Tests/ScreenshotCaptureServiceTests.cs
+++ b/QuickMail.Tests/ScreenshotCaptureServiceTests.cs
@@ -333,6 +333,44 @@ public class ScreenshotCaptureServiceTests : IDisposable
         }
     }
 
+    // ── Delete-with-logs (#436) ───────────────────────────────────────────────
+
+    [StaFact]
+    public void DeleteAllCaptures_RemovesEverySession_AndCaptureAfterwardsStillWorks()
+    {
+        var svc = NewService();
+        svc.PixelGrabber = _ => TinyFrame();
+        svc.Enabled = true;
+        var window = new Window();
+
+        svc.Capture(window, "BeforeDelete");
+        // Saves are async: wait for the file so no in-flight save can recreate
+        // the folder after the delete below (SavePng recreates missing dirs).
+        var before = Path.Combine(svc.SessionFolder, "0001-BeforeDelete.png");
+        for (var i = 0; i < 40 && !File.Exists(before); i++)
+            System.Threading.Thread.Sleep(50);
+        Assert.True(File.Exists(before), "BeforeDelete capture never landed");
+
+        // Two sessions: simulate an older leftover folder alongside the live one.
+        Directory.CreateDirectory(Path.Combine(_profileDir, "debug-screenshots", "20260101-000000"));
+
+        ScreenshotCaptureService.DeleteAllCaptures(_profileDir);
+        Assert.False(Directory.Exists(Path.Combine(_profileDir, "debug-screenshots")));
+
+        // The live session must recover: the next capture recreates its folder.
+        svc.Capture(window, "AfterDelete");
+        svc.Dispose();
+        var files = Directory.GetFiles(svc.SessionFolder, "*.png");
+        Assert.Contains(files, f => Path.GetFileName(f).EndsWith("-AfterDelete.png", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void DeleteAllCaptures_WithNothingToDelete_DoesNotThrow()
+    {
+        ScreenshotCaptureService.DeleteAllCaptures(_profileDir);   // folder never created
+        Assert.False(Directory.Exists(Path.Combine(_profileDir, "debug-screenshots")));
+    }
+
     [Fact]
     public void NullService_IsInertEverywhere()
     {

--- a/QuickMail/App.xaml.cs
+++ b/QuickMail/App.xaml.cs
@@ -22,6 +22,14 @@ public partial class App : Application
     /// <summary>Non-null only in --ui-probe automation mode (#180).</summary>
     public UiProbeOptions? UiProbe { get; private set; }
 
+    /// <summary>
+    /// The active profile. Exposed so Settings can clean profile-scoped
+    /// artifacts (debug screenshots, #436) regardless of which capture service
+    /// is wired — leftovers from an earlier /debug session must be deletable
+    /// from a normal launch too.
+    /// </summary>
+    public ProfileContext? Profile { get; private set; }
+
     // Held so OnExit can dispose them.
     private GraphSendMailService? _graphSendMail;
     private ContactService? _contactService;
@@ -174,6 +182,7 @@ public partial class App : Application
             Shutdown();
             return;
         }
+        Profile = profile;
 
         LogService.Configure(profile.ProfileDir);
 

--- a/QuickMail/Services/ScreenshotCaptureService.cs
+++ b/QuickMail/Services/ScreenshotCaptureService.cs
@@ -398,6 +398,10 @@ public class ScreenshotCaptureService : IScreenshotCaptureService
     {
         try
         {
+            // The session folder can vanish mid-session ("Delete QuickMail
+            // logs" now removes all captures, #436) — recreate rather than
+            // silently dropping every capture after a cleanup.
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
             var encoder = new PngBitmapEncoder();
             encoder.Frames.Add(BitmapFrame.Create(frame));
             using var stream = File.Create(path);
@@ -406,6 +410,27 @@ public class ScreenshotCaptureService : IScreenshotCaptureService
         catch (Exception ex)
         {
             LogService.Debug($"Screenshot save failed for {Path.GetFileName(path)}: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Deletes every capture session under the profile (#436). Static and
+    /// profile-keyed so Settings can clean leftovers from earlier /debug
+    /// sessions even in a normal launch, where only the null service is wired.
+    /// Screenshots are pixels of real mail — the delete-logs privacy story
+    /// must cover them.
+    /// </summary>
+    public static void DeleteAllCaptures(string profileDir)
+    {
+        var root = Path.Combine(profileDir, "debug-screenshots");
+        try
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+        catch (Exception ex)
+        {
+            LogService.Log($"Could not delete debug screenshots: {ex.Message}");
         }
     }
 

--- a/QuickMail/Services/ScreenshotCaptureService.cs
+++ b/QuickMail/Services/ScreenshotCaptureService.cs
@@ -194,6 +194,26 @@ public class ScreenshotCaptureService : IScreenshotCaptureService
         }
     }
 
+    /// <summary>
+    /// Blocks (bounded) until in-flight PNG saves finish. Called before a
+    /// delete-all so no open file handle can fail the recursive delete and no
+    /// late save can resurrect a screenshot after it (#436), and on dispose so
+    /// a capture taken just before exit isn't truncated.
+    /// </summary>
+    public void FlushPendingSaves(TimeSpan timeout)
+    {
+        Task[] pending;
+        lock (_gate) pending = _pendingSaves.ToArray();
+        try
+        {
+            Task.WaitAll(pending, timeout);
+        }
+        catch
+        {
+            // Individual save failures already logged in SavePng.
+        }
+    }
+
     public void Dispose()
     {
         if (_disposed) return;
@@ -201,17 +221,7 @@ public class ScreenshotCaptureService : IScreenshotCaptureService
         _enabled = false;
         foreach (var window in _titleKeepers.Keys.ToList())
             DetachTitleKeeper(window, refreshFromBinding: false);
-        Task[] pending;
-        lock (_gate) pending = _pendingSaves.ToArray();
-        try
-        {
-            // Best-effort flush so a capture taken just before exit isn't truncated.
-            Task.WaitAll(pending, TimeSpan.FromSeconds(3));
-        }
-        catch
-        {
-            // Individual save failures already logged in SavePng.
-        }
+        FlushPendingSaves(TimeSpan.FromSeconds(3));
         GC.SuppressFinalize(this);
     }
 
@@ -423,14 +433,26 @@ public class ScreenshotCaptureService : IScreenshotCaptureService
     public static void DeleteAllCaptures(string profileDir)
     {
         var root = Path.Combine(profileDir, "debug-screenshots");
-        try
+        // A straggler save can hold a handle briefly even after a flush; retry
+        // rather than leaving privacy-sensitive captures behind silently.
+        for (var attempt = 0; ; attempt++)
         {
-            if (Directory.Exists(root))
-                Directory.Delete(root, recursive: true);
-        }
-        catch (Exception ex)
-        {
-            LogService.Log($"Could not delete debug screenshots: {ex.Message}");
+            try
+            {
+                if (Directory.Exists(root))
+                    Directory.Delete(root, recursive: true);
+                return;
+            }
+            catch (Exception ex) when (attempt < 3)
+            {
+                LogService.Debug($"Delete debug screenshots attempt {attempt + 1} failed: {ex.Message}");
+                System.Threading.Thread.Sleep(250);
+            }
+            catch (Exception ex)
+            {
+                LogService.Log($"Could not delete debug screenshots: {ex.Message}");
+                return;
+            }
         }
     }
 

--- a/QuickMail/Views/SettingsDialog.xaml
+++ b/QuickMail/Views/SettingsDialog.xaml
@@ -400,7 +400,7 @@
                                         Margin="0,10,0,0"
                                         Click="DeleteLogButton_Click"
                                         AutomationProperties.Name="Delete QuickMail logs"/>
-                                <TextBlock Text="Deletes both the application log and the connection diagnostics log."
+                                <TextBlock Text="Deletes the application log, the connection diagnostics log, and any saved debug screenshots."
                                            Foreground="{DynamicResource Theme.TextSecondary}" FontSize="{DynamicResource Theme.FontSizeSmall}" Margin="0,3,0,0" TextWrapping="Wrap"/>
                             </StackPanel>
                         </GroupBox>

--- a/QuickMail/Views/SettingsDialog.xaml.cs
+++ b/QuickMail/Views/SettingsDialog.xaml.cs
@@ -51,13 +51,14 @@ public partial class SettingsDialog : Window
 
     private void DeleteLogButton_Click(object sender, RoutedEventArgs e)
     {
-        // Deletes BOTH logs. Someone deleting their logs means all of them — most often because the
-        // logs hold their email addresses and mail server names and they don't want them on disk.
-        // Leaving connection.log behind because it happens to be a second file would quietly defeat
-        // that, and nothing in the UI would hint that a second log still existed.
+        // Deletes BOTH logs and all debug screenshots. Someone deleting their logs means all of
+        // them — most often because the artifacts hold their email addresses, server names, or
+        // (for screenshots, #436) pictures of their actual mail, and they don't want them on
+        // disk. Leaving any diagnostic file behind because it happens to live elsewhere would
+        // quietly defeat that, and nothing in the UI would hint that it still existed.
         var result = MessageBox.Show(
-            "Delete QuickMail's log files? This deletes the application log and the connection " +
-            "diagnostics log, and cannot be undone.",
+            "Delete QuickMail's log files? This deletes the application log, the connection " +
+            "diagnostics log, and any saved debug screenshots, and cannot be undone.",
             "Delete Logs",
             MessageBoxButton.YesNo,
             MessageBoxImage.Question,
@@ -67,6 +68,10 @@ public partial class SettingsDialog : Window
         {
             LogService.DeleteLog();
             ConnectionJournal.DeleteLog();
+            // Static + profile-keyed: works in normal launches too, where only the
+            // null capture service is wired but old /debug screenshots may remain.
+            if ((Application.Current as App)?.Profile is { } profile)
+                ScreenshotCaptureService.DeleteAllCaptures(profile.ProfileDir);
         }
 
         DeleteLogButton.Focus();

--- a/QuickMail/Views/SettingsDialog.xaml.cs
+++ b/QuickMail/Views/SettingsDialog.xaml.cs
@@ -70,7 +70,11 @@ public partial class SettingsDialog : Window
             ConnectionJournal.DeleteLog();
             // Static + profile-keyed: works in normal launches too, where only the
             // null capture service is wired but old /debug screenshots may remain.
-            if ((Application.Current as App)?.Profile is { } profile)
+            // Flush first so no in-flight save holds a handle open against the
+            // delete or resurrects a capture after it.
+            var app = Application.Current as App;
+            (app?.ScreenshotCapture as ScreenshotCaptureService)?.FlushPendingSaves(TimeSpan.FromSeconds(3));
+            if (app?.Profile is { } profile)
                 ScreenshotCaptureService.DeleteAllCaptures(profile.ProfileDir);
         }
 


### PR DESCRIPTION
Fixes #436 (found by Kelly during the #175 live acceptance pass).

Static, profile-keyed deletion so it works from normal launches (cleaning leftovers of earlier /debug sessions), the live session recovers after a mid-session cleanup, and both UI texts plus the confirmation dialog now name screenshots explicitly. Full suite green: 2287/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)