### PR TITLE
Fix #464: the message-list field chooser had a phantom tab stop on the list container

### DIFF
--- a/QuickMail.Tests/RowFieldsWindowCheckBoxTests.cs
+++ b/QuickMail.Tests/RowFieldsWindowCheckBoxTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
 using System.Windows.Automation;
@@ -175,6 +176,116 @@ public class RowFieldsWindowCheckBoxTests
 
             // Selection follows keyboard focus, because the move commands act on the selection.
             Assert.Same(vm.Fields[3], vm.SelectedField);
+        }
+        finally { CloseAndReleaseFocus(window); }
+    }
+
+    // ── The whole list is one tab stop (#464) ─────────────────────────────────
+    //
+    // Tab lands on a row check box, once. It used to land on the list container first — an element
+    // with no name, value or state of its own, so it read as an empty list — and then on every
+    // single check box in turn, because a TabNavigation="Once" group whose own container is a tab
+    // stop inside it collapses nothing. Driven through MoveFocus, the same traversal Tab performs,
+    // so this is deterministic and not gated behind QUICKMAIL_RUN_INPUT_TESTS.
+
+    /// <summary>Tab stops from the row-type combo all the way round, in order.</summary>
+    private static List<IInputElement> WalkTabOrder(RowFieldsWindow window, ComboBox start)
+    {
+        start.Focus();
+        DrainDispatcher();
+
+        var stops = new List<IInputElement>();
+        // Generous bound: the window has well under 40 focusable elements even when every check
+        // box is (wrongly) its own stop, so this terminates on the wrap in either state.
+        for (int i = 0; i < 40; i++)
+        {
+            if (Keyboard.FocusedElement is not FrameworkElement current) break;
+            if (stops.Count > 0 && ReferenceEquals(current, start)) break;   // wrapped
+            stops.Add(current);
+            current.MoveFocus(new TraversalRequest(FocusNavigationDirection.Next));
+            DrainDispatcher();
+        }
+        return stops;
+    }
+
+    [StaFact]
+    public void TheFieldListIsExactlyOneTabStop_AndItLandsOnARowNotTheContainer()
+    {
+        var (window, _) = MakeWindow();
+        window.Show();
+        try
+        {
+            window.UpdateLayout();
+            DrainDispatcher();
+
+            var list = FieldList(window);
+            var combo = window.FindName("RowTypeList") as ComboBox;
+            Assert.NotNull(combo);
+
+            var stops = WalkTabOrder(window, combo!);
+
+            Assert.DoesNotContain(list, stops);
+            var inList = stops.OfType<DependencyObject>()
+                              .Where(e => list.IsAncestorOf(e))
+                              .ToArray();
+            Assert.Single(inList);
+            Assert.IsType<CheckBox>(inList[0]);
+        }
+        finally { CloseAndReleaseFocus(window); }
+    }
+
+    /// <summary>
+    /// The container being a tab stop is what created the phantom stop, so pin that rather than
+    /// only the behaviour it produced — a future edit that re-enables it fails here.
+    /// </summary>
+    [StaFact]
+    public void TheListContainerIsNotATabStop_OnlyItsRowsAre()
+    {
+        var (window, _) = MakeWindow();
+        window.Show();
+        try
+        {
+            window.UpdateLayout();
+            DrainDispatcher();
+            Assert.False(FieldList(window).IsTabStop, "the rows are the tab stop, not the list");
+        }
+        finally { CloseAndReleaseFocus(window); }
+    }
+
+    /// <summary>
+    /// Out of the tab order must not mean unreachable. The "_Fields, in spoken order" label
+    /// implements its access key as Target.Focus(), so Alt+F hands focus to the list itself — and
+    /// the list forwards it to a row, because a container the user cannot act on is not what
+    /// "focus the field list" means (#464).
+    /// </summary>
+    [StaFact]
+    public void FocusHandedToTheList_LandsOnARow_SoTheLabelsAccessKeyStillWorks()
+    {
+        var (window, _) = MakeWindow();
+        window.Show();
+        try
+        {
+            window.UpdateLayout();
+            DrainDispatcher();
+
+            var list = FieldList(window);
+            var label = window.FindName("FieldsLabel") as Label;
+            Assert.NotNull(label);
+            Assert.Same(list, label!.Target);      // …which is where Alt+F sends focus.
+
+            list.FocusRow(3);
+            DrainDispatcher();
+            Keyboard.ClearFocus();
+            DrainDispatcher();
+
+            list.Focus();
+            DrainDispatcher();
+
+            // Focus is on a row, not on the list. (Focus() reports false — WPF is answering
+            // "did THIS element take focus", and the point is that it did not.)
+            Assert.IsType<CheckBox>(Keyboard.FocusedElement);
+            // Back to the row the user was last on, the way returning to a list should behave.
+            Assert.Equal(3, list.FocusedIndex());
         }
         finally { CloseAndReleaseFocus(window); }
     }

--- a/QuickMail.Tests/RowFieldsWindowCheckBoxTests.cs
+++ b/QuickMail.Tests/RowFieldsWindowCheckBoxTests.cs
@@ -66,6 +66,13 @@ public class RowFieldsWindowCheckBoxTests
         return list!;
     }
 
+    private static TextBox PreviewBox(RowFieldsWindow w)
+    {
+        var box = w.FindName("PreviewBox") as TextBox;
+        Assert.NotNull(box);
+        return box!;
+    }
+
     private static CheckBox[] RowCheckBoxes(FieldCheckList list) =>
         Enumerable.Range(0, list.Items.Count)
             .Select(i => list.ItemContainerGenerator.ContainerFromIndex(i))
@@ -180,36 +187,76 @@ public class RowFieldsWindowCheckBoxTests
         finally { CloseAndReleaseFocus(window); }
     }
 
-    // ── The whole list is one tab stop (#464) ─────────────────────────────────
+    // ── The list container is not a tab stop of its own (#464) ────────────────
     //
-    // Tab lands on a row check box, once. It used to land on the list container first — an element
-    // with no name, value or state of its own, so it read as an empty list — and then on every
-    // single check box in turn, because a TabNavigation="Once" group whose own container is a tab
-    // stop inside it collapses nothing. Driven through MoveFocus, the same traversal Tab performs,
-    // so this is deterministic and not gated behind QUICKMAIL_RUN_INPUT_TESTS.
+    // Tab used to stop on the list container before reaching a row. TabNavigation="Once" already
+    // collapsed the rows to a single stop, so the container was the whole of the extra stop — and
+    // a container is not something the user can act on. These walk focus with MoveFocus, the same
+    // traversal Tab performs, so they are deterministic and not gated behind
+    // QUICKMAIL_RUN_INPUT_TESTS.
 
-    /// <summary>Tab stops from the row-type combo all the way round, in order.</summary>
-    private static List<IInputElement> WalkTabOrder(RowFieldsWindow window, ComboBox start)
+    /// <summary>
+    /// Tab stops from the row-type combo all the way round, plus every element the list was ASKED
+    /// to give focus to. The second half matters: the list redirects focus off itself onto a row,
+    /// so by the time <c>Keyboard.FocusedElement</c> is sampled a container stop has already been
+    /// papered over. Watching PreviewGotKeyboardFocus catches the attempt itself.
+    /// </summary>
+    private static (List<IInputElement> Stops, List<object> ListFocusAttempts) WalkTabOrder(
+        FieldCheckList list, ComboBox start)
     {
+        var attempts = new List<object>();
+        void OnPreview(object s, KeyboardFocusChangedEventArgs e)
+        {
+            if (ReferenceEquals(e.NewFocus, list)) attempts.Add(e.NewFocus);
+        }
+        // handledEventsToo, and not `+= OnPreview`: whether anything upstream marks this event
+        // handled is not this test's business, and a plain instance handler silently stops running
+        // if something does — reporting "nothing tried to focus the container" precisely when
+        // something did. That is not hypothetical; an earlier version of the redirect handled the
+        // preview event, and with `+=` this test passed with the fault reintroduced.
+        list.AddHandler(UIElement.PreviewGotKeyboardFocusEvent,
+                        new KeyboardFocusChangedEventHandler(OnPreview), handledEventsToo: true);
+
         start.Focus();
         DrainDispatcher();
 
         var stops = new List<IInputElement>();
-        // Generous bound: the window has well under 40 focusable elements even when every check
-        // box is (wrongly) its own stop, so this terminates on the wrap in either state.
-        for (int i = 0; i < 40; i++)
+        var wrapped = false;
+        try
         {
-            if (Keyboard.FocusedElement is not FrameworkElement current) break;
-            if (stops.Count > 0 && ReferenceEquals(current, start)) break;   // wrapped
-            stops.Add(current);
-            current.MoveFocus(new TraversalRequest(FocusNavigationDirection.Next));
-            DrainDispatcher();
+            // Generous bound: the window has well under 40 focusable elements even if every check
+            // box were (wrongly) its own stop, so this reaches the wrap in either state.
+            for (int i = 0; i < 40; i++)
+            {
+                if (Keyboard.FocusedElement is not FrameworkElement current) break;
+                if (stops.Count > 0 && ReferenceEquals(current, start)) { wrapped = true; break; }
+                stops.Add(current);
+                current.MoveFocus(new TraversalRequest(FocusNavigationDirection.Next));
+                DrainDispatcher();
+            }
         }
-        return stops;
+        finally
+        {
+            list.RemoveHandler(UIElement.PreviewGotKeyboardFocusEvent,
+                               new KeyboardFocusChangedEventHandler(OnPreview));
+        }
+
+        // Without this, a walk that stalls on one element surfaces as a baffling count assertion
+        // somewhere below rather than as "focus stopped moving".
+        Assert.True(wrapped, $"tab order never returned to the start; got: {Describe(stops)}");
+        return (stops, attempts);
     }
 
+    private static string Describe(IEnumerable<IInputElement> stops) =>
+        string.Join(" → ", stops.Select(s => s switch
+        {
+            ContentControl { Content: string text } => $"{s.GetType().Name}({text})",
+            FrameworkElement { Name.Length: > 0 } fe => $"{s.GetType().Name}({fe.Name})",
+            _ => s.GetType().Name,
+        }));
+
     [StaFact]
-    public void TheFieldListIsExactlyOneTabStop_AndItLandsOnARowNotTheContainer()
+    public void TabbingThroughTheWindow_NeverStopsOnTheListItself_OnlyOnOneRow()
     {
         var (window, _) = MakeWindow();
         window.Show();
@@ -222,12 +269,15 @@ public class RowFieldsWindowCheckBoxTests
             var combo = window.FindName("RowTypeList") as ComboBox;
             Assert.NotNull(combo);
 
-            var stops = WalkTabOrder(window, combo!);
+            var (stops, listFocusAttempts) = WalkTabOrder(list, combo!);
 
+            // The phantom stop, caught at the point WPF tries to make it — before the redirect
+            // hides it. This is what fails if IsTabStop comes back.
+            Assert.Empty(listFocusAttempts);
             Assert.DoesNotContain(list, stops);
-            var inList = stops.OfType<DependencyObject>()
-                              .Where(e => list.IsAncestorOf(e))
-                              .ToArray();
+
+            // …and the rows contribute exactly one stop between them, on a check box.
+            var inList = stops.OfType<DependencyObject>().Where(list.IsAncestorOf).ToArray();
             Assert.Single(inList);
             Assert.IsType<CheckBox>(inList[0]);
         }
@@ -235,8 +285,8 @@ public class RowFieldsWindowCheckBoxTests
     }
 
     /// <summary>
-    /// The container being a tab stop is what created the phantom stop, so pin that rather than
-    /// only the behaviour it produced — a future edit that re-enables it fails here.
+    /// The container being a tab stop is the cause, so pin that too and not only the behaviour it
+    /// produced — a future edit that re-enables it fails here, whatever else changes.
     /// </summary>
     [StaFact]
     public void TheListContainerIsNotATabStop_OnlyItsRowsAre()
@@ -255,8 +305,8 @@ public class RowFieldsWindowCheckBoxTests
     /// <summary>
     /// Out of the tab order must not mean unreachable. The "_Fields, in spoken order" label
     /// implements its access key as Target.Focus(), so Alt+F hands focus to the list itself — and
-    /// the list forwards it to a row, because a container the user cannot act on is not what
-    /// "focus the field list" means (#464).
+    /// the list passes it to a row, because a container the user cannot act on is not what "focus
+    /// the field list" means (#464).
     /// </summary>
     [StaFact]
     public void FocusHandedToTheList_LandsOnARow_SoTheLabelsAccessKeyStillWorks()
@@ -275,17 +325,59 @@ public class RowFieldsWindowCheckBoxTests
 
             list.FocusRow(3);
             DrainDispatcher();
-            Keyboard.ClearFocus();
+            // Focus goes elsewhere in the window, not nowhere: Alt+F is pressed from another
+            // control, and a cleared focus is a state the window is never actually in.
+            PreviewBox(window).Focus();
             DrainDispatcher();
 
             list.Focus();
             DrainDispatcher();
 
-            // Focus is on a row, not on the list. (Focus() reports false — WPF is answering
-            // "did THIS element take focus", and the point is that it did not.)
+            // What is asserted is where focus ENDS UP. The list does briefly hold focus on the way
+            // — see the remarks on OnGotKeyboardFocus for why cancelling the focus change instead
+            // was measured to be unreliable — so asserting the absence of that transient would be
+            // asserting something the implementation deliberately does not promise.
             Assert.IsType<CheckBox>(Keyboard.FocusedElement);
             // Back to the row the user was last on, the way returning to a list should behave.
             Assert.Equal(3, list.FocusedIndex());
+        }
+        finally { CloseAndReleaseFocus(window); }
+    }
+
+    /// <summary>
+    /// The remembered row belongs to the layout that was showing. Changing the Row type swaps the
+    /// field set and the view model resets its selection to the first field; if the list kept its
+    /// own index, Alt+F and F6 would land on different rows — and Move Up/Down act on whichever
+    /// one selection followed.
+    /// </summary>
+    [StaFact]
+    public void ChangingTheRowType_ForgetsTheRememberedRow_SoAltFAndF6Agree()
+    {
+        var (window, vm) = MakeWindow();
+        window.Show();
+        try
+        {
+            window.UpdateLayout();
+            DrainDispatcher();
+            var list = FieldList(window);
+
+            list.FocusRow(5);
+            DrainDispatcher();
+            Assert.Equal(5, list.FocusedIndex());
+
+            vm.SelectedRowKind = vm.RowKinds.First(k => k != vm.SelectedRowKind);
+            DrainDispatcher();
+            window.UpdateLayout();
+
+            PreviewBox(window).Focus();
+            DrainDispatcher();
+            list.Focus();
+            DrainDispatcher();
+
+            // The first field of the new layout — the same row the view model selected, and the
+            // same one F6 into the list goes to.
+            Assert.Equal(0, list.FocusedIndex());
+            Assert.Same(vm.Fields[0], vm.SelectedField);
         }
         finally { CloseAndReleaseFocus(window); }
     }

--- a/QuickMail/Views/FieldCheckList.cs
+++ b/QuickMail/Views/FieldCheckList.cs
@@ -28,7 +28,47 @@ public sealed class FieldCheckList : ItemsControl
     // than WPF TextSearch, which only works on a Selector.
     private readonly TypeAheadPrefixTracker _typeAhead = new();
 
+    /// <summary>Row the list returns to when focus comes back to it.</summary>
+    private int _lastFocusedIndex;
+
+    static FieldCheckList()
+    {
+        // The row check boxes are the tab stop; the list itself is never one. Control defaults
+        // IsTabStop to true, and inheriting that default cost this window extra stops (#464).
+        // Measured before and after: with the container a tab stop, Tab landed first on the list —
+        // which has no name, value or state of its own to report, so it read as an empty list —
+        // and then on every check box in turn, TabNavigation="Once" notwithstanding. With the
+        // container out of the tab order, Once does what it says: one stop, on a row.
+        //
+        // IsTabStop, not Focusable: the list still has to accept Focus() calls, because that is how
+        // Label implements an access key on its Target — turning Focusable off would silently make
+        // Alt+F do nothing. Focus handed to the list is forwarded to a row below.
+        IsTabStopProperty.OverrideMetadata(
+            typeof(FieldCheckList), new FrameworkPropertyMetadata(false));
+    }
+
     protected override AutomationPeer OnCreateAutomationPeer() => new FieldCheckListPeer(this);
+
+    /// <summary>
+    /// Focus belongs on a row, never on the list itself. Anything that hands focus to the list —
+    /// the label's Alt+F, a caller doing <c>FieldList.Focus()</c> — is asking for the list to be
+    /// usable, and a container the user cannot act on is not that.
+    /// </summary>
+    protected override void OnGotKeyboardFocus(KeyboardFocusChangedEventArgs e)
+    {
+        base.OnGotKeyboardFocus(e);
+
+        if (ReferenceEquals(e.NewFocus, this))
+        {
+            // Back to the row the user was last on, the way returning to a list should behave.
+            if (FocusRow(_lastFocusedIndex) || FocusRow(0)) e.Handled = true;
+            return;
+        }
+
+        // Otherwise this is the event bubbling up from a row's check box: remember which.
+        var idx = FocusedIndex();
+        if (idx >= 0) _lastFocusedIndex = idx;
+    }
 
     // ── keyboard ──────────────────────────────────────────────────────────────
 

--- a/QuickMail/Views/FieldCheckList.cs
+++ b/QuickMail/Views/FieldCheckList.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Linq;
 using System.Windows;
 using System.Windows.Automation.Peers;
@@ -34,15 +35,15 @@ public sealed class FieldCheckList : ItemsControl
     static FieldCheckList()
     {
         // The row check boxes are the tab stop; the list itself is never one. Control defaults
-        // IsTabStop to true, and inheriting that default cost this window extra stops (#464).
-        // Measured before and after: with the container a tab stop, Tab landed first on the list —
-        // which has no name, value or state of its own to report, so it read as an empty list —
-        // and then on every check box in turn, TabNavigation="Once" notwithstanding. With the
-        // container out of the tab order, Once does what it says: one stop, on a row.
+        // IsTabStop to true, and inheriting that default gave this window a second tab stop it
+        // was never meant to have (#464): Tab landed on the list container, which is not something
+        // the user can act on, and only then on a row. TabNavigation="Once" already collapsed the
+        // rows themselves to one stop — measured on both sides of this change — so removing the
+        // container from the tab order is the whole fix.
         //
         // IsTabStop, not Focusable: the list still has to accept Focus() calls, because that is how
         // Label implements an access key on its Target — turning Focusable off would silently make
-        // Alt+F do nothing. Focus handed to the list is forwarded to a row below.
+        // Alt+F do nothing. Focus handed to the list is redirected to a row below.
         IsTabStopProperty.OverrideMetadata(
             typeof(FieldCheckList), new FrameworkPropertyMetadata(false));
     }
@@ -52,8 +53,22 @@ public sealed class FieldCheckList : ItemsControl
     /// <summary>
     /// Focus belongs on a row, never on the list itself. Anything that hands focus to the list —
     /// the label's Alt+F, a caller doing <c>FieldList.Focus()</c> — is asking for the list to be
-    /// usable, and a container the user cannot act on is not that.
+    /// usable, and a container the user cannot act on is not that. This is the only way focus
+    /// reaches the container: Tab does not, because the list is not a tab stop.
     /// </summary>
+    /// <remarks>
+    /// <para>This corrects focus after the fact rather than cancelling it in
+    /// <c>PreviewGotKeyboardFocus</c>, which was tried first and is the tidier shape on paper: it
+    /// would mean the list never becomes the focused element at all. Cancelling requires focusing
+    /// the row re-entrantly, from inside WPF's own focus-change dispatch, and that inner
+    /// <c>Focus()</c> does not reliably succeed — it failed consistently in the full test run and
+    /// passed when the same test ran alone. When it fails the pending change is not cancelled and
+    /// focus simply stays on the list, which is the fault being fixed. Correcting afterwards always
+    /// ends on a row.</para>
+    /// <para>The cost is that the platform briefly reports the list as focused before the row, so
+    /// Alt+F may be spoken as the list and then the field. Tab, the path #464 was reported
+    /// against, does not go through here at all — the list is not a tab stop.</para>
+    /// </remarks>
     protected override void OnGotKeyboardFocus(KeyboardFocusChangedEventArgs e)
     {
         base.OnGotKeyboardFocus(e);
@@ -65,9 +80,22 @@ public sealed class FieldCheckList : ItemsControl
             return;
         }
 
-        // Otherwise this is the event bubbling up from a row's check box: remember which.
+        // Otherwise this is bubbling up from a row's check box: remember which, so focus comes
+        // back to it.
         var idx = FocusedIndex();
         if (idx >= 0) _lastFocusedIndex = idx;
+    }
+
+    /// <summary>
+    /// The remembered row belongs to the layout that was showing. Changing the Row type swaps the
+    /// whole field set, and the view model resets its own selection to the first field — so a
+    /// stale index here would send Alt+F to a different row than F6, in a list where the two must
+    /// agree because Move Up/Down act on the selection.
+    /// </summary>
+    protected override void OnItemsChanged(NotifyCollectionChangedEventArgs e)
+    {
+        base.OnItemsChanged(e);
+        if (e.Action == NotifyCollectionChangedAction.Reset) _lastFocusedIndex = 0;
     }
 
     // ── keyboard ──────────────────────────────────────────────────────────────

--- a/QuickMail/Views/RowFieldsWindow.xaml
+++ b/QuickMail/Views/RowFieldsWindow.xaml
@@ -83,7 +83,8 @@
                 <RowDefinition Height="*"/>
             </Grid.RowDefinitions>
 
-            <Label Grid.Row="0" Grid.Column="0"
+            <Label x:Name="FieldsLabel"
+                   Grid.Row="0" Grid.Column="0"
                    Content="_Fields, in spoken order"
                    Target="{Binding ElementName=FieldList}"
                    Padding="0" FontWeight="SemiBold" Margin="0,0,0,2"/>
@@ -91,7 +92,9 @@
             <!-- Each row IS a check box, and is ONLY a check box — see FieldCheckList for why a
                  stock ListBox/ItemsControl cannot be used here (both add a wrapper element that
                  repeats the row's name). Arrow keys move between the check boxes via directional
-                 navigation, and the whole group is a single tab stop.
+                 navigation, and the whole group is a single tab stop — the list itself is not a
+                 tab stop (FieldCheckList overrides the default), so Tab lands on a row rather
+                 than on the container first (#464).
 
                  DirectionalNavigation is Contained, not Cycle: this is a list, and a list's first
                  and last items are its ends — arrowing past them must stop, the way it does in any

--- a/QuickMail/Views/RowFieldsWindow.xaml.cs
+++ b/QuickMail/Views/RowFieldsWindow.xaml.cs
@@ -184,7 +184,9 @@ public partial class RowFieldsWindow : Window
         var prev = Keyboard.FocusedElement as IInputElement;
         var palette = new CommandPaletteWindow(_localRegistry) { Owner = this };
         palette.ShowDialog();
-        // FieldList.Focus() lands on a row: the list itself is not focusable (#464).
+        // FieldList.Focus() lands on a row rather than on the list container (#464). It is only
+        // the fallback: `prev` normally wins, and a command that rebuilds the field list (Reset)
+        // leaves `prev` detached, which this does not repair.
         (prev ?? FieldList).Focus();
     }
 

--- a/QuickMail/Views/RowFieldsWindow.xaml.cs
+++ b/QuickMail/Views/RowFieldsWindow.xaml.cs
@@ -184,6 +184,7 @@ public partial class RowFieldsWindow : Window
         var prev = Keyboard.FocusedElement as IInputElement;
         var palette = new CommandPaletteWindow(_localRegistry) { Owner = this };
         palette.ShowDialog();
+        // FieldList.Focus() lands on a row: the list itself is not focusable (#464).
         (prev ?? FieldList).Focus();
     }
 


### PR DESCRIPTION
Closes #464.

## What was wrong

Kelly's report was precise: "one tab stop to a list box that seems like it is empty and a second to all the check boxes." Measured tab order in the **Message List Fields** window on unmodified `main`:

```
Row type → Fields (the list container) → Flag → Speak field labels →
Move Down → Reset → Close → Spoken preview → (wraps)
```

Two different things, not one thing twice. The second stop is the field list working correctly — `TabNavigation="Once"` collapses all thirteen check boxes to a single stop. The first is the fault: `FieldCheckList` derives from `ItemsControl`, which inherits `IsTabStop = true` from `Control`, so the list *container* was a tab stop of its own. A container is not something the user can act on, which is why it read as an empty list.

## The fix

`FieldCheckList` overrides the `IsTabStop` default to `false`. Measured after:

```
Row type → Flag → Speak field labels → Move Down → Reset → Close → Spoken preview → (wraps)
```

**`IsTabStop`, not `Focusable`** — which was tried first and broke something quietly. `Label` implements an access key on its `Target` as `Target.Focus()`, so a non-focusable list would have made <kbd>Alt</kbd>+<kbd>F</kbd> on "Fields, in spoken order" do nothing at all. The list stays focusable and redirects focus handed to it onto a row — the one the user was last on.

Arrow keys, Home/End, first-letter type-ahead, Alt+Up/Alt+Down reordering, Space toggling and F6 are unchanged.

## One thing worth a listen before merge

The Alt+F redirect corrects focus **after** the list receives it, so the platform briefly reports the list as focused before the row — Alt+F may be spoken as the list and then the field. Cancelling the focus change in `PreviewGotKeyboardFocus` instead would avoid that entirely, and was tried; it requires focusing the row re-entrantly from inside WPF's focus-change dispatch, and that inner `Focus()` does not reliably succeed — it failed every time in the full test run and passed when the same test ran alone. On failure the change is not cancelled and focus stays on the list, i.e. the fault being fixed. Correcting after the fact always ends on a row, so that is what ships.

**Tab — the path the issue was reported against — does not go through that redirect at all**, because the list is no longer a tab stop.

## Independent review

An independent reviewer measured the change and found four real problems, all fixed here:

1. **The original diagnosis was half wrong.** The first commit claimed every check box had become its own tab stop and that `Once` collapsed nothing. Re-measured three times on clean `main` in a separate worktree: not true. Only the container stop is real. Comment and commit message corrected.
2. **Alt+F went to a stale row.** Changing the Row type swaps the whole field set and the view model resets its selection to the first field, but the list's remembered index survived — so Alt+F landed on a row from the previous layout while F6 went to the first, and whichever one focus reached took the selection with it (which is what Move Up/Down act on). Now reset on a collection reset.
3. **The tab-order test could not detect the fault it is named for.** The redirect fires the instant focus reaches the list, so sampling `Keyboard.FocusedElement` always saw a check box. It now watches `PreviewGotKeyboardFocus` with `handledEventsToo` and asserts nothing ever *tried* to focus the container.
4. **A misleading comment** on the command-palette focus restore, and a pre-existing focus-stranding bug on that path (Ctrl+Shift+P → Reset leaves `prev` detached and focus nowhere). Comment corrected to say what it does and does not cover; the stranding is untouched here and filed separately.

The reviewer also confirmed no regression to #459 arrow stops, Home/End, type-ahead, Space, reordering, the F6 cycle, or the automation tree shape.

## Tests

Four new tests in `RowFieldsWindowCheckBoxTests`, **each verified to fail against the specific defect it guards**, by reintroducing that defect alone:

- tabbing through the window never stops on the list itself, and the rows contribute exactly one stop, on a check box
- the container is not a tab stop (pins the cause, not just the symptom)
- focus handed to the list ends up on a row, at the last row used
- changing the Row type forgets the remembered row, so Alt+F and F6 agree

They walk focus with `MoveFocus` — the same traversal Tab performs — and assert the walk actually wrapped, so they are deterministic and not gated behind `QUICKMAIL_RUN_INPUT_TESTS`.

Full suite: **2450 passed, 3 skipped, 0 failed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
