### PR TITLE
Tell ARM switchers to uninstall first, or the switch fails silently (#18)

### DIFF
--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -7724,7 +7724,18 @@ public partial class MainViewModel : ObservableObject, IDisposable
 
         // States the benefit and the action, and does not imply the running build is broken —
         // it works, it is simply emulated.
+        //
+        // The uninstall-first instruction is load-bearing, not politeness. Both architectures
+        // pack from one packId, so their installers share an MSI UpgradeCode but get a fresh
+        // random ProductCode per pack, and the Upgrade row's VersionMax is exclusive. Installing
+        // the ARM build over an x64 build *of the same version* therefore matches neither the
+        // upgrade nor the downgrade row: Windows Installer registers it as a second, unrelated
+        // product beside the first, and Velopack — seeing that version already staged — leaves
+        // the existing x64 binary in current\. The user is still emulated, and because
+        // NativeArmNoticeVersion was stamped above, this notice never says so again. Uninstalling
+        // first is what keeps the switch from failing silently.
         Announce("This PC has an ARM processor, and QuickMail has an ARM version that runs faster on it. " +
+                 "Switching means uninstalling QuickMail first, then installing the ARM version. " +
                  "See Get the ARM Version in the Help menu.", AnnouncementCategory.Result);
     }
 

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -79,9 +79,11 @@ QuickMail mentions this once when it notices it is running on an ARM PC, and the
 2. Download and run **QuickMail-win-arm64.msi** from the [releases page](https://github.com/kellylford/QuickMail/releases).
 3. Start QuickMail. Everything is as you left it, for the same reason as above — your accounts, settings, and mail are stored separately from the program itself.
 
-From then on, automatic updates keep you on the ARM version. There is nothing further to do, and no need to repeat this for future releases.
+**Do not skip step 1.** Running the ARM installer on top of a regular QuickMail of the same version does not replace it — Windows treats the two as separate programs, leaves the regular one in place, and reports success. QuickMail keeps starting exactly as before, so nothing tells you the switch did not happen. Uninstalling first is what makes it work.
 
-This is a one-time step. From then on, updates arrive on their own.
+To confirm the switch worked, open the **Help** menu after restarting. **Get the ARM Version** appears only on an ARM PC that is running the regular build, so once you are on the ARM version it is gone. If it is still there, you are still on the regular build — uninstall and try again.
+
+From then on, automatic updates keep you on the ARM version. This is a one-time step — there is nothing further to do, and no need to repeat it for future releases.
 
 ### How updating works
 

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -81,7 +81,9 @@ QuickMail mentions this once when it notices it is running on an ARM PC, and the
 
 **Do not skip step 1.** Running the ARM installer on top of a regular QuickMail of the same version does not replace it — Windows treats the two as separate programs, leaves the regular one in place, and reports success. QuickMail keeps starting exactly as before, so nothing tells you the switch did not happen. Uninstalling first is what makes it work.
 
-To confirm the switch worked, open the **Help** menu after restarting. **Get the ARM Version** appears only on an ARM PC that is running the regular build, so once you are on the ARM version it is gone. If it is still there, you are still on the regular build — uninstall and try again.
+To confirm the switch worked, open the **Help** menu after restarting. **Get the ARM Version** is gone once you are on the ARM version, so if it is still listed, you are still running the regular build.
+
+If it is still listed, the ARM installer did not replace anything. Uninstall QuickMail from **Settings → Apps** — choosing **No** again when asked about your data — and then start over from step 1. Do not try to judge this from **Settings → Apps** itself: both builds report the same name and the same version number there, and only one QuickMail entry is ever listed, so it looks identical whichever one you have. The **Help** menu is the reliable check.
 
 From then on, automatic updates keep you on the ARM version. This is a one-time step — there is nothing further to do, and no need to repeat it for future releases.
 

--- a/docs/release-notes-v0.8.37.md
+++ b/docs/release-notes-v0.8.37.md
@@ -400,7 +400,7 @@ If you are on an ARM PC running the regular build, QuickMail says so once, and t
 2. Download and run **`QuickMail-win-arm64.msi`**.
 3. Start QuickMail. Your accounts, settings, contacts, rules, templates, saved views, and cached mail are all as you left them — your data lives separately from the program itself.
 
-Running the ARM installer on top of a regular QuickMail of the same version does **not** replace it. Windows treats the two as separate programs, installs the second beside the first, reports success, and leaves the regular build running. Nothing in QuickMail would look wrong afterwards, which is exactly why it is worth saying plainly: uninstall first, and check the Help menu once you have restarted. (#18)
+Running the ARM installer on top of a regular QuickMail of the same version does **not** replace it. Windows treats the two as separate programs, installs the second beside the first, reports success, and leaves the regular build running. Nothing in QuickMail would look wrong afterwards, which is exactly why it is worth saying plainly: uninstall first, and check the Help menu once you have restarted. If it has already happened, uninstalling and running the ARM installer again puts it right — and note that **Settings → Apps** cannot tell you which build you have, since both report the same name and version there. (#18)
 
 ---
 

--- a/docs/release-notes-v0.8.37.md
+++ b/docs/release-notes-v0.8.37.md
@@ -44,6 +44,8 @@ The last public release was **v0.8.36**, so if that is what you have been runnin
   - [Changed: themes](#changed-themes)
   - [Changed: Manage Themes moved to the View menu](#changed-manage-themes-moved-to-the-view-menu)
   - [Fixed: the Theme Manager's Import button at large text sizes](#fixed-the-theme-managers-import-button-at-large-text-sizes)
+- [Windows on ARM](#windows-on-arm)
+  - [New: a version built for ARM PCs](#new-a-version-built-for-arm-pcs)
 - [Diagnostics and troubleshooting](#diagnostics-and-troubleshooting)
   - [Fixed: adding an account no longer shows every other account as disconnected](#fixed-adding-an-account-no-longer-shows-every-other-account-as-disconnected)
   - [New: Connection Diagnostics, for when something looks wrong](#new-connection-diagnostics-for-when-something-looks-wrong)
@@ -56,14 +58,18 @@ The last public release was **v0.8.36**, so if that is what you have been runnin
 
 ## Download
 
-Two options are available for v0.8.37:
+v0.8.37 is the first release built for ARM PCs as well as regular ones, so there are four downloads. Take a regular one unless you know your PC has an ARM processor — to check, open **Settings → System → About** and read **System type**.
 
 | Download | When to use |
 |----------|-------------|
 | **`QuickMail-win.msi`** — Windows installer | Recommended for most users. A standard setup wizard with license agreement; installs per-user with no elevation required, adds the WebView2 Runtime if missing, and enables automatic updates. |
+| **`QuickMail-win-arm64.msi`** — Windows installer, ARM | The same installer for PCs with an ARM processor, such as the Snapdragon X models of Surface Laptop and Surface Pro. |
 | **`QuickMail.exe`** — standalone portable executable | No installation required. Copy it anywhere and run. |
+| **`QuickMail-arm64.exe`** — standalone portable executable, ARM | The portable version for PCs with an ARM processor. |
 
-Both downloads include the .NET 8 runtime — you do not need to install .NET separately.
+The regular downloads run on every supported PC, ARM ones included — just not as quickly there. The ARM downloads will not start at all on a non-ARM PC, so if you are unsure, the regular one is the safe guess.
+
+All downloads include the .NET 8 runtime — you do not need to install .NET separately.
 
 ---
 
@@ -375,6 +381,26 @@ Both options are also available as commands, **Density: Comfortable** and **Dens
 ### Fixed: the Theme Manager's Import button at large text sizes
 
 At a Windows text size of 150% the buttons beside the theme list ran past the bottom of the window and **Import** could not be reached at all. That column scrolls now, and moving to a button with the keyboard brings it into view.
+
+---
+
+## Windows on ARM
+
+### New: a version built for ARM PCs
+
+QuickMail now has a build for PCs with an ARM processor — the Snapdragon X models of Surface Laptop and Surface Pro, and similar machines from other manufacturers. Until now those PCs ran the regular build through Windows' built-in emulation, which works but costs speed and battery life. The ARM build runs on the processor directly.
+
+Nothing changes for anyone on a regular PC, and nothing changes for you automatically: automatic updates stay on whichever version you installed, and QuickMail will never move you across on its own.
+
+If you are on an ARM PC running the regular build, QuickMail says so once, and the **Help** menu keeps a **Get the ARM Version** entry that opens the download page. That entry appears only on an ARM PC running the regular build — which makes it the way to check where you stand. Once you are on the ARM version, it is gone.
+
+**Switching is a manual uninstall and reinstall, and the uninstall is not optional:**
+
+1. Uninstall QuickMail from **Settings → Apps**. When the uninstaller offers to delete your data, choose **No**.
+2. Download and run **`QuickMail-win-arm64.msi`**.
+3. Start QuickMail. Your accounts, settings, contacts, rules, templates, saved views, and cached mail are all as you left them — your data lives separately from the program itself.
+
+Running the ARM installer on top of a regular QuickMail of the same version does **not** replace it. Windows treats the two as separate programs, installs the second beside the first, reports success, and leaves the regular build running. Nothing in QuickMail would look wrong afterwards, which is exactly why it is worth saying plainly: uninstall first, and check the Help menu once you have restarted. (#18)
 
 ---
 


### PR DESCRIPTION
## What

The startup notice on an ARM PC running the x64 build says:

> "This PC has an ARM processor, and QuickMail has an ARM version that runs faster on it. See Get the ARM Version in the Help menu."

It never mentions that switching requires uninstalling first. The code comment on `OpenArmDownloadPage` knows (*"Switching is a manual uninstall and reinstall"*) and the user guide's numbered steps have it as step 1 — but the instruction never reaches the person who needs it.

## Why it matters

Skipping the uninstall does not fail loudly, it fails **silently**.

Both architectures pack from one `packId`, so their MSIs share an UpgradeCode but get a **fresh random ProductCode per pack**, and the Upgrade row's `VersionMax` is exclusive (`Attributes=1`, bit 512 not set):

```
{4F6E83C5-...}  VersionMin=(none)    VersionMax=0.8.37.0  Attributes=1  -> WIX_UPGRADE_DETECTED
{4F6E83C5-...}  VersionMin=0.8.37.0  VersionMax=(none)    Attributes=2  -> WIX_DOWNGRADE_DETECTED
```

Installing the ARM build over an x64 build **at the same version** matches neither row. Windows Installer registers it as a second, unrelated product beside the first and reports success; Velopack, seeing that version already staged, leaves the existing x64 binary in `current\`. The user stays emulated — and because `NativeArmNoticeVersion` was stamped when the notice fired, it never tells them again.

Verified against the real MSIs — four packs, four ProductCodes, one shared UpgradeCode:

| pack | version | ProductCode | UpgradeCode |
|---|---|---|---|
| win | 0.8.37.0 | `{9899DB7F-...}` | `{4F6E83C5-...}` |
| win-arm64 | 0.8.37.0 | `{64D7AE99-...}` | `{4F6E83C5-...}` |
| win | 0.8.38.0 | `{2791B51C-...}` | `{4F6E83C5-...}` |
| shipped ARM64 (CI) | 0.8.37.0 | `{70C9B51D-...}` | `{4F6E83C5-...}` |

**0.8.37 is the first release carrying both architectures**, so every ARM user who follows this prompt switches at the same version. The failing case is the normal case.

This was found the hard way: a local install sat one day stale across several reinstalls because two identically-named `QuickMail 0.8.37.0` products were registered and Add/Remove could only remove one.

## Changes

- **`MainViewModel.MaybeAnnounceNativeArmAvailable`** — the notice now names the uninstall as part of the switch. Category stays `Result`.
- **`docs/USER-GUIDE.md`** — says what happens if you skip step 1, and how to check afterwards. `Get the ARM Version` is bound to `IsEmulatedOnArm64`, so it disappears once you are native; still there after a restart means the switch did not take. Also folds a duplicated closing sentence.
- **`docs/release-notes-v0.8.37.md`** — had **no ARM section at all**, and a Download table listing two files when the release ships four. Adds a `Windows on ARM` section (with the uninstall-first warning), the two ARM downloads, and TOC entries.

## Out of scope

- The on-demand installer workflow producing same-version MSIs — separate PR.
- Reporting architecture in About. The Help-menu entry already answers it without new code.

## Testing

- `dotnet build -c Release -warnaserror` — clean, 0 warnings.
- `NativeArmNoticeTests` — 4/4 pass. No test pins the announcement string.
- The announcement change cannot be exercised on x64 CI; `IsEmulatedOnArm64` is false there by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
