### PR TITLE
Fix installer-breaking analyzer errors; make CI's -warnaserror gate real

### DIFF
--- a/.github/workflows/quickmail.yml
+++ b/.github/workflows/quickmail.yml
@@ -280,7 +280,15 @@ jobs:
         # -warnaserror: CI fails on ANY compiler/analyzer warning so a warning can never
         # land on main or ship in a release. Local build.bat stays permissive for WIP;
         # this is the enforcement point. Keep the tree warning-free or the build breaks.
-        run: dotnet publish QuickMail/QuickMail.csproj -c Release -o publish/ -warnaserror
+        #
+        # The clean is load-bearing: the Test step above already built Release, so
+        # without it this publish is an incremental no-op — the compiler (and thus
+        # every analyzer) never re-runs and -warnaserror has nothing to catch. That
+        # is how analyzer errors reached main twice and broke only the on-demand
+        # installer build, which compiles cold (runs 30597553629, 30635331364).
+        run: |
+          dotnet clean QuickMail/QuickMail.csproj -c Release -v quiet
+          dotnet publish QuickMail/QuickMail.csproj -c Release -o publish/ -warnaserror
         # PublishSingleFile, SelfContained, RuntimeIdentifier, ReadyToRun are set in .csproj
 
       - name: Upload artifact

--- a/QuickMail/Services/ConfigService.cs
+++ b/QuickMail/Services/ConfigService.cs
@@ -244,7 +244,7 @@ public class ConfigService : IConfigService
                     case "appearanceunderlinelinks":   config.AppearanceUnderlineLinks   = ParseBool(value); break;
                     case "appearancethickfocus":       config.AppearanceThickFocus       = ParseBool(value); break;
                     case "appearancelistdensity":
-                        config.AppearanceListDensity = value.ToLowerInvariant() == "compact" ? "compact" : "comfortable";
+                        config.AppearanceListDensity = string.Equals(value, "compact", StringComparison.OrdinalIgnoreCase) ? "compact" : "comfortable";
                         break;
                     case "appearanceforcemessagetheme": config.AppearanceForceMessageTheme = ParseBool(value); break;
                     case "customannouncements":  config.CustomAnnouncements = ParseBool(value); break;

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -6444,7 +6444,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
     [RelayCommand]
     private void SetListDensity(string? density)
     {
-        var normalized = density?.ToLowerInvariant() == "compact" ? "compact" : "comfortable";
+        var normalized = string.Equals(density, "compact", StringComparison.OrdinalIgnoreCase) ? "compact" : "comfortable";
         if (normalized == ListDensity) return;
         ListDensity = normalized;
 


### PR DESCRIPTION
Second installer break of the same class (run 30635331364), and this PR closes the class, not just the instance: the two density `ToLowerInvariant() ==` comparisons are fixed, and the QuickMail workflow's `-warnaserror` publish now runs after a clean — it had been an incremental no-op reusing the Test step's build, so analyzers never re-ran and the gate was decorative (the green run's compile took 0.5s). Proof will be visible in this PR's own CI: the Publish step should now take minutes, and any future analyzer warning fails the PR instead of Kelly's installer button.

Verified locally with the installer's exact `dotnet publish -c Release -warnaserror`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)