### PR TITLE
Fix #163: keep image alt text when the image is stripped

### DIFF
--- a/QuickMail.Tests/MessageBodyHtmlBuilderTests.cs
+++ b/QuickMail.Tests/MessageBodyHtmlBuilderTests.cs
@@ -47,6 +47,93 @@ public class MessageBodyHtmlBuilderTests
     }
 
     [Fact]
+    public void StripHeavyHtml_ImageAltText_SurvivesTheImage()
+    {
+        const string html = "<body><p>See the <img src=\"chart.png\" alt=\"Q3 revenue chart\"> above.</p></body>";
+
+        var result = MessageBodyHtmlBuilder.StripHeavyHtml(html);
+
+        Assert.DoesNotContain("<img", result, System.StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Q3 revenue chart", result);
+    }
+
+    [Fact]
+    public void StripHeavyHtml_IconOnlyLink_IsNamedByAltNotItsHref()
+    {
+        // Issue #163: the social-icon footer every newsletter ships. Dropping the image left the
+        // anchor empty, so it took its accessible name from the tracking href and was announced as
+        // "redirect" rather than "Facebook".
+        const string html =
+            "<body><a href=\"https://substack.com/redirect/a7992ee5\">" +
+            "<img src=\"fb.png\" alt=\"Facebook\"></a></body>";
+
+        var result = MessageBodyHtmlBuilder.StripHeavyHtml(html);
+
+        Assert.Contains(">Facebook</a>", result);
+    }
+
+    [Theory]
+    [InlineData("<img src='x.png' alt=''>")]           // author-declared decorative
+    [InlineData("<img src='x.png' alt='   '>")]        // whitespace is not a name
+    [InlineData("<img src='x.png'>")]                  // no alt at all
+    public void StripHeavyHtml_ImageWithoutUsefulAlt_LeavesNothingBehind(string img)
+    {
+        var result = MessageBodyHtmlBuilder.StripHeavyHtml("<body><p>A</p>" + img + "<p>B</p></body>");
+
+        Assert.DoesNotContain("<img", result, System.StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("x.png", result);
+        Assert.Contains("<p>A</p><p>B</p>", result);
+    }
+
+    [Fact]
+    public void StripHeavyHtml_AltTextWithMarkup_IsEncodedNotSpliced()
+    {
+        // A bare '<' is legal inside a quoted attribute; moved into content unescaped it would
+        // open a tag the sanitizer has already finished inspecting. (A literal <script> in the alt
+        // never reaches this pass — the script removal earlier in the chain eats it — so the case
+        // worth pinning is the markup that does survive to here.)
+        const string html = "<body><img src=\"x.png\" alt=\"a <b>bold</b> logo\"></body>";
+
+        var result = MessageBodyHtmlBuilder.StripHeavyHtml(html);
+
+        Assert.Contains("a &lt;b&gt;bold&lt;/b&gt; logo", result);
+    }
+
+    [Fact]
+    public void StripHeavyHtml_AltTextEntities_StayDecodedOnce()
+    {
+        const string html = "<body><img src=\"x.png\" alt=\"Tom &amp; Jerry\"></body>";
+
+        var result = MessageBodyHtmlBuilder.StripHeavyHtml(html);
+
+        Assert.Contains("Tom &amp; Jerry", result);
+        Assert.DoesNotContain("&amp;amp;", result);
+    }
+
+    [Fact]
+    public void HtmlToText_ImageAltText_ReachesTheSimplifiedBody()
+    {
+        var text = MessageBodyHtmlBuilder.HtmlToText(
+            "<body><p>Follow us on <a href=\"http://t.example/c/1p\"><img alt=\"Facebook\"></a></p></body>");
+
+        Assert.Contains("Facebook", text);
+    }
+
+    [Fact]
+    public void TryStripHeavyHtml_ImageAltPassTimeout_ReturnsFalse()
+    {
+        // The alt-substitution pass must fail closed with the rest: a partially substituted
+        // document is not a sanitized one.
+        var html = string.Concat(System.Linq.Enumerable.Repeat(
+            "<img src=\"x.png\" alt=\"icon\">", 5000));
+
+        var ok = MessageBodyHtmlBuilder.TryStripHeavyHtml(
+            html, System.TimeSpan.FromTicks(1), out _);
+
+        Assert.False(ok);
+    }
+
+    [Fact]
     public void TryStripHeavyHtml_NormalInput_ReturnsTrueAndStrips()
     {
         const string html = "<body><script>alert(1)</script><p onclick=\"x()\">Hello</p></body>";

--- a/QuickMail/Helpers/MessageBodyHtmlBuilder.cs
+++ b/QuickMail/Helpers/MessageBodyHtmlBuilder.cs
@@ -27,6 +27,16 @@ public static class MessageBodyHtmlBuilder
     private static readonly char[] AutoLinkTrailingPunct =
         ['.', ',', ';', ':', '!', '?', ')', ']', '}', '>', '\''];
 
+    /// <summary>
+    /// An <c>&lt;img&gt;</c> carrying a non-empty <c>alt</c>. An empty <c>alt=""</c> is deliberately
+    /// NOT matched: that is the author declaring the image decorative, and the right handling is the
+    /// plain removal the later pass performs.
+    /// </summary>
+    private static readonly Regex ImgWithAltText = new(
+        @"<img\b[^>]*?\balt\s*=\s*(?:""(?<alt>[^""]+)""|'(?<alt>[^']+)'|(?<alt>[^\s""'>]+))[^>]*>",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled,
+        HtmlRegexTimeout);
+
     /// <param name="themeCss">
     /// Optional theme CSS from <see cref="IThemeService.BuildMessageCss"/> — the
     /// <c>:root { --qm-* }</c> variable block. When null the document's CSS
@@ -243,6 +253,13 @@ public static class MessageBodyHtmlBuilder
             return result;
         }
 
+        string StepEval(string input, Regex regex, MatchEvaluator evaluator)
+        {
+            if (!TryRegexReplace(input, regex, evaluator, timeout, out var result))
+                complete = false;
+            return result;
+        }
+
         var body = html;
         // Remove elements hidden via inline display:none (e.g. newsletter preheader padding divs).
         // Must run before style-attribute stripping, which would make these visible.
@@ -254,6 +271,13 @@ public static class MessageBodyHtmlBuilder
         body = Step(body, "<style\\b.*?</style>", RegexOptions.IgnoreCase | RegexOptions.Singleline);
         body = Step(body, "<svg\\b.*?</svg>", RegexOptions.IgnoreCase | RegexOptions.Singleline);
         body = Step(body, "<(iframe|object|embed|video|audio|canvas|form)\\b.*?</\\1>", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+        // Substitute each image's alt text before images are removed (issue #163). Removing the
+        // element outright discards the only name the image has: the CSP blocks the pixels either
+        // way, so what is lost is not the picture but the words describing it. Worst where the
+        // image is the whole content of a link — the anchor is left empty, has no accessible name,
+        // and is announced from its href instead, so a row of social icons reads as whatever the
+        // tracking URLs happen to spell ("redirect", "c/1pfGAI30…") rather than "Facebook".
+        body = StepEval(body, ImgWithAltText, ImageAltReplacement);
         body = Step(body, "<(img|link|base|input|button|meta)\\b[^>]*>", RegexOptions.IgnoreCase | RegexOptions.Singleline);
         // target is stripped so that anchors navigate in-place: a target="_blank" link raises
         // WebView2's NewWindowRequested rather than NavigationStarting, and any host that
@@ -263,6 +287,22 @@ public static class MessageBodyHtmlBuilder
         body = Step(body, "\\s(on\\w+|style|src|srcset|background|target)\\s*=\\s*(\"[^\"]*\"|'[^']*'|[^\\s>]+)", RegexOptions.IgnoreCase | RegexOptions.Singleline);
         stripped = body;
         return complete;
+    }
+
+    /// <summary>
+    /// The text that stands in for an image: its alt text and nothing else, so a link whose content
+    /// is an icon reads by its label ("Facebook link") exactly as it does in a client that shows the
+    /// picture. No "Image:" prefix — the marker would be spoken on every icon in a footer row, and
+    /// the cost of that repetition outweighs telling the reader the words arrived from a graphic.
+    ///
+    /// Decoded then re-encoded rather than spliced through: the attribute may hold entities that are
+    /// already correct as text (<c>&amp;amp;</c>), but it may equally hold a bare <c>&lt;</c>, which
+    /// is legal inside a quoted attribute and would open a tag once moved into content.
+    /// </summary>
+    private static string ImageAltReplacement(Match match)
+    {
+        var alt = match.Groups["alt"].Value.Trim();
+        return alt.Length == 0 ? string.Empty : WebUtility.HtmlEncode(WebUtility.HtmlDecode(alt));
     }
 
     public static string RemoveTitle(string html) =>
@@ -317,6 +357,31 @@ public static class MessageBodyHtmlBuilder
         catch (RegexMatchTimeoutException)
         {
             LogService.Log($"HTML cleanup timed out for pattern: {pattern}");
+            result = input;
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// As <see cref="TryRegexReplace(string, string, string, RegexOptions, TimeSpan, out string)"/>,
+    /// for a pre-built <see cref="Regex"/> whose replacement is computed per match.
+    /// </summary>
+    private static bool TryRegexReplace(
+        string input, Regex regex, MatchEvaluator evaluator, TimeSpan timeout, out string result)
+    {
+        try
+        {
+            // The compiled Regex carries its own timeout; honor a caller-supplied one that differs
+            // (the tests drive a deliberately tiny value through this path).
+            var effective = regex.MatchTimeout == timeout
+                ? regex
+                : new Regex(regex.ToString(), regex.Options & ~RegexOptions.Compiled, timeout);
+            result = effective.Replace(input, evaluator);
+            return true;
+        }
+        catch (RegexMatchTimeoutException)
+        {
+            LogService.Log($"HTML cleanup timed out for pattern: {regex}");
             result = input;
             return false;
         }


### PR DESCRIPTION
Fixes #163.

## What was wrong

`MessageBodyHtmlBuilder.TryStripHeavyHtml` deleted `<img>` elements outright. The strict CSP (`img-src 'none'`) is what actually stops the pixels loading, so the deletion did not add safety — it discarded the only name the image had.

Two symptoms, one cause:

- **The original report**: an image with proper alt text, sent from Outlook, produced no indication of the image or its alt text in QuickMail.
- **Worse, and how this resurfaced**: when the image is the *entire* content of a link, the anchor is left empty. An empty link has no accessible name, so WebView2 falls back to the `href`. A newsletter social-icon row was announced from its tracking URLs — "redirect", "c/1pfGAI30…" — instead of Facebook, Twitter, Instagram.

Confirmed against real mail in the local cache, e.g.:

```html
<a href="https://emails.cunard.com/c/1pfGAI30g7qGgNMDNdQuVKHfkKEOKV"><img alt="Facebook" ...></a>
<a href="https://substack.com/redirect/a7992ee5-…"><img alt="Start writing" ...></a>
```

## The fix

A substitution pass runs immediately before the removal pass and replaces each image with its alt text.

- `alt=""` is left alone — that is the author declaring the image decorative, and plain removal is the correct handling. Whitespace-only alt is treated the same way.
- A missing `alt` is likewise left to the removal pass; there is no name to recover, and the link keeps today's href fallback.
- The value is HTML-decoded and re-encoded rather than spliced through: an attribute may hold entities that are already correct as text (`&amp;`), but may equally hold a bare `<`, which is legal inside a quoted attribute and would open a tag once moved into content.
- The pass fails closed with the rest of the chain — a partially substituted document is not a sanitized one.

No marker word in front of the text (no "Image: Facebook"). Kelly's call: the marker would be spoken on every icon in every footer row, and that repetition costs more than the provenance is worth. A social-icon row now reads "Facebook link, Twitter link, Instagram link", the same as a client that shows the picture.

The alt text also reaches `HtmlToText`, so simplified-body and plain-text views gain it too. Message-list preview text is unaffected — it comes from the server (IMAP `PREVIEW` / Graph `BodyPreview`), not from this path.

## Tests

Seven new cases in `MessageBodyHtmlBuilderTests`: alt survives the image; an icon-only link is named by its alt and not its href; the three no-useful-alt shapes leave nothing behind; markup in an alt is encoded not spliced; entities decode exactly once; alt reaches `HtmlToText`; and the new pass fails closed on timeout.

Full suite: 2685 passed, 1 failed — `ReportBugViewModelTests.CopyAndOpen_BlankSummary_DoesNotCopyOrOpen`, a `CLIPBRD_E_CANT_OPEN` from something else on the machine holding the clipboard. It fails identically with this change stashed, so it is not from this PR.

## Not in scope

Downloading remote images (a setting to opt in per message or per sender, and the CSP relaxation that requires) is a separate piece of work — the alt text is what names the image whether or not the pixels ever load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
