### PR TITLE
Tests: Tab & Window Management (Phase 6) — closes #40

### DIFF
--- a/QuickMail.Tests/ComposeWindowTitleTests.cs
+++ b/QuickMail.Tests/ComposeWindowTitleTests.cs
@@ -1,0 +1,163 @@
+using System.Collections.Generic;
+using QuickMail.Models;
+using QuickMail.ViewModels;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// Compose window title derivation, deferred from PR #38 (issue #40).
+///
+/// The title is "{subject or kind} - {mode} - QuickMail": the subject leads so the taskbar and
+/// Alt+Tab identify the message, and the compose mode follows so the editing format is always
+/// visible. Both halves are load-bearing for a screen reader user, who hears the window title on
+/// every window switch and has no other persistent indication of which format they are typing in.
+///
+/// Note for anyone comparing against issue #40: that issue predicted the title would read
+/// "Untitled" when the subject is blank. It does not — it falls back to the *kind* label
+/// ("New Message", "Reply", "Forward", …), which is strictly more informative. These tests pin
+/// the shipped behaviour. ("Untitled" is the blank-subject fallback for message TAB titles, a
+/// different surface; see TabSessionModelTests.)
+/// </summary>
+public class ComposeWindowTitleTests
+{
+    private static ComposeViewModel MakeVm() => new(
+        new StubSmtpService(),
+        new StubAccountService(),
+        new StubCredentialService(),
+        new StubImapMailService(),
+        new StubTemplateService());
+
+    private static ComposeViewModel MakeVm(ComposeKind kind, string subject = "")
+    {
+        var vm = MakeVm();
+        vm.Seed(new ComposeModel { Kind = kind, Subject = subject });
+        return vm;
+    }
+
+    public static IEnumerable<object[]> KindLabels() =>
+    [
+        [ComposeKind.NewMessage,   "New Message"],
+        [ComposeKind.Reply,        "Reply"],
+        [ComposeKind.ReplyAll,     "Reply All"],
+        [ComposeKind.Forward,      "Forward"],
+        [ComposeKind.EditDraft,    "Draft"],
+        [ComposeKind.NewDraft,     "Draft"],
+        [ComposeKind.EditTemplate, "Edit Template"],
+    ];
+
+    // ── Subject leads when present ───────────────────────────────────────────────
+
+    [Theory]
+    [MemberData(nameof(KindLabels))]
+    public void WithASubject_TheSubjectLeadsRegardlessOfKind(ComposeKind kind, string _)
+    {
+        var vm = MakeVm(kind, "Quarterly review");
+
+        Assert.Equal("Quarterly review - Plain Text - QuickMail", vm.WindowTitle);
+    }
+
+    [Fact]
+    public void SubjectIsTrimmed()
+    {
+        var vm = MakeVm(ComposeKind.NewMessage, "   spaced out   ");
+
+        Assert.Equal("spaced out - Plain Text - QuickMail", vm.WindowTitle);
+    }
+
+    // ── Kind label leads when the subject is blank ───────────────────────────────
+
+    [Theory]
+    [MemberData(nameof(KindLabels))]
+    public void WithNoSubject_TheKindLabelLeads(ComposeKind kind, string expectedLabel)
+    {
+        var vm = MakeVm(kind);
+
+        Assert.Equal($"{expectedLabel} - Plain Text - QuickMail", vm.WindowTitle);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\t")]
+    public void WhitespaceOnlySubject_CountsAsBlank(string subject)
+    {
+        var vm = MakeVm(ComposeKind.Reply, subject);
+
+        Assert.Equal("Reply - Plain Text - QuickMail", vm.WindowTitle);
+    }
+
+    [Fact]
+    public void DefaultKindIsNewMessage()
+    {
+        var vm = MakeVm(); // never seeded
+
+        Assert.Equal(ComposeKind.NewMessage, vm.ComposeKind);
+        Assert.Equal("New Message - Plain Text - QuickMail", vm.WindowTitle);
+    }
+
+    // ── Mode segment ─────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(ComposeMode.PlainText, "Plain Text")]
+    [InlineData(ComposeMode.Html,      "HTML")]
+    [InlineData(ComposeMode.Markdown,  "Markdown")]
+    public void ModeSegmentReflectsTheCurrentComposeMode(ComposeMode mode, string expected)
+    {
+        var vm = MakeVm(ComposeKind.NewMessage, "Subject");
+        vm.CurrentMode = mode;
+
+        Assert.Equal($"Subject - {expected} - QuickMail", vm.WindowTitle);
+    }
+
+    // ── Change notification ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void ChangingTheSubjectRaisesPropertyChangedForWindowTitle()
+    {
+        // Without this notification the taskbar and Alt+Tab keep the stale title, and a screen
+        // reader user switching back hears the wrong message identified.
+        var vm = MakeVm();
+        var raised = false;
+        vm.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(ComposeViewModel.WindowTitle)) raised = true;
+        };
+
+        vm.Subject = "New subject";
+
+        Assert.True(raised);
+        Assert.Equal("New subject - Plain Text - QuickMail", vm.WindowTitle);
+    }
+
+    [Fact]
+    public void ChangingTheModeRaisesPropertyChangedForWindowTitle()
+    {
+        var vm = MakeVm();
+        var raised = false;
+        vm.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(ComposeViewModel.WindowTitle)) raised = true;
+        };
+
+        vm.CurrentMode = ComposeMode.Html;
+
+        Assert.True(raised);
+    }
+
+    [Fact]
+    public void SeedingRaisesPropertyChangedForWindowTitle()
+    {
+        var vm = MakeVm();
+        var raised = false;
+        vm.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(ComposeViewModel.WindowTitle)) raised = true;
+        };
+
+        vm.Seed(new ComposeModel { Kind = ComposeKind.Forward });
+
+        Assert.True(raised);
+        Assert.Equal("Forward - Plain Text - QuickMail", vm.WindowTitle);
+    }
+}

--- a/QuickMail.Tests/MainViewModelTabTests.cs
+++ b/QuickMail.Tests/MainViewModelTabTests.cs
@@ -1,0 +1,572 @@
+using System;
+using System.Linq;
+using QuickMail.Models;
+using QuickMail.ViewModels;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// Tab management on <see cref="MainViewModel"/>, deferred from PR #38 (issue #40).
+///
+/// Two distinct arrangements are covered, because they behave differently and both ship:
+///
+/// <list type="bullet">
+/// <item><b>Tab mode</b> — a permanent <see cref="MessageListTabViewModel"/> sits at index 0.
+/// The strip never hides, tabs never move left of index 0, and closing the last message tab
+/// falls back to the list tab rather than to nothing.</item>
+/// <item><b>Reading-pane mode</b> — no list tab exists, but message tabs can still be opened
+/// (e.g. the explicit "open in tab" command). Closing the last one leaves no active tab and
+/// hides the strip.</item>
+/// </list>
+///
+/// Getting these two confused is the likely regression, so every test states which it is in.
+/// </summary>
+public class MainViewModelTabTests
+{
+    private static MailMessageSummary Msg(string id, string subject = "subject", Guid? accountId = null) => new()
+    {
+        MessageId  = id,
+        AccountId  = accountId ?? Guid.Empty,
+        FolderName = "INBOX",
+        Subject    = subject,
+    };
+
+    private static MainViewModel MakeVm(MessageOpenMode mode)
+    {
+        var config = new StubConfigService();
+        var model = config.Load();
+        model.Windowing.MessageOpenMode = mode;
+        config.Save(model); // MainViewModel reads Windowing.MessageOpenMode in its constructor.
+
+        return new MainViewModel(
+            new StubImapMailService(), new StubAccountService(), new StubCredentialService(),
+            new StubLocalStoreService(), new StubOAuthService(), new StubSyncService(), config,
+            new StubCommandRegistry(), new StubViewService(), new StubRuleService(), new StubSmtpService());
+    }
+
+    private static MainViewModel TabMode()        => MakeVm(MessageOpenMode.Tab);
+    private static MainViewModel ReadingPaneMode() => MakeVm(MessageOpenMode.ReadingPane);
+
+    private static int MessageTabCount(MainViewModel vm) => vm.OpenTabs.OfType<MessageTabViewModel>().Count();
+
+    // ── Construction ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void TabMode_SeedsThePermanentMessageListTabAtIndexZero()
+    {
+        var vm = TabMode();
+
+        Assert.Single(vm.OpenTabs);
+        Assert.IsType<MessageListTabViewModel>(vm.OpenTabs[0]);
+        Assert.Same(vm.OpenTabs[0], vm.ActiveTab);
+        Assert.True(vm.ShowTabStrip);
+    }
+
+    [Fact]
+    public void ReadingPaneMode_HasNoTabsAndNoStrip()
+    {
+        var vm = ReadingPaneMode();
+
+        Assert.Empty(vm.OpenTabs);
+        Assert.Null(vm.ActiveTab);
+        Assert.False(vm.ShowTabStrip);
+    }
+
+    // ── OpenMessageTab ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void OpenMessageTab_AddsTabAndActivatesIt()
+    {
+        var vm = ReadingPaneMode();
+
+        vm.OpenMessageTab(Msg("1", "hello"));
+
+        var tab = Assert.IsType<MessageTabViewModel>(Assert.Single(vm.OpenTabs));
+        Assert.Same(tab, vm.ActiveTab);
+        Assert.Equal("hello", tab.Title);
+        Assert.True(vm.ShowTabStrip);
+    }
+
+    [Fact]
+    public void OpenMessageTab_CarriesSourceFolderAndAccount()
+    {
+        var vm = ReadingPaneMode();
+        var accountId = Guid.NewGuid();
+
+        vm.OpenMessageTab(Msg("1", accountId: accountId));
+
+        var tab = Assert.IsType<MessageTabViewModel>(vm.OpenTabs[0]);
+        Assert.Equal("INBOX", tab.SourceFolderName);
+        Assert.Equal(accountId, tab.AccountId);
+    }
+
+    [Fact]
+    public void OpenMessageTab_SameMessageTwice_ActivatesExistingInsteadOfDuplicating()
+    {
+        var vm = ReadingPaneMode();
+        vm.OpenMessageTab(Msg("1"));
+        vm.OpenMessageTab(Msg("2"));
+        var first = vm.OpenTabs[0];
+
+        vm.OpenMessageTab(Msg("1")); // already open
+
+        Assert.Equal(2, MessageTabCount(vm));
+        Assert.Same(first, vm.ActiveTab);
+    }
+
+    [Fact]
+    public void OpenMessageTab_SameIdOnDifferentAccounts_OpensSeparateTabs()
+    {
+        // The dedupe key is (MessageId, AccountId): IMAP UIDs are only unique within a mailbox,
+        // so two accounts can legitimately both have a message with the same id.
+        var vm = ReadingPaneMode();
+
+        vm.OpenMessageTab(Msg("1", accountId: Guid.NewGuid()));
+        vm.OpenMessageTab(Msg("1", accountId: Guid.NewGuid()));
+
+        Assert.Equal(2, MessageTabCount(vm));
+    }
+
+    [Fact]
+    public void OpenMessageTab_InTabMode_KeepsListTabFirst()
+    {
+        var vm = TabMode();
+
+        vm.OpenMessageTab(Msg("1"));
+        vm.OpenMessageTab(Msg("2"));
+
+        Assert.IsType<MessageListTabViewModel>(vm.OpenTabs[0]);
+        Assert.Equal(3, vm.OpenTabs.Count);
+    }
+
+    // ── CloseTab ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void CloseTab_RemovesTheTab()
+    {
+        var vm = ReadingPaneMode();
+        vm.OpenMessageTab(Msg("1"));
+        vm.OpenMessageTab(Msg("2"));
+        var first = vm.OpenTabs[0];
+
+        vm.CloseTab(first);
+
+        Assert.Single(vm.OpenTabs);
+        Assert.DoesNotContain(first, vm.OpenTabs);
+    }
+
+    [Fact]
+    public void CloseTab_ActivatesTheTabThatTookItsPosition()
+    {
+        var vm = ReadingPaneMode();
+        vm.OpenMessageTab(Msg("1"));
+        vm.OpenMessageTab(Msg("2"));
+        vm.OpenMessageTab(Msg("3"));
+        var middle = vm.OpenTabs[1];
+        var third  = vm.OpenTabs[2];
+        vm.ActiveTab = middle;
+
+        vm.CloseTab(middle);
+
+        // Index 1 is now the tab that was third — focus stays put rather than jumping to an end.
+        Assert.Same(third, vm.ActiveTab);
+    }
+
+    [Fact]
+    public void CloseTab_ClosingTheLastPositionActivatesTheNewLastTab()
+    {
+        var vm = ReadingPaneMode();
+        vm.OpenMessageTab(Msg("1"));
+        vm.OpenMessageTab(Msg("2"));
+        var first = vm.OpenTabs[0];
+        var last  = vm.OpenTabs[1];
+        vm.ActiveTab = last;
+
+        vm.CloseTab(last);
+
+        Assert.Same(first, vm.ActiveTab);
+    }
+
+    [Fact]
+    public void CloseTab_InactiveTab_LeavesActiveTabAlone()
+    {
+        var vm = ReadingPaneMode();
+        vm.OpenMessageTab(Msg("1"));
+        vm.OpenMessageTab(Msg("2"));
+        var first  = vm.OpenTabs[0];
+        var active = vm.OpenTabs[1];
+        vm.ActiveTab = active;
+
+        vm.CloseTab(first);
+
+        Assert.Same(active, vm.ActiveTab);
+    }
+
+    [Fact]
+    public void CloseTab_LastTabInReadingPaneMode_ClearsActiveTabAndHidesStrip()
+    {
+        var vm = ReadingPaneMode();
+        vm.OpenMessageTab(Msg("1"));
+
+        vm.CloseTab(vm.OpenTabs[0]);
+
+        Assert.Empty(vm.OpenTabs);
+        Assert.Null(vm.ActiveTab);
+        Assert.False(vm.ShowTabStrip);
+        Assert.False(vm.IsMessageOpen);
+        Assert.Null(vm.MessageDetail);
+    }
+
+    [Fact]
+    public void CloseTab_LastMessageTabInTabMode_FallsBackToTheListTab()
+    {
+        var vm = TabMode();
+        vm.OpenMessageTab(Msg("1"));
+
+        vm.CloseTab(vm.OpenTabs[1]);
+
+        Assert.Same(vm.OpenTabs[0], vm.ActiveTab);
+        Assert.IsType<MessageListTabViewModel>(vm.ActiveTab);
+        // The strip stays visible in Tab mode even with no message tabs open.
+        Assert.True(vm.ShowTabStrip);
+        Assert.False(vm.IsMessageOpen);
+    }
+
+    [Fact]
+    public void CloseTab_MessageListTab_IsRefused()
+    {
+        var vm = TabMode();
+        var listTab = vm.OpenTabs[0];
+
+        vm.CloseTab(listTab);
+
+        Assert.Contains(listTab, vm.OpenTabs);
+    }
+
+    [Fact]
+    public void CloseTab_TabNotInTheStrip_IsANoOp()
+    {
+        var vm = ReadingPaneMode();
+        vm.OpenMessageTab(Msg("1"));
+        var stranger = new MessageTabViewModel(Msg("stranger"));
+
+        vm.CloseTab(stranger);
+
+        Assert.Single(vm.OpenTabs);
+    }
+
+    // Note: MainViewModel.OpenMessageTab subscribes to each tab's CloseRequested, but
+    // TabSessionViewModel.RequestClose() is protected and MessageTabViewModel exposes no command
+    // that raises it, so that wiring cannot be driven from a test (or, currently, from the app).
+    // The event contract itself is covered by TabSessionModelTests via a test subclass.
+
+    // ── Activation ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ActivateNextTab_MovesForwardThroughMessageTabs()
+    {
+        var vm = ReadingPaneMode();
+        vm.OpenMessageTab(Msg("1"));
+        vm.OpenMessageTab(Msg("2"));
+        vm.ActiveTab = vm.OpenTabs[0];
+
+        vm.ActivateNextTab();
+
+        Assert.Same(vm.OpenTabs[1], vm.ActiveTab);
+    }
+
+    [Fact]
+    public void ActivateNextTab_WrapsFromLastToFirst()
+    {
+        var vm = ReadingPaneMode();
+        vm.OpenMessageTab(Msg("1"));
+        vm.OpenMessageTab(Msg("2"));
+        vm.ActiveTab = vm.OpenTabs[1];
+
+        vm.ActivateNextTab();
+
+        Assert.Same(vm.OpenTabs[0], vm.ActiveTab);
+    }
+
+    [Fact]
+    public void ActivatePrevTab_WrapsFromFirstToLast()
+    {
+        var vm = ReadingPaneMode();
+        vm.OpenMessageTab(Msg("1"));
+        vm.OpenMessageTab(Msg("2"));
+        vm.ActiveTab = vm.OpenTabs[0];
+
+        vm.ActivatePrevTab();
+
+        Assert.Same(vm.OpenTabs[1], vm.ActiveTab);
+    }
+
+    [Fact]
+    public void ActivateNextTab_WithNoMessageTabs_IsANoOp()
+    {
+        var vm = TabMode(); // only the list tab exists
+        var before = vm.ActiveTab;
+
+        vm.ActivateNextTab();
+
+        Assert.Same(before, vm.ActiveTab);
+    }
+
+    [Fact]
+    public void ActivateNextTab_FromTheListTab_LandsOnTheFirstMessageTab()
+    {
+        // The list tab is not a MessageTabViewModel, so cycling starts at index 0.
+        var vm = TabMode();
+        vm.OpenMessageTab(Msg("1"));
+        vm.OpenMessageTab(Msg("2"));
+        vm.ActiveTab = vm.OpenTabs[0];
+
+        vm.ActivateNextTab();
+
+        Assert.Same(vm.OpenTabs[1], vm.ActiveTab);
+    }
+
+    [Fact]
+    public void ActivatePrevTab_FromTheListTab_LandsOnTheLastMessageTab()
+    {
+        var vm = TabMode();
+        vm.OpenMessageTab(Msg("1"));
+        vm.OpenMessageTab(Msg("2"));
+        vm.ActiveTab = vm.OpenTabs[0];
+
+        vm.ActivatePrevTab();
+
+        Assert.Same(vm.OpenTabs[2], vm.ActiveTab);
+    }
+
+    [Fact]
+    public void ActivateTabByIndex_IsOneBased()
+    {
+        var vm = ReadingPaneMode();
+        vm.OpenMessageTab(Msg("1"));
+        vm.OpenMessageTab(Msg("2"));
+
+        vm.ActivateTabByIndex(1);
+
+        Assert.Same(vm.OpenTabs[0], vm.ActiveTab);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(3)]
+    [InlineData(int.MaxValue)]
+    public void ActivateTabByIndex_OutOfBounds_IsANoOp(int index)
+    {
+        var vm = ReadingPaneMode();
+        vm.OpenMessageTab(Msg("1"));
+        vm.OpenMessageTab(Msg("2"));
+        var before = vm.ActiveTab;
+
+        vm.ActivateTabByIndex(index);
+
+        Assert.Same(before, vm.ActiveTab);
+    }
+
+    [Fact]
+    public void ActivateLastTab_WithNoTabs_IsANoOp()
+    {
+        var vm = ReadingPaneMode();
+
+        vm.ActivateLastTab();
+
+        Assert.Null(vm.ActiveTab);
+    }
+
+    [Fact]
+    public void ActivateLastTab_WithOneTab_ActivatesIt()
+    {
+        var vm = ReadingPaneMode();
+        vm.OpenMessageTab(Msg("1"));
+        vm.ActiveTab = null;
+
+        vm.ActivateLastTab();
+
+        Assert.Same(vm.OpenTabs[0], vm.ActiveTab);
+    }
+
+    [Fact]
+    public void ActivateLastTab_WithSeveralTabs_ActivatesTheRightmost()
+    {
+        var vm = ReadingPaneMode();
+        vm.OpenMessageTab(Msg("1"));
+        vm.OpenMessageTab(Msg("2"));
+        vm.OpenMessageTab(Msg("3"));
+        vm.ActiveTab = vm.OpenTabs[0];
+
+        vm.ActivateLastTab();
+
+        Assert.Same(vm.OpenTabs[2], vm.ActiveTab);
+    }
+
+    [Fact]
+    public void ActivateMessageListTab_InTabMode_SelectsTheListTab()
+    {
+        var vm = TabMode();
+        vm.OpenMessageTab(Msg("1"));
+
+        Assert.True(vm.ActivateMessageListTab());
+        Assert.IsType<MessageListTabViewModel>(vm.ActiveTab);
+    }
+
+    [Fact]
+    public void ActivateMessageListTab_OutsideTabMode_ReportsFailure()
+    {
+        var vm = ReadingPaneMode();
+        vm.OpenMessageTab(Msg("1"));
+
+        Assert.False(vm.ActivateMessageListTab());
+    }
+
+    // ── Reordering ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void MoveTabLeft_SwapsWithThePreviousTab()
+    {
+        var vm = ReadingPaneMode();
+        vm.OpenMessageTab(Msg("1", "first"));
+        vm.OpenMessageTab(Msg("2", "second"));
+        var second = vm.OpenTabs[1];
+        vm.ActiveTab = second;
+
+        vm.MoveTabLeft();
+
+        Assert.Same(second, vm.OpenTabs[0]);
+        Assert.Same(second, vm.ActiveTab); // the moved tab stays active
+    }
+
+    [Fact]
+    public void MoveTabLeft_AtTheLeftEdge_IsANoOp()
+    {
+        var vm = ReadingPaneMode();
+        vm.OpenMessageTab(Msg("1"));
+        vm.OpenMessageTab(Msg("2"));
+        var first = vm.OpenTabs[0];
+        vm.ActiveTab = first;
+
+        vm.MoveTabLeft();
+
+        Assert.Same(first, vm.OpenTabs[0]);
+    }
+
+    [Fact]
+    public void MoveTabLeft_InTabMode_WillNotDisplaceTheListTab()
+    {
+        // The list tab must stay at index 0, so the leftmost legal position for a message tab is 1.
+        var vm = TabMode();
+        vm.OpenMessageTab(Msg("1"));
+        var messageTab = vm.OpenTabs[1];
+        vm.ActiveTab = messageTab;
+
+        vm.MoveTabLeft();
+
+        Assert.IsType<MessageListTabViewModel>(vm.OpenTabs[0]);
+        Assert.Same(messageTab, vm.OpenTabs[1]);
+    }
+
+    [Fact]
+    public void MoveTabRight_SwapsWithTheNextTab()
+    {
+        var vm = ReadingPaneMode();
+        vm.OpenMessageTab(Msg("1"));
+        vm.OpenMessageTab(Msg("2"));
+        var first = vm.OpenTabs[0];
+        vm.ActiveTab = first;
+
+        vm.MoveTabRight();
+
+        Assert.Same(first, vm.OpenTabs[1]);
+    }
+
+    [Fact]
+    public void MoveTabRight_AtTheRightEdge_IsANoOp()
+    {
+        var vm = ReadingPaneMode();
+        vm.OpenMessageTab(Msg("1"));
+        vm.OpenMessageTab(Msg("2"));
+        var last = vm.OpenTabs[1];
+        vm.ActiveTab = last;
+
+        vm.MoveTabRight();
+
+        Assert.Same(last, vm.OpenTabs[1]);
+    }
+
+    [Fact]
+    public void MoveTab_WithTheListTabActive_IsANoOp()
+    {
+        var vm = TabMode();
+        vm.OpenMessageTab(Msg("1"));
+        vm.ActiveTab = vm.OpenTabs[0];
+
+        vm.MoveTabRight();
+        vm.MoveTabLeft();
+
+        Assert.IsType<MessageListTabViewModel>(vm.OpenTabs[0]);
+    }
+
+    // ── CloseAllOtherTabs ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void CloseAllOtherTabs_LeavesOnlyTheActiveTab()
+    {
+        var vm = ReadingPaneMode();
+        vm.OpenMessageTab(Msg("1"));
+        vm.OpenMessageTab(Msg("2"));
+        vm.OpenMessageTab(Msg("3"));
+        var keep = vm.OpenTabs[1];
+        vm.ActiveTab = keep;
+
+        vm.CloseAllOtherTabs();
+
+        Assert.Same(keep, Assert.Single(vm.OpenTabs));
+        Assert.Same(keep, vm.ActiveTab);
+    }
+
+    [Fact]
+    public void CloseAllOtherTabs_InTabMode_KeepsThePermanentListTab()
+    {
+        var vm = TabMode();
+        vm.OpenMessageTab(Msg("1"));
+        vm.OpenMessageTab(Msg("2"));
+        var keep = vm.OpenTabs[2];
+        vm.ActiveTab = keep;
+
+        vm.CloseAllOtherTabs();
+
+        Assert.Equal(2, vm.OpenTabs.Count);
+        Assert.IsType<MessageListTabViewModel>(vm.OpenTabs[0]);
+        Assert.Same(keep, vm.OpenTabs[1]);
+    }
+
+    [Fact]
+    public void CloseAllOtherTabs_WithASingleTab_IsANoOp()
+    {
+        var vm = ReadingPaneMode();
+        vm.OpenMessageTab(Msg("1"));
+        var only = vm.OpenTabs[0];
+
+        vm.CloseAllOtherTabs();
+
+        Assert.Same(only, Assert.Single(vm.OpenTabs));
+    }
+
+    [Fact]
+    public void CloseAllOtherTabs_WithNoActiveTab_IsANoOp()
+    {
+        var vm = ReadingPaneMode();
+        vm.OpenMessageTab(Msg("1"));
+        vm.OpenMessageTab(Msg("2"));
+        vm.ActiveTab = null;
+
+        vm.CloseAllOtherTabs();
+
+        Assert.Equal(2, vm.OpenTabs.Count);
+    }
+}

--- a/QuickMail.Tests/TabSessionModelTests.cs
+++ b/QuickMail.Tests/TabSessionModelTests.cs
@@ -1,0 +1,273 @@
+using System;
+using QuickMail.Models;
+using QuickMail.ViewModels;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// Tab session model/VM behaviour deferred from PR #38 (issue #40): title derivation for message
+/// tabs, the <see cref="TabSessionViewModel"/> defaults, and the close-request event.
+///
+/// Titles matter beyond the visual strip: <c>Title</c> is what the tab announces, and it is what
+/// <see cref="MainViewModel"/> reads back into its "Opened tab: …" / "Closed tab: …" announcements.
+/// A regression here is heard, not just seen.
+/// </summary>
+public class TabSessionModelTests
+{
+    private const int MaxTitleLength = 60;
+
+    private static MailMessageSummary Summary(string? subject, string id = "1") => new()
+    {
+        MessageId  = id,
+        AccountId  = Guid.NewGuid(),
+        FolderName = "INBOX",
+        Subject    = subject!,
+    };
+
+    /// <summary>Exposes the protected RequestClose() so the event contract can be exercised.</summary>
+    private sealed class TestTab : TabSessionViewModel
+    {
+        public TestTab(TabSessionModel model) : base(model) { }
+        public void RaiseClose() => RequestClose();
+    }
+
+    // ── Title truncation ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Title_ShortSubject_IsUsedVerbatim()
+    {
+        var tab = new MessageTabViewModel(Summary("Lunch tomorrow?"));
+        Assert.Equal("Lunch tomorrow?", tab.Title);
+    }
+
+    [Fact]
+    public void Title_SubjectIsTrimmed()
+    {
+        var tab = new MessageTabViewModel(Summary("   padded   "));
+        Assert.Equal("padded", tab.Title);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\t\n ")]
+    public void Title_BlankSubject_BecomesUntitled(string? subject)
+    {
+        var tab = new MessageTabViewModel(Summary(subject));
+        Assert.Equal("Untitled", tab.Title);
+    }
+
+    [Fact]
+    public void Title_ExactlyMaxLength_IsNotTruncated()
+    {
+        // Boundary: the truncation test is `> MaxTitleLength`, so 60 characters must survive intact.
+        var subject = new string('a', MaxTitleLength);
+        var tab = new MessageTabViewModel(Summary(subject));
+
+        Assert.Equal(subject, tab.Title);
+        Assert.DoesNotContain("…", tab.Title, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Title_OverMaxLength_IsTruncatedWithEllipsis()
+    {
+        var subject = new string('a', MaxTitleLength + 40);
+        var tab = new MessageTabViewModel(Summary(subject));
+
+        Assert.Equal(new string('a', MaxTitleLength) + "…", tab.Title);
+        // One ellipsis CHARACTER, not three periods — the strip budgets on character count.
+        Assert.Equal(MaxTitleLength + 1, tab.Title.Length);
+    }
+
+    [Fact]
+    public void Title_TrimHappensBeforeTruncation()
+    {
+        // Leading whitespace must not consume part of the 60-character budget.
+        var subject = "   " + new string('b', MaxTitleLength);
+        var tab = new MessageTabViewModel(Summary(subject));
+
+        Assert.Equal(new string('b', MaxTitleLength), tab.Title);
+        Assert.DoesNotContain("…", tab.Title, StringComparison.Ordinal);
+    }
+
+    // ── Title tracks the loaded detail ───────────────────────────────────────────
+
+    [Fact]
+    public void Detail_WhenSet_MarksLoadedAndRetitles()
+    {
+        var tab = new MessageTabViewModel(Summary("summary subject"));
+        Assert.False(tab.IsLoaded);
+
+        tab.Detail = new MailMessageDetail { Subject = "detail subject" };
+
+        Assert.True(tab.IsLoaded);
+        Assert.Equal("detail subject", tab.Title);
+        Assert.Equal("detail subject", tab.Model.Tooltip);
+    }
+
+    [Fact]
+    public void Detail_WithBlankSubject_FallsBackToSummarySubject()
+    {
+        var tab = new MessageTabViewModel(Summary("summary subject"));
+
+        // Subject is declared non-nullable, but the fallback in OnDetailChanged exists precisely
+        // because a server can hand back a detail with no subject. null! reproduces that.
+        tab.Detail = new MailMessageDetail { Subject = null! };
+
+        Assert.True(tab.IsLoaded);
+        Assert.Equal("summary subject", tab.Title);
+    }
+
+    [Fact]
+    public void Detail_LongSubject_IsTruncatedToo()
+    {
+        var tab = new MessageTabViewModel(Summary("short"));
+
+        tab.Detail = new MailMessageDetail { Subject = new string('c', MaxTitleLength + 10) };
+
+        Assert.Equal(new string('c', MaxTitleLength) + "…", tab.Title);
+    }
+
+    [Fact]
+    public void Detail_SetToNull_DoesNotRetitleOrMarkLoaded()
+    {
+        var tab = new MessageTabViewModel(Summary("summary subject"));
+
+        tab.Detail = null;
+
+        Assert.False(tab.IsLoaded);
+        Assert.Equal("summary subject", tab.Title);
+    }
+
+    // ── Model/VM sync and defaults ───────────────────────────────────────────────
+
+    [Fact]
+    public void Title_SetOnViewModel_WritesThroughToModel()
+    {
+        var tab = new MessageTabViewModel(Summary("original"));
+
+        tab.Title = "renamed";
+
+        Assert.Equal("renamed", tab.Model.Title);
+    }
+
+    [Fact]
+    public void IsDirty_SetOnViewModel_WritesThroughToModel()
+    {
+        var tab = new MessageTabViewModel(Summary("s"));
+
+        tab.IsDirty = true;
+
+        Assert.True(tab.Model.IsDirty);
+    }
+
+    [Fact]
+    public void MessageTab_Defaults_AreCleanAndCloseable()
+    {
+        var tab = new MessageTabViewModel(Summary("s"));
+
+        Assert.False(tab.IsDirty);
+        Assert.True(tab.CanClose);
+        Assert.True(tab.CanCloseNow());
+        Assert.Equal(TabKind.Message, tab.Model.Kind);
+    }
+
+    [Fact]
+    public void MessageTab_CarriesMessageIdAsContentKey()
+    {
+        var summary = Summary("s", id: "uid-42");
+        var tab = new MessageTabViewModel(summary);
+
+        Assert.Equal("uid-42", tab.Model.ContentKey);
+        Assert.Same(summary, tab.Summary);
+    }
+
+    [Fact]
+    public void MessageListTab_IsPermanentAndNeverCloseable()
+    {
+        var tab = new MessageListTabViewModel();
+
+        Assert.False(tab.CanClose);
+        Assert.False(tab.CanCloseNow());
+        Assert.Equal("Messages", tab.Title);
+        Assert.Equal(TabKind.MessageList, tab.Model.Kind);
+    }
+
+    [Fact]
+    public void ConstructorSeedsViewModelStateFromModel()
+    {
+        var tab = new TestTab(new TabSessionModel
+        {
+            Kind     = TabKind.Unknown,
+            Title    = "seeded",
+            IsDirty  = true,
+            CanClose = false,
+        });
+
+        Assert.Equal("seeded", tab.Title);
+        Assert.True(tab.IsDirty);
+        Assert.False(tab.CanClose);
+    }
+
+    // ── CloseRequested ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void RequestClose_RaisesCloseRequestedWithItself()
+    {
+        var tab = new TestTab(new TabSessionModel { Kind = TabKind.Unknown, Title = "t" });
+        TabSessionViewModel? raisedWith = null;
+        tab.CloseRequested += t => raisedWith = t;
+
+        tab.RaiseClose();
+
+        Assert.Same(tab, raisedWith);
+    }
+
+    [Fact]
+    public void RequestClose_WithNoSubscriber_DoesNotThrow()
+    {
+        var tab = new TestTab(new TabSessionModel { Kind = TabKind.Unknown, Title = "t" });
+
+        tab.RaiseClose(); // must be a no-op, not a NullReferenceException
+
+        Assert.Equal("t", tab.Title);
+    }
+
+    [Fact]
+    public void CloseRequested_AfterUnsubscribe_IsNotRaised()
+    {
+        var tab = new TestTab(new TabSessionModel { Kind = TabKind.Unknown, Title = "t" });
+        var count = 0;
+        void Handler(TabSessionViewModel _) => count++;
+
+        tab.CloseRequested += Handler;
+        tab.RaiseClose();
+        tab.CloseRequested -= Handler;
+        tab.RaiseClose();
+
+        Assert.Equal(1, count);
+    }
+
+    // ── CanCloseNow ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void CanCloseNow_CleanTab_IsTrue()
+    {
+        var tab = new TestTab(new TabSessionModel { Kind = TabKind.Unknown }) { IsDirty = false };
+        Assert.True(tab.CanCloseNow());
+    }
+
+    [Fact]
+    public void CanCloseNow_DirtyCloseableTab_IsFalse()
+    {
+        // The case the confirm-on-close prompt exists for.
+        var tab = new TestTab(new TabSessionModel { Kind = TabKind.Unknown })
+        {
+            IsDirty  = true,
+            CanClose = true,
+        };
+        Assert.False(tab.CanCloseNow());
+    }
+}

--- a/QuickMail.Tests/WindowingPreferencesTests.cs
+++ b/QuickMail.Tests/WindowingPreferencesTests.cs
@@ -1,0 +1,171 @@
+using System;
+using System.IO;
+using QuickMail.Models;
+using QuickMail.Services;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// Windowing preference persistence, deferred from PR #38 (issue #40).
+///
+/// These are round-trip tests on purpose. The failure this guards against is the one described in
+/// ConfigServiceSaveTests: a property and a Settings writer exist, but ConfigService has no parse
+/// case or no writer block, so the setting silently resets on every launch. A setting is not wired
+/// up until it survives Save → Load in a fresh service.
+/// </summary>
+public class WindowingPreferencesTests
+{
+    private static ProfileContext MakeTempProfile()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"QM-WIN-{Guid.NewGuid():N}");
+        return new ProfileContext(tempDir);
+    }
+
+    private static ConfigModel SaveThenReload(Action<ConfigModel> mutate)
+    {
+        var profile = MakeTempProfile();
+        var config = new ConfigService(profile).Load();
+        mutate(config);
+        new ConfigService(profile).Save(config);
+        return new ConfigService(profile).Load();
+    }
+
+    /// <summary>Writes a raw config.ini so the parse side can be tested independently of the writer.</summary>
+    private static ConfigModel LoadFromIni(string body)
+    {
+        var profile = MakeTempProfile();
+        File.WriteAllText(Path.Combine(profile.ProfileDir, "config.ini"), body);
+        return new ConfigService(profile).Load();
+    }
+
+    // ── Defaults ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Defaults_AreReadingPaneAndConfirmOn()
+    {
+        var config = new ConfigModel();
+
+        Assert.Equal(MessageOpenMode.ReadingPane, config.Windowing.MessageOpenMode);
+        Assert.True(config.Windowing.ConfirmCloseTabWithUnsaved);
+    }
+
+    // ── MessageOpenMode round trip ───────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(MessageOpenMode.ReadingPane)]
+    [InlineData(MessageOpenMode.Tab)]
+    [InlineData(MessageOpenMode.Window)]
+    public void MessageOpenMode_RoundTrips(MessageOpenMode mode)
+    {
+        var reloaded = SaveThenReload(c => c.Windowing.MessageOpenMode = mode);
+
+        Assert.Equal(mode, reloaded.Windowing.MessageOpenMode);
+    }
+
+    [Theory]
+    [InlineData("tab",         MessageOpenMode.Tab)]
+    [InlineData("TAB",         MessageOpenMode.Tab)]
+    [InlineData("Tab",         MessageOpenMode.Tab)]
+    [InlineData("window",      MessageOpenMode.Window)]
+    [InlineData("WINDOW",      MessageOpenMode.Window)]
+    [InlineData("readingpane", MessageOpenMode.ReadingPane)]
+    public void MessageOpenMode_ParsesCaseInsensitively(string raw, MessageOpenMode expected)
+    {
+        var config = LoadFromIni($"[windowing]\nMessageOpenMode = {raw}\n");
+
+        Assert.Equal(expected, config.Windowing.MessageOpenMode);
+    }
+
+    [Theory]
+    [InlineData("banana")]
+    [InlineData("")]
+    [InlineData("reading pane")] // note the space: not the accepted spelling
+    public void MessageOpenMode_UnknownValue_FallsBackToReadingPane(string raw)
+    {
+        // Falling back rather than throwing keeps a hand-edited config.ini from blocking startup.
+        var config = LoadFromIni($"[windowing]\nMessageOpenMode = {raw}\n");
+
+        Assert.Equal(MessageOpenMode.ReadingPane, config.Windowing.MessageOpenMode);
+    }
+
+    [Fact]
+    public void MessageOpenMode_AbsentFromFile_IsReadingPane()
+    {
+        var config = LoadFromIni("[windowing]\n");
+
+        Assert.Equal(MessageOpenMode.ReadingPane, config.Windowing.MessageOpenMode);
+    }
+
+    // ── ConfirmCloseTabWithUnsaved round trip ────────────────────────────────────
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void ConfirmCloseTabWithUnsaved_RoundTrips(bool value)
+    {
+        var reloaded = SaveThenReload(c => c.Windowing.ConfirmCloseTabWithUnsaved = value);
+
+        Assert.Equal(value, reloaded.Windowing.ConfirmCloseTabWithUnsaved);
+    }
+
+    [Fact]
+    public void ConfirmCloseTabWithUnsaved_OffSurvivesReload()
+    {
+        // Turning a confirmation OFF is the direction that matters: if it silently resets to on,
+        // the user is re-prompted forever and reasonably concludes the setting does nothing.
+        var reloaded = SaveThenReload(c => c.Windowing.ConfirmCloseTabWithUnsaved = false);
+
+        Assert.False(reloaded.Windowing.ConfirmCloseTabWithUnsaved);
+    }
+
+    // ── Whole-section integrity ──────────────────────────────────────────────────
+
+    [Fact]
+    public void WindowingSettings_RoundTripTogether()
+    {
+        // Guards a writer that emits one key and drops its neighbour.
+        var reloaded = SaveThenReload(c =>
+        {
+            c.Windowing.MessageOpenMode             = MessageOpenMode.Window;
+            c.Windowing.ConfirmCloseTabWithUnsaved  = false;
+        });
+
+        Assert.Equal(MessageOpenMode.Window, reloaded.Windowing.MessageOpenMode);
+        Assert.False(reloaded.Windowing.ConfirmCloseTabWithUnsaved);
+    }
+
+    [Fact]
+    public void WindowingSettings_SurviveASecondSaveLoadCycle()
+    {
+        // A value that round-trips once but not twice means the writer emits a form its own parser
+        // does not accept.
+        var profile = MakeTempProfile();
+        var first = new ConfigService(profile).Load();
+        first.Windowing.MessageOpenMode            = MessageOpenMode.Tab;
+        first.Windowing.ConfirmCloseTabWithUnsaved = false;
+        new ConfigService(profile).Save(first);
+
+        var second = new ConfigService(profile).Load();
+        new ConfigService(profile).Save(second);
+        var third = new ConfigService(profile).Load();
+
+        Assert.Equal(MessageOpenMode.Tab, third.Windowing.MessageOpenMode);
+        Assert.False(third.Windowing.ConfirmCloseTabWithUnsaved);
+    }
+
+    [Fact]
+    public void SavingWindowingDoesNotDisturbOtherSettings()
+    {
+        var profile = MakeTempProfile();
+        var config = new ConfigService(profile).Load();
+        config.AnnounceHints                      = false;
+        config.Windowing.MessageOpenMode          = MessageOpenMode.Tab;
+        new ConfigService(profile).Save(config);
+
+        var reloaded = new ConfigService(profile).Load();
+
+        Assert.False(reloaded.AnnounceHints);
+        Assert.Equal(MessageOpenMode.Tab, reloaded.Windowing.MessageOpenMode);
+    }
+}


### PR DESCRIPTION
Closes #40. Adds the four test classes deferred from PR #38 — **110 tests, no production code touched.**

## What is covered

| Class | Tests | Surface |
|---|---|---|
| `TabSessionModelTests` | 24 | Message-tab title derivation, detail-load retitling, VM↔model write-through, defaults, `CloseRequested` |
| `MainViewModelTabTests` | 41 | Open / close / activate / reorder, in **both** Tab mode and reading-pane mode |
| `ComposeWindowTitleTests` | 31 | `WindowTitle` across every `ComposeKind` and `ComposeMode`, plus change notification |
| `WindowingPreferencesTests` | 14 | `MessageOpenMode` and `ConfirmCloseTabWithUnsaved` through a real `Save`/`Load` round trip |

`MainViewModelTabTests` separates Tab mode from reading-pane mode throughout, because they genuinely diverge and confusing them is the likely regression: in Tab mode the permanent `MessageListTabViewModel` pins index 0, the strip stays visible with no message tabs open, and it is the fallback when the last message tab closes. In reading-pane mode tabs can still be opened, and closing the last one leaves `ActiveTab` null and hides the strip.

## Verified, not assumed

The tests passed on the first run, which is not by itself evidence they assert anything. Each class was **mutation-tested** against the production code:

| Mutation | Result |
|---|---|
| `MaxTitleLength` 60 → 50 | 4 truncation tests failed, no others |
| Dedupe drops the `AccountId` term | `OpenMessageTab_SameIdOnDifferentAccounts_OpensSeparateTabs` failed, alone |
| `MoveTabLeft` `minIdx` → always 0 | `MoveTabLeft_InTabMode_WillNotDisplaceTheListTab` failed, alone |

Every mutation failed exactly the tests naming that behaviour and nothing else. All mutations reverted; `git status` clean apart from the four new files.

Full suite green on **5 consecutive runs**: 2565 passed, 0 failed, 3 skipped. Worth stating honestly — at #380's observed ~1-in-11 flake rate, 5 clean runs is supportive but not conclusive. I ran them specifically because #380 notes that adding non-STA tests in new collections raises scheduling pressure on the `WpfTests` collection, and this PR adds 110 of them.

## Two deviations from the issue text, both deliberate

**1. Compose title on a blank subject.** #40 predicted `"Untitled"`. The shipped behaviour falls back to the *kind* label — `"Reply - Plain Text - QuickMail"` — which is strictly more informative. I pinned the shipped behaviour and commented the divergence in the file. `"Untitled"` is the blank fallback for message *tab* titles, a different surface. If you would rather the compose window said `"Untitled"`, that is a product change and belongs in its own PR.

**2. Closing the last tab.** #40 says it "clears `ActiveTab` and hides the strip". True in reading-pane mode only; in Tab mode the strip is permanent and the list tab takes over. Both paths are covered.

## Two things I found and did not act on

Neither is touched by this PR, because it is a tests-only change and both are your call:

**`TabSessionViewModel.CanCloseNow()` looks inverted.**
```csharp
public virtual bool CanCloseNow() => !IsDirty || !CanClose;
```
A tab that is dirty *and* marked `CanClose = false` returns **true** — a tab that cannot be closed reports itself closeable, and more closeable than a dirty one that can be. `CanClose && !IsDirty` looks like the intent. I deliberately wrote no test for that combination rather than freeze suspect behaviour into the suite; the two sane combinations are covered. Live impact today looks nil — `MessageListTabViewModel` overrides the method outright and nothing else sets `CanClose = false` — so this is latent, not a live bug.

**`MainViewModel`'s `CloseRequested` subscription is currently unreachable.** `OpenMessageTab` wires `tab.CloseRequested += t => CloseTab(t)`, but `RequestClose()` is `protected` and `MessageTabViewModel` exposes no command that raises it, so nothing can trigger it from the app or a test. The event contract itself is covered in `TabSessionModelTests` through a test subclass. Either a close affordance was intended to call it, or the subscription is dead — a note is in the test file at the point where the gap shows.

## Notes

- Built and run in a separate worktree; `main` untouched.
- New test names follow the existing `Method_Condition_Expectation` style, so they carry the same pre-existing project-wide CA1707 warnings as every other test file.