### PR TITLE
Fix #501: file bug reports through a relay instead of an embedded GitHub token

### DIFF
--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -85,13 +85,15 @@ jobs:
       - name: Write bug-report credentials
         shell: pwsh
         env:
-          BUG_REPORT_TOKEN: ${{ secrets.BUG_REPORT_TOKEN }}
+          BUG_REPORT_RELAY_URL: ${{ vars.BUG_REPORT_RELAY_URL }}
+          BUG_REPORT_RELAY_KEY: ${{ secrets.BUG_REPORT_RELAY_KEY }}
         run: |
           @"
           namespace QuickMail.Services;
           public partial class BugReportService
           {
-              private const string AppOwnedToken = "$env:BUG_REPORT_TOKEN";
+              private const string RelayUrl = "$env:BUG_REPORT_RELAY_URL";
+              private const string RelayKey = "$env:BUG_REPORT_RELAY_KEY";
           }
           "@ | Set-Content -Path "QuickMail/Services/BugReportService.Credentials.cs" -Encoding UTF8
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,13 +42,15 @@ jobs:
       - name: Write bug-report credentials
         shell: pwsh
         env:
-          BUG_REPORT_TOKEN: ${{ secrets.BUG_REPORT_TOKEN }}
+          BUG_REPORT_RELAY_URL: ${{ vars.BUG_REPORT_RELAY_URL }}
+          BUG_REPORT_RELAY_KEY: ${{ secrets.BUG_REPORT_RELAY_KEY }}
         run: |
           @"
           namespace QuickMail.Services;
           public partial class BugReportService
           {
-              private const string AppOwnedToken = "$env:BUG_REPORT_TOKEN";
+              private const string RelayUrl = "$env:BUG_REPORT_RELAY_URL";
+              private const string RelayKey = "$env:BUG_REPORT_RELAY_KEY";
           }
           "@ | Set-Content -Path "QuickMail/Services/BugReportService.Credentials.cs" -Encoding UTF8
 

--- a/.github/workflows/deploy-relay.yml
+++ b/.github/workflows/deploy-relay.yml
@@ -1,0 +1,96 @@
+name: Deploy bug-report relay
+
+# The relay is deployed from CI rather than a maintainer's machine because wrangler cannot
+# run on Windows ARM64 at all: it imports `workerd`, which publishes no win32-arm64 build and
+# throws "Unsupported platform" on startup — for `deploy` as much as for `dev`. A GitHub
+# runner is x64 Linux, so this sidesteps the problem and makes redeploys reproducible.
+#
+# Setup and the meaning of each secret are in relay/README.md. Issue #501.
+
+on:
+  workflow_dispatch:
+    inputs:
+      sync_secrets:
+        description: "Also push the Worker's secrets from repository secrets"
+        type: boolean
+        default: false
+  push:
+    branches: [main]
+    paths:
+      - 'relay/**'
+      - '.github/workflows/deploy-relay.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-relay
+  cancel-in-progress: false
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+
+      # No install step: the relay's tests deliberately use only the Node standard library, so
+      # they stay runnable on a machine where `npm install wrangler` cannot succeed.
+      - name: Test
+        working-directory: relay
+        run: node test/jwt.test.js
+
+  deploy:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+
+      - name: Deploy Worker
+        working-directory: relay
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+        run: npx --yes wrangler@4 deploy
+
+      # Opt-in, because a run whose repository secrets are missing would otherwise overwrite
+      # working Worker secrets with empty strings and silently break bug reporting.
+      - name: Sync Worker secrets
+        if: inputs.sync_secrets
+        working-directory: relay
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          APP_ID: ${{ secrets.RELAY_GITHUB_APP_ID }}
+          INSTALLATION_ID: ${{ secrets.RELAY_GITHUB_INSTALLATION_ID }}
+          PRIVATE_KEY: ${{ secrets.RELAY_GITHUB_PRIVATE_KEY }}
+          RELAY_KEY: ${{ secrets.BUG_REPORT_RELAY_KEY }}
+        run: |
+          for name in APP_ID INSTALLATION_ID PRIVATE_KEY RELAY_KEY; do
+            if [ -z "${!name}" ]; then
+              echo "::error::Repository secret for $name is empty. Set it before syncing, or the Worker will be left unable to reach GitHub."
+              exit 1
+            fi
+          done
+
+          # jq --arg handles the private key's embedded newlines; building this JSON by hand
+          # would mangle the PEM. The file is written to the runner's temp dir and removed
+          # immediately, and never reaches the workspace or the logs.
+          secrets_file="$(mktemp)"
+          trap 'rm -f "$secrets_file"' EXIT
+          jq -n \
+            --arg app_id "$APP_ID" \
+            --arg installation_id "$INSTALLATION_ID" \
+            --arg private_key "$PRIVATE_KEY" \
+            --arg relay_key "$RELAY_KEY" \
+            '{GITHUB_APP_ID: $app_id, GITHUB_INSTALLATION_ID: $installation_id, GITHUB_PRIVATE_KEY: $private_key, RELAY_KEY: $relay_key}' \
+            > "$secrets_file"
+
+          npx --yes wrangler@4 secret bulk "$secrets_file"

--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -55,13 +55,15 @@ jobs:
       - name: Write bug-report credentials
         shell: pwsh
         env:
-          BUG_REPORT_TOKEN: ${{ secrets.BUG_REPORT_TOKEN }}
+          BUG_REPORT_RELAY_URL: ${{ vars.BUG_REPORT_RELAY_URL }}
+          BUG_REPORT_RELAY_KEY: ${{ secrets.BUG_REPORT_RELAY_KEY }}
         run: |
           @"
           namespace QuickMail.Services;
           public partial class BugReportService
           {
-              private const string AppOwnedToken = "$env:BUG_REPORT_TOKEN";
+              private const string RelayUrl = "$env:BUG_REPORT_RELAY_URL";
+              private const string RelayKey = "$env:BUG_REPORT_RELAY_KEY";
           }
           "@ | Set-Content -Path "QuickMail/Services/BugReportService.Credentials.cs" -Encoding UTF8
 

--- a/.github/workflows/quickmail.yml
+++ b/.github/workflows/quickmail.yml
@@ -47,13 +47,15 @@ jobs:
       - name: Write bug-report credentials
         shell: pwsh
         env:
-          BUG_REPORT_TOKEN: ${{ secrets.BUG_REPORT_TOKEN }}
+          BUG_REPORT_RELAY_URL: ${{ vars.BUG_REPORT_RELAY_URL }}
+          BUG_REPORT_RELAY_KEY: ${{ secrets.BUG_REPORT_RELAY_KEY }}
         run: |
           @"
           namespace QuickMail.Services;
           public partial class BugReportService
           {
-              private const string AppOwnedToken = "$env:BUG_REPORT_TOKEN";
+              private const string RelayUrl = "$env:BUG_REPORT_RELAY_URL";
+              private const string RelayKey = "$env:BUG_REPORT_RELAY_KEY";
           }
           "@ | Set-Content -Path "QuickMail/Services/BugReportService.Credentials.cs" -Encoding UTF8
 
@@ -146,13 +148,15 @@ jobs:
       - name: Write bug-report credentials
         shell: pwsh
         env:
-          BUG_REPORT_TOKEN: ${{ secrets.BUG_REPORT_TOKEN }}
+          BUG_REPORT_RELAY_URL: ${{ vars.BUG_REPORT_RELAY_URL }}
+          BUG_REPORT_RELAY_KEY: ${{ secrets.BUG_REPORT_RELAY_KEY }}
         run: |
           @"
           namespace QuickMail.Services;
           public partial class BugReportService
           {
-              private const string AppOwnedToken = "$env:BUG_REPORT_TOKEN";
+              private const string RelayUrl = "$env:BUG_REPORT_RELAY_URL";
+              private const string RelayKey = "$env:BUG_REPORT_RELAY_KEY";
           }
           "@ | Set-Content -Path "QuickMail/Services/BugReportService.Credentials.cs" -Encoding UTF8
 

--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,7 @@ Thumbs.db
 # Google OAuth client credentials (real values — copy from docs/GoogleOAuthService.Credentials.example)
 **/GoogleOAuthService.Credentials.cs
 
-# Bug-report app-owned GitHub token (real values — copy from docs/BugReportService.Credentials.example)
+# Bug-report relay URL and key (real values — copy from docs/BugReportService.Credentials.example)
 **/BugReportService.Credentials.cs
 
 # Claude Code worktrees and local session data

--- a/QuickMail.Tests/BugReportServiceTests.cs
+++ b/QuickMail.Tests/BugReportServiceTests.cs
@@ -51,21 +51,38 @@ public class BugReportServiceTests
         StepsToReproduce = "1. Click button\n2. Observe crash",
     };
 
+    private const string RelayUrl = "https://relay.example.test/report";
+    private const string LegacyTokenKey = "QuickMail.BugReportService.AppOwnedToken";
+
     private static BugReportService MakeService(
         Func<HttpRequestMessage, HttpResponseMessage> responder,
         out FakeHttpMessageHandler handler,
         FakeCredentialService? credentials = null,
-        string appOwnedToken = "")   // hermetic: never inherit the CI-baked compiled-in token
+        // Hermetic: never inherit the CI-baked compiled-in relay coordinates.
+        string relayUrl = RelayUrl,
+        string relayKey = "relay-key")
     {
         handler = new FakeHttpMessageHandler(responder);
-        return new BugReportService(credentials ?? new FakeCredentialService(), handler, appOwnedToken);
+        return new BugReportService(credentials ?? new FakeCredentialService(), handler, relayUrl, relayKey);
     }
 
-    [Fact]
-    public async Task SubmitAsync_NoTokenAvailable_FailsWithoutHttpCall()
+    private static HttpResponseMessage IssueCreated(int number = 999) => new(HttpStatusCode.Created)
     {
+        Content = new StringContent(
+            $"{{\"issueUrl\":\"https://github.com/kellylford/QuickMail/issues/{number}\",\"number\":{number}}}"),
+    };
+
+    [Theory]
+    [InlineData("", "relay-key")]
+    [InlineData(RelayUrl, "")]
+    public async Task SubmitAsync_RelayNotConfigured_FailsWithoutHttpCall(string relayUrl, string relayKey)
+    {
+        // A build without relay coordinates (any local or fork build) must fall straight through
+        // to the clipboard path rather than POST the report somewhere unconfigured.
         var handlerCalled = false;
-        var service = MakeService(_ => { handlerCalled = true; return new HttpResponseMessage(HttpStatusCode.OK); }, out _);
+        var service = MakeService(
+            _ => { handlerCalled = true; return new HttpResponseMessage(HttpStatusCode.OK); },
+            out _, relayUrl: relayUrl, relayKey: relayKey);
 
         var result = await service.SubmitAsync(SampleReport());
 
@@ -75,51 +92,52 @@ public class BugReportServiceTests
     }
 
     [Fact]
-    public async Task SubmitAsync_UsesAppOwnedToken_WhenNoStoredSecret()
+    public async Task SubmitAsync_Success_PostsToRelayWithKey_AndReturnsIssueUrl()
     {
-        // No per-user stored secret; only the app-owned token is available (the normal
-        // release path). Submit must use it and cache it into the credential store.
-        var credentials = new FakeCredentialService();
-        var service = MakeService(_ => new HttpResponseMessage(HttpStatusCode.Created)
-        {
-            Content = new StringContent("{\"html_url\":\"https://github.com/kellylford/QuickMail/issues/1\"}"),
-        }, out var handler, credentials, appOwnedToken: "app-token");
-
-        var result = await service.SubmitAsync(SampleReport());
-
-        Assert.True(result.Success);
-        Assert.Equal("app-token", handler.LastRequest!.Headers.Authorization!.Parameter);
-        Assert.Equal("app-token", credentials.GetSecret("QuickMail.BugReportService.AppOwnedToken"));
-    }
-
-    [Fact]
-    public async Task SubmitAsync_Success_ReturnsIssueUrl()
-    {
-        var credentials = new FakeCredentialService();
-        credentials.SaveSecret("QuickMail.BugReportService.AppOwnedToken", "fake-token");
-
-        var service = MakeService(req => new HttpResponseMessage(HttpStatusCode.Created)
-        {
-            Content = new StringContent("{\"html_url\":\"https://github.com/kellylford/QuickMail/issues/999\"}"),
-        }, out var handler, credentials);
+        var service = MakeService(_ => IssueCreated(), out var handler);
 
         var result = await service.SubmitAsync(SampleReport());
 
         Assert.True(result.Success);
         Assert.Equal("https://github.com/kellylford/QuickMail/issues/999", result.IssueUrl);
-        Assert.Equal("Bearer", handler.LastRequest!.Headers.Authorization!.Scheme);
-        Assert.Equal("fake-token", handler.LastRequest!.Headers.Authorization!.Parameter);
-        Assert.Contains("user-reported", handler.LastRequestBody);
+        Assert.Equal(HttpMethod.Post, handler.LastRequest!.Method);
+        Assert.Equal(RelayUrl, handler.LastRequest!.RequestUri!.ToString());
+        Assert.Equal("relay-key", Assert.Single(handler.LastRequest!.Headers.GetValues("X-QuickMail-Key")));
         Assert.DoesNotContain("quickmail.log", handler.LastRequestBody, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
-    public async Task SubmitAsync_RevokedToken_FailsGracefully()
+    public async Task SubmitAsync_SendsNoGitHubCredential_AndNoClientChosenLabels()
     {
-        var credentials = new FakeCredentialService();
-        credentials.SaveSecret("QuickMail.BugReportService.AppOwnedToken", "bad-token");
+        // The whole point of #501: nothing that reaches the wire may be a GitHub credential,
+        // and the client must not name its own labels — an extracted relay key would otherwise
+        // let anyone apply arbitrary ones. The relay decides both.
+        var service = MakeService(_ => IssueCreated(), out var handler);
 
-        var service = MakeService(_ => new HttpResponseMessage(HttpStatusCode.Unauthorized), out _, credentials);
+        await service.SubmitAsync(SampleReport());
+
+        Assert.Null(handler.LastRequest!.Headers.Authorization);
+        Assert.DoesNotContain("github_pat", handler.LastRequestBody, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("\"labels\"", handler.LastRequestBody);
+    }
+
+    [Fact]
+    public void Constructor_DeletesThePreRelayGitHubToken_LeftBehindByOlderInstalls()
+    {
+        // Upgrading from a pre-relay build leaves a real PAT in Credential Manager. Nothing
+        // reads it any more, so it must not simply sit there.
+        var credentials = new FakeCredentialService();
+        credentials.SaveSecret(LegacyTokenKey, "github_pat_stale");
+
+        _ = MakeService(_ => IssueCreated(), out _, credentials);
+
+        Assert.Null(credentials.GetSecret(LegacyTokenKey));
+    }
+
+    [Fact]
+    public async Task SubmitAsync_RelayRejectsKey_FailsGracefully()
+    {
+        var service = MakeService(_ => new HttpResponseMessage(HttpStatusCode.Unauthorized), out _);
 
         var result = await service.SubmitAsync(SampleReport());
 
@@ -128,12 +146,21 @@ public class BugReportServiceTests
     }
 
     [Fact]
+    public async Task SubmitAsync_RateLimited_SaysToRetry_RatherThanShowingAStatusCode()
+    {
+        var service = MakeService(_ => new HttpResponseMessage(HttpStatusCode.TooManyRequests), out _);
+
+        var result = await service.SubmitAsync(SampleReport());
+
+        Assert.False(result.Success);
+        Assert.Contains("Try again", result.ErrorMessage!, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("429", result.ErrorMessage!);
+    }
+
+    [Fact]
     public async Task SubmitAsync_NetworkFailure_FailsGracefully()
     {
-        var credentials = new FakeCredentialService();
-        credentials.SaveSecret("QuickMail.BugReportService.AppOwnedToken", "fake-token");
-
-        var service = MakeService(_ => throw new HttpRequestException("offline"), out _, credentials);
+        var service = MakeService(_ => throw new HttpRequestException("offline"), out _);
 
         var result = await service.SubmitAsync(SampleReport());
 

--- a/QuickMail/Services/BugReportService.cs
+++ b/QuickMail/Services/BugReportService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
@@ -10,26 +11,28 @@ using QuickMail.Models;
 namespace QuickMail.Services;
 
 /// <summary>
-/// Submits user-initiated bug reports directly to GitHub Issues using an app-owned,
-/// narrowly-scoped credential (see docs/planning/bug-reporting-pm-dev-spec.md, Decision A) —
-/// the user is never asked to sign into GitHub. Falls back to a pre-filled issue URL +
-/// clipboard text (<see cref="BuildFallbackUrl"/>/<see cref="BuildReportText"/>) if the
-/// direct path is unavailable or fails.
+/// Submits user-initiated bug reports through QuickMail's relay (see relay/README.md and
+/// issue #501) — the user is never asked to sign into GitHub. Falls back to a pre-filled
+/// issue URL + clipboard text (<see cref="BuildFallbackUrl"/>/<see cref="BuildReportText"/>)
+/// if the relay is unavailable or fails.
+///
+/// The relay, not this app, holds the credential that can write to the repository. What
+/// ships here is a relay key that only means "may file an issue on kellylford/QuickMail" —
+/// it is assumed extractable from the binary, and is rotatable without touching any GitHub
+/// account. Do not reintroduce a GitHub token into this class; that was the #222/#501 defect.
 /// </summary>
 public partial class BugReportService : IBugReportService, IDisposable
 {
     private const string RepoOwner = "kellylford";
     private const string RepoName  = "QuickMail";
-    private const string ApiUrl    = $"https://api.github.com/repos/{RepoOwner}/{RepoName}/issues";
 
-    // Distinct from CredentialService's per-account "QuickMail:{Guid}" key shape — this is a
-    // single app-owned secret, not tied to any mail account.
-    private const string TokenCredentialKey = "QuickMail.BugReportService.AppOwnedToken";
+    // Releases before the relay cached a real GitHub PAT here. Nothing reads it any more, so
+    // on first run of an updated build we delete it rather than leave a live credential
+    // sitting in the user's Credential Manager forever.
+    private const string LegacyTokenCredentialKey = "QuickMail.BugReportService.AppOwnedToken";
 
-    private static readonly string[] IssueLabels = ["bug", "user-reported"];
-
-    private readonly ICredentialService _credentials;
-    private readonly string _appOwnedToken;
+    private readonly string _relayUrl;
+    private readonly string _relayKey;
     private readonly HttpClient _http;
     private readonly CancellationTokenSource _cts = new();
     private bool _disposed;
@@ -38,36 +41,43 @@ public partial class BugReportService : IBugReportService, IDisposable
     {
     }
 
-    // Internal overload so tests can substitute a fake HttpMessageHandler instead of hitting
-    // the real GitHub API, and pin the app-owned token. The compiled-in AppOwnedToken is baked
-    // in at build time (empty in most builds, a real secret on release CI), so tests must inject
-    // a known value rather than depend on whichever the build happens to carry.
-    internal BugReportService(ICredentialService credentials, HttpMessageHandler handler, string? appOwnedToken = null)
+    // Internal overload so tests can substitute a fake HttpMessageHandler instead of hitting the
+    // real relay, and pin the relay coordinates. RelayUrl/RelayKey are baked in at build time
+    // (empty in most builds, real values on release CI), so tests must inject known values rather
+    // than depend on whichever the build happens to carry.
+    internal BugReportService(
+        ICredentialService credentials,
+        HttpMessageHandler handler,
+        string? relayUrl = null,
+        string? relayKey = null)
     {
-        _credentials = credentials;
-        _appOwnedToken = appOwnedToken ?? AppOwnedToken;
+        _relayUrl = relayUrl ?? RelayUrl;
+        _relayKey = relayKey ?? RelayKey;
+
+        PurgeLegacyToken(credentials);
+
         _http = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(15) };
         _http.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("QuickMail", Helpers.AppVersion.Display));
-        _http.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github+json"));
+        _http.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
     }
 
     public async Task<BugReportResult> SubmitAsync(BugReportModel report, CancellationToken cancellationToken = default)
     {
-        var token = ResolveToken();
-        if (string.IsNullOrWhiteSpace(token))
-            return BugReportResult.Failed("No app-owned credential is available for automatic submission.");
+        if (string.IsNullOrWhiteSpace(_relayUrl) || string.IsNullOrWhiteSpace(_relayKey))
+            return BugReportResult.Failed("This build has no relay configured for automatic submission.");
 
         try
         {
             using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _cts.Token);
-            using var request = new HttpRequestMessage(HttpMethod.Post, ApiUrl);
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            using var request = new HttpRequestMessage(HttpMethod.Post, _relayUrl);
+            request.Headers.Add("X-QuickMail-Key", _relayKey);
 
+            // Labels are applied by the relay, not sent from here: a client that names its own
+            // labels lets anyone holding the extracted key apply arbitrary ones.
             var payload = JsonSerializer.Serialize(new
             {
                 title = report.Summary,
                 body = BuildReportText(report),
-                labels = IssueLabels,
             });
             request.Content = new StringContent(payload, Encoding.UTF8, "application/json");
 
@@ -77,13 +87,15 @@ public partial class BugReportService : IBugReportService, IDisposable
             if (!response.IsSuccessStatusCode)
             {
                 LogService.Log($"BugReportService: submit failed, status={(int)response.StatusCode}");
-                return BugReportResult.Failed($"GitHub returned status {(int)response.StatusCode}.");
+                return BugReportResult.Failed(response.StatusCode == HttpStatusCode.TooManyRequests
+                    ? "Too many reports were sent from this network recently. Try again in a minute."
+                    : $"The bug-report relay returned status {(int)response.StatusCode}.");
             }
 
             using var doc = JsonDocument.Parse(responseText);
-            var issueUrl = doc.RootElement.TryGetProperty("html_url", out var urlEl) ? urlEl.GetString() : null;
+            var issueUrl = doc.RootElement.TryGetProperty("issueUrl", out var urlEl) ? urlEl.GetString() : null;
             if (string.IsNullOrEmpty(issueUrl))
-                return BugReportResult.Failed("GitHub did not return an issue URL.");
+                return BugReportResult.Failed("The bug-report relay did not return an issue URL.");
 
             return BugReportResult.Succeeded(issueUrl);
         }
@@ -91,7 +103,25 @@ public partial class BugReportService : IBugReportService, IDisposable
                                        or OperationCanceledException or ObjectDisposedException)
         {
             LogService.Log("BugReportService: submit exception", ex);
-            return BugReportResult.Failed("Could not reach GitHub.");
+            return BugReportResult.Failed("Could not reach the bug-report relay.");
+        }
+    }
+
+    // Best-effort: a Credential Manager that refuses the delete must not stop the user filing a
+    // bug. The stale entry is inert either way — nothing reads that key any more.
+    private static void PurgeLegacyToken(ICredentialService credentials)
+    {
+        try
+        {
+            if (!string.IsNullOrEmpty(credentials.GetSecret(LegacyTokenCredentialKey)))
+            {
+                credentials.DeleteSecret(LegacyTokenCredentialKey);
+                LogService.Log("BugReportService: removed the pre-relay GitHub token from the credential store.");
+            }
+        }
+        catch (Exception ex)
+        {
+            LogService.Log("BugReportService: could not remove the pre-relay token", ex);
         }
     }
 
@@ -146,21 +176,6 @@ public partial class BugReportService : IBugReportService, IDisposable
         }
 
         return sb.ToString();
-    }
-
-    // Checks the credential store first (in case a future settings UI ever lets a user override
-    // it), otherwise falls back to the build-embedded token and caches it into the store — same
-    // resolve-then-cache shape as Quill's effective_github_token(), adapted to this codebase's
-    // existing ICredentialService rather than a new storage mechanism.
-    private string? ResolveToken()
-    {
-        var stored = _credentials.GetSecret(TokenCredentialKey);
-        if (!string.IsNullOrWhiteSpace(stored)) return stored;
-
-        if (string.IsNullOrWhiteSpace(_appOwnedToken)) return null;
-
-        _credentials.SaveSecret(TokenCredentialKey, _appOwnedToken);
-        return _appOwnedToken;
     }
 
     public void Dispose()

--- a/docs/BUG-REPORT-BOT-ACCOUNT.md
+++ b/docs/BUG-REPORT-BOT-ACCOUNT.md
@@ -1,225 +1,35 @@
-# Bug-Report Bot Account Setup
+# Bug-Report Bot Account Setup — superseded
 
-**Purpose:** QuickMail's in-app "Report a Bug" feature submits directly to the GitHub Issues
-API using a token baked into the release build, so users never have to sign into GitHub or
-reveal an email address. GitHub attributes each created issue to **whoever owns that token.**
+**This approach was never adopted. Do not follow it.** Setup for the mechanism actually in
+use is in [`relay/README.md`](../relay/README.md).
 
-This document explains how to provision a **dedicated bot account** to own that token, so that
-in-app reports are authored by an anonymous machine account (e.g. `quickmail-bot`) instead of a
-real person's account. It fixes [#222](https://github.com/kellylford/QuickMail/issues/222).
+This document described provisioning a dedicated GitHub machine account (`quickmail-bot`) to
+own the fine-grained token that QuickMail's "Report a Bug" feature used to submit issues
+with. It was written to fix
+[#222](https://github.com/kellylford/QuickMail/issues/222) — user-filed reports appearing
+under the maintainer's personal account.
 
-> **Do not use a personal account's token for this.** That is the exact defect #222 describes:
-> every user report ends up looking like the maintainer authored it, and an extracted token acts
-> as a real person's identity instead of an isolated throwaway.
+## Why it was replaced
 
-This doc is written to be followed either by the maintainer by hand, or by an AI agent that has
-been asked to do the setup. Steps that **must** be done by a human in a browser (GitHub does not
-allow them via API/CLI) are marked **[HUMAN-ONLY]**.
+A machine account fixes attribution and nothing else. The token still had to be compiled
+into the shipped single-file executable, so it was still extractable by anyone who
+downloaded QuickMail; all that changed was which account the extracted credential belonged
+to. The recurring cost — a second GitHub account with its own 2FA, recovery path, and
+collaborator grant on this repository — bought only the rename.
 
----
+[#501](https://github.com/kellylford/QuickMail/issues/501) removed the credential from the
+binary instead. A GitHub App's private key lives in a small Cloudflare Worker; the app posts
+reports there with a relay key whose entire authority is "file an issue on
+kellylford/QuickMail", rate-limited at the relay and rotatable without touching any GitHub
+account. Issues are authored by the App's bot identity, so the attribution problem #222
+raised is fixed as a side effect rather than as the goal.
 
-## What you are creating, and why each piece matters
+## What carried over
 
-| Piece | What it is | Why it must be this way |
-|---|---|---|
-| A second GitHub account | A "machine account" whose only job is filing bug issues | GitHub attributes issues to the token owner. A dedicated account means reports are authored by `quickmail-bot`, not by you. |
-| Triage collaborator role on this repo | The bot is added to `kellylford/QuickMail` as a collaborator with **Triage** | On a public repo *anyone* can open an issue, but **applying labels requires Triage or Write.** Without it, the `bug` / `user-reported` labels the app sends are silently dropped. Triage is the least privilege that keeps labeling working — it grants **no code write access.** |
-| Fine-grained PAT from the bot | A token scoped to this repo only, `Issues: Read and write` only | The token ships inside the distributed `.exe` and is extractable. Minimal scope on a throwaway account means the worst case of extraction is spam issues on this one repo — never a compromise of a real account or of code. |
+Two properties of the original design are load-bearing and were deliberately preserved:
 
-**What this deliberately does *not* do:** it does not collect the reporter's name or email, and it
-does not require reporters to have a GitHub account. Those properties are intentional and must be
-preserved. This change only alters *which account owns the submitting token.*
-
----
-
-## Prerequisites
-
-- Admin access to `kellylford/QuickMail` (you have this).
-- A separate email address for the bot account. A `+` alias on your existing email works
-  (e.g. `you+quickmailbot@example.com`) — GitHub treats it as a distinct address. Some password
-  managers also let you generate a unique alias.
-- An authenticator app for the bot account's 2FA (GitHub now requires 2FA on accounts that
-  contribute; set it up at creation time rather than being locked out later).
-
----
-
-## Step 1 — Create the bot account **[HUMAN-ONLY]**
-
-1. Sign **out** of your personal GitHub account (or use a separate browser profile / incognito
-   window — GitHub does not let you create a second account while signed in, and you want to avoid
-   accidentally acting as your personal account during setup).
-2. Go to <https://github.com/signup> and create the account:
-   - **Username:** `quickmail-bot` (or `quickmail-reports` if taken). Pick something that reads as
-     obviously-a-bot so issue authorship is self-explanatory.
-   - **Email:** the dedicated/alias address above.
-3. Verify the email.
-4. **Turn on two-factor authentication immediately:** Settings → Password and authentication →
-   Two-factor authentication → set up with an authenticator app. **Save the recovery codes**
-   somewhere durable (your password manager). If you lose access to this account, in-app bug
-   reporting breaks until you re-provision.
-5. **Set the profile so its purpose is unmistakable.** In Settings → Public profile:
-   - Name: `QuickMail Bug Bot`
-   - Bio: `Automated account. Files bug reports submitted through the QuickMail app. Not a person.`
-   - This matters because these issues are public; anyone reading them should immediately understand
-     the account is automated.
-
-> **Policy note:** GitHub's Terms of Service explicitly permit "machine accounts" and this exact
-> use. Per [Section B.3, Account Requirements](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service):
-> *"We do permit machine accounts: A machine account is an Account set up by an individual human who
-> accepts the Terms on behalf of the Account, provides a valid email address, and is responsible for
-> its actions,"* and *"You may maintain no more than one free machine account in addition to your
-> free Personal Account."* The one thing the same section forbids is *automated* signup —
-> *"Accounts registered by 'bots' or other automated methods are not permitted"* — which is why
-> Step 1 is done by hand and must not be scripted. A single machine account you create and control
-> for this purpose is squarely within the rules.
-
----
-
-## Step 2 — Add the bot as a Triage collaborator **[HUMAN-ONLY]**
-
-Do this from your **personal** account (the repo admin), not the bot.
-
-1. Go to <https://github.com/kellylford/QuickMail/settings/access>.
-2. **Add people** → enter `quickmail-bot` → select it.
-3. Choose the **Triage** role (not Write, not Admin). Send the invite.
-4. Sign in as the bot account (separate browser profile) and **accept the invitation**
-   (check the bot's email, or <https://github.com/kellylford/QuickMail/invitations>).
-
-**Why Triage specifically:** the app sends `labels: ["bug", "user-reported"]` on each issue
-(`QuickMail/Services/BugReportService.cs`). GitHub only honors those labels if the submitting
-account can triage the repo. A plain non-collaborator could still *create* the issue on this public
-repo, but the labels would be silently ignored — reports would land unlabeled. Triage fixes that
-without granting any ability to push code.
-
----
-
-## Step 3 — Generate the fine-grained PAT from the bot **[HUMAN-ONLY]**
-
-Signed in **as the bot account**:
-
-1. Go to Settings → Developer settings → **Fine-grained tokens** → **Generate new token**
-   (<https://github.com/settings/personal-access-tokens/new>).
-2. Configure it exactly:
-   - **Token name:** `quickmail-inapp-bugreports`
-   - **Expiration:** 1 year (the maximum). Note the date — see Step 6 on rotation. (Avoid
-     "No expiration": a non-expiring secret shipped in a binary is worse if leaked.)
-   - **Resource owner:** `kellylford`. If `kellylford` does not appear as a selectable owner, the
-     collaborator invitation from Step 2 has not been accepted yet — finish that first.
-   - **Repository access:** **Only select repositories** → `kellylford/QuickMail`. Nothing else.
-   - **Permissions → Repository permissions → Issues:** **Read and write.**
-   - Leave **every other permission at "No access."** Do not grant Contents, Administration,
-     Pull requests, Metadata-beyond-default, or anything else.
-3. Generate, then **copy the token now** (`github_pat_...`) — GitHub shows it only once. Store it in
-   your password manager immediately.
-
-> **Minimal scope is a named security principle for this feature** (see the spec, §3.5). If GitHub
-> ever indicates `Issues: Read and write` on this one repo is insufficient to create a labeled
-> issue, **stop and confirm before widening scope** — do not reflexively add permissions.
-
----
-
-## Step 4 — Put the token into the build
-
-The build reads the token from a **gitignored** partial-class file, per
-`docs/BugReportService.Credentials.example`:
-
-1. Copy the example to the real (gitignored) file if it does not already exist:
-
-   ```
-   cp docs/BugReportService.Credentials.example QuickMail/Services/BugReportService.Credentials.cs
-   ```
-
-2. Edit `QuickMail/Services/BugReportService.Credentials.cs` and set the bot's token:
-
-   ```csharp
-   namespace QuickMail.Services;
-
-   public partial class BugReportService
-   {
-       private const string AppOwnedToken = "github_pat_...";   // bot account token from Step 3
-   }
-   ```
-
-3. Confirm it is **not** tracked by git (it must never be committed):
-
-   ```
-   git check-ignore QuickMail/Services/BugReportService.Credentials.cs
-   ```
-
-   This should print the path (meaning it is ignored). If it prints nothing, **stop** — the
-   `.gitignore` entry is missing and the token would be committed. Fix `.gitignore` before going on.
-
-> On release CI the token is injected the same way (into `AppOwnedToken`) rather than being checked
-> in. Wherever you store CI secrets, replace the old personal-account token value with this bot
-> token. **Then revoke the old personal-account PAT** (Step 5).
-
----
-
-## Step 5 — Revoke the old personal-account token **[HUMAN-ONLY]**
-
-Once a build with the bot token is verified working (Step 7), retire the old one so nothing keeps
-authoring issues as you:
-
-1. Sign in as your **personal** account.
-2. Settings → Developer settings → Fine-grained tokens → find the old QuickMail bug-report token →
-   **Revoke.**
-
-Any binary still carrying the old token will simply fall back to the browser/clipboard path once
-it's revoked — it fails safe, it does not crash.
-
----
-
-## Step 6 — Record the rotation reminder
-
-Fine-grained PATs expire. When this one lapses, in-app submission starts failing and silently falls
-back to the browser path until a new build ships. To avoid a surprise:
-
-- Add a calendar reminder ~11 months out (a few weeks before the Step 3 expiration date) to
-  generate a fresh token from the bot account and ship a build with it.
-- Rotation is just Step 3 → Step 4 again (generate new, swap into the build). No account or
-  collaborator changes needed.
-
----
-
-## Step 7 — Verify
-
-1. Build QuickMail with the bot token embedded (`build.bat` / your normal release build).
-2. Run it, open **Report a Bug**, and submit a throwaway test report.
-3. Confirm on GitHub that the new issue:
-   - is **authored by `quickmail-bot`**, not by your personal account, **and**
-   - carries the **`bug`** and **`user-reported`** labels (this proves the Triage role is working).
-4. Close the test issue.
-
-If the author is correct but the labels are missing, the Triage collaborator step (Step 2) was not
-completed or accepted — revisit it. If submission fails entirely and falls back to the browser, the
-token is missing, mis-scoped, or the resource owner wasn't `kellylford` — revisit Step 3.
-
----
-
-## Quick reference for an AI agent doing this
-
-Most steps here are **[HUMAN-ONLY]** (account creation, 2FA, PAT generation, collaborator invite/
-accept, token revocation) because GitHub gates them behind an interactive, signed-in browser
-session and does not expose them to API/CLI. An agent's role is limited to:
-
-- **Step 4:** creating/editing the gitignored `BugReportService.Credentials.cs` with a token the
-  human supplies, and verifying `git check-ignore` reports it as ignored. **Never commit this file
-  or echo the token into any tracked file, log, or commit message.**
-- Prompting the human, in order, through the HUMAN-ONLY steps and confirming each is done before
-  moving on (especially: collaborator invite **accepted** before PAT generation, since the
-  `kellylford` resource owner won't appear otherwise).
-- Running the Step 7 verification checks against the GitHub API (issue author == `quickmail-bot`,
-  labels present) once the human reports a build exists.
-
-Do not attempt to script account creation or PAT generation; there is no supported non-interactive
-path, and trying to automate around GitHub's auth is out of scope and against the spirit of the ToS.
-
----
-
-## Related
-
-- [#222](https://github.com/kellylford/QuickMail/issues/222) — the issue this resolves
-- [GitHub Terms of Service, §B.3 Account Requirements](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service) — the policy permitting machine accounts
-- `docs/planning/bug-reporting-pm-dev-spec.md` — original feature spec (Decision A, §3.5 minimal scope)
-- `docs/BugReportService.Credentials.example` — the token file template
-- `QuickMail/Services/BugReportService.cs` — the submission code (unchanged by this setup)
+- Reporters do **not** need a GitHub account. This is why the pre-filled-issue-URL path
+  could not simply become the only path.
+- The report collects no name or email. The relay accepts an optional contact field, but the
+  app does not currently offer one — that remains an open product decision on #501, because
+  anything sent this way lands in a public issue.

--- a/docs/BugReportService.Credentials.example
+++ b/docs/BugReportService.Credentials.example
@@ -1,29 +1,28 @@
 // To build QuickMail with in-app bug-report submission enabled:
 //
-// 1. Generate a fine-grained token from the DEDICATED BOT ACCOUNT (quickmail-bot),
-//    NOT from your personal account. GitHub attributes every filed issue to the
-//    token owner, so a personal token makes all user reports look like the
-//    maintainer authored them (see issue #222). Full account/role/token setup is in
-//    docs/BUG-REPORT-BOT-ACCOUNT.md. The token must be scoped to ONLY:
-//        Repository access: kellylford/QuickMail (this repo only)
-//        Permissions:       Issues -> Read and write
-//    No other repository access, no other permissions. Fine-grained tokens
-//    cannot be created via API/CLI — this is a manual step in the GitHub UI
-//    (Settings -> Developer settings -> Fine-grained tokens, signed in as the bot).
+// 1. Deploy the relay. Setup is in relay/README.md — it creates a GitHub App, deploys a
+//    Cloudflare Worker, and gives you a Worker URL plus a relay key you choose yourself.
 // 2. Copy this file to:
 //        QuickMail/Services/BugReportService.Credentials.cs
-// 3. Fill in the token below.
+// 3. Fill in the two values below.
 // 4. That file is gitignored and will never be committed.
 //
-// The distributed release binary includes the baked-in token; end users do
-// not need to configure anything. Without this file (or with the placeholder
-// left in place), the app-owned submission path is unavailable and the
-// feature falls back to the clipboard + browser path automatically — the
-// build still compiles and runs correctly either way.
+// The relay key is NOT a GitHub credential and must never become one. It ships inside a
+// public single-file executable, so treat it as extractable by anyone who downloads
+// QuickMail. All it authorises is "file an issue on kellylford/QuickMail", rate-limited at
+// the relay; the GitHub App private key that can actually write stays at Cloudflare. Baking
+// a GitHub token in here instead is the defect #222 describes and #501 fixed — do not go
+// back to it.
+//
+// The distributed release binary carries both values; end users configure nothing. Without
+// this file (or with the placeholders left in place), the relay submission path is
+// unavailable and the feature falls back to the clipboard + browser path automatically —
+// the build still compiles and runs correctly either way.
 
 namespace QuickMail.Services;
 
 public partial class BugReportService
 {
-    private const string AppOwnedToken = "";
+    private const string RelayUrl = "https://quickmail-bug-relay.<your-subdomain>.workers.dev/report";
+    private const string RelayKey = "";
 }

--- a/relay/.gitignore
+++ b/relay/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.wrangler/
+package-lock.json
+.dev.vars

--- a/relay/README.md
+++ b/relay/README.md
@@ -59,10 +59,25 @@ Create it, then from the App's settings page:
 ### 2. Create a Cloudflare API token
 
 A Cloudflare account is needed, but nothing has to be configured inside it — no domain, no
-nameservers. Signing in with GitHub is fine.
+nameservers, no subdomain chosen up front. Signing in with GitHub is fine.
 
-At <https://dash.cloudflare.com/profile/api-tokens> → **Create Token** → use the **Edit
-Cloudflare Workers** template → **Continue to summary** → **Create Token**.
+At <https://dash.cloudflare.com/profile/api-tokens> → **Create Token**. Use **Create Custom
+Token** → **Get started**, which is at the *top* of that page, above the templates. Do not
+use the **Edit Cloudflare Workers** template: it grants a spread of Workers-adjacent
+permissions and a zone-scoped one, and there is no zone here to scope it to.
+
+- **Token name**: `QuickMail relay deploy`
+- **Permissions**, two rows:
+  - `Account` / `Workers Scripts` / **Edit** — uploads the Worker and sets its secrets
+  - `Account` / `Account Settings` / **Read** — lets wrangler resolve which account to deploy to
+- **Account Resources**: `Include` / your account
+- **Zone Resources**: leave empty. Nothing here touches DNS or zones.
+- **Client IP Address Filtering**: leave empty — GitHub runner IPs change constantly.
+- **TTL**: leave empty. An expiring token here fails silently months later, in a workflow
+  nobody is watching.
+
+**Continue to summary** → confirm it reads `Workers Scripts:Edit, Account Settings:Read` →
+**Create Token**.
 
 Copy the token. Like the private key, it is shown once.
 
@@ -93,6 +108,10 @@ node -e "console.log(require('crypto').randomBytes(32).toString('base64url'))"
 Keep that value: step 5 needs it again, and it is not readable back out of GitHub.
 
 ### 4. Deploy
+
+The workflow must be on `main` before it can be run — GitHub only registers
+`workflow_dispatch` from the default branch, and dispatching it from a feature branch fails
+with a 404 that reads as if the file does not exist.
 
 **Actions** → **Deploy bug-report relay** → **Run workflow**, and tick **Also push the
 Worker's secrets from repository secrets**. That box is off by default so a routine code

--- a/relay/README.md
+++ b/relay/README.md
@@ -1,0 +1,137 @@
+# QuickMail bug-report relay
+
+A single Cloudflare Worker that turns a bug report from the app into a GitHub issue.
+
+QuickMail used to POST straight to `api.github.com` with a personal access token compiled
+into the shipped executable. That token was extractable from any downloaded copy, and it
+made every user-filed issue look like the maintainer had filed it. This relay holds a GitHub
+App private key instead, so the only secret still shipping in the binary is a relay key that
+can do nothing but file an issue on one repo. See issue #501.
+
+Nothing runs until a report arrives. There is no server to patch, monitor, or restart.
+
+## One-time setup
+
+### 1. Create the GitHub App
+
+At <https://github.com/settings/apps/new>:
+
+- **Name**: `QuickMail Bug Reporter` (this becomes the issue author, shown as
+  `quickmail-bug-reporter[bot]`)
+- **Homepage URL**: `https://github.com/kellylford/QuickMail`
+- **Webhook**: uncheck **Active**. The relay does not receive webhooks.
+- **Repository permissions** → **Issues**: **Read and write**. Leave every other permission
+  at *No access*.
+- **Where can this App be installed?**: *Only on this account*
+
+Create it, then from the App's settings page:
+
+- Note the **App ID** near the top.
+- **Generate a private key** at the bottom. A `.pem` file downloads — this is the only copy,
+  GitHub does not show it again.
+- **Install App** in the left sidebar → install on your account → **Only select
+  repositories** → `QuickMail`.
+- After installing, the browser lands on a URL ending in a number, e.g.
+  `.../installations/12345678`. That number is the **installation ID**. To find it later:
+  App settings → **Install App** → the gear icon beside your account.
+
+### 2. Deploy the Worker
+
+From this folder:
+
+```bash
+npm install
+```
+
+```bash
+npx wrangler login
+```
+
+```bash
+npx wrangler deploy
+```
+
+The deploy prints the Worker URL, something like
+`https://quickmail-bug-relay.<your-subdomain>.workers.dev`. The app posts to that URL plus
+`/report`.
+
+### 3. Set the four secrets
+
+Each command prompts for the value and stores it encrypted at Cloudflare. Values are never
+echoed back and never appear in the repo.
+
+```bash
+npx wrangler secret put GITHUB_APP_ID
+```
+
+```bash
+npx wrangler secret put GITHUB_INSTALLATION_ID
+```
+
+```bash
+npx wrangler secret put GITHUB_PRIVATE_KEY
+```
+
+For the private key, paste the entire `.pem` file including the `-----BEGIN`/`-----END`
+lines. Either format GitHub gives you works — the Worker converts PKCS#1 to PKCS#8 itself.
+
+```bash
+npx wrangler secret put RELAY_KEY
+```
+
+Generate that one first — any long random string. For example:
+
+```bash
+node -e "console.log(require('crypto').randomBytes(32).toString('base64url'))"
+```
+
+### 4. Give the same relay key to the build
+
+Add the value as a repository secret named `BUG_REPORT_RELAY_KEY` at
+<https://github.com/kellylford/QuickMail/settings/secrets/actions>, and set the Worker URL
+as a repository **variable** named `BUG_REPORT_RELAY_URL` (Variables tab, same page). CI
+compiles both into the release build.
+
+The old `BUG_REPORT_TOKEN` secret can be deleted once a release carrying the new build has
+shipped — see *Retiring the old token* below.
+
+## Checking it works
+
+```bash
+curl -X POST https://quickmail-bug-relay.<your-subdomain>.workers.dev/report -H "X-QuickMail-Key: <relay key>" -H "Content-Type: application/json" -d "{\"title\":\"Relay smoke test\",\"body\":\"Ignore and close.\"}"
+```
+
+A success returns `{"issueUrl":"...","number":N}`. Close the issue afterwards.
+
+Live logs, while a report is being filed:
+
+```bash
+npx wrangler tail
+```
+
+## Retiring the old token
+
+Installs that have not updated yet still post to `api.github.com` with the old PAT, so
+revoking it early breaks bug reporting for exactly the users least likely to notice why.
+Ship the release first, give it a few weeks, then revoke the PAT at
+<https://github.com/settings/tokens> and delete the `BUG_REPORT_TOKEN` repository secret.
+
+## If the relay key leaks
+
+It will eventually — it ships in a public binary, and that is the design assumption, not a
+failure. The blast radius is junk issues on one repo. To cut it off: set a new `RELAY_KEY`
+secret, update `BUG_REPORT_RELAY_KEY` in the repo, and ship a build. Older installs fall
+back to the pre-filled issue URL and clipboard path, which needs no relay at all.
+
+Nothing about a leaked relay key touches your GitHub account, the App's private key, or any
+other repository.
+
+## Operating notes
+
+- **Cost.** The free tier is 100,000 requests/day. Expected volume is a handful per week.
+- **Rate limiting** is 5 reports per minute per IP, and fails *open* — if the limiter binding
+  is ever unavailable the report still goes through. A junk issue is deletable; a report a
+  user could not file is gone.
+- **The relay never sees mail content.** It forwards the same text the report window already
+  shows the user before sending — no log file, no message bodies, no addresses beyond an
+  optional contact line the user types.

--- a/relay/README.md
+++ b/relay/README.md
@@ -10,6 +10,26 @@ can do nothing but file an issue on one repo. See issue #501.
 
 Nothing runs until a report arrives. There is no server to patch, monitor, or restart.
 
+## Deployment runs in CI, not from a maintainer's machine
+
+**Do not try to install wrangler locally on Windows ARM64.** It will not work — wrangler
+imports `workerd`, which publishes no `win32-arm64` build and throws `Unsupported platform:
+win32 arm64 LE` on startup. That applies to `wrangler deploy` as much as to `wrangler dev`,
+and `npm install --ignore-scripts` does not get around it, because the failure is at import
+time rather than install time.
+
+The **Deploy bug-report relay** workflow
+(`.github/workflows/deploy-relay.yml`) runs on x64 Linux instead. Every value the Worker
+needs is a repository secret; the workflow pushes both the code and the secrets. You never
+run wrangler.
+
+The tests in `test/` deliberately use only the Node standard library, so they stay runnable
+here:
+
+```bash
+node relay/test/jwt.test.js
+```
+
 ## One-time setup
 
 ### 1. Create the GitHub App
@@ -33,81 +53,91 @@ Create it, then from the App's settings page:
   repositories** → `QuickMail`.
 - After installing, the browser lands on a URL ending in a number, e.g.
   `.../installations/12345678`. That number is the **installation ID**. To find it later:
-  App settings → **Install App** → the gear icon beside your account.
+  <https://github.com/settings/installations> → **Configure** beside the App → read it off
+  the URL.
 
-### 2. Deploy the Worker
+### 2. Create a Cloudflare API token
 
-From this folder:
+A Cloudflare account is needed, but nothing has to be configured inside it — no domain, no
+nameservers. Signing in with GitHub is fine.
 
-```bash
-npm install
-```
+At <https://dash.cloudflare.com/profile/api-tokens> → **Create Token** → use the **Edit
+Cloudflare Workers** template → **Continue to summary** → **Create Token**.
 
-```bash
-npx wrangler login
-```
+Copy the token. Like the private key, it is shown once.
 
-```bash
-npx wrangler deploy
-```
+### 3. Set the repository secrets
 
-The deploy prints the Worker URL, something like
-`https://quickmail-bug-relay.<your-subdomain>.workers.dev`. The app posts to that URL plus
-`/report`.
+At <https://github.com/kellylford/QuickMail/settings/secrets/actions>:
 
-### 3. Set the four secrets
+| Secret | Value |
+|---|---|
+| `CLOUDFLARE_API_TOKEN` | the token from step 2 |
+| `RELAY_GITHUB_APP_ID` | the App ID from step 1 |
+| `RELAY_GITHUB_INSTALLATION_ID` | the installation ID from step 1 |
+| `RELAY_GITHUB_PRIVATE_KEY` | the entire `.pem` file, `-----BEGIN`/`-----END` lines included |
+| `BUG_REPORT_RELAY_KEY` | a long random string you generate (below) |
 
-Each command prompts for the value and stores it encrypted at Cloudflare. Values are never
-echoed back and never appear in the repo.
+The `RELAY_` prefixes are not decoration: GitHub rejects repository secrets whose names begin
+with `GITHUB_`.
 
-```bash
-npx wrangler secret put GITHUB_APP_ID
-```
+Either PEM format works — the Worker converts PKCS#1 to PKCS#8 itself, so paste whichever
+GitHub gave you.
 
-```bash
-npx wrangler secret put GITHUB_INSTALLATION_ID
-```
-
-```bash
-npx wrangler secret put GITHUB_PRIVATE_KEY
-```
-
-For the private key, paste the entire `.pem` file including the `-----BEGIN`/`-----END`
-lines. Either format GitHub gives you works — the Worker converts PKCS#1 to PKCS#8 itself.
-
-```bash
-npx wrangler secret put RELAY_KEY
-```
-
-Generate that one first — any long random string. For example:
+To generate the relay key:
 
 ```bash
 node -e "console.log(require('crypto').randomBytes(32).toString('base64url'))"
 ```
 
-### 4. Give the same relay key to the build
+Keep that value: step 5 needs it again, and it is not readable back out of GitHub.
 
-Add the value as a repository secret named `BUG_REPORT_RELAY_KEY` at
-<https://github.com/kellylford/QuickMail/settings/secrets/actions>, and set the Worker URL
-as a repository **variable** named `BUG_REPORT_RELAY_URL` (Variables tab, same page). CI
-compiles both into the release build.
+### 4. Deploy
 
-The old `BUG_REPORT_TOKEN` secret can be deleted once a release carrying the new build has
-shipped — see *Retiring the old token* below.
+**Actions** → **Deploy bug-report relay** → **Run workflow**, and tick **Also push the
+Worker's secrets from repository secrets**. That box is off by default so a routine code
+redeploy cannot blank the Worker's secrets; it needs to be on for this first run and any time
+a secret changes.
 
-## Checking it works
+The **Deploy Worker** step's log ends with the Worker URL, of the form
+`https://quickmail-bug-relay.<your-subdomain>.workers.dev`.
+
+If that step fails saying more than one account is available, add a repository **variable**
+`CLOUDFLARE_ACCOUNT_ID` (Variables tab, same settings page) with your account ID — it is in
+the dashboard URL after `dash.cloudflare.com/`. Otherwise it is not needed.
+
+### 5. Point the app at the relay
+
+Still at <https://github.com/kellylford/QuickMail/settings/variables/actions>, add a
+repository **variable** (not a secret):
+
+| Variable | Value |
+|---|---|
+| `BUG_REPORT_RELAY_URL` | the Worker URL from step 4, plus `/report` |
+
+CI compiles that URL and `BUG_REPORT_RELAY_KEY` into release builds. The next release picks
+them up; nothing further is needed per build.
+
+### 6. Check it works
 
 ```bash
 curl -X POST https://quickmail-bug-relay.<your-subdomain>.workers.dev/report -H "X-QuickMail-Key: <relay key>" -H "Content-Type: application/json" -d "{\"title\":\"Relay smoke test\",\"body\":\"Ignore and close.\"}"
 ```
 
-A success returns `{"issueUrl":"...","number":N}`. Close the issue afterwards.
+Success returns `{"issueUrl":"...","number":N}`, and the issue is authored by
+`quickmail-bug-reporter[bot]` rather than by you — that authorship is the whole point, so it
+is worth confirming. Close the issue afterwards.
 
-Live logs, while a report is being filed:
+Failures worth recognising:
 
-```bash
-npx wrangler tail
-```
+| Response | Cause |
+|---|---|
+| `401 Unauthorized` | the `X-QuickMail-Key` header does not match `RELAY_KEY` at Cloudflare |
+| `502 Could not create the issue` | App credentials wrong, or the App is not installed on the repo |
+| `429` | the per-IP rate limit; wait a minute |
+
+For the underlying GitHub error behind a 502, check the Worker's logs: **Cloudflare
+dashboard** → **Workers & Pages** → `quickmail-bug-relay` → **Logs**.
 
 ## Retiring the old token
 
@@ -119,9 +149,10 @@ Ship the release first, give it a few weeks, then revoke the PAT at
 ## If the relay key leaks
 
 It will eventually — it ships in a public binary, and that is the design assumption, not a
-failure. The blast radius is junk issues on one repo. To cut it off: set a new `RELAY_KEY`
-secret, update `BUG_REPORT_RELAY_KEY` in the repo, and ship a build. Older installs fall
-back to the pre-filled issue URL and clipboard path, which needs no relay at all.
+failure. The blast radius is junk issues on one repo. To cut it off: update the
+`BUG_REPORT_RELAY_KEY` repository secret, re-run the deploy workflow **with the secrets box
+ticked**, and ship a build. Older installs fall back to the pre-filled issue URL and
+clipboard path, which needs no relay at all.
 
 Nothing about a leaked relay key touches your GitHub account, the App's private key, or any
 other repository.
@@ -135,3 +166,5 @@ other repository.
 - **The relay never sees mail content.** It forwards the same text the report window already
   shows the user before sending — no log file, no message bodies, no addresses beyond an
   optional contact line the user types.
+- **Changing the Worker's code** needs no ceremony: merge to `main` with changes under
+  `relay/`, and the workflow redeploys automatically without touching secrets.

--- a/relay/package.json
+++ b/relay/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "quickmail-bug-relay",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Cloudflare Worker that files QuickMail bug reports as a GitHub App",
+  "scripts": {
+    "test": "node test/jwt.test.js",
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "tail": "wrangler tail"
+  },
+  "devDependencies": {
+    "wrangler": "^4.0.0"
+  }
+}

--- a/relay/package.json
+++ b/relay/package.json
@@ -4,13 +4,8 @@
   "private": true,
   "type": "module",
   "description": "Cloudflare Worker that files QuickMail bug reports as a GitHub App",
+  "//": "No dependencies on purpose. wrangler cannot be installed on Windows ARM64 (its workerd dependency has no build for that platform), so listing it here would make `npm install` fail on the maintainer's machine for no gain — CI invokes it with `npx wrangler@4`. Keeping the tests on the Node standard library keeps them runnable everywhere.",
   "scripts": {
-    "test": "node test/jwt.test.js",
-    "dev": "wrangler dev",
-    "deploy": "wrangler deploy",
-    "tail": "wrangler tail"
-  },
-  "devDependencies": {
-    "wrangler": "^4.0.0"
+    "test": "node test/jwt.test.js"
   }
 }

--- a/relay/src/index.js
+++ b/relay/src/index.js
@@ -1,0 +1,229 @@
+/**
+ * QuickMail bug-report relay.
+ *
+ * QuickMail used to POST bug reports straight to api.github.com with a personal access
+ * token compiled into the shipped executable. That token was extractable by anyone who
+ * downloaded the app, and every user-filed issue was authored by the maintainer.
+ *
+ * This Worker holds a GitHub App private key instead. The app posts a report here with a
+ * low-value relay key; the Worker mints a one-hour installation token and creates the
+ * issue under the App's bot identity. The relay key is still extractable from the binary,
+ * but all it can do is file an issue on one repo — and it can be rotated without touching
+ * any GitHub account.
+ *
+ * See issue #501.
+ */
+
+const REPO_OWNER = 'kellylford';
+const REPO_NAME = 'QuickMail';
+const USER_AGENT = 'QuickMail-BugReport-Relay';
+const ISSUE_LABELS = ['bug', 'user-reported'];
+
+// The app's own timeout is 15s (BugReportService), so anything slower than this is already
+// a failure the user has seen. Bail out rather than hold the request open.
+const GITHUB_TIMEOUT_MS = 10_000;
+
+const MAX_BODY_BYTES = 64 * 1024;
+const MAX_TITLE_CHARS = 200;
+const MAX_FIELD_CHARS = 8_000;
+const MAX_CONTACT_CHARS = 200;
+
+export default {
+  async fetch(request, env, ctx) {
+    if (request.method !== 'POST') return text(405, 'Method not allowed.');
+
+    const url = new URL(request.url);
+    if (url.pathname !== '/report') return text(404, 'Not found.');
+
+    if (!timingSafeEqual(request.headers.get('X-QuickMail-Key') || '', env.RELAY_KEY || '')) {
+      return text(401, 'Unauthorized.');
+    }
+
+    // Fail open on a rate-limiter problem. A misconfigured binding blocking every bug report
+    // is worse than the junk issues it would have stopped — junk is deletable, a report the
+    // user could not file is gone.
+    try {
+      const ip = request.headers.get('CF-Connecting-IP') || 'unknown';
+      const { success } = await env.RATE_LIMITER.limit({ key: ip });
+      if (!success) return text(429, 'Too many reports from this address. Try again shortly.');
+    } catch (err) {
+      console.error('rate limiter unavailable, allowing request:', err);
+    }
+
+    const raw = await request.text();
+    if (byteLength(raw) > MAX_BODY_BYTES) return text(413, 'Report too large.');
+
+    let report;
+    try {
+      report = JSON.parse(raw);
+    } catch {
+      return text(400, 'Malformed JSON.');
+    }
+
+    const title = clip(report?.title, MAX_TITLE_CHARS);
+    const body = clip(report?.body, MAX_FIELD_CHARS);
+    if (!title || !body) return text(400, 'Both title and body are required.');
+
+    const contact = clip(report?.contact, MAX_CONTACT_CHARS);
+    const issueBody = contact ? `${body}\n\n### Contact\n${contact}\n` : body;
+
+    try {
+      const token = await getInstallationToken(env, ctx);
+      const issue = await githubFetch(
+        `https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/issues`,
+        token,
+        { title, body: issueBody, labels: ISSUE_LABELS },
+      );
+      return Response.json({ issueUrl: issue.html_url, number: issue.number });
+    } catch (err) {
+      // The message may carry GitHub's response text; log it, but tell the caller nothing
+      // it could use to probe the App's permissions.
+      console.error('issue creation failed:', err);
+      return text(502, 'Could not create the issue.');
+    }
+  },
+};
+
+// ---------------------------------------------------------------- GitHub auth
+
+// Installation tokens last an hour. Caching per isolate saves two round-trips on the (rare)
+// second report handled by the same instance; a cold isolate just mints a fresh one.
+let cachedToken = null; // { token, expiresAt }
+
+async function getInstallationToken(env, ctx) {
+  const now = Date.now();
+  if (cachedToken && cachedToken.expiresAt > now + 60_000) return cachedToken.token;
+
+  const jwt = await createAppJwt(env.GITHUB_APP_ID, env.GITHUB_PRIVATE_KEY);
+  const result = await githubFetch(
+    `https://api.github.com/app/installations/${env.GITHUB_INSTALLATION_ID}/access_tokens`,
+    jwt,
+    undefined,
+  );
+
+  cachedToken = { token: result.token, expiresAt: Date.parse(result.expires_at) };
+  return result.token;
+}
+
+async function createAppJwt(appId, privateKeyPem) {
+  const key = await importRsaKey(privateKeyPem);
+  const now = Math.floor(Date.now() / 1000);
+
+  // iat is backdated 60s because GitHub rejects a JWT whose iat is in its future, and the
+  // Worker's clock and GitHub's can differ by a few seconds.
+  const header = b64url(JSON.stringify({ alg: 'RS256', typ: 'JWT' }));
+  const payload = b64url(JSON.stringify({ iat: now - 60, exp: now + 540, iss: appId }));
+  const signingInput = `${header}.${payload}`;
+
+  const signature = await crypto.subtle.sign(
+    'RSASSA-PKCS1-v1_5',
+    key,
+    new TextEncoder().encode(signingInput),
+  );
+
+  return `${signingInput}.${b64urlBytes(new Uint8Array(signature))}`;
+}
+
+/**
+ * GitHub hands out App private keys in PKCS#1 ("BEGIN RSA PRIVATE KEY"), which WebCrypto
+ * cannot import — it only takes PKCS#8. Rather than make key setup depend on remembering an
+ * `openssl pkcs8 -topk8` incantation, accept either and wrap PKCS#1 here. A key pasted in
+ * whichever form GitHub happened to give you should just work.
+ */
+async function importRsaKey(pem) {
+  const isPkcs1 = /BEGIN RSA PRIVATE KEY/.test(pem);
+  const der = pemBody(pem);
+  const pkcs8 = isPkcs1 ? wrapPkcs1AsPkcs8(der) : der;
+
+  return crypto.subtle.importKey(
+    'pkcs8',
+    pkcs8,
+    { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+}
+
+function pemBody(pem) {
+  const base64 = pem
+    .replace(/-----BEGIN [^-]+-----/, '')
+    .replace(/-----END [^-]+-----/, '')
+    .replace(/\s+/g, '');
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+// PrivateKeyInfo ::= SEQUENCE { version INTEGER, algorithm AlgorithmIdentifier, key OCTET STRING }
+function wrapPkcs1AsPkcs8(pkcs1) {
+  const version = [0x02, 0x01, 0x00];
+  // AlgorithmIdentifier for rsaEncryption (1.2.840.113549.1.1.1) with NULL parameters.
+  const algorithm = [
+    0x30, 0x0d, 0x06, 0x09, 0x2a, 0x86, 0x48, 0x86,
+    0xf7, 0x0d, 0x01, 0x01, 0x01, 0x05, 0x00,
+  ];
+  const keyOctetString = [0x04, ...derLength(pkcs1.length), ...pkcs1];
+  const contents = [...version, ...algorithm, ...keyOctetString];
+  return new Uint8Array([0x30, ...derLength(contents.length), ...contents]);
+}
+
+function derLength(n) {
+  if (n < 0x80) return [n];
+  const bytes = [];
+  for (let v = n; v > 0; v >>>= 8) bytes.unshift(v & 0xff);
+  return [0x80 | bytes.length, ...bytes];
+}
+
+// ---------------------------------------------------------------- helpers
+
+async function githubFetch(url, token, jsonBody) {
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+      'User-Agent': USER_AGENT,
+      ...(jsonBody ? { 'Content-Type': 'application/json' } : {}),
+    },
+    body: jsonBody ? JSON.stringify(jsonBody) : undefined,
+    signal: AbortSignal.timeout(GITHUB_TIMEOUT_MS),
+  });
+
+  if (!response.ok) {
+    throw new Error(`GitHub ${response.status} for ${url}: ${await response.text()}`);
+  }
+  return response.json();
+}
+
+function clip(value, max) {
+  if (typeof value !== 'string') return '';
+  const trimmed = value.trim();
+  return trimmed.length <= max ? trimmed : `${trimmed.slice(0, max)}\n\n…(truncated)`;
+}
+
+function byteLength(str) {
+  return new TextEncoder().encode(str).length;
+}
+
+function timingSafeEqual(a, b) {
+  if (a.length !== b.length || a.length === 0) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  return diff === 0;
+}
+
+function b64url(str) {
+  return b64urlBytes(new TextEncoder().encode(str));
+}
+
+function b64urlBytes(bytes) {
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function text(status, message) {
+  return new Response(message, { status, headers: { 'Content-Type': 'text/plain' } });
+}

--- a/relay/test/jwt.test.js
+++ b/relay/test/jwt.test.js
@@ -1,0 +1,105 @@
+/**
+ * Verifies the two pieces of the Worker that fail silently and expensively if wrong: the
+ * PKCS#1 -> PKCS#8 conversion (GitHub hands out App keys in PKCS#1, WebCrypto only imports
+ * PKCS#8), and RS256 JWT signing.
+ *
+ * Plain node, no test framework:  node relay/test/jwt.test.js
+ */
+
+import { generateKeyPairSync, createVerify } from 'node:crypto';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+// The Worker is a default-export module, so pull the internals out by evaluating the source
+// with the pieces under test re-exported. Keeping them unexported in the Worker itself avoids
+// widening its public surface just for tests.
+const workerSource = readFileSync(
+  join(dirname(fileURLToPath(import.meta.url)), '..', 'src', 'index.js'),
+  'utf8',
+);
+const testable = `${workerSource}\nexport { importRsaKey, createAppJwt, wrapPkcs1AsPkcs8, timingSafeEqual, clip };`;
+const module = await import(
+  `data:text/javascript;base64,${Buffer.from(testable).toString('base64')}`
+);
+
+const { publicKey, privateKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+const pkcs1Pem = privateKey.export({ type: 'pkcs1', format: 'pem' });
+const pkcs8Pem = privateKey.export({ type: 'pkcs8', format: 'pem' });
+
+let failures = 0;
+async function check(name, fn) {
+  try {
+    await fn();
+    console.log(`  ok   ${name}`);
+  } catch (err) {
+    failures++;
+    console.error(`  FAIL ${name}\n       ${err.message}`);
+  }
+}
+
+console.log('relay JWT tests');
+
+await check('imports a PKCS#8 key as GitHub-compatible signing material', async () => {
+  const key = await module.importRsaKey(pkcs8Pem);
+  assert.equal(key.algorithm.name, 'RSASSA-PKCS1-v1_5');
+});
+
+await check('imports a PKCS#1 key — the format GitHub actually downloads', async () => {
+  assert.match(pkcs1Pem, /BEGIN RSA PRIVATE KEY/);
+  const key = await module.importRsaKey(pkcs1Pem);
+  assert.equal(key.algorithm.name, 'RSASSA-PKCS1-v1_5');
+});
+
+await check('PKCS#1 conversion yields byte-identical DER to a real PKCS#8 export', async () => {
+  const pkcs1Der = privateKey.export({ type: 'pkcs1', format: 'der' });
+  const expected = privateKey.export({ type: 'pkcs8', format: 'der' });
+  const actual = module.wrapPkcs1AsPkcs8(new Uint8Array(pkcs1Der));
+  assert.deepEqual(Buffer.from(actual), Buffer.from(expected));
+});
+
+await check('signs a JWT that verifies against the public key', async () => {
+  const jwt = await module.createAppJwt('123456', pkcs1Pem);
+  const [header, payload, signature] = jwt.split('.');
+  assert.ok(header && payload && signature);
+
+  const verifier = createVerify('RSA-SHA256');
+  verifier.update(`${header}.${payload}`);
+  const ok = verifier.verify(
+    publicKey,
+    Buffer.from(signature.replace(/-/g, '+').replace(/_/g, '/'), 'base64'),
+  );
+  assert.ok(ok, 'signature did not verify');
+});
+
+await check('JWT claims match what GitHub requires', async () => {
+  const jwt = await module.createAppJwt('123456', pkcs8Pem);
+  const [headerB64, payloadB64] = jwt.split('.');
+  const header = JSON.parse(Buffer.from(headerB64, 'base64url'));
+  const claims = JSON.parse(Buffer.from(payloadB64, 'base64url'));
+
+  assert.equal(header.alg, 'RS256');
+  assert.equal(claims.iss, '123456');
+  // GitHub rejects a JWT whose iat is in its future and caps lifetime at 10 minutes.
+  const now = Math.floor(Date.now() / 1000);
+  assert.ok(claims.iat < now, 'iat must be backdated for clock skew');
+  assert.ok(claims.exp - claims.iat <= 600, 'lifetime must stay within 10 minutes');
+});
+
+await check('relay key comparison rejects mismatches and empty keys', () => {
+  assert.equal(module.timingSafeEqual('secret', 'secret'), true);
+  assert.equal(module.timingSafeEqual('secret', 'secrat'), false);
+  assert.equal(module.timingSafeEqual('secret', 'secretx'), false);
+  // An unconfigured RELAY_KEY must fail closed, not admit an empty header.
+  assert.equal(module.timingSafeEqual('', ''), false);
+});
+
+await check('oversized fields are truncated rather than dropped', () => {
+  assert.equal(module.clip('  hello  ', 100), 'hello');
+  assert.equal(module.clip(undefined, 100), '');
+  assert.match(module.clip('x'.repeat(50), 10), /^x{10}\n\n…\(truncated\)$/);
+});
+
+console.log(failures ? `\n${failures} failure(s)` : '\nall passed');
+process.exit(failures ? 1 : 0);

--- a/relay/wrangler.toml
+++ b/relay/wrangler.toml
@@ -1,0 +1,21 @@
+name = "quickmail-bug-relay"
+main = "src/index.js"
+compatibility_date = "2026-01-01"
+
+# Secrets (set with `wrangler secret put`, never committed):
+#   GITHUB_APP_ID           the App's numeric ID
+#   GITHUB_INSTALLATION_ID  the installation of that App on kellylford/QuickMail
+#   GITHUB_PRIVATE_KEY      the App's private key PEM (PKCS#1 or PKCS#8 both work)
+#   RELAY_KEY               shared with the shipped app; low-value, rotatable
+
+# Per-IP cap on issue creation. 5/minute is far above any human filing a bug and far below
+# what makes a spam run worthwhile. `namespace_id` is an arbitrary label, not a resource to
+# create; `period` accepts only 10 or 60.
+[[unsafe.bindings]]
+name = "RATE_LIMITER"
+type = "ratelimit"
+namespace_id = "1001"
+simple = { limit = 5, period = 60 }
+
+[observability]
+enabled = true


### PR DESCRIPTION
Closes #501. Closes #222.

## What changed

Release builds compiled a fine-grained GitHub PAT into the single-file executable and posted bug reports straight to `api.github.com` with it — extractable by anyone who downloaded QuickMail, and GitHub attributed every user-filed issue to the token owner.

A GitHub App now owns the write capability, with its private key held by a Cloudflare Worker in `relay/`. The app posts to the Worker with a relay key whose whole authority is "file an issue on kellylford/QuickMail". That key still ships in the binary and is still extractable — the difference is that it grants nothing beyond issue creation, is rate-limited at the relay, and rotates without touching any GitHub account.

Reporters still need no GitHub account. The clipboard + pre-filled-issue-URL fallback is unchanged and still covers a relay outage.

## Notable decisions

- **The client no longer sends labels.** A client that names its own labels lets anyone holding the extracted key apply arbitrary ones. The relay decides.
- **Upgrading installs get the old PAT deleted from Credential Manager** on first run. The previous code cached it there; nothing reads it now, so leaving a live credential behind would be the worst of both designs.
- **Rate limiting fails open.** A misconfigured limiter blocking every bug report is worse than the junk it would have stopped — junk is deletable, a report the user could not file is gone.
- **`docs/BUG-REPORT-BOT-ACCOUNT.md` is marked superseded.** A machine account fixes attribution and nothing else; the credential would still be in the binary.

## Verification

- `relay/test/jwt.test.js` — 7/7 pass. The load-bearing one asserts the PKCS#1 → PKCS#8 conversion is byte-identical to a real Node PKCS#8 export. GitHub downloads App keys as PKCS#1, WebCrypto imports only PKCS#8, and getting this wrong fails at runtime with an opaque error.
- `BugReportServiceTests` — 16/16 pass, including a regression guard that no GitHub credential and no client-chosen labels reach the wire.
- `QuickMail.csproj` builds clean under `-warnaserror`.
- One pre-existing environmental failure in `ReportBugViewModelTests.CopyAndOpen_BlankSummary_DoesNotCopyOrOpen` — `Clipboard.SetText` returns `CLIPBRD_E_CANT_OPEN` because something on this machine holds the Win32 clipboard. That test uses `FakeBugReportService` and never reaches changed code.

## Not done here

- **Manual setup.** The GitHub App, the Worker deploy, and the four secrets need account access. Steps are in `relay/README.md`.
- **Revoking the old PAT.** Deliberately deferred — installs that have not updated still submit with it. Revoking now breaks bug reporting for exactly the users least likely to work out why.
- **The optional contact field.** The relay accepts one, the app does not offer one. It needs a product decision first: anything sent this way lands in a public issue, so a reporter's email would be published and scraped. Worth having, but not worth shipping silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)