### PR TITLE
Message list density setting: Comfortable / Compact (#421)

### DIFF
--- a/QuickMail.Tests/SettingsViewModelTests.cs
+++ b/QuickMail.Tests/SettingsViewModelTests.cs
@@ -44,6 +44,29 @@ public class SettingsViewModelTests
     }
 
     [Fact]
+    public void ListDensity_RoundTripsThroughConfig_AndRadiosStayExclusive()
+    {
+        var configService = new StubConfigService();
+        var registry = new StubCommandRegistry();
+
+        configService.Save(new ConfigModel { AppearanceListDensity = "compact" });
+        var vm = new SettingsViewModel(configService, registry);
+        Assert.True(vm.IsListDensityCompact);
+        Assert.False(vm.IsListDensityComfortable);
+
+        vm.IsListDensityComfortable = true;
+        Assert.False(vm.IsListDensityCompact);
+        vm.SaveCommand.Execute(null);
+        Assert.Equal("comfortable", configService.Load().AppearanceListDensity);
+
+        // Unknown persisted values normalize to the default rather than
+        // leaving both radios unchecked.
+        configService.Save(new ConfigModel { AppearanceListDensity = "garbage" });
+        var vm2 = new SettingsViewModel(configService, registry);
+        Assert.True(vm2.IsListDensityComfortable);
+    }
+
+    [Fact]
     public void Save_PersistsChanges()
     {
         var configService = new StubConfigService();

--- a/QuickMail.Tests/ThemeServiceTests.cs
+++ b/QuickMail.Tests/ThemeServiceTests.cs
@@ -202,6 +202,32 @@ public class ThemeServiceTests : IDisposable
         Assert.Equal("Verdana", ((FontFamily)dict[ThemeKeys.FontFamily]).Source);
     }
 
+    /// <summary>
+    /// Density (#421) publishes padding only. Comfortable is the default;
+    /// compact reproduces the original shipped rendering; anything else
+    /// normalizes to comfortable. ApplyAppearance with a changed density must
+    /// re-publish (the signature includes it).
+    /// </summary>
+    [StaFact]
+    public void TokenDictionary_ListDensity_PublishesPaddingOnly()
+    {
+        using var svc = NewService();
+        var cfg = Config("parchment");
+        svc.Initialize(cfg);
+        Assert.Equal(new Thickness(4, 3, 4, 3),
+            svc.BuildTokenDictionary(svc.ResolvedTheme)[ThemeKeys.ListRowPadding]);
+
+        cfg.AppearanceListDensity = "compact";
+        svc.ApplyAppearance(cfg);
+        Assert.Equal(new Thickness(2, 1, 2, 1),
+            svc.BuildTokenDictionary(svc.ResolvedTheme)[ThemeKeys.ListRowPadding]);
+
+        cfg.AppearanceListDensity = "SomethingElse";
+        svc.ApplyAppearance(cfg);
+        Assert.Equal(new Thickness(4, 3, 4, 3),
+            svc.BuildTokenDictionary(svc.ResolvedTheme)[ThemeKeys.ListRowPadding]);
+    }
+
     // ── WebView2 CSS bridge ───────────────────────────────────────────────────
 
     [StaFact]

--- a/QuickMail/Models/ConfigModel.cs
+++ b/QuickMail/Models/ConfigModel.cs
@@ -92,6 +92,13 @@ public class ConfigModel
     /// <summary>Thicker keyboard focus indicators (2px → 4px). Default off.</summary>
     public bool AppearanceThickFocus { get; set; } = false;
 
+    /// <summary>
+    /// Message-list row density: "comfortable" (default) or "compact". Affects
+    /// row padding ONLY — the accessibility surface (UIA tree, announcements)
+    /// is identical in both modes, by design (#421).
+    /// </summary>
+    public string AppearanceListDensity { get; set; } = "comfortable";
+
     /// <summary>Override sender HTML colors/fonts with theme colors in the reading pane. Default off.</summary>
     public bool AppearanceForceMessageTheme { get; set; } = false;
 

--- a/QuickMail/Services/ConfigService.cs
+++ b/QuickMail/Services/ConfigService.cs
@@ -243,6 +243,9 @@ public class ConfigService : IConfigService
                         break;
                     case "appearanceunderlinelinks":   config.AppearanceUnderlineLinks   = ParseBool(value); break;
                     case "appearancethickfocus":       config.AppearanceThickFocus       = ParseBool(value); break;
+                    case "appearancelistdensity":
+                        config.AppearanceListDensity = value.ToLowerInvariant() == "compact" ? "compact" : "comfortable";
+                        break;
                     case "appearanceforcemessagetheme": config.AppearanceForceMessageTheme = ParseBool(value); break;
                     case "customannouncements":  config.CustomAnnouncements = ParseBool(value); break;
                     case "announcehints":        config.AnnounceHints        = ParseBool(value); break;
@@ -447,6 +450,7 @@ public class ConfigService : IConfigService
         sb.AppendLine();
 
         sb.AppendLine($"AppearanceThickFocus = {(config.AppearanceThickFocus ? "on" : "off")}");
+        sb.AppendLine($"AppearanceListDensity = {config.AppearanceListDensity}");
         sb.AppendLine("# Thicker keyboard focus indicators. Values: on, off.");
         sb.AppendLine();
 

--- a/QuickMail/Services/ConfigService.cs
+++ b/QuickMail/Services/ConfigService.cs
@@ -450,8 +450,11 @@ public class ConfigService : IConfigService
         sb.AppendLine();
 
         sb.AppendLine($"AppearanceThickFocus = {(config.AppearanceThickFocus ? "on" : "off")}");
-        sb.AppendLine($"AppearanceListDensity = {config.AppearanceListDensity}");
         sb.AppendLine("# Thicker keyboard focus indicators. Values: on, off.");
+        sb.AppendLine();
+
+        sb.AppendLine($"AppearanceListDensity = {config.AppearanceListDensity}");
+        sb.AppendLine("# Message list row spacing. Values: comfortable, compact.");
         sb.AppendLine();
 
         sb.AppendLine($"AppearanceForceMessageTheme = {(config.AppearanceForceMessageTheme ? "on" : "off")}");

--- a/QuickMail/Services/ThemeService.cs
+++ b/QuickMail/Services/ThemeService.cs
@@ -44,6 +44,7 @@ public class ThemeService : IThemeService
     private string _fontFamilyOverride = string.Empty;
     private bool _underlineLinks;
     private bool _thickFocus;
+    private bool _compactList;
 
     // Published dictionaries (tracked by reference for atomic replacement).
     private ResourceDictionary? _publishedTokens;
@@ -225,6 +226,7 @@ public class ThemeService : IThemeService
         _fontFamilyOverride = config.AppearanceFontFamily?.Trim() ?? string.Empty;
         _underlineLinks = config.AppearanceUnderlineLinks;
         _thickFocus = config.AppearanceThickFocus;
+        _compactList = string.Equals(config.AppearanceListDensity, "compact", StringComparison.OrdinalIgnoreCase);
     }
 
     public IReadOnlyList<ThemeDefinition> GetAvailableThemes()
@@ -437,7 +439,7 @@ public class ThemeService : IThemeService
         var c = CultureInfo.InvariantCulture;
         return $"{_isHighContrast}|{resolved.Id}|{string.Join(",", resolved.Colors.OrderBy(kv => kv.Key, StringComparer.Ordinal).Select(kv => kv.Value))}"
             + $"|{resolved.Typography.FontFamily}|{resolved.Typography.MonoFontFamily}|{resolved.Typography.BaseFontSize.ToString(c)}"
-            + $"|{_textScale.ToString(c)}|{_fontFamilyOverride}|{_underlineLinks}|{_thickFocus}";
+            + $"|{_textScale.ToString(c)}|{_fontFamilyOverride}|{_underlineLinks}|{_thickFocus}|{_compactList}";
     }
 
     private void PublishDictionary(ThemeDefinition resolved)
@@ -506,6 +508,11 @@ public class ThemeService : IThemeService
         var focusThickness = _thickFocus ? 4.0 : 2.0;
         dict[ThemeKeys.FocusThickness] = focusThickness;
         dict[ThemeKeys.FocusHaloThickness] = focusThickness + 2.0;
+
+        // Density = padding only (#421): the UIA tree and announcements are
+        // identical in both modes, by design. Compact reproduces the original
+        // shipped rendering exactly.
+        dict[ThemeKeys.ListRowPadding] = _compactList ? new Thickness(2, 1, 2, 1) : new Thickness(4, 3, 4, 3);
 
         return dict;
     }

--- a/QuickMail/Services/ThemeService.cs
+++ b/QuickMail/Services/ThemeService.cs
@@ -510,8 +510,8 @@ public class ThemeService : IThemeService
         dict[ThemeKeys.FocusHaloThickness] = focusThickness + 2.0;
 
         // Density = padding only (#421): the UIA tree and announcements are
-        // identical in both modes, by design. Compact reproduces the original
-        // shipped rendering exactly.
+        // identical in both modes, by design. Compact reproduces the message
+        // list's original shipped rendering (its template hardcoded 2,1).
         dict[ThemeKeys.ListRowPadding] = _compactList ? new Thickness(2, 1, 2, 1) : new Thickness(4, 3, 4, 3);
 
         return dict;

--- a/QuickMail/Styles/ThemedControls.xaml
+++ b/QuickMail/Styles/ThemedControls.xaml
@@ -1002,8 +1002,8 @@
          column layout is preserved. -->
     <Style x:Key="{x:Static GridView.GridViewItemContainerStyleKey}" TargetType="ListViewItem">
         <Setter Property="FocusVisualStyle" Value="{DynamicResource FocusVisual}"/>
-        <!-- 4,3 (was 2): visual review found 2px rows too dense to scan (#421). -->
-        <Setter Property="Padding" Value="4,3"/>
+        <!-- Density token: comfortable 4,3 / compact 2,1 (#421). -->
+        <Setter Property="Padding" Value="{DynamicResource Theme.ListRowPadding}"/>
         <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
         <Setter Property="Template">
             <Setter.Value>

--- a/QuickMail/Theming/ThemeKeys.cs
+++ b/QuickMail/Theming/ThemeKeys.cs
@@ -71,6 +71,11 @@ public static class ThemeKeys
     /// visible on any fill (including accent-strength selection).</summary>
     public const string FocusHaloThickness = Prefix + "FocusHaloThickness";
 
+    /// <summary>Message-list row padding (Thickness), from the density setting:
+    /// comfortable 4,3 / compact 2,1. Padding only — never anything a screen
+    /// reader can observe.</summary>
+    public const string ListRowPadding = Prefix + "ListRowPadding";
+
     /// <summary>camelCase JSON name → application resource key, for all 26 color tokens.</summary>
     public static readonly IReadOnlyDictionary<string, string> ColorTokens =
         new Dictionary<string, string>(StringComparer.Ordinal)

--- a/QuickMail/ViewModels/SettingsViewModel.cs
+++ b/QuickMail/ViewModels/SettingsViewModel.cs
@@ -255,6 +255,26 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty]
     private bool _appearanceForceMessageTheme;
 
+    /// <summary>
+    /// Message-list density, "comfortable" or "compact" (#421). Padding only —
+    /// both modes present the identical accessibility surface, by design.
+    /// </summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsListDensityComfortable))]
+    [NotifyPropertyChangedFor(nameof(IsListDensityCompact))]
+    private string _appearanceListDensity = "comfortable";
+
+    public bool IsListDensityComfortable
+    {
+        get => AppearanceListDensity == "comfortable";
+        set { if (value) AppearanceListDensity = "comfortable"; }
+    }
+    public bool IsListDensityCompact
+    {
+        get => AppearanceListDensity == "compact";
+        set { if (value) AppearanceListDensity = "compact"; }
+    }
+
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(IsLogFormatActionFirst))]
     [NotifyPropertyChangedFor(nameof(IsLogFormatTimeFirst))]
@@ -323,6 +343,7 @@ public partial class SettingsViewModel : ObservableObject
             FontOptions.Add(AppearanceFontOption); // keep an uninstalled configured font selectable
         AppearanceUnderlineLinks    = cfg.AppearanceUnderlineLinks;
         AppearanceThickFocus        = cfg.AppearanceThickFocus;
+        AppearanceListDensity       = cfg.AppearanceListDensity == "compact" ? "compact" : "comfortable";
         AppearanceForceMessageTheme = cfg.AppearanceForceMessageTheme;
 
         PreviewLines = cfg.PreviewLines;
@@ -399,6 +420,7 @@ public partial class SettingsViewModel : ObservableObject
             : AppearanceFontOption;
         cfg.AppearanceUnderlineLinks    = AppearanceUnderlineLinks;
         cfg.AppearanceThickFocus        = AppearanceThickFocus;
+        cfg.AppearanceListDensity       = AppearanceListDensity;
         cfg.AppearanceForceMessageTheme = AppearanceForceMessageTheme;
 
         cfg.PreviewLines = PreviewLines;

--- a/QuickMail/Views/MainWindow.xaml
+++ b/QuickMail/Views/MainWindow.xaml
@@ -1510,8 +1510,11 @@
                                                     BorderThickness="{TemplateBinding BorderThickness}"
                                                     SnapsToDevicePixels="True">
                                                 <!-- 1px bottom border: row divider so adjacent rows
-                                                     stay distinguishable in dense lists. -->
-                                                <Border x:Name="rowBg" Background="Transparent" Padding="2,1"
+                                                     stay distinguishable in dense lists. Padding is
+                                                     the density token (comfortable/compact, #421) —
+                                                     padding only, never the accessibility surface. -->
+                                                <Border x:Name="rowBg" Background="Transparent"
+                                                        Padding="{DynamicResource Theme.ListRowPadding}"
                                                         BorderBrush="{DynamicResource Theme.BorderSubtle}"
                                                         BorderThickness="0,0,0,1">
                                                     <DockPanel>

--- a/QuickMail/Views/SettingsDialog.xaml
+++ b/QuickMail/Views/SettingsDialog.xaml
@@ -645,6 +645,27 @@
                             </StackPanel>
                         </GroupBox>
 
+                        <!-- Message List Density Group (#421). Padding only: both
+                             modes present the identical accessibility surface. -->
+                        <GroupBox Header="Message _List Density" Padding="10" Margin="0,0,0,15"
+                                  AutomationProperties.Name="Message list density">
+                            <StackPanel KeyboardNavigation.TabNavigation="Once"
+                                        KeyboardNavigation.DirectionalNavigation="Cycle">
+                                <RadioButton Content="Comfortable (recommended)"
+                                             IsChecked="{Binding IsListDensityComfortable, Mode=TwoWay}"
+                                             GroupName="ListDensity"
+                                             AutomationProperties.Name="Comfortable"/>
+                                <TextBlock Text="More space around each message row — easier visual scanning."
+                                           Foreground="{DynamicResource Theme.TextSecondary}" FontSize="{DynamicResource Theme.FontSizeSmall}" Margin="16,2,0,8" TextWrapping="Wrap"/>
+                                <RadioButton Content="Compact"
+                                             IsChecked="{Binding IsListDensityCompact, Mode=TwoWay}"
+                                             GroupName="ListDensity"
+                                             AutomationProperties.Name="Compact"/>
+                                <TextBlock Text="Tighter rows — more messages visible at once."
+                                           Foreground="{DynamicResource Theme.TextSecondary}" FontSize="{DynamicResource Theme.FontSizeSmall}" Margin="16,2,0,0" TextWrapping="Wrap"/>
+                            </StackPanel>
+                        </GroupBox>
+
                         <!-- Vision Group -->
                         <GroupBox Header="_Vision" Padding="10"
                                   AutomationProperties.Name="Vision settings">


### PR DESCRIPTION
Implements Kelly's decision on the #421 row-padding question: a user choice rather than a hardcoded value.

- `Theme.ListRowPadding` token from the new `AppearanceListDensity` config value; Comfortable (4,3, default) / Compact (2,1).
- **Density is padding only — the accessibility surface is identical in both modes, by explicit design** (per Kelly's Outlook for Mac experience, layout modes must never change how accessibility info works).
- Fixes the latent bug that #422's padding never reached the real message-list row template (it hardcoded 2,1); Compact now reproduces the previously shipped rendering exactly.
- Radio group on the Appearance tab per the repo's radio-group rules; accelerator audit done.
- Verified: affected test classes + full suite green; probe shots of both densities (compact pixel-equivalent to the original).

Release-time note: add the setting to USER-GUIDE.md with the next release's doc pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)