### PR TITLE
Relay README: record the workers.dev subdomain step

### DIFF
--- a/relay/README.md
+++ b/relay/README.md
@@ -107,6 +107,19 @@ node -e "console.log(require('crypto').randomBytes(32).toString('base64url'))"
 
 Keep that value: step 5 needs it again, and it is not readable back out of GitHub.
 
+### 3b. Register a workers.dev subdomain
+
+Signing up through GitHub never prompts for one, and without it the first deploy fails with
+*"You need to register a workers.dev subdomain before publishing to workers.dev"* — there is
+simply nowhere to publish to.
+
+Register it at `https://dash.cloudflare.com/<account id>/workers/subdomain`. **Not** the
+`/workers/onboarding` URL wrangler prints in that error; that page 404s.
+
+The name is lowercase letters, digits and hyphens, globally unique across Cloudflare, and
+permanent — it becomes part of the public relay address. This account uses `quickmail`, so
+the Worker lives at `https://quickmail-bug-relay.quickmail.workers.dev`.
+
 ### 4. Deploy
 
 The workflow must be on `main` before it can be run — GitHub only registers


### PR DESCRIPTION
Follow-up to #501, documentation only.

Setting the relay up for real turned up a step the README did not have. Signing up for Cloudflare via GitHub never prompts for a `workers.dev` subdomain, so the first deploy failed with nothing to publish to. The onboarding URL wrangler prints for that fix 404s; the live page is `/workers/subdomain`.

Both are now in the setup steps, along with the registered name (`quickmail`) and the resulting Worker address.

🤖 Generated with [Claude Code](https://claude.com/claude-code)