### PR TITLE
Fix #448/#449/#450: calendar agenda columns, rules clipping, compose 150% row

### DIFF
--- a/QuickMail.Tests/ThemedControlCoverageTests.cs
+++ b/QuickMail.Tests/ThemedControlCoverageTests.cs
@@ -150,6 +150,65 @@ public class ThemedControlCoverageTests
             + "(these render default white in dark themes):\n" + string.Join("\n", missing));
     }
 
+    /// <summary>
+    /// A ListView whose View is a GridView renders its columns through a
+    /// GridViewRowPresenter, which lives only in the container style keyed by
+    /// GridView.GridViewItemContainerStyleKey. An explicit ItemContainerStyle
+    /// that is based on the plain ListViewItem style (whose themed template
+    /// hosts a ContentPresenter) silently drops every column and renders
+    /// item.ToString() instead — the calendar agenda listed
+    /// "QuickMail.Models.CalendarEvent" for months that way (#448). It is
+    /// invisible to a screen reader, because the row's AutomationProperties.Name
+    /// is stamped separately and stays correct, so only a visual check catches
+    /// it. Basing on no style at all is equally wrong: the row then falls back
+    /// to WPF's unthemed default chrome.
+    /// </summary>
+    [Fact]
+    public void GridViewListViews_BaseTheirContainerStyleOnTheGridViewStyle()
+    {
+        var root = FindRepoRoot();
+        Assert.False(root is null, "Repo source tree not found from test base directory.");
+
+        var xamlFiles = new[] { "Views", "Controls" }
+            .Select(sub => Path.Combine(root!, "QuickMail", sub))
+            .Where(Directory.Exists)
+            .SelectMany(dir => Directory.EnumerateFiles(dir, "*.xaml"));
+
+        var violations = new List<string>();
+        foreach (var file in xamlFiles)
+        {
+            var doc = XDocument.Load(file);
+            foreach (var listView in doc.Descendants().Where(e => e.Name.LocalName == "ListView"))
+            {
+                var hasGridView = listView.Descendants().Any(e => e.Name.LocalName == "GridView");
+                if (!hasGridView) continue;
+
+                var containerStyle = listView.Elements()
+                    .FirstOrDefault(e => e.Name.LocalName == "ListView.ItemContainerStyle")
+                    ?.Elements().FirstOrDefault(e => e.Name.LocalName == "Style");
+                if (containerStyle is null) continue;   // no explicit style: WPF picks the right one
+
+                // A style that supplies its own Template with a GridViewRowPresenter
+                // is fine too — that is how the message list paints its unread bar.
+                var suppliesRowPresenter = containerStyle.Descendants()
+                    .Any(e => e.Name.LocalName == "GridViewRowPresenter");
+                var basedOn = containerStyle.Attribute("BasedOn")?.Value ?? string.Empty;
+                if (suppliesRowPresenter ||
+                    basedOn.Contains("GridViewItemContainerStyleKey", StringComparison.Ordinal))
+                    continue;
+
+                violations.Add($"{Path.GetFileName(file)}: ListView '{listView.Attribute(XName.Get("Name", "http://schemas.microsoft.com/winfx/2006/xaml"))?.Value ?? "(unnamed)"}' "
+                    + $"container style BasedOn=\"{(basedOn.Length == 0 ? "(none)" : basedOn)}\"");
+            }
+        }
+
+        Assert.True(violations.Count == 0,
+            "GridView ListViews whose ItemContainerStyle neither derives from the GridView container "
+            + "style nor supplies its own GridViewRowPresenter — their columns will not render:\n"
+            + string.Join("\n", violations)
+            + "\nUse BasedOn=\"{StaticResource {x:Static GridView.GridViewItemContainerStyleKey}}\".");
+    }
+
     [Fact]
     public void ExemptionTable_HasNoStaleEntries()
     {

--- a/QuickMail.Tests/ThemedControlCoverageTests.cs
+++ b/QuickMail.Tests/ThemedControlCoverageTests.cs
@@ -162,6 +162,13 @@ public class ThemedControlCoverageTests
     /// is stamped separately and stays correct, so only a visual check catches
     /// it. Basing on no style at all is equally wrong: the row then falls back
     /// to WPF's unthemed default chrome.
+    ///
+    /// Known limits (no GridView list uses these shapes today; extend the scan
+    /// if one starts to): only the inline &lt;ListView.ItemContainerStyle&gt;
+    /// element is inspected, so an attribute-form ItemContainerStyle="{...}" or
+    /// an ItemContainerStyleSelector is skipped, and the GridView probe walks
+    /// all descendants, so an outer list wrapping a nested GridView list would
+    /// be treated as GridView-bearing.
     /// </summary>
     [Fact]
     public void GridViewListViews_BaseTheirContainerStyleOnTheGridViewStyle()

--- a/QuickMail/Views/ComposeWindow.xaml
+++ b/QuickMail/Views/ComposeWindow.xaml
@@ -184,50 +184,18 @@
 
         <!-- Status / progress bar -->
         <DockPanel DockPanel.Dock="Bottom" Margin="0,6,0,0">
-            <Button DockPanel.Dock="Right"
-                    Content="_Cancel"
-                    Command="{Binding CancelCommand}"
-                    AutomationProperties.Name="Cancel and close compose window"
-                    IsCancel="True"
-                    MinWidth="80" Margin="6,0,0,0"
-                    TabIndex="11"/>
-            <Button DockPanel.Dock="Right"
-                    Content="Save Draft"
-                    Command="{Binding SaveDraftCommand}"
-                    AutomationProperties.Name="Save as draft"
-                    AutomationProperties.AcceleratorKey="Ctrl+S"
-                    MinWidth="100" Margin="6,0,0,0"
-                    TabIndex="10"/>
-            <Button DockPanel.Dock="Right"
-                    Content="Save as Template"
-                    Command="{Binding SaveAsTemplateCommand}"
-                    AutomationProperties.Name="Save current message as template"
-                    MinWidth="120" Margin="6,0,0,0"
-                    TabIndex="9"/>
-            <Button DockPanel.Dock="Right"
-                    Content="Insert Template…"
-                    Command="{Binding InsertTemplateCommand}"
-                    AutomationProperties.Name="Insert a saved template"
-                    MinWidth="120" Margin="6,0,0,0"
-                    TabIndex="8"/>
-            <Button DockPanel.Dock="Right"
-                    x:Name="SendButton"
-                    Content="Send"
-                    Command="{Binding SendCommand}"
-                    AutomationProperties.Name="Send message"
-                    AutomationProperties.AcceleratorKey="Alt+S"
-                    MinWidth="80"
-                    TabIndex="7"/>
-            <!-- Deliberately NOT IsDefault. A default button makes Enter send the
-                 message from any control that does not handle Enter itself — the
-                 From combo, the compose-mode combo, the Subject box, the attachment
-                 list. Choosing a sending account with arrow-then-Enter would send
-                 the half-written message and disclose its contents (issue #201).
-                 Send is reachable by Alt+S, Ctrl+Enter, or Enter/Space with the
-                 Send button focused. Do not re-add IsDefault. -->
+            <!-- Order matters: DockPanel hands out space in DECLARATION order, so
+                 the mode selector is declared first and takes its MinWidth before
+                 the buttons see any. Previously the buttons docked Right first and
+                 consumed the whole row, crushing the selector to a sliver at 150%
+                 text (#450). The buttons then sit in a WrapPanel — measured against
+                 what is left — so they break onto a second line instead of clipping.
+                 Declaration order here is visual order (it was reversed when each
+                 button docked Right individually) and matches TabIndex. -->
             <ComboBox DockPanel.Dock="Left"
                       x:Name="ModeSelector"
-                      MinWidth="110" Margin="0,0,6,0"
+                      MinWidth="110" Margin="0,2,6,0"
+                      VerticalAlignment="Center"
                       AutomationProperties.Name="Compose mode"
                       TabIndex="12"
                       SelectionChanged="ModeSelector_SelectionChanged">
@@ -235,6 +203,44 @@
                 <ComboBoxItem Content="Markdown"/>
                 <ComboBoxItem Content="HTML"/>
             </ComboBox>
+            <WrapPanel DockPanel.Dock="Right" HorizontalAlignment="Right">
+                <Button x:Name="SendButton"
+                        Content="Send"
+                        Command="{Binding SendCommand}"
+                        AutomationProperties.Name="Send message"
+                        AutomationProperties.AcceleratorKey="Alt+S"
+                        MinWidth="80" Margin="6,2,0,0"
+                        TabIndex="7"/>
+                <Button Content="Insert Template…"
+                        Command="{Binding InsertTemplateCommand}"
+                        AutomationProperties.Name="Insert a saved template"
+                        MinWidth="120" Margin="6,2,0,0"
+                        TabIndex="8"/>
+                <Button Content="Save as Template"
+                        Command="{Binding SaveAsTemplateCommand}"
+                        AutomationProperties.Name="Save current message as template"
+                        MinWidth="120" Margin="6,2,0,0"
+                        TabIndex="9"/>
+                <Button Content="Save Draft"
+                        Command="{Binding SaveDraftCommand}"
+                        AutomationProperties.Name="Save as draft"
+                        AutomationProperties.AcceleratorKey="Ctrl+S"
+                        MinWidth="100" Margin="6,2,0,0"
+                        TabIndex="10"/>
+                <Button Content="_Cancel"
+                        Command="{Binding CancelCommand}"
+                        AutomationProperties.Name="Cancel and close compose window"
+                        IsCancel="True"
+                        MinWidth="80" Margin="6,2,0,0"
+                        TabIndex="11"/>
+            </WrapPanel>
+            <!-- Deliberately NOT IsDefault. A default button makes Enter send the
+                 message from any control that does not handle Enter itself — the
+                 From combo, the compose-mode combo, the Subject box, the attachment
+                 list. Choosing a sending account with arrow-then-Enter would send
+                 the half-written message and disclose its contents (issue #201).
+                 Send is reachable by Alt+S, Ctrl+Enter, or Enter/Space with the
+                 Send button focused. Do not re-add IsDefault. -->
             <TextBlock DockPanel.Dock="Left"
                        VerticalAlignment="Center"
                        Text="{Binding AutoSaveText}"

--- a/QuickMail/Views/GroupManagerWindow.xaml
+++ b/QuickMail/Views/GroupManagerWindow.xaml
@@ -84,7 +84,7 @@
                           KeyboardNavigation.TabNavigation="Once"
                           PreviewKeyDown="MembersList_PreviewKeyDown">
                     <ListView.ItemContainerStyle>
-                        <Style TargetType="ListViewItem">
+                        <Style TargetType="ListViewItem" BasedOn="{StaticResource {x:Static GridView.GridViewItemContainerStyleKey}}">
                             <Setter Property="AutomationProperties.Name" Value="{Binding Display}"/>
                             <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
                         </Style>
@@ -113,7 +113,7 @@
                               KeyboardNavigation.TabNavigation="Once"
                               PreviewKeyDown="CandidatesList_PreviewKeyDown">
                         <ListView.ItemContainerStyle>
-                            <Style TargetType="ListViewItem">
+                            <Style TargetType="ListViewItem" BasedOn="{StaticResource {x:Static GridView.GridViewItemContainerStyleKey}}">
                                 <Setter Property="AutomationProperties.Name" Value="{Binding Display}"/>
                                 <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
                             </Style>

--- a/QuickMail/Views/MainWindow.xaml
+++ b/QuickMail/Views/MainWindow.xaml
@@ -1336,7 +1336,14 @@
                                   GotKeyboardFocus="CalendarList_GotKeyboardFocus"
                                   PreviewKeyDown="CalendarList_PreviewKeyDown">
                             <ListView.ItemContainerStyle>
-                                <Style TargetType="ListViewItem" BasedOn="{StaticResource {x:Type ListViewItem}}">
+                                <!-- BasedOn the GRIDVIEW container style, not the plain ListViewItem
+                                     style: the plain one's template hosts a ContentPresenter, so rows
+                                     rendered item.ToString() ("QuickMail.Models.CalendarEvent") and the
+                                     columns never appeared (#448). Invisible to a screen reader — the
+                                     row name below was always correct — which is why it took the visual
+                                     harness to catch it. -->
+                                <Style TargetType="ListViewItem"
+                                       BasedOn="{StaticResource {x:Static GridView.GridViewItemContainerStyleKey}}">
                                     <!-- Row name = the stamped accessible name (data-only or field-labeled
                                          per the CalendarListShowFieldLabels setting); the visual columns
                                          aid sighted users. -->

--- a/QuickMail/Views/PropertiesWindow.xaml
+++ b/QuickMail/Views/PropertiesWindow.xaml
@@ -55,7 +55,7 @@
                         </GridView>
                     </ListView.View>
                     <ListView.ItemContainerStyle>
-                        <Style TargetType="ListViewItem">
+                        <Style TargetType="ListViewItem" BasedOn="{StaticResource {x:Static GridView.GridViewItemContainerStyleKey}}">
                             <Setter Property="AutomationProperties.Name"
                                 Value="{Binding Converter={x:Static local:PropertyItemNameConverter.Instance}}"/>
                             <Style.Triggers>

--- a/QuickMail/Views/RulesManagerWindow.xaml
+++ b/QuickMail/Views/RulesManagerWindow.xaml
@@ -21,11 +21,15 @@
         <Style TargetType="TextBox" x:Key="RuleTextBox" BasedOn="{StaticResource {x:Type TextBox}}">
             <Setter Property="Margin" Value="0,2,0,8"/>
             <Setter Property="Padding" Value="4,3"/>
-            <Setter Property="Height" Value="26"/>
+            <!-- MinHeight, never Height: a fixed height clipped the text at large
+                 text scales (#449). -->
+            <Setter Property="MinHeight" Value="26"/>
         </Style>
         <Style TargetType="ComboBox" x:Key="RuleComboBox" BasedOn="{StaticResource {x:Type ComboBox}}">
             <Setter Property="Margin" Value="0,2,0,8"/>
-            <Setter Property="Height" Value="26"/>
+            <!-- MinHeight, never Height: a fixed height clipped the text at large
+                 text scales (#449). -->
+            <Setter Property="MinHeight" Value="26"/>
         </Style>
         <Style TargetType="CheckBox" x:Key="RuleCheckBox" BasedOn="{StaticResource {x:Type CheckBox}}">
             <Setter Property="Margin" Value="0,4,0,4"/>
@@ -55,13 +59,12 @@
 
                 <WrapPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,6">
                     <Button Content="New Rule" Command="{Binding NewRuleCommand}"
-                            Width="80" Height="26" Margin="0,0,6,6"
+                            MinWidth="80" Margin="0,0,6,6"
                             AutomationProperties.Name="Create new rule"/>
                     <Button Content="Delete" Command="{Binding DeleteRuleCommand}"
-                            Width="60" Height="26" Margin="0,0,6,6"
+                            MinWidth="60" Margin="0,0,6,6"
                             AutomationProperties.Name="Delete selected rule"/>
-                    <Button Content="Run on Existing Mail" Command="{Binding RunOnExistingCommand}"
-                            Height="26" Padding="8,0" Margin="0,0,0,6"
+                    <Button Content="Run on Existing Mail" Command="{Binding RunOnExistingCommand}" Padding="8,0" Margin="0,0,0,6"
                             AutomationProperties.Name="Run all rules on existing mail now"/>
                 </WrapPanel>
 
@@ -239,7 +242,7 @@
                          picked. PickFolder raises PropertyChanged(SelectedRule), refreshing both. -->
                     <Button Content="{Binding SelectedRule.TargetFolder, TargetNullValue=Choose Folder…, FallbackValue=Choose Folder…}"
                             Command="{Binding PickFolderCommand}"
-                            Width="140" Height="26" Margin="0,2,0,8"
+                            MinWidth="140" Margin="0,2,0,8"
                             HorizontalAlignment="Left"
                             AutomationProperties.Name="{Binding SelectedRule.TargetFolder, TargetNullValue=Choose target folder, FallbackValue=Choose target folder}"/>
                     <TextBlock Text="{Binding FolderError}" Foreground="{DynamicResource Theme.Error}"
@@ -264,14 +267,14 @@
                     <!-- Buttons -->
                     <StackPanel Orientation="Horizontal" Margin="0,16,0,0">
                         <Button Content="Test Rule" Command="{Binding TestRuleCommand}"
-                                Width="80" Height="26" Margin="0,0,8,0"
+                                MinWidth="80" Margin="0,0,8,0"
                                 AutomationProperties.Name="Test rule against selected messages"/>
                         <Button Content="Save" Command="{Binding SaveRuleCommand}"
-                                Width="60" Height="26" Margin="0,0,8,0"
+                                MinWidth="60" Margin="0,0,8,0"
                                 AutomationProperties.Name="Save rule"
                                 IsDefault="True"/>
                         <Button Content="Close" Command="{Binding CloseCommand}"
-                                Width="60" Height="26"
+                                MinWidth="60"
                                 AutomationProperties.Name="Close rules manager"
                                 IsCancel="True"/>
                     </StackPanel>
@@ -309,19 +312,13 @@
                            AutomationProperties.LiveSetting="Polite"/>
 
                 <WrapPanel Orientation="Horizontal" Margin="0,0,0,6">
-                    <Button Content="New" Command="{Binding CreateRuleCommand}"
-                            Height="26" Padding="10,0" Margin="0,0,6,4" AutomationProperties.Name="New server rule"/>
-                    <Button Content="Edit" Command="{Binding EditRuleCommand}"
-                            Height="26" Padding="10,0" Margin="0,0,6,4" AutomationProperties.Name="Edit selected server rule"/>
-                    <Button Content="Delete" Command="{Binding DeleteRuleCommand}"
-                            Height="26" Padding="10,0" Margin="0,0,6,4" AutomationProperties.Name="Delete selected server rule"/>
-                    <Button Content="{Binding ToggleEnabledLabel}" Command="{Binding ToggleEnabledCommand}"
-                            Height="26" Padding="10,0" Margin="0,0,6,4"
+                    <Button Content="New" Command="{Binding CreateRuleCommand}" Padding="10,0" Margin="0,0,6,4" AutomationProperties.Name="New server rule"/>
+                    <Button Content="Edit" Command="{Binding EditRuleCommand}" Padding="10,0" Margin="0,0,6,4" AutomationProperties.Name="Edit selected server rule"/>
+                    <Button Content="Delete" Command="{Binding DeleteRuleCommand}" Padding="10,0" Margin="0,0,6,4" AutomationProperties.Name="Delete selected server rule"/>
+                    <Button Content="{Binding ToggleEnabledLabel}" Command="{Binding ToggleEnabledCommand}" Padding="10,0" Margin="0,0,6,4"
                             AutomationProperties.Name="{Binding ToggleEnabledLabel, StringFormat={}{0} selected server rule}"/>
-                    <Button Content="Move Up" Command="{Binding MoveUpCommand}"
-                            Height="26" Padding="10,0" Margin="0,0,6,4" AutomationProperties.Name="Move selected server rule up"/>
-                    <Button Content="Move Down" Command="{Binding MoveDownCommand}"
-                            Height="26" Padding="10,0" Margin="0,0,0,4" AutomationProperties.Name="Move selected server rule down"/>
+                    <Button Content="Move Up" Command="{Binding MoveUpCommand}" Padding="10,0" Margin="0,0,6,4" AutomationProperties.Name="Move selected server rule up"/>
+                    <Button Content="Move Down" Command="{Binding MoveDownCommand}" Padding="10,0" Margin="0,0,0,4" AutomationProperties.Name="Move selected server rule down"/>
                 </WrapPanel>
                 <Grid>
                     <Grid.ColumnDefinitions>

--- a/QuickMail/Views/ServerRuleEditorWindow.xaml
+++ b/QuickMail/Views/ServerRuleEditorWindow.xaml
@@ -151,9 +151,9 @@
                        TextWrapping="Wrap" Margin="0,0,0,6" KeyboardNavigation.IsTabStop="False"/>
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
                 <Button Content="Save" Command="{Binding SaveCommand}" IsDefault="True"
-                        Width="80" Height="28" Margin="0,0,8,0" AutomationProperties.Name="Save rule"/>
+                        MinWidth="80" Margin="0,0,8,0" AutomationProperties.Name="Save rule"/>
                 <Button Content="Cancel" Command="{Binding CancelCommand}" IsCancel="True"
-                        Width="80" Height="28" AutomationProperties.Name="Cancel"/>
+                        MinWidth="80" AutomationProperties.Name="Cancel"/>
             </StackPanel>
         </StackPanel>
     </Grid>

--- a/QuickMail/Views/SettingsDialog.xaml
+++ b/QuickMail/Views/SettingsDialog.xaml
@@ -1,4 +1,4 @@
-﻿<Window x:Class="QuickMail.Views.SettingsDialog"
+<Window x:Class="QuickMail.Views.SettingsDialog"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -496,7 +496,7 @@
                               SelectionChanged="HotkeyListView_SelectionChanged"
                               AutomationProperties.Name="Keyboard shortcuts list">
                         <ListView.ItemContainerStyle>
-                            <Style TargetType="ListViewItem">
+                            <Style TargetType="ListViewItem" BasedOn="{StaticResource {x:Static GridView.GridViewItemContainerStyleKey}}">
                                 <Setter Property="AutomationProperties.Name" Value="{Binding AccessibleName}"/>
                             </Style>
                         </ListView.ItemContainerStyle>

--- a/QuickMail/Views/SettingsDialog.xaml
+++ b/QuickMail/Views/SettingsDialog.xaml
@@ -1,4 +1,4 @@
-<Window x:Class="QuickMail.Views.SettingsDialog"
+﻿<Window x:Class="QuickMail.Views.SettingsDialog"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/QuickMail/Views/UnifiedRulesWindow.xaml
+++ b/QuickMail/Views/UnifiedRulesWindow.xaml
@@ -93,22 +93,15 @@
                 <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
             <WrapPanel Grid.Column="0" Orientation="Horizontal">
-                <Button Content="New" Command="{Binding NewRuleCommand}"
-                        Height="26" Padding="10,0" Margin="0,0,6,4" AutomationProperties.Name="New rule"/>
-                <Button Content="Edit" Command="{Binding EditRuleCommand}"
-                        Height="26" Padding="10,0" Margin="0,0,6,4" AutomationProperties.Name="Edit selected rule"/>
-                <Button Content="Delete" Command="{Binding DeleteRuleCommand}"
-                        Height="26" Padding="10,0" Margin="0,0,6,4" AutomationProperties.Name="Delete selected rule"/>
-                <Button Content="{Binding ToggleEnabledLabel}" Command="{Binding ToggleEnabledCommand}"
-                        Height="26" Padding="10,0" Margin="0,0,6,4"
+                <Button Content="New" Command="{Binding NewRuleCommand}" Padding="10,0" Margin="0,0,6,4" AutomationProperties.Name="New rule"/>
+                <Button Content="Edit" Command="{Binding EditRuleCommand}" Padding="10,0" Margin="0,0,6,4" AutomationProperties.Name="Edit selected rule"/>
+                <Button Content="Delete" Command="{Binding DeleteRuleCommand}" Padding="10,0" Margin="0,0,6,4" AutomationProperties.Name="Delete selected rule"/>
+                <Button Content="{Binding ToggleEnabledLabel}" Command="{Binding ToggleEnabledCommand}" Padding="10,0" Margin="0,0,6,4"
                         AutomationProperties.Name="{Binding ToggleEnabledLabel, StringFormat={}{0} selected rule}"/>
-                <Button Content="Move Up" Command="{Binding MoveUpCommand}"
-                        Height="26" Padding="10,0" Margin="0,0,6,4" AutomationProperties.Name="Move selected rule up"/>
-                <Button Content="Move Down" Command="{Binding MoveDownCommand}"
-                        Height="26" Padding="10,0" Margin="0,0,0,4" AutomationProperties.Name="Move selected rule down"/>
+                <Button Content="Move Up" Command="{Binding MoveUpCommand}" Padding="10,0" Margin="0,0,6,4" AutomationProperties.Name="Move selected rule up"/>
+                <Button Content="Move Down" Command="{Binding MoveDownCommand}" Padding="10,0" Margin="0,0,0,4" AutomationProperties.Name="Move selected rule down"/>
             </WrapPanel>
-            <Button Grid.Column="1" Content="Close" Click="CloseButton_Click"
-                    Height="26" Padding="12,0" VerticalAlignment="Top" AutomationProperties.Name="Close rules manager"/>
+            <Button Grid.Column="1" Content="Close" Click="CloseButton_Click" Padding="12,0" VerticalAlignment="Top" AutomationProperties.Name="Close rules manager"/>
         </Grid>
     </Grid>
 </Window>


### PR DESCRIPTION
The three app bugs the Phase-4 AI review found in the 2026-07-31 sweep. Details and rationale in the commit message.

**#448 is the notable one** — the calendar agenda rendered `QuickMail.Models.CalendarEvent` in every row because its container style derived from the plain ListViewItem style (ContentPresenter template) instead of the GridView one (GridViewRowPresenter). The accessible name is stamped separately and was always correct, so it was invisible to screen reader use and obvious in one screenshot. Three other GridView lists had the same wiring and are fixed with it, plus a guard test that fails when any GridView ListView's container style bypasses the GridView style — verified in both directions by temporarily reverting the calendar fix.

Before/after probe shots at 100% and 150% confirm all three; full suite 2438 passed / 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)