### PR TITLE
#333: rules status line drops the live region (F6-on-demand); editor Tab-only documented

### DIFF
--- a/QuickMail/Views/RulesManagerWindow.xaml
+++ b/QuickMail/Views/RulesManagerWindow.xaml
@@ -305,8 +305,7 @@
                      on demand; IsTabStop=False keeps it out of the Tab order. -->
                 <TextBlock x:Name="ServerRulesStatusText" Text="{Binding StatusText}" Margin="0,0,0,6"
                            Focusable="True" KeyboardNavigation.IsTabStop="False"
-                           AutomationProperties.Name="{Binding StatusText}"
-                           AutomationProperties.LiveSetting="Polite"/>
+                           AutomationProperties.Name="{Binding StatusText}"/>
 
                 <WrapPanel Orientation="Horizontal" Margin="0,0,0,6">
                     <Button Content="New" Command="{Binding CreateRuleCommand}"
@@ -379,8 +378,7 @@
             <StatusBarItem>
                 <TextBlock x:Name="MainStatusText" Text="{Binding StatusText}"
                            Focusable="True" KeyboardNavigation.IsTabStop="False"
-                           AutomationProperties.Name="{Binding StatusText}"
-                           AutomationProperties.LiveSetting="Polite"/>
+                           AutomationProperties.Name="{Binding StatusText}"/>
             </StatusBarItem>
         </StatusBar>
     </Grid>

--- a/QuickMail/Views/ServerRuleEditorWindow.xaml.cs
+++ b/QuickMail/Views/ServerRuleEditorWindow.xaml.cs
@@ -12,6 +12,13 @@ namespace QuickMail.Views;
 /// live WebView2 reading pane must not run under a nested modal loop), so Escape/Cancel close it
 /// explicitly. The owning <see cref="ServerRuleEditorViewModel"/> raises the save/close/folder-pick
 /// requests as events; persistence is wired by the list VM that created the editor.
+/// <para>
+/// No F6 ring or Ctrl+Shift+P command palette here, and that is deliberate (#333, confirmed with the
+/// screen-reader user): this is a single compact form — Name → conditions → action → Save/Cancel is
+/// one linear Tab group with no distinct panes to cycle between, so F6 has nothing to jump to and a
+/// palette would only duplicate the two visible buttons. The New Window Checklist's F6/palette items
+/// apply to multi-pane windows; a leaf editor form is the documented exception.
+/// </para>
 /// </summary>
 public partial class ServerRuleEditorWindow : Window
 {

--- a/QuickMail/Views/UnifiedRulesWindow.xaml
+++ b/QuickMail/Views/UnifiedRulesWindow.xaml
@@ -35,11 +35,12 @@
                       Margin="0,2,0,0" AutomationProperties.Name="Account"/>
         </StackPanel>
 
-        <!-- Status line: focusable (F6 ring) so counts can be re-read; not in the Tab order. -->
+        <!-- Status line: focusable (F6 ring) so counts can be re-read on demand; not in the Tab order.
+             No LiveSetting live region — it double-spoke with the gated custom announces and ignored
+             the user's announcement config; the status is read on demand via F6 instead (#333). -->
         <TextBlock Grid.Row="1" x:Name="StatusText" Text="{Binding StatusText}" Margin="0,0,0,6"
                    Focusable="True" KeyboardNavigation.IsTabStop="False"
-                   AutomationProperties.Name="{Binding StatusText}"
-                   AutomationProperties.LiveSetting="Polite"/>
+                   AutomationProperties.Name="{Binding StatusText}"/>
 
         <!-- Content (row 2) comes BEFORE the buttons in Tab order: picker → list → detail → buttons. -->
         <Grid Grid.Row="2">


### PR DESCRIPTION
Resolves the two accessibility items deferred from the #367 review (§20.7), settled with the screen-reader user against a flag-on build.

## Item 3 — status-line double-announcement
The rules status lines carried **two** speech mechanisms on the same text: an `AutomationProperties.LiveSetting="Polite"` live region **and** the config-gated custom `Announce` path. The live region ignored the user's announcement settings and, depending on the screen reader, double-spoke the count.

**Fix:** removed `LiveSetting` from all three rules status TextBlocks (the unified window + the client window's two). The status line now:
- **never auto-announces** the count on open/refresh — no chatter, and it respects the user's announcement config,
- stays **focusable so F6 reads the count on demand** (kept `AutomationProperties.Name`),
- still surfaces **action outcomes** ("Rule enabled", "Applied rules to existing mail: N moved") through the gated custom path — unchanged.

This is the "confirm which mechanism you intend and drop the other" you asked for: keep the gated announce + F6-readable name, drop the ungated live region.

## Item 4 — F6 and the editor
Since the editor unified into its own modeless window, it's a single linear form (Name → conditions → action → Save/Cancel) with no distinct panes to cycle. Confirmed with the screen-reader user that **Tab-only is correct** there, and documented it as a deliberate New-Window-Checklist exception so it reads as *decided*, not missed.

## Verification
Listened through by the screen-reader user on a flag-on build: status is silent on open, **F6 reads the count on demand**, and action outcomes still announce.

## Announcement impact
The rules status line changes from auto-announcing (via the ungated live region) to **read-on-demand via F6**. Action-outcome announcements are unaffected.