### PR TITLE
View menu: Density submenu + Manage Themes moved from Tools (#421)

### DIFF
--- a/QuickMail.Tests/CommandRegistryTests.cs
+++ b/QuickMail.Tests/CommandRegistryTests.cs
@@ -278,4 +278,37 @@ public class CommandRegistryTests
         Assert.Equal("mail.archive", registry.FindByGesture(Key.M, ModifierKeys.Control | ModifierKeys.Shift)!.Id);
         Assert.Equal("mail.delete",  registry.FindByGesture(Key.Delete, ModifierKeys.None)!.Id);
     }
+
+    /// <summary>
+    /// Density on the View menu (#421): both commands are registered (palette +
+    /// hotkey-assignable), and executing one persists the same config value the
+    /// Settings dialog writes.
+    /// </summary>
+    [Fact]
+    public void DensityCommands_AreRegistered_AndPersistTheSetting()
+    {
+        var registry = new CommandRegistry();
+        var configService = new StubConfigService();
+        var vm = new MainViewModel(
+            new StubImapMailService(), new StubAccountService(), new StubCredentialService(),
+            new StubLocalStoreService(), new StubOAuthService(), new StubSyncService(),
+            configService, registry, new StubViewService(), new StubRuleService(),
+            new StubSmtpService());
+        Assert.NotNull(vm);
+
+        var comfortable = registry.FindById("view.density.comfortable");
+        var compact = registry.FindById("view.density.compact");
+        Assert.NotNull(comfortable);
+        Assert.NotNull(compact);
+        Assert.Equal("View", comfortable!.Category);
+        Assert.Equal("View", compact!.Category);
+
+        compact.Execute();
+        Assert.Equal("compact", configService.Load().AppearanceListDensity);
+        Assert.True(vm.IsListDensityCompact);
+
+        comfortable.Execute();
+        Assert.Equal("comfortable", configService.Load().AppearanceListDensity);
+        Assert.True(vm.IsListDensityComfortable);
+    }
 }

--- a/QuickMail.Tests/ThemeServiceTests.cs
+++ b/QuickMail.Tests/ThemeServiceTests.cs
@@ -228,6 +228,32 @@ public class ThemeServiceTests : IDisposable
             svc.BuildTokenDictionary(svc.ResolvedTheme)[ThemeKeys.ListRowPadding]);
     }
 
+    /// <summary>
+    /// A density-only change re-publishes the dictionary (padding must swap)
+    /// but must NOT raise ThemeChanged — subscribers announce "Theme changed
+    /// to …" and re-render the reading pane, both wrong for padding. A real
+    /// theme change still raises.
+    /// </summary>
+    [StaFact]
+    public void ThemeChanged_NotRaisedForDensityOnlyChanges()
+    {
+        using var svc = NewService();
+        var cfg = Config("parchment");
+        svc.Initialize(cfg);
+        var raised = 0;
+        svc.ThemeChanged += (_, _) => raised++;
+
+        cfg.AppearanceListDensity = "compact";
+        svc.ApplyAppearance(cfg);
+        Assert.Equal(0, raised);
+        Assert.Equal(new Thickness(2, 1, 2, 1),
+            svc.BuildTokenDictionary(svc.ResolvedTheme)[ThemeKeys.ListRowPadding]);   // republished anyway
+
+        cfg.AppearanceThemeId = "dark";
+        svc.ApplyAppearance(cfg);
+        Assert.Equal(1, raised);
+    }
+
     // ── WebView2 CSS bridge ───────────────────────────────────────────────────
 
     [StaFact]

--- a/QuickMail/Services/ThemeService.cs
+++ b/QuickMail/Services/ThemeService.cs
@@ -56,6 +56,7 @@ public class ThemeService : IThemeService
     private bool _initialized;
     private bool _disposed;
     private string _lastPublishedSignature = string.Empty;
+    private string _lastAnnounceSignature = string.Empty;
 
     /// <summary>Test hook: overrides the OS light/dark probe (default reads AppsUseLightTheme).</summary>
     internal Func<bool> OsLightModeProbe { get; set; } = ReadOsLightMode;
@@ -416,12 +417,20 @@ public class ThemeService : IThemeService
         if (signature == _lastPublishedSignature && wasHc == _isHighContrast)
             return; // effective theme unchanged — no dictionary churn, no event
 
+        // Density-only changes re-publish the token dictionary (the row-padding
+        // resource must swap) but must NOT raise ThemeChanged: subscribers
+        // announce "Theme changed to …" and re-render the reading pane, both
+        // wrong when only list padding moved (#421 density on the View menu).
+        var announceSignature = BuildAnnounceSignature(resolved);
+        var themeActuallyChanged = announceSignature != _lastAnnounceSignature || wasHc != _isHighContrast;
+
         _resolved = resolved;
         _lastPublishedSignature = signature;
+        _lastAnnounceSignature = announceSignature;
 
         PublishDictionary(resolved);
 
-        if (raiseEvent)
+        if (raiseEvent && themeActuallyChanged)
         {
             // Raised on the Dispatcher thread per the interface contract.
             if (_dispatcher is null || _dispatcher.CheckAccess())
@@ -431,7 +440,10 @@ public class ThemeService : IThemeService
         }
     }
 
-    private string BuildSignature(ThemeDefinition resolved)
+    /// <summary>Everything that makes a change worth ANNOUNCING (and re-rendering
+    /// the reading pane for) — deliberately excludes list density, which is
+    /// padding-only and announces as its own result at the call site.</summary>
+    private string BuildAnnounceSignature(ThemeDefinition resolved)
     {
         // Format doubles with InvariantCulture (like the rest of this file) so the
         // signature is locale-stable — it is only compared to itself today, but a
@@ -439,8 +451,12 @@ public class ThemeService : IThemeService
         var c = CultureInfo.InvariantCulture;
         return $"{_isHighContrast}|{resolved.Id}|{string.Join(",", resolved.Colors.OrderBy(kv => kv.Key, StringComparer.Ordinal).Select(kv => kv.Value))}"
             + $"|{resolved.Typography.FontFamily}|{resolved.Typography.MonoFontFamily}|{resolved.Typography.BaseFontSize.ToString(c)}"
-            + $"|{_textScale.ToString(c)}|{_fontFamilyOverride}|{_underlineLinks}|{_thickFocus}|{_compactList}";
+            + $"|{_textScale.ToString(c)}|{_fontFamilyOverride}|{_underlineLinks}|{_thickFocus}";
     }
+
+    /// <summary>Everything that requires RE-PUBLISHING the token dictionary.</summary>
+    private string BuildSignature(ThemeDefinition resolved) =>
+        BuildAnnounceSignature(resolved) + $"|{_compactList}";
 
     private void PublishDictionary(ThemeDefinition resolved)
     {

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -1106,6 +1106,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
         _showPreview = _previewLines > 0;
         _syncDays = cfg.SyncDays;
         _viewMode = ConfigModel.ParseViewMode(cfg.ViewMode);
+        _listDensity = cfg.AppearanceListDensity == "compact" ? "compact" : "comfortable";
         MessageOpenMode = cfg.Windowing.MessageOpenMode;
         EnsureMessageListTab();
         _activeSort = ConfigModel.ParseSort(cfg.Sort);
@@ -1664,6 +1665,9 @@ public partial class MainViewModel : ObservableObject, IDisposable
 
         ApplyConnectionDiagnosticsSetting(cfg.ConnectionDiagnostics);
 
+        // Keep the View menu's density check marks in sync with a Settings save.
+        ListDensity = cfg.AppearanceListDensity == "compact" ? "compact" : "comfortable";
+
         ShowMessageStatus = cfg.ShowMessageStatus;
         ReadAsPlainText   = cfg.ReadAsPlainText;
         _announceFlagStatus = cfg.AnnounceFlagStatus;
@@ -1780,6 +1784,16 @@ public partial class MainViewModel : ObservableObject, IDisposable
         registry.Register(new CommandDefinition(
             id: "view.toggleConversation", category: "View", title: "Cycle View Mode",
             execute: () => ViewMode = (ViewMode)(((int)ViewMode + 1) % 4)));
+
+        // Density (#421): the same setting the Settings dialog persists, adjustable
+        // from the View menu, the palette, and (via these registrations) a hotkey.
+        registry.Register(new CommandDefinition(
+            id: "view.density.comfortable", category: "View", title: "Density: Comfortable",
+            execute: () => SetListDensity("comfortable")));
+
+        registry.Register(new CommandDefinition(
+            id: "view.density.compact", category: "View", title: "Density: Compact",
+            execute: () => SetListDensity("compact")));
 
         registry.Register(new CommandDefinition(
             id: "account.manage", category: "Account", title: "Manage Accounts",
@@ -6408,6 +6422,38 @@ public partial class MainViewModel : ObservableObject, IDisposable
     private void SetViewMode(string? mode)
     {
         ViewMode = ConfigModel.ParseViewMode(mode);
+    }
+
+    // ── List density command (#421, View menu) ────────────────────────────────
+
+    /// <summary>Current message-list density ("comfortable"/"compact"); drives
+    /// the View menu check marks. The token publish itself lives in ThemeService.</summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsListDensityComfortable))]
+    [NotifyPropertyChangedFor(nameof(IsListDensityCompact))]
+    private string _listDensity = "comfortable";
+
+    public bool IsListDensityComfortable => ListDensity == "comfortable";
+    public bool IsListDensityCompact => ListDensity == "compact";
+
+    /// <summary>
+    /// Same setting the Settings dialog persists — the View menu adjusts it in
+    /// place. Density is padding-only, so ThemeService re-publishes without
+    /// raising ThemeChanged; the result announcement here is the only speech.
+    /// </summary>
+    [RelayCommand]
+    private void SetListDensity(string? density)
+    {
+        var normalized = density?.ToLowerInvariant() == "compact" ? "compact" : "comfortable";
+        if (normalized == ListDensity) return;
+        ListDensity = normalized;
+
+        var cfg = _configService.Load();
+        cfg.AppearanceListDensity = normalized;
+        _configService.Save(cfg);
+        _themeService?.ApplyAppearance(cfg);
+
+        Announce(normalized == "compact" ? "Compact density." : "Comfortable density.");
     }
 
     // ── Search command ────────────────────────────────────────────────────────

--- a/QuickMail/Views/MainWindow.xaml
+++ b/QuickMail/Views/MainWindow.xaml
@@ -426,6 +426,21 @@
                               IsChecked="{Binding CalendarVm.IsMonthView, Mode=OneWay}"
                               Command="{Binding CalendarVm.ShowMonthCommand}"/>
                 </MenuItem>
+                <!-- Density (#421): the same setting as Settings → Appearance,
+                     adjustable in place. Padding only — never the accessibility
+                     surface. Registered as view.density.* for palette/hotkeys. -->
+                <MenuItem Header="_Density">
+                    <MenuItem Header="_Comfortable"
+                              IsCheckable="True"
+                              IsChecked="{Binding IsListDensityComfortable, Mode=OneWay}"
+                              Command="{Binding SetListDensityCommand}"
+                              CommandParameter="comfortable"/>
+                    <MenuItem Header="Co_mpact"
+                              IsCheckable="True"
+                              IsChecked="{Binding IsListDensityCompact, Mode=OneWay}"
+                              Command="{Binding SetListDensityCommand}"
+                              CommandParameter="compact"/>
+                </MenuItem>
                 <MenuItem Header="F_ilter">
                     <MenuItem Header="S_how All"
                               IsCheckable="True"
@@ -561,6 +576,13 @@
                               CommandParameter="0"/>
                 </MenuItem>
                 <Separator/>
+                <!-- Moved from Tools: choosing how the app looks belongs on View.
+                     Next/Previous Theme remain palette commands (theme.next/previous)
+                     without menu items, per design. -->
+                <MenuItem Header="Manage _Themes…"
+                          Click="MenuManageThemes_Click"
+                          AutomationProperties.Name="Manage Themes"/>
+                <Separator/>
                 <MenuItem Header="Go to _Folder…"
                           Click="MenuFolderPicker_Click"/>
                 <MenuItem Header="_Search Folders…"
@@ -571,14 +593,6 @@
             <!-- Tools — always available (mirrors the Compose window's Tools menu).
                  Each command lives here only; not duplicated in File/Message/View. -->
             <MenuItem Header="_Tools">
-                <MenuItem Header="Manage _Themes…"
-                          Click="MenuManageThemes_Click"
-                          AutomationProperties.Name="Manage Themes"/>
-                <MenuItem Header="_Next Theme"
-                          Click="MenuNextTheme_Click"/>
-                <MenuItem Header="Pre_vious Theme"
-                          Click="MenuPreviousTheme_Click"/>
-                <Separator/>
                 <MenuItem Header="Address _Book…"
                           Click="MenuAddressBook_Click"
                           InputGestureText="Ctrl+Shift+B"/>

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -5697,15 +5697,9 @@ public partial class MainWindow : Window
         window.Show();
     }
 
-    // ── Tools menu (theme actions dispatch through the registered commands so the
-    //    Command Palette and any custom hotkeys stay the single source of truth) ──
+    // ── View menu theme entry (moved from Tools; Next/Previous Theme are
+    //    palette-only commands — theme.next / theme.previous — by design) ──
     private void MenuManageThemes_Click(object sender, RoutedEventArgs e) => OpenThemeManager();
-
-    private void MenuNextTheme_Click(object sender, RoutedEventArgs e)
-        => _registry.FindById("theme.next")?.Execute();
-
-    private void MenuPreviousTheme_Click(object sender, RoutedEventArgs e)
-        => _registry.FindById("theme.previous")?.Execute();
 
     private void MenuGrabAddresses_Click(object sender, RoutedEventArgs e)
         => GrabAddressesFromMessage();

--- a/docs/KEYBOARD-SHORTCUTS.md
+++ b/docs/KEYBOARD-SHORTCUTS.md
@@ -60,6 +60,8 @@
 | *(unassigned)* | `theme.next` | Next Theme |
 | *(unassigned)* | `theme.previous` | Previous Theme |
 | *(unassigned)* | `theme.apply.{id}` | Theme: [name] — one per available theme |
+| *(unassigned)* | `view.density.comfortable` | Density: Comfortable |
+| *(unassigned)* | `view.density.compact` | Density: Compact |
 
 ## Compose Window
 


### PR DESCRIPTION
Implements Kelly's two View-menu placement decisions. Branched from post-#443 main — no overlap with that session's files.

- **Density on the View menu**: checkable Comfortable/Compact items honoring and persisting the Settings value, registered as `view.density.comfortable` / `view.density.compact` (palette + hotkey-assignable). Announces its result ("Compact density.").
- **Manage Themes moves Tools → View**; Next/Previous Theme lose their menu items but keep their registered commands, so the palette and any assigned hotkeys still work.
- **Bonus correctness fix**: ThemeService now distinguishes "needs re-publish" from "theme actually changed" — a density-only change no longer raises ThemeChanged, which used to announce "Theme changed to …" and re-render the reading pane spuriously (latent since #440's Settings path).

Full suite green (2291/0); menu accelerators audited (D and T free at the View menu level).

🤖 Generated with [Claude Code](https://claude.com/claude-code)