### PR TITLE
Remove the "Show message status column" setting (#19)

### DIFF
--- a/QuickMail.Tests/SettingsViewModelTests.cs
+++ b/QuickMail.Tests/SettingsViewModelTests.cs
@@ -18,7 +18,6 @@ public class SettingsViewModelTests
         var vm = new SettingsViewModel(configService, registry);
 
         Assert.Equal(3, vm.PreviewLines);
-        Assert.True(vm.ShowMessageStatus);
         Assert.False(vm.ReadAsPlainText);
         Assert.Equal("messages", vm.ViewMode);
         Assert.Equal(30, vm.SyncDays);
@@ -74,7 +73,6 @@ public class SettingsViewModelTests
         var vm = new SettingsViewModel(configService, registry);
 
         vm.PreviewLines = 5;
-        vm.ShowMessageStatus = false;
         vm.ViewMode = "conversations";
         vm.SyncDays = 7;
         vm.InitialSyncCount = 100;
@@ -83,7 +81,6 @@ public class SettingsViewModelTests
 
         var loadedConfig = configService.Load();
         Assert.Equal(5, loadedConfig.PreviewLines);
-        Assert.False(loadedConfig.ShowMessageStatus);
         Assert.Equal("conversations", loadedConfig.ViewMode);
         Assert.Equal(7, loadedConfig.SyncDays);
         Assert.Equal(100, loadedConfig.InitialSyncCount);

--- a/QuickMail/Models/ConfigModel.cs
+++ b/QuickMail/Models/ConfigModel.cs
@@ -11,9 +11,6 @@ public class ConfigModel
     /// <summary>Number of body-preview lines shown in the message list. 0 = disabled.</summary>
     public int PreviewLines { get; set; } = 3;
 
-    /// <summary>Whether to display the message-status column in the message list.</summary>
-    public bool ShowMessageStatus { get; set; } = true;
-
     /// <summary>
     /// Read messages as plain text: render each message from its original text/plain part
     /// (falling back to text extracted from the HTML when the sender sent no plain-text part)

--- a/QuickMail/Services/ConfigService.cs
+++ b/QuickMail/Services/ConfigService.cs
@@ -196,9 +196,6 @@ public class ConfigService : IConfigService
                     case "previewlines":
                         if (int.TryParse(value, out var pl)) config.PreviewLines = Math.Max(0, pl);
                         break;
-                    case "showmessagestatus":
-                        config.ShowMessageStatus = ParseBool(value);
-                        break;
                     case "readasplaintext":
                         config.ReadAsPlainText = ParseBool(value);
                         break;
@@ -373,12 +370,6 @@ public class ConfigService : IConfigService
         sb.AppendLine($"PreviewLines = {config.PreviewLines}");
         sb.AppendLine("# Number of body-preview lines shown in the message list.");
         sb.AppendLine("# Set to 0 to disable previews.");
-        sb.AppendLine();
-
-        sb.AppendLine($"ShowMessageStatus = {(config.ShowMessageStatus ? "on" : "off")}");
-        sb.AppendLine("# Show a status column in the message list.");
-        sb.AppendLine("# When on, the first column shows the message status: New, Replied, Fwd, or blank (read).");
-        sb.AppendLine("# Values: on, off.");
         sb.AppendLine();
 
         sb.AppendLine($"ReadAsPlainText = {(config.ReadAsPlainText ? "on" : "off")}");

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -776,9 +776,6 @@ public partial class MainViewModel : ObservableObject, IDisposable
     [ObservableProperty]
     private bool _isBusy;
 
-    [ObservableProperty]
-    private bool _showMessageStatus;
-
     /// <summary>
     /// Sticky "read as plain text" preference (issue #34). Bound one-way to the View-menu
     /// check state; the View reads it when rendering a message body. Kept in sync with
@@ -1144,7 +1141,6 @@ public partial class MainViewModel : ObservableObject, IDisposable
         OnlineMode            = onlineMode;
 
         var cfg = _configService.Load();
-        _showMessageStatus = cfg.ShowMessageStatus;
         _readAsPlainText = cfg.ReadAsPlainText;
         _previewLines = cfg.PreviewLines;
         _showPreview = _previewLines > 0;
@@ -1733,7 +1729,6 @@ public partial class MainViewModel : ObservableObject, IDisposable
         // Keep the View menu's density check marks in sync with a Settings save.
         ListDensity = cfg.AppearanceListDensity == "compact" ? "compact" : "comfortable";
 
-        ShowMessageStatus = cfg.ShowMessageStatus;
         ReadAsPlainText   = cfg.ReadAsPlainText;
         _announceFlagStatus = cfg.AnnounceFlagStatus;
         OnPropertyChanged(nameof(AnnounceFlagStatus));

--- a/QuickMail/ViewModels/SettingsViewModel.cs
+++ b/QuickMail/ViewModels/SettingsViewModel.cs
@@ -16,9 +16,6 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty]
     private int _previewLines;
 
-    [ObservableProperty]
-    private bool _showMessageStatus;
-
     /// <summary>Read messages as plain text instead of HTML (issue #34).</summary>
     [ObservableProperty]
     private bool _readAsPlainText;
@@ -347,7 +344,6 @@ public partial class SettingsViewModel : ObservableObject
         AppearanceForceMessageTheme = cfg.AppearanceForceMessageTheme;
 
         PreviewLines = cfg.PreviewLines;
-        ShowMessageStatus = cfg.ShowMessageStatus;
         ReadAsPlainText = cfg.ReadAsPlainText;
         ViewMode = cfg.ViewMode;
         SyncDays = cfg.SyncDays;
@@ -424,7 +420,6 @@ public partial class SettingsViewModel : ObservableObject
         cfg.AppearanceForceMessageTheme = AppearanceForceMessageTheme;
 
         cfg.PreviewLines = PreviewLines;
-        cfg.ShowMessageStatus = ShowMessageStatus;
         cfg.ReadAsPlainText = ReadAsPlainText;
         cfg.ViewMode = ViewMode;
         cfg.SyncDays = SyncDays;

--- a/QuickMail/Views/MainWindow.xaml
+++ b/QuickMail/Views/MainWindow.xaml
@@ -19,7 +19,6 @@
         <local:BoolToFontWeightConverter x:Key="BoolToWeightConverter"/>
         <BooleanToVisibilityConverter    x:Key="BoolToVisibilityConverter"/>
         <local:InverseBoolToVisibilityConverter x:Key="InverseBoolToVisibilityConverter"/>
-        <local:BoolToColumnWidthConverter       x:Key="BoolToColumnWidthConverter"/>
         <local:BoolToGridLengthConverter        x:Key="BoolToGridLengthConverter"/>
         <local:StringToVisibilityConverter      x:Key="StringToVisibilityConverter"/>
         <local:StringToBrushConverter           x:Key="StringToBrushConverter"/>
@@ -1414,23 +1413,17 @@
                              is not shadowed by a local style here. -->
                         <ListView.View>
                             <GridView>
-                                <GridViewColumn Width="{Binding ShowMessageStatus, Converter={StaticResource BoolToColumnWidthConverter}}">
+                                <GridViewColumn Width="65">
                                     <GridViewColumn.Header>
                                         <TextBlock Text="Status"
-                                                   AutomationProperties.IsColumnHeader="True"
-                                                   Visibility="{Binding DataContext.ShowMessageStatus,
-                                                       RelativeSource={RelativeSource AncestorType=Window},
-                                                       Converter={StaticResource BoolToVisibilityConverter}}"/>
+                                                   AutomationProperties.IsColumnHeader="True"/>
                                     </GridViewColumn.Header>
                                     <GridViewColumn.CellTemplate>
                                         <DataTemplate>
                                             <TextBlock Text="{Binding StatusDisplay}"
                                                        FontSize="{DynamicResource Theme.FontSizeSmall}"
                                                        TextAlignment="Center"
-                                                       TextTrimming="CharacterEllipsis"
-                                                       Visibility="{Binding DataContext.ShowMessageStatus,
-                                                           RelativeSource={RelativeSource AncestorType=Window},
-                                                           Converter={StaticResource BoolToVisibilityConverter}}"/>
+                                                       TextTrimming="CharacterEllipsis"/>
                                         </DataTemplate>
                                     </GridViewColumn.CellTemplate>
                                 </GridViewColumn>

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -50,19 +50,6 @@ public class InverseBoolToVisibilityConverter : IValueConverter
 }
 
 /// <summary>
-/// Converts a bool (ShowMessageStatus) to a GridViewColumn width.
-/// true → fixed column width; false → 0 (hidden).
-/// </summary>
-public class BoolToColumnWidthConverter : IValueConverter
-{
-    public object Convert(object value, Type targetType, object parameter, CultureInfo culture) =>
-        value is true ? 65.0 : 0.0;
-
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) =>
-        throw new NotSupportedException();
-}
-
-/// <summary>
 /// Converts a bool to a GridLength using a "trueValue|falseValue" parameter, e.g. "*|0" or
 /// "Auto|*". Each token is parsed as a GridLength ("*", "Auto", "0", "2*", "200"). Used to swap
 /// the message-list and reading-pane row sizes so a message opened in a tab fills the content

--- a/QuickMail/Views/SettingsDialog.xaml
+++ b/QuickMail/Views/SettingsDialog.xaml
@@ -57,12 +57,6 @@
                                                Margin="0,4,0,0"/>
                                 </StackPanel>
 
-                                <!-- Show Message Status -->
-                                <CheckBox Content="Show message _status column"
-                                          IsChecked="{Binding ShowMessageStatus, Mode=TwoWay}"
-                                          Margin="0,8,0,0"
-                                          AutomationProperties.Name="Show message status column in message list"/>
-
                                 <!-- Read as Plain Text (issue #34) -->
                                 <CheckBox Content="Read messages as _plain text"
                                           IsChecked="{Binding ReadAsPlainText, Mode=TwoWay}"

--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -170,7 +170,6 @@ Open **File → Settings** (or press `Ctrl+,`) to change application-wide prefer
 | **View Mode** | Default message grouping when the app starts (Messages, Conversations, By Sender, By Recipient) |
 | **Sync Days** | How many days back to fetch messages on sync. `0` means all mail. |
 | **Preview Lines** | Number of body-preview lines shown under each subject in the message list (0–5). |
-| **Show Message Status** | Whether the read/unread/replied/forwarded status indicator appears in the message list. |
 | **Initial Sync Count** | Maximum messages fetched per folder on the first sync of a newly connected account. |
 
 The **Composing** group on the General tab controls the compose window:
@@ -1448,7 +1447,6 @@ Lines starting with `#` are comments and are ignored. The file uses a simple `ke
 | Setting | Values | Default | What it does |
 |---------|--------|---------|--------------|
 | `PreviewLines` | `0`–`5` | `3` | Number of body-preview lines shown under each subject in the message list. Set to `0` to hide previews entirely. |
-| `ShowMessageStatus` | `true` / `false` | `true` | Show or hide the read/unread status indicator column in the message list. |
 | `ConversationView` | `true` / `false` | `false` | Start with conversation threading on. |
 | `SyncDays` | integer >= `0` | `30` | How many days back to look for messages when syncing. Set to `0` to fetch all messages (may be slow on large mailboxes). |
 | `InitialSyncCount` | integer >= `0` | `500` | Maximum number of messages fetched per folder on the very first sync of a newly connected account. |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -15,7 +15,7 @@ Every service has a matching interface in `Services/I*.cs`, making them fully su
 
 **OAuthService** wraps MSAL (`Microsoft.Identity.Client`) for Microsoft 365 / Outlook OAuth2. Token refresh is handled automatically; passwords for OAuth accounts are not stored in Credential Manager.
 
-**ConfigService** reads/writes `config.ini` (INI format, human-editable) and `hotkeys.json` (JSON). Settings include `PreviewLines`, `ShowMessageStatus`, `ViewMode`, `SyncDays`, `InitialSyncCount`, `AutoDiscoverOnline`, with optional per-account `[account:{guid}]` overrides. Results are cached after first load.
+**ConfigService** reads/writes `config.ini` (INI format, human-editable) and `hotkeys.json` (JSON). Settings include `PreviewLines`, `ViewMode`, `SyncDays`, `InitialSyncCount`, `AutoDiscoverOnline`, with optional per-account `[account:{guid}]` overrides. Results are cached after first load.
 
 **ProviderCatalog** (`IProviderCatalog`) is the built-in table of well-known mail providers — Gmail, Outlook.com / Microsoft 365, Yahoo, iCloud, and an "Other" catch-all. Each `MailProvider` carries IMAP/SMTP hosts, ports, SSL modes, a default `AuthType` and `BackendKind`, and an optional app-password hint plus the URL where the user creates one. `MatchByEmail` maps an address's domain to a provider; `Resolve(AccountModel)` prefers the persisted `AccountModel.ProviderId` and falls back to matching the IMAP host, so accounts created before the catalog existed still resolve without a migration. A static `ProviderCatalog.IsICloud(account)` replaces what used to be an `ImapHost == "imap.mail.me.com"` comparison duplicated across six files.
 

--- a/docs/release-notes-v0.8.37.md
+++ b/docs/release-notes-v0.8.37.md
@@ -181,6 +181,8 @@ Other fields you can now add: **To**, **Mailing list**, and **Source folder**.
 
 Two small consequences. The **Announce flag status** checkbox has left Settings, because Flag is now one field with its own checkbox; if you had it turned off, Flag starts out unchecked for you. And a conversation or sender group used to keep saying "Has unread" after you had read its last unread message — it now updates. (#457)
 
+**Show message status column** has also left Settings. It only ever governed the visible Status column — the one showing New, Replied, Fwd, or a flag name — and never what a row said out loud, which is what people reasonably expected of a setting with that name; turning it off changed nothing you could hear. Speech is now chosen field by field in the window above. The column itself is always shown, so if you are among the few who turned it off to reclaim the space on screen, it comes back and there is currently no way to hide it — say so and it can be made resizable. The `ShowMessageStatus` line in `config.ini` is no longer read and can be deleted; it will disappear on its own the next time QuickMail rewrites the file. ([#19](https://github.com/kellylford/QuickMail/issues/19))
+
 ### New: combined views say which folder a message is in
 
 In a view that gathers mail from more than one place, a row never told you where the message actually lives, so an inbox message and one a rule had filed into a custom folder read identically. Each row now ends with its folder — "… 12:24 PM. Inbox." — and when the view spans more than one account the folder is named with its account, "Work -- Inbox".


### PR DESCRIPTION
Closes #19 alongside #457.

The setting was introduced in b5fa552 to hide the Status column "and all UIA/automation nodes", so it was reaching for control over what assistive tech reported. It could never do that: a screen reader reads a list row's composed accessible name, and that name was built by a separate binding that always included `ReadStatusLabel`. Hiding the cell removed an automation node nobody lands on — which is exactly what #19 reports, a checkbox that does nothing no matter its state.

Now that **Message List Fields** (#457) makes every spoken field individually selectable, the only job left for this setting was a display toggle nobody asked for, sitting in Settings under a name that misleads screen reader users into thinking it governs speech. So it goes, and the Status column is always shown.

## What was removed

- `ConfigModel.ShowMessageStatus`, its `ConfigService` parse case and writer block.
- The Settings checkbox and the `SettingsViewModel` property behind it.
- Both `MainViewModel` sites — the constructor seed and the post-save refresh.
- Three `MainWindow.xaml` bindings. The column takes the fixed 65px width the converter used to hand it, and the header and cell drop their `Visibility` bindings, so it renders exactly as it did in the `ShowMessageStatus = true` state.
- `BoolToColumnWidthConverter`, whose only use this was.
- Three assertions in `SettingsViewModelTests` (both tests keep meaningful coverage).
- The `USERGUIDE.md` Settings and `config.ini` reference rows, and the `ARCHITECTURE.md` settings list. `CODE_REVIEW.md` and the planning specs mention it historically and are left alone.

## Existing configs

The `[global]` parse switch has no `default:` case, so a `ShowMessageStatus = off` line left in someone's `config.ini` is ignored rather than an error, and the key drops out the next time the file is rewritten.

## Known limitation, called out in the release notes

Hiding the column was also the only way to reclaim its 65px, and that escape hatch is now gone. The width is unchanged from before, so this is not a regression, but at raised text scale a long flag name in `StatusDisplay` ellipsizes with no way out. Making the column resizable is the follow-up if anyone wants the space back.

## Verification

Release build, 0 warnings with `-warnaserror`. Full suite: **2450 passed, 0 failed, 3 skipped**. Independently reviewed for dangling XAML resource keys and bindings, source-generator attribute damage on neighbouring `[ObservableProperty]` fields, config round-trip safety, and writer-block whitespace — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
