### PR TITLE
Release notes v0.8.38: the four changes that landed after the notes were started

### DIFF
--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -539,7 +539,9 @@ Press **Ctrl+Enter** to open a message in a new tab regardless of the Reading Mo
 
 ### Reading Pane
 
-The reading pane renders HTML messages with WebView2. Links open in your default browser. Images from remote sources are blocked by default.
+The reading pane renders HTML messages with WebView2. Links open in your default browser.
+
+Images from remote sources are not loaded — fetching them tells the sender your address is live, which is what a tracking pixel in a newsletter is for. Where the sender wrote a description for a picture, QuickMail shows that description in its place, so a picture that is also a link reads by what it is ("Facebook link") rather than by its web address. A picture the sender marked as decorative contributes nothing, which is what marking it that way asks for.
 
 Press **F6** or **Shift+F6** to move between the reading pane and other panes.
 
@@ -1077,6 +1079,8 @@ Invitations you receive by email show in the calendar with a **Pending** status 
 2. Choose **Accept**, **Tentative**, or **Decline** — or **Open full appointment** to read the original email instead. Press **Escape** to close the menu without responding.
 
 QuickMail sends your reply to the organizer from the account that received the invitation and updates the appointment's status, so it no longer shows as pending. Accept, Tentative, and Decline are also in the Command Palette (**Ctrl+Shift+P**) when a pending invitation is selected.
+
+You can also answer from the email itself. Open the invitation and the message starts with a short card giving the title, when the meeting is, where, and who organized it, followed by **Accept**, **Tentative**, and **Decline**. The card is worth reading even when you plan to answer elsewhere: for many invitations it is the only place the date and time appear at all — a meeting sent from Outlook for a Zoom call is a body of join links and dial-in numbers, and the when is carried in the attachment rather than written out. The card appears however you have QuickMail set to open messages, and in a message window the three responses are on that window's Command Palette (**Ctrl+Shift+P**) as well.
 
 ### Creating an appointment
 

--- a/docs/release-notes-v0.8.38.md
+++ b/docs/release-notes-v0.8.38.md
@@ -6,8 +6,8 @@ There are four downloads. Take a regular one unless you know your PC has an ARM 
 
 | Download | When to use |
 |----------|-------------|
-| **`QuickMail-win.msi`** — Windows installer | Recommended for most users. A standard setup wizard with license agreement; installs per-user with no elevation required, adds the WebView2 Runtime if missing, and enables automatic updates. |
-| **`QuickMail-win-arm64.msi`** — Windows installer, ARM | The same installer for PCs with an ARM processor, such as the Snapdragon X models of Surface Laptop and Surface Pro. |
+| **`QuickMail-0.8.38-win.msi`** — Windows installer | Recommended for most users. A standard setup wizard with license agreement; installs per-user with no elevation required, adds the WebView2 Runtime if missing, and enables automatic updates. |
+| **`QuickMail-0.8.38-win-arm64.msi`** — Windows installer, ARM | The same installer for PCs with an ARM processor, such as the Snapdragon X models of Surface Laptop and Surface Pro. |
 | **`QuickMail.exe`** — standalone portable executable | No installation required. Copy it anywhere and run. |
 | **`QuickMail-arm64.exe`** — standalone portable executable, ARM | The portable version for PCs with an ARM processor. |
 
@@ -49,6 +49,32 @@ Both windows honor it now. With it on, a rule in the account-at-a-time window re
 
 The three **Show field labels in the … list** checkboxes — contact list, calendar event list, rules list — were each read out with "accessible names" tacked on the end, and the contact one called the list "the address book contact list" rather than what the label says. Each is now read out as its own label. ([#493](https://github.com/kellylford/QuickMail/issues/493))
 
+## Changed: Report a Bug files through a QuickMail service
+
+**Help → Report a Bug → Send** works exactly as it did — fill in the report, choose **Send**, and the issue is filed for you. What changed is what happens behind that button.
+
+Until now QuickMail talked to GitHub directly, using a GitHub access token built into the program. A token inside a program you can download is a token anyone who downloads it can pull back out, and every report filed this way arrived on GitHub under the QuickMail author's own account rather than as a report from a user.
+
+Reports now go to a QuickMail service that files them, and that service is the only thing holding any GitHub credential. Issues you send arrive under a QuickMail bot identity. The report itself is unchanged, and still contains no email address or anything else identifying you.
+
+If you are upgrading, QuickMail removes the old credential from Windows Credential Manager the first time it starts. Nothing you need to do. ([#501](https://github.com/kellylford/QuickMail/issues/501))
+
+## Fixed: a meeting invitation opened in its own window had no date or time
+
+With **Settings → Windowing** set to open messages in their own window, an invitation was missing the card that states when the meeting is and offers **Accept**, **Tentative**, and **Decline**. The card only ever appeared in the reading pane.
+
+This is worse than it sounds, because for many invitations the card is the *only* place the date and time appear. An invitation sent through Outlook for a Zoom meeting is a body full of join links and dial-in numbers; the actual when lives in the attached calendar part and nowhere else. In window mode there was no date, no time, and no way to answer.
+
+The card now appears wherever a message is opened, and the message window answers invitations too — the three responses are on its command palette (**Ctrl+Shift+P**) as well as in the card.
+
+## Fixed: pictures in a message lost their descriptions
+
+QuickMail does not load images from the internet, and that has not changed. But it was removing each image so completely that the description the sender wrote for it — the text meant to be read when the picture cannot be seen — went with it. Where a sender had described a picture properly, you got nothing at all.
+
+It was worst where a picture *is* a link, which is how nearly every newsletter builds the row of social media links at the bottom. Removing the picture left a link with no text in it, so it was announced by its web address instead — and those addresses are tracking links. A row that should read "Facebook link, Twitter link, Instagram link" read as "redirect" three times over.
+
+Descriptions now stay when the picture goes. A picture the sender marked as decorative still contributes nothing, which is what marking it that way asks for. ([#163](https://github.com/kellylford/QuickMail/issues/163))
+
 ---
 
 ## Internal
@@ -67,6 +93,18 @@ Everything below is developer detail — implementation notes, test coverage, an
 
 - **Run on Existing Mail was the same parity gap as Test Rule, one sweep later, and it carried a scope decision with it.** The unified window had the command wired and registered but no button and no context-menu item, so it was palette-only for every Microsoft 365 user — the one the v0.8.37 Test-Rule sweep missed (#493). The mechanical half was the easy half. `RunClientRulesOnExisting` had always built its Inbox map over **every** account in `CachedFolders`, which was unambiguous in the client-only window because that window lists every account together; under an account picker, a button directly below **Account: Work** would have read as "run this for Work" while processing every mailbox. `RunOnExistingRequested` now carries a `Guid?`: the unified window passes `SelectedAccount.Id` and the shared handler filters the map to it; the client-only window passes `null` and keeps its all-accounts run, byte-for-byte unchanged. The scope is enforced where it is load-bearing rather than cosmetically — `ApplyRulesToExistingAsync` only ever touches messages whose account is a key in that map, so an *unscoped* legacy rule reaching an out-of-scope mailbox is not possible. The scope decision then settled the `CanExecute` question filed alongside it: because the run is now exactly the account on screen, "this account has no enabled QuickMail rules" is an unambiguous statement, so `CanRunOnExisting` gates on it. A Graph mailbox whose rules are all server-side therefore gets a disabled control rather than one that reports "0 moved". The outcome also sets `StatusText`, not just `Announce`: the same `Result`-category reasoning as Test Rule, since a newly surfaced button whose only feedback is an announcement is imperceptible to a user running with announcements off, error included.
 - **`RuleListShowFieldLabels` was read by one window and ignored by the other.** The **Show field labels in the rules list** checkbox is in Settings for every user regardless of account type, but only `RulesManagerViewModel` read it — so for a Microsoft 365 user the checkbox silently did nothing. `UnifiedRuleRow` now takes the flag through its `ForServer`/`ForClient` factories and prefixes each field in `RowText`: `Rule Newsletters, runs on server, status enabled` rather than `Newsletters, on server, enabled`. Read once when the manager opens, matching the client window, so a Settings change applies the next time it is opened. Note the one asymmetry between the two windows: in the client window the setting shapes `AccessibleName` only, while `UnifiedRuleRow.ToString()` returns `RowText`, so here it changes the visible row text too. The detail pane is untouched either way — it always carries the full definition.
+
+### Message rendering
+
+- **The event card moved from a call site to the builder, because the obligation was the bug.** `MainViewModel` built the invite card and `MainWindow` injected it, so every other render surface silently shipped without one — `MessageWindow` had done so since it existed. Splitting it into `Helpers/EventCardHtmlBuilder` and injecting it inside `MessageBodyHtmlBuilder.BuildMessageHtml`, from the detail's own `CalendarInvite`, means no surface can omit it by forgetting. The failure mode is what makes this worth the move rather than a second call: the card is the only rendering of the ICS part, so a surface that drops it shows an invitation with no date and no time at all, and a body that is all join links reads as though the meeting has no when. `MessageWindow` also intercepts the card's `quickmail:` links, guards its `aria-live` confirmation against having navigated away mid-send, and carries the three RSVP actions in its palette.
+- **Image alt text is substituted before the removal pass, not preserved by weakening it.** `TryStripHeavyHtml` deleted `<img>` outright; the CSP's `img-src 'none'` is what blocks the pixels, so the deletion was discarding the name and buying nothing. The new pass replaces each image with its alt text and leaves the removal pass to take the tag. `alt=""` and whitespace-only alt are deliberately not matched — that is the author declaring the image decorative, and plain removal is the correct handling — and a missing `alt` keeps today's href fallback because there is no name to recover. The value is HTML-decoded and re-encoded rather than spliced: an attribute may hold entities that are already correct as text, but may equally hold a bare `<`, which is legal inside a quoted attribute and would open a tag once moved into content. The pass fails closed with the rest of the chain, since a partially substituted document is not a sanitized one. The link case is what makes this an accessibility defect rather than a cosmetic one: an anchor whose only content was the image is left empty, an empty link has no accessible name, and WebView2 names it from the `href` — which for a newsletter footer is a tracking URL. `MessageBodyHtmlBuilderTests` pins the icon-only-link shape against a real captured example, plus the three no-useful-alt shapes, entity round-tripping, markup in an alt, and the timeout. Message-list preview text is unaffected: it comes from the server (IMAP `PREVIEW` / Graph `BodyPreview`), not from this path. ([#163](https://github.com/kellylford/QuickMail/issues/163))
+- **Loading remote images at all is deliberately still not offered.** ([#508](https://github.com/kellylford/QuickMail/issues/508)) tracks the opt-in — per message, per sender, and the `img-src` relaxation confined to that path. Alt text is the right fix independent of it: it is what names an image whether or not the pixels ever load.
+
+### Bug reporting
+
+- **The capability moved out of the binary; the key that stayed in it was reduced to something worth extracting nothing for.** Release builds compiled a fine-grained GitHub PAT into the single-file executable and posted to `api.github.com` with it, so anyone who downloaded QuickMail could pull the token out, and GitHub attributed every user-filed report to the token owner (#222). A GitHub App now owns the write capability with its private key held by a Cloudflare Worker (`relay/`). The client posts to the Worker with a relay key that still ships in the binary and is still extractable — the difference is that its whole authority is "file an issue on kellylford/QuickMail", it is rate-limited at the relay, and it rotates without touching a GitHub account. The client also stopped sending its own labels: a client that names them lets anyone holding the extracted key apply arbitrary ones, so the relay decides labels. Upgrading installs delete the pre-relay PAT from Credential Manager on first run.
+- **The PKCS#1 → PKCS#8 conversion is tested against a real Node export, byte for byte.** GitHub hands out App keys as PKCS#1 and WebCrypto imports only PKCS#8, so a wrong conversion fails at runtime with an opaque error and nothing to bisect. `relay/test/jwt.test.js` asserts identical DER rather than "it parsed".
+- **`docs/BUG-REPORTING.md` is the runbook** — rotating the relay key, reading Worker logs, and what to check when reports stop arriving. `relay/README.md` records the workers.dev subdomain step that broke the first deploy.
 
 ---
 


### PR DESCRIPTION
Completes `docs/release-notes-v0.8.38.md`, which stopped at the #495 checkbox fix.

Added, user-facing: the bug-report relay (#501), the Window-mode invite card, and image alt text (#163). Added, engineering: a **Message rendering** section (event card moved into the builder; the alt-text pass and why `alt=""` is excluded) and a **Bug reporting** section (GitHub App + Worker, the PKCS#1→PKCS#8 test, the runbook).

Also corrects the download table. It has named the installers `QuickMail-win.msi` / `QuickMail-win-arm64.msi` for several releases, while the assets actually attached carry the version — v0.8.37 shipped `QuickMail-0.8.37-win.msi`. Someone reading the table and looking for that filename on the release page does not find it.

User guide: the reading-pane images paragraph now says descriptions stand in for pictures, and **Responding to a meeting invitation** gained the from-the-email path, which was undocumented — worth stating plainly because the card is the only place the date and time appear for an Outlook-sent Zoom invitation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)