### PR TITLE
Settings: name the three field-label checkboxes after their own labels

### DIFF
--- a/QuickMail/Views/SettingsDialog.xaml
+++ b/QuickMail/Views/SettingsDialog.xaml
@@ -330,17 +330,17 @@
                                 <CheckBox Content="Show field _labels in the contact list"
                                           IsChecked="{Binding ContactListShowFieldLabels, Mode=TwoWay}"
                                           Margin="16,4,0,0"
-                                          AutomationProperties.Name="Show field labels in the address book contact list accessible names"/>
+                                          AutomationProperties.Name="Show field labels in the contact list"/>
 
                                 <CheckBox Content="Show field labels in the _calendar event list"
                                           IsChecked="{Binding CalendarListShowFieldLabels, Mode=TwoWay}"
                                           Margin="16,4,0,0"
-                                          AutomationProperties.Name="Show field labels in the calendar event list accessible names"/>
+                                          AutomationProperties.Name="Show field labels in the calendar event list"/>
 
                                 <CheckBox Content="Show field labels in the r_ules list"
                                           IsChecked="{Binding RuleListShowFieldLabels, Mode=TwoWay}"
                                           Margin="16,4,0,0"
-                                          AutomationProperties.Name="Show field labels in the rules list accessible names"/>
+                                          AutomationProperties.Name="Show field labels in the rules list"/>
 
                                 <CheckBox Content="Remind me before appoin_tments"
                                           IsChecked="{Binding CalendarReminders, Mode=TwoWay}"


### PR DESCRIPTION
Follow-on from #494, noticed while checking which Settings tab hosts the rules checkbox.

## The problem

All three **Show field labels in the … list** checkboxes (contact, calendar event, rules) carried an `AutomationProperties.Name` that neither matched the visible label nor stayed a short label:

| Visible label | Automation name |
|---|---|
| Show field labels in the contact list | Show field labels in the **address book** contact list **accessible names** |
| Show field labels in the calendar event list | Show field labels in the calendar event list **accessible names** |
| Show field labels in the rules list | Show field labels in the rules list **accessible names** |

The contact one also renames the list the setting refers to.

The `accessible names` suffix is now inaccurate as well as long: #493 made the rules setting shape the **visible** row text in the account-at-a-time Rules Manager, because `UnifiedRuleRow.ToString()` returns the same `RowText` the automation peer reads. The setting no longer only touches accessible names.

## The change

Each name is now the checkbox's own label, set explicitly rather than left to access-key stripping. Per CLAUDE.md the name is a short identifying label — the role and state are the platform's to report.

## Verification

Debug build `-warnaserror` clean; 109 XAML-parse / settings / accessibility / radio-group tests pass.

## Not in this PR

The same shape appears on ~11 other Settings checkboxes, where the automation name is a sentence explaining the setting rather than its label (e.g. line 318, "Announce block type such as heading level when the caret moves to a different paragraph in HTML compose mode"). Those are descriptions rather than inaccuracies, so they are left alone here — worth a sweep of their own if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)