### PR TITLE
Tell ARM64 users a native build exists (#18)

### DIFF
--- a/QuickMail.Tests/NativeArmNoticeTests.cs
+++ b/QuickMail.Tests/NativeArmNoticeTests.cs
@@ -1,0 +1,78 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using QuickMail.Services;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// The "a native ARM build is available" notice (issue #18): an x64 copy running under
+/// emulation on an ARM64 device says so once per version and offers a Help menu entry.
+///
+/// The detection itself cannot be unit-tested on an x64 CI runner — it reads the real
+/// machine's architecture — so these cover the parts that are testable anywhere: the
+/// once-per-version bookkeeping that decides whether the notice repeats, and the fact that
+/// detection is correctly false on non-ARM hardware.
+/// </summary>
+public class NativeArmNoticeTests
+{
+    private static ProfileContext MakeTempProfile()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"QM-ArmNotice-{Guid.NewGuid():N}");
+        return new ProfileContext(tempDir);
+    }
+
+    [Fact]
+    public void NativeArmNoticeVersion_RoundTripsThroughConfigIni()
+    {
+        var profile = MakeTempProfile();
+        var service = new ConfigService(profile);
+
+        var config = service.Load();
+        config.NativeArmNoticeVersion = "0.8.37";
+        service.Save(config);
+
+        Assert.Equal("0.8.37", new ConfigService(profile).Load().NativeArmNoticeVersion);
+    }
+
+    [Fact]
+    public void NativeArmNoticeVersion_DefaultsToEmpty_SoTheNoticeIsHeardOnce()
+    {
+        // Empty is what makes the first eligible launch announce; a non-empty default would
+        // silence the notice permanently for everyone.
+        Assert.Equal(string.Empty, new ConfigService(MakeTempProfile()).Load().NativeArmNoticeVersion);
+    }
+
+    [Fact]
+    public void NativeArmNoticeVersion_SurvivesAnUnrelatedSave()
+    {
+        // The notice is stamped by MainViewModel and every other config write must preserve
+        // it — losing it would make the announcement repeat at every launch, which is the
+        // failure this key exists to prevent.
+        var profile = MakeTempProfile();
+        var service = new ConfigService(profile);
+
+        var config = service.Load();
+        config.NativeArmNoticeVersion = "0.8.37";
+        service.Save(config);
+
+        var second = new ConfigService(profile).Load();
+        second.AppearanceThemeId = "ember";
+        new ConfigService(profile).Save(second);
+
+        Assert.Equal("0.8.37", new ConfigService(profile).Load().NativeArmNoticeVersion);
+    }
+
+    [Fact]
+    public void IsEmulatedOnArm64_IsFalse_WhenProcessAndOsArchitecturesAgree()
+    {
+        // On any machine where the process and the OS are the same architecture — every CI
+        // runner, and a native ARM64 build on ARM64 hardware — nothing must be surfaced.
+        if (RuntimeInformation.ProcessArchitecture != RuntimeInformation.OSArchitecture)
+            return; // genuinely emulated; the assertion below would not apply
+
+        Assert.False(QuickMail.Helpers.ProcessArchitectureInfo.IsEmulatedOnArm64);
+    }
+}

--- a/QuickMail/Helpers/ProcessArchitectureInfo.cs
+++ b/QuickMail/Helpers/ProcessArchitectureInfo.cs
@@ -1,0 +1,28 @@
+using System.Runtime.InteropServices;
+
+namespace QuickMail.Helpers;
+
+/// <summary>
+/// Answers "is this copy of QuickMail running under emulation on an ARM64 device?" so the
+/// x64 build can point those users at the native ARM64 build (issue #18).
+///
+/// Nothing migrates a QuickMail install from one CPU architecture to another: Velopack
+/// records the channel an installed copy came from and only ever checks that channel, so an
+/// x64 install on an ARM64 machine is never offered the ARM64 build. Without the app saying
+/// so, those users have no way to learn the native build exists.
+/// </summary>
+internal static class ProcessArchitectureInfo
+{
+    /// <summary>
+    /// True when this is an x64 process on an ARM64 operating system — i.e. running under
+    /// Windows' Prism emulation while a native build is available.
+    ///
+    /// The two properties genuinely differ here: since .NET 7 corrected it,
+    /// <c>OSArchitecture</c> reports the real machine (Arm64) while
+    /// <c>ProcessArchitecture</c> reports this process (X64). On a native ARM64 build both
+    /// read Arm64, so this is false and nothing is surfaced.
+    /// </summary>
+    public static bool IsEmulatedOnArm64 =>
+        RuntimeInformation.ProcessArchitecture == Architecture.X64 &&
+        RuntimeInformation.OSArchitecture      == Architecture.Arm64;
+}

--- a/QuickMail/Models/ConfigModel.cs
+++ b/QuickMail/Models/ConfigModel.cs
@@ -276,6 +276,12 @@ public class ConfigModel
     /// means an update was applied since; used to trigger the update-installed dialog.</summary>
     public string LastRunVersion { get; set; } = string.Empty;
 
+    /// <summary>The app version for which the "a native ARM build is available" notice was last
+    /// announced, so an x64 copy running on an ARM64 device mentions it once per version rather
+    /// than at every launch (issue #18). Empty until the notice has been announced. The Help
+    /// menu entry stays available regardless, so the notice never needs repeating to be found.</summary>
+    public string NativeArmNoticeVersion { get; set; } = string.Empty;
+
     // ── Windowing (Phase 6) ───────────────────────────────────────────────────────
 
     /// <summary>Tab and window management preferences.</summary>

--- a/QuickMail/Services/ConfigService.cs
+++ b/QuickMail/Services/ConfigService.cs
@@ -280,6 +280,7 @@ public class ConfigService : IConfigService
                     case "autoupdate":              config.AutoUpdate              = ParseBool(value); break;
                     case "showupdateinstalledalerts": config.ShowUpdateInstalledAlerts = ParseBool(value); break;
                     case "lastrunversion":          config.LastRunVersion          = value; break;
+                    case "nativearmnoticeversion":  config.NativeArmNoticeVersion  = value; break;
                     case "defaultcomposemode":
                         config.DefaultComposeMode = value.ToLowerInvariant() switch
                         {
@@ -606,6 +607,12 @@ public class ConfigService : IConfigService
         sb.AppendLine($"LastRunVersion = {config.LastRunVersion}");
         sb.AppendLine("# The app version recorded on the previous run. Maintained automatically;");
         sb.AppendLine("# used to detect that an update was applied.");
+        sb.AppendLine();
+
+        sb.AppendLine($"NativeArmNoticeVersion = {config.NativeArmNoticeVersion}");
+        sb.AppendLine("# The version for which the \"a native ARM build is available\" notice was");
+        sb.AppendLine("# announced. Maintained automatically; only used on ARM devices running the");
+        sb.AppendLine("# regular build. Clear it to hear the notice again.");
         sb.AppendLine();
 
         sb.AppendLine($"DefaultComposeMode = {config.DefaultComposeMode switch

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -803,6 +803,14 @@ public partial class MainViewModel : ObservableObject, IDisposable
     [ObservableProperty]
     private string _updateReleaseUrl = string.Empty;
 
+    /// <summary>
+    /// True when this x64 copy is running under emulation on an ARM64 device, so a native
+    /// ARM build would be faster (issue #18). Drives the Help menu entry's visibility.
+    /// Evaluated once — the hardware does not change underneath us — and kept an instance
+    /// property because the menu binds to it through the DataContext.
+    /// </summary>
+    public bool IsNativeArmAvailable { get; } = Helpers.ProcessArchitectureInfo.IsEmulatedOnArm64;
+
     private bool _showPreview;
     private int  _previewLines;
 
@@ -1863,6 +1871,13 @@ public partial class MainViewModel : ObservableObject, IDisposable
             id: "help.userGuide", category: "Help", title: "Open User Guide",
             execute: () => ViewUserGuideCommand.Execute(null),
             defaultKey: Key.F1, defaultModifiers: ModifierKeys.None));
+
+        // Registered unconditionally so the palette listing does not vary by machine, matching
+        // how every other Help command is registered. The menu entry is what hides on
+        // non-ARM hardware; running this on an x64 PC simply opens the releases page.
+        registry.Register(new CommandDefinition(
+            id: "help.armVersion", category: "Help", title: "Get the ARM Version",
+            execute: () => OpenArmDownloadPageCommand.Execute(null)));
 
         registry.Register(new CommandDefinition(
             id: "view.search", category: "View", title: "Search Messages…",
@@ -7685,6 +7700,41 @@ public partial class MainViewModel : ObservableObject, IDisposable
         UpdateInstalledDialogRequested?.Invoke(this,
             (CurrentVersion, UpdateCheckService.ReleaseTagUrl(CurrentVersion)));
     }
+
+    /// <summary>
+    /// On an ARM64 device running the x64 build, mentions once per version that a native ARM
+    /// build exists. Called at the same startup moment as the update-installed notice.
+    ///
+    /// Deliberately an announcement and a Help menu entry rather than a dialog: nothing here
+    /// is urgent, and a modal at launch would interrupt the first thing a screen reader user
+    /// hears. Category is Result, not Status, for the same reason the update-available notice
+    /// is — a one-time discovery outcome, which users who silence background progress chatter
+    /// must still hear. The Help entry stays visible afterwards, so this never repeats to
+    /// remain findable.
+    /// </summary>
+    public void MaybeAnnounceNativeArmAvailable()
+    {
+        if (!IsNativeArmAvailable) return;
+
+        var cfg = _configService.Load();
+        if (cfg.NativeArmNoticeVersion == CurrentVersion) return;
+
+        cfg.NativeArmNoticeVersion = CurrentVersion;
+        _configService.Save(cfg);
+
+        // States the benefit and the action, and does not imply the running build is broken —
+        // it works, it is simply emulated.
+        Announce("This PC has an ARM processor, and QuickMail has an ARM version that runs faster on it. " +
+                 "See Get the ARM Version in the Help menu.", AnnouncementCategory.Result);
+    }
+
+    /// <summary>Opens the releases page so the user can download the native ARM build. Switching
+    /// is a manual uninstall and reinstall — no update path crosses architectures.</summary>
+#pragma warning disable CA1822 // [RelayCommand] target must be an instance method for the MVVM Toolkit source generator
+    [RelayCommand]
+    private void OpenArmDownloadPage() =>
+        Helpers.ExternalUriPolicy.TryOpenExternal(ReleasesPageUrl);
+#pragma warning restore CA1822
 
     [RelayCommand]
     private void OpenUpdatePage()

--- a/QuickMail/Views/MainWindow.xaml
+++ b/QuickMail/Views/MainWindow.xaml
@@ -613,6 +613,13 @@
             <MenuItem Header="_Help">
                 <MenuItem Header="{Binding UpdateAvailableText, Mode=OneWay}"
                           Command="{Binding OpenUpdatePageCommand}"/>
+                <!-- Only on an ARM64 PC running the x64 build: nothing migrates an install
+                     across architectures, so this entry is how those users find the native
+                     build. Hidden everywhere else. -->
+                <MenuItem Header="Get the _ARM Version"
+                          AutomationProperties.Name="Get the ARM Version"
+                          Visibility="{Binding IsNativeArmAvailable, Converter={StaticResource BoolToVisibilityConverter}}"
+                          Command="{Binding OpenArmDownloadPageCommand}"/>
                 <Separator/>
                 <MenuItem Header="User _Guide"
                           Command="{Binding ViewUserGuideCommand}"

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -1412,6 +1412,12 @@ public partial class MainWindow : Window
         // "QuickMail Update Installed" notice, once per applied update. After the shortcut
         // offer so a first-run-after-migration launch never stacks two dialogs.
         _vm.MaybeShowUpdateInstalledNotice();
+
+        // "A native ARM build exists" notice, once per version, and only when this x64 copy is
+        // emulated on an ARM64 device. Last of the startup notices: it is the least urgent of
+        // them, and going last keeps it from talking over a dialog either of the two above may
+        // have opened.
+        _vm.MaybeAnnounceNativeArmAvailable();
     }
 
     // ── ui-probe hooks (#180) — internal, driver-only; never user-reachable ──

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -71,7 +71,9 @@ Versions before 0.8.0 used a different installer, so moving onto the self-updati
 
 ### Moving to the ARM version on a Snapdragon PC
 
-If you have been running the regular QuickMail on a Snapdragon PC, you can switch to the ARM version to get better speed and battery life. QuickMail will not make this switch for you — automatic updates stay on the version you installed — so it is a one-time manual change:
+If you have been running the regular QuickMail on a Snapdragon PC, you can switch to the ARM version to get better speed and battery life. QuickMail will not make this switch for you — automatic updates stay on the version you installed — so it is a one-time manual change.
+
+QuickMail mentions this once when it notices it is running on an ARM PC, and the **Help** menu then keeps a **Get the ARM Version** entry that takes you to the download page. That entry appears only on ARM PCs running the regular build; you can also reach it from the command palette. To switch:
 
 1. Uninstall QuickMail from **Settings → Apps**. When the uninstaller offers to delete your data, choose **No**.
 2. Download and run **QuickMail-win-arm64.msi** from the [releases page](https://github.com/kellylford/QuickMail/releases).

--- a/docs/planning/windows-arm64-support-plan.md
+++ b/docs/planning/windows-arm64-support-plan.md
@@ -1,8 +1,8 @@
 # Windows ARM64 Support — Plan
 
 **Issue:** [#18 — Windows ARM64 Support](https://github.com/kellylford/QuickMail/issues/18)
-**Status:** Phases 1–4 implemented on branch `arm64-support`, pending validation on ARM64
-hardware. Phase 5 not started.
+**Status:** Phases 1–4 merged to main (PR #470). Phase 5 implemented on branch
+`arm64-emulation-notice`. All pending validation on ARM64 hardware.
 **Date:** 2026-08-01
 
 ## Summary
@@ -224,7 +224,7 @@ ARM64 — confirm the ARM64 Setup actually installs the ARM64 runtime on a machi
   profile in `%APPDATA%\QuickMail` and Windows Credential Manager entries are preserved).
 - `CLAUDE.md` — the ARM64 build target in the Build & Run section.
 
-## Phase 5 — Emulation notice in the x64 build
+## Phase 5 — Emulation notice in the x64 build *(implemented)*
 
 Because there is no cross-channel migration, an ARM64 user who installed the x64 build will
 never be told the native build exists unless the application says so. Detection is trivial in
@@ -232,16 +232,47 @@ never be told the native build exists unless the application says so. Detection 
 .NET 7) while `RuntimeInformation.ProcessArchitecture` returns `X64`. That mismatch is exactly
 "emulated x64 process on ARM64 hardware".
 
-Design:
+Design as built:
 
-- A `Hint` announcement plus a Help menu entry — **not** a startup dialog. A modal at launch
-  would interrupt the first thing a screen reader user hears, for information that is not
-  urgent.
-- Shown once per version, tracked alongside the existing `LastRunVersion` state, so it never
-  becomes nagging.
-- Wording states the benefit plainly and says the switch is a manual uninstall/reinstall with
-  settings preserved. It must not imply the current build is broken — it is not.
-- The Help entry stays available after the one-time notice, so it can be found again.
+- An announcement plus a Help menu entry — **not** a startup dialog. A modal at launch would
+  interrupt the first thing a screen reader user hears, for information that is not urgent.
+- **Category is `Result`, not `Hint`.** This follows the precedent set by the
+  update-available announcement, which documents its own reasoning: a one-time discovery
+  outcome, which users who silence background chatter must still hear. `Hint` is for
+  instructional tips delivered at the moment a control is focused; this is neither.
+- Announced once per version, recorded in `NativeArmNoticeVersion` in `config.ini` alongside
+  the existing `LastRunVersion`, so it never becomes nagging.
+- Fires last of the three startup notices (desktop shortcut offer, update-installed notice,
+  then this) so it cannot talk over a dialog either of the others opened.
+- The Help entry stays visible afterwards, so the notice never has to repeat to remain
+  findable. It is hidden on non-ARM hardware; the command is registered unconditionally so
+  the palette listing does not vary by machine.
+- Wording states the benefit and the action, and does not imply the running build is broken —
+  it works, it is simply emulated.
+
+### Keyboard walkthrough
+
+On an ARM64 PC running the x64 build, first launch of a new version:
+
+1. QuickMail starts normally. Nothing is interrupted; focus lands where it always does.
+2. After the message list loads, the screen reader announces: "This PC has an ARM processor,
+   and QuickMail has an ARM version that runs faster on it. See Get the ARM Version in the
+   Help menu." Users who have turned off action-outcome announcements hear nothing.
+3. The user presses Alt then H, or arrows to Help. The menu contains **Get the ARM Version**
+   below the update entry.
+4. Pressing Enter on it opens the releases page in the default browser. Focus stays in
+   QuickMail; the menu closes as any menu does.
+5. Every later launch of the same version: no announcement. The Help entry is still there.
+
+On any non-ARM PC, and on the native ARM64 build itself, none of this exists — no
+announcement, no menu entry.
+
+### Not covered by tests
+
+The detection reads the real machine's architecture, so it cannot be exercised on an x64 CI
+runner. `NativeArmNoticeTests` covers the once-per-version bookkeeping and asserts detection
+is false when process and OS architectures agree. That the announcement actually fires, and
+sounds right, needs ARM64 hardware.
 
 This phase is independent of the packaging work and could ship in an x64 release *before* the
 ARM64 build exists, so the notice is already in the field when the native build lands. It is


### PR DESCRIPTION
Phase 5 of [docs/planning/windows-arm64-support-plan.md](docs/planning/windows-arm64-support-plan.md). Addresses #18. Independent of the packaging work in #470 — this could ship in an x64 release before the ARM64 build exists, so the notice is already in the field when the native build lands.

## Why

Nothing migrates a QuickMail install across CPU architectures. Velopack records the channel an installed copy came from and only ever checks that one, so an x64 install on an ARM64 device is never offered the native build. Without the app saying so, those users have no way to learn it exists.

## What

`ProcessArchitectureInfo.IsEmulatedOnArm64` detects the case: since .NET 7 corrected it, `OSArchitecture` reports the real machine (`Arm64`) while `ProcessArchitecture` reports this process (`X64`). On a native ARM64 build both read `Arm64`, so nothing is surfaced.

- Announced once per version, recorded in `NativeArmNoticeVersion` in `config.ini`.
- A permanent **Get the ARM Version** entry in the Help menu, so the notice never has to repeat to stay findable. Hidden on non-ARM hardware; the command is registered unconditionally so the palette listing does not vary by machine.

## Design calls

**`Result`, not `Hint`.** Follows the update-available announcement's documented reasoning — a one-time discovery outcome, which users who silence background chatter must still hear. `Hint` is for instructional tips delivered when a control is focused, which this is not.

**An announcement, not a dialog.** Nothing here is urgent, and a modal at launch would interrupt the first thing a screen reader user hears. It fires last of the three startup notices so it cannot talk over a dialog the desktop-shortcut offer or the update-installed notice may have opened.

**Wording avoids implying the current build is broken.** It works — it is simply emulated.

## Keyboard walkthrough

Full walkthrough is in the plan doc under Phase 5. In short: launch is uninterrupted, the announcement lands after the message list loads, and the Help menu gains one entry that opens the releases page.

## Testing

`NativeArmNoticeTests` covers the once-per-version bookkeeping and asserts detection is false when process and OS architectures agree. The detection reads the real machine's architecture, so **that the announcement actually fires cannot be tested on an x64 CI runner** — it needs ARM64 hardware.

Note: `AddressBookFilterMenuTests.ActivatingTheButton_OpensTheMenu_OnTheActiveFilter` fails locally on this machine, but it fails identically on unmodified `main` and passes in CI — a pre-existing focus-dependent test, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)