### PR TITLE
Arrowing past the ends of the message-list field list no longer wraps (#459)

### DIFF
--- a/QuickMail.Tests/RowFieldsWindowCheckBoxTests.cs
+++ b/QuickMail.Tests/RowFieldsWindowCheckBoxTests.cs
@@ -179,6 +179,92 @@ public class RowFieldsWindowCheckBoxTests
         finally { CloseAndReleaseFocus(window); }
     }
 
+    // ── Arrow keys stop at the ends (#459) ────────────────────────────────────
+    //
+    // Arrow navigation between the rows is WPF's directional navigation, so the tests drive
+    // MoveFocus with the same TraversalRequest the arrow keys produce — deterministic, and not
+    // gated behind QUICKMAIL_RUN_INPUT_TESTS. The list is Contained, not Cycle: this is a list,
+    // and arrowing past its first or last item must stop rather than wrap.
+
+    private static bool Arrow(CheckBox from, FocusNavigationDirection direction) =>
+        from.MoveFocus(new TraversalRequest(direction));
+
+    [StaFact]
+    public void DownArrow_OnTheLastField_StaysOnIt()
+    {
+        var (window, _) = MakeWindow();
+        window.Show();
+        try
+        {
+            window.UpdateLayout();
+            DrainDispatcher();
+            var list = FieldList(window);
+            var boxes = RowCheckBoxes(list);
+            var last = boxes.Length - 1;
+
+            boxes[last].Focus();
+            DrainDispatcher();
+            Arrow(boxes[last], FocusNavigationDirection.Down);
+            DrainDispatcher();
+
+            Assert.Equal(last, list.FocusedIndex());
+        }
+        finally { CloseAndReleaseFocus(window); }
+    }
+
+    [StaFact]
+    public void UpArrow_OnTheFirstField_StaysOnIt()
+    {
+        var (window, _) = MakeWindow();
+        window.Show();
+        try
+        {
+            window.UpdateLayout();
+            DrainDispatcher();
+            var list = FieldList(window);
+            var boxes = RowCheckBoxes(list);
+
+            boxes[0].Focus();
+            DrainDispatcher();
+            Arrow(boxes[0], FocusNavigationDirection.Up);
+            DrainDispatcher();
+
+            Assert.Equal(0, list.FocusedIndex());
+        }
+        finally { CloseAndReleaseFocus(window); }
+    }
+
+    /// <summary>
+    /// The other half of the fix: stopping at the ends must not have stopped arrows working in
+    /// between, and it must not have stranded focus outside the list either.
+    /// </summary>
+    [StaFact]
+    public void ArrowsStillMoveBetweenAdjacentFields()
+    {
+        var (window, vm) = MakeWindow();
+        window.Show();
+        try
+        {
+            window.UpdateLayout();
+            DrainDispatcher();
+            var list = FieldList(window);
+            var boxes = RowCheckBoxes(list);
+
+            boxes[0].Focus();
+            DrainDispatcher();
+            Arrow(boxes[0], FocusNavigationDirection.Down);
+            DrainDispatcher();
+            Assert.Equal(1, list.FocusedIndex());
+            Assert.Same(vm.Fields[1], vm.SelectedField);
+
+            Arrow(boxes[1], FocusNavigationDirection.Up);
+            DrainDispatcher();
+            Assert.Equal(0, list.FocusedIndex());
+            Assert.Same(vm.Fields[0], vm.SelectedField);
+        }
+        finally { CloseAndReleaseFocus(window); }
+    }
+
     // ── Home / End / first-letter ─────────────────────────────────────────────
     //
     // These come free inside a ListBox and had to be written by hand here. Driven through the

--- a/QuickMail/Views/RowFieldsWindow.xaml
+++ b/QuickMail/Views/RowFieldsWindow.xaml
@@ -91,7 +91,13 @@
             <!-- Each row IS a check box, and is ONLY a check box — see FieldCheckList for why a
                  stock ListBox/ItemsControl cannot be used here (both add a wrapper element that
                  repeats the row's name). Arrow keys move between the check boxes via directional
-                 navigation, and the whole group is a single tab stop. -->
+                 navigation, and the whole group is a single tab stop.
+
+                 DirectionalNavigation is Contained, not Cycle: this is a list, and a list's first
+                 and last items are its ends — arrowing past them must stop, the way it does in any
+                 list box (#459). Cycle belongs to radio groups, where wrapping is the platform
+                 behaviour. Contained also keeps arrows inside the group, so focus is not thrown
+                 out of the list at either end. -->
             <ScrollViewer Grid.Row="1" Grid.Column="0"
                           VerticalScrollBarVisibility="Auto"
                           HorizontalScrollBarVisibility="Disabled"
@@ -102,7 +108,7 @@
                                       ItemsSource="{Binding Fields}"
                                       Margin="4"
                                       KeyboardNavigation.TabNavigation="Once"
-                                      KeyboardNavigation.DirectionalNavigation="Cycle"
+                                      KeyboardNavigation.DirectionalNavigation="Contained"
                                       AutomationProperties.Name="Fields">
                     <views:FieldCheckList.ItemTemplate>
                         <DataTemplate>

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -1420,7 +1420,7 @@ Open it and you get a list of every available field, each one a real check box. 
 
 | Key | Action |
 |-----|--------|
-| `Up` / `Down` | Move between fields |
+| `Up` / `Down` | Move between fields; stops at the first and last one |
 | `Space` | Turn the focused field on or off |
 | `Alt+Up` / `Alt+Down` | Move the focused field earlier or later in the spoken order |
 | `Home` / `End` | First / last field |

--- a/docs/release-notes-v0.8.37.md
+++ b/docs/release-notes-v0.8.37.md
@@ -97,7 +97,7 @@ Adding an account now always shows the permission screen, so the full set is app
 
 Every row in a message list is read as one line — sender, subject, date, and so on — and until now that line was fixed. **View → Message List Fields…** lets you decide which pieces are spoken and where each one falls.
 
-Every field is a check box. Check one to include it, uncheck it to leave it out, and use **Alt+Up** and **Alt+Down** to move it. Up and Down arrow move through the fields and stop at the first and last one, the way they do in any list. **Home** and **End** go straight to those ends, and typing a letter jumps to the next field starting with it. Moving a field that is switched off says so, since that changes nothing you can hear.
+Every field is a check box. Check one to include it, uncheck it to leave it out, and use **Alt+Up** and **Alt+Down** to move it. The Up and Down arrows move through the fields and stop at the first and last one, the way they do in any list. **Home** and **End** go straight to those ends, and typing a letter jumps to the next field starting with it. Moving a field that is switched off says so, since that changes nothing you can hear.
 
 A **Spoken preview** box shows the message you had selected when you opened the window, read exactly as the list would read it, updating as you go. There is no OK or Cancel — changes take effect as you make them, and the window is modeless, so you can leave it open, arrow through the list behind it, and hear the result.
 

--- a/docs/release-notes-v0.8.37.md
+++ b/docs/release-notes-v0.8.37.md
@@ -97,7 +97,7 @@ Adding an account now always shows the permission screen, so the full set is app
 
 Every row in a message list is read as one line — sender, subject, date, and so on — and until now that line was fixed. **View → Message List Fields…** lets you decide which pieces are spoken and where each one falls.
 
-Every field is a check box. Check one to include it, uncheck it to leave it out, and use **Alt+Up** and **Alt+Down** to move it. **Home** and **End** go to the first and last field, and typing a letter jumps to the next field starting with it. Moving a field that is switched off says so, since that changes nothing you can hear.
+Every field is a check box. Check one to include it, uncheck it to leave it out, and use **Alt+Up** and **Alt+Down** to move it. Up and Down arrow move through the fields and stop at the first and last one, the way they do in any list. **Home** and **End** go straight to those ends, and typing a letter jumps to the next field starting with it. Moving a field that is switched off says so, since that changes nothing you can hear.
 
 A **Spoken preview** box shows the message you had selected when you opened the window, read exactly as the list would read it, updating as you go. There is no OK or Cancel — changes take effect as you make them, and the window is modeless, so you can leave it open, arrow through the list behind it, and hear the result.
 


### PR DESCRIPTION
Fixes #459.

## The bug

In **View → Message List Fields…**, arrowing down past the last field jumped to the first, and arrowing up past the first jumped to the last. The list should have ends.

## Cause

`FieldCheckList` in `RowFieldsWindow.xaml` declared `KeyboardNavigation.DirectionalNavigation="Cycle"`. Cycle is the right mode for a radio group, where wrapping is the platform behaviour — it was applied here by pattern rather than by fit.

## Fix

`DirectionalNavigation="Contained"`. Arrows stop at the first and last field, and are still kept inside the group, so focus is not thrown out of the list at either end instead.

Unaffected:

- **Alt+Up / Alt+Down** reordering was already clamped by `CanMoveUp` / `CanMoveDown`.
- **First-letter type-ahead** still wraps — that is what list type-ahead does everywhere, and it is a separate mechanism (`TypeAheadMatcher.FindNext`).
- **Home / End** unchanged.
- The radio groups that legitimately use `Cycle` (Settings, EventEditor, FlagManager swatches, and the *When to speak* group in this same window) are untouched.

## Tests

Three new deterministic tests in `RowFieldsWindowCheckBoxTests`, driving `MoveFocus` with the same `TraversalRequest` the arrow keys produce — so they are not gated behind `QUICKMAIL_RUN_INPUT_TESTS`:

- `DownArrow_OnTheLastField_StaysOnIt`
- `UpArrow_OnTheFirstField_StaysOnIt`
- `ArrowsStillMoveBetweenAdjacentFields` — the other half: stopping at the ends must not have broken arrowing in between, or stranded focus outside the list.

Run on this branch (Release), all green:

| Class | Passed |
|---|---|
| RowFieldsWindowCheckBoxTests | 13 |
| RowFieldsViewModelTests | 19 |
| RowFieldsPreviewConsistencyTests | 12 |
| RadioGroupNavigationTests | 9 |
| RadioGroupWiringTests | 6 |
| XamlParseTests | 26 |

0 failed, 0 skipped, no hangs under `--blame-hang-timeout 3m`.

## Docs

0.8.37 has not shipped yet, so this is corrected in place rather than added as a fix entry: the release notes and the User Guide's key table both described only Home/End, and now say where arrowing stops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
