### PR TITLE
Fix #497: let users pick a default calendar for new appointments

### DIFF
--- a/QuickMail.Tests/CalendarContextMenuTests.cs
+++ b/QuickMail.Tests/CalendarContextMenuTests.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Linq;
+using System.Windows;
+using System.Windows.Automation;
+using System.Windows.Controls;
+using QuickMail.Models;
+using QuickMail.ViewModels;
+using QuickMail.Views;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// The folder tree hands calendar nodes a different context menu from mail folders (issue #497).
+///
+/// This is worth a test because the failure is silent in both directions: the trigger binding is a
+/// string, so a typo leaves calendar nodes on the mail folder menu — the exact state this change
+/// fixes, where New Folder / Move / Delete are offered on a calendar and every one of them does
+/// nothing — and an over-broad trigger would strip real folders of the menu that is their only
+/// mouse path to Move, Copy, and Set as Archive.
+/// </summary>
+public class CalendarContextMenuTests
+{
+    private static void EnsureThemedApplication()
+    {
+        lock (typeof(Application))
+        {
+            if (Application.Current == null)
+                new Application { ShutdownMode = ShutdownMode.OnExplicitShutdown };
+        }
+
+        var app = Application.Current!;
+        foreach (var style in new[] { "AccessibleStyles", "ThemedControls" })
+        {
+            var uri = new Uri($"pack://application:,,,/QuickMail;component/Styles/{style}.xaml",
+                UriKind.Absolute);
+            if (app.Resources.MergedDictionaries.All(d => d.Source != uri))
+                app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = uri });
+        }
+    }
+
+    private static MainWindow MakeWindow()
+    {
+        var imap     = new StubImapMailService();
+        var accounts = new StubAccountService();
+        var creds    = new StubCredentialService();
+        var store    = new StubLocalStoreService();
+        var config   = new StubConfigService();
+        var registry = new StubCommandRegistry();
+
+        var vm = new MainViewModel(imap, accounts, creds, store, new StubOAuthService(),
+            new StubSyncService(), config, registry, new StubViewService(), new StubRuleService(),
+            new StubSmtpService());
+
+        return new MainWindow(vm, new StubSmtpService(), accounts, creds, imap,
+            new StubOAuthService(), registry, new StubContactService(), config, store,
+            new StubViewService(), new StubRuleService(), new StubTemplateService(),
+            new StubFeatureGate());
+    }
+
+    /// <summary>
+    /// Resolves the ContextMenu a tree item would actually get for the given node, by applying the
+    /// live ItemContainerStyle to a container the way the TreeView does. DataTriggers evaluate off
+    /// DataContext, so no visual parent is needed.
+    /// </summary>
+    private static ContextMenu? MenuFor(TreeView tree, FolderTreeNode node)
+    {
+        var item = new TreeViewItem();
+        item.BeginInit();
+        item.DataContext = node;
+        item.Style = tree.ItemContainerStyle;
+        item.EndInit();   // style triggers are evaluated at initialization, not at assignment
+        return item.ContextMenu;
+    }
+
+    [StaFact]
+    public void CalendarNodesGetCalendarActions_AndMailFoldersKeepFolderActions()
+    {
+        EnsureThemedApplication();
+        var window = MakeWindow();
+        try
+        {
+            var tree = window.FindName("FolderList") as TreeView;
+            Assert.NotNull(tree);
+
+            var folderMenu   = window.FindResource("FolderContextMenu")   as ContextMenu;
+            var calendarMenu = window.FindResource("CalendarContextMenu") as ContextMenu;
+            Assert.NotNull(folderMenu);
+            Assert.NotNull(calendarMenu);
+            Assert.NotSame(folderMenu, calendarMenu);
+
+            var calendarNode = new FolderTreeNode
+            {
+                Folder = new MailFolderModel
+                {
+                    FullName = MainViewModel.CalendarSourcePrefix + "local",
+                    DisplayName = "Local Calendar",
+                },
+                Label = "Local Calendar",
+                IsCalendarNode = true,
+            };
+            var mailNode = new FolderTreeNode
+            {
+                Folder = new MailFolderModel
+                {
+                    AccountId = Guid.NewGuid(), FullName = "INBOX", DisplayName = "Inbox",
+                },
+                Label = "Inbox",
+            };
+
+            Assert.Same(calendarMenu, MenuFor(tree!, calendarNode));
+            Assert.Same(folderMenu,   MenuFor(tree!, mailNode));
+        }
+        finally { window.Close(); }
+    }
+
+    /// <summary>
+    /// Both calendar actions must be on the menu — the context menu is the primary entry point, and
+    /// a user who set a default with no way to unset it is worse off than before.
+    /// </summary>
+    [StaFact]
+    public void CalendarMenuOffersSetAndClear_WithShortAccessibleNames()
+    {
+        EnsureThemedApplication();
+        var window = MakeWindow();
+        try
+        {
+            var menu = window.FindResource("CalendarContextMenu") as ContextMenu;
+            Assert.NotNull(menu);
+
+            var names = menu!.Items.OfType<MenuItem>()
+                .Select(AutomationProperties.GetName)
+                .ToList();
+
+            Assert.Contains("Use as Default Calendar for New Appointments", names);
+            Assert.Contains("Clear Default Calendar", names);
+            // No role words, no shortcut text, no sentences — the accessibility checklist's rule.
+            Assert.All(names, n => Assert.DoesNotContain(".", n));
+        }
+        finally { window.Close(); }
+    }
+}

--- a/QuickMail.Tests/DefaultCalendarTests.cs
+++ b/QuickMail.Tests/DefaultCalendarTests.cs
@@ -1,0 +1,267 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using QuickMail.Models;
+using QuickMail.Services;
+using QuickMail.ViewModels;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// Default calendar for new appointments (issue #497): the calendar chosen from the folder tree's
+/// context menu preselects the appointment editor's Calendar picker.
+///
+/// The three failure modes worth guarding are all about a default that cannot be honored exactly:
+/// the tree offers a node per discovered calendar while a Microsoft or Google account contributes a
+/// single save target, a saved default can name an account that has since been removed, and no
+/// default at all must leave the editor exactly where it was before this feature existed (Local).
+/// </summary>
+public class DefaultCalendarTests
+{
+    // ── Config round trip ────────────────────────────────────────────────────────
+    // Same reasoning as WindowingPreferencesTests: a property with no parse case or no writer block
+    // resets silently on the next launch, and the setting looks wired up right up until relaunch.
+
+    private static ProfileContext MakeTempProfile()
+        => new(Path.Combine(Path.GetTempPath(), $"QM-CAL-{Guid.NewGuid():N}"));
+
+    [Fact]
+    public void DefaultCalendarSource_DefaultsToEmpty()
+        => Assert.Equal(string.Empty, new ConfigModel().DefaultCalendarSource);
+
+    [Theory]
+    [InlineData("local")]
+    [InlineData("2f9d3b7e-0000-4000-8000-000000000001")]
+    [InlineData("2f9d3b7e-0000-4000-8000-000000000001|https%3A%2F%2Fp42-caldav.icloud.com%2F1%2Fcalendars%2Fhome%2F")]
+    public void DefaultCalendarSource_RoundTrips(string tail)
+    {
+        var profile = MakeTempProfile();
+        var config = new ConfigService(profile).Load();
+        config.DefaultCalendarSource = tail;
+        new ConfigService(profile).Save(config);
+
+        Assert.Equal(tail, new ConfigService(profile).Load().DefaultCalendarSource);
+    }
+
+    [Fact]
+    public void DefaultCalendarSource_ClearedValue_RoundTripsAsEmpty()
+    {
+        var profile = MakeTempProfile();
+        var config = new ConfigService(profile).Load();
+        config.DefaultCalendarSource = "local";
+        new ConfigService(profile).Save(config);
+
+        var reloaded = new ConfigService(profile).Load();
+        reloaded.DefaultCalendarSource = string.Empty;
+        new ConfigService(profile).Save(reloaded);
+
+        Assert.Equal(string.Empty, new ConfigService(profile).Load().DefaultCalendarSource);
+    }
+
+    /// <summary>
+    /// The stored value is the calendar tree node's tail, so it must survive the round trip the
+    /// tree itself parses it with — one encoding, one parser.
+    /// </summary>
+    [Fact]
+    public void StoredTail_ParsesBackToTheFilterItCameFrom()
+    {
+        var acct = Guid.NewGuid();
+        var calId = "https://p42-caldav.icloud.com/1/calendars/home/";
+        var tail = acct.ToString("D") + "|" + Uri.EscapeDataString(calId);
+
+        Assert.Equal(new MainViewModel.CalendarFilter(acct, calId),
+            MainViewModel.CalendarFilterFor(MainViewModel.CalendarSourcePrefix + tail));
+    }
+
+    // ── Editor target selection ──────────────────────────────────────────────────
+
+    private static EventEditorViewModel MakeEditor(params CalendarSaveTarget[] accountTargets)
+        => new(DateTime.Today.AddHours(9), accountTargets);
+
+    [Fact]
+    public void SelectTarget_ExactCalendar_IsSelected()
+    {
+        var apple = Guid.NewGuid();
+        var editor = MakeEditor(
+            new CalendarSaveTarget("Apple: Home", apple, "cal-home", "Home"),
+            new CalendarSaveTarget("Apple: Family", apple, "cal-family", "Family"));
+
+        Assert.True(editor.SelectTarget(apple, "cal-family"));
+        Assert.Equal(apple, editor.SelectedTargetAccountId);
+        Assert.Equal("cal-family", editor.SelectedTargetCalendarId);
+        Assert.Equal("Family", editor.SelectedTargetCalendarName);
+    }
+
+    /// <summary>
+    /// A Microsoft or Google account shows a node per synced calendar in the tree but offers ONE
+    /// save target (its default calendar). Defaulting to one of those calendars must land on the
+    /// account rather than falling back to Local, which is a different mailbox entirely.
+    /// </summary>
+    [Fact]
+    public void SelectTarget_UnofferedCalendar_FallsBackToTheSameAccount()
+    {
+        var work = Guid.NewGuid();
+        var editor = MakeEditor(new CalendarSaveTarget("Work", work));
+
+        Assert.True(editor.SelectTarget(work, "cal-team"));
+        Assert.Equal(work, editor.SelectedTargetAccountId);
+        Assert.Null(editor.SelectedTargetCalendarId);
+    }
+
+    [Fact]
+    public void SelectTarget_LocalCalendar_SelectsIndexZero()
+    {
+        var editor = MakeEditor(new CalendarSaveTarget("Work", Guid.NewGuid()));
+
+        Assert.True(editor.SelectTarget(CalendarEvent.LocalAccountId, null));
+        Assert.Equal(0, editor.SelectedTargetIndex);
+        Assert.Equal(CalendarEvent.LocalAccountId, editor.SelectedTargetAccountId);
+    }
+
+    [Fact]
+    public void SelectTarget_UnknownAccount_LeavesTheEditorOnLocal()
+    {
+        var editor = MakeEditor(new CalendarSaveTarget("Work", Guid.NewGuid()));
+
+        Assert.False(editor.SelectTarget(Guid.NewGuid(), null));
+        Assert.Equal(0, editor.SelectedTargetIndex);
+        Assert.Equal(CalendarEvent.LocalAccountId, editor.SelectedTargetAccountId);
+    }
+
+    // ── NewEvent honors the default ──────────────────────────────────────────────
+
+    private static (CalendarViewModel Vm, AccountModel Apple, string HomeId, string FamilyId) MakeICloudVm()
+    {
+        var apple = new AccountModel
+        {
+            Id = Guid.NewGuid(), ImapHost = "imap.mail.me.com", AccountName = "Apple", SyncCalendar = true,
+        };
+        const string home = "https://p42-caldav.icloud.com/1/calendars/home/";
+        const string family = "https://p42-caldav.icloud.com/1/calendars/family/";
+        var vm = new CalendarViewModel(new StubCalendarService(), onlineMode: false,
+            showDeclinedEvents: false, showFieldLabels: false,
+            graphSync: new StubGraphCalendarSyncService(),
+            graphAccountsProvider: () => new[] { apple },
+            calendarSourcesProvider: () => new List<(Guid, string, string)>
+            {
+                (apple.Id, home, "Home"),
+                (apple.Id, family, "Family"),
+            });
+        return (vm, apple, home, family);
+    }
+
+    private static EventEditorViewModel OpenNewEventEditor(CalendarViewModel vm)
+    {
+        EventEditorViewModel? editor = null;
+        vm.EditorRequested += e => editor = e;
+        vm.NewEventCommand.Execute(null);
+        Assert.NotNull(editor);
+        return editor!;
+    }
+
+    [Fact]
+    public void NewEvent_WithNoDefault_OpensOnLocalCalendar()
+    {
+        var (vm, _, _, _) = MakeICloudVm();
+
+        var editor = OpenNewEventEditor(vm);
+
+        Assert.Equal(0, editor.SelectedTargetIndex);
+        Assert.Equal(CalendarEvent.LocalAccountId, editor.SelectedTargetAccountId);
+    }
+
+    [Fact]
+    public void NewEvent_WithDefaultCalendar_OpensOnThatCalendar()
+    {
+        var (vm, apple, _, family) = MakeICloudVm();
+        vm.DefaultCalendar = new MainViewModel.CalendarFilter(apple.Id, family);
+
+        var editor = OpenNewEventEditor(vm);
+        editor.Title = "Reunion";
+
+        Assert.Equal(apple.Id, editor.SelectedTargetAccountId);
+        Assert.True(editor.TryBuildEvent(out var evt, out _));
+        Assert.Equal(apple.Id, evt.AccountId);
+        Assert.Equal(family, evt.CalendarId);
+        Assert.Equal("Family", evt.CalendarName);
+    }
+
+    /// <summary>The default only preselects; the user can still pick something else before saving.</summary>
+    [Fact]
+    public void NewEvent_DefaultIsOnlyAPreselection()
+    {
+        var (vm, apple, _, family) = MakeICloudVm();
+        vm.DefaultCalendar = new MainViewModel.CalendarFilter(apple.Id, family);
+
+        var editor = OpenNewEventEditor(vm);
+        Assert.True(editor.ShowSaveTarget);          // the picker is still offered
+        editor.SelectedTargetIndex = 0;              // …and still works
+        editor.Title = "Dentist";
+
+        Assert.True(editor.TryBuildEvent(out var evt, out _));
+        Assert.Equal(CalendarEvent.LocalAccountId, evt.AccountId);
+    }
+
+    /// <summary>
+    /// A default naming an account that has since been removed must not strand the editor on a
+    /// target that no longer exists — it falls back to Local, which always saves.
+    /// </summary>
+    [Fact]
+    public void NewEvent_DefaultForMissingAccount_FallsBackToLocal()
+    {
+        var (vm, _, _, _) = MakeICloudVm();
+        vm.DefaultCalendar = new MainViewModel.CalendarFilter(Guid.NewGuid(), "cal-gone");
+
+        var editor = OpenNewEventEditor(vm);
+
+        Assert.Equal(0, editor.SelectedTargetIndex);
+        Assert.Equal(CalendarEvent.LocalAccountId, editor.SelectedTargetAccountId);
+    }
+
+    [Fact]
+    public void NewEvent_DefaultOfLocal_OpensOnLocalCalendar()
+    {
+        var (vm, _, _, _) = MakeICloudVm();
+        vm.DefaultCalendar = new MainViewModel.CalendarFilter(CalendarEvent.LocalAccountId, null);
+
+        var editor = OpenNewEventEditor(vm);
+
+        Assert.Equal(0, editor.SelectedTargetIndex);
+    }
+
+    // ── Tree node marker ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void DefaultCalendarNode_CarriesTheMarkerInItsAccessibleName()
+    {
+        var node = new FolderTreeNode
+        {
+            Folder = new MailFolderModel { FullName = MainViewModel.CalendarSourcePrefix + "local", DisplayName = "Local Calendar" },
+            Label = "Local Calendar",
+            IsCalendarNode = true,
+        };
+
+        Assert.Equal("Local Calendar", node.AutomationName);
+        Assert.Equal(string.Empty, node.DefaultCalendarDisplay);
+
+        node.IsDefaultCalendar = true;
+
+        // The state has to be IN the name — an ItemStatus-only marker is not reliably spoken (#227).
+        Assert.Equal("Local Calendar, default calendar", node.AutomationName);
+        Assert.Equal("(default)", node.DefaultCalendarDisplay);
+    }
+
+    [Fact]
+    public void DefaultCalendarNode_RaisesPropertyChangedForTheDerivedDisplays()
+    {
+        var node = new FolderTreeNode { Label = "Apple", IsCalendarNode = true };
+        var changed = new List<string?>();
+        node.PropertyChanged += (_, e) => changed.Add(e.PropertyName);
+
+        node.IsDefaultCalendar = true;
+
+        Assert.Contains(nameof(FolderTreeNode.AutomationName), changed);
+        Assert.Contains(nameof(FolderTreeNode.DefaultCalendarDisplay), changed);
+    }
+}

--- a/QuickMail/Models/ConfigModel.cs
+++ b/QuickMail/Models/ConfigModel.cs
@@ -300,6 +300,15 @@ public class ConfigModel
     public bool ShowDeclinedEvents { get; set; } = false;
 
     /// <summary>
+    /// Which calendar the appointment editor preselects for a NEW appointment (issue #497), chosen
+    /// from the folder tree's calendar context menu. Stored as the calendar tree node's tail
+    /// encoding so one string round-trips through <c>MainViewModel.CalendarFilterFor</c>:
+    /// <c>"local"</c>, <c>"{accountGuid}"</c>, or <c>"{accountGuid}|{escapedCalendarId}"</c>.
+    /// Empty (the default) means no preference — the editor opens on the local calendar as before.
+    /// </summary>
+    public string DefaultCalendarSource { get; set; } = string.Empty;
+
+    /// <summary>
     /// Obsolete: the calendar is now a folder in the folder tree, not a toggle pane.
     /// Retained only so older config.ini files do not break on parse.
     /// </summary>

--- a/QuickMail/Models/FolderTreeNode.cs
+++ b/QuickMail/Models/FolderTreeNode.cs
@@ -14,6 +14,13 @@ public sealed class FolderTreeNode : INotifyPropertyChanged
     /// <summary>True for account-level group nodes that serve as collapsible containers for folder children.</summary>
     public bool IsHeader { get; init; }
 
+    /// <summary>
+    /// True for the Calendar node and every node beneath it. Drives which context menu the tree
+    /// item gets: the mail folder actions (New Folder, Move, Delete…) mean nothing on a calendar,
+    /// and every one of them silently does nothing when activated there.
+    /// </summary>
+    public bool IsCalendarNode { get; init; }
+
     public string Label { get; init; } = string.Empty;
 
     public ObservableCollection<FolderTreeNode> Children { get; } = [];
@@ -28,7 +35,33 @@ public sealed class FolderTreeNode : INotifyPropertyChanged
     /// Do not move the count back out of the Name without checking with a screen-reader user first.
     /// </summary>
     public string AutomationName =>
-        ShowUnread ? $"{Label}, {Folder!.UnreadCount} unread" : Label;
+        ShowUnread ? $"{Label}, {Folder!.UnreadCount} unread"
+        : IsDefaultCalendar ? $"{Label}, default calendar"
+        : Label;
+
+    private bool _isDefaultCalendar;
+
+    /// <summary>
+    /// True for the one calendar node that new appointments are created on by default (issue #497).
+    /// Carried in <see cref="AutomationName"/> for the same reason the unread count is (#227): a
+    /// state that lives only in ItemStatus is not reliably announced, and a default the user cannot
+    /// hear is a default they cannot check.
+    /// </summary>
+    public bool IsDefaultCalendar
+    {
+        get => _isDefaultCalendar;
+        set
+        {
+            if (_isDefaultCalendar == value) return;
+            _isDefaultCalendar = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsDefaultCalendar)));
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(AutomationName)));
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(DefaultCalendarDisplay)));
+        }
+    }
+
+    /// <summary>Visual marker next to a default calendar's label. Empty for every other node.</summary>
+    public string DefaultCalendarDisplay => IsDefaultCalendar ? "(default)" : string.Empty;
 
     // Gmail's All Mail / Important / Starred report unread counts that overlap the Inbox and include
     // archived mail, so they're hidden here to avoid a misleading count (issue #227).

--- a/QuickMail/Services/ConfigService.cs
+++ b/QuickMail/Services/ConfigService.cs
@@ -302,6 +302,7 @@ public class ConfigService : IConfigService
                         if (Guid.TryParse(value, out _)) config.DefaultFlagId = value;
                         break;
                     case "showdeclinedevents": config.ShowDeclinedEvents = ParseBool(value); break;
+                    case "defaultcalendarsource": config.DefaultCalendarSource = value; break;
                     case "calendarpaneopen":   config.CalendarPaneOpen   = ParseBool(value); break;
                 }
             }
@@ -658,6 +659,14 @@ public class ConfigService : IConfigService
         sb.AppendLine("# Whether declined calendar events appear in the calendar list.");
         sb.AppendLine($"CalendarPaneOpen = {(config.CalendarPaneOpen ? "on" : "off")}");
         sb.AppendLine("# Whether the calendar pane was open when the app last closed.");
+        if (!string.IsNullOrEmpty(config.DefaultCalendarSource))
+        {
+            sb.AppendLine($"DefaultCalendarSource = {config.DefaultCalendarSource}");
+            sb.AppendLine("# The calendar new appointments are created on by default. Set it from the");
+            sb.AppendLine("# folder tree: select a calendar, open its context menu, and choose");
+            sb.AppendLine("# \"Use as Default Calendar for New Appointments\". Remove this line to go");
+            sb.AppendLine("# back to the local calendar.");
+        }
         sb.AppendLine();
 
         // ── [windowing] ──────────────────────────────────────────────────────────

--- a/QuickMail/ViewModels/CalendarViewModel.cs
+++ b/QuickMail/ViewModels/CalendarViewModel.cs
@@ -190,6 +190,14 @@ public partial class CalendarViewModel : ObservableObject
         }
     }
 
+    /// <summary>
+    /// The calendar new appointments are created on by default (issue #497), chosen from the folder
+    /// tree's calendar context menu. Null means no preference — the editor opens on the local
+    /// calendar. Set by MainViewModel from <c>DefaultCalendarSource</c> in config.ini. This only
+    /// preselects the editor's Calendar picker; the user is free to change it before saving.
+    /// </summary>
+    public MainViewModel.CalendarFilter? DefaultCalendar { get; set; }
+
     /// <summary>Clears and hides search, restoring the unfiltered view.</summary>
     public void ClearSearch()
     {
@@ -437,6 +445,10 @@ public partial class CalendarViewModel : ObservableObject
             }
         }
         var editor = new EventEditorViewModel(DateTime.Now, accountTargets);
+        // Preselect the user's default calendar (#497). Left alone the picker opens on Local, which
+        // is what an unset default should keep doing — so only a set default touches it.
+        if (DefaultCalendar is { Account: { } defaultAccount })
+            editor.SelectTarget(defaultAccount, DefaultCalendar.CalendarId);
         editor.Saved += evt => _ = SaveNewEventAsync(evt);
         EditorRequested?.Invoke(editor);
     }

--- a/QuickMail/ViewModels/EventEditorViewModel.cs
+++ b/QuickMail/ViewModels/EventEditorViewModel.cs
@@ -343,6 +343,24 @@ public partial class EventEditorViewModel : ObservableObject
         _end = _start + _duration;
     }
 
+    /// <summary>
+    /// Preselects the save target matching the user's default calendar (issue #497), and reports
+    /// whether one was found. Prefers the exact calendar; falls back to any target on the same
+    /// account, because the tree offers a node per discovered calendar while a Microsoft or Google
+    /// account contributes a single target (its default calendar) — "that account" is still the
+    /// right answer there. An unmatched default (the account was removed, or the calendar has not
+    /// synced yet) leaves the picker on the local calendar rather than guessing.
+    /// </summary>
+    public bool SelectTarget(Guid accountId, string? calendarId)
+    {
+        var index = _saveTargets.FindIndex(t => t.AccountId == accountId
+            && string.Equals(t.CalendarId ?? string.Empty, calendarId ?? string.Empty, StringComparison.Ordinal));
+        if (index < 0) index = _saveTargets.FindIndex(t => t.AccountId == accountId);
+        if (index < 0) return false;
+        SelectedTargetIndex = index;
+        return true;
+    }
+
     private static List<CalendarSaveTarget> BuildSaveTargets(IReadOnlyList<CalendarSaveTarget>? accountTargets)
     {
         var targets = new List<CalendarSaveTarget>

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -314,6 +314,77 @@ public partial class MainViewModel : ObservableObject, IDisposable
     /// </summary>
     public sealed record CalendarFilter(Guid? Account, string? CalendarId);
 
+    // ── Default calendar for new appointments (issue #497) ────────────────────────
+    //
+    // Stored as the calendar tree node's tail encoding ("local", "{guid}", "{guid}|{escapedCalId}")
+    // rather than as a pair of fields, so the one string the user picked in the tree round-trips
+    // through CalendarFilterFor with no second parser to keep in step. Empty = no preference.
+    private string _defaultCalendarSource = string.Empty;
+
+    /// <summary>The chosen default calendar as a filter, or null when the user has set no default.</summary>
+    private CalendarFilter? DefaultCalendarFilter =>
+        string.IsNullOrEmpty(_defaultCalendarSource)
+            ? null
+            : CalendarFilterFor(CalendarSourcePrefix + _defaultCalendarSource);
+
+    /// <summary>
+    /// Makes <paramref name="node"/> the calendar new appointments are created on, and returns the
+    /// sentence the View reports. Refuses the nodes that are not one calendar: the bare Calendar
+    /// node, which selects nothing, and All Calendars, which selects every source at once and so
+    /// names no single place to save to.
+    /// </summary>
+    public string SetDefaultCalendar(FolderTreeNode? node)
+    {
+        if (node?.Folder is not { } folder || !IsCalendarFolderName(folder.FullName))
+            return "Select a calendar in the folder tree first.";
+
+        var tail = folder.FullName.StartsWith(CalendarSourcePrefix, StringComparison.Ordinal)
+            ? folder.FullName[CalendarSourcePrefix.Length..]
+            : string.Empty;
+        if (tail.Length == 0 || tail == "all")
+            return $"'{node.Label}' is not a single calendar, so it cannot be the default. "
+                 + "Choose Local Calendar, an account, or one of its calendars.";
+
+        _defaultCalendarSource = tail;
+        PersistDefaultCalendar();
+        return $"New appointments will be created on {node.Label}.";
+    }
+
+    /// <summary>
+    /// Drops the default calendar, so the appointment editor opens on the local calendar again.
+    /// Returns the sentence the View reports.
+    /// </summary>
+    public string ClearDefaultCalendar()
+    {
+        if (string.IsNullOrEmpty(_defaultCalendarSource))
+            return "No default calendar is set. New appointments already start on Local Calendar.";
+        _defaultCalendarSource = string.Empty;
+        PersistDefaultCalendar();
+        return "Default calendar cleared. New appointments will start on Local Calendar.";
+    }
+
+    private void PersistDefaultCalendar()
+    {
+        var cfg = _configService.Load();
+        cfg.DefaultCalendarSource = _defaultCalendarSource;
+        _configService.Save(cfg);
+        if (CalendarVm != null) CalendarVm.DefaultCalendar = DefaultCalendarFilter;
+        // The marker moves between existing node objects rather than rebuilding the tree, which
+        // would replace every node and throw keyboard focus out of the item the user just acted on.
+        MarkDefaultCalendarNodes();
+    }
+
+    /// <summary>Puts the "(default)" marker on the one calendar node that matches the setting.</summary>
+    private void MarkDefaultCalendarNodes()
+    {
+        if (FolderTree == null) return;
+        foreach (var n in FlattenAllNodes(FolderTree))
+            if (n.IsCalendarNode && n.Folder is { } f)
+                n.IsDefaultCalendar = _defaultCalendarSource.Length > 0
+                    && string.Equals(f.FullName, CalendarSourcePrefix + _defaultCalendarSource,
+                                     StringComparison.Ordinal);
+    }
+
     /// <summary>
     /// True for accounts with a server calendar the app can push appointments to: Microsoft
     /// (Graph backend), Google-signed-in accounts (keyed by auth type — Gmail mail is IMAP), and
@@ -1197,6 +1268,8 @@ public partial class MainViewModel : ObservableObject, IDisposable
                                                // Discovered calendar sources (per iCloud calendar) feed the
                                                // save-target picker so each iCloud calendar is its own target.
                                                () => _calendarSources);
+            _defaultCalendarSource = cfg.DefaultCalendarSource ?? string.Empty;
+            CalendarVm.DefaultCalendar = DefaultCalendarFilter;
             RemindersEnabled = cfg.CalendarReminders;
             ReminderLeadMinutes = cfg.CalendarReminderMinutes;
             StartReminderTimer();
@@ -3633,16 +3706,19 @@ public partial class MainViewModel : ObservableObject, IDisposable
             {
                 Folder = CalendarFolder,
                 Label  = CalendarFolder.DisplayName,
+                IsCalendarNode = true,
             };
             calNode.Children.Add(new FolderTreeNode
             {
                 Folder = new MailFolderModel { FullName = CalendarSourcePrefix + "all", DisplayName = "All Calendars" },
                 Label  = "All Calendars",
+                IsCalendarNode = true,
             });
             calNode.Children.Add(new FolderTreeNode
             {
                 Folder = new MailFolderModel { FullName = CalendarSourcePrefix + "local", DisplayName = "Local Calendar" },
                 Label  = "Local Calendar",
+                IsCalendarNode = true,
             });
             // Only accounts the user opted into calendar sync for (#282) get a source node.
             foreach (var acct in Accounts.Where(a => a.SyncCalendar))
@@ -3655,6 +3731,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
                         DisplayName = acct.AccountLabel,
                     },
                     Label = acct.AccountLabel,
+                    IsCalendarNode = true,
                 };
 
                 // A grandchild per discovered calendar so the user can view Home vs. Work vs. Family.
@@ -3670,6 +3747,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
                                 DisplayName = calName,
                             },
                             Label = calName,
+                            IsCalendarNode = true,
                         });
 
                 calNode.Children.Add(acctNode);
@@ -3779,6 +3857,8 @@ public partial class MainViewModel : ObservableObject, IDisposable
                 n.IsExpanded = true;
 
         FolderTree = new ObservableCollection<FolderTreeNode>(roots);
+        // Fresh node objects start unmarked; restore the default calendar's marker on the rebuild.
+        MarkDefaultCalendarNodes();
     }
 
     private static string NodeKey(FolderTreeNode n) =>

--- a/QuickMail/Views/MainWindow.xaml
+++ b/QuickMail/Views/MainWindow.xaml
@@ -253,6 +253,20 @@
                       AutomationProperties.Name="Delete Folder"
                       Click="FolderContextMenu_DeleteFolder_Click"/>
         </ContextMenu>
+
+        <!-- Calendar context menu — replaces FolderContextMenu on the Calendar node and its
+             children (issue #497). None of the mail folder actions apply to a calendar; every one
+             of them silently did nothing there. Same Window.Resources rule as above: a ContextMenu
+             with Click handlers must not be declared inside a Style setter. -->
+        <ContextMenu x:Key="CalendarContextMenu"
+                     AutomationProperties.Name="Calendar actions">
+            <MenuItem Header="Use as _Default Calendar for New Appointments"
+                      AutomationProperties.Name="Use as Default Calendar for New Appointments"
+                      Click="CalendarContextMenu_SetDefault_Click"/>
+            <MenuItem Header="_Clear Default Calendar"
+                      AutomationProperties.Name="Clear Default Calendar"
+                      Click="CalendarContextMenu_ClearDefault_Click"/>
+        </ContextMenu>
     </Window.Resources>
 
     <Window.InputBindings>
@@ -966,6 +980,24 @@
                                         </Style>
                                     </local:AriaHiddenTextBlock.Style>
                                 </local:AriaHiddenTextBlock>
+                                <!-- Default-calendar marker: "(default)" — collapsed when empty.
+                                     Same treatment as the unread badge; the accessible name
+                                     carries the same state via AutomationName. -->
+                                <local:AriaHiddenTextBlock Margin="4,0,0,0"
+                                                           Opacity="0.75"
+                                                           FontSize="{DynamicResource Theme.FontSizeSmall}"
+                                                           Text="{Binding DefaultCalendarDisplay}">
+                                    <local:AriaHiddenTextBlock.Style>
+                                        <Style TargetType="local:AriaHiddenTextBlock">
+                                            <Setter Property="Visibility" Value="Visible"/>
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding DefaultCalendarDisplay}" Value="">
+                                                    <Setter Property="Visibility" Value="Collapsed"/>
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </local:AriaHiddenTextBlock.Style>
+                                </local:AriaHiddenTextBlock>
                             </StackPanel>
                         </HierarchicalDataTemplate>
                     </TreeView.Resources>
@@ -977,6 +1009,12 @@
                             <!-- Tag exposes the window DataContext (MainViewModel) to the ContextMenu -->
                             <Setter Property="Tag" Value="{Binding DataContext, RelativeSource={RelativeSource AncestorType=Window}}"/>
                             <Setter Property="ContextMenu" Value="{StaticResource FolderContextMenu}"/>
+                            <Style.Triggers>
+                                <!-- Calendar nodes get calendar actions, not folder actions (#497). -->
+                                <DataTrigger Binding="{Binding IsCalendarNode}" Value="True">
+                                    <Setter Property="ContextMenu" Value="{StaticResource CalendarContextMenu}"/>
+                                </DataTrigger>
+                            </Style.Triggers>
                         </Style>
                     </TreeView.ItemContainerStyle>
                 </TreeView>

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -1283,6 +1283,22 @@ public partial class MainWindow : Window
             execute: () => _vm.CalendarVm?.ExportEventCommand.Execute(_vm.CalendarVm.SelectedEvent),
             isAvailable: () => CalendarList.IsKeyboardFocusWithin && _vm.CalendarVm?.SelectedEvent != null));
 
+        // ── Default calendar for new appointments (issue #497) ──────────────────
+        // No default key: both act on the folder tree's calendar selection, and the context menu on
+        // that node is the primary entry point. Registered so they are also reachable — and
+        // rebindable — from the Command Palette.
+        _registry.Register(new CommandDefinition(
+            id: "calendar.setDefaultCalendar", category: "Calendar",
+            title: "Use as Default Calendar for New Appointments",
+            execute: SetDefaultCalendarFromSelection,
+            isAvailable: () => FolderList.IsKeyboardFocusWithin
+                               && (FolderList.SelectedItem as FolderTreeNode)?.IsCalendarNode == true));
+
+        _registry.Register(new CommandDefinition(
+            id: "calendar.clearDefaultCalendar", category: "Calendar", title: "Clear Default Calendar",
+            execute: () => Report(_vm.ClearDefaultCalendar()),
+            isAvailable: () => _vm.CalendarVm != null));
+
         // ── Respond to a pending invitation (Enter opens the menu; these are the palette entries) ──
         // No default key: Enter (calendar.openSourceMessage) shows the response menu, which is the
         // primary entry point. These keep the actions discoverable and rebindable in the palette.
@@ -5567,6 +5583,20 @@ public partial class MainWindow : Window
             category: AnnouncementCategory.Result);
         await reload;
     }
+
+    // ── Calendar context menu handlers (issue #497) ──────────────────────────
+
+    private void CalendarContextMenu_SetDefault_Click(object sender, RoutedEventArgs e)
+        => Report(_vm.SetDefaultCalendar(GetContextMenuFolderNode(sender)));
+
+    private void CalendarContextMenu_ClearDefault_Click(object sender, RoutedEventArgs e)
+        => Report(_vm.ClearDefaultCalendar());
+
+    // Entry point for the calendar.setDefaultCalendar command (Command Palette / customizable
+    // hotkey), acting on the folder tree's selection. The context menu must not be the only way in:
+    // that is the dead end #250 filed against folder creation.
+    private void SetDefaultCalendarFromSelection()
+        => Report(_vm.SetDefaultCalendar(FolderList.SelectedItem as FolderTreeNode));
 
     // Deletes the folder and lands focus on the folder above. The VM splices the node out of the
     // tree in place (no rebuild), so the captured neighbour reference stays valid for FocusTreeItem.

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -1019,6 +1019,24 @@ Expand the **Calendar** node in the folder tree to choose which events you are l
 
 Selecting a source filters the list to it. "All Calendars" is the usual choice for day-to-day use.
 
+### Choosing a default calendar for new appointments
+
+If most of your appointments belong on one calendar, tell QuickMail which one and it will open the appointment editor on that calendar every time.
+
+1. In the folder tree, move to the calendar you want — **Local Calendar**, an account, or one of the calendars beneath an account.
+2. Open the context menu with **Shift+F10** or the Applications key (or right-click).
+3. Choose **Use as Default Calendar for New Appointments**.
+
+QuickMail confirms the choice in the status bar and announces it, and the calendar is marked **(default)** in the folder tree — its name is announced as "…, default calendar" — so you can always tell which one is set. The choice is remembered between sessions.
+
+To go back to saving new appointments on your local calendar, choose **Clear Default Calendar** from the same menu.
+
+Two things this does not do. It does not change which events you are *looking at* — that is still whatever source you have selected in the tree. And it is only a starting point: the **Calendar** picker in the appointment editor still lets you send any individual appointment somewhere else.
+
+**All Calendars** cannot be the default, because it is several calendars at once and so names no single place to save to. If you choose it, QuickMail says so and leaves your existing default alone.
+
+Both commands are also in the Command Palette (**Ctrl+Shift+P**) — as **Use as Default Calendar for New Appointments** and **Clear Default Calendar** — and you can assign them keys in **Settings → Keyboard**.
+
 ### The four views
 
 Your events can be shown four ways. Switch between them with the toolbar buttons or these keys while the event list has focus:
@@ -1070,7 +1088,7 @@ Press **N** (or the **New** toolbar button) to open the appointment editor. It i
 - **Location** — optional.
 - **Repeat** — leave as "Does not repeat" for a one-off, or set up a repeating appointment (see below).
 - **Notes** — free text.
-- **Calendar** — when you have a Microsoft, Google, or iCloud account connected, a picker lets you choose where the new appointment is saved: your **Local Calendar** or a connected account. For iCloud the picker lists each of your Apple calendars (Home, Family, …) so you can choose which one. With no connected calendar this picker does not appear and everything is saved locally.
+- **Calendar** — when you have a Microsoft, Google, or iCloud account connected, a picker lets you choose where the new appointment is saved: your **Local Calendar** or a connected account. For iCloud the picker lists each of your Apple calendars (Home, Family, …) so you can choose which one. With no connected calendar this picker does not appear and everything is saved locally. The picker starts on your [default calendar](#choosing-a-default-calendar-for-new-appointments) if you have set one, and on **Local Calendar** if you have not.
 
 Press **Enter** (or the **Save** button) to save, or **Escape** to cancel. If something is wrong, QuickMail puts focus on the field at fault and shows the reason on an error line above the buttons; the message clears itself as soon as you fix it.
 
@@ -1232,7 +1250,7 @@ These work while the calendar list (or, where noted, the Month grid) has focus:
 | `F5` | Refresh |
 | `F6` | Move to the next pane |
 
-Export as `.ics`, and the invitation responses (Accept, Tentative, Decline), are available from the command palette (**Ctrl+Shift+P**) and have no default key until you assign one.
+Export as `.ics`, the invitation responses (Accept, Tentative, Decline), and the two [default-calendar](#choosing-a-default-calendar-for-new-appointments) commands are available from the command palette (**Ctrl+Shift+P**) and have no default key until you assign one.
 
 ---
 

--- a/docs/release-notes-v0.8.38.md
+++ b/docs/release-notes-v0.8.38.md
@@ -17,6 +17,20 @@ All downloads include the .NET 8 runtime — you do not need to install .NET sep
 
 ---
 
+## New: choose which calendar new appointments start on
+
+If most of your appointments belong on one calendar, you no longer have to steer the **Calendar** picker away from **Local Calendar** every time you create one.
+
+In the folder tree, move to the calendar you want — **Local Calendar**, an account, or one of the calendars beneath an account — open its context menu with **Shift+F10** or the Applications key, and choose **Use as Default Calendar for New Appointments**. From then on the appointment editor opens on that calendar. **Clear Default Calendar** on the same menu goes back to the local calendar. Both are also in the Command Palette (**Ctrl+Shift+P**) and can be given keys in **Settings → Keyboard**.
+
+The calendar you picked is marked **(default)** in the folder tree and its name is announced as "…, default calendar", so which one is set is something you can check rather than remember.
+
+Two things it deliberately does not do. It does not change which events you are *looking at* — that is still whatever you have selected in the tree. And it is a starting point, not a rule: the **Calendar** picker in the editor still sends any individual appointment wherever you want. ([#497](https://github.com/kellylford/QuickMail/issues/497))
+
+## Fixed: the calendar's context menu offered mail folder actions
+
+The context menu on the **Calendar** node and everything under it was the mail folder menu — **New Folder**, **Move Folder**, **Set as Archive Folder**, **Delete Folder**. None of them mean anything on a calendar, and every one of them did nothing at all when activated. That menu is now the calendar's own. ([#497](https://github.com/kellylford/QuickMail/issues/497))
+
 ## Fixed: Run on Existing Mail has a button again with a Microsoft 365 account
 
 With a Microsoft 365 account, **Tools → Rules** opens the Rules Manager that works one account at a time, and in v0.8.37 that window had no **Run on Existing Mail** control — the only way to reach it was **Ctrl+Shift+P**. It is now a button beside the others, and is also on the rule list's context menu, alongside the Command Palette entry that was already there.
@@ -40,6 +54,14 @@ The three **Show field labels in the … list** checkboxes — contact list, cal
 ## Internal
 
 Everything below is developer detail — implementation notes, test coverage, and build changes. Nothing here is needed to use QuickMail.
+
+### Calendar
+
+- **The default is stored as the tree node's own tail encoding, so there is one parser rather than two.** `ConfigModel.DefaultCalendarSource` holds exactly what follows `CalendarSourcePrefix` on the node the user chose — `local`, `{guid}`, or `{guid}|{escapedCalId}` — and `MainViewModel.DefaultCalendarFilter` reads it back through the existing `CalendarFilterFor`. Storing an account/calendar pair instead would have meant a second encoding to keep in step with the tree's, for no gain: the setting is only ever produced by, and only ever refers to, a node in that tree. Empty means no preference, which is distinct from an explicit `local` in the config file but identical in behavior.
+- **Honoring the default is a preselection in `NewEvent`, not a change to `BuildSaveTargets`.** `EventEditorViewModel.SelectTarget(accountId, calendarId)` moves `SelectedTargetIndex`; the target list itself still puts Local at index 0 unconditionally. That keeps the no-default path byte-for-byte what it was, and keeps the fallbacks in one testable place. The fallback ladder matters because the tree and the picker do not offer the same set: the tree shows a node per *discovered* calendar for any account with more than one, while only iCloud contributes a target per calendar (Microsoft and Google contribute one, their default calendar). So an exact `(account, calendar)` match is tried first, then any target on the same account — landing on "that account" rather than on Local, which is a different mailbox entirely — and only a default whose account is gone at all leaves the editor on Local. `SelectTarget` returns whether it matched so the fallback is observable in tests rather than inferred.
+- **Calendar nodes now carry `IsCalendarNode` and get their own context menu.** The `ItemContainerStyle` set `FolderContextMenu` on every tree item including the Calendar subtree, where all five entries fell through `IsMovableFolder`'s `\0` guard and silently did nothing. A `DataTrigger` on the new flag swaps in `CalendarContextMenu`. The menu is declared in `Window.Resources` and referenced from the trigger's setter — the XAML-compiler crash the neighbouring comment documents is about *declaring* a Click-handler menu inside a `Style.Setter.Value`, which this does not do.
+- **The marker lives in `AutomationName`, not only in `ItemStatus`.** `FolderTreeNode.IsDefaultCalendar` appends ", default calendar" to the accessible name and drives a `(default)` badge modelled on the unread badge. This is the #227 finding applied to a second piece of state: a marker carried only in `ItemStatus` is not reliably spoken, and a default the user cannot hear is a default they cannot check. `PersistDefaultCalendar` moves the marker between existing node objects via `MarkDefaultCalendarNodes` rather than rebuilding the tree, which would replace every node and throw keyboard focus out of the item the user just acted on; `BuildFolderTree` re-applies it after a genuine rebuild.
+- **Both commands are registered, so the context menu is not the only way in.** `calendar.setDefaultCalendar` and `calendar.clearDefaultCalendar` are Calendar-category `CommandDefinition`s with no default key — palette-reachable and rebindable. That is the #250 lesson (folder creation was context-menu-only and therefore undiscoverable without a mouse) applied up front. Refusals are sentences, not silence: the bare Calendar node and All Calendars are not one calendar, and `SetDefaultCalendar` returns why, which the View sends to both `StatusText` and a `Result` announcement.
 
 ### Rules
 


### PR DESCRIPTION
Closes #497.

## What changed

New appointments always opened the editor on **Local Calendar**. Anyone whose appointments actually live on a connected account had to steer the **Calendar** picker away from it every time.

Kelly's suggested shape — a context menu on the calendar list — is what this implements, with one thing the shape needed: the calendars *are* the folder tree's `Calendar` subtree, and that subtree was getting the **mail folder** context menu (New Folder, Move Folder, Set as Archive, Delete Folder). All five fell through `IsMovableFolder`'s `\0` guard and silently did nothing. Calendar nodes now get their own menu:

- **Use as Default Calendar for New Appointments**
- **Clear Default Calendar**

Both are also registered `CommandDefinition`s (Calendar category, no default key) so the context menu is not the only way in — the #250 lesson applied up front.

## Design notes

**One encoding, one parser.** `ConfigModel.DefaultCalendarSource` stores exactly the tail of the node the user chose — `local`, `{guid}`, or `{guid}|{escapedCalId}` — and reads back through the existing `CalendarFilterFor`. An account/calendar pair would have meant a second encoding to keep in step with the tree's, for no gain: the setting is only ever produced by, and only ever refers to, a node in that tree.

**A preselection, not a change to the target list.** `EventEditorViewModel.SelectTarget` moves `SelectedTargetIndex`; `BuildSaveTargets` still puts Local at index 0 unconditionally, so the no-default path is byte-for-byte what it was.

**The tree and the picker do not offer the same set.** The tree shows a node per *discovered* calendar for any account with more than one; only iCloud contributes a save target per calendar (Microsoft and Google contribute one, their default). So `SelectTarget` tries the exact `(account, calendar)` match, then any target on the same account — landing on "that account" rather than on Local, which is a different mailbox — and only a default whose account is gone leaves the editor on Local. It returns whether it matched, so the fallback is observable in tests rather than inferred.

**Scope held deliberately.** The default does not change which events the list *shows* (that is still the tree selection), and it does not override the picker. **All Calendars** is refused with a sentence saying why, rather than silently — it is several calendars at once and names no single place to save to.

## Accessibility

- The marker is in `AutomationName` (`"Apple: Family, default calendar"`), not only `ItemStatus` — the #227 finding applied to a second piece of state. A default the user cannot hear is a default they cannot check. A `(default)` badge in the tree carries the same state visually.
- `PersistDefaultCalendar` moves the marker between existing node objects rather than rebuilding the tree, which would replace every node and throw keyboard focus out of the item the user just acted on.
- Menu item `AutomationProperties.Name`s are short labels, no role words or shortcut text (asserted).
- Refusals go to both `StatusText` and a `Result`-category announcement, so they are perceptible with announcements off.

## Verification

- **Full suite: 2674 passed, 0 failed, 3 skipped** (the input-gated ones).
- **19 new tests.** `DefaultCalendarTests` — config round trip (including that clearing round-trips as empty), `SelectTarget`'s four outcomes, `NewEvent` with no default / with a default / with a default whose account is gone, and the node marker. `CalendarContextMenuTests` — the `DataTrigger` really does swap in the calendar menu for a calendar node and really does leave a mail folder on `FolderContextMenu`.
- **UI probe** on the inbox surface (parchment 100, dark 100, parchment 150) after the XAML change: 3/3 captured, folder tree layout unchanged, no gap from the collapsed marker. The marker's own rendering is **not** screenshot-verified — the probe cannot expand the Calendar node — but its markup is the unread badge's, verbatim.
- Not verified here: a live keyboard/screen-reader walkthrough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)