### PR TITLE
Shared mailboxes PR 1: linked-account model + manual add (feature-gated, no backend access)

### DIFF
--- a/QuickMail.Tests/AddSharedMailboxViewModelTests.cs
+++ b/QuickMail.Tests/AddSharedMailboxViewModelTests.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using QuickMail.Models;
+using QuickMail.ViewModels;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+public class AddSharedMailboxViewModelTests
+{
+    private static AccountModel Graph(string name, bool personal = false) => new()
+    {
+        Id = Guid.NewGuid(), AccountName = name, Username = name.ToLowerInvariant() + "@work.com",
+        BackendKind = BackendKind.MicrosoftGraph, IsPersonalMicrosoftAccount = personal,
+    };
+    private static AccountModel Imap(string name) => new()
+    {
+        Id = Guid.NewGuid(), AccountName = name, Username = name.ToLowerInvariant() + "@host.com",
+        BackendKind = BackendKind.ImapSmtp,
+    };
+    private static AccountModel SharedOf(AccountModel parent, string addr) => new()
+    {
+        Id = Guid.NewGuid(), AccountName = addr, Username = addr, SharedAddress = addr,
+        IsShared = true, ParentAccountId = parent.Id, BackendKind = parent.BackendKind,
+    };
+
+    [Fact]
+    public void ParentOptions_ExcludeSharedAndPersonalMicrosoft()
+    {
+        var work = Graph("Work");
+        var personal = Graph("Personal", personal: true);
+        var imap = Imap("Home");
+        var shared = SharedOf(work, "support@work.com");
+
+        var vm = new AddSharedMailboxViewModel([work, personal, imap, shared]);
+
+        Assert.Contains(work, vm.ParentOptions);
+        Assert.Contains(imap, vm.ParentOptions);
+        Assert.DoesNotContain(personal, vm.ParentOptions);   // personal MS has no shared mailboxes
+        Assert.DoesNotContain(shared, vm.ParentOptions);     // a shared account can't be a parent
+    }
+
+    [Fact]
+    public void ShowGraphPollNote_TrueForGraphParent_FalseForImap()
+    {
+        var vm = new AddSharedMailboxViewModel([Graph("Work"), Imap("Home")]);
+
+        vm.SelectedParent = vm.ParentOptions.First(a => a.BackendKind == BackendKind.MicrosoftGraph);
+        Assert.True(vm.ShowGraphPollNote);
+
+        vm.SelectedParent = vm.ParentOptions.First(a => a.BackendKind == BackendKind.ImapSmtp);
+        Assert.False(vm.ShowGraphPollNote);
+    }
+
+    [Fact]
+    public void Add_ValidAddress_RaisesEvent_WithSharedAccountLinkedToParent()
+    {
+        var work = Graph("Work");
+        var vm = new AddSharedMailboxViewModel([work], preferredParentId: work.Id)
+        {
+            Address = "support@work.com",
+        };
+        AccountModel? created = null;
+        vm.SharedMailboxAdded += a => created = a;
+
+        vm.AddCommand.Execute(null);
+
+        Assert.NotNull(created);
+        Assert.True(created!.IsShared);
+        Assert.Equal(work.Id, created.ParentAccountId);
+        Assert.Equal("support@work.com", created.SharedAddress);
+        Assert.Equal(BackendKind.MicrosoftGraph, created.BackendKind);   // follows the parent
+        Assert.Empty(vm.ErrorText);
+    }
+
+    [Fact]
+    public void Add_InvalidAddress_SetsError_NoEvent()
+    {
+        var vm = new AddSharedMailboxViewModel([Graph("Work")]) { Address = "not-an-email" };
+        vm.SelectedParent = vm.ParentOptions.First();
+        var raised = false;
+        vm.SharedMailboxAdded += _ => raised = true;
+
+        vm.AddCommand.Execute(null);
+
+        Assert.False(raised);
+        Assert.Contains("valid email", vm.ErrorText);
+    }
+
+    [Fact]
+    public void Add_DuplicateAddress_SetsError_NoEvent()
+    {
+        var work = Graph("Work");                       // work@work.com already exists
+        var vm = new AddSharedMailboxViewModel([work]) { Address = "work@work.com" };
+        vm.SelectedParent = vm.ParentOptions.First();
+        var raised = false;
+        vm.SharedMailboxAdded += _ => raised = true;
+
+        vm.AddCommand.Execute(null);
+
+        Assert.False(raised);
+        Assert.Contains("already exists", vm.ErrorText);
+    }
+
+    [Fact]
+    public void AddCommand_Disabled_UntilAddressAndParentPresent()
+    {
+        var vm = new AddSharedMailboxViewModel([Graph("Work")]);
+        vm.SelectedParent = null;
+        Assert.False(vm.AddCommand.CanExecute(null));
+
+        vm.SelectedParent = vm.ParentOptions.First();
+        Assert.False(vm.AddCommand.CanExecute(null));   // still no address
+
+        vm.Address = "support@work.com";
+        Assert.True(vm.AddCommand.CanExecute(null));
+    }
+}

--- a/QuickMail.Tests/AllArchiveVirtualFolderTests.cs
+++ b/QuickMail.Tests/AllArchiveVirtualFolderTests.cs
@@ -20,67 +20,6 @@ namespace QuickMail.Tests;
 
 public class AllArchiveVirtualFolderTests
 {
-    // Folder + message source for a fixed set of accounts. Folders are keyed by account so each
-    // account can have a different archive shape (server-flagged, override, or none at all).
-    private sealed class FolderedMailService : IMailService
-    {
-        private readonly Dictionary<Guid, List<MailFolderModel>> _folders;
-        private readonly Dictionary<(Guid, string), List<MailMessageSummary>> _messages;
-
-        public FolderedMailService(
-            Dictionary<Guid, List<MailFolderModel>> folders,
-            Dictionary<(Guid, string), List<MailMessageSummary>> messages)
-        {
-            _folders  = folders;
-            _messages = messages;
-        }
-
-        public Task<List<MailFolderModel>> GetFoldersAsync(Guid accountId, CancellationToken ct = default) =>
-            Task.FromResult(_folders.TryGetValue(accountId, out var f) ? new List<MailFolderModel>(f) : []);
-
-        public Task<List<MailMessageSummary>> GetMessageSummariesAsync(
-            Guid accountId, string folderName, int maxMessages, CancellationToken ct = default) =>
-            Task.FromResult(_messages.TryGetValue((accountId, folderName), out var m)
-                ? new List<MailMessageSummary>(m) : []);
-
-        public Task<List<MailMessageSummary>> GetMessagesSinceDateAsync(Guid accountId, string folderName, DateTime since, CancellationToken ct = default)
-            => GetMessageSummariesAsync(accountId, folderName, int.MaxValue, ct);
-
-        public Task ConnectAsync(AccountModel account, string? password = null, CancellationToken ct = default) => Task.CompletedTask;
-        public bool IsConnected(Guid accountId) => true;
-        public Task DisconnectAsync(Guid accountId, CancellationToken ct = default) => Task.CompletedTask;
-        public Task<List<MailMessageSummary>> GetMessagesSinceAsync(Guid accountId, string folderName, string sinceMessageId, int initialCount, CancellationToken ct = default) => Task.FromResult(new List<MailMessageSummary>());
-        public Task<MailMessageDetail> GetMessageDetailAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default) => Task.FromResult(new MailMessageDetail());
-        public Task<MailMessageDetail> PrefetchMessageDetailAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default) => Task.FromResult(new MailMessageDetail());
-        public Task MarkReadAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default) => Task.CompletedTask;
-        public Task MarkReadBatchAsync(Guid accountId, string folderName, IList<string> messageIds, CancellationToken ct = default) => Task.CompletedTask;
-        public Task SetMessageFlaggedAsync(Guid accountId, string folderName, string messageId, bool flagged, CancellationToken ct = default) => Task.CompletedTask;
-        public Task MoveToTrashAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default) => Task.CompletedTask;
-        public Task MoveToTrashBatchAsync(Guid accountId, string folderName, IList<string> messageIds, CancellationToken ct = default) => Task.CompletedTask;
-        public Task PermanentlyDeleteBatchAsync(Guid accountId, string folderName, IList<string> messageIds, CancellationToken ct = default) => Task.CompletedTask;
-        public Task NoOpAsync(Guid accountId, CancellationToken ct = default) => Task.CompletedTask;
-        public Task<int> CountTrashMessagesAsync(Guid accountId, CancellationToken ct = default) => Task.FromResult(0);
-        public Task<int> EmptyTrashAsync(Guid accountId, CancellationToken ct = default) => Task.FromResult(0);
-        public Task<IList<string>> GetFolderMessageIdsAsync(Guid accountId, string folderName, CancellationToken ct = default) => Task.FromResult<IList<string>>(Array.Empty<string>());
-        public Task<IReadOnlyList<(string Id, DateTimeOffset ReceivedUtc, bool IsRead)>> GetFolderMessageIdDatesAsync(Guid accountId, string folderName, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(string, DateTimeOffset, bool)>>([]);
-        public Task<IReadOnlyDictionary<string, string>> FetchPreviewsAsync(Guid accountId, string folderName, IList<string> messageIds, int maxLines, CancellationToken ct = default) => Task.FromResult<IReadOnlyDictionary<string, string>>(new Dictionary<string, string>());
-        public Task<int> PollAsync(Guid accountId, string folderName, CancellationToken ct = default) => Task.FromResult(0);
-        public Task<(int Total, int Unread)> GetInboxStatusAsync(Guid accountId, CancellationToken ct = default) => Task.FromResult((0, 0));
-        public Task<string?> FindDraftsFolderNameAsync(Guid accountId, CancellationToken ct = default) => Task.FromResult<string?>(null);
-        public Task<string> AppendDraftAsync(Guid accountId, ComposeModel draft, string? replaceMessageId, CancellationToken ct = default) => Task.FromResult("0");
-        public Task AppendToSentAsync(Guid accountId, ComposeModel sent, CancellationToken ct = default) => Task.CompletedTask;
-        public Task<byte[]> DownloadAttachmentAsync(Guid accountId, string folderName, string messageId, string partSpecifier, CancellationToken ct = default) => Task.FromResult(Array.Empty<byte>());
-        public Task CopyMessagesAsync(Guid accountId, string folderName, IList<string> messageIds, string destinationFolder, CancellationToken ct = default) => Task.CompletedTask;
-        public Task MoveMessagesAsync(Guid accountId, string folderName, IList<string> messageIds, string destinationFolder, CancellationToken ct = default) => Task.CompletedTask;
-        public Task CreateFolderAsync(Guid accountId, string? parentFolderName, string name, CancellationToken ct = default) => Task.CompletedTask;
-        public Task DeleteFolderAsync(Guid accountId, string folderName, CancellationToken ct = default) => Task.CompletedTask;
-        public Task RenameFolderAsync(Guid accountId, string folderName, string newName, string? newParentFolderName, CancellationToken ct = default) => Task.CompletedTask;
-        public Task CopyFolderAsync(Guid accountId, string folderName, string? destinationParentName, CancellationToken ct = default) => Task.CompletedTask;
-        public void StartWatchers(IReadOnlyList<AccountModel> accounts, CancellationToken ct = default) { }
-        public void StopWatchers() { }
-        public void Dispose() { }
-    }
-
     // Sync service whose FolderSynced event the test can raise on demand, to exercise the
     // live-arrival branch of OnFolderSynced.
     private sealed class RaisableSyncService : ISyncService

--- a/QuickMail.Tests/FolderedMailService.cs
+++ b/QuickMail.Tests/FolderedMailService.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using QuickMail.Models;
+using QuickMail.Services;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// Shared test <see cref="IMailService"/> whose folders and messages are supplied per account, so a
+/// test can stand up a <see cref="ViewModels.MainViewModel"/> with a known folder tree without a real
+/// backend. Extracted from AllArchiveVirtualFolderTests (#452) so the shared-mailbox tests (#31) can
+/// reuse it. Everything except folder/message lookup is an inert no-op.
+/// </summary>
+internal sealed class FolderedMailService : IMailService
+{
+    private readonly Dictionary<Guid, List<MailFolderModel>> _folders;
+    private readonly Dictionary<(Guid, string), List<MailMessageSummary>> _messages;
+
+    public FolderedMailService(
+        Dictionary<Guid, List<MailFolderModel>> folders,
+        Dictionary<(Guid, string), List<MailMessageSummary>> messages)
+    {
+        _folders  = folders;
+        _messages = messages;
+    }
+
+    public Task<List<MailFolderModel>> GetFoldersAsync(Guid accountId, CancellationToken ct = default) =>
+        Task.FromResult(_folders.TryGetValue(accountId, out var f) ? new List<MailFolderModel>(f) : []);
+
+    public Task<List<MailMessageSummary>> GetMessageSummariesAsync(
+        Guid accountId, string folderName, int maxMessages, CancellationToken ct = default) =>
+        Task.FromResult(_messages.TryGetValue((accountId, folderName), out var m)
+            ? new List<MailMessageSummary>(m) : []);
+
+    public Task<List<MailMessageSummary>> GetMessagesSinceDateAsync(Guid accountId, string folderName, DateTime since, CancellationToken ct = default)
+        => GetMessageSummariesAsync(accountId, folderName, int.MaxValue, ct);
+
+    public Task ConnectAsync(AccountModel account, string? password = null, CancellationToken ct = default) => Task.CompletedTask;
+    public bool IsConnected(Guid accountId) => true;
+    public Task DisconnectAsync(Guid accountId, CancellationToken ct = default) => Task.CompletedTask;
+    public Task<List<MailMessageSummary>> GetMessagesSinceAsync(Guid accountId, string folderName, string sinceMessageId, int initialCount, CancellationToken ct = default) => Task.FromResult(new List<MailMessageSummary>());
+    public Task<MailMessageDetail> GetMessageDetailAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default) => Task.FromResult(new MailMessageDetail());
+    public Task<MailMessageDetail> PrefetchMessageDetailAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default) => Task.FromResult(new MailMessageDetail());
+    public Task MarkReadAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default) => Task.CompletedTask;
+    public Task MarkReadBatchAsync(Guid accountId, string folderName, IList<string> messageIds, CancellationToken ct = default) => Task.CompletedTask;
+    public Task SetMessageFlaggedAsync(Guid accountId, string folderName, string messageId, bool flagged, CancellationToken ct = default) => Task.CompletedTask;
+    public Task MoveToTrashAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default) => Task.CompletedTask;
+    public Task MoveToTrashBatchAsync(Guid accountId, string folderName, IList<string> messageIds, CancellationToken ct = default) => Task.CompletedTask;
+    public Task PermanentlyDeleteBatchAsync(Guid accountId, string folderName, IList<string> messageIds, CancellationToken ct = default) => Task.CompletedTask;
+    public Task NoOpAsync(Guid accountId, CancellationToken ct = default) => Task.CompletedTask;
+    public Task<int> CountTrashMessagesAsync(Guid accountId, CancellationToken ct = default) => Task.FromResult(0);
+    public Task<int> EmptyTrashAsync(Guid accountId, CancellationToken ct = default) => Task.FromResult(0);
+    public Task<IList<string>> GetFolderMessageIdsAsync(Guid accountId, string folderName, CancellationToken ct = default) => Task.FromResult<IList<string>>(Array.Empty<string>());
+    public Task<IReadOnlyList<(string Id, DateTimeOffset ReceivedUtc, bool IsRead)>> GetFolderMessageIdDatesAsync(Guid accountId, string folderName, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(string, DateTimeOffset, bool)>>([]);
+    public Task<IReadOnlyDictionary<string, string>> FetchPreviewsAsync(Guid accountId, string folderName, IList<string> messageIds, int maxLines, CancellationToken ct = default) => Task.FromResult<IReadOnlyDictionary<string, string>>(new Dictionary<string, string>());
+    public Task<int> PollAsync(Guid accountId, string folderName, CancellationToken ct = default) => Task.FromResult(0);
+    public Task<(int Total, int Unread)> GetInboxStatusAsync(Guid accountId, CancellationToken ct = default) => Task.FromResult((0, 0));
+    public Task<string?> FindDraftsFolderNameAsync(Guid accountId, CancellationToken ct = default) => Task.FromResult<string?>(null);
+    public Task<string> AppendDraftAsync(Guid accountId, ComposeModel draft, string? replaceMessageId, CancellationToken ct = default) => Task.FromResult("0");
+    public Task AppendToSentAsync(Guid accountId, ComposeModel sent, CancellationToken ct = default) => Task.CompletedTask;
+    public Task<byte[]> DownloadAttachmentAsync(Guid accountId, string folderName, string messageId, string partSpecifier, CancellationToken ct = default) => Task.FromResult(Array.Empty<byte>());
+    public Task CopyMessagesAsync(Guid accountId, string folderName, IList<string> messageIds, string destinationFolder, CancellationToken ct = default) => Task.CompletedTask;
+    public Task MoveMessagesAsync(Guid accountId, string folderName, IList<string> messageIds, string destinationFolder, CancellationToken ct = default) => Task.CompletedTask;
+    public Task CreateFolderAsync(Guid accountId, string? parentFolderName, string name, CancellationToken ct = default) => Task.CompletedTask;
+    public Task DeleteFolderAsync(Guid accountId, string folderName, CancellationToken ct = default) => Task.CompletedTask;
+    public Task RenameFolderAsync(Guid accountId, string folderName, string newName, string? newParentFolderName, CancellationToken ct = default) => Task.CompletedTask;
+    public Task CopyFolderAsync(Guid accountId, string folderName, string? destinationParentName, CancellationToken ct = default) => Task.CompletedTask;
+    public void StartWatchers(IReadOnlyList<AccountModel> accounts, CancellationToken ct = default) { }
+    public void StopWatchers() { }
+    public void Dispose() { }
+}

--- a/QuickMail.Tests/GraphBackendGateTests.cs
+++ b/QuickMail.Tests/GraphBackendGateTests.cs
@@ -450,4 +450,34 @@ public class ConfigFeatureGateTests
     public void CliDisable_WinsOverCliEnable()
         => Assert.False(new ConfigFeatureGate(new ConfigModel(), new[] { "GraphBackend" }, new[] { "GraphBackend" })
             .IsEnabled(FeatureFlag.GraphBackend));
+
+    [Fact]
+    public void Default_SharedMailboxesOff() // #31: off while the multi-PR feature is built
+        => Assert.False(new ConfigFeatureGate(new ConfigModel(), Array.Empty<string>())
+            .IsEnabled(FeatureFlag.SharedMailboxes));
+
+    [Fact]
+    public void Config_EnablesSharedMailboxes() // testers turn it on with SharedMailboxes=true
+        => Assert.True(new ConfigFeatureGate(ConfigWith("SharedMailboxes", "true"), Array.Empty<string>())
+            .IsEnabled(FeatureFlag.SharedMailboxes));
+}
+
+/// <summary>#31: the "Add shared…" button — the sole shared-mailbox creation path — is bound to
+/// <see cref="AccountManagerViewModel.IsSharedMailboxesEnabled"/>, which must track the gate.</summary>
+public class SharedMailboxButtonGateTests
+{
+    private static AccountManagerViewModel Make(bool sharedEnabled)
+    {
+        var gate = new StubFeatureGate { [FeatureFlag.SharedMailboxes] = sharedEnabled };
+        return new AccountManagerViewModel(
+            new StubAccountService(), new StubCredentialService(), new StubImapMailService(),
+            new StubOAuthService(), new StubLocalStoreService(), new StubConfigService(),
+            gate, new ProviderCatalog());
+    }
+
+    [Fact]
+    public void GateOff_ButtonHidden() => Assert.False(Make(sharedEnabled: false).IsSharedMailboxesEnabled);
+
+    [Fact]
+    public void GateOn_ButtonShown() => Assert.True(Make(sharedEnabled: true).IsSharedMailboxesEnabled);
 }

--- a/QuickMail.Tests/NodeKeyTests.cs
+++ b/QuickMail.Tests/NodeKeyTests.cs
@@ -1,0 +1,42 @@
+using System;
+using QuickMail.Models;
+using QuickMail.ViewModels;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// Pins the folder-tree node-key fix (#31, spec §5.4): a header node keyed only by its label collides
+/// for two same-named accounts (their expansion state and selection get confused). Header nodes for
+/// accounts (and shared mailboxes) now carry the account id, so their keys are distinct.
+/// </summary>
+public class NodeKeyTests
+{
+    private static FolderTreeNode Header(string label, Guid? accountId = null) =>
+        new() { IsHeader = true, Label = label, AccountId = accountId };
+
+    [Fact]
+    public void SameNamedAccountHeaders_GetDistinctKeys()
+    {
+        var a = Guid.NewGuid();
+        var b = Guid.NewGuid();
+        Assert.NotEqual(MainViewModel.NodeKey(Header("Work", a)), MainViewModel.NodeKey(Header("Work", b)));
+    }
+
+    [Fact]
+    public void HeaderWithoutAccountId_StillKeysByLabel()
+    {
+        // Non-account group headers (All Mail, Views) have no account id and are unique by label.
+        Assert.Equal(MainViewModel.NodeKey(Header("All Mail")), MainViewModel.NodeKey(Header("All Mail")));
+    }
+
+    [Fact]
+    public void FolderNode_KeysByAccountAndFullName()
+    {
+        var acct = Guid.NewGuid();
+        var node = new FolderTreeNode { Folder = new MailFolderModel { AccountId = acct, FullName = "INBOX" } };
+        var key = MainViewModel.NodeKey(node);
+        Assert.Contains(acct.ToString(), key);
+        Assert.Contains("INBOX", key);
+    }
+}

--- a/QuickMail.Tests/SharedMailboxAggregateTests.cs
+++ b/QuickMail.Tests/SharedMailboxAggregateTests.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using QuickMail.Models;
+using QuickMail.ViewModels;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// Pins the shared-mailbox aggregate rule (#31, spec §5.1/§5.4 — the "item-2 trap"): a shared mailbox
+/// is excluded from the All-* aggregates via the <c>IsShared</c> predicate, NOT via
+/// <c>ExcludeFromAllMail</c> — so it stays out of All Inboxes / All Mail yet is still covered by the
+/// #456 sweep (whose filter is the folder flag, which shared folders never set). Also pins that a
+/// shared account gets its own top-level tree node with the "shared mailbox" accessible name.
+/// </summary>
+public class SharedMailboxAggregateTests
+{
+    private static readonly Guid NormalId = Guid.Parse("a1111111-1111-1111-1111-111111111111");
+    private static readonly Guid ParentId = Guid.Parse("a2222222-2222-2222-2222-222222222222");
+    private static readonly Guid SharedId = Guid.Parse("a3333333-3333-3333-3333-333333333333");
+
+    private static AccountModel Normal(Guid id, string label) => new()
+    {
+        Id = id, AccountName = label, Username = label.ToLowerInvariant() + "@example.com",
+        AuthType = AuthType.OAuth2Microsoft,
+    };
+
+    private static AccountModel Shared(Guid id, Guid parent, string label) => new()
+    {
+        Id = id, AccountName = label, Username = label.ToLowerInvariant() + "@example.com",
+        AuthType = AuthType.OAuth2Microsoft, BackendKind = BackendKind.MicrosoftGraph,
+        IsShared = true, ParentAccountId = parent, SharedAddress = label.ToLowerInvariant() + "@example.com",
+    };
+
+    private static MailFolderModel Inbox(Guid accountId) => new()
+    {
+        AccountId = accountId, FullName = "INBOX", DisplayName = "Inbox", Kind = SpecialFolderKind.Inbox,
+    };
+
+    private static async Task<MainViewModel> MakeVmAsync(
+        IEnumerable<AccountModel> accounts, Dictionary<Guid, List<MailFolderModel>> folders)
+    {
+        var vm = new MainViewModel(
+            new FolderedMailService(folders, new()), new StubAccountService(), new StubCredentialService(),
+            new StubLocalStoreService(), new StubOAuthService(), new StubSyncService(),
+            new StubConfigService(), new StubCommandRegistry(), new StubViewService(),
+            new StubRuleService(), new StubSmtpService());
+        foreach (var a in accounts) vm.Accounts.Add(a);
+        await vm.ConnectAllAccountsAsync();
+        return vm;
+    }
+
+    [Fact]
+    public async Task SharedAccount_ExcludedFromAllInboxes_ButStillSwept()
+    {
+        var sharedInbox = Inbox(SharedId);
+        var vm = await MakeVmAsync(
+            [Normal(NormalId, "Work"), Shared(SharedId, ParentId, "Support")],
+            new() { [NormalId] = [Inbox(NormalId)], [SharedId] = [sharedInbox] });
+
+        var sources = vm.FolderScopedAggregateSources(MainViewModel.AllInboxesFolder.FullName).ToList();
+
+        Assert.Contains(sources, s => s.Account.Id == NormalId);        // normal account contributes
+        Assert.DoesNotContain(sources, s => s.Account.Id == SharedId);  // shared is excluded from the aggregate
+
+        // The exclusion is by IsShared, not by the folder flag the sweep filters on — so the shared
+        // Inbox is NOT marked ExcludeFromAllMail and the #456 sweep still covers it.
+        Assert.False(sharedInbox.ExcludeFromAllMail);
+        Assert.True(vm.IsSharedAccountId(SharedId));
+        Assert.False(vm.IsSharedAccountId(NormalId));
+    }
+
+    [Fact]
+    public async Task SharedAccount_HasOwnTopLevelTreeNode_WithSharedAccessibleName()
+    {
+        // PR 1 reality: a shared account has no backend access yet, so it renders as a placeholder
+        // top-level node (no folders) — which must still carry the account id and the shared qualifier.
+        var vm = await MakeVmAsync([Shared(SharedId, ParentId, "Support")], new());
+
+        var node = vm.FolderTree.FirstOrDefault(n => n.IsHeader && n.AccountId == SharedId);
+        Assert.NotNull(node);
+        Assert.True(node!.IsSharedAccount);
+        Assert.Equal("Support, shared mailbox", node.AutomationName);
+    }
+}

--- a/QuickMail.Tests/SharedMailboxAggregateTests.cs
+++ b/QuickMail.Tests/SharedMailboxAggregateTests.cs
@@ -60,16 +60,54 @@ public class SharedMailboxAggregateTests
             [Normal(NormalId, "Work"), Shared(SharedId, ParentId, "Support")],
             new() { [NormalId] = [Inbox(NormalId)], [SharedId] = [sharedInbox] });
 
+        // Seed the shared account's folder cache (ConnectAllAccounts skips shared, so it would otherwise
+        // be absent and the TryGetValue guard — not the new IsShared guard — would do the excluding).
+        // With the cache populated, the exclusion can only come from `if (account.IsShared) continue;`,
+        // which is the line this test exists to pin (and the state PR 2 will actually be in).
+        await vm.RefreshFolderListAsync(SharedId);
+        Assert.NotEmpty(vm.FolderScopedAggregateSources(MainViewModel.AllInboxesFolder.FullName)); // sanity: cache is live
+
         var sources = vm.FolderScopedAggregateSources(MainViewModel.AllInboxesFolder.FullName).ToList();
 
         Assert.Contains(sources, s => s.Account.Id == NormalId);        // normal account contributes
-        Assert.DoesNotContain(sources, s => s.Account.Id == SharedId);  // shared is excluded from the aggregate
+        Assert.DoesNotContain(sources, s => s.Account.Id == SharedId);  // shared excluded despite cached folders
 
         // The exclusion is by IsShared, not by the folder flag the sweep filters on — so the shared
         // Inbox is NOT marked ExcludeFromAllMail and the #456 sweep still covers it.
         Assert.False(sharedInbox.ExcludeFromAllMail);
         Assert.True(vm.IsSharedAccountId(SharedId));
         Assert.False(vm.IsSharedAccountId(NormalId));
+    }
+
+    [Fact]
+    public async Task MainWindowDelete_OfParent_CascadesSharedChildren()
+    {
+        // The main-window account context menu delete (MainViewModel) must cascade a parent's shared
+        // mailboxes exactly as the Account Manager does — otherwise the shared account is orphaned with a
+        // ParentAccountId pointing at nothing (PR review finding 1). Shared child's parent = the Work account.
+        var vm = await MakeVmAsync(
+            [Normal(NormalId, "Work"), Shared(SharedId, NormalId, "Support")],
+            new() { [NormalId] = [Inbox(NormalId)] });
+        vm.ConfirmationRequested = (_, _) => true;
+
+        await vm.DeleteAccountCommand.ExecuteAsync(vm.Accounts.First(a => a.Id == NormalId));
+
+        Assert.DoesNotContain(vm.Accounts, a => a.Id == NormalId);   // parent removed
+        Assert.DoesNotContain(vm.Accounts, a => a.Id == SharedId);   // shared child cascaded away — no orphan
+    }
+
+    [Fact]
+    public async Task MainWindowDelete_FailsClosed_WhenConfirmationDeclined()
+    {
+        var vm = await MakeVmAsync(
+            [Normal(NormalId, "Work"), Shared(SharedId, NormalId, "Support")],
+            new() { [NormalId] = [Inbox(NormalId)] });
+        vm.ConfirmationRequested = (_, _) => false;   // user declines
+
+        await vm.DeleteAccountCommand.ExecuteAsync(vm.Accounts.First(a => a.Id == NormalId));
+
+        Assert.Contains(vm.Accounts, a => a.Id == NormalId);   // nothing removed
+        Assert.Contains(vm.Accounts, a => a.Id == SharedId);
     }
 
     [Fact]

--- a/QuickMail.Tests/SharedMailboxModelTests.cs
+++ b/QuickMail.Tests/SharedMailboxModelTests.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Text.Json;
+using QuickMail.Models;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// Pins the shared-mailbox linkage fields on <see cref="AccountModel"/> (#31, PR 1): they persist
+/// through the same JSON serialization accounts.json uses, a normal account is unaffected (no
+/// migration), and the accessible name inserts the "shared mailbox" qualifier exactly where §7 says.
+/// </summary>
+public class SharedMailboxModelTests
+{
+    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+
+    private static AccountModel RoundTrip(AccountModel a) =>
+        JsonSerializer.Deserialize<AccountModel>(JsonSerializer.Serialize(a, JsonOptions), JsonOptions)!;
+
+    [Fact]
+    public void SharedFields_RoundTripThroughJson()
+    {
+        var parentId = Guid.NewGuid();
+        var back = RoundTrip(new AccountModel
+        {
+            AccountName = "Support",
+            Username = "support@bits-acb.org",
+            BackendKind = BackendKind.MicrosoftGraph,
+            IsShared = true,
+            ParentAccountId = parentId,
+            SharedAddress = "support@bits-acb.org",
+        });
+
+        Assert.True(back.IsShared);
+        Assert.Equal(parentId, back.ParentAccountId);
+        Assert.Equal("support@bits-acb.org", back.SharedAddress);
+        Assert.Equal(BackendKind.MicrosoftGraph, back.BackendKind);
+    }
+
+    [Fact]
+    public void NormalAccount_DefaultsUnshared_NoMigration()
+    {
+        var back = RoundTrip(new AccountModel { AccountName = "Idea Place", Username = "tim@icanbrew.com" });
+
+        Assert.False(back.IsShared);
+        Assert.Null(back.ParentAccountId);
+        Assert.Null(back.SharedAddress);
+    }
+
+    [Fact]
+    public void AccessibleName_Shared_InsertsQualifierAfterLabel()
+    {
+        var shared = new AccountModel { AccountName = "Support", IsShared = true, IsConnected = true, TotalUnread = 12 };
+        Assert.Equal("Support, shared mailbox, connected, 12 unread", shared.AccessibleName);
+
+        shared.TotalUnread = 0;
+        Assert.Equal("Support, shared mailbox, connected", shared.AccessibleName);
+
+        shared.IsConnected = false;
+        Assert.Equal("Support, shared mailbox, disconnected", shared.AccessibleName);
+    }
+
+    [Fact]
+    public void AccessibleName_Normal_Unchanged()
+    {
+        var normal = new AccountModel { AccountName = "Kelly", IsConnected = true, TotalUnread = 1630 };
+        Assert.Equal("Kelly, connected, 1630 unread", normal.AccessibleName);
+
+        normal.IsConnected = false;
+        Assert.Equal("Kelly, disconnected", normal.AccessibleName);
+    }
+}

--- a/QuickMail.Tests/SharedMailboxRemovalTests.cs
+++ b/QuickMail.Tests/SharedMailboxRemovalTests.cs
@@ -84,3 +84,88 @@ public class SharedMailboxRemovalTests
         Assert.Contains(vm.Accounts, a => a.Id == shared.Id);
     }
 }
+
+/// <summary>
+/// Pins the Account Manager editor gating for a selected shared mailbox (#31): a shared account has no
+/// credentials or connection of its own, so the connection/auth/sign-in/Test-Connection surface and the
+/// contact/calendar sync (out of scope by spec — mail only) are all hidden, and a read-only summary
+/// names the parent. A normal account is unaffected.
+/// </summary>
+public class SharedMailboxEditorTests
+{
+    private static readonly ProviderCatalog Catalog = new();
+
+    private static AccountManagerViewModel Manager(params AccountModel[] accounts)
+    {
+        var vm = new AccountManagerViewModel(
+            new StubAccountService(), new StubCredentialService(), new StubImapMailService(),
+            new StubOAuthService(), new StubLocalStoreService(), new StubConfigService(),
+            new StubFeatureGate(), Catalog,
+            contactSync: new StubContactSyncService(), graphCalendarSync: new StubGraphCalendarSyncService());
+        foreach (var a in accounts) vm.Accounts.Add(a);
+        return vm;
+    }
+
+    private static AccountModel Parent(string name) => new()
+    {
+        Id = Guid.NewGuid(), AccountName = name, Username = name.ToLowerInvariant() + "@work.com",
+        BackendKind = BackendKind.MicrosoftGraph, AuthType = AuthType.OAuth2Microsoft,
+    };
+    private static AccountModel SharedOf(AccountModel parent, string addr) => new()
+    {
+        Id = Guid.NewGuid(), AccountName = addr, Username = addr, SharedAddress = addr,
+        IsShared = true, ParentAccountId = parent.Id, BackendKind = parent.BackendKind,
+        AuthType = parent.AuthType,
+    };
+
+    [Fact]
+    public void SharedSelected_HidesConnectionAndSyncSurface()
+    {
+        var parent = Parent("Work");
+        var shared = SharedOf(parent, "support@work.com");
+        var vm = Manager(parent, shared);
+
+        vm.SelectedAccount = shared;
+
+        Assert.True(vm.IsSharedSelected);
+        Assert.False(vm.ShowConnectionEditing); // password / OAuth sign-in / Advanced servers hidden
+        Assert.False(vm.ShowTestConnection);    // nothing of its own to test
+        Assert.False(vm.CanSyncContacts);       // mail only, per spec
+        Assert.False(vm.CanSyncCalendar);
+        Assert.Equal("Work", vm.SharedParentName);
+    }
+
+    [Fact]
+    public void NormalMicrosoftSelected_KeepsFullSurface()
+    {
+        var parent = Parent("Work");
+        var shared = SharedOf(parent, "support@work.com");
+        var vm = Manager(parent, shared);
+
+        vm.SelectedAccount = parent;
+
+        Assert.False(vm.IsSharedSelected);
+        Assert.True(vm.ShowConnectionEditing);
+        Assert.True(vm.ShowTestConnection);
+        Assert.True(vm.CanSyncContacts);        // a normal Microsoft account still offers sync
+        Assert.True(vm.CanSyncCalendar);
+        Assert.Equal(string.Empty, vm.SharedParentName);
+    }
+
+    [Fact]
+    public void SwitchingSharedToNormal_RestoresSurface()
+    {
+        var parent = Parent("Work");
+        var shared = SharedOf(parent, "support@work.com");
+        var vm = Manager(parent, shared);
+
+        vm.SelectedAccount = shared;
+        Assert.False(vm.ShowConnectionEditing);
+
+        // Selecting a normal account must bring the connection surface back — the gate tracks the
+        // selection, it is not a one-way latch.
+        vm.SelectedAccount = parent;
+        Assert.True(vm.ShowConnectionEditing);
+        Assert.True(vm.ShowTestConnection);
+    }
+}

--- a/QuickMail.Tests/SharedMailboxRemovalTests.cs
+++ b/QuickMail.Tests/SharedMailboxRemovalTests.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using QuickMail.Models;
+using QuickMail.Services;
+using QuickMail.ViewModels;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// Pins shared-mailbox removal (#31, spec §5.4): removing a parent cascades to its shared mailboxes
+/// (with a naming confirmation the user can decline); removing a shared mailbox on its own is an
+/// ordinary single delete that leaves the parent intact.
+/// </summary>
+public class SharedMailboxRemovalTests
+{
+    private static readonly ProviderCatalog Catalog = new();
+
+    private static AccountManagerViewModel Manager(params AccountModel[] accounts)
+    {
+        var vm = new AccountManagerViewModel(
+            new StubAccountService(), new StubCredentialService(), new StubImapMailService(),
+            new StubOAuthService(), new StubLocalStoreService(), new StubConfigService(),
+            new StubFeatureGate(), Catalog);
+        foreach (var a in accounts) vm.Accounts.Add(a);
+        return vm;
+    }
+
+    private static AccountModel Parent(string name) => new()
+    {
+        Id = Guid.NewGuid(), AccountName = name, Username = name.ToLowerInvariant() + "@work.com",
+        BackendKind = BackendKind.MicrosoftGraph, AuthType = AuthType.OAuth2Microsoft,
+    };
+    private static AccountModel SharedOf(AccountModel parent, string addr) => new()
+    {
+        Id = Guid.NewGuid(), AccountName = addr, Username = addr, SharedAddress = addr,
+        IsShared = true, ParentAccountId = parent.Id, BackendKind = parent.BackendKind,
+    };
+
+    [Fact]
+    public async Task RemovingParent_CascadesToSharedChildren_LeavesOthers()
+    {
+        var parent = Parent("Work");
+        var shared = SharedOf(parent, "support@work.com");
+        var other  = Parent("Home");
+        var vm = Manager(parent, shared, other);
+        vm.ConfirmCascadeRemoval = _ => true;   // user confirms the cascade
+        vm.SelectedAccount = parent;
+
+        await vm.DeleteAccountCommand.ExecuteAsync(null);
+
+        Assert.DoesNotContain(vm.Accounts, a => a.Id == parent.Id);
+        Assert.DoesNotContain(vm.Accounts, a => a.Id == shared.Id);   // cascaded away
+        Assert.Contains(vm.Accounts, a => a.Id == other.Id);          // untouched
+    }
+
+    [Fact]
+    public async Task RemovingSharedMailboxOnly_LeavesParent()
+    {
+        var parent = Parent("Work");
+        var shared = SharedOf(parent, "support@work.com");
+        var vm = Manager(parent, shared);
+        vm.SelectedAccount = shared;
+
+        await vm.DeleteAccountCommand.ExecuteAsync(null);
+
+        Assert.DoesNotContain(vm.Accounts, a => a.Id == shared.Id);
+        Assert.Contains(vm.Accounts, a => a.Id == parent.Id);         // parent intact — no reverse cascade
+    }
+
+    [Fact]
+    public async Task CascadeConfirmationDeclined_RemovesNothing()
+    {
+        var parent = Parent("Work");
+        var shared = SharedOf(parent, "support@work.com");
+        var vm = Manager(parent, shared);
+        vm.ConfirmCascadeRemoval = _ => false;   // user declines
+        vm.SelectedAccount = parent;
+
+        await vm.DeleteAccountCommand.ExecuteAsync(null);
+
+        Assert.Contains(vm.Accounts, a => a.Id == parent.Id);
+        Assert.Contains(vm.Accounts, a => a.Id == shared.Id);
+    }
+}

--- a/QuickMail.Tests/SharedMailboxRemovalTests.cs
+++ b/QuickMail.Tests/SharedMailboxRemovalTests.cs
@@ -128,10 +128,11 @@ public class SharedMailboxEditorTests
         vm.SelectedAccount = shared;
 
         Assert.True(vm.IsSharedSelected);
-        Assert.False(vm.ShowConnectionEditing); // password / OAuth sign-in / Advanced servers hidden
-        Assert.False(vm.ShowTestConnection);    // nothing of its own to test
-        Assert.False(vm.CanSyncContacts);       // mail only, per spec
+        Assert.False(vm.ShowNormalAccountFields); // password / OAuth sign-in / Advanced servers / display name hidden
+        Assert.False(vm.ShowTestConnection);      // nothing of its own to test
+        Assert.False(vm.CanSyncContacts);         // mail only, per spec
         Assert.False(vm.CanSyncCalendar);
+        Assert.False(vm.SetDefaultCommand.CanExecute(shared)); // credential-less — cannot be default
         Assert.Equal("Work", vm.SharedParentName);
     }
 
@@ -145,10 +146,11 @@ public class SharedMailboxEditorTests
         vm.SelectedAccount = parent;
 
         Assert.False(vm.IsSharedSelected);
-        Assert.True(vm.ShowConnectionEditing);
+        Assert.True(vm.ShowNormalAccountFields);
         Assert.True(vm.ShowTestConnection);
         Assert.True(vm.CanSyncContacts);        // a normal Microsoft account still offers sync
         Assert.True(vm.CanSyncCalendar);
+        Assert.True(vm.SetDefaultCommand.CanExecute(parent)); // a real account can be the default
         Assert.Equal(string.Empty, vm.SharedParentName);
     }
 
@@ -160,12 +162,12 @@ public class SharedMailboxEditorTests
         var vm = Manager(parent, shared);
 
         vm.SelectedAccount = shared;
-        Assert.False(vm.ShowConnectionEditing);
+        Assert.False(vm.ShowNormalAccountFields);
 
         // Selecting a normal account must bring the connection surface back — the gate tracks the
         // selection, it is not a one-way latch.
         vm.SelectedAccount = parent;
-        Assert.True(vm.ShowConnectionEditing);
+        Assert.True(vm.ShowNormalAccountFields);
         Assert.True(vm.ShowTestConnection);
     }
 }

--- a/QuickMail.Tests/SharedMailboxRemovalTests.cs
+++ b/QuickMail.Tests/SharedMailboxRemovalTests.cs
@@ -83,6 +83,22 @@ public class SharedMailboxRemovalTests
         Assert.Contains(vm.Accounts, a => a.Id == parent.Id);
         Assert.Contains(vm.Accounts, a => a.Id == shared.Id);
     }
+
+    [Fact]
+    public async Task CascadeWithoutConfirmCallback_FailsClosed_RemovesNothing()
+    {
+        var parent = Parent("Work");
+        var shared = SharedOf(parent, "support@work.com");
+        var vm = Manager(parent, shared);
+        // ConfirmCascadeRemoval deliberately not wired: with children present there is no way to obtain
+        // the required confirmation, so the delete must fail closed and remove nothing.
+        vm.SelectedAccount = parent;
+
+        await vm.DeleteAccountCommand.ExecuteAsync(null);
+
+        Assert.Contains(vm.Accounts, a => a.Id == parent.Id);
+        Assert.Contains(vm.Accounts, a => a.Id == shared.Id);
+    }
 }
 
 /// <summary>

--- a/QuickMail.Tests/UnitTest1.cs
+++ b/QuickMail.Tests/UnitTest1.cs
@@ -259,6 +259,18 @@ public class XamlParseTests
     }
 
     [StaFact]
+    public void AddSharedMailboxWindow_XamlParsesWithoutException()
+    {
+        EnsureApplication();
+        // Guards the {StaticResource BoolToVisibility} converter being declared locally — a build
+        // compiles the XAML but the converter only resolves at parse time (#31).
+        var vm = new AddSharedMailboxViewModel([new AccountModel { AccountName = "Work", BackendKind = BackendKind.MicrosoftGraph }]);
+        var window = new AddSharedMailboxWindow(vm);
+        Assert.NotNull(window);
+        window.Close();
+    }
+
+    [StaFact]
     public void ComposeWindow_XamlParsesWithoutException()
     {
         EnsureApplication();

--- a/QuickMail/Models/AccountModel.cs
+++ b/QuickMail/Models/AccountModel.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json.Serialization;
 using CommunityToolkit.Mvvm.ComponentModel;
 
@@ -155,6 +157,17 @@ public partial class AccountModel : ObservableObject
     /// account.
     /// </summary>
     public string? SharedAddress { get; set; }
+
+    /// <summary>
+    /// The shared mailboxes (#31) that read through <paramref name="parent"/>, taken from
+    /// <paramref name="all"/>. Empty when <paramref name="parent"/> is itself shared — a shared mailbox
+    /// is never a parent. Both account-delete paths (the Account Manager and the main-window account
+    /// context menu) call this so a parent's removal cascades to its shared mailboxes identically.
+    /// </summary>
+    public static List<AccountModel> SharedChildrenOf(AccountModel parent, IEnumerable<AccountModel> all) =>
+        parent.IsShared
+            ? new List<AccountModel>()
+            : all.Where(a => a.IsShared && a.ParentAccountId == parent.Id).ToList();
 
     // ── Runtime-only status (not serialized, updated after each connection) ──────
 

--- a/QuickMail/Models/AccountModel.cs
+++ b/QuickMail/Models/AccountModel.cs
@@ -133,6 +133,29 @@ public partial class AccountModel : ObservableObject
     /// </summary>
     public string? ArchiveFolderFullName { get; set; }
 
+    // ── Shared mailbox linkage (#31) ─────────────────────────────────────────────
+
+    /// <summary>
+    /// True if this account is a Microsoft 365 / Exchange shared mailbox added by address (Approach B):
+    /// a first-class account with its own <see cref="Id"/>, but no credentials of its own — it reads and
+    /// sends through its <see cref="ParentAccountId"/>'s token and backend. Optional; defaults false, so
+    /// existing accounts round-trip unchanged (no migration).
+    /// </summary>
+    public bool IsShared { get; set; }
+
+    /// <summary>
+    /// For a shared account (<see cref="IsShared"/>), the <see cref="Id"/> of the parent account whose
+    /// token authorizes access and whose backend serves it. Null for a normal account.
+    /// </summary>
+    public Guid? ParentAccountId { get; set; }
+
+    /// <summary>
+    /// For a shared account, the shared mailbox's own SMTP address — the <c>/users/{SharedAddress}</c>
+    /// target for a Graph parent, or the XOAUTH2 <c>user=</c> for an IMAP parent. Null for a normal
+    /// account.
+    /// </summary>
+    public string? SharedAddress { get; set; }
+
     // ── Runtime-only status (not serialized, updated after each connection) ──────
 
     [ObservableProperty]
@@ -175,17 +198,20 @@ public partial class AccountModel : ObservableObject
     /// Full accessible name for screen readers: account label + connection status + unread count.
     /// TotalUnread covers all folders. Placed in AutomationProperties.Name on the list item
     /// container so it is announced on focus without requiring the user to hover.
-    /// Examples: "Idea Place, disconnected", "Kelly, connected", "Kelly, connected, 1630 unread"
+    /// Examples: "Idea Place, disconnected", "Kelly, connected", "Kelly, connected, 1630 unread".
+    /// A shared mailbox (#31) inserts the qualifier right after the label:
+    /// "Support, shared mailbox, connected, 12 unread".
     /// </summary>
     [JsonIgnore]
     public string AccessibleName
     {
         get
         {
-            if (!IsConnected) return $"{AccountLabel}, disconnected";
+            var shared = IsShared ? ", shared mailbox" : "";
+            if (!IsConnected) return $"{AccountLabel}{shared}, disconnected";
             return TotalUnread > 0
-                ? $"{AccountLabel}, connected, {TotalUnread} unread"
-                : $"{AccountLabel}, connected";
+                ? $"{AccountLabel}{shared}, connected, {TotalUnread} unread"
+                : $"{AccountLabel}{shared}, connected";
         }
     }
 

--- a/QuickMail/Models/FeatureFlag.cs
+++ b/QuickMail/Models/FeatureFlag.cs
@@ -38,4 +38,18 @@ public enum FeatureFlag
     /// ServerRules=false under [features] in config.ini, or --no-feature ServerRules at launch.
     /// </summary>
     ServerRules,
+
+    /// <summary>
+    /// Enables shared mailboxes (#31): the "Add shared…" button in the Account Manager, which is the
+    /// sole path that can create a shared <see cref="QuickMail.Models.AccountModel"/> (IsShared). This
+    /// gates the whole feature, because everything downstream — the shared tree node, aggregate
+    /// exclusion, the connect-skip, cascade removal — is data-driven off a shared account that only the
+    /// button can produce; with no shared account, every IsShared branch is a no-op.
+    ///
+    /// Default: false while the feature is built across multiple PRs (PR 1 is the linked-account model
+    /// and manual add only — no backend access yet, so a shared node has no folders). Turn it on to
+    /// test with SharedMailboxes=true under [features] in config.ini, or --feature SharedMailboxes at
+    /// launch. Flips to true by default once the feature is complete.
+    /// </summary>
+    SharedMailboxes,
 }

--- a/QuickMail/Models/FolderTreeNode.cs
+++ b/QuickMail/Models/FolderTreeNode.cs
@@ -15,6 +15,17 @@ public sealed class FolderTreeNode : INotifyPropertyChanged
     public bool IsHeader { get; init; }
 
     /// <summary>
+    /// The account this node belongs to, for account header/placeholder nodes (#31). Header nodes carry
+    /// no <see cref="Folder"/>, so without this two same-named accounts produce the same node key and
+    /// collide (their expansion state and selection get confused). Null for non-account nodes.
+    /// </summary>
+    public System.Guid? AccountId { get; init; }
+
+    /// <summary>True for the top-level node of a shared mailbox (#31) — drives the "shared mailbox"
+    /// qualifier in <see cref="AutomationName"/>.</summary>
+    public bool IsSharedAccount { get; init; }
+
+    /// <summary>
     /// True for the Calendar node and every node beneath it. Drives which context menu the tree
     /// item gets: the mail folder actions (New Folder, Move, Delete…) mean nothing on a calendar,
     /// and every one of them silently does nothing when activated there.
@@ -37,6 +48,7 @@ public sealed class FolderTreeNode : INotifyPropertyChanged
     public string AutomationName =>
         ShowUnread ? $"{Label}, {Folder!.UnreadCount} unread"
         : IsDefaultCalendar ? $"{Label}, default calendar"
+        : IsSharedAccount ? $"{Label}, shared mailbox"
         : Label;
 
     private bool _isDefaultCalendar;

--- a/QuickMail/Services/ConfigFeatureGate.cs
+++ b/QuickMail/Services/ConfigFeatureGate.cs
@@ -23,6 +23,10 @@ public class ConfigFeatureGate : IFeatureGate
         // On by default: server-rule list/create/edit/delete/reorder and the unified per-account rules
         // window are complete and tested (#333). Set ServerRules=false under [features] to hide it again.
         [FeatureFlag.ServerRules]  = true,
+        // Off while shared mailboxes (#31) is built across multiple PRs — the "Add shared…" button, the
+        // sole creation path, stays hidden until the feature is whole. Set SharedMailboxes=true under
+        // [features] to test.
+        [FeatureFlag.SharedMailboxes] = false,
     };
 
     private readonly Dictionary<string, string> _configFlags;

--- a/QuickMail/Services/FolderTreeBuilder.cs
+++ b/QuickMail/Services/FolderTreeBuilder.cs
@@ -31,6 +31,8 @@ public static class FolderTreeBuilder
                 Folder     = null,
                 IsHeader   = true,
                 IsExpanded = true,
+                AccountId       = account.Id,        // #31: node-key disambiguation
+                IsSharedAccount = account.IsShared,  // #31: "shared mailbox" in the accessible name
             };
             foreach (var root in folderRoots)
                 accountNode.Children.Add(root);

--- a/QuickMail/ViewModels/AccountManagerViewModel.cs
+++ b/QuickMail/ViewModels/AccountManagerViewModel.cs
@@ -32,8 +32,9 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
     [NotifyPropertyChangedFor(nameof(CanSyncCalendar))]
     [NotifyPropertyChangedFor(nameof(ShowTestConnection))]
     [NotifyPropertyChangedFor(nameof(IsSharedSelected))]
-    [NotifyPropertyChangedFor(nameof(ShowConnectionEditing))]
+    [NotifyPropertyChangedFor(nameof(ShowNormalAccountFields))]
     [NotifyPropertyChangedFor(nameof(SharedParentName))]
+    [NotifyCanExecuteChangedFor(nameof(SetDefaultCommand))]
     private AccountModel? _selectedAccount;
 
     public bool IsEditing => SelectedAccount != null;
@@ -48,9 +49,12 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
     /// </summary>
     public bool IsSharedSelected => SelectedAccount?.IsShared == true;
 
-    /// <summary>The editable connection/auth surface (password, OAuth sign-in, Advanced servers) is
-    /// shown for a normal account and hidden for a shared mailbox, which configures none of it.</summary>
-    public bool ShowConnectionEditing => !IsSharedSelected;
+    /// <summary>Fields that only apply to a real, credentialed account — the connection/auth surface
+    /// (password, OAuth sign-in, Advanced servers) and the sender display name — are shown for a normal
+    /// account and hidden for a shared mailbox, which has none of them (it reads and sends through its
+    /// parent under the mailbox's own directory identity). "Set as default" is likewise unavailable for
+    /// a shared account (see <see cref="CanSetDefault"/>) — credential-less, per spec §4.</summary>
+    public bool ShowNormalAccountFields => !IsSharedSelected;
 
     /// <summary>Name of the parent account a shared mailbox reads through — for its read-only summary.</summary>
     public string SharedParentName =>
@@ -489,7 +493,12 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
         StatusText = "Shared mailbox added.";
     }
 
-    [RelayCommand]
+    /// <summary>A shared mailbox cannot be the default account (#31, spec §4: default-account semantics
+    /// are out — it is credential-less and never the identity a new message composes from). Also guards
+    /// the no-selection case, which the command used to accept and no-op.</summary>
+    private static bool CanSetDefault(AccountModel? account) => account is { IsShared: false };
+
+    [RelayCommand(CanExecute = nameof(CanSetDefault))]
     private void SetDefault(AccountModel? account)
     {
         if (account == null) return;

--- a/QuickMail/ViewModels/AccountManagerViewModel.cs
+++ b/QuickMail/ViewModels/AccountManagerViewModel.cs
@@ -415,7 +415,9 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
     }
 
     /// <summary>Set by the View to confirm removing a parent that has shared mailboxes (#31): message →
-    /// user's yes/no. Absent (or no children) → delete proceeds as before.</summary>
+    /// user's yes/no. With no children, delete proceeds as before. When there ARE children this is the
+    /// only way to get the required yes, so an unset callback fails closed — the cascade is treated as
+    /// declined and nothing is removed, never removed unconfirmed. The shipped View always wires it.</summary>
     public Func<string, bool>? ConfirmCascadeRemoval { get; set; }
 
     [RelayCommand]
@@ -430,13 +432,15 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
         var sharedChildren = account.IsShared
             ? new List<AccountModel>()
             : Accounts.Where(a => a.IsShared && a.ParentAccountId == account.Id).ToList();
-        if (sharedChildren.Count > 0 && ConfirmCascadeRemoval != null)
+        if (sharedChildren.Count > 0)
         {
+            // The cascade needs an explicit yes. With no confirmation mechanism wired we cannot get one,
+            // so fail closed (?? false) — never remove a parent's shared mailboxes unconfirmed.
             var names = string.Join(", ", sharedChildren.Select(c => c.AccountLabel));
             var one = sharedChildren.Count == 1;
-            if (!ConfirmCascadeRemoval(
-                    $"Removing {account.AccountLabel} will also remove its shared mailbox{(one ? "" : "es")}: {names}. Continue?"))
-                return;
+            var confirmed = ConfirmCascadeRemoval?.Invoke(
+                $"Removing {account.AccountLabel} will also remove its shared mailbox{(one ? "" : "es")}: {names}. Continue?") ?? false;
+            if (!confirmed) return;
         }
 
         _credentials.DeletePassword(account.Id);

--- a/QuickMail/ViewModels/AccountManagerViewModel.cs
+++ b/QuickMail/ViewModels/AccountManagerViewModel.cs
@@ -383,25 +383,51 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
         }
     }
 
+    /// <summary>Set by the View to confirm removing a parent that has shared mailboxes (#31): message →
+    /// user's yes/no. Absent (or no children) → delete proceeds as before.</summary>
+    public Func<string, bool>? ConfirmCascadeRemoval { get; set; }
+
     [RelayCommand]
     private async Task DeleteAccountAsync()
     {
         if (SelectedAccount == null) return;
         var account = SelectedAccount;
 
+        // #31: a shared mailbox has no independent existence — it lives entirely through its parent's
+        // token and backend — so removing the parent removes its shared mailboxes too. Confirm and name
+        // them first. Removing a shared mailbox on its own is an ordinary single-account delete.
+        var sharedChildren = account.IsShared
+            ? new List<AccountModel>()
+            : Accounts.Where(a => a.IsShared && a.ParentAccountId == account.Id).ToList();
+        if (sharedChildren.Count > 0 && ConfirmCascadeRemoval != null)
+        {
+            var names = string.Join(", ", sharedChildren.Select(c => c.AccountLabel));
+            var one = sharedChildren.Count == 1;
+            if (!ConfirmCascadeRemoval(
+                    $"Removing {account.AccountLabel} will also remove its shared mailbox{(one ? "" : "es")}: {names}. Continue?"))
+                return;
+        }
+
         _credentials.DeletePassword(account.Id);
         Accounts.Remove(account);
+        foreach (var child in sharedChildren) Accounts.Remove(child);
         SelectedAccount = null;
         _accountService.SaveAccounts([.. Accounts]);
 
         var config = _configService.Load();
-        if (config.Accounts.Remove(account.Id))
-            _configService.Save(config);
+        var configChanged = config.Accounts.Remove(account.Id);
+        foreach (var child in sharedChildren) configChanged |= config.Accounts.Remove(child.Id);
+        if (configChanged) _configService.Save(config);
 
         StatusText = "Account deleted. Cleaning up…";
 
         try   { await _localStore.DeleteAccountDataAsync(account.Id); }
         catch (Exception ex) { LogService.Log($"AccountManager.DeleteAccount: failed to purge mail.db — {ex.Message}"); }
+        foreach (var child in sharedChildren)
+        {
+            try   { await _localStore.DeleteAccountDataAsync(child.Id); }
+            catch (Exception ex) { LogService.Log($"AccountManager.DeleteAccount: failed to purge shared mailbox data — {ex.Message}"); }
+        }
 
         if (account.AuthType is AuthType.OAuth2Microsoft or AuthType.OAuth2Google)
         {
@@ -416,7 +442,24 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
             catch (Exception ex) { LogService.Log($"AccountManager.DeleteAccount: failed to remove synced contacts — {ex.Message}"); }
         }
 
-        StatusText = "Account deleted.";
+        StatusText = sharedChildren.Count > 0
+            ? $"Account deleted, along with {sharedChildren.Count} shared mailbox{(sharedChildren.Count == 1 ? "" : "es")}."
+            : "Account deleted.";
+    }
+
+    // ── Add shared mailbox (#31) ──────────────────────────────────────────────────
+    public AddSharedMailboxViewModel CreateAddSharedMailboxViewModel() =>
+        new(Accounts, SelectedAccount?.Id);
+
+    /// <summary>Adds a created shared mailbox to the list and persists it — no credentials to save (it
+    /// reads through its parent). The dialog closes on success; the manager's close refreshes the main
+    /// window, which registers the backend and shows the new top-level node.</summary>
+    public void CommitNewSharedMailbox(AccountModel sharedMailbox)
+    {
+        Accounts.Add(sharedMailbox);
+        _accountService.SaveAccounts([.. Accounts]);
+        SelectedAccount = sharedMailbox;
+        StatusText = "Shared mailbox added.";
     }
 
     [RelayCommand]

--- a/QuickMail/ViewModels/AccountManagerViewModel.cs
+++ b/QuickMail/ViewModels/AccountManagerViewModel.cs
@@ -71,6 +71,10 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
 
     protected override bool IsGoogleAuthEnabled => _featureGate.IsEnabled(FeatureFlag.GoogleAuth);
 
+    /// <summary>#31: gates the "Add shared…" button — the sole path that can create a shared mailbox.
+    /// Off by default while the multi-PR feature is built (see <see cref="FeatureFlag.SharedMailboxes"/>).</summary>
+    public bool IsSharedMailboxesEnabled => _featureGate.IsEnabled(FeatureFlag.SharedMailboxes);
+
     public AccountManagerViewModel(
         IAccountService accountService,
         ICredentialService credentials,

--- a/QuickMail/ViewModels/AccountManagerViewModel.cs
+++ b/QuickMail/ViewModels/AccountManagerViewModel.cs
@@ -31,9 +31,32 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
     [NotifyPropertyChangedFor(nameof(CanSyncContacts))]
     [NotifyPropertyChangedFor(nameof(CanSyncCalendar))]
     [NotifyPropertyChangedFor(nameof(ShowTestConnection))]
+    [NotifyPropertyChangedFor(nameof(IsSharedSelected))]
+    [NotifyPropertyChangedFor(nameof(ShowConnectionEditing))]
+    [NotifyPropertyChangedFor(nameof(SharedParentName))]
     private AccountModel? _selectedAccount;
 
     public bool IsEditing => SelectedAccount != null;
+
+    /// <summary>
+    /// True when the selected account is a shared mailbox (#31). A shared mailbox has no credentials
+    /// and no connection of its own — it reads through its parent — so its connection method,
+    /// authentication, password, IMAP/SMTP servers, sign-in, Test Connection, and contact/calendar
+    /// sync are all meaningless. The editor hides that whole surface and shows a read-only summary,
+    /// the same way a Graph account already hides IMAP/SMTP. Calendar and contacts are out of scope
+    /// for shared mailboxes by spec (mail only), so those checkboxes are hidden here too.
+    /// </summary>
+    public bool IsSharedSelected => SelectedAccount?.IsShared == true;
+
+    /// <summary>The editable connection/auth surface (password, OAuth sign-in, Advanced servers) is
+    /// shown for a normal account and hidden for a shared mailbox, which configures none of it.</summary>
+    public bool ShowConnectionEditing => !IsSharedSelected;
+
+    /// <summary>Name of the parent account a shared mailbox reads through — for its read-only summary.</summary>
+    public string SharedParentName =>
+        SelectedAccount?.ParentAccountId is { } pid
+            ? Accounts.FirstOrDefault(a => a.Id == pid)?.AccountName ?? "another account"
+            : string.Empty;
 
     /// <summary>
     /// Test Connection is offered only when there is an account to test. With nothing selected the
@@ -45,7 +68,7 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
     /// could only probe IMAP, but it now probes Graph accounts too, via the backend's GET /me — so
     /// hiding it for Microsoft 365 would hide it exactly where it just started working.
     /// </summary>
-    public bool ShowTestConnection => IsEditing;
+    public bool ShowTestConnection => IsEditing && !IsSharedSelected;
 
     /// <summary>
     /// Contact sync (issue #256) is offered for Microsoft and Google (OAuth contact APIs), plus
@@ -53,7 +76,7 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
     /// calendar sync. Other password/IMAP accounts show no checkbox.
     /// </summary>
     public bool CanSyncContacts =>
-        _contactSync != null && SelectedAccount is { } acct &&
+        _contactSync != null && SelectedAccount is { IsShared: false } acct &&
         (acct.AuthType is AuthType.OAuth2Microsoft or AuthType.OAuth2Google
          || ProviderCatalog.IsICloud(acct));
 
@@ -65,7 +88,7 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
     /// accounts show no checkbox.
     /// </summary>
     public bool CanSyncCalendar =>
-        _graphCalendarSync != null && SelectedAccount is { } acct &&
+        _graphCalendarSync != null && SelectedAccount is { IsShared: false } acct &&
         (acct.AuthType is AuthType.OAuth2Microsoft or AuthType.OAuth2Google
          || ProviderCatalog.IsICloud(acct));
 

--- a/QuickMail/ViewModels/AccountManagerViewModel.cs
+++ b/QuickMail/ViewModels/AccountManagerViewModel.cs
@@ -429,9 +429,7 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
         // #31: a shared mailbox has no independent existence — it lives entirely through its parent's
         // token and backend — so removing the parent removes its shared mailboxes too. Confirm and name
         // them first. Removing a shared mailbox on its own is an ordinary single-account delete.
-        var sharedChildren = account.IsShared
-            ? new List<AccountModel>()
-            : Accounts.Where(a => a.IsShared && a.ParentAccountId == account.Id).ToList();
+        var sharedChildren = AccountModel.SharedChildrenOf(account, Accounts);
         if (sharedChildren.Count > 0)
         {
             // The cascade needs an explicit yes. With no confirmation mechanism wired we cannot get one,
@@ -494,7 +492,9 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
         Accounts.Add(sharedMailbox);
         _accountService.SaveAccounts([.. Accounts]);
         SelectedAccount = sharedMailbox;
-        StatusText = "Shared mailbox added.";
+        // Result, not Status: the add succeeded and the add window has already closed, so this is the
+        // only feedback — it must be spoken even for a user who has AnnounceStatus off (#396 pattern).
+        SetStatusOutcome("Shared mailbox added.");
     }
 
     /// <summary>A shared mailbox cannot be the default account (#31, spec §4: default-account semantics

--- a/QuickMail/ViewModels/AddSharedMailboxViewModel.cs
+++ b/QuickMail/ViewModels/AddSharedMailboxViewModel.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using QuickMail.Models;
+using QuickMail.Services;
+
+namespace QuickMail.ViewModels;
+
+/// <summary>
+/// The add-shared-mailbox dialog (#31, spec §6 Path A). Collects an address and a parent account, and
+/// on Add builds a credential-less shared <see cref="AccountModel"/> (Approach B) linked to that parent
+/// — the owner persists it, registers its backend, and adds it to the account list. No backend access
+/// happens here; validation is synchronous, so the dialog is a leaf single-form window (no F6/palette).
+/// </summary>
+public partial class AddSharedMailboxViewModel : ObservableObject
+{
+    private readonly List<AccountModel> _allAccounts;
+
+    public AddSharedMailboxViewModel(IEnumerable<AccountModel> accounts, Guid? preferredParentId = null)
+    {
+        _allAccounts = accounts.ToList();
+
+        // Only shared-capable accounts can host a shared mailbox: a work/school Microsoft 365 (Graph)
+        // account, or an IMAP account. A personal Microsoft account has no Exchange shared mailboxes,
+        // and a shared account can't itself be a parent.
+        ParentOptions = _allAccounts
+            .Where(a => !a.IsShared
+                        && !(a.BackendKind == BackendKind.MicrosoftGraph && a.IsPersonalMicrosoftAccount == true))
+            .ToList();
+
+        _selectedParent = ParentOptions.FirstOrDefault(a => a.Id == preferredParentId)
+                          ?? ParentOptions.FirstOrDefault();
+    }
+
+    public List<AccountModel> ParentOptions { get; }
+
+    /// <summary>True when there is more than one parent to choose between (one needs no picker).</summary>
+    public bool ShowParentSelector => ParentOptions.Count > 1;
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(AddCommand))]
+    private string _address = string.Empty;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(ShowGraphPollNote))]
+    [NotifyCanExecuteChangedFor(nameof(AddCommand))]
+    private AccountModel? _selectedParent;
+
+    /// <summary>Graph shared mailboxes have no live watcher — only the #456 sweep — so the dialog warns
+    /// (static text, not an announce) that they update on a poll. Absent for an IMAP parent (IDLE).</summary>
+    public bool ShowGraphPollNote => SelectedParent?.BackendKind == BackendKind.MicrosoftGraph;
+
+    [ObservableProperty] private string _errorText = string.Empty;
+
+    /// <summary>Raised when a valid shared mailbox is created. The owner persists it, registers its
+    /// backend, adds it to the account list, and closes the dialog.</summary>
+    public event Action<AccountModel>? SharedMailboxAdded;
+    public event Action? CancelRequested;
+    public event Action<string, AnnouncementCategory>? AnnouncementRequested;
+
+    private bool CanAdd => !string.IsNullOrWhiteSpace(Address) && SelectedParent != null;
+
+    [RelayCommand(CanExecute = nameof(CanAdd))]
+    private void Add()
+    {
+        var address = Address.Trim();
+        if (SelectedParent is not { } parent) return;
+
+        if (!LooksLikeEmail(address))
+        {
+            Fail("Enter a valid email address for the shared mailbox.");
+            return;
+        }
+        if (_allAccounts.Any(a => AddressMatches(a, address)))
+        {
+            Fail("An account with that address already exists.");
+            return;
+        }
+
+        SharedMailboxAdded?.Invoke(new AccountModel
+        {
+            AccountName     = address,
+            Username        = address,
+            SharedAddress   = address,
+            IsShared        = true,
+            ParentAccountId = parent.Id,
+            BackendKind     = parent.BackendKind,   // access follows the parent's backend (§5.1)
+            AuthType        = parent.AuthType,
+            ImapHost        = parent.ImapHost,       // IMAP parents connect over the parent's host
+            ProviderId      = parent.ProviderId,
+        });
+    }
+
+    [RelayCommand]
+    private void Cancel() => CancelRequested?.Invoke();
+
+    private void Fail(string message)
+    {
+        ErrorText = message;
+        AnnouncementRequested?.Invoke(message, AnnouncementCategory.Result);
+    }
+
+    private static bool AddressMatches(AccountModel a, string address) =>
+        string.Equals(a.Username, address, StringComparison.OrdinalIgnoreCase)
+        || string.Equals(a.SharedAddress, address, StringComparison.OrdinalIgnoreCase);
+
+    // Deliberately minimal: a non-empty local part, an "@", and a dotted domain. The real gate is the
+    // backend rejecting a bad address on first access (PR 2); this only stops obvious typos here.
+    private static bool LooksLikeEmail(string s)
+    {
+        var at = s.IndexOf('@');
+        return at > 0 && at < s.Length - 1 && s.IndexOf('.', at) > at + 1 && !s.Contains(' ');
+    }
+}

--- a/QuickMail/ViewModels/AddSharedMailboxViewModel.cs
+++ b/QuickMail/ViewModels/AddSharedMailboxViewModel.cs
@@ -32,6 +32,11 @@ public partial class AddSharedMailboxViewModel : ObservableObject
 
         _selectedParent = ParentOptions.FirstOrDefault(a => a.Id == preferredParentId)
                           ?? ParentOptions.FirstOrDefault();
+
+        // A shared mailbox reads through a parent account's token, so it needs one. Say so rather than
+        // present an inert form with no parent and a disabled Add.
+        if (ParentOptions.Count == 0)
+            _errorText = "Add a Microsoft 365 (work or school) or IMAP account first — a shared mailbox reads through one of your accounts.";
     }
 
     public List<AccountModel> ParentOptions { get; }

--- a/QuickMail/ViewModels/AddSharedMailboxViewModel.cs
+++ b/QuickMail/ViewModels/AddSharedMailboxViewModel.cs
@@ -34,10 +34,16 @@ public partial class AddSharedMailboxViewModel : ObservableObject
                           ?? ParentOptions.FirstOrDefault();
 
         // A shared mailbox reads through a parent account's token, so it needs one. Say so rather than
-        // present an inert form with no parent and a disabled Add.
+        // present an inert form with no parent and a disabled Add. The Account Manager also reads this
+        // to decline opening the dialog at all and report it in its status line (the primary path).
         if (ParentOptions.Count == 0)
-            _errorText = "Add a Microsoft 365 (work or school) or IMAP account first — a shared mailbox reads through one of your accounts.";
+            _errorText = NoEligibleParentMessage;
     }
+
+    /// <summary>Shown when no account can host a shared mailbox. The Account Manager reports this in its
+    /// status line instead of opening a dead-end dialog; the dialog also carries it as a fallback.</summary>
+    public const string NoEligibleParentMessage =
+        "Add a Microsoft 365 (work or school) or IMAP account first — a shared mailbox reads through one of your accounts.";
 
     public List<AccountModel> ParentOptions { get; }
 
@@ -53,9 +59,15 @@ public partial class AddSharedMailboxViewModel : ObservableObject
     [NotifyCanExecuteChangedFor(nameof(AddCommand))]
     private AccountModel? _selectedParent;
 
-    /// <summary>Graph shared mailboxes have no live watcher — only the #456 sweep — so the dialog warns
-    /// (static text, not an announce) that they update on a poll. Absent for an IMAP parent (IDLE).</summary>
+    /// <summary>Graph shared mailboxes have no live watcher — only the #456 sweep. True for a Graph
+    /// parent (shows the poll caption and drives its Hint announce); false for an IMAP parent (IDLE).</summary>
     public bool ShowGraphPollNote => SelectedParent?.BackendKind == BackendKind.MicrosoftGraph;
+
+    /// <summary>The poll caption for a Graph parent. Shown visibly AND spoken once as a Hint when the
+    /// dialog opens on a Graph parent — a screen-reader user would not otherwise discover static text.</summary>
+#pragma warning disable CA1822 // instance property: bound via {Binding GraphPollNote} in the window XAML, which resolves against the DataContext instance
+    public string GraphPollNote => "Shared mailboxes update every few minutes, not instantly.";
+#pragma warning restore CA1822
 
     [ObservableProperty] private string _errorText = string.Empty;
 
@@ -93,7 +105,11 @@ public partial class AddSharedMailboxViewModel : ObservableObject
             ParentAccountId = parent.Id,
             BackendKind     = parent.BackendKind,   // access follows the parent's backend (§5.1)
             AuthType        = parent.AuthType,
-            ImapHost        = parent.ImapHost,       // IMAP parents connect over the parent's host
+            // Copied so SyncService can group by host in PR 1 (no access yet). This is a second copy of
+            // the parent's state that would drift if the parent's host later changed — PR 2 (when access
+            // is actually wired) should resolve the host from the parent at access time to match the
+            // "reads through its parent" architecture, rather than persist a snapshot here. (review)
+            ImapHost        = parent.ImapHost,
             ProviderId      = parent.ProviderId,
         });
     }

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -3446,7 +3446,8 @@ public partial class MainViewModel : ObservableObject, IDisposable
         // per-IP connection limit shared hosting enforces (same rationale as SyncService); accounts
         // on different hosts still connect in parallel.
         var resultsByHost = await Task.WhenAll(
-            Accounts.GroupBy(a => a.ImapHost, StringComparer.OrdinalIgnoreCase)
+            Accounts.Where(a => !a.IsShared)   // #31: shared mailboxes are not connected in PR 1 (no own creds)
+                    .GroupBy(a => a.ImapHost, StringComparer.OrdinalIgnoreCase)
                     .Select(async hostGroup =>
                     {
                         var groupResults = new List<(Guid Id, List<MailFolderModel>? Folders)>();
@@ -7759,7 +7760,9 @@ public partial class MainViewModel : ObservableObject, IDisposable
         IEnumerable<AccountModel> accounts,
         Func<Guid, bool> isBackendConnected,
         Func<Guid, bool> hasCachedFolders)
-        => accounts.Where(a => !isBackendConnected(a.Id) || !hasCachedFolders(a.Id)).ToList();
+        // #31: a shared mailbox has no credentials of its own — it reads through its parent's token
+        // (from PR 2). PR 1 never connects it: it's a navigable, empty top-level node until then.
+        => accounts.Where(a => !a.IsShared && (!isBackendConnected(a.Id) || !hasCachedFolders(a.Id))).ToList();
 
     public void RefreshAccountList()
     {

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -2647,8 +2647,9 @@ public partial class MainViewModel : ObservableObject, IDisposable
             // Watched Conversations — accept arrivals belonging to a watched conversation. This
             // branch IS the feature: a reply to a watched thread joins the open folder during sync
             // with no user action. It must stay above the real-folder branch below, which would
-            // otherwise never let an aggregate see these messages.
-            relevant = incoming.Where(IsWatchedMessage);
+            // otherwise never let an aggregate see these messages. Shared mailboxes are excluded here
+            // too (#31), so the live path agrees with the cache read in FetchWatchedAsync.
+            relevant = incoming.Where(m => IsWatchedMessage(m) && !IsSharedAccountId(m.AccountId));
         }
         else if (IsFolderScopedAggregate(selected.FullName))
         {
@@ -2664,8 +2665,10 @@ public partial class MainViewModel : ObservableObject, IDisposable
         }
         else if (TryGetContactMailFromSentinel(selected.FullName, out var contactAddress, out var contactDirection))
         {
-            // Contact mail results (#370) — only accept messages that still match the address.
-            relevant = incoming.Where(m => MatchesContactAddress(m, contactAddress, contactDirection));
+            // Contact mail results (#370) — only accept messages that still match the address, and
+            // never from a shared mailbox (#31), so the live path agrees with the cache read.
+            relevant = incoming.Where(m =>
+                MatchesContactAddress(m, contactAddress, contactDirection) && !IsSharedAccountId(m.AccountId));
         }
         else if (!selected.IsHeader && selected.AccountId != Guid.Empty)
         {

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -2157,7 +2157,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
             ConnectionStatusText = "Connecting…";
             return;
         }
-        var cached = await _localStore.LoadAllSummariesAsync();
+        var cached = ExcludeSharedMail(await _localStore.LoadAllSummariesAsync()); // #31: All Mail excludes shared
         await ResolveFlagNamesAsync(cached);
         SetMessages(cached);
         StatusText = cached.Count > 0
@@ -4621,7 +4621,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
                 // ── Phase 1: show cache immediately (same data as InitialLoadAsync) ──
                 // This keeps the view consistent regardless of how many times the user
                 // navigates to All Mail.  The IMAP fetch in Phase 2 adds truly new messages.
-                cached = await _localStore.LoadAllSummariesAsync();
+                cached = ExcludeSharedMail(await _localStore.LoadAllSummariesAsync()); // #31: All Mail excludes shared
                 if (!IsCurrentFolderLoad(loadVersion, AllMailFolder))
                     return;
 
@@ -4894,6 +4894,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
                 all = new List<MailMessageSummary>();
                 foreach (var account in Accounts)
                 {
+                    if (account.IsShared) continue;   // #31: shared excluded from All Watched
                     if (!_cachedFolders.TryGetValue(account.Id, out var folders)) continue;
                     foreach (var folder in folders)
                     {
@@ -4917,7 +4918,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
             }
             else
             {
-                all = await _localStore.LoadAllSummariesAsync();
+                all = ExcludeSharedMail(await _localStore.LoadAllSummariesAsync()); // #31: aggregate excludes shared
             }
             if (!IsCurrentFolderLoad(loadVersion, expectedFolder)) return;
 
@@ -4967,6 +4968,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
                 all = new List<MailMessageSummary>();
                 foreach (var account in Accounts)
                 {
+                    if (account.IsShared) continue;   // #31: shared excluded from All Flagged
                     if (!_cachedFolders.TryGetValue(account.Id, out var folders)) continue;
                     foreach (var folder in folders)
                     {
@@ -4990,7 +4992,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
             }
             else
             {
-                all = await _localStore.LoadAllSummariesAsync();
+                all = ExcludeSharedMail(await _localStore.LoadAllSummariesAsync()); // #31: aggregate excludes shared
             }
             if (!IsCurrentFolderLoad(loadVersion, expectedFolder)) return;
 
@@ -5078,6 +5080,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
                 all = new List<MailMessageSummary>();
                 foreach (var account in Accounts)
                 {
+                    if (account.IsShared) continue;   // #31: shared excluded from contact-mail results
                     if (!_cachedFolders.TryGetValue(account.Id, out var folders)) continue;
                     foreach (var folder in folders)
                     {
@@ -5101,7 +5104,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
             }
             else
             {
-                all = await _localStore.LoadAllSummariesAsync();
+                all = ExcludeSharedMail(await _localStore.LoadAllSummariesAsync()); // #31: aggregate excludes shared
             }
             if (!IsCurrentFolderLoad(loadVersion, expectedFolder)) return;
 
@@ -5614,6 +5617,27 @@ public partial class MainViewModel : ObservableObject, IDisposable
          string.Equals(fullName, AllTrashFolder.FullName,   StringComparison.Ordinal) ||
          string.Equals(fullName, AllArchiveFolder.FullName, StringComparison.Ordinal));
 
+    /// <summary>True if the given account id belongs to a shared mailbox (#31) — used to keep shared
+    /// mail out of the global aggregates (All Mail / All Flagged / All Watched / contact-mail) while it
+    /// still gets swept.</summary>
+    internal bool IsSharedAccountId(Guid accountId) =>
+        Accounts.FirstOrDefault(a => a.Id == accountId)?.IsShared == true;
+
+    /// <summary>
+    /// Drops shared-mailbox messages (#31) from a cross-account aggregate read from cache. The global
+    /// aggregates never include shared mail; this is the cache-read counterpart to the
+    /// <see cref="IsSharedAccountId"/> filter the live-arrival path applies in <c>OnFolderSynced</c>, so
+    /// the fetch and the live filter can never disagree (the invariant <see cref="FolderScopedAggregateSources"/>
+    /// documents). Fast-paths the common no-shared-accounts case so All Mail loads pay nothing for it.
+    /// </summary>
+    private List<MailMessageSummary> ExcludeSharedMail(IEnumerable<MailMessageSummary> summaries)
+    {
+        var sharedIds = Accounts.Where(a => a.IsShared).Select(a => a.Id).ToHashSet();
+        return sharedIds.Count == 0
+            ? summaries as List<MailMessageSummary> ?? summaries.ToList()
+            : summaries.Where(m => !sharedIds.Contains(m.AccountId)).ToList();
+    }
+
     /// <summary>
     /// The real (account, folder) pairs a folder-scoped aggregate spans. All Inboxes / Drafts / Sent
     /// / Trash match on <see cref="SpecialFolderKind"/>; All Archive resolves each account's archive
@@ -5622,11 +5646,6 @@ public partial class MainViewModel : ObservableObject, IDisposable
     /// list has not been cached yet, and accounts with no archive destination, contribute nothing.
     /// Both the fetch and the live-arrival filter read this, so they can never disagree.
     /// </summary>
-    /// <summary>True if the given account id belongs to a shared mailbox (#31) — used to keep shared
-    /// mail out of the global aggregates (All Mail / All Flagged) while it still gets swept.</summary>
-    internal bool IsSharedAccountId(Guid accountId) =>
-        Accounts.FirstOrDefault(a => a.Id == accountId)?.IsShared == true;
-
     internal IEnumerable<(AccountModel Account, MailFolderModel Folder)> FolderScopedAggregateSources(
         string fullName)
     {
@@ -6782,18 +6801,31 @@ public partial class MainViewModel : ObservableObject, IDisposable
     {
         if (account == null) return;
 
-        if (ConfirmationRequested?.Invoke(
-            $"Remove the account '{account.AccountLabel}'? This only removes it from QuickMail — your mail on the server is not affected.",
-            "Remove Account") != true) return;
+        // #31: a parent's shared mailboxes have no independent existence — remove them with it, naming
+        // them in the confirmation, exactly as the Account Manager does (AccountManagerViewModel uses the
+        // same AccountModel.SharedChildrenOf helper). Without this, deleting a parent here left orphaned
+        // shared accounts whose ParentAccountId points at nothing — unconnectable and unrepairable.
+        var sharedChildren = AccountModel.SharedChildrenOf(account, Accounts);
+        var prompt = sharedChildren.Count == 0
+            ? $"Remove the account '{account.AccountLabel}'? This only removes it from QuickMail — your mail on the server is not affected."
+            : $"Removing '{account.AccountLabel}' will also remove its shared mailbox{(sharedChildren.Count == 1 ? "" : "es")}: "
+              + $"{string.Join(", ", sharedChildren.Select(c => c.AccountLabel))}. This only removes them from QuickMail — your mail on the server is not affected.";
+        // Fail closed: an unwired or declined confirmation removes nothing.
+        if (ConfirmationRequested?.Invoke(prompt, "Remove Account") != true) return;
 
-        _credentials.DeletePassword(account.Id);
-        Accounts.Remove(account);
+        var removed = new List<AccountModel> { account };
+        removed.AddRange(sharedChildren);
+
+        foreach (var a in removed)
+        {
+            _credentials.DeletePassword(a.Id);
+            Accounts.Remove(a);
+            _cachedFolders.Remove(a.Id);
+        }
         _accountService.SaveAccounts([.. Accounts]);
-
-        _cachedFolders.Remove(account.Id);
         RebuildFolderListFromCache();
 
-        if (SelectedAccount?.Id == account.Id)
+        if (SelectedAccount != null && removed.Any(a => a.Id == SelectedAccount.Id))
         {
             SelectedAccount  = Accounts.FirstOrDefault();
             SelectedFolder   = AllMailFolder;
@@ -6801,21 +6833,30 @@ public partial class MainViewModel : ObservableObject, IDisposable
         }
 
         var config = _configService.Load();
-        if (config.Accounts.Remove(account.Id))
-            _configService.Save(config);
+        var configChanged = false;
+        foreach (var a in removed) configChanged |= config.Accounts.Remove(a.Id);
+        if (configChanged) _configService.Save(config);
 
         StatusText = $"Account '{account.AccountLabel}' removed. Cleaning up local data…";
 
-        try   { await _localStore.DeleteAccountDataAsync(account.Id); }
-        catch (Exception ex) { LogService.Log($"DeleteAccount: failed to purge mail.db — {ex.Message}"); }
-
-        if (account.AuthType is AuthType.OAuth2Microsoft or AuthType.OAuth2Google)
+        foreach (var a in removed)
         {
-            try   { await _oauthService.SignOutAsync(account); }
-            catch (Exception ex) { LogService.Log($"DeleteAccount: failed OAuth sign-out — {ex.Message}"); }
+            try   { await _localStore.DeleteAccountDataAsync(a.Id); }
+            catch (Exception ex) { LogService.Log($"DeleteAccount: failed to purge mail.db for {a.AccountLabel} — {ex.Message}"); }
+
+            // A shared child inherits the parent's AuthType, so it enters this block too; SignOutAsync
+            // matches the MSAL cache by Username (the shared address, never the parent's), so it resolves
+            // to no account and is a harmless no-op — the parent's token is not touched by the child.
+            if (a.AuthType is AuthType.OAuth2Microsoft or AuthType.OAuth2Google)
+            {
+                try   { await _oauthService.SignOutAsync(a); }
+                catch (Exception ex) { LogService.Log($"DeleteAccount: failed OAuth sign-out for {a.AccountLabel} — {ex.Message}"); }
+            }
         }
 
-        StatusText = $"Account '{account.AccountLabel}' removed.";
+        StatusText = sharedChildren.Count == 0
+            ? $"Account '{account.AccountLabel}' removed."
+            : $"Account '{account.AccountLabel}' removed, along with {sharedChildren.Count} shared mailbox{(sharedChildren.Count == 1 ? "" : "es")}.";
         ConnectionStatusText = Accounts.Count == 0 ? "Offline" : $"{Accounts.Count} account(s) connected";
     }
 

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -2629,8 +2629,8 @@ public partial class MainViewModel : ObservableObject, IDisposable
         IEnumerable<MailMessageSummary> relevant;
         if (selected.FullName == AllMailFolder.FullName)
         {
-            // Global "All Mail" - accept messages from every account.
-            relevant = incoming;
+            // Global "All Mail" - accept messages from every account except shared mailboxes (#31).
+            relevant = incoming.Where(m => !IsSharedAccountId(m.AccountId));
         }
         else if (TryGetAccountIdFromSentinel(selected.FullName, out var watchedAccountId))
         {
@@ -2639,8 +2639,8 @@ public partial class MainViewModel : ObservableObject, IDisposable
         }
         else if (selected.FullName == AllFlaggedFolder.FullName)
         {
-            // All Flagged Mail — only accept flagged incoming messages.
-            relevant = incoming.Where(m => m.IsFlagged);
+            // All Flagged Mail — only accept flagged incoming messages (shared mailboxes excluded, #31).
+            relevant = incoming.Where(m => m.IsFlagged && !IsSharedAccountId(m.AccountId));
         }
         else if (selected.FullName == AllWatchedFolder.FullName)
         {
@@ -3840,12 +3840,16 @@ public partial class MainViewModel : ObservableObject, IDisposable
             }
             else
             {
-                // Placeholder node for accounts that have not yet loaded folders.
+                // Placeholder node for accounts that have not yet loaded folders. A shared mailbox (#31)
+                // stays here through PR 1 (no backend access yet) — a navigable top-level node with no
+                // children — so it must carry the account id + shared flag for the node key and name.
                 roots.Add(new FolderTreeNode
                 {
                     IsHeader = true,
                     Label    = account.AccountLabel,
                     Folder   = null,
+                    AccountId       = account.Id,
+                    IsSharedAccount = account.IsShared,
                 });
             }
         }
@@ -3861,8 +3865,10 @@ public partial class MainViewModel : ObservableObject, IDisposable
         MarkDefaultCalendarNodes();
     }
 
-    private static string NodeKey(FolderTreeNode n) =>
-        n.Folder != null ? $"F:{n.Folder.AccountId}:{n.Folder.FullName}" : $"H:{n.Label}";
+    internal static string NodeKey(FolderTreeNode n) =>
+        n.Folder != null ? $"F:{n.Folder.AccountId}:{n.Folder.FullName}"
+        : n.AccountId is { } id ? $"H:{id}:{n.Label}"   // #31: disambiguate same-named account/shared headers
+        : $"H:{n.Label}";
 
     private static IEnumerable<FolderTreeNode> FlattenAllNodes(IEnumerable<FolderTreeNode> nodes)
     {
@@ -4637,7 +4643,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
                 (cached.Any(m => string.IsNullOrWhiteSpace(m.To))
                     || await _localStore.HasSummariesMissingRecipientsAsync());
             var perAccountTasks = Accounts
-                .Where(a => _cachedFolders.ContainsKey(a.Id))
+                .Where(a => _cachedFolders.ContainsKey(a.Id) && !a.IsShared)   // #31: shared excluded from All Mail
                 .Select(account => (OnlineMode || needsRecipientRepair)
                     ? FetchAccountAllFoldersAsync(account, ct)
                     : FetchAccountNewMessagesAsync(account, ct));
@@ -5615,7 +5621,12 @@ public partial class MainViewModel : ObservableObject, IDisposable
     /// list has not been cached yet, and accounts with no archive destination, contribute nothing.
     /// Both the fetch and the live-arrival filter read this, so they can never disagree.
     /// </summary>
-    private IEnumerable<(AccountModel Account, MailFolderModel Folder)> FolderScopedAggregateSources(
+    /// <summary>True if the given account id belongs to a shared mailbox (#31) — used to keep shared
+    /// mail out of the global aggregates (All Mail / All Flagged) while it still gets swept.</summary>
+    internal bool IsSharedAccountId(Guid accountId) =>
+        Accounts.FirstOrDefault(a => a.Id == accountId)?.IsShared == true;
+
+    internal IEnumerable<(AccountModel Account, MailFolderModel Folder)> FolderScopedAggregateSources(
         string fullName)
     {
         var isArchive = string.Equals(fullName, AllArchiveFolder.FullName, StringComparison.Ordinal);
@@ -5628,6 +5639,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
 
         foreach (var account in Accounts)
         {
+            if (account.IsShared) continue;   // #31: shared mailboxes are excluded from All-* aggregates (still swept)
             if (!_cachedFolders.TryGetValue(account.Id, out var folders)) continue;
 
             if (isArchive)

--- a/QuickMail/Views/AccountManagerDialog.xaml
+++ b/QuickMail/Views/AccountManagerDialog.xaml
@@ -100,7 +100,7 @@
                          Text="{Binding SelectedProvider.DisplayName, Mode=OneWay}"
                          IsReadOnly="True"
                          AutomationProperties.LabeledBy="{Binding ElementName=LblProvider}"
-                         TabIndex="4"
+                         TabIndex="5"
                          Margin="0,0,0,4"/>
 
                 <!-- Account Name -->
@@ -108,7 +108,7 @@
                 <TextBox x:Name="AccountNameBox"
                          Text="{Binding AccountName, UpdateSourceTrigger=PropertyChanged}"
                          AutomationProperties.LabeledBy="{Binding ElementName=LblAccountName}"
-                         TabIndex="5"/>
+                         TabIndex="6"/>
 
                 <!-- Sender Display Name — hidden for a shared mailbox (#31): its outgoing identity is the
                      mailbox's own directory display name on send, not a name set per-account here. -->
@@ -117,7 +117,7 @@
                     <TextBox x:Name="DisplayNameBox"
                              Text="{Binding DisplayName, UpdateSourceTrigger=PropertyChanged}"
                              AutomationProperties.LabeledBy="{Binding ElementName=LblDisplayName}"
-                             TabIndex="6"/>
+                             TabIndex="7"/>
                 </StackPanel>
 
                 <!-- The account's own email address. Since #396 it is only that: a server whose
@@ -127,7 +127,7 @@
                          Text="{Binding Username, UpdateSourceTrigger=PropertyChanged}"
                          IsReadOnly="{Binding IsSharedSelected}"
                          AutomationProperties.LabeledBy="{Binding ElementName=LblUsername}"
-                         TabIndex="7"/>
+                         TabIndex="8"/>
 
                 <!-- #31: a shared mailbox has no credentials or connection of its own — it reads through
                      its parent account and shows mail only. In place of the connection/auth/sync
@@ -153,7 +153,7 @@
                     <Label x:Name="LblPassword" Content="Pass_word:" Target="{Binding ElementName=PasswordBox}" Padding="0" Margin="0,8,0,2"/>
                     <PasswordBox x:Name="PasswordBox"
                                  AutomationProperties.LabeledBy="{Binding ElementName=LblPassword}"
-                                 TabIndex="8"
+                                 TabIndex="9"
                                  PasswordChanged="PasswordBox_PasswordChanged"/>
 
                     <!-- App-specific password warning, driven by the account's provider (Gmail, Yahoo,
@@ -167,7 +167,7 @@
                         <StackPanel>
                             <TextBlock Text="{Binding AppPasswordHint}" TextWrapping="Wrap" FontWeight="SemiBold"/>
                             <TextBlock Margin="0,4,0,0" TextWrapping="Wrap">
-                                <Hyperlink NavigateUri="{Binding AppPasswordUrl}" KeyboardNavigation.TabIndex="9"
+                                <Hyperlink NavigateUri="{Binding AppPasswordUrl}" KeyboardNavigation.TabIndex="10"
                                            RequestNavigate="AppPasswordLink_RequestNavigate"
                                            AutomationProperties.Name="Create an app password">
                                     <Run Text="{Binding AppPasswordUrl, Mode=OneWay}"/>
@@ -182,13 +182,13 @@
                         Visibility="{Binding IsOAuth2, Converter={StaticResource BoolToVisibility}}"
                         Command="{Binding SignInMicrosoftCommand}"
                         AutomationProperties.Name="Sign in with Microsoft"
-                        HorizontalAlignment="Left" MinWidth="200" Margin="0,8,0,0" TabIndex="10"/>
+                        HorizontalAlignment="Left" MinWidth="200" Margin="0,8,0,0" TabIndex="11"/>
 
                 <Button Content="Sign in _with Google…"
                         Visibility="{Binding IsGoogleOAuth, Converter={StaticResource BoolToVisibility}}"
                         Command="{Binding SignInGoogleCommand}"
                         AutomationProperties.Name="Sign in with Google"
-                        HorizontalAlignment="Left" MinWidth="200" Margin="0,8,0,0" TabIndex="11"/>
+                        HorizontalAlignment="Left" MinWidth="200" Margin="0,8,0,0" TabIndex="12"/>
 
                 </StackPanel>
                 <!-- end #31 ShowNormalAccountFields wrapper (password + OAuth sign-in) -->
@@ -203,7 +203,7 @@
                               IsChecked="{Binding SyncContacts}"
                               Click="SyncContactsCheckBox_Click"
                               AutomationProperties.Name="Sync contacts from this account"
-                              Margin="0,0,0,4" TabIndex="12"/>
+                              Margin="0,0,0,4" TabIndex="13"/>
                 </StackPanel>
 
                 <!-- Calendar sync (#282) — shown for Microsoft, Google, and iCloud accounts. -->
@@ -215,7 +215,7 @@
                               IsChecked="{Binding SyncCalendar}"
                               Click="SyncCalendarCheckBox_Click"
                               AutomationProperties.Name="Sync calendar from this account"
-                              Margin="0,0,0,4" TabIndex="13"/>
+                              Margin="0,0,0,4" TabIndex="14"/>
                 </StackPanel>
 
                 <!-- Server settings live behind the same expander as the Add Account dialog, so an

--- a/QuickMail/Views/AccountManagerDialog.xaml
+++ b/QuickMail/Views/AccountManagerDialog.xaml
@@ -54,6 +54,7 @@
                         x:Name="AddSharedButton"
                         Click="AddSharedMailboxButton_Click"
                         AutomationProperties.Name="Add shared mailbox"
+                        Visibility="{Binding IsSharedMailboxesEnabled, Converter={StaticResource BoolToVisibility}}"
                         MinWidth="90" TabIndex="4"/>
             </StackPanel>
             <ListBox x:Name="AccountListBox"

--- a/QuickMail/Views/AccountManagerDialog.xaml
+++ b/QuickMail/Views/AccountManagerDialog.xaml
@@ -49,7 +49,12 @@
                         Command="{Binding SetDefaultCommand}"
                         CommandParameter="{Binding SelectedAccount}"
                         AutomationProperties.Name="Set as default"
-                        MinWidth="75" TabIndex="3"/>
+                        MinWidth="75" Margin="0,0,4,0" TabIndex="3"/>
+                <Button Content="Add _shared…"
+                        x:Name="AddSharedButton"
+                        Click="AddSharedMailboxButton_Click"
+                        AutomationProperties.Name="Add shared mailbox"
+                        MinWidth="90" TabIndex="4"/>
             </StackPanel>
             <ListBox x:Name="AccountListBox"
                      TabIndex="0"

--- a/QuickMail/Views/AccountManagerDialog.xaml
+++ b/QuickMail/Views/AccountManagerDialog.xaml
@@ -122,8 +122,28 @@
                 <Label x:Name="LblUsername" Content="_Email address:" Target="{Binding ElementName=UsernameBox}" Padding="0" Margin="0,8,0,2"/>
                 <TextBox x:Name="UsernameBox"
                          Text="{Binding Username, UpdateSourceTrigger=PropertyChanged}"
+                         IsReadOnly="{Binding IsSharedSelected}"
                          AutomationProperties.LabeledBy="{Binding ElementName=LblUsername}"
                          TabIndex="7"/>
+
+                <!-- #31: a shared mailbox has no credentials or connection of its own — it reads through
+                     its parent account and shows mail only. In place of the connection/auth/sync
+                     surface (hidden below), a read-only summary says what it is. A read-only TextBox,
+                     not a TextBlock, so a screen reader reads the value (same reasoning as ProviderText). -->
+                <StackPanel Visibility="{Binding IsSharedSelected, Converter={StaticResource BoolToVisibility}}"
+                            Margin="0,8,0,0">
+                    <Label x:Name="LblSharedParent" Content="Shared mailbox:" Target="{Binding ElementName=SharedSummaryText}" Padding="0" Margin="0,0,0,2"/>
+                    <TextBox x:Name="SharedSummaryText"
+                             Text="{Binding SharedParentName, Mode=OneWay, StringFormat=Reads through {0}. Mail only — no separate sign-in.}"
+                             IsReadOnly="True"
+                             TextWrapping="Wrap"
+                             AutomationProperties.LabeledBy="{Binding ElementName=LblSharedParent}"/>
+                </StackPanel>
+
+                <!-- #31: the whole editable connection surface (password, OAuth sign-in) is hidden for a
+                     shared mailbox — it authenticates through its parent, not itself. The inner panels
+                     keep their own auth-type visibility for normal accounts. -->
+                <StackPanel Visibility="{Binding ShowConnectionEditing, Converter={StaticResource BoolToVisibility}}">
 
                 <!-- Password panel -->
                 <StackPanel Visibility="{Binding IsPasswordAuth, Converter={StaticResource BoolToVisibility}}">
@@ -167,6 +187,9 @@
                         AutomationProperties.Name="Sign in with Google"
                         HorizontalAlignment="Left" MinWidth="200" Margin="0,8,0,0" TabIndex="11"/>
 
+                </StackPanel>
+                <!-- end #31 ShowConnectionEditing wrapper (password + OAuth sign-in) -->
+
                 <!-- Contact sync (issue #256) — shown only for accounts with a contact API. Stays on
                      the main surface: it is a per-account choice, not a server setting. -->
                 <StackPanel Visibility="{Binding CanSyncContacts, Converter={StaticResource BoolToVisibility}}">
@@ -199,6 +222,7 @@
                           Header="Ad_vanced settings"
                           IsExpanded="{Binding IsAdvancedExpanded, Mode=TwoWay}"
                           AutomationProperties.Name="Advanced settings"
+                          Visibility="{Binding ShowConnectionEditing, Converter={StaticResource BoolToVisibility}}"
                           Margin="0,14,0,0">
                     <StackPanel Margin="0,8,0,0">
 

--- a/QuickMail/Views/AccountManagerDialog.xaml
+++ b/QuickMail/Views/AccountManagerDialog.xaml
@@ -110,12 +110,15 @@
                          AutomationProperties.LabeledBy="{Binding ElementName=LblAccountName}"
                          TabIndex="5"/>
 
-                <!-- Sender Display Name -->
-                <Label x:Name="LblDisplayName" Content="Sender _display name:" Target="{Binding ElementName=DisplayNameBox}" Padding="0" Margin="0,8,0,2"/>
-                <TextBox x:Name="DisplayNameBox"
-                         Text="{Binding DisplayName, UpdateSourceTrigger=PropertyChanged}"
-                         AutomationProperties.LabeledBy="{Binding ElementName=LblDisplayName}"
-                         TabIndex="6"/>
+                <!-- Sender Display Name — hidden for a shared mailbox (#31): its outgoing identity is the
+                     mailbox's own directory display name on send, not a name set per-account here. -->
+                <StackPanel Visibility="{Binding ShowNormalAccountFields, Converter={StaticResource BoolToVisibility}}">
+                    <Label x:Name="LblDisplayName" Content="Sender _display name:" Target="{Binding ElementName=DisplayNameBox}" Padding="0" Margin="0,8,0,2"/>
+                    <TextBox x:Name="DisplayNameBox"
+                             Text="{Binding DisplayName, UpdateSourceTrigger=PropertyChanged}"
+                             AutomationProperties.LabeledBy="{Binding ElementName=LblDisplayName}"
+                             TabIndex="6"/>
+                </StackPanel>
 
                 <!-- The account's own email address. Since #396 it is only that: a server whose
                      login differs has a separate Login username box under Advanced settings. -->
@@ -143,7 +146,7 @@
                 <!-- #31: the whole editable connection surface (password, OAuth sign-in) is hidden for a
                      shared mailbox — it authenticates through its parent, not itself. The inner panels
                      keep their own auth-type visibility for normal accounts. -->
-                <StackPanel Visibility="{Binding ShowConnectionEditing, Converter={StaticResource BoolToVisibility}}">
+                <StackPanel Visibility="{Binding ShowNormalAccountFields, Converter={StaticResource BoolToVisibility}}">
 
                 <!-- Password panel -->
                 <StackPanel Visibility="{Binding IsPasswordAuth, Converter={StaticResource BoolToVisibility}}">
@@ -188,7 +191,7 @@
                         HorizontalAlignment="Left" MinWidth="200" Margin="0,8,0,0" TabIndex="11"/>
 
                 </StackPanel>
-                <!-- end #31 ShowConnectionEditing wrapper (password + OAuth sign-in) -->
+                <!-- end #31 ShowNormalAccountFields wrapper (password + OAuth sign-in) -->
 
                 <!-- Contact sync (issue #256) — shown only for accounts with a contact API. Stays on
                      the main surface: it is a per-account choice, not a server setting. -->
@@ -222,7 +225,7 @@
                           Header="Ad_vanced settings"
                           IsExpanded="{Binding IsAdvancedExpanded, Mode=TwoWay}"
                           AutomationProperties.Name="Advanced settings"
-                          Visibility="{Binding ShowConnectionEditing, Converter={StaticResource BoolToVisibility}}"
+                          Visibility="{Binding ShowNormalAccountFields, Converter={StaticResource BoolToVisibility}}"
                           Margin="0,14,0,0">
                     <StackPanel Margin="0,8,0,0">
 

--- a/QuickMail/Views/AccountManagerDialog.xaml.cs
+++ b/QuickMail/Views/AccountManagerDialog.xaml.cs
@@ -35,6 +35,19 @@ public partial class AccountManagerDialog : Window
         // password itself — otherwise the box keeps showing dots for a password that is gone.
         vm.PasswordCleared += OnPasswordCleared;
         vm.EmailAddressRejected += OnEmailAddressRejected;
+        // #31: removing a parent takes its shared mailboxes with it — confirm, naming them, first.
+        vm.ConfirmCascadeRemoval = message =>
+            MessageBox.Show(this, message, "Remove shared mailboxes",
+                MessageBoxButton.YesNo, MessageBoxImage.Warning) == MessageBoxResult.Yes;
+    }
+
+    private void AddSharedMailboxButton_Click(object sender, RoutedEventArgs e)
+    {
+        var addVm = _vm.CreateAddSharedMailboxViewModel();
+        addVm.SharedMailboxAdded += _vm.CommitNewSharedMailbox;   // commit + persist; the window closes itself
+        // Modeless (Show), not ShowDialog: an editable field over the main window's live WebView2 would
+        // deadlock under a nested modal loop — the GrabAddresses lesson (spec §7).
+        new AddSharedMailboxWindow(addVm) { Owner = this }.Show();
     }
 
     private void OnPasswordCleared()

--- a/QuickMail/Views/AccountManagerDialog.xaml.cs
+++ b/QuickMail/Views/AccountManagerDialog.xaml.cs
@@ -44,13 +44,31 @@ public partial class AccountManagerDialog : Window
     private void AddSharedMailboxButton_Click(object sender, RoutedEventArgs e)
     {
         var addVm = _vm.CreateAddSharedMailboxViewModel();
+        // No shared-capable account to read through: don't open a dead-end form the user can't complete.
+        // Report why in the manager's status line, where it is announced as a Result.
+        if (addVm.ParentOptions.Count == 0)
+        {
+            _vm.SetStatusOutcome(AddSharedMailboxViewModel.NoEligibleParentMessage);
+            return;
+        }
+
         addVm.SharedMailboxAdded += _vm.CommitNewSharedMailbox;   // commit + persist; the window closes itself
-        // Modeless (Show), not ShowDialog: an editable field over the main window's live WebView2 would
-        // deadlock under a nested modal loop — the GrabAddresses lesson (spec §7).
+        // Modeless (Show), not ShowDialog: this window has an editable field and can sit over the main
+        // window's live WebView2. Note the manager itself is modal (ShowDialog), so the editable field is
+        // already inside a nested modal loop — the same position the manager's own text boxes occupy and
+        // use without issue; Show() keeps this window from adding a SECOND nested loop. Verify with a
+        // screen reader before default-on (spec §7 modal rule; PR review finding 5).
         var window = new AddSharedMailboxWindow(addVm) { Owner = this };
-        // New-Window-Checklist focus restoration: a modeless window does not reliably return focus to
-        // its launcher, so put it back on the button that opened this dialog when it closes.
-        window.Closed += (_, _) => AddSharedButton.Focus();
+        // Don't let repeated presses stack several add windows.
+        AddSharedButton.IsEnabled = false;
+        window.Closed += (_, _) =>
+        {
+            addVm.SharedMailboxAdded -= _vm.CommitNewSharedMailbox;   // pair the += so no ghost callback survives
+            AddSharedButton.IsEnabled = true;
+            // Focus restoration (New-Window-Checklist): a modeless window does not reliably return focus
+            // to its launcher, so put it back on the button that opened this dialog.
+            AddSharedButton.Focus();
+        };
         window.Show();
     }
 

--- a/QuickMail/Views/AccountManagerDialog.xaml.cs
+++ b/QuickMail/Views/AccountManagerDialog.xaml.cs
@@ -47,7 +47,11 @@ public partial class AccountManagerDialog : Window
         addVm.SharedMailboxAdded += _vm.CommitNewSharedMailbox;   // commit + persist; the window closes itself
         // Modeless (Show), not ShowDialog: an editable field over the main window's live WebView2 would
         // deadlock under a nested modal loop — the GrabAddresses lesson (spec §7).
-        new AddSharedMailboxWindow(addVm) { Owner = this }.Show();
+        var window = new AddSharedMailboxWindow(addVm) { Owner = this };
+        // New-Window-Checklist focus restoration: a modeless window does not reliably return focus to
+        // its launcher, so put it back on the button that opened this dialog when it closes.
+        window.Closed += (_, _) => AddSharedButton.Focus();
+        window.Show();
     }
 
     private void OnPasswordCleared()

--- a/QuickMail/Views/AddSharedMailboxWindow.xaml
+++ b/QuickMail/Views/AddSharedMailboxWindow.xaml
@@ -14,6 +14,10 @@
         FontFamily="{DynamicResource Theme.FontFamily}"
         FontSize="{DynamicResource Theme.FontSizeBase}">
 
+    <Window.Resources>
+        <BooleanToVisibilityConverter x:Key="BoolToVisibility"/>
+    </Window.Resources>
+
     <StackPanel Margin="16">
 
         <TextBlock Text="Shared mailbox address" Margin="0,0,0,2"/>

--- a/QuickMail/Views/AddSharedMailboxWindow.xaml
+++ b/QuickMail/Views/AddSharedMailboxWindow.xaml
@@ -1,0 +1,50 @@
+<Window x:Class="QuickMail.Views.AddSharedMailboxWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Add shared mailbox"
+        AutomationProperties.Name="Add shared mailbox"
+        Width="440" SizeToContent="Height"
+        MinWidth="380"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="NoResize"
+        ShowInTaskbar="False"
+        WindowStyle="SingleBorderWindow"
+        Background="{DynamicResource Theme.WindowBackground}"
+        Foreground="{DynamicResource Theme.TextPrimary}"
+        FontFamily="{DynamicResource Theme.FontFamily}"
+        FontSize="{DynamicResource Theme.FontSizeBase}">
+
+    <StackPanel Margin="16">
+
+        <TextBlock Text="Shared mailbox address" Margin="0,0,0,2"/>
+        <TextBox x:Name="AddressBox"
+                 Text="{Binding Address, UpdateSourceTrigger=PropertyChanged}"
+                 AutomationProperties.Name="Shared mailbox address"
+                 Padding="4,3" Margin="0,0,0,10"/>
+
+        <StackPanel Visibility="{Binding ShowParentSelector, Converter={StaticResource BoolToVisibility}}">
+            <TextBlock Text="Parent account" Margin="0,0,0,2"/>
+            <ComboBox ItemsSource="{Binding ParentOptions}"
+                      SelectedItem="{Binding SelectedParent}"
+                      AutomationProperties.Name="Parent account"
+                      Margin="0,0,0,10"/>
+        </StackPanel>
+
+        <!-- Static note, not an announce: a Graph shared mailbox has no live watcher, only the sweep. -->
+        <TextBlock Text="Shared mailboxes update every few minutes, not instantly."
+                   TextWrapping="Wrap" Opacity="0.85" Margin="0,0,0,10"
+                   Visibility="{Binding ShowGraphPollNote, Converter={StaticResource BoolToVisibility}}"/>
+
+        <TextBlock Text="{Binding ErrorText}" TextWrapping="Wrap" FontWeight="SemiBold"
+                   Margin="0,0,0,10"/>
+
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+            <Button Content="Add" Command="{Binding AddCommand}" IsDefault="True"
+                    MinWidth="72" Margin="0,0,8,0"
+                    AutomationProperties.Name="Add shared mailbox"/>
+            <Button Content="Cancel" Click="CancelButton_Click" MinWidth="72"
+                    AutomationProperties.Name="Cancel"/>
+        </StackPanel>
+
+    </StackPanel>
+</Window>

--- a/QuickMail/Views/AddSharedMailboxWindow.xaml
+++ b/QuickMail/Views/AddSharedMailboxWindow.xaml
@@ -20,34 +20,49 @@
 
     <StackPanel Margin="16">
 
-        <TextBlock Text="Shared mailbox address" Margin="0,0,0,2"/>
+        <!-- Label + Target/LabeledBy (not a bare TextBlock) so there is an Alt+A access key to the box
+             and the screen reader reads "Shared mailbox address" as the field's name. -->
+        <Label x:Name="LblAddress" Content="Shared mailbox _address:" Target="{Binding ElementName=AddressBox}"
+               Padding="0" Margin="0,0,0,2"/>
         <TextBox x:Name="AddressBox"
                  Text="{Binding Address, UpdateSourceTrigger=PropertyChanged}"
-                 AutomationProperties.Name="Shared mailbox address"
+                 AutomationProperties.LabeledBy="{Binding ElementName=LblAddress}"
                  Padding="4,3" Margin="0,0,0,10"/>
 
         <StackPanel Visibility="{Binding ShowParentSelector, Converter={StaticResource BoolToVisibility}}">
-            <TextBlock Text="Parent account" Margin="0,0,0,2"/>
-            <ComboBox ItemsSource="{Binding ParentOptions}"
+            <Label x:Name="LblParent" Content="_Parent account:" Target="{Binding ElementName=ParentCombo}"
+                   Padding="0" Margin="0,0,0,2"/>
+            <ComboBox x:Name="ParentCombo"
+                      ItemsSource="{Binding ParentOptions}"
                       SelectedItem="{Binding SelectedParent}"
-                      AutomationProperties.Name="Parent account"
+                      AutomationProperties.LabeledBy="{Binding ElementName=LblParent}"
                       Margin="0,0,0,10"/>
         </StackPanel>
 
-        <!-- Static note, not an announce: a Graph shared mailbox has no live watcher, only the sweep. -->
-        <TextBlock Text="Shared mailboxes update every few minutes, not instantly."
+        <!-- Visible poll caption for a Graph parent; also spoken once as a Hint on open (code-behind),
+             since a screen-reader user would not otherwise find static screen text. -->
+        <TextBlock Text="{Binding GraphPollNote}"
                    TextWrapping="Wrap" Opacity="0.85" Margin="0,0,0,10"
                    Visibility="{Binding ShowGraphPollNote, Converter={StaticResource BoolToVisibility}}"/>
 
-        <TextBlock Text="{Binding ErrorText}" TextWrapping="Wrap" FontWeight="SemiBold"
-                   Margin="0,0,0,10"/>
+        <!-- Collapses when empty so it contributes no stray margin to the layout. -->
+        <TextBlock Text="{Binding ErrorText}" TextWrapping="Wrap" FontWeight="SemiBold" Margin="0,0,0,10">
+            <TextBlock.Style>
+                <Style TargetType="TextBlock">
+                    <Setter Property="Visibility" Value="Visible"/>
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding ErrorText}" Value="">
+                            <Setter Property="Visibility" Value="Collapsed"/>
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </TextBlock.Style>
+        </TextBlock>
 
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-            <Button Content="Add" Command="{Binding AddCommand}" IsDefault="True"
-                    MinWidth="72" Margin="0,0,8,0"
-                    AutomationProperties.Name="Add shared mailbox"/>
-            <Button Content="Cancel" Click="CancelButton_Click" MinWidth="72"
-                    AutomationProperties.Name="Cancel"/>
+            <Button Content="_Add" Command="{Binding AddCommand}" IsDefault="True"
+                    MinWidth="72" Margin="0,0,8,0"/>
+            <Button Content="_Cancel" Click="CancelButton_Click" MinWidth="72"/>
         </StackPanel>
 
     </StackPanel>

--- a/QuickMail/Views/AddSharedMailboxWindow.xaml.cs
+++ b/QuickMail/Views/AddSharedMailboxWindow.xaml.cs
@@ -35,6 +35,10 @@ public partial class AddSharedMailboxWindow : Window
         {
             AddressBox.Focus();
             Keyboard.Focus(AddressBox);
+            // A Graph parent updates only on the sweep. Speak the poll caption once as a Hint — a screen
+            // reader user would not otherwise find the static on-screen text. Respects AnnounceHints.
+            if (_vm.ShowGraphPollNote)
+                AccessibilityHelper.Announce(this, _vm.GraphPollNote, category: AnnouncementCategory.Hint);
         };
     }
 

--- a/QuickMail/Views/AddSharedMailboxWindow.xaml.cs
+++ b/QuickMail/Views/AddSharedMailboxWindow.xaml.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Windows;
+using System.Windows.Input;
+using QuickMail.Helpers;
+using QuickMail.Models;
+using QuickMail.Services;
+using QuickMail.ViewModels;
+
+namespace QuickMail.Views;
+
+/// <summary>
+/// Add-shared-mailbox dialog (#31, spec §6/§7). A leaf single-form window (Address → Parent →
+/// Add/Cancel), so it deliberately has no F6 ring and no command palette — there is nothing to jump
+/// between and a palette would only duplicate the two buttons (same New-Window-Checklist exception as
+/// <see cref="ServerRuleEditorWindow"/>). It has an editable TextBox and can open over the main
+/// window's live WebView2, so it is shown modeless (<c>Show()</c>) with Escape/Cancel wired explicitly
+/// — the GrabAddresses deadlock lesson. Focus lands on Address; the owner restores focus on close.
+/// </summary>
+public partial class AddSharedMailboxWindow : Window
+{
+    private readonly AddSharedMailboxViewModel _vm;
+
+    public AddSharedMailboxWindow(AddSharedMailboxViewModel vm)
+    {
+        _vm = vm;
+        InitializeComponent();
+        DataContext = vm;
+
+        _vm.CancelRequested += OnCancelRequested;
+        _vm.SharedMailboxAdded += OnSharedMailboxAdded;
+        _vm.AnnouncementRequested += OnAnnouncementRequested;
+
+        Loaded += (_, _) =>
+        {
+            AddressBox.Focus();
+            Keyboard.Focus(AddressBox);
+        };
+    }
+
+    private void OnCancelRequested() => Close();
+
+    // Close on a successful add; the owner (Account Manager) commits and persists via its own
+    // subscription to the same event.
+    private void OnSharedMailboxAdded(AccountModel _) => Close();
+
+    private void OnAnnouncementRequested(string text, AnnouncementCategory category)
+        => AccessibilityHelper.Announce(this, text, category: category);
+
+    private void CancelButton_Click(object sender, RoutedEventArgs e) => Close();
+
+    protected override void OnPreviewKeyDown(KeyEventArgs e)
+    {
+        base.OnPreviewKeyDown(e);
+        if (e.Handled) return;
+
+        // Modeless: no DialogResult, so Escape doesn't auto-close. Wire it, but step aside when a
+        // ComboBox dropdown is open so it can consume Escape itself.
+        if (e.Key == Key.Escape && Keyboard.FocusedElement is not System.Windows.Controls.ComboBox { IsDropDownOpen: true })
+        {
+            Close();
+            e.Handled = true;
+        }
+    }
+
+    protected override void OnClosed(EventArgs e)
+    {
+        _vm.CancelRequested -= OnCancelRequested;
+        _vm.SharedMailboxAdded -= OnSharedMailboxAdded;
+        _vm.AnnouncementRequested -= OnAnnouncementRequested;
+        base.OnClosed(e);
+    }
+}

--- a/QuickMail/Views/AddSharedMailboxWindow.xaml.cs
+++ b/QuickMail/Views/AddSharedMailboxWindow.xaml.cs
@@ -14,7 +14,8 @@ namespace QuickMail.Views;
 /// between and a palette would only duplicate the two buttons (same New-Window-Checklist exception as
 /// <see cref="ServerRuleEditorWindow"/>). It has an editable TextBox and can open over the main
 /// window's live WebView2, so it is shown modeless (<c>Show()</c>) with Escape/Cancel wired explicitly
-/// — the GrabAddresses deadlock lesson. Focus lands on Address; the owner restores focus on close.
+/// — the GrabAddresses deadlock lesson. Focus lands on Address; the owner (Account Manager) restores
+/// focus to the "Add shared…" button it was launched from when this window closes.
 /// </summary>
 public partial class AddSharedMailboxWindow : Window
 {

--- a/docs/planning/shared-mailboxes-pm-dev-spec.md
+++ b/docs/planning/shared-mailboxes-pm-dev-spec.md
@@ -114,6 +114,12 @@ it would break the link). The account **label stays editable**. Gated on
 `AccountManagerViewModel.IsSharedSelected` / `ShowNormalAccountFields`, the same way a Graph account
 already hides IMAP/SMTP on `IsImapBackend`.
 
+**Signature is deferred to PR 3 (send-as), by decision.** The Signature field lives inside the Advanced
+expander, so it is hidden for a shared mailbox along with the rest of that surface. Nothing sends from a
+shared mailbox until send-as ships in PR 3, so there is nothing for a signature to append to in PR 1.
+Whether a shared mailbox gets its own signature — or inherits the parent's — is a send-as design
+question and is resolved there, not left to fall out of the layout here.
+
 ## 5. Architecture & Technical Decisions
 
 ### 5.1 Key architectural decisions

--- a/docs/planning/shared-mailboxes-pm-dev-spec.md
+++ b/docs/planning/shared-mailboxes-pm-dev-spec.md
@@ -104,12 +104,15 @@ missing when #59 was written.
 **Account Manager editor for a selected shared mailbox (added PR 1):** a shared account has no
 credentials or connection of its own, so when it is the selected account the editor hides the entire
 connection/auth surface — connection method, Authentication, Password, IMAP/SMTP servers (the whole
-Advanced expander), the OAuth **Sign-in** buttons, **Test Connection** — and the **Sync contacts /
-Sync calendar** checkboxes (mail only, per the out-of-scope rows above). In their place a **read-only
-summary** names the parent it reads through (*"Reads through {parent}. Mail only — no separate
-sign-in."*), and the shared **email address is read-only** (editing it would break the link). The
-account **label stays editable**. Gated on `AccountManagerViewModel.IsSharedSelected`, the same way a
-Graph account already hides IMAP/SMTP on `IsImapBackend`.
+Advanced expander), the OAuth **Sign-in** buttons, **Test Connection** — plus the **Sync contacts /
+Sync calendar** checkboxes (mail only, per the out-of-scope rows above) and the **Sender display name**
+(a shared mailbox sends under its own directory identity, not a per-account name set here). **Set as
+default** is disabled for a shared account (default-account semantics are out — credential-less). In
+place of the hidden surface a **read-only summary** names the parent it reads through (*"Reads through
+{parent}. Mail only — no separate sign-in."*), and the shared **email address is read-only** (editing
+it would break the link). The account **label stays editable**. Gated on
+`AccountManagerViewModel.IsSharedSelected` / `ShowNormalAccountFields`, the same way a Graph account
+already hides IMAP/SMTP on `IsImapBackend`.
 
 ## 5. Architecture & Technical Decisions
 

--- a/docs/planning/shared-mailboxes-pm-dev-spec.md
+++ b/docs/planning/shared-mailboxes-pm-dev-spec.md
@@ -101,6 +101,16 @@ missing when #59 was written.
 | Contact scraping / sync | **out** | Not "your" mail. |
 | Default-account semantics | **out** | Credential-less. |
 
+**Account Manager editor for a selected shared mailbox (added PR 1):** a shared account has no
+credentials or connection of its own, so when it is the selected account the editor hides the entire
+connection/auth surface — connection method, Authentication, Password, IMAP/SMTP servers (the whole
+Advanced expander), the OAuth **Sign-in** buttons, **Test Connection** — and the **Sync contacts /
+Sync calendar** checkboxes (mail only, per the out-of-scope rows above). In their place a **read-only
+summary** names the parent it reads through (*"Reads through {parent}. Mail only — no separate
+sign-in."*), and the shared **email address is read-only** (editing it would break the link). The
+account **label stays editable**. Gated on `AccountManagerViewModel.IsSharedSelected`, the same way a
+Graph account already hides IMAP/SMTP on `IsImapBackend`.
+
 ## 5. Architecture & Technical Decisions
 
 ### 5.1 Key architectural decisions


### PR DESCRIPTION
**Part of #31** (shared mailboxes — PR 1 of a 5-PR, access-first plan; spec: `docs/planning/shared-mailboxes-pm-dev-spec.md`).

## What this PR does

Lays the **linked-account model and manual add** for shared mailboxes. A shared mailbox is a credential-less `AccountModel` (`IsShared`, `ParentAccountId`, `SharedAddress`) that later PRs will read/send through its **parent** account's token and backend. **This PR does no backend access yet** — a shared node is a placeholder with no folders until PR 2.

Everything ships behind a feature gate (`FeatureFlag.SharedMailboxes`, **default OFF**), so `main` stays shippable while the feature is built.

## Included

- **Model** — `AccountModel` gains `IsShared` / `ParentAccountId` / `SharedAddress` and a `", shared mailbox"` qualifier in `AccessibleName` (e.g. *"Support, shared mailbox, connected, 12 unread"*). JSON round-trips; no migration.
- **Tree** — a shared mailbox is its own top-level node (`FolderTreeNode.AccountId` / `IsSharedAccount`); `NodeKey` now keys header nodes as `H:{id}:{label}` (fixes a collision between same-named accounts).
- **Aggregate exclusion** — shared mail is excluded from All-Inboxes / All-Mail via the `IsShared` predicate, **not** `ExcludeFromAllMail`, so it is still swept for freshness (spec's "item-2" rule).
- **Add dialog** — `AddSharedMailboxViewModel` + `AddSharedMailboxWindow`: pick an address and a shared-capable parent (excludes shared and personal-Graph accounts), validate address + duplicates, build the linked account. Modeless `Show()` with explicit Escape/Cancel and focus restoration (the GrabAddresses modal-deadlock rule). Reached via a new **"Add shared…"** button in the Account Manager (the sole creation path).
- **Connect / send skip** — shared accounts are skipped by `AccountsNeedingConnect` / `ConnectAllAccountsAsync` (no credentials of their own).
- **Cascade removal** — removing a parent removes its shared mailboxes too, behind a naming confirmation the user can decline; the cascade fails closed if unconfirmed. Removing a shared mailbox on its own leaves the parent intact.
- **Account Manager editor gating** — when a shared account is selected, the editor hides the connection/auth/servers/sign-in/Test-Connection surface, the contact/calendar sync (mail only, per spec) and the sender display name, and disables Set-as-default; a read-only summary names the parent it reads through. Mirrors how a Graph account already hides IMAP/SMTP.

## Testing

- New: `SharedMailboxModelTests`, `NodeKeyTests`, `SharedMailboxAggregateTests`, `SharedMailboxRemovalTests` (incl. editor gating + fail-closed cascade), `AddSharedMailboxViewModelTests`, feature-gate defaults + button gate, and an `AddSharedMailboxWindow` XAML-parse guard.
- Green locally; 0 CA analyzer warnings in a Release build.
- Independent adversarial review run pre-PR: no HIGH/MEDIUM; two LOW items fixed (fail-closed cascade, explicit focus restore).
- Manually exercised on an isolated profile (add flow, tree node, editor gating, removal) with the flag enabled.

## Out of scope (later PRs)

Backend read/send through the parent (Graph `/users/{shared}` + `.Shared` scopes / IMAP `user=` XOAUTH2), the Entra app-registration scope bump, and default-on. Calendar/contacts for a shared mailbox are permanently out (mail only).
