### PR TITLE
#346 follow-up: Inbox-scope "Run on Existing Mail"

### DIFF
--- a/QuickMail.Tests/ClientRulesOnGraphTests.cs
+++ b/QuickMail.Tests/ClientRulesOnGraphTests.cs
@@ -240,4 +240,56 @@ public class ClientRulesOnGraphTests : IDisposable
         Assert.Empty(h.Graph.Actions);
         Assert.Empty(h.Imap.Actions);
     }
+
+    // ── "Run on Existing Mail" is Inbox-scoped (issue #346 follow-up) ─────────────
+
+    private MailMessageSummary Cached(string id, string folder, string subject = "invoice ready") => new()
+    {
+        MessageId = id,
+        AccountId = _graphAccountId,
+        FolderName = folder,
+        From = "sender@example.com",
+        To = "me@example.com",
+        Subject = subject,
+        Preview = "body text",
+    };
+
+    [Fact]
+    public async Task RunOnExisting_OnlyAppliesToInbox_LeavesOtherFoldersUntouched()
+    {
+        // A rule that matches mail sitting in BOTH the Inbox and a non-Inbox folder must act only on
+        // the Inbox copy — never reach into Sent/Archive/Junk/Trash/custom folders — so "Run on
+        // Existing Mail" can't move or delete mail the user deliberately filed elsewhere.
+        var h = Build(MoveRule(_graphAccountId));
+        await _store.UpsertSummariesAsync([Cached("in-1", "INBOX"), Cached("ar-1", "Archive")]);
+
+        var inboxByAccount = new Dictionary<Guid, string> { [_graphAccountId] = "INBOX" };
+        var removed = await h.Rules.ApplyRulesToExistingAsync(_store, inboxByAccount, CancellationToken.None);
+
+        // Only the Inbox copy was moved.
+        var move = Assert.Single(h.Graph.Actions);
+        Assert.Equal("Move", move.Method);
+        Assert.Equal(["in-1"], move.Ids);
+        Assert.Equal(["in-1"], removed.Select(m => m.MessageId).ToList());
+
+        // The Archive copy is still cached — rules never touched it.
+        var stillCached = await _store.LoadAllSummariesAsync();
+        Assert.Contains(stillCached, m => m.MessageId == "ar-1");
+        Assert.DoesNotContain(stillCached, m => m.MessageId == "in-1");
+    }
+
+    [Fact]
+    public async Task RunOnExisting_AccountMissingFromInboxMap_IsSkipped()
+    {
+        // Fail-closed: if the caller couldn't resolve an account's Inbox, none of that account's mail
+        // is touched — doing nothing beats guessing a folder and moving mail out of it.
+        var h = Build(MoveRule(_graphAccountId));
+        await _store.UpsertSummariesAsync([Cached("in-1", "INBOX")]);
+
+        var removed = await h.Rules.ApplyRulesToExistingAsync(
+            _store, new Dictionary<Guid, string>(), CancellationToken.None);
+
+        Assert.Empty(h.Graph.Actions);
+        Assert.Empty(removed);
+    }
 }

--- a/QuickMail.Tests/StubServices.cs
+++ b/QuickMail.Tests/StubServices.cs
@@ -282,7 +282,7 @@ sealed class StubRuleService : IRuleService
         => messages.ToList(); // Stub matches everything
 
     public Task<List<MailMessageSummary>> ApplyRulesToExistingAsync(
-        ILocalStoreService store, CancellationToken ct)
+        ILocalStoreService store, IReadOnlyDictionary<Guid, string> inboxFolderByAccount, CancellationToken ct)
         => Task.FromResult(new List<MailMessageSummary>());
 }
 

--- a/QuickMail.Tests/SyncServiceRuleApplicationTests.cs
+++ b/QuickMail.Tests/SyncServiceRuleApplicationTests.cs
@@ -81,7 +81,7 @@ public class SyncServiceRuleApplicationTests : IDisposable
         public List<MailRule> LoadRules() => OneEnabledRule;
         public void SaveRules(List<MailRule> rules) { }
         public List<MailMessageSummary> TestRule(MailRule rule, IEnumerable<MailMessageSummary> messages) => [];
-        public Task<List<MailMessageSummary>> ApplyRulesToExistingAsync(ILocalStoreService store, CancellationToken ct)
+        public Task<List<MailMessageSummary>> ApplyRulesToExistingAsync(ILocalStoreService store, IReadOnlyDictionary<Guid, string> inboxFolderByAccount, CancellationToken ct)
             => Task.FromResult(new List<MailMessageSummary>());
     }
 

--- a/QuickMail/Services/IRuleService.cs
+++ b/QuickMail/Services/IRuleService.cs
@@ -33,11 +33,22 @@ public interface IRuleService
     List<MailMessageSummary> TestRule(MailRule rule, IEnumerable<MailMessageSummary> messages);
 
     /// <summary>
-    /// Apply all enabled rules to messages already in the local store.
-    /// Used after rules are created/edited so existing mail is processed.
+    /// Apply all enabled rules to messages already in the local store, restricted to
+    /// each account's Inbox (issue #346 follow-up). Invoked by the user-facing
+    /// "Run on Existing Mail" action.
+    /// <para>
+    /// <paramref name="inboxFolderByAccount"/> maps an account id to the
+    /// <see cref="MailFolderModel.FullName"/> of that account's Inbox. The caller supplies
+    /// it because folder-kind knowledge lives in the view layer, not here — for a Graph
+    /// account the Inbox's opaque id is never <c>"INBOX"</c>, so it cannot be recognised by
+    /// name. Messages in any other folder (Sent, Archive, Junk, Trash, custom) are left
+    /// untouched, and any account missing from the map is skipped entirely (fail-closed),
+    /// matching the "client rules only ever act on the Inbox" model.
+    /// </para>
     /// Returns messages that were moved or deleted (should be removed from UI).
     /// </summary>
     Task<List<MailMessageSummary>> ApplyRulesToExistingAsync(
         ILocalStoreService store,
+        IReadOnlyDictionary<Guid, string> inboxFolderByAccount,
         CancellationToken ct);
 }

--- a/QuickMail/Services/RuleService.cs
+++ b/QuickMail/Services/RuleService.cs
@@ -361,6 +361,7 @@ public class RuleService : IRuleService
 
     public async Task<List<MailMessageSummary>> ApplyRulesToExistingAsync(
         ILocalStoreService store,
+        IReadOnlyDictionary<Guid, string> inboxFolderByAccount,
         CancellationToken ct)
     {
         var rules = LoadRules();
@@ -369,15 +370,22 @@ public class RuleService : IRuleService
 
         var removedMessages = new List<MailMessageSummary>();
 
-        // Load all cached messages once
+        // Load all cached messages once, then keep only Inbox mail (issue #346 follow-up).
+        // Client rules act on the Inbox only, so drop everything in Sent/Archive/Junk/Trash/custom
+        // folders — and any account we weren't given an Inbox for (fail-closed). FolderName holds the
+        // folder's FullName (set at sync time), matched Ordinal against the caller-supplied Inbox
+        // FullName from the same folder enumeration.
         var allMessages = await store.LoadAllSummariesAsync();
-        LogService.Debug($"ApplyRulesToExisting: {allMessages.Count} cached messages, {enabledRules.Count} enabled rules");
+        var inboxMessages = allMessages.Where(m =>
+            inboxFolderByAccount.TryGetValue(m.AccountId, out var inbox) &&
+            string.Equals(m.FolderName, inbox, StringComparison.Ordinal)).ToList();
+        LogService.Debug($"ApplyRulesToExisting: {allMessages.Count} cached, {inboxMessages.Count} in Inbox, {enabledRules.Count} enabled rules");
 
         foreach (var rule in enabledRules)
         {
             ct.ThrowIfCancellationRequested();
 
-            var matched = allMessages.Where(m =>
+            var matched = inboxMessages.Where(m =>
             {
                 if (rule.AccountId.HasValue && rule.AccountId.Value != m.AccountId)
                     return false;

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -5995,6 +5995,14 @@ public partial class MainWindow : Window
                 if (inbox != null) inboxByAccount[accountId] = inbox.FullName;
             }
 
+            // Fail-closed: any account whose Inbox we couldn't resolve (not connected/enumerated yet)
+            // is skipped by the rule service rather than guessed at. Log which ones so a "my rules
+            // didn't run on account X" report is diagnosable — the run is otherwise silent about it.
+            var skipped = _vm.Accounts.Where(a => !inboxByAccount.ContainsKey(a.Id)).ToList();
+            if (skipped.Count > 0)
+                LogService.Log($"Run on Existing Mail: skipping {skipped.Count} account(s) with no resolved Inbox: " +
+                    string.Join(", ", skipped.Select(a => a.AccountLabel)));
+
             using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
             var removed = await Task.Run(() => _ruleService.ApplyRulesToExistingAsync(_localStore, inboxByAccount, cts.Token));
             if (removed.Count > 0)

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -5976,8 +5976,22 @@ public partial class MainWindow : Window
         // client rules over cached mail off the UI thread and returns how many were moved/deleted.
         async Task<int> RunClientRulesOnExisting()
         {
+            // Client rules act on the Inbox only (issue #346 follow-up). Resolve each account's Inbox
+            // here, where folder kinds are known, and hand the map to the rule service so it never
+            // moves or deletes mail out of Sent/Archive/Junk/Trash/custom folders. A Graph inbox's id
+            // is never "INBOX", so Kind == Inbox is the load-bearing check; the name match only covers
+            // IMAP accounts whose folder tree isn't yet kind-tagged.
+            var inboxByAccount = new Dictionary<Guid, string>();
+            foreach (var (accountId, folders) in _vm.CachedFolders)
+            {
+                var inbox = folders.FirstOrDefault(f =>
+                    f.Kind == SpecialFolderKind.Inbox ||
+                    string.Equals(f.FullName, "INBOX", StringComparison.OrdinalIgnoreCase));
+                if (inbox != null) inboxByAccount[accountId] = inbox.FullName;
+            }
+
             using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
-            var removed = await Task.Run(() => _ruleService.ApplyRulesToExistingAsync(_localStore, cts.Token));
+            var removed = await Task.Run(() => _ruleService.ApplyRulesToExistingAsync(_localStore, inboxByAccount, cts.Token));
             if (removed.Count > 0)
                 _vm.RefreshCommand.Execute(null);
             return removed.Count;


### PR DESCRIPTION
## What & why

Client rules only act on the **Inbox** for live-arriving mail (the #336 fix). The explicit **Run on Existing Mail** action, though, still swept *every* cached folder — so it could move or delete mail the user had deliberately filed into Sent / Archive / Junk / Trash / custom folders. This aligns that action with the "client rules only ever touch the Inbox" model Kelly chose on #427.

## Change

- **`IRuleService.ApplyRulesToExistingAsync`** now takes an `IReadOnlyDictionary<Guid, string>` mapping each account to its **Inbox folder `FullName`**. `RuleService` keeps only cached mail whose `(account, folder)` is that account's Inbox (Ordinal match on `FolderName`, which is stored as `folder.FullName`), and **skips any account absent from the map (fail-closed)**.
- The caller supplies the map because **folder-kind knowledge lives in the view layer**, not in `RuleService` — a Graph Inbox's opaque id is never `"INBOX"`, so it can't be recognised by name down here. `MainWindow.RunClientRulesOnExisting` builds it from `CachedFolders` using the canonical predicate (`Kind == Inbox`, with a `FullName == "INBOX"` fallback for not-yet-kind-tagged IMAP trees).
- Accounts whose Inbox can't be resolved (not connected/enumerated yet) are logged, so a "rules didn't run on account X" report is diagnosable.

## Tests

- A rule matching mail in **both** the Inbox and Archive moves **only** the Inbox copy and leaves the Archive copy cached.
- An account **missing from the map** is skipped entirely (no server action, nothing removed).
- Stubs updated for the new signature. Full suite green.

## Notes / known limitation

The fail-closed skip is safe but currently **silent** to the user — the confirmation reads "Applied rules to existing mail" whether or not some accounts were skipped. In the common case (all accounts synced) nothing is skipped, so this only bites an unsynced/not-yet-connected account. Surfacing a "skipped N account(s)" message would mean widening the run's return contract through both rules-manager view models; happy to do that as a small follow-up if you'd like it in the UI rather than just the log.