### PR TITLE
Test installers ship Setup.exe at a per-run version, not a same-version MSI

### DIFF
--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -5,10 +5,15 @@ name: Build Installer (on demand)
 # you can download and test.
 #
 # Test builds ship Velopack's Setup.exe, not the MSI, and carry a per-run version
-# (0.8.37-test.<run_number>). Both are deliberate and load-bearing — see the "Determine
-# package version" and "Pack Velopack installer" steps for why. In short: two MSIs packed at
-# the same version register as separate products instead of replacing each other, which
-# leaves a stale binary installed while every reinstall reports success.
+# (0.8.37-test.<run_number>.<run_attempt>). Both are deliberate and load-bearing — see the
+# "Determine package version" and "Pack Velopack installer" steps for why. In short: two MSIs
+# packed at the same version register as separate products instead of replacing each other,
+# which leaves a stale binary installed while every reinstall reports success.
+#
+# Know what this costs: Setup.exe is the one-click bootstrapper that releases deliberately do
+# NOT ship (see quickmail.yml), so a test build does not exercise the MSI wizard — welcome,
+# license acceptance, conclusion — nor MSI packing and signing. Those first run on a pushed
+# v* tag. Test the wizard against a release candidate, not against this artifact.
 #
 # Why this exists: the real Google OAuth client id/secret and the bug-report token
 # live only in GitHub Actions secrets. A locally built installer compiles against the
@@ -133,9 +138,14 @@ jobs:
       # the survivor keeps owning the install directory. Every later test installer silently
       # no-ops against it. This cost a day of testing against a stale build.
       #
-      # So each run gets its own SemVer prerelease: 0.8.37-test.<run_number>. That sorts above
-      # the released 0.8.37 and below a future 0.8.38, and strictly increases run over run, so
-      # a new test build always supersedes the last one and never fights a real release.
+      # So each run gets its own SemVer prerelease: 0.8.37-test.<run_number>.<run_attempt>.
+      # That sorts above the released 0.8.37 and below a future 0.8.38, and strictly increases
+      # run over run, so a new test build always supersedes the last one and never fights a
+      # real release. run_attempt is in there because re-running a failed run reuses its
+      # run_number and bumps only run_attempt — without it, a retry would pack the same
+      # version as the run it replaces, which is the whole failure this step exists to avoid.
+      # Dotted numeric prerelease identifiers compare field by field, so test.482.2 sorts
+      # above test.482 and below test.483.
       #
       # Appending `test` to the version is necessary but NOT sufficient on its own: vpk strips
       # the prerelease tag when deriving the MSI ProductVersion (0.8.37-test.482 -> 0.8.37.0),
@@ -147,22 +157,10 @@ jobs:
         run: |
           $base = (Select-Xml -Path QuickMail/QuickMail.csproj -XPath '/Project/PropertyGroup/Version').Node.InnerText
           if (-not $base) { throw "Could not read <Version> from QuickMail/QuickMail.csproj." }
-          $version = "$base-test.${{ github.run_number }}"
+          $version = "$base-test.${{ github.run_number }}.${{ github.run_attempt }}"
           "version=$version" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-          Write-Host "Package version: $version   (base $base, run ${{ github.run_number }}, commit ${{ github.sha }})"
+          Write-Host "Package version: $version   (base $base, run ${{ github.run_number }} attempt ${{ github.run_attempt }}, commit ${{ github.sha }})"
 
-      # Near-identical vpk pack invocation to the release workflow so the test installer
-      # behaves like a shipped one (wizard pages, per-user install, WebView2 on demand).
-      # Differences: no `vpk download github` beforehand, so this is a full package with no
-      # delta — and no --msi, so this ships Velopack's own Setup.exe instead.
-      #
-      # Dropping the MSI is the other half of the versioning fix above. Setup.exe creates no
-      # Windows Installer product registration at all, so it cannot leave an Add/Remove entry
-      # behind, cannot register beside an earlier test build, and cannot shadow a real install.
-      # It installs to the same per-user location and honours the same SemVer ordering, which
-      # is what makes -test.<run_number> actually take effect. The release workflow keeps
-      # --msi: releases always bump the version, so the Upgrade row works there as designed,
-      # and the MSI is what managed deployment needs.
       # --- Code signing (Azure Artifact Signing via GitHub OIDC) --------------
       - name: Azure login (code signing)
         uses: azure/login@v3
@@ -181,6 +179,23 @@ jobs:
           } | ConvertTo-Json
           [System.IO.File]::WriteAllText("$env:GITHUB_WORKSPACE\signing-metadata.json", $json)
 
+      # Near-identical vpk pack invocation to the release workflow, so the test installer runs
+      # the same per-user install and WebView2-on-demand path a shipped one does. Differences:
+      # no `vpk download github` beforehand, so this is a full package with no delta — and no
+      # --msi, so this ships Velopack's own Setup.exe instead.
+      #
+      # Dropping the MSI is the other half of the versioning fix above. Setup.exe creates no
+      # Windows Installer product registration at all, so it cannot leave an Add/Remove entry
+      # behind, cannot register beside an earlier test build, and cannot shadow a real install.
+      # It honours the SemVer ordering that makes -test.<run_number>.<run_attempt> take effect,
+      # which the MSI cannot: vpk strips the prerelease tag when deriving ProductVersion. The
+      # release workflow keeps --msi: releases always bump the version, so the Upgrade row
+      # works there as designed, and the MSI is what managed deployment needs.
+      #
+      # What that costs: Setup.exe is one-click, so the --inst* wizard pages below (welcome,
+      # license acceptance, conclusion) are not shown by this artifact — quickmail.yml ships
+      # the MSI for exactly that reason. They stay on the command line so the two invocations
+      # do not drift, and so restoring --msi needs no other edit.
       - name: Pack Velopack installer
         shell: pwsh
         run: |

--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -1,8 +1,14 @@
 name: Build Installer (on demand)
 
-# Manual-only: build the full MSI installer for whatever branch you pick in the
-# "Run workflow" dropdown, WITHOUT publishing a GitHub release. The installer is
-# uploaded as a run artifact you can download and test.
+# Manual-only: build a full installer for whatever branch you pick in the "Run workflow"
+# dropdown, WITHOUT publishing a GitHub release. The installer is uploaded as a run artifact
+# you can download and test.
+#
+# Test builds ship Velopack's Setup.exe, not the MSI, and carry a per-run version
+# (0.8.37-test.<run_number>). Both are deliberate and load-bearing — see the "Determine
+# package version" and "Pack Velopack installer" steps for why. In short: two MSIs packed at
+# the same version register as separate products instead of replacing each other, which
+# leaves a stale binary installed while every reinstall reports success.
 #
 # Why this exists: the real Google OAuth client id/secret and the bug-report token
 # live only in GitHub Actions secrets. A locally built installer compiles against the
@@ -114,23 +120,49 @@ jobs:
       - name: Install vpk
         run: dotnet tool install -g vpk
 
-      # No tag to read from on a manual run, so the package version comes from the
-      # csproj <Version>. This produces a full package only (no delta) — a delta needs
-      # the previous release's assets, which only matters for the published update feed,
-      # not for a standalone test installer.
+      # No tag to read from on a manual run, so the base version comes from the csproj
+      # <Version> — but a test build must never carry that version bare.
+      #
+      # Two builds packed at the same version cannot replace each other. `vpk` mints a fresh
+      # random MSI ProductCode on every pack while the UpgradeCode stays fixed, and the
+      # generated Upgrade row's VersionMax is exclusive, so installing 0.8.37 over an existing
+      # 0.8.37 matches neither the upgrade nor the downgrade row: Windows Installer registers
+      # a second, unrelated product beside the first and reports success, and Velopack — seeing
+      # that version already staged — leaves the old binary in current\. Two indistinguishable
+      # "QuickMail 0.8.37.0" rows then appear in Add/Remove, uninstalling removes only one, and
+      # the survivor keeps owning the install directory. Every later test installer silently
+      # no-ops against it. This cost a day of testing against a stale build.
+      #
+      # So each run gets its own SemVer prerelease: 0.8.37-test.<run_number>. That sorts above
+      # the released 0.8.37 and below a future 0.8.38, and strictly increases run over run, so
+      # a new test build always supersedes the last one and never fights a real release.
+      #
+      # Appending `test` to the version is necessary but NOT sufficient on its own: vpk strips
+      # the prerelease tag when deriving the MSI ProductVersion (0.8.37-test.482 -> 0.8.37.0),
+      # and MSI ignores the fourth field when comparing, so no MSI-based scheme can encode this
+      # without colliding with the release version line. That is why the MSI is dropped below.
       - name: Determine package version
         id: version
         shell: pwsh
         run: |
-          $version = (Select-Xml -Path QuickMail/QuickMail.csproj -XPath '/Project/PropertyGroup/Version').Node.InnerText
-          if (-not $version) { throw "Could not read <Version> from QuickMail/QuickMail.csproj." }
+          $base = (Select-Xml -Path QuickMail/QuickMail.csproj -XPath '/Project/PropertyGroup/Version').Node.InnerText
+          if (-not $base) { throw "Could not read <Version> from QuickMail/QuickMail.csproj." }
+          $version = "$base-test.${{ github.run_number }}"
           "version=$version" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-          Write-Host "Package version: $version"
+          Write-Host "Package version: $version   (base $base, run ${{ github.run_number }}, commit ${{ github.sha }})"
 
-      # Identical vpk pack invocation to the release workflow so the test installer
-      # behaves exactly like a shipped one (wizard pages, per-user install, WebView2
-      # on demand). Only difference: no `vpk download github` beforehand, so this is a
-      # full package with no delta.
+      # Near-identical vpk pack invocation to the release workflow so the test installer
+      # behaves like a shipped one (wizard pages, per-user install, WebView2 on demand).
+      # Differences: no `vpk download github` beforehand, so this is a full package with no
+      # delta — and no --msi, so this ships Velopack's own Setup.exe instead.
+      #
+      # Dropping the MSI is the other half of the versioning fix above. Setup.exe creates no
+      # Windows Installer product registration at all, so it cannot leave an Add/Remove entry
+      # behind, cannot register beside an earlier test build, and cannot shadow a real install.
+      # It installs to the same per-user location and honours the same SemVer ordering, which
+      # is what makes -test.<run_number> actually take effect. The release workflow keeps
+      # --msi: releases always bump the version, so the Upgrade row works there as designed,
+      # and the MSI is what managed deployment needs.
       # --- Code signing (Azure Artifact Signing via GitHub OIDC) --------------
       - name: Azure login (code signing)
         uses: azure/login@v3
@@ -161,28 +193,29 @@ jobs:
           # machine. See docs/planning/windows-arm64-support-plan.md.
           $archArgs = @()
           if ($arch -eq 'arm64') { $archArgs = @('--runtime', 'win-arm64', '--channel', 'win-arm64') }
-          # --azureTrustedSignFile signs the app binaries, Velopack Update/Setup, and the MSI.
+          # --azureTrustedSignFile signs the app binaries and Velopack Update/Setup.
           vpk pack --packId QuickMail --packVersion $version --packDir publish `
             --mainExe QuickMail.exe --packTitle QuickMail --packAuthors "Kelly Ford" `
             --shortcuts StartMenuRoot --outputDir installer/Output/Releases `
             --framework webview2 `
             --azureTrustedSignFile "$env:GITHUB_WORKSPACE\signing-metadata.json" `
-            --msi --instLocation PerUser `
+            --instLocation PerUser `
             --instWelcome installer/velopack/welcome.txt `
             --instLicense installer/velopack/license.txt `
             --instConclusion installer/velopack/conclusion.txt @archArgs
           if ($LASTEXITCODE -ne 0) { throw "vpk pack failed with exit code $LASTEXITCODE." }
-          # vpk emits the MSI with no version in the name, and the exact name varies with
-          # the channel — rename whichever single .msi landed rather than assuming it, so
-          # a naming change in vpk fails loudly here instead of silently shipping nothing.
-          $msi = @(Get-ChildItem installer/Output/Releases/*.msi)
-          if ($msi.Count -ne 1) { throw "Expected exactly one .msi, found $($msi.Count): $($msi.Name -join ', ')" }
+          # vpk emits Setup.exe with no version in the name, and the exact name varies with
+          # the channel — rename whichever single Setup landed rather than assuming it, so a
+          # naming change in vpk fails loudly here instead of silently shipping nothing.
+          $setup = @(Get-ChildItem installer/Output/Releases/*Setup.exe)
+          if ($setup.Count -ne 1) { throw "Expected exactly one *Setup.exe, found $($setup.Count): $($setup.Name -join ', ')" }
           $suffix = if ($arch -eq 'arm64') { 'win-arm64' } else { 'win' }
-          Write-Host "vpk emitted $($msi[0].Name); renaming to QuickMail-$version-$suffix.msi"
-          Rename-Item $msi[0].FullName "QuickMail-$version-$suffix.msi"
-          # Record the full asset set for this channel. The release workflow will publish
-          # both channels into one GitHub release, so these names must not collide across
-          # architectures — this listing is how that gets verified before Phase 3 lands.
+          Write-Host "vpk emitted $($setup[0].Name); renaming to QuickMail-$version-$suffix-Setup.exe"
+          Rename-Item $setup[0].FullName "QuickMail-$version-$suffix-Setup.exe"
+          # Guard the version fix itself: an .msi here means --msi came back, and with it the
+          # duplicate-product failure this workflow exists to avoid.
+          $msi = @(Get-ChildItem installer/Output/Releases/*.msi -ErrorAction SilentlyContinue)
+          if ($msi.Count -ne 0) { throw "Unexpected .msi in test-build output: $($msi.Name -join ', '). Test builds ship Setup.exe only — see the versioning note above." }
           Write-Host "--- Velopack output ($arch) ---"
           Get-ChildItem installer/Output/Releases | Select-Object -ExpandProperty Name
 
@@ -203,9 +236,9 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: QuickMail-${{ steps.version.outputs.version }}-${{ matrix.arch }}-installer
-          # The MSI is the full installer; the portable exe is bundled for convenience.
+          # Setup.exe is the full installer; the portable exe is bundled for convenience.
           path: |
-            installer/Output/Releases/QuickMail-*.msi
+            installer/Output/Releases/QuickMail-*-Setup.exe
             publish/QuickMail.exe
           if-no-files-found: error
           retention-days: 14


### PR DESCRIPTION
## The problem

Every on-demand build packed the bare csproj `<Version>`, so consecutive test builds were all `0.8.37`. **Two MSIs at the same version cannot replace each other.**

`vpk` mints a fresh random ProductCode on every pack while the UpgradeCode stays fixed, and the generated Upgrade row's `VersionMax` is exclusive (`Attributes=1`, bit 512 not set):

```
{4F6E83C5-...}  VersionMin=(none)    VersionMax=0.8.37.0  Attributes=1  -> WIX_UPGRADE_DETECTED
{4F6E83C5-...}  VersionMin=0.8.37.0  VersionMax=(none)    Attributes=2  -> WIX_DOWNGRADE_DETECTED
```

Installing 0.8.37 over an installed 0.8.37 matches **neither** row. Windows Installer registers a second unrelated product beside the first and reports success; Velopack, seeing that version already staged, leaves the old binary in `current\`.

The result is two indistinguishable `QuickMail / 0.8.37.0` rows in Add/Remove. Uninstall removes one, the survivor keeps owning the install directory, and every later test installer silently no-ops against it.

**This cost a day of testing against a build that was 18 commits stale** while each reinstall reported success. The visible symptom was a shipped feature simply not being in the app.

## The fix — two parts, both required

**1. Version per run: `0.8.37-test.<run_number>`.** Sorts above the released `0.8.37`, below a future `0.8.38`, and strictly increases run over run — so a new test build always supersedes the last and never fights a real release.

**2. Drop `--msi`; ship Velopack's `Setup.exe`.** The version alone is *not sufficient* — `vpk` strips the prerelease tag when deriving the MSI ProductVersion:

```
--packVersion 0.8.37-test.482   ->   MSI ProductVersion 0.8.37.0
```

and MSI ignores the fourth field when comparing, so no MSI-based scheme encodes this without colliding with the release version line. Make test builds sort below the release and they won't install over it; make them sort above and the next real release is refused as a downgrade.

`Setup.exe` creates no Windows Installer registration at all, so it cannot leave an Add/Remove entry, register beside an earlier test build, or shadow a real install — and it honours the SemVer ordering that makes `-test.<run_number>` take effect.

## Notes

- A guard fails the run if an `.msi` reappears in the output, so restoring `--msi` cannot quietly reintroduce this.
- `--instLocation PerUser` is **kept** — it is not MSI-scoped and defaults to `Either`.
- `quickmail.yml` is untouched. Releases always bump the version, so the Upgrade row works there as designed, and the MSI is what managed deployment needs.
- The run log now prints base version, run number, and commit SHA together, so an artifact can be traced to a commit without guessing.

## Testing

Verified locally against real `vpk` output, not from docs:

| pack | version | ProductCode | UpgradeCode |
|---|---|---|---|
| win | 0.8.37.0 | `{9899DB7F-...}` | `{4F6E83C5-...}` |
| win-arm64 | 0.8.37.0 | `{64D7AE99-...}` | `{4F6E83C5-...}` |
| win | 0.8.38.0 | `{2791B51C-...}` | `{4F6E83C5-...}` |
| shipped ARM64 (CI) | 0.8.37.0 | `{70C9B51D-...}` | `{4F6E83C5-...}` |

- `--packVersion 0.8.37-test.999` with the new argument list emits exactly **one** `*Setup.exe` and **zero** `.msi`, so both the rename and the guard match reality.
- Packing drops from ~45s to ~8s without the WiX step.
- YAML parses; step count unchanged at 13.

Not verifiable locally: the Azure signing steps and artifact upload run only in CI. First merged run is the real check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
