### PR TITLE
Fix #477: Get the ARM Version opens the guide's switching steps, not the releases page (#18)

### DIFF
--- a/QuickMail.Tests/NativeArmNoticeTests.cs
+++ b/QuickMail.Tests/NativeArmNoticeTests.cs
@@ -2,7 +2,9 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
 using QuickMail.Services;
+using QuickMail.ViewModels;
 using Xunit;
 
 namespace QuickMail.Tests;
@@ -74,5 +76,53 @@ public class NativeArmNoticeTests
             return; // genuinely emulated; the assertion below would not apply
 
         Assert.False(QuickMail.Helpers.ProcessArchitectureInfo.IsEmulatedOnArm64);
+    }
+
+    [Fact]
+    public void ArmSwitchGuideUrl_PointsAtAHeadingThatExistsInTheUserGuide()
+    {
+        // Help → Get the ARM Version deep-links into the published guide: the page name comes
+        // from the enclosing "## " title, the fragment from the "### " heading under it, and both
+        // are derived from heading text at publish time. Reword either heading and the link still
+        // compiles, still resolves, and quietly opens the guide at the top — with the switching
+        // steps and the uninstall-first warning nowhere in sight, which is the whole reason the
+        // entry stopped pointing at the releases page (#477).
+        var guide = File.ReadAllLines(Path.Combine(RepoRoot(), "docs", "USER-GUIDE.md"));
+
+        string? section = null, sectionHoldingTheAnchor = null;
+        foreach (var line in guide)
+        {
+            if (line.StartsWith("## ", StringComparison.Ordinal))
+                section = Slug(line[3..]);
+            else if (line.StartsWith("### ", StringComparison.Ordinal) &&
+                     Slug(line[4..]) == MainViewModel.ArmSwitchGuideAnchor)
+                sectionHoldingTheAnchor = section;
+        }
+
+        Assert.True(sectionHoldingTheAnchor != null,
+            $"No '### ' heading in docs/USER-GUIDE.md slugifies to " +
+            $"'{MainViewModel.ArmSwitchGuideAnchor}'. Either restore the heading or update " +
+             "MainViewModel.ArmSwitchGuideAnchor to match its new wording.");
+
+        Assert.Contains($"/{sectionHoldingTheAnchor}.html#{MainViewModel.ArmSwitchGuideAnchor}",
+            MainViewModel.ArmSwitchGuideUrl, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The slug publish-user-guide.yml builds for a section page, which is also the id pandoc
+    /// generates for a heading: drop anything that is not a word character, whitespace, or a
+    /// hyphen, lowercase the rest, and turn spaces into hyphens.
+    /// </summary>
+    private static string Slug(string title) =>
+        Regex.Replace(title, @"[^\w\s-]", "").Trim().ToLowerInvariant().Replace(' ', '-');
+
+    private static string RepoRoot()
+    {
+        for (var dir = new DirectoryInfo(AppContext.BaseDirectory); dir != null; dir = dir.Parent)
+        {
+            if (Directory.Exists(Path.Combine(dir.FullName, "QuickMail", "Views")))
+                return dir.FullName;
+        }
+        throw new InvalidOperationException($"Repo source tree not found from {AppContext.BaseDirectory}.");
     }
 }

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -7644,6 +7644,14 @@ public partial class MainViewModel : ObservableObject, IDisposable
     // "No updates available" Help entry still takes users somewhere useful.
     private const string ReleasesPageUrl = UpdateCheckService.ReleasesPageUrl;
 
+    // The published user guide splits on top-level headings, one page per "## " section, with a
+    // pandoc-generated id on every heading beneath it. "Moving to the ARM version on a Snapdragon
+    // PC" is a "### " under "Installing and Updating QuickMail", hence page + fragment rather than
+    // a page of its own. Both halves are asserted against docs/USER-GUIDE.md by NativeArmNoticeTests.
+    internal const string ArmSwitchGuideAnchor = "moving-to-the-arm-version-on-a-snapdragon-pc";
+    internal const string ArmSwitchGuideUrl =
+        $"https://kellylford.github.io/QuickMail/installing-and-updating-quickmail.html#{ArmSwitchGuideAnchor}";
+
     // Version string of a found update (e.g. "0.8.1"); empty when up to date. Feeds the
     // update dialog for self-updating (installed) copies.
     private string _updateVersion = string.Empty;
@@ -7739,12 +7747,22 @@ public partial class MainViewModel : ObservableObject, IDisposable
                  "See Get the ARM Version in the Help menu.", AnnouncementCategory.Result);
     }
 
-    /// <summary>Opens the releases page so the user can download the native ARM build. Switching
-    /// is a manual uninstall and reinstall — no update path crosses architectures.</summary>
+    /// <summary>
+    /// Opens the user guide's ARM section rather than the releases page. Switching is a manual
+    /// uninstall and reinstall — no update path crosses architectures — and doing it in the wrong
+    /// order fails silently, so the instruction has to travel with the download link.
+    ///
+    /// The releases page carried that warning only while v0.8.37 was newest; every release after
+    /// it puts notes with no ARM section on top, and this entry would then hand an ARM user the
+    /// installer with nothing telling them to uninstall first (#477). The guide section is
+    /// versionless, holds the numbered steps and the recovery, and links on to the releases page
+    /// for the download itself. <see cref="ArmSwitchGuideAnchor"/> is pinned to the real heading
+    /// by <c>NativeArmNoticeTests</c>, since a reworded heading would break the anchor silently.
+    /// </summary>
 #pragma warning disable CA1822 // [RelayCommand] target must be an instance method for the MVVM Toolkit source generator
     [RelayCommand]
     private void OpenArmDownloadPage() =>
-        Helpers.ExternalUriPolicy.TryOpenExternal(ReleasesPageUrl);
+        Helpers.ExternalUriPolicy.TryOpenExternal(ArmSwitchGuideUrl);
 #pragma warning restore CA1822
 
     [RelayCommand]

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -73,7 +73,7 @@ Versions before 0.8.0 used a different installer, so moving onto the self-updati
 
 If you have been running the regular QuickMail on a Snapdragon PC, you can switch to the ARM version to get better speed and battery life. QuickMail will not make this switch for you — automatic updates stay on the version you installed — so it is a one-time manual change.
 
-QuickMail mentions this once when it notices it is running on an ARM PC, and the **Help** menu then keeps a **Get the ARM Version** entry that takes you to the download page. That entry appears only on ARM PCs running the regular build; you can also reach it from the command palette. To switch:
+QuickMail mentions this once when it notices it is running on an ARM PC, and the **Help** menu then keeps a **Get the ARM Version** entry that brings you back to this section, where step 2 links to the download. That entry appears only on ARM PCs running the regular build; you can also reach it from the command palette. To switch:
 
 1. Uninstall QuickMail from **Settings → Apps**. When the uninstaller offers to delete your data, choose **No**.
 2. Download and run **QuickMail-win-arm64.msi** from the [releases page](https://github.com/kellylford/QuickMail/releases).

--- a/docs/release-notes-v0.8.37.md
+++ b/docs/release-notes-v0.8.37.md
@@ -392,7 +392,7 @@ QuickMail now has a build for PCs with an ARM processor — the Snapdragon X mod
 
 Nothing changes for anyone on a regular PC, and nothing changes for you automatically: automatic updates stay on whichever version you installed, and QuickMail will never move you across on its own.
 
-If you are on an ARM PC running the regular build, QuickMail says so once, and the **Help** menu keeps a **Get the ARM Version** entry that opens the download page. That entry appears only on an ARM PC running the regular build — which makes it the way to check where you stand. Once you are on the ARM version, it is gone.
+If you are on an ARM PC running the regular build, QuickMail says so once, and the **Help** menu keeps a **Get the ARM Version** entry that opens the switching instructions in the user guide, where the download is linked. That entry appears only on an ARM PC running the regular build — which makes it the way to check where you stand. Once you are on the ARM version, it is gone.
 
 **Switching is a manual uninstall and reinstall, and the uninstall is not optional:**
 


### PR DESCRIPTION
Closes #477.

## What

**Help → Get the ARM Version** now opens the user guide's switching section instead of the releases page.

## Why

The uninstall-first instruction reached ARM switchers through two channels, and both could be absent at the moment they act. The startup announcement is once per version and `AnnouncementCategory.Result`, so it is silent for anyone who has turned result announcements off. The releases page carried the warning only because v0.8.37's notes are on top of it — from v0.8.38 on, that page opens with notes that say nothing about ARM.

So a user who found the Help entry visually and followed it would be handed `QuickMail-win-arm64.msi` with no warning anywhere in the path, install it over the running x64 build at the same version, and land in exactly the silent failure #475 set out to prevent.

The guide section is versionless, holds the numbered steps, the warning and the recovery, and its step 2 links to the releases page for the download. One extra hop, gap closed permanently.

## The anchor is load-bearing, so it is pinned

The destination is a deep link — page name from the `## ` title, fragment from the `### ` heading — and both are generated from heading text at publish time by `publish-user-guide.yml` and pandoc. Reword either heading and the link still compiles and still resolves; it just opens the page at the top with the switching steps out of sight. Nothing would report it.

`NativeArmNoticeTests.ArmSwitchGuideUrl_PointsAtAHeadingThatExistsInTheUserGuide` slugifies the real headings out of `docs/USER-GUIDE.md` using the same rule the workflow applies, finds the section enclosing the anchor heading, and asserts the URL matches both halves. A reword now fails the build with a message naming the constant to update.

## Changes

- **`MainViewModel`** — `ArmSwitchGuideAnchor` / `ArmSwitchGuideUrl` constants; `OpenArmDownloadPage` opens the guide URL. `ReleasesPageUrl` is untouched and still serves the update entries.
- **`NativeArmNoticeTests`** — the anchor guard above.
- **`docs/USER-GUIDE.md`**, **`docs/release-notes-v0.8.37.md`** — both described the entry as opening the download page.

## Out of scope

- The shared `packId` that makes a same-version cross-architecture install register a second product instead of replacing the first. Manual switching is the settled design (`windows-arm64-support-plan.md`); this PR and #475 make the instruction reach the user, they do not change packaging.
- Renaming the Help entry. "Get the ARM Version" still describes where it takes you.

## Testing

- `dotnet build QuickMail/QuickMail.csproj -c Release -warnaserror` — 0 warnings, 0 errors.
- `NativeArmNoticeTests` — 5/5 pass.
- The published guide must be republished (**Actions → Publish User Guide**) before the anchor resolves live; the ARM section postdates the last publish. Until then the link opens the correct page at the top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
