### PR TITLE
Startup folder as a first-class setting, and a configurable startup sync scope (#516)

### DIFF
--- a/QuickMail.Tests/ConfigServiceSaveTests.cs
+++ b/QuickMail.Tests/ConfigServiceSaveTests.cs
@@ -49,6 +49,76 @@ public class ConfigServiceSaveTests
     }
 
     [Fact]
+    public void SaveThenLoad_RoundTripsStartupSettings()
+    {
+        // The startup folder is the whole point of #516; if it does not survive a save/load it is
+        // not a setting, it is a session preference. Also guards the [windowing] ordering trap
+        // documented in SaveThenLoad_RoundTripsCalendarSettings below — these keys are parsed
+        // under [global] and would be silently dropped if written after that header.
+        var profile = MakeTempProfile();
+        var service = new ConfigService(profile);
+
+        var config = service.Load();
+        config.StartupFolder        = "INBOX/Work";
+        config.StartupFolderAccount = "8f14e45f-ceea-467a-9575-1b1c1b1c1b1c";
+        config.StartupFolderLabel   = "Work";
+        config.StartupSyncScope     = ConfigModel.StartupSyncScopeInboxes;
+        service.Save(config);
+
+        var reloaded = new ConfigService(profile).Load();
+        Assert.Equal("INBOX/Work", reloaded.StartupFolder);
+        Assert.Equal("8f14e45f-ceea-467a-9575-1b1c1b1c1b1c", reloaded.StartupFolderAccount);
+        Assert.Equal("Work", reloaded.StartupFolderLabel);
+        Assert.Equal(ConfigModel.StartupSyncScopeInboxes, reloaded.StartupSyncScope);
+    }
+
+    [Fact]
+    public void SaveThenLoad_RoundTripsAVirtualStartupFolder()
+    {
+        // The common case: "open me in All Inboxes". Stored without the NUL sentinel prefix
+        // because an INI file cannot carry one.
+        var profile = MakeTempProfile();
+        var service = new ConfigService(profile);
+
+        var config = service.Load();
+        config.StartupFolder      = "AllInboxes";
+        config.StartupFolderLabel = "All Inboxes";
+        service.Save(config);
+
+        var reloaded = new ConfigService(profile).Load();
+        Assert.Equal("AllInboxes", reloaded.StartupFolder);
+        Assert.Equal(string.Empty, reloaded.StartupFolderAccount);
+    }
+
+    [Fact]
+    public void FreshConfig_DefaultsToAllMailAndStartupFolderScope()
+    {
+        var profile = MakeTempProfile();
+
+        var config = new ConfigService(profile).Load();
+
+        Assert.Equal(string.Empty, config.StartupFolder);          // empty == All Mail
+        Assert.Equal(string.Empty, config.StartupFolderAccount);
+        Assert.Equal(ConfigModel.StartupSyncScopeStartupFolder, config.StartupSyncScope);
+
+        var ini = File.ReadAllText(Path.Combine(profile.ProfileDir, "config.ini"));
+        Assert.Contains("StartupSyncScope = startupFolder", ini, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Load_UnknownStartupSyncScope_NormalizesToTheDefault()
+    {
+        var profile = MakeTempProfile();
+        var service = new ConfigService(profile);
+        var config  = service.Load();
+        config.StartupSyncScope = "everything-please";
+        service.Save(config);
+
+        Assert.Equal(ConfigModel.StartupSyncScopeStartupFolder,
+                     new ConfigService(profile).Load().StartupSyncScope);
+    }
+
+    [Fact]
     public void SaveThenLoad_RoundTripsCalendarSettings()
     {
         // Regression test: ShowDeclinedEvents and CalendarPaneOpen were being written by

--- a/QuickMail.Tests/FlagServiceTests.cs
+++ b/QuickMail.Tests/FlagServiceTests.cs
@@ -137,6 +137,9 @@ sealed class RecordingFlagStore : ILocalStoreService
     public Task DeleteAccountDataAsync(Guid accountId) => Task.CompletedTask;
     public Task ClearCachedMailAsync(System.Collections.Generic.IEnumerable<System.Guid> accountIds) => Task.CompletedTask;
     public Task PurgeCalendarEventsForUnknownAccountsAsync(IReadOnlyCollection<Guid> knownAccountIds) => Task.CompletedTask;
+    public Task SaveFoldersAsync(Guid accountId, IReadOnlyList<MailFolderModel> folders) => Task.CompletedTask;
+    public Task<Dictionary<Guid, List<MailFolderModel>>> LoadFoldersAsync() => Task.FromResult(new Dictionary<Guid, List<MailFolderModel>>());
+    public Task PurgeFoldersForUnknownAccountsAsync(IReadOnlyCollection<Guid> knownAccountIds) => Task.CompletedTask;
     public Task UpdateIsReadAsync(Guid accountId, string folderName, string messageId, bool isRead) => Task.CompletedTask;
     public Task UpdateIsReadBatchAsync(IEnumerable<(Guid AccountId, string FolderName, string MessageId)> items, bool isRead) => Task.CompletedTask;
     public Task UpdatePreviewAsync(Guid accountId, string folderName, string messageId, string preview) => Task.CompletedTask;

--- a/QuickMail.Tests/FolderPickerTreeTests.cs
+++ b/QuickMail.Tests/FolderPickerTreeTests.cs
@@ -6,6 +6,7 @@ using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Threading;
 using QuickMail.Models;
+using QuickMail.ViewModels;
 using QuickMail.Views;
 using Xunit;
 
@@ -371,5 +372,97 @@ public class FolderPickerTreeTests
             AccessibilityHelper.AnnouncementObserver = null;
             window.Close();
         }
+    }
+
+    // ── ForStartupFolder (#516) ──────────────────────────────────────────────────
+
+    private static FolderPickerWindow StartupPicker(string? currentKey = null, Guid? currentAccount = null) =>
+        Shown(FolderPickerWindow.ForStartupFolder(
+            [Account()], Folders(), MainViewModel.AllVirtualFolders, currentKey, currentAccount));
+
+    [StaFact]
+    public void ForStartupFolder_OffersTheVirtualAggregatesAsRoots()
+    {
+        // The regression this pins: tree mode returned before virtualFolders was ever read, so every
+        // aggregate was silently dropped and Settings could not select All Inboxes at all — the most
+        // asked-for value of the whole setting. The call-site test that only checked the argument
+        // appeared in MainWindow's source passed the entire time.
+        var window = StartupPicker();
+        try
+        {
+            var roots = Roots(window);
+            Assert.Contains(roots, r => r.Folder?.FullName == MainViewModel.AllInboxesFolder.FullName);
+            Assert.Contains(roots, r => r.Folder?.FullName == MainViewModel.AllMailFolder.FullName);
+
+            // Aggregates come first, matching the main folder tree's order.
+            Assert.Equal(MainViewModel.AllMailFolder.FullName, roots[0].Folder?.FullName);
+        }
+        finally { window.Close(); }
+    }
+
+    [StaFact]
+    public void ForStartupFolder_StillOffersTheRealFolders()
+    {
+        var window = StartupPicker();
+        try
+        {
+            Assert.Contains(Flatten(Roots(window)),
+                            n => n.Folder is { IsHeader: false } f && f.FullName == "INBOX");
+        }
+        finally { window.Close(); }
+    }
+
+    [StaFact]
+    public void ForStartupFolder_OpensOnTheCurrentVirtualChoice()
+    {
+        // Stored without the NUL sentinel prefix, so the factory has to restore it to match.
+        var window = StartupPicker(currentKey: "AllInboxes");
+        try
+        {
+            var selected = Assert.IsType<FolderTreeNode>(
+                Named<TreeView>(window, "FolderTreeView").SelectedItem);
+            Assert.Equal(MainViewModel.AllInboxesFolder.FullName, selected.Folder?.FullName);
+        }
+        finally { window.Close(); }
+    }
+
+    [StaFact]
+    public void ForStartupFolder_OpensOnTheCurrentRealFolder()
+    {
+        var window = StartupPicker(currentKey: "INBOX", currentAccount: AccountId);
+        try
+        {
+            var selected = Assert.IsType<FolderTreeNode>(
+                Named<TreeView>(window, "FolderTreeView").SelectedItem);
+            Assert.Equal("INBOX", selected.Folder?.FullName);
+        }
+        finally { window.Close(); }
+    }
+
+    [StaFact]
+    public void ForStartupFolder_NeverOpensWithNothingSelected()
+    {
+        // The picker rule: a tree with no selection announces the tree and no item, leaving the user
+        // to work out that Down is what starts things.
+        var window = StartupPicker();
+        try
+        {
+            Assert.NotNull(Named<TreeView>(window, "FolderTreeView").SelectedItem);
+        }
+        finally { window.Close(); }
+    }
+
+    [StaFact]
+    public void MoveCopyPicker_StillOffersNoAggregates()
+    {
+        // The other side of the same change: an aggregate is not a legal move/copy destination, and
+        // adding virtual-folder support to tree mode must not have leaked them in here.
+        var window = Picker();
+        try
+        {
+            Assert.DoesNotContain(Flatten(Roots(window)),
+                                  n => n.Folder is { } f && f.FullName.StartsWith('\0'));
+        }
+        finally { window.Close(); }
     }
 }

--- a/QuickMail.Tests/FolderStoreTests.cs
+++ b/QuickMail.Tests/FolderStoreTests.cs
@@ -1,0 +1,233 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using QuickMail.Models;
+using QuickMail.Services;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// Round-trip tests for the Folder SQLite table via LocalStoreService (#516).
+///
+/// The folder list is what lets the startup folder resolve — and the folder tree draw — before any
+/// account connects. Before it was persisted, "open me in All Inboxes" was unimplementable at launch
+/// because inbox-ness is only known once <c>GetFoldersAsync</c> has run. So the properties these
+/// tests pin are not incidental: <see cref="MailFolderModel.Kind"/> surviving the round trip is the
+/// whole point, and replace-on-save is what stops a folder deleted on the server from haunting the
+/// tree forever.
+///
+/// Each test uses a fresh temp-directory profile so migrations run from scratch.
+/// </summary>
+public class FolderStoreTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly LocalStoreService _store;
+
+    public FolderStoreTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"qm-folder-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        _store = new LocalStoreService(new ProfileContext(_tempDir));
+        _store.Initialize();
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); } catch { }
+        GC.SuppressFinalize(this);
+    }
+
+    private static MailFolderModel Folder(
+        Guid accountId, string fullName, string display,
+        SpecialFolderKind kind = SpecialFolderKind.None,
+        bool excluded = false, int unread = 0, int total = 0, string? parentId = null) => new()
+        {
+            AccountId          = accountId,
+            FullName           = fullName,
+            DisplayName        = display,
+            Kind               = kind,
+            ExcludeFromAllMail = excluded,
+            UnreadCount        = unread,
+            MessageCount       = total,
+            ParentId           = parentId,
+        };
+
+    [Fact]
+    public async Task SaveThenLoad_RoundTripsEveryPersistedField()
+    {
+        var account = Guid.NewGuid();
+        await _store.SaveFoldersAsync(account,
+        [
+            Folder(account, "INBOX", "Inbox", SpecialFolderKind.Inbox, unread: 7, total: 120),
+            Folder(account, "INBOX/Work", "Work", parentId: "INBOX", unread: 2, total: 30),
+            Folder(account, "Trash", "Trash", SpecialFolderKind.Trash, excluded: true),
+        ]);
+
+        var loaded = await _store.LoadFoldersAsync();
+
+        var folders = Assert.Contains(account, loaded);
+        Assert.Equal(3, folders.Count);
+
+        var inbox = folders[0];
+        Assert.Equal("INBOX", inbox.FullName);
+        Assert.Equal("Inbox", inbox.DisplayName);
+        Assert.Equal(SpecialFolderKind.Inbox, inbox.Kind);
+        Assert.Equal(7, inbox.UnreadCount);
+        Assert.Equal(120, inbox.MessageCount);
+        Assert.False(inbox.ExcludeFromAllMail);
+        Assert.Null(inbox.ParentId);
+        Assert.Equal(account, inbox.AccountId);
+
+        Assert.Equal("INBOX", folders[1].ParentId);
+
+        Assert.Equal(SpecialFolderKind.Trash, folders[2].Kind);
+        Assert.True(folders[2].ExcludeFromAllMail);
+    }
+
+    [Fact]
+    public async Task Load_PreservesSaveOrder()
+    {
+        // The tree and the All Mail aggregate both present folders in the order the backend listed
+        // them; a set that comes back alphabetised would reorder the user's tree on every restart.
+        var account = Guid.NewGuid();
+        var names = new[] { "INBOX", "Zebra", "Alpha", "INBOX/Sub" };
+        await _store.SaveFoldersAsync(account, [.. names.Select(n => Folder(account, n, n))]);
+
+        var loaded = await _store.LoadFoldersAsync();
+
+        Assert.Equal(names, loaded[account].Select(f => f.FullName));
+    }
+
+    [Fact]
+    public async Task Save_ReplacesThatAccountsFolders_RatherThanMerging()
+    {
+        // A folder deleted or renamed on the server must disappear locally. An upsert would leave
+        // the old row behind and the tree would keep offering a folder that no longer exists.
+        var account = Guid.NewGuid();
+        await _store.SaveFoldersAsync(account,
+        [
+            Folder(account, "INBOX", "Inbox", SpecialFolderKind.Inbox),
+            Folder(account, "OldName", "OldName"),
+        ]);
+
+        await _store.SaveFoldersAsync(account,
+        [
+            Folder(account, "INBOX", "Inbox", SpecialFolderKind.Inbox),
+            Folder(account, "NewName", "NewName"),
+        ]);
+
+        var folders = (await _store.LoadFoldersAsync())[account];
+        Assert.Equal(["INBOX", "NewName"], folders.Select(f => f.FullName));
+    }
+
+    [Fact]
+    public async Task Save_LeavesOtherAccountsAlone()
+    {
+        // A partial connect refreshes only the accounts it reached; the rest must keep the folders
+        // they had, otherwise one failing account would blank another's tree.
+        var a = Guid.NewGuid();
+        var b = Guid.NewGuid();
+        await _store.SaveFoldersAsync(a, [Folder(a, "INBOX", "Inbox")]);
+        await _store.SaveFoldersAsync(b, [Folder(b, "INBOX", "Inbox"), Folder(b, "Archive", "Archive")]);
+
+        await _store.SaveFoldersAsync(a, [Folder(a, "INBOX", "Inbox"), Folder(a, "Sent", "Sent")]);
+
+        var loaded = await _store.LoadFoldersAsync();
+        Assert.Equal(2, loaded[a].Count);
+        Assert.Equal(["INBOX", "Archive"], loaded[b].Select(f => f.FullName));
+    }
+
+    [Fact]
+    public async Task Save_SkipsHeaderRowsAndEmptyNames()
+    {
+        // Header rows are synthesized by RebuildFolderListFromCache for display; they carry no
+        // server folder, and a stored one would come back as a phantom child in the tree.
+        var account = Guid.NewGuid();
+        await _store.SaveFoldersAsync(account,
+        [
+            new MailFolderModel { AccountId = account, IsHeader = true, FullName = "\u0000Header:x", DisplayName = "Work" },
+            new MailFolderModel { AccountId = account, FullName = "", DisplayName = "nameless" },
+            Folder(account, "INBOX", "Inbox"),
+        ]);
+
+        var folders = (await _store.LoadFoldersAsync())[account];
+        Assert.Equal(["INBOX"], folders.Select(f => f.FullName));
+    }
+
+    [Fact]
+    public async Task Save_EmptyList_ClearsTheAccount()
+    {
+        var account = Guid.NewGuid();
+        await _store.SaveFoldersAsync(account, [Folder(account, "INBOX", "Inbox")]);
+
+        await _store.SaveFoldersAsync(account, []);
+
+        Assert.DoesNotContain(account, await _store.LoadFoldersAsync());
+    }
+
+    [Fact]
+    public async Task PurgeForUnknownAccounts_DropsOrphansAndKeepsKnown()
+    {
+        var known  = Guid.NewGuid();
+        var orphan = Guid.NewGuid();
+        await _store.SaveFoldersAsync(known,  [Folder(known,  "INBOX", "Inbox")]);
+        await _store.SaveFoldersAsync(orphan, [Folder(orphan, "INBOX", "Inbox")]);
+
+        await _store.PurgeFoldersForUnknownAccountsAsync([known]);
+
+        var loaded = await _store.LoadFoldersAsync();
+        Assert.Contains(known, loaded);
+        Assert.DoesNotContain(orphan, loaded);
+    }
+
+    [Fact]
+    public async Task PurgeForUnknownAccounts_WithNoKnownAccounts_ClearsEverything()
+    {
+        // Unlike calendar events there is no Guid.Empty "local" bucket to preserve — every folder
+        // belongs to a real account, so an empty known-set means every row is an orphan.
+        var account = Guid.NewGuid();
+        await _store.SaveFoldersAsync(account, [Folder(account, "INBOX", "Inbox")]);
+
+        await _store.PurgeFoldersForUnknownAccountsAsync([]);
+
+        Assert.Empty(await _store.LoadFoldersAsync());
+    }
+
+    [Fact]
+    public async Task DeleteAccountData_AlsoRemovesItsFolders()
+    {
+        // Otherwise a removed account's folders would still be restored into the tree at next launch.
+        var account = Guid.NewGuid();
+        await _store.SaveFoldersAsync(account, [Folder(account, "INBOX", "Inbox")]);
+
+        await _store.DeleteAccountDataAsync(account);
+
+        Assert.Empty(await _store.LoadFoldersAsync());
+    }
+
+    [Fact]
+    public async Task Load_OnAFreshDatabase_ReturnsEmpty()
+    {
+        Assert.Empty(await _store.LoadFoldersAsync());
+    }
+
+    [Fact]
+    public async Task Initialize_IsIdempotent_AndKeepsStoredFolders()
+    {
+        // Initialize runs on every launch. The Folder table is created with CREATE TABLE IF NOT
+        // EXISTS and no user_version bump, so a second run must neither throw nor drop rows —
+        // this is the guard for an existing database picking up the new table.
+        var account = Guid.NewGuid();
+        await _store.SaveFoldersAsync(account, [Folder(account, "INBOX", "Inbox", SpecialFolderKind.Inbox)]);
+
+        _store.Initialize();
+        var reopened = new LocalStoreService(new ProfileContext(_tempDir));
+        reopened.Initialize();
+
+        var folders = (await reopened.LoadFoldersAsync())[account];
+        Assert.Equal(SpecialFolderKind.Inbox, Assert.Single(folders).Kind);
+    }
+}

--- a/QuickMail.Tests/MainViewModelFlagTests.cs
+++ b/QuickMail.Tests/MainViewModelFlagTests.cs
@@ -224,6 +224,9 @@ sealed class FilterableStoreForFlags : ILocalStoreService
     public Task DeleteAccountDataAsync(Guid accountId) => Task.CompletedTask;
     public Task ClearCachedMailAsync(System.Collections.Generic.IEnumerable<System.Guid> accountIds) => Task.CompletedTask;
     public Task PurgeCalendarEventsForUnknownAccountsAsync(IReadOnlyCollection<Guid> knownAccountIds) => Task.CompletedTask;
+    public Task SaveFoldersAsync(Guid accountId, IReadOnlyList<MailFolderModel> folders) => Task.CompletedTask;
+    public Task<Dictionary<Guid, List<MailFolderModel>>> LoadFoldersAsync() => Task.FromResult(new Dictionary<Guid, List<MailFolderModel>>());
+    public Task PurgeFoldersForUnknownAccountsAsync(IReadOnlyCollection<Guid> knownAccountIds) => Task.CompletedTask;
     public Task UpdateIsReadAsync(Guid accountId, string folderName, string messageId, bool isRead) => Task.CompletedTask;
     public Task UpdateIsReadBatchAsync(IEnumerable<(Guid AccountId, string FolderName, string MessageId)> items, bool isRead) => Task.CompletedTask;
     public Task UpdatePreviewAsync(Guid accountId, string folderName, string messageId, string preview) => Task.CompletedTask;

--- a/QuickMail.Tests/MainViewModelStartupTests.cs
+++ b/QuickMail.Tests/MainViewModelStartupTests.cs
@@ -1,0 +1,230 @@
+// Startup folder resolution — issue #516.
+//
+// The point of the feature is that the chosen folder is on screen from the FIRST painted frame,
+// loaded from the local store with no network. Applying it after connect is what these tests exist
+// to prevent: that was the old default-saved-view behaviour, and the All Mail flash it produced is
+// what users reported. So every test here asserts state after InitialLoadAsync alone — nothing in
+// this file connects, syncs, or touches StartBackgroundSyncAsync.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using QuickMail.Models;
+using QuickMail.Services;
+using QuickMail.ViewModels;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+public class MainViewModelStartupTests
+{
+    private static readonly Guid WorkId     = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid PersonalId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    private sealed class AccountsStub(params AccountModel[] accounts) : IAccountService
+    {
+        public List<AccountModel> LoadAccounts() => [.. accounts];
+        public void SaveAccounts(List<AccountModel> a) { }
+        public void SetDefaultAccount(Guid accountId) { }
+    }
+
+    private static MailFolderModel Folder(Guid account, string full, string display,
+                                          SpecialFolderKind kind = SpecialFolderKind.None) => new()
+    {
+        AccountId = account, FullName = full, DisplayName = display, Kind = kind,
+    };
+
+    private static MailMessageSummary Msg(Guid account, string folder, string id, int daysAgo = 0) => new()
+    {
+        MessageId = id, AccountId = account, FolderName = folder,
+        From = "someone@example.com", To = "kelly@example.com", Subject = $"Subject {id}",
+        Date = DateTimeOffset.Now.AddDays(-daysAgo),
+    };
+
+    /// <summary>Builds a VM over two accounts whose folders are already persisted, plus a message in
+    /// each folder, and returns it with the config service so a test can set startup keys first.</summary>
+    private static (MainViewModel Vm, StubConfigService Config, StubLocalStoreService Store) MakeVm(
+        Action<ConfigModel>? configure = null, IViewService? views = null, bool onlineMode = false)
+    {
+        var store = new StubLocalStoreService();
+        store.SeededFolders[WorkId] =
+        [
+            Folder(WorkId, "INBOX", "Inbox", SpecialFolderKind.Inbox),
+            Folder(WorkId, "INBOX/Projects", "Projects"),
+            Folder(WorkId, "Sent", "Sent", SpecialFolderKind.Sent),
+        ];
+        store.SeededFolders[PersonalId] =
+        [
+            Folder(PersonalId, "INBOX", "Inbox", SpecialFolderKind.Inbox),
+        ];
+        store.SeededSummaries[(WorkId, "INBOX")]          = [Msg(WorkId, "INBOX", "w-inbox", 1)];
+        store.SeededSummaries[(WorkId, "INBOX/Projects")] = [Msg(WorkId, "INBOX/Projects", "w-proj", 2)];
+        store.SeededSummaries[(WorkId, "Sent")]           = [Msg(WorkId, "Sent", "w-sent", 3)];
+        store.SeededSummaries[(PersonalId, "INBOX")]      = [Msg(PersonalId, "INBOX", "p-inbox", 0)];
+
+        var config = new StubConfigService();
+        var cfg = config.Load();
+        configure?.Invoke(cfg);
+        config.Save(cfg);
+
+        var accounts = new AccountsStub(
+            new AccountModel { Id = WorkId,     AccountName = "Work",     Username = "k@work.example" },
+            new AccountModel { Id = PersonalId, AccountName = "Personal", Username = "k@home.example" });
+
+        var vm = new MainViewModel(
+            new StubImapMailService(), accounts, new StubCredentialService(),
+            store, new StubOAuthService(), new StubSyncService(), config,
+            new StubCommandRegistry(), views ?? new StubViewService(), new StubRuleService(),
+            new StubSmtpService(), onlineMode);
+        vm.LoadAccountList();   // App does this before OnLoaded; the resolver scopes by account
+        return (vm, config, store);
+    }
+
+    [Fact]
+    public async Task NoStartupFolderConfigured_LandsInAllMail()
+    {
+        // The default, and what every existing install gets until it opts in.
+        var (vm, _, _) = MakeVm();
+
+        await vm.InitialLoadAsync();
+
+        Assert.Equal(MainViewModel.AllMailFolder.FullName, vm.SelectedFolder?.FullName);
+    }
+
+    [Fact]
+    public async Task RestoredFolderCache_PopulatesTheTreeBeforeAnythingConnects()
+    {
+        // The prerequisite for everything else here: no connect has happened, yet the real folders
+        // are present. Before #516 the tree held only the virtual aggregates at this point.
+        var (vm, _, _) = MakeVm();
+
+        await vm.InitialLoadAsync();
+
+        Assert.Contains(vm.Folders, f => f.AccountId == WorkId && f.FullName == "INBOX/Projects");
+        Assert.Equal(3, vm.CachedFolders[WorkId].Count);
+    }
+
+    [Fact]
+    public async Task RealStartupFolder_IsSelectedAndLoadedFromCache()
+    {
+        var (vm, _, _) = MakeVm(c =>
+        {
+            c.StartupFolder        = "INBOX/Projects";
+            c.StartupFolderAccount = WorkId.ToString();
+            c.StartupFolderLabel   = "Projects";
+        });
+
+        await vm.InitialLoadAsync();
+
+        Assert.Equal("INBOX/Projects", vm.SelectedFolder?.FullName);
+        Assert.Equal(WorkId, vm.SelectedFolder?.AccountId);
+        Assert.Equal(["w-proj"], vm.Messages.Select(m => m.MessageId));
+    }
+
+    [Fact]
+    public async Task VirtualStartupFolder_AllInboxes_UnionsEveryAccountsInbox()
+    {
+        // The most-requested choice, and the one that needs persisted folder KINDS to resolve —
+        // without them nothing offline can tell which folder is an Inbox.
+        var (vm, _, _) = MakeVm(c =>
+        {
+            c.StartupFolder      = "AllInboxes";
+            c.StartupFolderLabel = "All Inboxes";
+        });
+
+        await vm.InitialLoadAsync();
+
+        Assert.Equal(MainViewModel.AllInboxesFolder.FullName, vm.SelectedFolder?.FullName);
+        Assert.Equal(["p-inbox", "w-inbox"], vm.Messages.Select(m => m.MessageId));   // newest first
+    }
+
+    [Fact]
+    public async Task DeletedAccount_FallsBackToAllMail_AndSaysWhy()
+    {
+        var (vm, _, _) = MakeVm(c =>
+        {
+            c.StartupFolder        = "INBOX";
+            c.StartupFolderAccount = Guid.NewGuid().ToString();   // never configured
+            c.StartupFolderLabel   = "Inbox";
+        });
+
+        await vm.InitialLoadAsync();
+
+        Assert.Equal(MainViewModel.AllMailFolder.FullName, vm.SelectedFolder?.FullName);
+        Assert.Contains("no longer set up", vm.StatusText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task RenamedFolder_FallsBackToAllMail_AndNamesTheFolder()
+    {
+        // Silently showing All Mail reads as "the setting was ignored"; the user cannot tell which.
+        var (vm, _, _) = MakeVm(c =>
+        {
+            c.StartupFolder        = "INBOX/GoneAway";
+            c.StartupFolderAccount = WorkId.ToString();
+            c.StartupFolderLabel   = "GoneAway";
+        });
+
+        await vm.InitialLoadAsync();
+
+        Assert.Equal(MainViewModel.AllMailFolder.FullName, vm.SelectedFolder?.FullName);
+        Assert.Contains("GoneAway", vm.StatusText, StringComparison.Ordinal);
+        Assert.Contains("All Mail", vm.StatusText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task GarbageStartupFolder_FallsBackToAllMail_WithoutThrowing()
+    {
+        var (vm, _, _) = MakeVm(c => c.StartupFolder = "NotAThingAtAll");
+
+        await vm.InitialLoadAsync();
+
+        Assert.Equal(MainViewModel.AllMailFolder.FullName, vm.SelectedFolder?.FullName);
+    }
+
+    [Fact]
+    public async Task StartupFolderNamingAnotherAccountsFolder_DoesNotResolve()
+    {
+        // Folder names collide across accounts ("INBOX" everywhere). The stored account scopes it,
+        // and a mismatch must fall back rather than silently open the wrong account's folder.
+        var (vm, _, _) = MakeVm(c =>
+        {
+            c.StartupFolder        = "INBOX/Projects";     // exists, but on Work
+            c.StartupFolderAccount = PersonalId.ToString();
+            c.StartupFolderLabel   = "Projects";
+        });
+
+        await vm.InitialLoadAsync();
+
+        Assert.Equal(MainViewModel.AllMailFolder.FullName, vm.SelectedFolder?.FullName);
+    }
+
+    [Fact]
+    public async Task OnlineMode_StillHonoursTheStartupFolder()
+    {
+        // --online skips the local store entirely, and the old default-view application sat behind
+        // an early return on this path, so the setting was ignored there. It is not any more.
+        var (vm, _, _) = MakeVm(c =>
+        {
+            c.StartupFolder        = "INBOX/Projects";
+            c.StartupFolderAccount = WorkId.ToString();
+            c.StartupFolderLabel   = "Projects";
+        }, onlineMode: true);
+
+        await vm.InitialLoadAsync();
+
+        Assert.Equal("INBOX/Projects", vm.SelectedFolder?.FullName);
+        Assert.Equal("Projects", vm.SelectedFolder?.DisplayName);   // label carries Graph's opaque ids
+    }
+
+    [Fact]
+    public async Task OnlineMode_VirtualStartupFolder_ResolvesToTheSentinel()
+    {
+        var (vm, _, _) = MakeVm(c => c.StartupFolder = "AllInboxes", onlineMode: true);
+
+        await vm.InitialLoadAsync();
+
+        Assert.Equal(MainViewModel.AllInboxesFolder.FullName, vm.SelectedFolder?.FullName);
+    }
+}

--- a/QuickMail.Tests/MainViewModelStartupTests.cs
+++ b/QuickMail.Tests/MainViewModelStartupTests.cs
@@ -227,4 +227,46 @@ public class MainViewModelStartupTests
 
         Assert.Equal(MainViewModel.AllInboxesFolder.FullName, vm.SelectedFolder?.FullName);
     }
+
+    [Fact]
+    public async Task OnlineMode_DoesNotWriteFoldersToTheLocalStore()
+    {
+        // --online never initializes the store, and the connection string is ReadWriteCreate, so a
+        // write here would create an empty mail.db in the profile and then throw per account.
+        var (vm, _, store) = MakeVm(onlineMode: true);
+        ((StubLocalStoreService)store).SeededFolders.Clear();
+
+        await vm.InitialLoadAsync();
+
+        Assert.Empty(((StubLocalStoreService)store).SeededFolders);
+    }
+
+    [Fact]
+    public async Task NoPersistedFolders_DefersRatherThanClaimingTheFolderIsMissing()
+    {
+        // The first launch after upgrading is exactly when the migration writes a startup folder,
+        // and exactly when nothing has ever been persisted to resolve it against. Announcing
+        // "not found" there would be wrong: it is not missing, we just cannot see it yet. The
+        // deferred retry runs once the connect pass fills the cache.
+        var store = new StubLocalStoreService();          // no SeededFolders at all
+        var config = new StubConfigService();
+        var cfg = config.Load();
+        cfg.StartupFolder        = "INBOX/Projects";
+        cfg.StartupFolderAccount = WorkId.ToString();
+        cfg.StartupFolderLabel   = "Projects";
+        config.Save(cfg);
+
+        var vm = new MainViewModel(
+            new StubImapMailService(),
+            new AccountsStub(new AccountModel { Id = WorkId, AccountName = "Work" }),
+            new StubCredentialService(), store, new StubOAuthService(), new StubSyncService(),
+            config, new StubCommandRegistry(), new StubViewService(), new StubRuleService(),
+            new StubSmtpService());
+        vm.LoadAccountList();
+
+        await vm.InitialLoadAsync();
+
+        Assert.Equal(MainViewModel.AllMailFolder.FullName, vm.SelectedFolder?.FullName);
+        Assert.DoesNotContain("not found", vm.StatusText, StringComparison.OrdinalIgnoreCase);
+    }
 }

--- a/QuickMail.Tests/MarkReadOnOpenTests.cs
+++ b/QuickMail.Tests/MarkReadOnOpenTests.cs
@@ -132,6 +132,9 @@ public class MarkReadOnOpenTests
         public Task DeleteAccountDataAsync(Guid accountId) => Task.CompletedTask;
         public Task ClearCachedMailAsync(System.Collections.Generic.IEnumerable<System.Guid> accountIds) => Task.CompletedTask;
         public Task PurgeCalendarEventsForUnknownAccountsAsync(IReadOnlyCollection<Guid> knownAccountIds) => Task.CompletedTask;
+        public Task SaveFoldersAsync(Guid accountId, IReadOnlyList<MailFolderModel> folders) => Task.CompletedTask;
+        public Task<Dictionary<Guid, List<MailFolderModel>>> LoadFoldersAsync() => Task.FromResult(new Dictionary<Guid, List<MailFolderModel>>());
+        public Task PurgeFoldersForUnknownAccountsAsync(IReadOnlyCollection<Guid> knownAccountIds) => Task.CompletedTask;
         public Task UpdateIsReadAsync(Guid accountId, string folderName, string messageId, bool isRead) => Task.CompletedTask;
         public Task UpdateIsReadBatchAsync(IEnumerable<(Guid AccountId, string FolderName, string MessageId)> items, bool isRead) => Task.CompletedTask;
         public Task UpdatePreviewAsync(Guid accountId, string folderName, string messageId, string preview) => Task.CompletedTask;

--- a/QuickMail.Tests/MessageFilterTests.cs
+++ b/QuickMail.Tests/MessageFilterTests.cs
@@ -34,6 +34,9 @@ public class MessageFilterTests
         public Task DeleteAccountDataAsync(Guid accountId) => Task.CompletedTask;
         public Task ClearCachedMailAsync(System.Collections.Generic.IEnumerable<System.Guid> accountIds) => Task.CompletedTask;
         public Task PurgeCalendarEventsForUnknownAccountsAsync(IReadOnlyCollection<Guid> knownAccountIds) => Task.CompletedTask;
+        public Task SaveFoldersAsync(Guid accountId, IReadOnlyList<MailFolderModel> folders) => Task.CompletedTask;
+        public Task<Dictionary<Guid, List<MailFolderModel>>> LoadFoldersAsync() => Task.FromResult(new Dictionary<Guid, List<MailFolderModel>>());
+        public Task PurgeFoldersForUnknownAccountsAsync(IReadOnlyCollection<Guid> knownAccountIds) => Task.CompletedTask;
         public Task UpdateIsReadAsync(Guid accountId, string folderName, string messageId, bool isRead) => Task.CompletedTask;
         public Task UpdateIsReadBatchAsync(IEnumerable<(Guid AccountId, string FolderName, string MessageId)> items, bool isRead) => Task.CompletedTask;
         public Task UpdatePreviewAsync(Guid accountId, string folderName, string messageId, string preview) => Task.CompletedTask;

--- a/QuickMail.Tests/RadioGroupWiringTests.cs
+++ b/QuickMail.Tests/RadioGroupWiringTests.cs
@@ -22,6 +22,7 @@ public class RadioGroupWiringTests
         { "SettingsDialog.xaml",    "ListDensity" },
         { "SettingsDialog.xaml",    "LogFormat" },
         { "SettingsDialog.xaml",    "SpellingSuggestionsVerbosity" },
+        { "SettingsDialog.xaml",    "StartupSyncScope" },
         { "EventEditorWindow.xaml", "EditScope" },
     };
 

--- a/QuickMail.Tests/SavedViewsTests.cs
+++ b/QuickMail.Tests/SavedViewsTests.cs
@@ -833,6 +833,9 @@ public class SavedViewsMainViewModelTests
         public Task DeleteAccountDataAsync(Guid accountId) => Task.CompletedTask;
         public Task ClearCachedMailAsync(System.Collections.Generic.IEnumerable<System.Guid> accountIds) => Task.CompletedTask;
         public Task PurgeCalendarEventsForUnknownAccountsAsync(IReadOnlyCollection<Guid> knownAccountIds) => Task.CompletedTask;
+        public Task SaveFoldersAsync(Guid accountId, IReadOnlyList<MailFolderModel> folders) => Task.CompletedTask;
+        public Task<Dictionary<Guid, List<MailFolderModel>>> LoadFoldersAsync() => Task.FromResult(new Dictionary<Guid, List<MailFolderModel>>());
+        public Task PurgeFoldersForUnknownAccountsAsync(IReadOnlyCollection<Guid> knownAccountIds) => Task.CompletedTask;
         public Task UpdateIsReadAsync(Guid accountId, string folderName, string messageId, bool isRead) => Task.CompletedTask;
         public Task UpdateIsReadBatchAsync(IEnumerable<(Guid AccountId, string FolderName, string MessageId)> items, bool isRead) => Task.CompletedTask;
         public Task UpdatePreviewAsync(Guid accountId, string folderName, string messageId, string preview) => Task.CompletedTask;

--- a/QuickMail.Tests/SessionFeaturesTests.cs
+++ b/QuickMail.Tests/SessionFeaturesTests.cs
@@ -94,6 +94,9 @@ public class PreviewSuppressionTests
         public Task DeleteAccountDataAsync(Guid accountId) => Task.CompletedTask;
         public Task ClearCachedMailAsync(System.Collections.Generic.IEnumerable<System.Guid> accountIds) => Task.CompletedTask;
         public Task PurgeCalendarEventsForUnknownAccountsAsync(IReadOnlyCollection<Guid> knownAccountIds) => Task.CompletedTask;
+        public Task SaveFoldersAsync(Guid accountId, IReadOnlyList<MailFolderModel> folders) => Task.CompletedTask;
+        public Task<Dictionary<Guid, List<MailFolderModel>>> LoadFoldersAsync() => Task.FromResult(new Dictionary<Guid, List<MailFolderModel>>());
+        public Task PurgeFoldersForUnknownAccountsAsync(IReadOnlyCollection<Guid> knownAccountIds) => Task.CompletedTask;
         public Task UpdateIsReadAsync(Guid accountId, string folderName, string messageId, bool isRead) => Task.CompletedTask;
         public Task UpdateIsReadBatchAsync(IEnumerable<(Guid AccountId, string FolderName, string MessageId)> items, bool isRead) => Task.CompletedTask;
         public Task UpdatePreviewAsync(Guid accountId, string folderName, string messageId, string preview) => Task.CompletedTask;

--- a/QuickMail.Tests/StartupFolderCommandTests.cs
+++ b/QuickMail.Tests/StartupFolderCommandTests.cs
@@ -1,0 +1,182 @@
+// Setting the startup folder from the folder tree — issue #516.
+//
+// The guard here deliberately differs from the move/copy one: a startup folder MAY be a top-level
+// virtual aggregate, because "open me in All Inboxes" is the most-requested form of the setting.
+// What it must still refuse is anything that is not a place mail lives — and it has to say why,
+// since a context-menu item that silently does nothing is the dead end #250 was filed about.
+
+using System;
+using System.Collections.Generic;
+using QuickMail.Models;
+using QuickMail.Services;
+using QuickMail.ViewModels;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+public class StartupFolderCommandTests
+{
+    private static readonly Guid WorkId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+
+    private sealed class AccountsStub(params AccountModel[] accounts) : IAccountService
+    {
+        public List<AccountModel> LoadAccounts() => [.. accounts];
+        public void SaveAccounts(List<AccountModel> a) { }
+        public void SetDefaultAccount(Guid accountId) { }
+    }
+
+    private static (MainViewModel Vm, StubConfigService Config) MakeVm()
+    {
+        var config = new StubConfigService();
+        var vm = new MainViewModel(
+            new StubImapMailService(),
+            new AccountsStub(new AccountModel { Id = WorkId, AccountName = "Work" }),
+            new StubCredentialService(), new StubLocalStoreService(), new StubOAuthService(),
+            new StubSyncService(), config, new StubCommandRegistry(), new StubViewService(),
+            new StubRuleService(), new StubSmtpService());
+        vm.LoadAccountList();
+        return (vm, config);
+    }
+
+    private static FolderTreeNode Node(MailFolderModel folder, string label) =>
+        new() { Folder = folder, Label = label };
+
+    [Fact]
+    public void SettingARealFolder_StoresItScopedToItsAccount()
+    {
+        var (vm, config) = MakeVm();
+        var folder = new MailFolderModel
+        {
+            AccountId = WorkId, FullName = "INBOX/Projects", DisplayName = "Projects",
+        };
+
+        var message = vm.SetStartupFolder(Node(folder, "Projects"));
+
+        var cfg = config.Load();
+        Assert.Equal("INBOX/Projects", cfg.StartupFolder);
+        Assert.Equal(WorkId.ToString(), cfg.StartupFolderAccount);
+        Assert.Equal("Projects", cfg.StartupFolderLabel);
+        Assert.Contains("Projects", message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SettingAVirtualAggregate_StoresTheKeyWithoutTheSentinelPrefix()
+    {
+        // An INI file cannot carry a NUL, so the prefix is stripped on write.
+        var (vm, config) = MakeVm();
+
+        vm.SetStartupFolder(Node(MainViewModel.AllInboxesFolder, "All Inboxes"));
+
+        var cfg = config.Load();
+        Assert.Equal("AllInboxes", cfg.StartupFolder);
+        Assert.Equal(string.Empty, cfg.StartupFolderAccount);
+        Assert.Equal("All Inboxes", cfg.StartupFolderLabel);
+    }
+
+    [Theory]
+    [InlineData("\u0000AllMail",  "All Mail")]
+    [InlineData("\u0000AllSent",  "All Sent")]
+    [InlineData("\u0000AllTrash", "All Trash")]
+    [InlineData("\u0000AllWatched", "Watched Conversations")]
+    public void EveryTopLevelAggregate_IsAcceptable(string fullName, string display)
+    {
+        var (vm, config) = MakeVm();
+        var folder = new MailFolderModel { FullName = fullName, DisplayName = display };
+
+        vm.SetStartupFolder(Node(folder, display));
+
+        Assert.Equal(fullName[1..], config.Load().StartupFolder);
+    }
+
+    [Fact]
+    public void AHeaderNode_IsRefusedWithAReason()
+    {
+        var (vm, config) = MakeVm();
+        var header = new MailFolderModel { AccountId = WorkId, IsHeader = true, DisplayName = "Work" };
+
+        var message = vm.SetStartupFolder(new FolderTreeNode { Folder = header, IsHeader = true, Label = "Work" });
+
+        Assert.Equal(string.Empty, config.Load().StartupFolder);
+        Assert.False(string.IsNullOrWhiteSpace(message));
+    }
+
+    [Fact]
+    public void APerAccountAllMailSentinel_IsRefused_NotSilentlyStored()
+    {
+        // Carries a real AccountId but a \0-prefixed name no server would accept. Storing it would
+        // produce a startup folder that can never resolve.
+        var (vm, config) = MakeVm();
+        var sentinel = new MailFolderModel
+        {
+            AccountId = WorkId, FullName = $"\u0000AccountMail:{WorkId}", DisplayName = "Work — All Mail",
+        };
+
+        var message = vm.SetStartupFolder(Node(sentinel, "Work — All Mail"));
+
+        Assert.Equal(string.Empty, config.Load().StartupFolder);
+        Assert.Contains("not a folder", message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ACalendarNode_IsRefusedWithACalendarSpecificReason()
+    {
+        var (vm, config) = MakeVm();
+        var calendar = new MailFolderModel { FullName = "\u0000Calendar", DisplayName = "Calendar" };
+
+        var message = vm.SetStartupFolder(Node(calendar, "Calendar"));
+
+        Assert.Equal(string.Empty, config.Load().StartupFolder);
+        Assert.Contains("calendar", message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ANullNode_IsRefusedWithAReason()
+    {
+        var (vm, config) = MakeVm();
+
+        var message = vm.SetStartupFolder(null);
+
+        Assert.Equal(string.Empty, config.Load().StartupFolder);
+        Assert.False(string.IsNullOrWhiteSpace(message));
+    }
+
+    [Fact]
+    public void Clearing_RemovesAllThreeKeys()
+    {
+        var (vm, config) = MakeVm();
+        vm.SetStartupFolder(Node(
+            new MailFolderModel { AccountId = WorkId, FullName = "INBOX", DisplayName = "Inbox" }, "Inbox"));
+
+        var message = vm.ClearStartupFolder();
+
+        var cfg = config.Load();
+        Assert.Equal(string.Empty, cfg.StartupFolder);
+        Assert.Equal(string.Empty, cfg.StartupFolderAccount);
+        Assert.Equal(string.Empty, cfg.StartupFolderLabel);
+        Assert.Contains("Inbox", message, StringComparison.Ordinal);
+        Assert.Contains("All Mail", message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ClearingWhenNothingIsSet_SaysSoRatherThanClaimingItCleared()
+    {
+        var (vm, _) = MakeVm();
+
+        Assert.Contains("No startup folder is set", vm.ClearStartupFolder(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SettingReplacesAPreviousChoice_RatherThanAccumulating()
+    {
+        var (vm, config) = MakeVm();
+        vm.SetStartupFolder(Node(
+            new MailFolderModel { AccountId = WorkId, FullName = "INBOX", DisplayName = "Inbox" }, "Inbox"));
+
+        vm.SetStartupFolder(Node(MainViewModel.AllInboxesFolder, "All Inboxes"));
+
+        var cfg = config.Load();
+        Assert.Equal("AllInboxes", cfg.StartupFolder);
+        // The account must be cleared too, or the virtual key would be read as a real folder name.
+        Assert.Equal(string.Empty, cfg.StartupFolderAccount);
+    }
+}

--- a/QuickMail.Tests/StartupFolderMigrationTests.cs
+++ b/QuickMail.Tests/StartupFolderMigrationTests.cs
@@ -5,6 +5,8 @@
 // could not express the very thing being migrated.
 
 using System;
+using System.Collections.Generic;
+using System.IO;
 using QuickMail.Models;
 using QuickMail.Services;
 using Xunit;
@@ -175,4 +177,53 @@ public class StartupFolderMigrationTests
     [Fact]
     public void ApplyToConfig_RejectsANullConfig()
         => Assert.Throws<ArgumentNullException>(() => StartupFolderMigration.ApplyToConfig(null!, "[]"));
+
+    [Fact]
+    public void VirtualAndViewForms_LeaveNoStaleAccountBehind()
+    {
+        // A stale account id paired with a virtual key would send ResolveStartupFolder down the
+        // real-folder branch, where the key is not a folder name and never resolves.
+        var virtualCfg = new ConfigModel { StartupFolderAccount = WorkAccount };
+        Assert.True(StartupFolderMigration.ApplyToConfig(virtualCfg, Views(VirtualView("AllInboxes"))));
+        Assert.Equal(string.Empty, virtualCfg.StartupFolderAccount);
+
+        var viewCfg = new ConfigModel { StartupFolderAccount = WorkAccount };
+        Assert.True(StartupFolderMigration.ApplyToConfig(viewCfg, Views(MultiFolderView)));
+        Assert.Equal(string.Empty, viewCfg.StartupFolderAccount);
+    }
+
+    /// <summary>Fails every Load, the way ViewService does when views.json cannot be deserialized —
+    /// it swallows the exception and returns an empty list.</summary>
+    private sealed class FailingViewService : IViewService
+    {
+        public int SaveCount { get; private set; }
+        public List<SavedView> Load() => [];              // "read failed", indistinguishable from empty
+        public void Save(List<SavedView> views) => SaveCount++;
+    }
+
+    [Fact]
+    public void AFailedReReadOfViewsJson_DoesNotOverwriteIt()
+    {
+        // ViewService.Load() has a bare catch returning []. Blindly doing Save(Load()) would write
+        // [] over every saved view the user has — atomically, silently, on the first launch after
+        // upgrade. ApplyToConfig succeeding proves the file held at least one view, so an empty
+        // re-read is provably a read failure, not an empty file.
+        var tempDir = Path.Combine(Path.GetTempPath(), $"qm-migrate-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            File.WriteAllText(Path.Combine(tempDir, "views.json"), Views(VirtualView("AllInboxes")));
+            var views = new FailingViewService();
+
+            var migrated = StartupFolderMigration.Run(
+                new ProfileContext(tempDir), new ConfigModel(), new StubConfigService(), views);
+
+            Assert.True(migrated);
+            Assert.Equal(0, views.SaveCount);   // the file was left alone
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
 }

--- a/QuickMail.Tests/StartupFolderMigrationTests.cs
+++ b/QuickMail.Tests/StartupFolderMigrationTests.cs
@@ -1,0 +1,178 @@
+// One-time migration off SavedView.IsDefault — issue #516.
+//
+// The flag is read from raw views.json because it no longer exists on the model, so these tests
+// feed JSON text rather than objects. That is deliberate: a test built from SavedView instances
+// could not express the very thing being migrated.
+
+using System;
+using QuickMail.Models;
+using QuickMail.Services;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+public class StartupFolderMigrationTests
+{
+    private const string WorkAccount = "11111111-1111-1111-1111-111111111111";
+
+    private static string Views(string body) => $"[{body}]";
+
+    private static string VirtualView(string key, bool isDefault = true, string name = "My Inboxes") => $$"""
+        { "Id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "Name": "{{name}}",
+          "Folders": [], "VirtualFolderKey": "{{key}}", "IsDefault": {{(isDefault ? "true" : "false")}} }
+        """;
+
+    private static string SingleFolderView(bool isDefault = true) => $$"""
+        { "Id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", "Name": "Work Projects",
+          "Folders": [ { "AccountId": "{{WorkAccount}}", "FolderFullName": "INBOX/Projects",
+                         "AccountDisplayName": "Work", "FolderDisplayName": "Projects" } ],
+          "IsDefault": {{(isDefault ? "true" : "false")}} }
+        """;
+
+    private const string MultiFolderView = """
+        { "Id": "cccccccc-cccc-cccc-cccc-cccccccccccc", "Name": "Both Inboxes",
+          "Folders": [ { "AccountId": "11111111-1111-1111-1111-111111111111", "FolderFullName": "INBOX",
+                         "AccountDisplayName": "Work", "FolderDisplayName": "Inbox" },
+                       { "AccountId": "22222222-2222-2222-2222-222222222222", "FolderFullName": "INBOX",
+                         "AccountDisplayName": "Home", "FolderDisplayName": "Inbox" } ],
+          "IsDefault": true }
+        """;
+
+    [Fact]
+    public void VirtualDefaultView_BecomesTheVirtualStartupKey()
+    {
+        // The common shape: someone made a saved view over All Inboxes purely to open there.
+        var cfg = new ConfigModel();
+
+        Assert.True(StartupFolderMigration.ApplyToConfig(cfg, Views(VirtualView("AllInboxes"))));
+
+        Assert.Equal("AllInboxes", cfg.StartupFolder);
+        Assert.Equal("All Inboxes", cfg.StartupFolderLabel);
+        Assert.Equal(string.Empty, cfg.StartupFolderAccount);
+    }
+
+    [Fact]
+    public void SingleFolderDefaultView_BecomesAnAccountScopedFolder()
+    {
+        var cfg = new ConfigModel();
+
+        Assert.True(StartupFolderMigration.ApplyToConfig(cfg, Views(SingleFolderView())));
+
+        Assert.Equal("INBOX/Projects", cfg.StartupFolder);
+        Assert.Equal(WorkAccount, cfg.StartupFolderAccount);
+        Assert.Equal("Projects", cfg.StartupFolderLabel);
+    }
+
+    [Fact]
+    public void MultiFolderDefaultView_IsKeptByReference_NotDropped()
+    {
+        // No single folder can express it. Preserving the reference beats silently losing a setup
+        // the user deliberately built; nothing in the UI can create this form.
+        var cfg = new ConfigModel();
+
+        Assert.True(StartupFolderMigration.ApplyToConfig(cfg, Views(MultiFolderView)));
+
+        Assert.Equal("view:cccccccc-cccc-cccc-cccc-cccccccccccc", cfg.StartupFolder);
+        Assert.Equal("Both Inboxes", cfg.StartupFolderLabel);
+    }
+
+    [Fact]
+    public void NoDefaultView_ChangesNothing()
+    {
+        var cfg = new ConfigModel();
+
+        Assert.False(StartupFolderMigration.ApplyToConfig(
+            cfg, Views(VirtualView("AllInboxes", isDefault: false))));
+
+        Assert.Equal(string.Empty, cfg.StartupFolder);
+    }
+
+    [Fact]
+    public void AnExplicitStartupFolder_IsNeverOverwritten()
+    {
+        // The user's own choice always wins over an inherited one — and this is what keeps the
+        // migration one-time for anyone who already ran it.
+        var cfg = new ConfigModel { StartupFolder = "AllMail", StartupFolderLabel = "All Mail" };
+
+        Assert.False(StartupFolderMigration.ApplyToConfig(cfg, Views(VirtualView("AllInboxes"))));
+
+        Assert.Equal("AllMail", cfg.StartupFolder);
+    }
+
+    [Fact]
+    public void OnlyTheFirstDefaultViewWins()
+    {
+        // IsDefault was supposed to be exclusive, but a hand-edited views.json need not be.
+        var cfg = new ConfigModel();
+
+        Assert.True(StartupFolderMigration.ApplyToConfig(
+            cfg, Views($"{VirtualView("AllInboxes")},{SingleFolderView()}")));
+
+        Assert.Equal("AllInboxes", cfg.StartupFolder);
+    }
+
+    [Fact]
+    public void LegacyDefaultView_WithNoFoldersAndNoKey_MigratesNothing()
+    {
+        // That shape already means All Mail, which is the default.
+        var cfg = new ConfigModel();
+
+        Assert.False(StartupFolderMigration.ApplyToConfig(cfg, Views("""
+            { "Id": "dddddddd-dddd-dddd-dddd-dddddddddddd", "Name": "Legacy",
+              "Folders": [], "IsDefault": true }
+            """)));
+
+        Assert.Equal(string.Empty, cfg.StartupFolder);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not json at all")]
+    [InlineData("{ \"notAnArray\": true }")]
+    [InlineData("[ \"a string, not an object\" ]")]
+    [InlineData("[]")]
+    public void MalformedOrEmptyViewsFile_IsTreatedAsNothingToMigrate(string? json)
+    {
+        // A migration must never be the reason the app will not start.
+        var cfg = new ConfigModel();
+
+        Assert.False(StartupFolderMigration.ApplyToConfig(cfg, json));
+        Assert.Equal(string.Empty, cfg.StartupFolder);
+    }
+
+    [Fact]
+    public void DefaultViewMissingItsId_FallsThroughWithoutThrowing()
+    {
+        var cfg = new ConfigModel();
+
+        Assert.False(StartupFolderMigration.ApplyToConfig(cfg, Views("""
+            { "Name": "No id", "IsDefault": true,
+              "Folders": [ { "AccountId": "11111111-1111-1111-1111-111111111111", "FolderFullName": "A" },
+                           { "AccountId": "11111111-1111-1111-1111-111111111111", "FolderFullName": "B" } ] }
+            """)));
+
+        Assert.Equal(string.Empty, cfg.StartupFolder);
+    }
+
+    [Fact]
+    public void SingleFolderViewWithoutADisplayName_FallsBackToTheViewName()
+    {
+        var cfg = new ConfigModel();
+
+        Assert.True(StartupFolderMigration.ApplyToConfig(cfg, Views("""
+            { "Id": "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee", "Name": "Nameless Folder View",
+              "Folders": [ { "AccountId": "11111111-1111-1111-1111-111111111111",
+                             "FolderFullName": "INBOX/Deep/Nested" } ],
+              "IsDefault": true }
+            """)));
+
+        Assert.Equal("INBOX/Deep/Nested", cfg.StartupFolder);
+        Assert.Equal("Nameless Folder View", cfg.StartupFolderLabel);
+    }
+
+    [Fact]
+    public void ApplyToConfig_RejectsANullConfig()
+        => Assert.Throws<ArgumentNullException>(() => StartupFolderMigration.ApplyToConfig(null!, "[]"));
+}

--- a/QuickMail.Tests/StartupSettingsTests.cs
+++ b/QuickMail.Tests/StartupSettingsTests.cs
@@ -1,0 +1,212 @@
+// Settings -> Startup — issue #516.
+//
+// Two halves. The VM half pins that the tab's fields survive a save/load and that Choose/Clear do
+// what their labels say. The call-site half reads MainWindow's source, because the picker cannot be
+// stood up without a live main window — and the property that matters most about it (that it is
+// UNSCOPED, unlike every other destination picker) is invisible to a presentation test: scoping it
+// by accident would still produce a tree, just one missing most of the user's folders.
+
+using System;
+using System.IO;
+using System.Text.RegularExpressions;
+using QuickMail.Models;
+using QuickMail.Services;
+using QuickMail.ViewModels;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+public class StartupSettingsTests
+{
+    private static SettingsViewModel MakeVm(IConfigService config)
+        => new(config, new StubCommandRegistry());
+
+    [Fact]
+    public void FreshSettings_ShowAllMail_AndTheRecommendedScope()
+    {
+        var vm = MakeVm(new StubConfigService());
+
+        Assert.Equal("All Mail", vm.StartupFolderDisplay);   // empty StartupFolder == All Mail
+        Assert.True(vm.IsStartupSyncScopeStartupFolder);
+        Assert.False(vm.IsStartupSyncScopeInboxes);
+        Assert.False(vm.IsStartupSyncScopeAll);
+    }
+
+    [Fact]
+    public void StartupFolder_RoundTripsThroughConfig()
+    {
+        var config = new StubConfigService();
+        var save = MakeVm(config);
+        save.PickStartupFolderRequested = () =>
+            new SettingsViewModel.StartupFolderChoice("INBOX/Projects", "11111111-1111-1111-1111-111111111111", "Projects");
+
+        save.ChooseStartupFolderCommand.Execute(null);
+        save.SaveCommand.Execute(null);
+
+        var load = MakeVm(config);
+        Assert.Equal("INBOX/Projects", load.StartupFolder);
+        Assert.Equal("11111111-1111-1111-1111-111111111111", load.StartupFolderAccount);
+        Assert.Equal("Projects", load.StartupFolderDisplay);
+    }
+
+    [Fact]
+    public void CancellingThePicker_LeavesTheCurrentChoiceAlone()
+    {
+        var config = new StubConfigService();
+        var vm = MakeVm(config);
+        vm.PickStartupFolderRequested = () =>
+            new SettingsViewModel.StartupFolderChoice("AllInboxes", string.Empty, "All Inboxes");
+        vm.ChooseStartupFolderCommand.Execute(null);
+
+        vm.PickStartupFolderRequested = () => null;    // user pressed Escape
+        vm.ChooseStartupFolderCommand.Execute(null);
+
+        Assert.Equal("AllInboxes", vm.StartupFolder);
+        Assert.Equal("All Inboxes", vm.StartupFolderDisplay);
+    }
+
+    [Fact]
+    public void Clear_ResetsToAllMail_AndPersists()
+    {
+        var config = new StubConfigService();
+        var vm = MakeVm(config);
+        vm.PickStartupFolderRequested = () =>
+            new SettingsViewModel.StartupFolderChoice("INBOX", "11111111-1111-1111-1111-111111111111", "Inbox");
+        vm.ChooseStartupFolderCommand.Execute(null);
+
+        vm.ClearStartupFolderCommand.Execute(null);
+        vm.SaveCommand.Execute(null);
+
+        var reloaded = MakeVm(config);
+        Assert.Equal(string.Empty, reloaded.StartupFolder);
+        Assert.Equal(string.Empty, reloaded.StartupFolderAccount);
+        Assert.Equal("All Mail", reloaded.StartupFolderDisplay);
+    }
+
+    [Fact]
+    public void ChoosingAVirtualFolderAfterARealOne_ClearsTheAccount()
+    {
+        // Otherwise the virtual key would be read back as a real folder name on that account.
+        var config = new StubConfigService();
+        var vm = MakeVm(config);
+        vm.PickStartupFolderRequested = () =>
+            new SettingsViewModel.StartupFolderChoice("INBOX", "11111111-1111-1111-1111-111111111111", "Inbox");
+        vm.ChooseStartupFolderCommand.Execute(null);
+
+        vm.PickStartupFolderRequested = () =>
+            new SettingsViewModel.StartupFolderChoice("AllInboxes", string.Empty, "All Inboxes");
+        vm.ChooseStartupFolderCommand.Execute(null);
+        vm.SaveCommand.Execute(null);
+
+        Assert.Equal(string.Empty, MakeVm(config).StartupFolderAccount);
+    }
+
+    [Theory]
+    [InlineData(ConfigModel.StartupSyncScopeInboxes)]
+    [InlineData(ConfigModel.StartupSyncScopeAll)]
+    [InlineData(ConfigModel.StartupSyncScopeStartupFolder)]
+    public void SyncScope_RoundTripsThroughConfig(string scope)
+    {
+        var config = new StubConfigService();
+        var save = MakeVm(config);
+        save.StartupSyncScope = scope;
+        save.SaveCommand.Execute(null);
+
+        Assert.Equal(scope, MakeVm(config).StartupSyncScope);
+    }
+
+    [Fact]
+    public void SyncScopeRadios_StayMutuallyExclusive()
+    {
+        var vm = MakeVm(new StubConfigService());
+
+        vm.IsStartupSyncScopeAll = true;
+
+        Assert.True(vm.IsStartupSyncScopeAll);
+        Assert.False(vm.IsStartupSyncScopeInboxes);
+        Assert.False(vm.IsStartupSyncScopeStartupFolder);
+    }
+
+    [Fact]
+    public void AnUnrecognisedPersistedScope_NormalizesToTheDefault()
+    {
+        var config = new StubConfigService();
+        var cfg = config.Load();
+        cfg.StartupSyncScope = "whatever";
+        config.Save(cfg);
+
+        Assert.True(MakeVm(config).IsStartupSyncScopeStartupFolder);
+    }
+
+    // ── Call-site guards ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void TheSettingsPickerIsBuiltThroughForStartupFolder()
+    {
+        var body = MethodBody("Views/MainWindow.xaml.cs", "MenuSettings_Click");
+
+        Assert.Contains("FolderPickerWindow.ForStartupFolder", body, StringComparison.Ordinal);
+        Assert.False(Regex.IsMatch(body, @"new\s+FolderPickerWindow\s*\("),
+                     "MenuSettings_Click constructs a FolderPickerWindow directly — go through the factory.");
+    }
+
+    [Fact]
+    public void TheSettingsPickerOffersTheVirtualFolders()
+    {
+        // "Open me in All Inboxes" is the single most-requested form of this setting, and the
+        // aggregates reach the picker only by being passed in — nothing else would fail without it.
+        var body = MethodBody("Views/MainWindow.xaml.cs", "MenuSettings_Click");
+
+        Assert.Contains("AllVirtualFolders", body, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TheSettingsPickerIsNotScopedToOneAccount()
+    {
+        // The opposite of the rule-target and move/copy pickers, deliberately: a startup folder is
+        // one global choice stored with its owning account, so there is no name-collision hazard to
+        // scope against, and scoping would hide most of the tree.
+        var body = MethodBody("Views/MainWindow.xaml.cs", "MenuSettings_Click");
+        var call = Regex.Match(body, @"ForStartupFolder\s*\((?<args>[^;]*?)\)\s*;", RegexOptions.Singleline);
+
+        Assert.True(call.Success, "could not find the ForStartupFolder call.");
+        Assert.Contains("_vm.Accounts", call.Groups["args"].Value, StringComparison.Ordinal);
+        Assert.Contains("_vm.CachedFolders", call.Groups["args"].Value, StringComparison.Ordinal);
+        Assert.DoesNotContain(".Where(", call.Groups["args"].Value, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Text of one method, from its DECLARATION to the first closing brace at the same indentation.
+    /// Anchored on the modifier rather than the bare name: MainWindow also has the one-line probe
+    /// wrapper <c>ShowSettingsDialogForProbe() => MenuSettings_Click(...)</c>, and a name-only match
+    /// finds that first and returns a "body" containing nothing this file asserts about.
+    /// </summary>
+    private static string MethodBody(string relativePath, string methodName)
+    {
+        var path = Path.Combine(RepoRoot(), "QuickMail", relativePath.Replace('/', Path.DirectorySeparatorChar));
+        Assert.True(File.Exists(path), $"{path} not found.");
+
+        var source = File.ReadAllText(path);
+        var start  = Regex.Match(
+            source,
+            $@"^(?<indent>[ \t]*)(?:private|internal|public|protected)[^\r\n(]*\b{Regex.Escape(methodName)}\s*\([^)]*\)\s*[\r\n]",
+            RegexOptions.Multiline);
+        Assert.True(start.Success, $"{methodName} declaration not found in {relativePath} — renamed or removed?");
+
+        var end = Regex.Match(
+            source[start.Index..], $@"^{start.Groups["indent"].Value}}}", RegexOptions.Multiline);
+        Assert.True(end.Success, $"could not find the end of {methodName} in {relativePath}.");
+
+        return source.Substring(start.Index, end.Index + end.Length);
+    }
+
+    private static string RepoRoot()
+    {
+        for (var dir = new DirectoryInfo(AppContext.BaseDirectory); dir != null; dir = dir.Parent)
+        {
+            if (Directory.Exists(Path.Combine(dir.FullName, "QuickMail", "Views")))
+                return dir.FullName;
+        }
+        throw new InvalidOperationException($"Repo source tree not found from {AppContext.BaseDirectory}.");
+    }
+}

--- a/QuickMail.Tests/StartupSettingsTests.cs
+++ b/QuickMail.Tests/StartupSettingsTests.cs
@@ -32,21 +32,41 @@ public class StartupSettingsTests
         Assert.False(vm.IsStartupSyncScopeAll);
     }
 
+    private static readonly Guid WorkId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+
+    private static MailFolderModel RealFolder(string full, string display) =>
+        new() { AccountId = WorkId, FullName = full, DisplayName = display };
+
     [Fact]
     public void StartupFolder_RoundTripsThroughConfig()
     {
         var config = new StubConfigService();
         var save = MakeVm(config);
-        save.PickStartupFolderRequested = () =>
-            new SettingsViewModel.StartupFolderChoice("INBOX/Projects", "11111111-1111-1111-1111-111111111111", "Projects");
+        save.PickStartupFolderRequested = () => RealFolder("INBOX/Projects", "Projects");
 
         save.ChooseStartupFolderCommand.Execute(null);
         save.SaveCommand.Execute(null);
 
         var load = MakeVm(config);
         Assert.Equal("INBOX/Projects", load.StartupFolder);
-        Assert.Equal("11111111-1111-1111-1111-111111111111", load.StartupFolderAccount);
+        Assert.Equal(WorkId.ToString(), load.StartupFolderAccount);
         Assert.Equal("Projects", load.StartupFolderDisplay);
+    }
+
+    [Fact]
+    public void PickingAVirtualAggregate_StripsTheSentinelAndDropsTheAccount()
+    {
+        // The VM owns this conversion, not the code-behind — one rule, one place. A virtual folder
+        // spans every account, so carrying an account id would make it resolve as a real folder name.
+        var config = new StubConfigService();
+        var vm = MakeVm(config);
+        vm.PickStartupFolderRequested = () => MainViewModel.AllInboxesFolder;
+
+        vm.ChooseStartupFolderCommand.Execute(null);
+
+        Assert.Equal("AllInboxes", vm.StartupFolder);
+        Assert.Equal(string.Empty, vm.StartupFolderAccount);
+        Assert.Equal("All Inboxes", vm.StartupFolderDisplay);
     }
 
     [Fact]
@@ -54,8 +74,7 @@ public class StartupSettingsTests
     {
         var config = new StubConfigService();
         var vm = MakeVm(config);
-        vm.PickStartupFolderRequested = () =>
-            new SettingsViewModel.StartupFolderChoice("AllInboxes", string.Empty, "All Inboxes");
+        vm.PickStartupFolderRequested = () => MainViewModel.AllInboxesFolder;
         vm.ChooseStartupFolderCommand.Execute(null);
 
         vm.PickStartupFolderRequested = () => null;    // user pressed Escape
@@ -70,8 +89,7 @@ public class StartupSettingsTests
     {
         var config = new StubConfigService();
         var vm = MakeVm(config);
-        vm.PickStartupFolderRequested = () =>
-            new SettingsViewModel.StartupFolderChoice("INBOX", "11111111-1111-1111-1111-111111111111", "Inbox");
+        vm.PickStartupFolderRequested = () => RealFolder("INBOX", "Inbox");
         vm.ChooseStartupFolderCommand.Execute(null);
 
         vm.ClearStartupFolderCommand.Execute(null);
@@ -89,12 +107,10 @@ public class StartupSettingsTests
         // Otherwise the virtual key would be read back as a real folder name on that account.
         var config = new StubConfigService();
         var vm = MakeVm(config);
-        vm.PickStartupFolderRequested = () =>
-            new SettingsViewModel.StartupFolderChoice("INBOX", "11111111-1111-1111-1111-111111111111", "Inbox");
+        vm.PickStartupFolderRequested = () => RealFolder("INBOX", "Inbox");
         vm.ChooseStartupFolderCommand.Execute(null);
 
-        vm.PickStartupFolderRequested = () =>
-            new SettingsViewModel.StartupFolderChoice("AllInboxes", string.Empty, "All Inboxes");
+        vm.PickStartupFolderRequested = () => MainViewModel.AllInboxesFolder;
         vm.ChooseStartupFolderCommand.Execute(null);
         vm.SaveCommand.Execute(null);
 

--- a/QuickMail.Tests/StartupSyncScopeTests.cs
+++ b/QuickMail.Tests/StartupSyncScopeTests.cs
@@ -1,0 +1,223 @@
+// How much QuickMail syncs at launch — issue #516.
+//
+// SyncAllAccountsAsync has exactly one caller, the startup pass, so it IS the startup sync and reads
+// the scope from config itself. These tests drive it against a mail service that records which
+// folders it was asked to fetch, because "which folders did we touch" is the whole behaviour.
+//
+// Worth keeping in mind while reading: nothing skipped here is skipped permanently. The periodic
+// sweep visits every folder, and the IMAP IDLE / Graph delta watchers cover every account's Inbox
+// live, so new-mail notifications are unaffected by any scope.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using QuickMail.Models;
+using QuickMail.Services;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+public class StartupSyncScopeTests : IDisposable
+{
+    private static readonly Guid WorkId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid HomeId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    private readonly string _tempDir;
+    private readonly LocalStoreService _store;
+
+    public StartupSyncScopeTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"qm-startup-scope-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        _store = new LocalStoreService(new ProfileContext(_tempDir));
+        _store.Initialize();
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); } catch { }
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>Records every (account, folder) the sync actually reached.</summary>
+    private sealed class RecordingMailService : StubImapMailServiceBase
+    {
+        public List<(Guid Account, string Folder)> Fetched { get; } = [];
+
+        public override Task<List<MailMessageSummary>> GetMessagesSinceDateAsync(
+            Guid accountId, string folderName, DateTime since, CancellationToken ct = default)
+        {
+            Fetched.Add((accountId, folderName));
+            return Task.FromResult(new List<MailMessageSummary>());
+        }
+
+        public override Task<List<MailMessageSummary>> GetMessagesSinceAsync(
+            Guid accountId, string folderName, string sinceMessageId, int initialCount, CancellationToken ct = default)
+        {
+            Fetched.Add((accountId, folderName));
+            return Task.FromResult(new List<MailMessageSummary>());
+        }
+    }
+
+    private static MailFolderModel Folder(string full, string display, SpecialFolderKind kind = SpecialFolderKind.None) =>
+        new() { FullName = full, DisplayName = display, Kind = kind };
+
+    private static readonly List<MailFolderModel> WorkFolders =
+    [
+        Folder("INBOX", "Inbox", SpecialFolderKind.Inbox),
+        Folder("INBOX/Projects", "Projects"),
+        Folder("Archive", "Archive", SpecialFolderKind.Archive),
+        Folder("Sent", "Sent", SpecialFolderKind.Sent),          // ExcludeFromAllMail is false here
+    ];
+
+    private static readonly List<MailFolderModel> HomeFolders =
+    [
+        Folder("INBOX", "Inbox", SpecialFolderKind.Inbox),
+        Folder("Lists", "Lists"),
+    ];
+
+    private static readonly Dictionary<Guid, List<MailFolderModel>> Cached = new()
+    {
+        [WorkId] = WorkFolders,
+        [HomeId] = HomeFolders,
+    };
+
+    private static readonly List<AccountModel> Accounts =
+    [
+        new() { Id = WorkId, AccountName = "Work", ImapHost = "work.example" },
+        new() { Id = HomeId, AccountName = "Home", ImapHost = "home.example" },
+    ];
+
+    private async Task<List<(Guid Account, string Folder)>> RunAsync(Action<ConfigModel> configure)
+    {
+        var config = new StubConfigService();
+        var cfg = config.Load();
+        configure(cfg);
+        config.Save(cfg);
+
+        var imap = new RecordingMailService();
+        var sync = new SyncService(imap, _store, config, new StubRuleService());
+
+        await sync.SyncAllAccountsAsync(Accounts, Cached, CancellationToken.None);
+        return imap.Fetched;
+    }
+
+    [Fact]
+    public async Task ScopeAll_SyncsEveryNonExcludedFolderOnEveryAccount()
+    {
+        var fetched = await RunAsync(c => c.StartupSyncScope = ConfigModel.StartupSyncScopeAll);
+
+        Assert.Equal(6, fetched.Count);
+        Assert.Contains((WorkId, "INBOX/Projects"), fetched);
+        Assert.Contains((HomeId, "Lists"), fetched);
+    }
+
+    [Fact]
+    public async Task ScopeInboxes_SyncsOnlyInboxes_AcrossEveryAccount()
+    {
+        var fetched = await RunAsync(c => c.StartupSyncScope = ConfigModel.StartupSyncScopeInboxes);
+
+        Assert.Equal([(WorkId, "INBOX"), (HomeId, "INBOX")], fetched.OrderBy(f => f.Account).ToList());
+    }
+
+    [Fact]
+    public async Task ScopeStartupFolder_WithARealFolder_SyncsThatFolderAlone()
+    {
+        // The lightest launch there is, and the case the default exists for.
+        var fetched = await RunAsync(c =>
+        {
+            c.StartupSyncScope       = ConfigModel.StartupSyncScopeStartupFolder;
+            c.StartupFolder          = "INBOX/Projects";
+            c.StartupFolderAccount   = WorkId.ToString();
+        });
+
+        Assert.Equal([(WorkId, "INBOX/Projects")], fetched);
+    }
+
+    [Fact]
+    public async Task ScopeStartupFolder_WithAllInboxes_SyncsEveryInbox()
+    {
+        var fetched = await RunAsync(c =>
+        {
+            c.StartupSyncScope = ConfigModel.StartupSyncScopeStartupFolder;
+            c.StartupFolder    = "AllInboxes";
+        });
+
+        Assert.Equal([(WorkId, "INBOX"), (HomeId, "INBOX")], fetched.OrderBy(f => f.Account).ToList());
+    }
+
+    [Fact]
+    public async Task ScopeStartupFolder_WithNoStartupFolder_SyncsEverything()
+    {
+        // No startup folder means All Mail, which spans every folder — a narrower sync would put
+        // stale rows on screen. So the saving is opted into by choosing a narrower place to start,
+        // not imposed on someone who never configured one.
+        var fetched = await RunAsync(c => c.StartupSyncScope = ConfigModel.StartupSyncScopeStartupFolder);
+
+        Assert.Equal(6, fetched.Count);
+    }
+
+    [Fact]
+    public async Task ScopeStartupFolder_WithAllMail_SyncsEverything()
+    {
+        var fetched = await RunAsync(c =>
+        {
+            c.StartupSyncScope = ConfigModel.StartupSyncScopeStartupFolder;
+            c.StartupFolder    = "AllMail";
+        });
+
+        Assert.Equal(6, fetched.Count);
+    }
+
+    [Fact]
+    public async Task ScopeStartupFolder_WhoseFolderNoLongerExists_SyncsWide_NotNothing()
+    {
+        // Startup falls back to All Mail in this case, so the sync has to cover All Mail. Syncing
+        // one folder that is not there would leave the user looking at an unsynced All Mail.
+        var fetched = await RunAsync(c =>
+        {
+            c.StartupSyncScope     = ConfigModel.StartupSyncScopeStartupFolder;
+            c.StartupFolder        = "INBOX/GoneAway";
+            c.StartupFolderAccount = WorkId.ToString();
+        });
+
+        Assert.Equal(6, fetched.Count);
+    }
+
+    [Fact]
+    public async Task ScopeStartupFolder_WithAViewReference_SyncsEverything()
+    {
+        // This layer has no view service to resolve view:{guid}, and guessing narrow would under-sync.
+        var fetched = await RunAsync(c =>
+        {
+            c.StartupSyncScope = ConfigModel.StartupSyncScopeStartupFolder;
+            c.StartupFolder    = "view:cccccccc-cccc-cccc-cccc-cccccccccccc";
+        });
+
+        Assert.Equal(6, fetched.Count);
+    }
+
+    [Fact]
+    public async Task ProgressTotal_CountsOnlyTheFoldersInScope()
+    {
+        // Otherwise "Synced 2 of 6 folders" announces a total the sync never intends to reach, and
+        // the completion announcement never fires.
+        var config = new StubConfigService();
+        var cfg = config.Load();
+        cfg.StartupSyncScope = ConfigModel.StartupSyncScopeInboxes;
+        config.Save(cfg);
+
+        var sync = new SyncService(new RecordingMailService(), _store, config, new StubRuleService());
+        var progress = new List<(int Done, int Total)>();
+        sync.SyncProgressChanged += (done, total) => progress.Add((done, total));
+
+        await sync.SyncAllAccountsAsync(Accounts, Cached, CancellationToken.None);
+
+        Assert.NotEmpty(progress);
+        Assert.All(progress, p => Assert.Equal(2, p.Total));
+        Assert.Equal(2, progress[^1].Done);
+    }
+}

--- a/QuickMail.Tests/StubServices.cs
+++ b/QuickMail.Tests/StubServices.cs
@@ -63,8 +63,10 @@ class StubImapMailServiceBase : IMailService
     public virtual Task DisconnectAsync(Guid accountId, CancellationToken ct = default) => _inner.DisconnectAsync(accountId, ct);
     public Task<List<MailFolderModel>> GetFoldersAsync(Guid accountId, CancellationToken ct = default) => _inner.GetFoldersAsync(accountId, ct);
     public Task<List<MailMessageSummary>> GetMessageSummariesAsync(Guid accountId, string folderName, int maxMessages, CancellationToken ct = default) => _inner.GetMessageSummariesAsync(accountId, folderName, maxMessages, ct);
-    public Task<List<MailMessageSummary>> GetMessagesSinceDateAsync(Guid accountId, string folderName, DateTime since, CancellationToken ct = default) => _inner.GetMessagesSinceDateAsync(accountId, folderName, since, ct);
-    public Task<List<MailMessageSummary>> GetMessagesSinceAsync(Guid accountId, string folderName, string sinceMessageId, int initialCount, CancellationToken ct = default) => _inner.GetMessagesSinceAsync(accountId, folderName, sinceMessageId, initialCount, ct);
+    // Virtual: the two fetch entry points a sync exercises, so a double can record which folders
+    // were actually visited (#516 startup sync scope) without reimplementing IMailService.
+    public virtual Task<List<MailMessageSummary>> GetMessagesSinceDateAsync(Guid accountId, string folderName, DateTime since, CancellationToken ct = default) => _inner.GetMessagesSinceDateAsync(accountId, folderName, since, ct);
+    public virtual Task<List<MailMessageSummary>> GetMessagesSinceAsync(Guid accountId, string folderName, string sinceMessageId, int initialCount, CancellationToken ct = default) => _inner.GetMessagesSinceAsync(accountId, folderName, sinceMessageId, initialCount, ct);
     public Task<MailMessageDetail> GetMessageDetailAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default) => _inner.GetMessageDetailAsync(accountId, folderName, messageId, ct);
     public Task<MailMessageDetail> PrefetchMessageDetailAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default) => _inner.PrefetchMessageDetailAsync(accountId, folderName, messageId, ct);
     public Task MarkReadAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default) => _inner.MarkReadAsync(accountId, folderName, messageId, ct);

--- a/QuickMail.Tests/StubServices.cs
+++ b/QuickMail.Tests/StubServices.cs
@@ -198,6 +198,25 @@ sealed class StubLocalStoreService : ILocalStoreService
     public Task DeleteAccountDataAsync(Guid accountId) => Task.CompletedTask;
     public Task ClearCachedMailAsync(System.Collections.Generic.IEnumerable<System.Guid> accountIds) => Task.CompletedTask;
     public Task PurgeCalendarEventsForUnknownAccountsAsync(IReadOnlyCollection<Guid> knownAccountIds) => Task.CompletedTask;
+
+    /// <summary>Folders the stub hands back from <see cref="LoadFoldersAsync"/> — seed this to stand in
+    /// for a persisted folder list at startup (#516). <see cref="SaveFoldersAsync"/> writes into it too,
+    /// so a save/load round-trip works without a real database.</summary>
+    public Dictionary<Guid, List<MailFolderModel>> SeededFolders { get; } = [];
+    public Task SaveFoldersAsync(Guid accountId, IReadOnlyList<MailFolderModel> folders)
+    {
+        SeededFolders[accountId] = [.. folders.Where(f => !f.IsHeader && f.FullName.Length > 0)];
+        return Task.CompletedTask;
+    }
+    public Task<Dictionary<Guid, List<MailFolderModel>>> LoadFoldersAsync()
+        => Task.FromResult(SeededFolders.ToDictionary(kv => kv.Key, kv => new List<MailFolderModel>(kv.Value)));
+    public Task PurgeFoldersForUnknownAccountsAsync(IReadOnlyCollection<Guid> knownAccountIds)
+    {
+        foreach (var id in SeededFolders.Keys.Where(k => !knownAccountIds.Contains(k)).ToList())
+            SeededFolders.Remove(id);
+        return Task.CompletedTask;
+    }
+
     public Task UpdateIsReadAsync(Guid accountId, string folderName, string messageId, bool isRead) => Task.CompletedTask;
     public Task UpdateIsReadBatchAsync(IEnumerable<(Guid AccountId, string FolderName, string MessageId)> items, bool isRead) => Task.CompletedTask;
     public Task UpdatePreviewAsync(Guid accountId, string folderName, string messageId, string preview) => Task.CompletedTask;

--- a/QuickMail.Tests/StubServices.cs
+++ b/QuickMail.Tests/StubServices.cs
@@ -191,9 +191,22 @@ sealed class StubLocalStoreService : ILocalStoreService
 {
     public void Initialize() { }
     public Task UpsertSummariesAsync(IEnumerable<MailMessageSummary> summaries) => Task.CompletedTask;
-    public Task<List<MailMessageSummary>> LoadAllSummariesAsync() => Task.FromResult(new List<MailMessageSummary>());
-    public Task<List<MailMessageSummary>> LoadAllSummariesAsync(Guid accountId) => Task.FromResult(new List<MailMessageSummary>());
-    public Task<List<MailMessageSummary>> LoadFolderSummariesAsync(Guid accountId, string folderName, int? limit = null) => Task.FromResult(new List<MailMessageSummary>());
+
+    /// <summary>Cached rows keyed by (account, folder). Empty by default, so every existing test that
+    /// never seeds it keeps seeing an empty cache; seed it to exercise a cache-first load such as the
+    /// startup folder (#516).</summary>
+    public Dictionary<(Guid AccountId, string Folder), List<MailMessageSummary>> SeededSummaries { get; } = [];
+
+    private static List<MailMessageSummary> Newest(IEnumerable<MailMessageSummary> rows)
+        => [.. rows.OrderByDescending(m => m.Date)];
+
+    public Task<List<MailMessageSummary>> LoadAllSummariesAsync()
+        => Task.FromResult(Newest(SeededSummaries.Values.SelectMany(v => v)));
+    public Task<List<MailMessageSummary>> LoadAllSummariesAsync(Guid accountId)
+        => Task.FromResult(Newest(SeededSummaries.Where(kv => kv.Key.AccountId == accountId).SelectMany(kv => kv.Value)));
+    public Task<List<MailMessageSummary>> LoadFolderSummariesAsync(Guid accountId, string folderName, int? limit = null)
+        => Task.FromResult(SeededSummaries.TryGetValue((accountId, folderName), out var rows)
+            ? Newest(rows) : []);
     public Task DeleteSummariesAsync(Guid accountId, string folderName, IEnumerable<string> messageIds) => Task.CompletedTask;
     public Task DeleteAccountDataAsync(Guid accountId) => Task.CompletedTask;
     public Task ClearCachedMailAsync(System.Collections.Generic.IEnumerable<System.Guid> accountIds) => Task.CompletedTask;

--- a/QuickMail.Tests/ViewManagerViewModelTests.cs
+++ b/QuickMail.Tests/ViewManagerViewModelTests.cs
@@ -143,24 +143,26 @@ public class ViewManagerViewModelTests
     [Fact]
     public void SelectingAView_PopulatesEditFields()
     {
-        var view = new SavedView { Name = "Work Inbox", IsDefault = true };
+        var view = new SavedView { Name = "Work Inbox", Hotkey = "Ctrl+1", DaysOfMail = 7 };
         var vm   = MakeVm(views: [view], selectedView: view);
 
         Assert.Equal("Work Inbox", vm.EditName);
-        Assert.True(vm.EditIsDefault);
+        Assert.Equal("7", vm.EditDaysOfMail);
+        Assert.False(vm.EditUnlimitedDays);
     }
 
     [Fact]
     public void ClearingSelection_ResetsEditFields()
     {
-        var view = new SavedView { Name = "Work Inbox", IsDefault = true };
+        var view = new SavedView { Name = "Work Inbox", Hotkey = "Ctrl+1", DaysOfMail = 7 };
         var vm   = MakeVm(views: [view], selectedView: view);
 
         vm.SelectedView = null;
 
         Assert.Equal(string.Empty, vm.EditName);
         Assert.Equal(string.Empty, vm.EditHotkey);
-        Assert.False(vm.EditIsDefault);
+        Assert.Equal(string.Empty, vm.EditDaysOfMail);
+        Assert.True(vm.EditUnlimitedDays);
     }
 
     // ── Commands ──────────────────────────────────────────────────────────────────────

--- a/QuickMail/App.xaml.cs
+++ b/QuickMail/App.xaml.cs
@@ -411,6 +411,11 @@ public partial class App : Application
             commandRegistry.ApplyUserOverrides(startupCfg.CustomHotkeys);
 
             var viewService = new ViewService(profile);
+
+            // One-time: convert an old "default view (applied on startup)" into the startup folder
+            // setting that replaced it (#516). No-ops once a startup folder is configured, and
+            // rewrites views.json so the retired IsDefault flag cannot come back.
+            StartupFolderMigration.Run(profile, startupCfg, configService, viewService);
             var watchService = new WatchService(profile);
             var rowLayoutService = new RowLayoutService(profile, configService);
             var flagService = new FlagService(profile, configService, localStore, effectiveMail);

--- a/QuickMail/Models/ConfigModel.cs
+++ b/QuickMail/Models/ConfigModel.cs
@@ -37,6 +37,63 @@ public class ConfigModel
     /// </summary>
     public int SyncDays { get; set; } = 30;
 
+    // ── Startup (#516) ───────────────────────────────────────────────────────────
+    // Which folder QuickMail opens in, and how much it syncs getting there. Replaces the old
+    // "mark a saved view as the default" route, which took four steps and a permanent saved-view
+    // artifact to express one preference.
+
+    /// <summary>
+    /// Where QuickMail opens. Empty (the default) means All Mail — the behaviour before this
+    /// setting existed. Three other forms:
+    /// <list type="bullet">
+    /// <item>A virtual-folder key with no NUL prefix, e.g. <c>"AllInboxes"</c>. An INI file cannot
+    /// carry a NUL, so the sentinel prefix is stripped on write and restored on read — the same
+    /// convention <see cref="SavedView.VirtualFolderKey"/> already uses.</item>
+    /// <item>A real folder's <c>FullName</c>, paired with <see cref="StartupFolderAccount"/>.</item>
+    /// <item><c>"view:{guid}"</c> — only ever written by the one-time migration off
+    /// <c>SavedView.IsDefault</c>, for a multi-folder default view that no single folder can
+    /// express. No picker offers this form.</item>
+    /// </list>
+    /// An unresolvable value falls back to All Mail; it is never an error.
+    /// </summary>
+    public string StartupFolder { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Owning account for <see cref="StartupFolder"/> when it names a real folder. Empty means
+    /// <see cref="StartupFolder"/> is a virtual-folder key or a view reference, which belong to no
+    /// single account.
+    /// </summary>
+    public string StartupFolderAccount { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Display text for the configured startup folder, shown in Settings. Stored rather than
+    /// derived because for Microsoft Graph accounts <c>FullName</c> is an opaque server id, so
+    /// there is nothing human-readable to fall back on when the folder list is not loaded yet.
+    /// </summary>
+    public string StartupFolderLabel { get; set; } = string.Empty;
+
+    /// <summary>
+    /// How much to sync at launch. Values: <c>"startupFolder"</c> (default — only the folders the
+    /// startup folder covers), <c>"inboxes"</c> (every account's Inbox), <c>"all"</c> (every
+    /// non-excluded folder on every account, the behaviour before this setting existed).
+    /// Nothing is skipped permanently under any value: the periodic sweep still visits every
+    /// folder, and the IMAP IDLE / Graph delta watchers still cover every account's Inbox live,
+    /// so new-mail notifications are unaffected.
+    /// </summary>
+    public string StartupSyncScope { get; set; } = StartupSyncScopeStartupFolder;
+
+    public const string StartupSyncScopeStartupFolder = "startupFolder";
+    public const string StartupSyncScopeInboxes       = "inboxes";
+    public const string StartupSyncScopeAll           = "all";
+
+    /// <summary>Normalizes a persisted or user-supplied scope, falling back to the default.</summary>
+    public static string ParseStartupSyncScope(string? value) => value?.Trim().ToLowerInvariant() switch
+    {
+        "inboxes" => StartupSyncScopeInboxes,
+        "all"     => StartupSyncScopeAll,
+        _         => StartupSyncScopeStartupFolder,
+    };
+
     /// <summary>Maximum simultaneous IMAP connections QuickMail may open per account.</summary>
     public int MaxImapConnectionsPerAccount { get; set; } = 6;
 

--- a/QuickMail/Models/ConfigModel.cs
+++ b/QuickMail/Models/ConfigModel.cs
@@ -89,9 +89,10 @@ public class ConfigModel
     /// <summary>Normalizes a persisted or user-supplied scope, falling back to the default.</summary>
     public static string ParseStartupSyncScope(string? value) => value?.Trim().ToLowerInvariant() switch
     {
-        "inboxes" => StartupSyncScopeInboxes,
-        "all"     => StartupSyncScopeAll,
-        _         => StartupSyncScopeStartupFolder,
+        "inboxes"        => StartupSyncScopeInboxes,
+        "all"            => StartupSyncScopeAll,
+        "startupfolder"  => StartupSyncScopeStartupFolder,   // explicit, not just the fallback
+        _                => StartupSyncScopeStartupFolder,
     };
 
     /// <summary>Maximum simultaneous IMAP connections QuickMail may open per account.</summary>

--- a/QuickMail/Models/SavedView.cs
+++ b/QuickMail/Models/SavedView.cs
@@ -32,8 +32,10 @@ public class SavedView
     /// <summary>Gesture string for the default keyboard shortcut, e.g. "Ctrl+1". Null = no shortcut.</summary>
     public string? Hotkey  { get; set; }
 
-    /// <summary>When true this view is applied automatically on startup.</summary>
-    public bool IsDefault  { get; set; }
+    // IsDefault ("applied automatically on startup") was removed in #516. Choosing where QuickMail
+    // opens no longer requires creating a saved view: see ConfigModel.StartupFolder. Existing
+    // views.json files still carry the property; StartupFolderMigration reads it once, converts it
+    // to the new setting, and it drops out on the next save.
 
     /// <summary>
     /// When set, only messages received within this many days are shown.

--- a/QuickMail/Services/ConfigService.cs
+++ b/QuickMail/Services/ConfigService.cs
@@ -705,8 +705,9 @@ public class ConfigService : IConfigService
         sb.AppendLine("# How much mail to sync at launch.");
         sb.AppendLine("# Values: startupFolder (default) syncs only the folders your startup folder");
         sb.AppendLine("#   covers; inboxes syncs every account's Inbox; all syncs every folder.");
-        sb.AppendLine("# Nothing is skipped permanently under any value — the periodic check still");
-        sb.AppendLine("# visits every folder, and new-mail notifications are unaffected.");
+        sb.AppendLine("# New-mail notifications are unaffected by this setting — inboxes are always");
+        sb.AppendLine("# watched. Other folders are caught up by the periodic check; if");
+        sb.AppendLine("# MailSyncPollMinutes is 0 (off), they are only synced when you open them.");
         sb.AppendLine();
 
         // ── [windowing] ──────────────────────────────────────────────────────────

--- a/QuickMail/Services/ConfigService.cs
+++ b/QuickMail/Services/ConfigService.cs
@@ -211,6 +211,16 @@ public class ConfigService : IConfigService
                     case "syncdays":
                         if (int.TryParse(value, out var sd)) config.SyncDays = Math.Max(0, sd);
                         break;
+                    // ── Startup (#516) ──
+                    // Values are round-tripped verbatim: a folder name is whatever the server calls
+                    // it (for Graph, an opaque id), so there is nothing to validate here. An
+                    // unresolvable startup folder is handled at launch by falling back to All Mail.
+                    case "startupfolder":        config.StartupFolder        = value; break;
+                    case "startupfolderaccount": config.StartupFolderAccount = value; break;
+                    case "startupfolderlabel":   config.StartupFolderLabel   = value; break;
+                    case "startupsyncscope":
+                        config.StartupSyncScope = ConfigModel.ParseStartupSyncScope(value);
+                        break;
                     case "maximapconnectionsperaccount":
                         if (int.TryParse(value, out var maxConn))
                             config.MaxImapConnectionsPerAccount = Math.Clamp(maxConn, 1, 15);
@@ -669,11 +679,42 @@ public class ConfigService : IConfigService
         }
         sb.AppendLine();
 
+        // ── Startup (#516) ───────────────────────────────────────────────────────
+        // Parsed under [global], so these must stay above the [windowing] header — see the note
+        // below. Written unconditionally (even when empty) so the file documents the settings and
+        // shows a user where to look; empty StartupFolder means All Mail.
+        sb.AppendLine($"StartupFolder = {config.StartupFolder}");
+        sb.AppendLine("# The folder QuickMail opens in. Empty means All Mail.");
+        sb.AppendLine("# Set it from the folder tree's context menu (\"Set as Startup Folder\") or");
+        sb.AppendLine("# under Tools > Settings > Startup. A virtual folder is stored by name, e.g.");
+        sb.AppendLine("# AllInboxes; a real folder is stored as its server name plus the account");
+        sb.AppendLine("# below. A folder that no longer exists falls back to All Mail at launch.");
+        sb.AppendLine();
+
+        sb.AppendLine($"StartupFolderAccount = {config.StartupFolderAccount}");
+        sb.AppendLine("# The account owning StartupFolder, when it names a real folder.");
+        sb.AppendLine("# Empty when StartupFolder is a virtual folder such as AllInboxes.");
+        sb.AppendLine();
+
+        sb.AppendLine($"StartupFolderLabel = {config.StartupFolderLabel}");
+        sb.AppendLine("# Display name for the startup folder, shown in Settings. Cosmetic only —");
+        sb.AppendLine("# stored because Microsoft 365 folder names are opaque server ids.");
+        sb.AppendLine();
+
+        sb.AppendLine($"StartupSyncScope = {config.StartupSyncScope}");
+        sb.AppendLine("# How much mail to sync at launch.");
+        sb.AppendLine("# Values: startupFolder (default) syncs only the folders your startup folder");
+        sb.AppendLine("#   covers; inboxes syncs every account's Inbox; all syncs every folder.");
+        sb.AppendLine("# Nothing is skipped permanently under any value — the periodic check still");
+        sb.AppendLine("# visits every folder, and new-mail notifications are unaffected.");
+        sb.AppendLine();
+
         // ── [windowing] ──────────────────────────────────────────────────────────
         // NOTE: ShowDeclinedEvents and CalendarPaneOpen above are parsed under the [global]
         // section (see ParseFile) — they must stay above this header. They were previously
         // written after it by mistake, so both settings were silently dropped back to their
         // default (off) on the very next load, regardless of what the user configured.
+        // The Startup block immediately above is [global] too, for the same reason.
 
         sb.AppendLine("[windowing]");
         sb.AppendLine();

--- a/QuickMail/Services/ILocalStoreService.cs
+++ b/QuickMail/Services/ILocalStoreService.cs
@@ -25,6 +25,32 @@ public interface ILocalStoreService
     /// removed-and-re-added account or a cache rebuild). Local events (<see cref="Guid.Empty"/>) are kept.
     /// </summary>
     Task PurgeCalendarEventsForUnknownAccountsAsync(IReadOnlyCollection<Guid> knownAccountIds);
+
+    // ── Folders (#516) ───────────────────────────────────────────────────────────
+    // The folder list is persisted so the startup folder can be resolved — and the folder tree
+    // drawn — before any account connects. Without this, folder metadata exists only in
+    // MainViewModel._cachedFolders, populated by GetFoldersAsync after connect, so nothing at
+    // launch knows which folders exist or which of them are Inboxes.
+
+    /// <summary>
+    /// Replaces the stored folder list for one account, in a single transaction. Replace rather than
+    /// upsert: a folder deleted or renamed on the server must disappear locally. Header rows and rows
+    /// with an empty <c>FullName</c> are skipped — they are display artifacts, not server folders.
+    /// Other accounts are untouched, so a partial connect refreshes only what it reached.
+    /// </summary>
+    Task SaveFoldersAsync(Guid accountId, IReadOnlyList<MailFolderModel> folders);
+
+    /// <summary>
+    /// Every stored folder, grouped by account and in the order it was last saved. Shaped to drop
+    /// straight into <c>MainViewModel._cachedFolders</c>.
+    /// </summary>
+    Task<Dictionary<Guid, List<MailFolderModel>>> LoadFoldersAsync();
+
+    /// <summary>
+    /// Deletes folders for accounts not in <paramref name="knownAccountIds"/> — orphans left by an
+    /// account removed while the app was closed, or removed and re-added under a new id.
+    /// </summary>
+    Task PurgeFoldersForUnknownAccountsAsync(IReadOnlyCollection<Guid> knownAccountIds);
     Task UpdateIsReadAsync(Guid accountId, string folderName, string messageId, bool isRead);
     Task UpdateIsReadBatchAsync(IEnumerable<(Guid AccountId, string FolderName, string MessageId)> items, bool isRead);
     Task UpdatePreviewAsync(Guid accountId, string folderName, string messageId, string preview);

--- a/QuickMail/Services/LocalStoreService.cs
+++ b/QuickMail/Services/LocalStoreService.cs
@@ -142,6 +142,31 @@ public class LocalStoreService : ILocalStoreService
         // invite rows. Unversioned idempotent ALTER, like calendar_id/calendar_name above.
         RunMigration(conn, "ALTER TABLE CalendarEvent ADD COLUMN resource_url TEXT NOT NULL DEFAULT '';");
 
+        // Folder table (#516). The folder list used to live only in MainViewModel._cachedFolders,
+        // filled by GetFoldersAsync after connect — so at launch nothing knew which folders existed,
+        // let alone which were Inboxes. That made a startup folder impossible to honour before the
+        // network came up, and left the folder tree showing only the virtual aggregates. Persisting
+        // the list makes both work offline. Additive, no existing table touched, so no user_version
+        // bump is needed (same reasoning as CalendarEvent above).
+        //
+        // SuppressUnreadCount is deliberately NOT a column — it is derived from Kind on the model.
+        // Header rows are synthesized by RebuildFolderListFromCache and are never stored.
+        cmd.CommandText = """
+            CREATE TABLE IF NOT EXISTS Folder (
+                account_id            TEXT    NOT NULL,
+                full_name             TEXT    NOT NULL,
+                display_name          TEXT    NOT NULL DEFAULT '',
+                parent_id             TEXT    DEFAULT NULL,
+                kind                  INTEGER NOT NULL DEFAULT 0,
+                exclude_from_all_mail INTEGER NOT NULL DEFAULT 0,
+                unread_count          INTEGER NOT NULL DEFAULT 0,
+                message_count         INTEGER NOT NULL DEFAULT 0,
+                sort_order            INTEGER NOT NULL DEFAULT 0,
+                PRIMARY KEY (account_id, full_name)
+            );
+            """;
+        cmd.ExecuteNonQuery();
+
         RunDataMigrations(conn);
     }
 
@@ -472,7 +497,8 @@ public class LocalStoreService : ILocalStoreService
         cmd.CommandText =
             "DELETE FROM MessageDetail  WHERE account_id = $aid;" +
             "DELETE FROM MessageSummary WHERE account_id = $aid;" +
-            "DELETE FROM CalendarEvent  WHERE account_id = $aid;";
+            "DELETE FROM CalendarEvent  WHERE account_id = $aid;" +
+            "DELETE FROM Folder         WHERE account_id = $aid;";
         cmd.Parameters.AddWithValue("$aid", accountId.ToString());
         await cmd.ExecuteNonQueryAsync();
         await tx.CommitAsync();
@@ -510,6 +536,131 @@ public class LocalStoreService : ILocalStoreService
     /// so the old id's events linger and show as duplicates), or after a cache rebuild. Local events
     /// (<see cref="Guid.Empty"/>) are always kept. No-op when there are no orphans.
     /// </summary>
+    // ── Folders (#516) ───────────────────────────────────────────────────────────
+
+    public async Task SaveFoldersAsync(Guid accountId, IReadOnlyList<MailFolderModel> folders)
+    {
+        // Replace-all for this account, in one transaction: a folder deleted or renamed on the
+        // server must disappear locally, and an upsert alone would leave the old row behind.
+        // Other accounts are untouched, so a partial connect only refreshes what it reached.
+        await using var conn = await OpenAsync();
+        await using var tx   = await conn.BeginTransactionAsync();
+
+        await using (var del = conn.CreateCommand())
+        {
+            del.CommandText = "DELETE FROM Folder WHERE account_id = $aid;";
+            del.Parameters.AddWithValue("$aid", accountId.ToString());
+            await del.ExecuteNonQueryAsync();
+        }
+
+        await using (var ins = conn.CreateCommand())
+        {
+            ins.CommandText = """
+                INSERT OR REPLACE INTO Folder
+                    (account_id, full_name, display_name, parent_id, kind,
+                     exclude_from_all_mail, unread_count, message_count, sort_order)
+                VALUES ($aid, $fn, $dn, $pid, $kind, $excl, $unread, $total, $ord);
+                """;
+            var pFn    = ins.Parameters.Add("$fn",     Microsoft.Data.Sqlite.SqliteType.Text);
+            var pDn    = ins.Parameters.Add("$dn",     Microsoft.Data.Sqlite.SqliteType.Text);
+            var pPid   = ins.Parameters.Add("$pid",    Microsoft.Data.Sqlite.SqliteType.Text);
+            var pKind  = ins.Parameters.Add("$kind",   Microsoft.Data.Sqlite.SqliteType.Integer);
+            var pExcl  = ins.Parameters.Add("$excl",   Microsoft.Data.Sqlite.SqliteType.Integer);
+            var pUnr   = ins.Parameters.Add("$unread", Microsoft.Data.Sqlite.SqliteType.Integer);
+            var pTot   = ins.Parameters.Add("$total",  Microsoft.Data.Sqlite.SqliteType.Integer);
+            var pOrd   = ins.Parameters.Add("$ord",    Microsoft.Data.Sqlite.SqliteType.Integer);
+            ins.Parameters.AddWithValue("$aid", accountId.ToString());
+
+            var order = 0;
+            foreach (var f in folders)
+            {
+                // Header rows are synthesized for display and carry no server folder.
+                if (f.IsHeader || string.IsNullOrEmpty(f.FullName)) continue;
+
+                pFn.Value   = f.FullName;
+                pDn.Value   = f.DisplayName ?? string.Empty;
+                pPid.Value  = (object?)f.ParentId ?? DBNull.Value;
+                pKind.Value = (int)f.Kind;
+                pExcl.Value = f.ExcludeFromAllMail ? 1 : 0;
+                pUnr.Value  = f.UnreadCount;
+                pTot.Value  = f.MessageCount;
+                pOrd.Value  = order++;
+                await ins.ExecuteNonQueryAsync();
+            }
+        }
+
+        await tx.CommitAsync();
+    }
+
+    public async Task<Dictionary<Guid, List<MailFolderModel>>> LoadFoldersAsync()
+    {
+        var result = new Dictionary<Guid, List<MailFolderModel>>();
+        await using var conn = await OpenAsync();
+        await using var cmd  = conn.CreateCommand();
+        cmd.CommandText = """
+            SELECT account_id, full_name, display_name, parent_id, kind,
+                   exclude_from_all_mail, unread_count, message_count
+            FROM Folder
+            ORDER BY account_id, sort_order;
+            """;
+        await using var r = await cmd.ExecuteReaderAsync();
+        while (await r.ReadAsync())
+        {
+            // A row whose account_id no longer parses is unusable; skip rather than throw and
+            // lose every other account's folders on one bad value.
+            if (!Guid.TryParse(r.GetString(0), out var accountId)) continue;
+
+            if (!result.TryGetValue(accountId, out var list))
+                result[accountId] = list = [];
+
+            list.Add(new MailFolderModel
+            {
+                AccountId          = accountId,
+                FullName           = r.GetString(1),
+                DisplayName        = r.GetString(2),
+                ParentId           = r.IsDBNull(3) ? null : r.GetString(3),
+                Kind               = (SpecialFolderKind)r.GetInt32(4),
+                ExcludeFromAllMail = r.GetInt32(5) != 0,
+                UnreadCount        = r.GetInt32(6),
+                MessageCount       = r.GetInt32(7),
+            });
+        }
+        return result;
+    }
+
+    public async Task PurgeFoldersForUnknownAccountsAsync(IReadOnlyCollection<Guid> knownAccountIds)
+    {
+        await using var conn = await OpenAsync();
+
+        // Unlike calendar events there is no Guid.Empty "local" bucket to preserve — every folder
+        // belongs to a real account, so an unrecognised id is always an orphan.
+        var keep = new HashSet<string>(knownAccountIds.Select(id => id.ToString()),
+                                       StringComparer.OrdinalIgnoreCase);
+
+        var present = new List<string>();
+        await using (var q = conn.CreateCommand())
+        {
+            q.CommandText = "SELECT DISTINCT account_id FROM Folder;";
+            await using var r = await q.ExecuteReaderAsync();
+            while (await r.ReadAsync()) present.Add(r.GetString(0));
+        }
+
+        var orphans = present.Where(a => !keep.Contains(a)).ToList();
+        if (orphans.Count == 0) return;
+
+        await using var del = conn.CreateCommand();
+        del.CommandText = "DELETE FROM Folder WHERE account_id = $aid;";
+        var p = del.CreateParameter();
+        p.ParameterName = "$aid";
+        del.Parameters.Add(p);
+        foreach (var orphan in orphans)
+        {
+            p.Value = orphan;
+            await del.ExecuteNonQueryAsync();
+        }
+        LogService.Log($"LocalStoreService: purged folders for {orphans.Count} unknown account(s).");
+    }
+
     public async Task PurgeCalendarEventsForUnknownAccountsAsync(IReadOnlyCollection<Guid> knownAccountIds)
     {
         await using var conn = await OpenAsync();

--- a/QuickMail/Services/LocalStoreService.cs
+++ b/QuickMail/Services/LocalStoreService.cs
@@ -530,12 +530,6 @@ public class LocalStoreService : ILocalStoreService
         await tx.CommitAsync();
     }
 
-    /// <summary>
-    /// Deletes calendar events whose <c>account_id</c> is not among <paramref name="knownAccountIds"/> —
-    /// orphans left behind when an account is removed and re-added (the re-added account gets a new id,
-    /// so the old id's events linger and show as duplicates), or after a cache rebuild. Local events
-    /// (<see cref="Guid.Empty"/>) are always kept. No-op when there are no orphans.
-    /// </summary>
     // ── Folders (#516) ───────────────────────────────────────────────────────────
 
     public async Task SaveFoldersAsync(Guid accountId, IReadOnlyList<MailFolderModel> folders)
@@ -661,6 +655,12 @@ public class LocalStoreService : ILocalStoreService
         LogService.Log($"LocalStoreService: purged folders for {orphans.Count} unknown account(s).");
     }
 
+    /// <summary>
+    /// Deletes calendar events whose <c>account_id</c> is not among <paramref name="knownAccountIds"/> —
+    /// orphans left behind when an account is removed and re-added (the re-added account gets a new id,
+    /// so the old id's events linger and show as duplicates), or after a cache rebuild. Local events
+    /// (<see cref="Guid.Empty"/>) are always kept. No-op when there are no orphans.
+    /// </summary>
     public async Task PurgeCalendarEventsForUnknownAccountsAsync(IReadOnlyCollection<Guid> knownAccountIds)
     {
         await using var conn = await OpenAsync();

--- a/QuickMail/Services/StartupFolderMigration.cs
+++ b/QuickMail/Services/StartupFolderMigration.cs
@@ -114,10 +114,17 @@ public static class StartupFolderMigration
                 ? fn.GetString() : null;
             if (string.IsNullOrEmpty(full)) continue;
 
-            Guid.TryParse(
-                f.TryGetProperty("AccountId", out var aid) && aid.ValueKind == JsonValueKind.String
-                    ? aid.GetString() : null,
-                out var accountId);
+            // An unreadable account id falls back to Guid.Empty deliberately: the folder name is
+            // still real, and Guid.Empty is the documented "no owning account" value, which
+            // ResolveStartupFolder treats as unresolvable. So a corrupt entry declines to migrate
+            // rather than migrating to a folder on the wrong account. Written as an explicit
+            // assignment because discarding TryParse's result trips CA1806, and this build treats
+            // analyzer warnings as errors on publish.
+            if (!Guid.TryParse(
+                    f.TryGetProperty("AccountId", out var aid) && aid.ValueKind == JsonValueKind.String
+                        ? aid.GetString() : null,
+                    out var accountId))
+                accountId = Guid.Empty;
 
             var display = f.TryGetProperty("FolderDisplayName", out var dn) && dn.ValueKind == JsonValueKind.String
                 ? dn.GetString() ?? string.Empty : string.Empty;

--- a/QuickMail/Services/StartupFolderMigration.cs
+++ b/QuickMail/Services/StartupFolderMigration.cs
@@ -1,0 +1,173 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using QuickMail.Models;
+
+namespace QuickMail.Services;
+
+/// <summary>
+/// One-time conversion of the old "mark a saved view as the default" startup mechanism into
+/// <see cref="ConfigModel.StartupFolder"/> (#516).
+///
+/// <para><c>SavedView.IsDefault</c> no longer exists on the model, so the flag is read straight out
+/// of the raw <c>views.json</c> — deserializing would silently drop it. After a successful
+/// migration the file is rewritten through <see cref="IViewService"/>, which serializes the current
+/// model and therefore leaves <c>IsDefault</c> behind for good. That rewrite is what makes this
+/// genuinely one-time: without it, a user who later cleared their startup folder would have the old
+/// default view resurrected on the next launch.</para>
+/// </summary>
+public static class StartupFolderMigration
+{
+    /// <summary>
+    /// Converts a default saved view in <paramref name="viewsJson"/> into startup settings on
+    /// <paramref name="config"/>. Returns true when something was migrated.
+    ///
+    /// Runs only when no startup folder is configured — an explicit choice always wins over an
+    /// inherited one. Malformed JSON is treated as "nothing to migrate"; this must never be the
+    /// reason an app fails to start.
+    /// </summary>
+    public static bool ApplyToConfig(ConfigModel config, string? viewsJson)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+        if (!string.IsNullOrWhiteSpace(config.StartupFolder)) return false;
+        if (string.IsNullOrWhiteSpace(viewsJson)) return false;
+
+        JsonElement root;
+        try
+        {
+            using var doc = JsonDocument.Parse(viewsJson);
+            if (doc.RootElement.ValueKind != JsonValueKind.Array) return false;
+            root = doc.RootElement.Clone();
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+
+        foreach (var view in root.EnumerateArray())
+        {
+            if (view.ValueKind != JsonValueKind.Object) continue;
+            if (!view.TryGetProperty("IsDefault", out var isDefault) ||
+                isDefault.ValueKind != JsonValueKind.True) continue;
+
+            var name = view.TryGetProperty("Name", out var n) && n.ValueKind == JsonValueKind.String
+                ? n.GetString() ?? string.Empty : string.Empty;
+
+            // A view over a virtual folder — All Inboxes and friends. The key is already stored
+            // without the NUL sentinel prefix, which is exactly the form StartupFolder wants.
+            if (view.TryGetProperty("VirtualFolderKey", out var vfk) &&
+                vfk.ValueKind == JsonValueKind.String &&
+                !string.IsNullOrWhiteSpace(vfk.GetString()))
+            {
+                config.StartupFolder      = vfk.GetString()!;
+                config.StartupFolderLabel = VirtualFolderLabel(config.StartupFolder, name);
+                return true;
+            }
+
+            var folders = ReadFolders(view);
+
+            // A single real folder maps cleanly onto the new setting.
+            if (folders.Count == 1)
+            {
+                config.StartupFolder        = folders[0].FullName;
+                config.StartupFolderAccount = folders[0].AccountId.ToString();
+                config.StartupFolderLabel   = string.IsNullOrWhiteSpace(folders[0].DisplayName)
+                    ? name : folders[0].DisplayName;
+                return true;
+            }
+
+            // A multi-folder view has no single folder to point at. Keep it working by reference
+            // rather than silently dropping a setup the user deliberately built — no picker offers
+            // or can create this form.
+            if (folders.Count > 1 &&
+                view.TryGetProperty("Id", out var idEl) &&
+                idEl.ValueKind == JsonValueKind.String &&
+                Guid.TryParse(idEl.GetString(), out var id))
+            {
+                config.StartupFolder      = $"view:{id}";
+                config.StartupFolderLabel = name;
+                return true;
+            }
+
+            // A default view with no folders and no virtual key is the legacy "All Mail" shape,
+            // which is already the default. Nothing to store.
+            return false;
+        }
+
+        return false;
+    }
+
+    private static List<(Guid AccountId, string FullName, string DisplayName)> ReadFolders(JsonElement view)
+    {
+        var result = new List<(Guid, string, string)>();
+        if (!view.TryGetProperty("Folders", out var folders) ||
+            folders.ValueKind != JsonValueKind.Array) return result;
+
+        foreach (var f in folders.EnumerateArray())
+        {
+            if (f.ValueKind != JsonValueKind.Object) continue;
+            var full = f.TryGetProperty("FolderFullName", out var fn) && fn.ValueKind == JsonValueKind.String
+                ? fn.GetString() : null;
+            if (string.IsNullOrEmpty(full)) continue;
+
+            Guid.TryParse(
+                f.TryGetProperty("AccountId", out var aid) && aid.ValueKind == JsonValueKind.String
+                    ? aid.GetString() : null,
+                out var accountId);
+
+            var display = f.TryGetProperty("FolderDisplayName", out var dn) && dn.ValueKind == JsonValueKind.String
+                ? dn.GetString() ?? string.Empty : string.Empty;
+
+            result.Add((accountId, full, display));
+        }
+        return result;
+    }
+
+    /// <summary>Friendly name for a virtual folder key, falling back to the view's own name.</summary>
+    private static string VirtualFolderLabel(string key, string viewName) => key switch
+    {
+        "AllMail"    => "All Mail",
+        "AllInboxes" => "All Inboxes",
+        "AllDrafts"  => "All Drafts",
+        "AllSent"    => "All Sent",
+        "AllArchive" => "All Archive",
+        "AllTrash"   => "All Trash",
+        "AllFlagged" => "All Flagged",
+        "AllWatched" => "Watched Conversations",
+        _            => string.IsNullOrWhiteSpace(viewName) ? key : viewName,
+    };
+
+    /// <summary>
+    /// Reads <c>views.json</c> from the profile, migrates a default view into
+    /// <paramref name="config"/>, persists the config, and rewrites <c>views.json</c> so the now
+    /// model-less <c>IsDefault</c> property is dropped. Best-effort: any IO failure is logged and
+    /// swallowed, because a migration must never be the reason the app will not start.
+    /// </summary>
+    public static bool Run(ProfileContext profile, ConfigModel config,
+                           IConfigService configService, IViewService viewService)
+    {
+        ArgumentNullException.ThrowIfNull(profile);
+        ArgumentNullException.ThrowIfNull(configService);
+        ArgumentNullException.ThrowIfNull(viewService);
+        try
+        {
+            var path = Path.Combine(profile.ProfileDir, "views.json");
+            if (!File.Exists(path)) return false;
+
+            if (!ApplyToConfig(config, File.ReadAllText(path))) return false;
+
+            configService.Save(config);
+            viewService.Save(viewService.Load());   // re-serialize without IsDefault
+            LogService.Log($"Startup migration: default view converted to StartupFolder " +
+                           $"'{config.StartupFolder}' ({config.StartupFolderLabel}).");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            LogService.Log("Startup migration: converting the default saved view", ex);
+            return false;
+        }
+    }
+}

--- a/QuickMail/Services/StartupFolderMigration.cs
+++ b/QuickMail/Services/StartupFolderMigration.cs
@@ -61,8 +61,9 @@ public static class StartupFolderMigration
                 vfk.ValueKind == JsonValueKind.String &&
                 !string.IsNullOrWhiteSpace(vfk.GetString()))
             {
-                config.StartupFolder      = vfk.GetString()!;
-                config.StartupFolderLabel = VirtualFolderLabel(config.StartupFolder, name);
+                config.StartupFolder        = vfk.GetString()!;
+                config.StartupFolderAccount = string.Empty;   // a virtual folder spans every account
+                config.StartupFolderLabel   = VirtualFolderLabel(config.StartupFolder, name);
                 return true;
             }
 
@@ -86,8 +87,9 @@ public static class StartupFolderMigration
                 idEl.ValueKind == JsonValueKind.String &&
                 Guid.TryParse(idEl.GetString(), out var id))
             {
-                config.StartupFolder      = $"view:{id}";
-                config.StartupFolderLabel = name;
+                config.StartupFolder        = $"view:{id}";
+                config.StartupFolderAccount = string.Empty;   // a view is not scoped to one account
+                config.StartupFolderLabel   = name;
                 return true;
             }
 
@@ -159,7 +161,21 @@ public static class StartupFolderMigration
             if (!ApplyToConfig(config, File.ReadAllText(path))) return false;
 
             configService.Save(config);
-            viewService.Save(viewService.Load());   // re-serialize without IsDefault
+
+            // Re-serialize through the current model so the retired IsDefault property is dropped
+            // for good. Guarded, because ViewService.Load() swallows every failure and returns an
+            // empty list — a type mismatch on any property, or a transient sharing violation from a
+            // backup agent, would otherwise have us write [] over every saved view the user has,
+            // atomically and silently, on the first launch after upgrade. ApplyToConfig returning
+            // true proves the file held at least one view, so an empty load here is provably a read
+            // failure rather than an empty file. Leaving IsDefault in place costs nothing: the
+            // config gate above already makes the migration one-time.
+            var views = viewService.Load();
+            if (views.Count > 0)
+                viewService.Save(views);
+            else
+                LogService.Log("Startup migration: views.json migrated but re-read as empty — " +
+                               "leaving the file untouched rather than overwriting it.");
             LogService.Log($"Startup migration: default view converted to StartupFolder " +
                            $"'{config.StartupFolder}' ({config.StartupFolderLabel}).");
             return true;

--- a/QuickMail/Services/SyncService.cs
+++ b/QuickMail/Services/SyncService.cs
@@ -75,6 +75,60 @@ public class SyncService : ISyncService
         foreach (var id in accountIds) _rebuildAccounts.TryAdd(id, 0);
     }
 
+    /// <summary>
+    /// Which folders this launch's sync covers, per <see cref="ConfigModel.StartupSyncScope"/>.
+    /// Returns a predicate rather than a set so the two-pass loop stays untouched.
+    ///
+    /// <para><c>startupFolder</c> — the default — syncs exactly what the startup folder shows. That
+    /// means a real folder syncs alone, All Inboxes syncs every Inbox, and All Mail syncs
+    /// everything, because All Mail spans everything and a narrower sync would put stale rows on
+    /// screen. So a user who has not chosen a startup folder still gets today's full sweep: the
+    /// saving is opted into by choosing a narrower place to start, not imposed.</para>
+    ///
+    /// <para>All Archive is approximated by <see cref="SpecialFolderKind.Archive"/>; resolving a
+    /// per-account archive override lives in the VM and is not worth reaching for here, since
+    /// guessing wide only costs one extra folder. A <c>view:{guid}</c> startup folder syncs
+    /// everything for the same reason — this layer has no view service to resolve it.</para>
+    /// </summary>
+    private static Func<AccountModel, MailFolderModel, bool> BuildStartupScopeFilter(
+        ConfigModel cfg, string scope,
+        IReadOnlyDictionary<Guid, List<MailFolderModel>> cachedFolders)
+    {
+        if (scope == ConfigModel.StartupSyncScopeAll)
+            return static (_, _) => true;
+
+        if (scope == ConfigModel.StartupSyncScopeInboxes)
+            return static (_, f) => f.Kind == SpecialFolderKind.Inbox;
+
+        // startupFolder: mirror whatever the startup folder covers.
+        var key = cfg.StartupFolder;
+        if (string.IsNullOrWhiteSpace(key) || key.StartsWith("view:", StringComparison.Ordinal))
+            return static (_, _) => true;                       // All Mail, or a view we cannot resolve
+
+        if (!string.IsNullOrWhiteSpace(cfg.StartupFolderAccount))
+        {
+            if (!Guid.TryParse(cfg.StartupFolderAccount, out var accountId))
+                return static (_, _) => true;                   // unreadable — sync wide rather than nothing
+            // One real folder. Its account must still be one we know about; if the folder itself has
+            // gone, startup falls back to All Mail, so sync wide rather than sync nothing.
+            var known = cachedFolders.TryGetValue(accountId, out var fl) &&
+                        fl.Any(f => string.Equals(f.FullName, key, StringComparison.OrdinalIgnoreCase));
+            if (!known) return static (_, _) => true;
+            return (a, f) => a.Id == accountId &&
+                             string.Equals(f.FullName, key, StringComparison.OrdinalIgnoreCase);
+        }
+
+        return key switch
+        {
+            "AllInboxes" => static (_, f) => f.Kind == SpecialFolderKind.Inbox,
+            "AllDrafts"  => static (_, f) => f.Kind == SpecialFolderKind.Drafts,
+            "AllSent"    => static (_, f) => f.Kind == SpecialFolderKind.Sent,
+            "AllTrash"   => static (_, f) => f.Kind == SpecialFolderKind.Trash,
+            "AllArchive" => static (_, f) => f.Kind == SpecialFolderKind.Archive,
+            _            => static (_, _) => true,              // AllMail, AllFlagged, AllWatched, unknown
+        };
+    }
+
     public async Task SyncAllAccountsAsync(
         IEnumerable<AccountModel> accounts,
         IReadOnlyDictionary<Guid, List<MailFolderModel>> cachedFolders,
@@ -83,8 +137,19 @@ public class SyncService : ISyncService
         var previewJobs = new ConcurrentBag<(AccountModel Account, MailFolderModel Folder, List<MailMessageSummary> Incoming)>();
         var accountList = accounts.ToList();
 
+        // Startup sync scope (#516). This method has exactly one caller — MainViewModel's startup
+        // pass — so it IS the startup sync, and reading the setting here keeps it off the interface
+        // and out of five test stubs. InScope decides which folders this launch covers; everything
+        // it skips is still picked up by the periodic sweep, which visits every folder, and by the
+        // IMAP IDLE / Graph delta watchers, which cover every account's Inbox live. Nothing is
+        // skipped permanently, and new-mail notifications are unaffected.
+        var startupCfg = _config.Load();
+        var scope      = ConfigModel.ParseStartupSyncScope(startupCfg.StartupSyncScope);
+        var inScope    = BuildStartupScopeFilter(startupCfg, scope, cachedFolders);
+
         int totalFolders = accountList.Sum(a =>
-            cachedFolders.TryGetValue(a.Id, out var fl) ? fl.Count(f => !f.ExcludeFromAllMail) : 0);
+            cachedFolders.TryGetValue(a.Id, out var fl)
+                ? fl.Count(f => !f.ExcludeFromAllMail && inScope(a, f)) : 0);
 
         // int[] so Interlocked.Increment works inside async lambdas (can't use ref locals there).
         int[] completedFolders = { 0 };
@@ -107,6 +172,7 @@ public class SyncService : ISyncService
                     {
                         ct.ThrowIfCancellationRequested();
                         if (folder.ExcludeFromAllMail || !folderFilter(folder)) continue;
+                        if (!inScope(account, folder)) continue;
                         try
                         {
                             var incoming = await SyncFolderAsync(account, folder, ct);

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -386,6 +386,70 @@ public partial class MainViewModel : ObservableObject, IDisposable
         return "Default calendar cleared. New appointments will start on Local Calendar.";
     }
 
+    /// <summary>
+    /// Makes the given folder-tree node the startup folder (#516). Returns the sentence the View
+    /// reports — status bar plus a Result announcement, the pairing every folder context-menu
+    /// outcome uses.
+    ///
+    /// <para>Unlike the move/copy guard this accepts a top-level virtual aggregate: "open me in All
+    /// Inboxes" is the single most-requested form of this setting. What it must still reject is
+    /// anything that is not a place mail lives — account headers, calendar nodes, and the
+    /// per-account All Mail sentinels — and it says why rather than doing nothing, because a menu
+    /// item that silently no-ops is the dead end #250 was about.</para>
+    /// </summary>
+    public string SetStartupFolder(FolderTreeNode? node)
+    {
+        if (node is null || node.IsHeader || node.Folder is not { } folder)
+            return "Select a folder in the folder tree first.";
+
+        if (IsCalendarFolderName(folder.FullName))
+            return $"'{node.Label}' is a calendar, not a mail folder, so QuickMail cannot start there.";
+
+        var isVirtual = AllVirtualFolders.Any(v =>
+            string.Equals(v.FullName, folder.FullName, StringComparison.Ordinal));
+
+        if (!isVirtual &&
+            (folder.AccountId == Guid.Empty || folder.FullName.Length == 0 || folder.FullName[0] == '\0'))
+            return $"'{node.Label}' is a view, not a folder, so it cannot be the startup folder.";
+
+        var cfg = _configService.Load();
+        if (isVirtual)
+        {
+            // Stored without the NUL sentinel prefix — an INI file cannot carry one.
+            cfg.StartupFolder        = folder.FullName[1..];
+            cfg.StartupFolderAccount = string.Empty;
+        }
+        else
+        {
+            cfg.StartupFolder        = folder.FullName;
+            cfg.StartupFolderAccount = folder.AccountId.ToString();
+        }
+        cfg.StartupFolderLabel = folder.DisplayName;
+        _configService.Save(cfg);
+
+        return $"QuickMail will open in {folder.DisplayName}.";
+    }
+
+    /// <summary>
+    /// Drops the startup folder, so QuickMail opens in All Mail again. Returns the sentence the
+    /// View reports.
+    /// </summary>
+    public string ClearStartupFolder()
+    {
+        var cfg = _configService.Load();
+        if (string.IsNullOrEmpty(cfg.StartupFolder))
+            return "No startup folder is set. QuickMail already opens in All Mail.";
+
+        var previous = string.IsNullOrWhiteSpace(cfg.StartupFolderLabel)
+            ? cfg.StartupFolder : cfg.StartupFolderLabel;
+        cfg.StartupFolder        = string.Empty;
+        cfg.StartupFolderAccount = string.Empty;
+        cfg.StartupFolderLabel   = string.Empty;
+        _configService.Save(cfg);
+
+        return $"Startup folder '{previous}' cleared. QuickMail will open in All Mail.";
+    }
+
     private void PersistDefaultCalendar()
     {
         var cfg = _configService.Load();

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -202,6 +202,15 @@ public partial class MainViewModel : ObservableObject, IDisposable
     private readonly HashSet<Guid> _connectedAccountIds = [];
 
     /// <summary>
+    /// Set when <see cref="InitialLoadAsync"/> had a startup folder configured but no persisted
+    /// folder list to resolve it against — the first launch after upgrading (the migration has just
+    /// written one), a fresh <c>--profileDir</c>, or a rebuilt <c>mail.db</c>. Consumed once by
+    /// <see cref="StartBackgroundSyncAsync"/> after the connect pass, so the user's choice is
+    /// honoured in that same session rather than only from the next launch.
+    /// </summary>
+    private bool _startupFolderNeedsRetry;
+
+    /// <summary>
     /// Records an account's folder list, marks it connected, and persists it so the next launch can
     /// resolve the startup folder and draw the tree before any network call (#516). Every write to
     /// <see cref="_cachedFolders"/> that comes from a live server fetch goes through here.
@@ -211,6 +220,26 @@ public partial class MainViewModel : ObservableObject, IDisposable
     {
         _cachedFolders[accountId] = folders;
         _connectedAccountIds.Add(accountId);
+
+        // Never let an empty result overwrite a good cache. SaveFoldersAsync is replace-all, so
+        // persisting [] erases the account's folders — and an empty list is reachable from a
+        // SUCCESSFUL call: ProbeOfflineMailService returns one by design, and a server can answer a
+        // LIST with nothing during a partial outage. The in-memory cache still takes the empty value
+        // (this session genuinely has no folders for that account), but the last good copy on disk
+        // survives to be restored at the next launch. A real "this account has no folders at all" is
+        // indistinguishable here and not worth the cost of getting the common case wrong.
+        if (folders.Count == 0)
+        {
+            LogService.Debug($"SetCachedFolders: {accountId} returned no folders — keeping the stored list.");
+            return;
+        }
+
+        // --online never initializes the local store, and the connection string is ReadWriteCreate,
+        // so writing here would create an empty mail.db in the profile and then throw "no such
+        // table: Folder" on every account. Every other store write in this class is guarded the
+        // same way.
+        if (OnlineMode) return;
+
         _localStore.SaveFoldersAsync(accountId, folders).LogFaults("persist folder list");
     }
 
@@ -2264,8 +2293,14 @@ public partial class MainViewModel : ObservableObject, IDisposable
                 fallbackReason = $"The account for startup folder '{label}' is no longer set up — showing All Mail.";
                 return null;
             }
+            // The trimmed comparison is the fallback, not the rule. config.ini is hand-parsed and
+            // trims every value, so a mailbox legitimately named "Work " (IMAP permits it) comes
+            // back as "Work" and would otherwise never resolve again — the user would see the
+            // fallback notice on every launch with no way to fix it from the UI, since re-picking
+            // writes the same untrimmable value.
             var match = _cachedFolders.TryGetValue(accountId, out var folders)
                 ? folders.FirstOrDefault(f => string.Equals(f.FullName, key, StringComparison.OrdinalIgnoreCase))
+                  ?? folders.FirstOrDefault(f => string.Equals(f.FullName.Trim(), key, StringComparison.OrdinalIgnoreCase))
                 : null;
             if (match == null)
             {
@@ -2323,8 +2358,9 @@ public partial class MainViewModel : ObservableObject, IDisposable
             string.Equals(f.FullName, sentinel, StringComparison.Ordinal));
     }
 
-    /// <summary>Every top-level virtual aggregate, in folder-tree order. One list so the startup
-    /// resolver, the folder tree, and the context-menu guard cannot drift apart.</summary>
+    /// <summary>Every top-level virtual aggregate, in folder-tree order. Shared by the startup
+    /// resolver, the context-menu guard, and the Settings picker. (RebuildFolderListFromCache and
+    /// BuildFolderTree still list them separately — worth unifying, but not in #516.)</summary>
     internal static readonly MailFolderModel[] AllVirtualFolders =
     [
         AllMailFolder, AllInboxesFolder, AllDraftsFolder, AllSentFolder,
@@ -2343,7 +2379,12 @@ public partial class MainViewModel : ObservableObject, IDisposable
 
         var all = new List<MailMessageSummary>();
         foreach (var vf in view.Folders)
+        {
+            // Legacy views could carry a virtual sentinel in Folders; it names no real folder and
+            // would query the store for a row that cannot exist. Same guard FetchViewFoldersAsync has.
+            if (string.IsNullOrEmpty(vf.FolderFullName) || vf.FolderFullName[0] == '\0') continue;
             all.AddRange(await _localStore.LoadFolderSummariesAsync(vf.AccountId, vf.FolderFullName));
+        }
         return [.. all.OrderByDescending(m => m.Date)];
     }
 
@@ -2485,7 +2526,20 @@ public partial class MainViewModel : ObservableObject, IDisposable
 
         // A configured startup folder that no longer resolves must say so. Silently showing All Mail
         // looks like the setting was ignored, and the user has no way to tell which it was.
-        if (fallbackReason != null)
+        //
+        // Unless we simply had nothing to resolve against. On the FIRST launch after upgrading —
+        // exactly when the migration writes a startup folder — the Folder table is still empty,
+        // because nothing has ever persisted it. Same for a fresh --profileDir or a rebuilt mail.db.
+        // Announcing "not found" there would be wrong twice over: it is not missing, and the old
+        // post-connect application (deleted in #516) did honour it in that session. So defer instead
+        // and retry once the folder lists arrive.
+        if (fallbackReason != null && _cachedFolders.Count == 0)
+        {
+            _startupFolderNeedsRetry = true;
+            LogService.Log("InitialLoad: no cached folder list yet — deferring the startup folder " +
+                           "until the first connect completes.");
+        }
+        else if (fallbackReason != null)
         {
             StatusText = fallbackReason;
             Announce(fallbackReason, AnnouncementCategory.Status);
@@ -2494,6 +2548,38 @@ public partial class MainViewModel : ObservableObject, IDisposable
 
         ConnectionStatusText = "Connecting…";
         StartPrefetchTopOfFolder();
+    }
+
+    /// <summary>
+    /// Applies the startup folder that <see cref="InitialLoadAsync"/> had to defer because no folder
+    /// list was cached yet (#516). Runs at most once per session, after the connect pass has filled
+    /// the cache. If it still cannot resolve, the folder really is gone and the user is told so —
+    /// the message deferred earlier.
+    /// </summary>
+    private async Task RetryStartupFolderIfDeferredAsync()
+    {
+        if (!_startupFolderNeedsRetry) return;
+        _startupFolderNeedsRetry = false;
+
+        var cfg      = _configService.Load();
+        var resolved = ResolveStartupFolder(cfg, out var fallbackReason);
+        var view     = StartupView(cfg);
+
+        if (view == null && resolved == null)
+        {
+            if (fallbackReason == null) return;      // nothing was configured after all
+            StatusText = fallbackReason;
+            Announce(fallbackReason, AnnouncementCategory.Status);
+            LogService.Log($"StartupFolder retry: {fallbackReason}");
+            return;
+        }
+
+        if (view != null) await ApplyViewAsync(view);
+        else
+        {
+            SelectedFolder = resolved!;
+            await RefreshAsync();
+        }
     }
 
     /// <summary>
@@ -2587,6 +2673,12 @@ public partial class MainViewModel : ObservableObject, IDisposable
         // post-connect view switch here. Applying it at this point is what produced the All Mail
         // flash: #57 moved it from post-sync to post-connect, which shortened the flash without
         // removing it. #516 moved it to the cached load, which removes it.
+        //
+        // The one exception is the launch where there was no persisted folder list to resolve
+        // against, so InitialLoadAsync could not apply it at all — see _startupFolderNeedsRetry.
+        // Now that the folder lists are in, resolve once. This is the first launch after upgrade,
+        // which is precisely when a migrated setting must be seen to work.
+        await RetryStartupFolderIfDeferredAsync();
 
         StatusText = "Syncing mail…";
         ConnectionStatusText = "Syncing…";
@@ -3463,9 +3555,12 @@ public partial class MainViewModel : ObservableObject, IDisposable
         // Aggregate/virtual views union multiple folders, so one physical message can arrive as
         // several per-folder copies (notably Gmail: INBOX + All Mail + labels). Collapse them to one
         // representative here (issue #220). Single real-folder views show their own contents as-is.
-        // Note: on the very first cached load (InitialLoadAsync) _cachedFolders is not yet populated,
-        // so ResolveFolderKind returns None and representative *ranking* is neutral (date/name tie-
-        // break) — collapse is still correct; the preferred Inbox representative settles on first fetch.
+        // Note: _cachedFolders is restored from the local store before the first cached load since
+        // #516, so ResolveFolderKind usually has real kinds even at launch and the preferred Inbox
+        // representative is picked correctly straight away. On a profile that has never persisted a
+        // folder list (first run, fresh --profileDir, rebuilt mail.db) it is still empty, ranking is
+        // neutral (date/name tie-break), and the representative settles on the first fetch — collapse
+        // is correct either way.
         if (IsVirtualFolder(SelectedFolder))
         {
             list = MessageDeduplicator.CollapseForAggregate(list, ResolveFolderKind);
@@ -4919,9 +5014,22 @@ public partial class MainViewModel : ObservableObject, IDisposable
         foreach (var (account, folders) in results)
         {
             if (folders == null) continue;
-            if (!_cachedFolders.TryGetValue(account.Id, out var prev) || FolderSetChanged(prev, folders))
+
+            // Capture the previous set BEFORE updating the cache — SetCachedFolders replaces it.
+            var isNew = !_cachedFolders.TryGetValue(account.Id, out var prev) || FolderSetChanged(prev, folders);
+
+            // A successful GetFoldersAsync means this account IS connected — the client pool
+            // connects lazily on demand — so record that regardless of whether the tree needs
+            // rebuilding. Since #516 the folder cache is restored from disk at launch, so an account
+            // that was down at startup and has come back returns a folder set identical to the
+            // persisted one, making isNew false. Marking connected only inside that branch left such
+            // an account absent from _connectedAccountIds for the rest of the session: no IDLE
+            // watcher and so no new-mail notifications, skipped by the sweep and by All Mail,
+            // undercounted in the status bar. F5 used to recover it completely.
+            SetCachedFolders(account.Id, folders);
+
+            if (isNew)
             {
-                SetCachedFolders(account.Id, folders);
                 ApplyAccountStatus(account, folders, "refresh-folder-lists");
                 changed = true;
             }
@@ -5991,9 +6099,16 @@ public partial class MainViewModel : ObservableObject, IDisposable
     /// and the aggregate always shows exactly where Move to Archive puts mail. Accounts whose folder
     /// list has not been cached yet, and accounts with no archive destination, contribute nothing.
     /// Both the fetch and the live-arrival filter read this, so they can never disagree.
+    ///
+    /// <para><paramref name="connectedOnly"/> exists because the two callers want different sets
+    /// since #516. A LIVE fetch must skip accounts that never connected: the client pool connects
+    /// lazily, so including one turns opening All Inboxes into a blocking wait on its connect
+    /// timeout before anything renders — the same hazard the periodic sweep already guards against.
+    /// A CACHE read wants every account whose folders we know, which is exactly what the restored
+    /// cache gives us and why the startup load can render All Inboxes offline at all.</para>
     /// </summary>
     internal IEnumerable<(AccountModel Account, MailFolderModel Folder)> FolderScopedAggregateSources(
-        string fullName)
+        string fullName, bool connectedOnly = false)
     {
         var isArchive = string.Equals(fullName, AllArchiveFolder.FullName, StringComparison.Ordinal);
         var kind = string.Equals(fullName, AllInboxesFolder.FullName, StringComparison.Ordinal) ? SpecialFolderKind.Inbox
@@ -6006,6 +6121,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
         foreach (var account in Accounts)
         {
             if (account.IsShared) continue;   // #31: shared mailboxes are excluded from All-* aggregates (still swept)
+            if (connectedOnly && !_connectedAccountIds.Contains(account.Id)) continue;
             if (!_cachedFolders.TryGetValue(account.Id, out var folders)) continue;
 
             if (isArchive)
@@ -6052,7 +6168,10 @@ public partial class MainViewModel : ObservableObject, IDisposable
 
         try
         {
-            var perAccountTasks = FolderScopedAggregateSources(fullName)
+            // connectedOnly: this is the live-fetch path. An account that never connected would
+            // otherwise be handed to GetMessageSummariesAsync, and the lazy client pool would sit on
+            // its connect timeout inside Task.WhenAll before the view could render.
+            var perAccountTasks = FolderScopedAggregateSources(fullName, connectedOnly: true)
                 .GroupBy(s => s.Account)
                 .Select(g => FetchAccountFoldersAsync(g.Key, g.Select(s => s.Folder).ToList(), ct));
 

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -1615,6 +1615,41 @@ public partial class MainViewModel : ObservableObject, IDisposable
 
     private async Task ApplyViewAsync(SavedView view, bool allFolders = false)
     {
+        await ApplyViewStateAsync(view);
+
+        if (view.Folders.Count == 0)
+        {
+            if (!string.IsNullOrEmpty(view.VirtualFolderKey))
+            {
+                // VirtualFolderKey is stored without the \x00 sentinel prefix.
+                // Reconstruct the full sentinel name to look up the folder.
+                var sentinelName  = "\x00" + view.VirtualFolderKey;
+                var virtualFolder = Folders.FirstOrDefault(f =>
+                    string.Equals(f.FullName, sentinelName, StringComparison.Ordinal))
+                    ?? new MailFolderModel { FullName = sentinelName, DisplayName = view.Name };
+                SelectedFolder = virtualFolder;
+                await FetchVirtualAsync(virtualFolder);
+                return;
+            }
+            // Legacy view (null key or pre-fix garbled key): default to All Mail and
+            // patch the key so a future Save will persist the correct value.
+            view.VirtualFolderKey = AllMailFolder.FullName.Substring(1); // "AllMail"
+            SelectedFolder = AllMailFolder;
+            await FetchVirtualAsync(AllMailFolder);
+            return;
+        }
+
+        await ApplyViewFoldersAsync(view, allFolders);
+    }
+
+    /// <summary>
+    /// Applies a saved view's presentation state — mode, filter, sort, flag filter, day limit — and
+    /// clears search and open-message state. Split out of <see cref="ApplyViewAsync"/> so the startup
+    /// path can adopt a view's state while loading its messages from the local store instead of the
+    /// network (#516); everything here is pure VM state with no fetch of its own.
+    /// </summary>
+    private async Task ApplyViewStateAsync(SavedView view)
+    {
         ActiveView = view;
 
         // Apply view's mode/filter/sort before clearing search so rebuild
@@ -1651,29 +1686,14 @@ public partial class MainViewModel : ObservableObject, IDisposable
         IsSearchActive = false;
         MessageDetail  = null;
         IsMessageOpen  = false;
+    }
 
-        if (view.Folders.Count == 0)
-        {
-            if (!string.IsNullOrEmpty(view.VirtualFolderKey))
-            {
-                // VirtualFolderKey is stored without the \x00 sentinel prefix.
-                // Reconstruct the full sentinel name to look up the folder.
-                var sentinelName  = "\x00" + view.VirtualFolderKey;
-                var virtualFolder = Folders.FirstOrDefault(f =>
-                    string.Equals(f.FullName, sentinelName, StringComparison.Ordinal))
-                    ?? new MailFolderModel { FullName = sentinelName, DisplayName = view.Name };
-                SelectedFolder = virtualFolder;
-                await FetchVirtualAsync(virtualFolder);
-                return;
-            }
-            // Legacy view (null key or pre-fix garbled key): default to All Mail and
-            // patch the key so a future Save will persist the correct value.
-            view.VirtualFolderKey = AllMailFolder.FullName.Substring(1); // "AllMail"
-            SelectedFolder = AllMailFolder;
-            await FetchVirtualAsync(AllMailFolder);
-            return;
-        }
-
+    /// <summary>
+    /// Selects and fetches the folder(s) a saved view covers. Assumes the view's presentation state
+    /// has already been applied by <see cref="ApplyViewStateAsync"/>.
+    /// </summary>
+    private async Task ApplyViewFoldersAsync(SavedView view, bool allFolders)
+    {
         bool multiFolder = view.Folders.Count > 1 || allFolders;
 
         if (!multiFolder)
@@ -2146,8 +2166,153 @@ public partial class MainViewModel : ObservableObject, IDisposable
         "Microsoft 365 mail is doing a one-time re-sync — this may take a few minutes.";
 
     /// <summary>
-    /// Shows All Mail from the local store immediately (no network).
-    /// Called first in OnLoaded so the UI is populated before any IMAP work begins.
+    /// The saved view a <c>view:{guid}</c> startup value points at, or null. Only the one-time
+    /// migration off <c>SavedView.IsDefault</c> writes that form (#516).
+    /// </summary>
+    private SavedView? StartupView(ConfigModel cfg) =>
+        cfg.StartupFolder.StartsWith("view:", StringComparison.Ordinal) &&
+        Guid.TryParse(cfg.StartupFolder["view:".Length..], out var id)
+            ? SavedViews.FirstOrDefault(v => v.Id == id)
+            : null;
+
+    /// <summary>
+    /// The folder the configured startup folder names, or null to mean All Mail. Resolves entirely
+    /// against <see cref="_cachedFolders"/> — restored from the local store moments earlier — so it
+    /// works with no network, which is the whole point: applying the choice after connect is what
+    /// produced the All Mail flash users complained about.
+    /// <paramref name="fallbackReason"/> is set when a folder was configured but could not be
+    /// resolved, so the caller can say why rather than silently showing the wrong thing.
+    /// </summary>
+    private MailFolderModel? ResolveStartupFolder(ConfigModel cfg, out string? fallbackReason)
+    {
+        fallbackReason = null;
+        var key = cfg.StartupFolder;
+        if (string.IsNullOrWhiteSpace(key)) return null;    // empty == All Mail, the default
+
+        var label = string.IsNullOrWhiteSpace(cfg.StartupFolderLabel) ? key : cfg.StartupFolderLabel;
+
+        // A real folder on a specific account.
+        if (!string.IsNullOrWhiteSpace(cfg.StartupFolderAccount))
+        {
+            if (!Guid.TryParse(cfg.StartupFolderAccount, out var accountId) ||
+                !Accounts.Any(a => a.Id == accountId))
+            {
+                fallbackReason = $"The account for startup folder '{label}' is no longer set up — showing All Mail.";
+                return null;
+            }
+            var match = _cachedFolders.TryGetValue(accountId, out var folders)
+                ? folders.FirstOrDefault(f => string.Equals(f.FullName, key, StringComparison.OrdinalIgnoreCase))
+                : null;
+            if (match == null)
+            {
+                fallbackReason = $"Startup folder '{label}' was not found — showing All Mail.";
+                return null;
+            }
+            return match;
+        }
+
+        // A saved view (migration-only form). Its own folders are resolved by the caller.
+        if (key.StartsWith("view:", StringComparison.Ordinal))
+        {
+            if (StartupView(cfg) != null) return null;      // handled separately, not a folder
+            fallbackReason = $"The startup view '{label}' no longer exists — showing All Mail.";
+            return null;
+        }
+
+        // A virtual folder, stored without the NUL sentinel prefix (an INI cannot carry one).
+        var sentinel = "\x00" + key;
+        var virtualFolder = Folders.FirstOrDefault(f =>
+            string.Equals(f.FullName, sentinel, StringComparison.Ordinal));
+        if (virtualFolder != null) return virtualFolder;
+
+        fallbackReason = $"Startup folder '{label}' is no longer available — showing All Mail.";
+        return null;
+    }
+
+    /// <summary>
+    /// The startup folder for <c>--online</c>, where there is no local store and so no folder cache
+    /// to match against. Virtual keys resolve to their sentinel singletons; a real folder is
+    /// fabricated from the configured account, name, and label, which is enough for the fetch that
+    /// follows connect. Returns null to mean All Mail.
+    /// </summary>
+    private MailFolderModel? ResolveOnlineStartupFolder(ConfigModel cfg)
+    {
+        var key = cfg.StartupFolder;
+        if (string.IsNullOrWhiteSpace(key) || key.StartsWith("view:", StringComparison.Ordinal))
+            return null;
+
+        if (!string.IsNullOrWhiteSpace(cfg.StartupFolderAccount))
+        {
+            if (!Guid.TryParse(cfg.StartupFolderAccount, out var accountId) ||
+                !Accounts.Any(a => a.Id == accountId))
+                return null;
+            return new MailFolderModel
+            {
+                AccountId   = accountId,
+                FullName    = key,
+                DisplayName = string.IsNullOrWhiteSpace(cfg.StartupFolderLabel) ? key : cfg.StartupFolderLabel,
+            };
+        }
+
+        var sentinel = "\x00" + key;
+        return AllVirtualFolders.FirstOrDefault(f =>
+            string.Equals(f.FullName, sentinel, StringComparison.Ordinal));
+    }
+
+    /// <summary>Every top-level virtual aggregate, in folder-tree order. One list so the startup
+    /// resolver, the folder tree, and the context-menu guard cannot drift apart.</summary>
+    internal static readonly MailFolderModel[] AllVirtualFolders =
+    [
+        AllMailFolder, AllInboxesFolder, AllDraftsFolder, AllSentFolder,
+        AllArchiveFolder, AllTrashFolder, AllFlaggedFolder, AllWatchedFolder,
+    ];
+
+    /// <summary>
+    /// Cached messages for a saved view's folders, read from the local store only. Used at startup
+    /// for the migration-only <c>view:{guid}</c> form, where a multi-folder view has no single
+    /// folder to select (#516).
+    /// </summary>
+    private async Task<List<MailMessageSummary>> LoadViewSummariesAsync(SavedView view)
+    {
+        if (view.Folders.Count == 0)
+            return ExcludeSharedMail(await _localStore.LoadAllSummariesAsync());
+
+        var all = new List<MailMessageSummary>();
+        foreach (var vf in view.Folders)
+            all.AddRange(await _localStore.LoadFolderSummariesAsync(vf.AccountId, vf.FolderFullName));
+        return [.. all.OrderByDescending(m => m.Date)];
+    }
+
+    /// <summary>
+    /// Cached messages for the startup selection, read from the local store only — no network.
+    /// All Mail keeps loading the whole cache as it always has; a real folder reads just its own
+    /// rows; a folder-scoped aggregate unions the folders it spans, which is resolvable offline
+    /// now that folder kinds are persisted (#516).
+    /// </summary>
+    private async Task<List<MailMessageSummary>> LoadStartupSummariesAsync(MailFolderModel folder)
+    {
+        if (string.Equals(folder.FullName, AllMailFolder.FullName, StringComparison.Ordinal))
+            return ExcludeSharedMail(await _localStore.LoadAllSummariesAsync());   // #31
+
+        if (IsFolderScopedAggregate(folder.FullName))
+        {
+            var all = new List<MailMessageSummary>();
+            foreach (var (account, source) in FolderScopedAggregateSources(folder.FullName))
+                all.AddRange(await _localStore.LoadFolderSummariesAsync(account.Id, source.FullName));
+            return [.. all.OrderByDescending(m => m.Date)];
+        }
+
+        if (folder.AccountId != Guid.Empty && folder.FullName.Length > 0 && folder.FullName[0] != '\0')
+            return await _localStore.LoadFolderSummariesAsync(folder.AccountId, folder.FullName);
+
+        // Any other sentinel (All Flagged, Watched, a view, contact mail…) has no cheap cached
+        // form here; fall back to the whole cache and let the post-connect refresh narrow it.
+        return ExcludeSharedMail(await _localStore.LoadAllSummariesAsync());
+    }
+
+    /// <summary>
+    /// Shows the startup folder's cached mail immediately (no network) — All Mail unless the user
+    /// chose otherwise. Called first in OnLoaded so the UI is populated before any IMAP work begins.
     /// </summary>
     public async Task InitialLoadAsync()
     {
@@ -2174,32 +2339,34 @@ public partial class MainViewModel : ObservableObject, IDisposable
             ImmutableIdRebuildAnnouncePending = false;
             Announce(ImmutableIdRebuildNotice, AnnouncementCategory.Status);
         }
+        var startupCfg = _configService.Load();
+
         if (OnlineMode)
         {
+            // Online mode never initializes the local store, so there is no folder cache to resolve
+            // against. Select what the config names anyway — the fetch that follows connect reads
+            // SelectedFolder — so the choice is honoured here too. It was not before: the old
+            // default-view application sat after an early return on this path.
+            SelectedFolder = ResolveOnlineStartupFolder(startupCfg) ?? AllMailFolder;
             StatusText = "Online mode — connecting…";
             ConnectionStatusText = "Connecting…";
             return;
         }
-        var cached = ExcludeSharedMail(await _localStore.LoadAllSummariesAsync()); // #31: All Mail excludes shared
-        await ResolveFlagNamesAsync(cached);
-        SetMessages(cached);
-        StatusText = cached.Count > 0
-            ? $"{cached.Count} messages (cached — syncing…)"
-            : rebuildNotice ? ImmutableIdRebuildNotice : "Connecting and syncing…";
-        ConnectionStatusText = "Connecting…";
-        StartPrefetchTopOfFolder();
+
         // Drop calendar events left behind by accounts that no longer exist — e.g. an account removed
         // and re-added during setup gets a new id, so its old events would otherwise linger and show
         // as duplicates (one per stale id). Local events (empty account id) are kept.
         var knownAccountIds = Accounts.Select(a => a.Id).ToList();
         await _localStore.PurgeCalendarEventsForUnknownAccountsAsync(knownAccountIds);
 
-        // Restore the folder list from the local store (#516). Until this landed, _cachedFolders was
-        // empty until ConnectAllAccountsAsync returned, so the tree below showed only the virtual
+        // Restore the folder list from the local store (#516) — BEFORE resolving the startup folder
+        // and loading messages, because both depend on it. Until this landed, _cachedFolders was
+        // empty until ConnectAllAccountsAsync returned, so the tree showed only the virtual
         // aggregates and nothing could tell which folders were Inboxes — which is why a startup
         // folder could not be honoured before the network came up. Purge first so an account removed
         // while the app was closed does not reappear in the tree. Failure here is not fatal: the
-        // cache repopulates on connect, exactly as it did before.
+        // cache repopulates on connect, exactly as it did before, and the startup folder falls back
+        // to All Mail.
         try
         {
             await _localStore.PurgeFoldersForUnknownAccountsAsync(knownAccountIds);
@@ -2212,8 +2379,57 @@ public partial class MainViewModel : ObservableObject, IDisposable
             LogService.Log("InitialLoad: restoring cached folder list", ex);
         }
 
+        // Build the folder list now: ResolveStartupFolder matches virtual sentinels against Folders,
+        // and the tree is worth drawing before the message load either way.
         await ReloadCalendarSourcesAsync(); // populate before the tree is built so calendars show at startup
         RebuildFolderListFromCache();
+
+        // Apply the startup folder here, not after sync. CLAUDE.md's startup rule is explicit about
+        // this, and the alternative is what users reported: All Mail on screen for the first seconds,
+        // then a jarring switch once connections came up.
+        var startupView   = StartupView(startupCfg);
+        var startupFolder = ResolveStartupFolder(startupCfg, out var fallbackReason);
+        if (startupView != null)
+        {
+            await ApplyViewStateAsync(startupView);        // mode/filter/sort only — no fetch
+            // Select the view sentinel, the same shape ApplyViewFoldersAsync uses for a multi-folder
+            // view, so RefreshAsync and the post-sync reload resolve it like any other selection.
+            SelectedFolder = new MailFolderModel
+            {
+                FullName    = $"{ViewPrefix}{startupView.Id}",
+                DisplayName = startupView.Name,
+            };
+        }
+        else
+        {
+            SelectedFolder = startupFolder ?? AllMailFolder;
+        }
+
+        var cached = startupView != null
+            ? await LoadViewSummariesAsync(startupView)
+            : await LoadStartupSummariesAsync(SelectedFolder);
+        await ResolveFlagNamesAsync(cached);
+        SetMessages(cached);
+
+        var where = SelectedFolder == AllMailFolder && startupView == null
+            ? null : startupView?.Name ?? SelectedFolder.DisplayName;
+        StatusText = cached.Count > 0
+            ? where == null
+                ? $"{cached.Count} messages (cached — syncing…)"
+                : $"{cached.Count} messages in {where} (cached — syncing…)"
+            : rebuildNotice ? ImmutableIdRebuildNotice : "Connecting and syncing…";
+
+        // A configured startup folder that no longer resolves must say so. Silently showing All Mail
+        // looks like the setting was ignored, and the user has no way to tell which it was.
+        if (fallbackReason != null)
+        {
+            StatusText = fallbackReason;
+            Announce(fallbackReason, AnnouncementCategory.Status);
+            LogService.Log($"InitialLoad: {fallbackReason}");
+        }
+
+        ConnectionStatusText = "Connecting…";
+        StartPrefetchTopOfFolder();
     }
 
     /// <summary>
@@ -2297,15 +2513,16 @@ public partial class MainViewModel : ObservableObject, IDisposable
         if (OnlineMode)
         {
             // In online mode there is no background sync — just load the current folder live.
-            await FetchVirtualAsync(AllMailFolder);
+            // RefreshAsync rather than a hardcoded All Mail fetch: InitialLoadAsync has already
+            // selected the startup folder, and it handles every sentinel and view shape (#516).
+            await RefreshAsync();
             return;
         }
 
-        // Apply default view now that connections are ready, so the user sees the right
-        // view during sync rather than waiting ~40s for sync to complete (issue #57).
-        var defaultView = SavedViews.FirstOrDefault(v => v.IsDefault);
-        if (defaultView != null)
-            await ApplyViewAsync(defaultView);
+        // The startup folder is applied in InitialLoadAsync now, before this method runs — no
+        // post-connect view switch here. Applying it at this point is what produced the All Mail
+        // flash: #57 moved it from post-sync to post-connect, which shortened the flash without
+        // removing it. #516 moved it to the cached load, which removes it.
 
         StatusText = "Syncing mail…";
         ConnectionStatusText = "Syncing…";

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -187,9 +187,32 @@ public partial class MainViewModel : ObservableObject, IDisposable
     private EventHandler? _onFlagDefinitionsChanged;
     private Action<Guid, bool>? _onReachabilityChanged;
 
-    // Retains folder lists for every account that has been connected this session
+    // Folder lists per account. Since #516 this is ALSO seeded from the local store at startup, so
+    // presence here no longer implies the account connected — see _connectedAccountIds below.
     private readonly Dictionary<Guid, List<MailFolderModel>> _cachedFolders = new();
     public IReadOnlyDictionary<Guid, List<MailFolderModel>> CachedFolders => _cachedFolders;
+
+    /// <summary>
+    /// Accounts that have actually connected this session. Before #516, <c>_cachedFolders.Count</c>
+    /// carried this meaning — an account appeared there only after <c>GetFoldersAsync</c> succeeded.
+    /// Now the dictionary is pre-filled from SQLite at launch so the startup folder can be resolved
+    /// and the tree drawn offline, which would make that count report "connected" for accounts that
+    /// never came up. Anything asking "did we connect?" must use this set, not the dictionary.
+    /// </summary>
+    private readonly HashSet<Guid> _connectedAccountIds = [];
+
+    /// <summary>
+    /// Records an account's folder list, marks it connected, and persists it so the next launch can
+    /// resolve the startup folder and draw the tree before any network call (#516). Every write to
+    /// <see cref="_cachedFolders"/> that comes from a live server fetch goes through here.
+    /// The save is fire-and-forget: a failed cache write must never break the folder list in hand.
+    /// </summary>
+    private void SetCachedFolders(Guid accountId, List<MailFolderModel> folders)
+    {
+        _cachedFolders[accountId] = folders;
+        _connectedAccountIds.Add(accountId);
+        _localStore.SaveFoldersAsync(accountId, folders).LogFaults("persist folder list");
+    }
 
     // Debounced folder-unread-count refresh (issue #227). Folder counts are server-authoritative
     // (IMAP STATUS), which matters for Gmail where marking one message read propagates \Seen across
@@ -2168,7 +2191,27 @@ public partial class MainViewModel : ObservableObject, IDisposable
         // Drop calendar events left behind by accounts that no longer exist — e.g. an account removed
         // and re-added during setup gets a new id, so its old events would otherwise linger and show
         // as duplicates (one per stale id). Local events (empty account id) are kept.
-        await _localStore.PurgeCalendarEventsForUnknownAccountsAsync(Accounts.Select(a => a.Id).ToList());
+        var knownAccountIds = Accounts.Select(a => a.Id).ToList();
+        await _localStore.PurgeCalendarEventsForUnknownAccountsAsync(knownAccountIds);
+
+        // Restore the folder list from the local store (#516). Until this landed, _cachedFolders was
+        // empty until ConnectAllAccountsAsync returned, so the tree below showed only the virtual
+        // aggregates and nothing could tell which folders were Inboxes — which is why a startup
+        // folder could not be honoured before the network came up. Purge first so an account removed
+        // while the app was closed does not reappear in the tree. Failure here is not fatal: the
+        // cache repopulates on connect, exactly as it did before.
+        try
+        {
+            await _localStore.PurgeFoldersForUnknownAccountsAsync(knownAccountIds);
+            foreach (var (accountId, folders) in await _localStore.LoadFoldersAsync())
+                if (folders.Count > 0)
+                    _cachedFolders[accountId] = folders;   // NOT SetCachedFolders — nothing has connected yet
+        }
+        catch (Exception ex)
+        {
+            LogService.Log("InitialLoad: restoring cached folder list", ex);
+        }
+
         await ReloadCalendarSourcesAsync(); // populate before the tree is built so calendars show at startup
         RebuildFolderListFromCache();
     }
@@ -2206,9 +2249,15 @@ public partial class MainViewModel : ObservableObject, IDisposable
 
         // Nothing connected — skip the heavy full sync. Watchers/labels are already handled above, and
         // WireUpWatchers will start the watcher once an account connects later.
-        if (_cachedFolders.Count == 0) return;
+        // Must ask _connectedAccountIds, not _cachedFolders: since #516 the folder cache is restored
+        // from SQLite at launch, so it is non-empty even when every connect failed. Testing the
+        // dictionary here would send the full sync at accounts that have no connection (#516).
+        if (_connectedAccountIds.Count == 0) return;
 
-        var accountList = Accounts.ToList();
+        // Connected accounts only. Everything downstream of this list needs a live connection —
+        // the full sync, the folder-count STATUS sweep, and the NOOP heartbeat — and since #516 the
+        // folder cache no longer implies one.
+        var accountList = Accounts.Where(a => _connectedAccountIds.Contains(a.Id)).ToList();
 
         // Subscribe to sync progress updates.
         // Announce every 10 folders to avoid excessive screen reader chatter.
@@ -2272,7 +2321,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
 
         try
         {
-            await _syncService.SyncAllAccountsAsync(Accounts, _cachedFolders, ct);
+            await _syncService.SyncAllAccountsAsync(accountList, _cachedFolders, ct);
 
             // Sync done — refresh the current view/folder once so the UI reflects every
             // folder that was synced without N intermediate screen-reader announcements.
@@ -2287,7 +2336,9 @@ public partial class MainViewModel : ObservableObject, IDisposable
             var count = Messages.Count;
             StatusText = $"{count} messages.";
             LastSyncText = $"Synced {DateTime.Now:t}";
-            ConnectionStatusText = $"{Accounts.Count} account{(Accounts.Count == 1 ? "" : "s")} connected";
+            // Report accounts that connected, not accounts configured — this label read
+            // "3 accounts connected" with two of them offline.
+            ConnectionStatusText = $"{accountList.Count} account{(accountList.Count == 1 ? "" : "s")} connected";
             Announce($"{count} {(count == 1 ? "message" : "messages")} loaded.", AnnouncementCategory.Status);
 
             // Start periodic NOOP heartbeat (10-minute interval) to keep connections alive
@@ -2305,7 +2356,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
             StatusText = $"Sync error: {ex.Message}";
             Announce($"Sync error: {ex.Message}", AnnouncementCategory.Status);
             // Only set "Connection error" if no accounts connected at all.
-            if (_cachedFolders.Count == 0)
+            if (_connectedAccountIds.Count == 0)
                 ConnectionStatusText = "Connection error";
         }
         finally
@@ -2337,7 +2388,10 @@ public partial class MainViewModel : ObservableObject, IDisposable
     /// </summary>
     private void WireUpWatchers()
     {
-        var connected    = Accounts.Where(a => _cachedFolders.ContainsKey(a.Id)).ToList();
+        // Connected means "this session reached the server", not "we have folders for it" — the
+        // folder cache is restored from SQLite at launch (#516), so keying off it here would start
+        // watchers against accounts that never connected.
+        var connected    = Accounts.Where(a => _connectedAccountIds.Contains(a.Id)).ToList();
         var connectedIds = connected.Select(a => a.Id).ToHashSet();
 
         // Only (re)start watchers when the connected set changed — StartWatchers stops and restarts
@@ -2379,13 +2433,13 @@ public partial class MainViewModel : ObservableObject, IDisposable
             }
         }
 
-        ConnectionStatusText = _cachedFolders.Count > 0
-            ? $"{_cachedFolders.Count} account{(_cachedFolders.Count == 1 ? "" : "s")} connected"
+        ConnectionStatusText = _connectedAccountIds.Count > 0
+            ? $"{_connectedAccountIds.Count} account{(_connectedAccountIds.Count == 1 ? "" : "s")} connected"
             : "Offline";
 
         // Don't leave the label stuck at its pre-sync defaults once an account is actually connected;
         // the sync/poll paths (OnFolderSynced, StartBackgroundSyncAsync) keep it current from here.
-        if (_cachedFolders.Count > 0 && LastSyncText is "Never synced" or "In progress")
+        if (_connectedAccountIds.Count > 0 && LastSyncText is "Never synced" or "In progress")
             LastSyncText = $"Synced {DateTime.Now:t}";
     }
 
@@ -2484,6 +2538,10 @@ public partial class MainViewModel : ObservableObject, IDisposable
                 {
                     foreach (var account in Accounts)
                     {
+                        // Sweep only accounts that actually connected — the folder cache is restored
+                        // from SQLite at launch (#516), so it lists folders for offline accounts too
+                        // and every job queued for one of those would just fail.
+                        if (!_connectedAccountIds.Contains(account.Id)) continue;
                         if (!_cachedFolders.TryGetValue(account.Id, out var folders)) continue;
                         foreach (var folder in folders)
                         {
@@ -3466,16 +3524,18 @@ public partial class MainViewModel : ObservableObject, IDisposable
             if (account != null)
                 ApplyAccountStatus(account, folders, "initial-connect");
             if (folders != null)
-                _cachedFolders[id] = folders;
+                SetCachedFolders(id, folders);
         }
 
         IsBusy = false;
         RebuildFolderListFromCache();
-        StatusText = _cachedFolders.Count > 0
-            ? $"{_cachedFolders.Count} of {Accounts.Count} account(s) connected."
+        // Count connections, not cache entries: since #516 _cachedFolders is pre-filled from the
+        // local store at launch, so its size would report accounts that never connected.
+        StatusText = _connectedAccountIds.Count > 0
+            ? $"{_connectedAccountIds.Count} of {Accounts.Count} account(s) connected."
             : "No accounts could be connected.";
-        ConnectionStatusText = _cachedFolders.Count > 0
-            ? $"{_cachedFolders.Count} account(s) connected"
+        ConnectionStatusText = _connectedAccountIds.Count > 0
+            ? $"{_connectedAccountIds.Count} account(s) connected"
             : "Offline";
     }
 
@@ -4115,7 +4175,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
             ReplaceCts(ref _connectCts, out var ct);
             await _imap.ConnectAsync(account, password, ct);
             var folderList = await _imap.GetFoldersAsync(account.Id, ct);
-            _cachedFolders[account.Id] = folderList;
+            SetCachedFolders(account.Id, folderList);
             ApplyAccountStatus(account, folderList, "select-account");
             RebuildFolderListFromCache();
             // Start this account's new-mail watcher and refresh the status labels — a manual
@@ -4580,7 +4640,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
             if (folders == null) continue;
             if (!_cachedFolders.TryGetValue(account.Id, out var prev) || FolderSetChanged(prev, folders))
             {
-                _cachedFolders[account.Id] = folders;
+                SetCachedFolders(account.Id, folders);
                 ApplyAccountStatus(account, folders, "refresh-folder-lists");
                 changed = true;
             }
@@ -4647,7 +4707,9 @@ public partial class MainViewModel : ObservableObject, IDisposable
                 (cached.Any(m => string.IsNullOrWhiteSpace(m.To))
                     || await _localStore.HasSummariesMissingRecipientsAsync());
             var perAccountTasks = Accounts
-                .Where(a => _cachedFolders.ContainsKey(a.Id) && !a.IsShared)   // #31: shared excluded from All Mail
+                // Connected, not merely cached: this phase issues live IMAP fetches, and since #516
+                // the folder cache is populated before any account connects.
+                .Where(a => _connectedAccountIds.Contains(a.Id) && !a.IsShared)   // #31: shared excluded from All Mail
                 .Select(account => (OnlineMode || needsRecipientRepair)
                     ? FetchAccountAllFoldersAsync(account, ct)
                     : FetchAccountNewMessagesAsync(account, ct));
@@ -6769,9 +6831,11 @@ public partial class MainViewModel : ObservableObject, IDisposable
     /// notification activation (cold start) open its message once the account is reachable.</summary>
     public event Action? StartupConnectCompleted;
 
-    /// <summary>True when the account's folders are cached, i.e. it is connected and a message detail
-    /// fetch by id can succeed. Used to decide whether to open a toast's message now or defer it.</summary>
-    public bool IsAccountReady(Guid accountId) => _cachedFolders.ContainsKey(accountId);
+    /// <summary>True when the account has connected this session, i.e. a message detail fetch by id
+    /// can succeed. Used to decide whether to open a toast's message now or defer it. Deliberately
+    /// not "are its folders cached" — since #516 folders are restored from SQLite before any
+    /// connect, so that question is true offline and the fetch would fail.</summary>
+    public bool IsAccountReady(Guid accountId) => _connectedAccountIds.Contains(accountId);
 
     [RelayCommand]
     private void Exit() => ExitRequested?.Invoke();
@@ -6824,7 +6888,10 @@ public partial class MainViewModel : ObservableObject, IDisposable
             _credentials.DeletePassword(a.Id);
             Accounts.Remove(a);
             _cachedFolders.Remove(a.Id);
+            _connectedAccountIds.Remove(a.Id);
         }
+        // DeleteAccountDataAsync drops the account's persisted folders too, so a removed account
+        // does not come back in the folder tree on the next launch (#516).
         _accountService.SaveAccounts([.. Accounts]);
         RebuildFolderListFromCache();
 
@@ -6882,7 +6949,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
         {
             using var cts   = new CancellationTokenSource(TimeSpan.FromSeconds(30));
             var folderList  = await _imap.GetFoldersAsync(accountId, cts.Token);
-            _cachedFolders[accountId] = folderList;
+            SetCachedFolders(accountId, folderList);
             var account = Accounts.FirstOrDefault(a => a.Id == accountId);
             if (account != null) ApplyAccountStatus(account, folderList, "folder-refresh");
             RebuildFolderListFromCache();
@@ -6999,7 +7066,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
             f.FullName.StartsWith(deleted.FullName + "/", StringComparison.OrdinalIgnoreCase) ||
             f.FullName.StartsWith(deleted.FullName + ".", StringComparison.OrdinalIgnoreCase);
 
-        _cachedFolders[accountId] = folders.Where(f => !ShouldRemove(f)).ToList();
+        SetCachedFolders(accountId, folders.Where(f => !ShouldRemove(f)).ToList());
 
         // Keep the flat Folders collection in sync — it backs saved-view resolution, the folder
         // picker, and the next tree rebuild, so a stale entry there would resolve a deleted folder.
@@ -7073,7 +7140,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
             using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
             await _imap.CreateFolderAsync(accountId, parentFolderName, name, cts.Token);
             var folderList = await _imap.GetFoldersAsync(accountId, cts.Token);
-            _cachedFolders[accountId] = folderList;
+            SetCachedFolders(accountId, folderList);
             var account = Accounts.FirstOrDefault(a => a.Id == accountId);
             if (account != null) ApplyAccountStatus(account, folderList, "folder-created");
             _folderTreeRebuildPending = true;
@@ -7830,8 +7897,11 @@ public partial class MainViewModel : ObservableObject, IDisposable
         // it, so folder ops fail "…is not connected" until an app restart (#219). Reconnecting it
         // here fixes that without a restart. _cachedFolders is UI-thread-owned: read it on the UI
         // thread and marshal every write back through _ui so the background loop never touches it.
+        // The VM-side predicate asks "has this account connected this session", which _cachedFolders
+        // stopped answering in #516 — it is restored from SQLite at launch, so a never-connected
+        // account would look present here and never be reconnected.
         var accountsToConnect = AccountsNeedingConnect(
-            Accounts, _imap.IsConnected, id => _cachedFolders.ContainsKey(id));
+            Accounts, _imap.IsConnected, id => _connectedAccountIds.Contains(id));
         _ = Task.Run(async () =>
         {
             foreach (var account in accountsToConnect)
@@ -7842,7 +7912,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
                     ApplyAccountStatus(account, result.Folders, "account-list-refresh");
                     if (result.Folders != null)
                     {
-                        _cachedFolders[result.Id] = result.Folders;
+                        SetCachedFolders(result.Id, result.Folders);
                         RebuildFolderListFromCache();
                     }
                 });

--- a/QuickMail/ViewModels/SettingsViewModel.cs
+++ b/QuickMail/ViewModels/SettingsViewModel.cs
@@ -303,6 +303,76 @@ public partial class SettingsViewModel : ObservableObject
         set { if (value) LogFormat = "timeFirst"; }
     }
 
+    // ── Startup (#516) ────────────────────────────────────────────────────────────
+
+    /// <summary>What the View hands back when the user picks a folder: the stored key, the owning
+    /// account (empty for a virtual folder), and the text to show. A plain record so the VM never
+    /// sees a folder-picker or any other UI type.</summary>
+    public sealed record StartupFolderChoice(string Key, string AccountId, string Label);
+
+    /// <summary>
+    /// Set by the View to show the folder picker and return the chosen folder, or null if the user
+    /// cancelled. Same shape as <c>MainViewModel.SaveFolderPathRequested</c>: picking needs a window,
+    /// which is the View's job, so the VM asks rather than opens.
+    /// </summary>
+    public Func<StartupFolderChoice?>? PickStartupFolderRequested { get; set; }
+
+    [ObservableProperty]
+    private string _startupFolder = string.Empty;
+
+    [ObservableProperty]
+    private string _startupFolderAccount = string.Empty;
+
+    /// <summary>Read-only text of the current choice. "All Mail" stands for "nothing configured",
+    /// which is what an empty <see cref="StartupFolder"/> means and what the app does anyway.</summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(StartupFolderDisplay))]
+    private string _startupFolderLabel = string.Empty;
+
+    public string StartupFolderDisplay =>
+        string.IsNullOrWhiteSpace(StartupFolderLabel) ? "All Mail" : StartupFolderLabel;
+
+    [RelayCommand]
+    private void ChooseStartupFolder()
+    {
+        if (PickStartupFolderRequested?.Invoke() is not { } choice) return;   // cancelled
+        StartupFolder        = choice.Key;
+        StartupFolderAccount = choice.AccountId;
+        StartupFolderLabel   = choice.Label;
+    }
+
+    [RelayCommand]
+    private void ClearStartupFolder()
+    {
+        StartupFolder        = string.Empty;
+        StartupFolderAccount = string.Empty;
+        StartupFolderLabel   = string.Empty;
+    }
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsStartupSyncScopeStartupFolder))]
+    [NotifyPropertyChangedFor(nameof(IsStartupSyncScopeInboxes))]
+    [NotifyPropertyChangedFor(nameof(IsStartupSyncScopeAll))]
+    private string _startupSyncScope = ConfigModel.StartupSyncScopeStartupFolder;
+
+    public bool IsStartupSyncScopeStartupFolder
+    {
+        get => StartupSyncScope == ConfigModel.StartupSyncScopeStartupFolder;
+        set { if (value) StartupSyncScope = ConfigModel.StartupSyncScopeStartupFolder; }
+    }
+
+    public bool IsStartupSyncScopeInboxes
+    {
+        get => StartupSyncScope == ConfigModel.StartupSyncScopeInboxes;
+        set { if (value) StartupSyncScope = ConfigModel.StartupSyncScopeInboxes; }
+    }
+
+    public bool IsStartupSyncScopeAll
+    {
+        get => StartupSyncScope == ConfigModel.StartupSyncScopeAll;
+        set { if (value) StartupSyncScope = ConfigModel.StartupSyncScopeAll; }
+    }
+
     public ObservableCollection<HotkeyRowViewModel> HotkeyRows { get; } = [];
 
     [ObservableProperty]
@@ -385,6 +455,10 @@ public partial class SettingsViewModel : ObservableObject
             _                           => "plain",
         };
         LogFormat                        = cfg.LogFormat;
+        StartupFolder                    = cfg.StartupFolder;
+        StartupFolderAccount             = cfg.StartupFolderAccount;
+        StartupFolderLabel               = cfg.StartupFolderLabel;
+        StartupSyncScope                 = ConfigModel.ParseStartupSyncScope(cfg.StartupSyncScope);
         EnableLogging                    = cfg.EnableLogging;
         ConnectionDiagnostics            = cfg.ConnectionDiagnostics;
         MessageOpenMode = cfg.Windowing.MessageOpenMode switch
@@ -485,6 +559,10 @@ public partial class SettingsViewModel : ObservableObject
             _          => Models.ComposeMode.PlainText,
         };
         cfg.LogFormat                        = LogFormat;
+        cfg.StartupFolder                    = StartupFolder;
+        cfg.StartupFolderAccount             = StartupFolderAccount;
+        cfg.StartupFolderLabel               = StartupFolderLabel;
+        cfg.StartupSyncScope                 = StartupSyncScope;
         cfg.EnableLogging                    = EnableLogging;
         cfg.ConnectionDiagnostics            = ConnectionDiagnostics;
         cfg.Windowing.MessageOpenMode = MessageOpenMode switch

--- a/QuickMail/ViewModels/SettingsViewModel.cs
+++ b/QuickMail/ViewModels/SettingsViewModel.cs
@@ -305,17 +305,18 @@ public partial class SettingsViewModel : ObservableObject
 
     // ── Startup (#516) ────────────────────────────────────────────────────────────
 
-    /// <summary>What the View hands back when the user picks a folder: the stored key, the owning
-    /// account (empty for a virtual folder), and the text to show. A plain record so the VM never
-    /// sees a folder-picker or any other UI type.</summary>
-    public sealed record StartupFolderChoice(string Key, string AccountId, string Label);
-
     /// <summary>
     /// Set by the View to show the folder picker and return the chosen folder, or null if the user
     /// cancelled. Same shape as <c>MainViewModel.SaveFolderPathRequested</c>: picking needs a window,
     /// which is the View's job, so the VM asks rather than opens.
+    ///
+    /// <para>Returns the picked <see cref="MailFolderModel"/> — a Models type, so no UI type crosses
+    /// the boundary — and the VM converts it to storage form. The View must not do that conversion:
+    /// it is the same rule <see cref="MainViewModel.SetStartupFolder"/> applies, and a second copy
+    /// in code-behind is a data transformation the MVVM rules put in the VM precisely so the two
+    /// cannot drift.</para>
     /// </summary>
-    public Func<StartupFolderChoice?>? PickStartupFolderRequested { get; set; }
+    public Func<MailFolderModel?>? PickStartupFolderRequested { get; set; }
 
     [ObservableProperty]
     private string _startupFolder = string.Empty;
@@ -335,10 +336,18 @@ public partial class SettingsViewModel : ObservableObject
     [RelayCommand]
     private void ChooseStartupFolder()
     {
-        if (PickStartupFolderRequested?.Invoke() is not { } choice) return;   // cancelled
-        StartupFolder        = choice.Key;
-        StartupFolderAccount = choice.AccountId;
-        StartupFolderLabel   = choice.Label;
+        if (PickStartupFolderRequested?.Invoke() is not { } folder) return;   // cancelled
+
+        // Same rule as MainViewModel.SetStartupFolder, and the same allow-list: a virtual aggregate
+        // is stored without its NUL sentinel prefix (an INI cannot carry one) and with no account,
+        // since it spans them all. A real folder keeps its name and carries its owning account,
+        // because folder names collide across accounts and the pair is what resolves at startup.
+        var isVirtual = MainViewModel.AllVirtualFolders.Any(v =>
+            string.Equals(v.FullName, folder.FullName, StringComparison.Ordinal));
+
+        StartupFolder        = isVirtual ? folder.FullName[1..] : folder.FullName;
+        StartupFolderAccount = isVirtual ? string.Empty : folder.AccountId.ToString();
+        StartupFolderLabel   = folder.DisplayName;
     }
 
     [RelayCommand]

--- a/QuickMail/ViewModels/ViewManagerViewModel.cs
+++ b/QuickMail/ViewModels/ViewManagerViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;

--- a/QuickMail/ViewModels/ViewManagerViewModel.cs
+++ b/QuickMail/ViewModels/ViewManagerViewModel.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -77,8 +77,9 @@ public partial class ViewManagerViewModel : ObservableObject
     [ObservableProperty]
     private string _editHotkey = string.Empty;
 
-    [ObservableProperty]
-    private bool _editIsDefault;
+    // EditIsDefault (and SavedView.IsDefault behind it) was removed in #516. A startup folder is a
+    // folder, set from the folder tree or Settings > Startup — not a flag on a saved view the user
+    // had to create first.
 
     /// <summary>Bound to the day-limit TextBox. Empty string means no limit.</summary>
     [ObservableProperty]
@@ -340,7 +341,6 @@ public partial class ViewManagerViewModel : ObservableObject
         SelectedView   = view;
         EditName       = view.Name;
         EditHotkey     = string.Empty;
-        EditIsDefault  = false;
         EditUnlimitedDays = !CurrentDayLimit.HasValue;
         EditDaysOfMail = CurrentDayLimit.HasValue ? CurrentDayLimit.Value.ToString() : string.Empty;
 
@@ -417,7 +417,6 @@ public partial class ViewManagerViewModel : ObservableObject
         SelectedView      = null;
         EditName          = string.Empty;
         EditHotkey        = string.Empty;
-        EditIsDefault     = false;
         EditUnlimitedDays = true;
         EditDaysOfMail    = string.Empty;
         Persist();
@@ -463,7 +462,6 @@ public partial class ViewManagerViewModel : ObservableObject
         {
             EditName       = SelectedView.Name;
             EditHotkey     = GetEffectiveHotkey(SelectedView);
-            EditIsDefault  = SelectedView.IsDefault;
             EditUnlimitedDays = !SelectedView.DaysOfMail.HasValue;
             EditDaysOfMail = SelectedView.DaysOfMail.HasValue ? SelectedView.DaysOfMail.Value.ToString() : string.Empty;
         }
@@ -505,7 +503,6 @@ public partial class ViewManagerViewModel : ObservableObject
         {
             EditName          = string.Empty;
             EditHotkey        = string.Empty;
-            EditIsDefault     = false;
             EditUnlimitedDays = true;
             EditDaysOfMail    = string.Empty;
         }
@@ -513,7 +510,6 @@ public partial class ViewManagerViewModel : ObservableObject
         {
             EditName          = value.Name;
             EditHotkey        = GetEffectiveHotkey(value);
-            EditIsDefault     = value.IsDefault;
             EditUnlimitedDays = !value.DaysOfMail.HasValue;
             EditDaysOfMail    = value.DaysOfMail.HasValue ? value.DaysOfMail.Value.ToString() : string.Empty;
         }
@@ -599,14 +595,6 @@ public partial class ViewManagerViewModel : ObservableObject
 
         if (SelectedView.Hotkey != oldHotkey)
             PersistHotkey(SelectedView);
-
-        // Update default — clear any other default first
-        if (EditIsDefault && !SelectedView.IsDefault)
-        {
-            foreach (var v in SavedViews.Where(v => v != SelectedView))
-                v.IsDefault = false;
-        }
-        SelectedView.IsDefault = EditIsDefault;
 
         // Update day limit — "unlimited" checkbox wins; otherwise parse the text box
         SelectedView.DaysOfMail = EditUnlimitedDays

--- a/QuickMail/Views/FolderPickerWindow.xaml.cs
+++ b/QuickMail/Views/FolderPickerWindow.xaml.cs
@@ -451,6 +451,57 @@ public partial class FolderPickerWindow : Window
             useTreeView: true);
     }
 
+    /// <summary>
+    /// The picker for Settings → Startup (#516). A tree, like the other destination pickers, because
+    /// the user is choosing a folder they already know from the main window's folder tree.
+    ///
+    /// <para>Deliberately <b>unscoped</b>, unlike <see cref="ForFolderMoveCopy"/> and
+    /// <see cref="ForRuleTarget"/>. Those two scope to one account because their backends act by
+    /// folder <i>name</i> over that account's connection, so offering another account's "Archive"
+    /// silently operates on the wrong mailbox. A startup folder does the opposite: it is one global
+    /// choice across every account, stored with its owning account id, and resolved by that pair. So
+    /// the account-collision hazard does not apply, and scoping would make most of the tree
+    /// unreachable.</para>
+    ///
+    /// <para><paramref name="virtualFolders"/> carries the aggregates — All Inboxes, All Mail and the
+    /// rest — because "open me in All Inboxes" is the most-requested form of this setting, and they
+    /// are legitimate startup destinations even though no other destination picker offers them.</para>
+    ///
+    /// <para>Opens on the current choice: <paramref name="currentAccountId"/> plus
+    /// <paramref name="currentKey"/> for a real folder, or the matching aggregate for a virtual one.
+    /// A picker must not open with nothing selected — <see cref="SelectOpeningNode"/> stands in the
+    /// first real folder when there is no current choice to land on.</para>
+    /// </summary>
+    public static FolderPickerWindow ForStartupFolder(
+        IEnumerable<AccountModel> accounts,
+        IReadOnlyDictionary<Guid, List<MailFolderModel>> cachedFolders,
+        IEnumerable<MailFolderModel> virtualFolders,
+        string? currentKey,
+        Guid? currentAccountId)
+    {
+        var virtualList = virtualFolders?.ToList() ?? [];
+
+        MailFolderModel? initial = null;
+        if (!string.IsNullOrEmpty(currentKey))
+        {
+            initial = currentAccountId is Guid acct && acct != Guid.Empty
+                ? (cachedFolders.TryGetValue(acct, out var owned)
+                    ? owned.FirstOrDefault(f => string.Equals(f.FullName, currentKey, StringComparison.Ordinal))
+                    : null)
+                // A virtual key is stored without the NUL sentinel prefix; the aggregates carry it.
+                : virtualList.FirstOrDefault(f =>
+                    string.Equals(f.FullName, "\x00" + currentKey, StringComparison.Ordinal));
+        }
+
+        return new FolderPickerWindow(
+            accounts,
+            cachedFolders,
+            virtualFolders: virtualList,
+            title: "Choose Startup Folder",
+            initialFolder: initial,
+            useTreeView: true);
+    }
+
     private static bool IsInbox(MailFolderModel folder) =>
         folder.Kind == SpecialFolderKind.Inbox ||
         folder.FullName.Equals("INBOX", StringComparison.OrdinalIgnoreCase);

--- a/QuickMail/Views/FolderPickerWindow.xaml.cs
+++ b/QuickMail/Views/FolderPickerWindow.xaml.cs
@@ -47,6 +47,10 @@ public partial class FolderPickerWindow : Window
     private List<AccountModel>? _treeAccounts;
     private Dictionary<Guid, List<MailFolderModel>>? _treeFolders;
 
+    /// <summary>Virtual aggregates offered as tree roots above the accounts (#516). Empty for the
+    /// pickers where an aggregate is not a legal destination — move/copy and rule targets.</summary>
+    private List<MailFolderModel> _treeVirtualFolders = [];
+
     // Tree view only: a folder (and everything under it) to leave out of the destination tree.
     // Set when the thing being moved or copied is itself a folder — see ForFolderMoveCopy.
     private readonly MailFolderModel? _excludeFolder;
@@ -108,7 +112,12 @@ public partial class FolderPickerWindow : Window
 
         if (_useTreeView)
         {
-            BuildTreeView(accounts, cachedFolders);
+            // Virtual folders reach tree mode too (#516). Until the startup picker needed them, the
+            // only tree-mode callers were move/copy and rule targets, for which an aggregate is not
+            // a legal destination — so virtualFolders was read only by the flat-list path below and
+            // silently dropped here. A startup folder may be an aggregate: All Inboxes is the most
+            // asked-for value of the whole setting.
+            BuildTreeView(accounts, cachedFolders, virtualFolders);
             return;
         }
 
@@ -169,11 +178,14 @@ public partial class FolderPickerWindow : Window
 
     private void BuildTreeView(
         IEnumerable<AccountModel> accounts,
-        IReadOnlyDictionary<Guid, List<MailFolderModel>> cachedFolders)
+        IReadOnlyDictionary<Guid, List<MailFolderModel>> cachedFolders,
+        IEnumerable<MailFolderModel>? virtualFolders = null)
     {
         SearchBox.Visibility = Visibility.Collapsed;
         FolderListBox.Visibility = Visibility.Collapsed;
         FolderTreeView.Visibility = Visibility.Visible;
+
+        _treeVirtualFolders = virtualFolders?.ToList() ?? [];
 
         // Retain a private, mutable copy so RebuildTreeView can regenerate the tree after a folder
         // is created without depending on the caller's snapshot (which may be a filtered copy).
@@ -245,6 +257,12 @@ public partial class FolderPickerWindow : Window
         if (_treeAccounts == null || _treeFolders == null) return;
 
         var roots = new List<FolderTreeNode>();
+
+        // Aggregates first, matching the main folder tree's order, so a user arriving from there
+        // finds All Inboxes where they expect it. Leaf nodes: an aggregate has no children.
+        foreach (var vf in _treeVirtualFolders)
+            roots.Add(new FolderTreeNode { Folder = vf, Label = vf.DisplayName });
+
         foreach (var account in _treeAccounts)
         {
             if (!_treeFolders.TryGetValue(account.Id, out var folders) || folders.Count == 0)

--- a/QuickMail/Views/MainWindow.xaml
+++ b/QuickMail/Views/MainWindow.xaml
@@ -249,11 +249,13 @@
                       AutomationProperties.Name="Use Automatic Archive Folder"
                       Click="FolderContextMenu_ClearArchive_Click"/>
             <Separator/>
-            <!-- #516. Mnemonics: N, M, C, A, u and D are taken above, so S and the u in "Start_up". -->
+            <!-- #516. N, M, C, A, U and D are taken by the items above — note U, from "Use A_utomatic
+                 Archive Folder" — leaving S and F. WPF cycles between duplicate access keys instead
+                 of invoking, so a collision here would make the key highlight rather than activate. -->
             <MenuItem Header="Set as _Startup Folder"
                       AutomationProperties.Name="Set as Startup Folder"
                       Click="FolderContextMenu_SetStartupFolder_Click"/>
-            <MenuItem Header="Clear Start_up Folder"
+            <MenuItem Header="Clear Startup _Folder"
                       AutomationProperties.Name="Clear Startup Folder"
                       Click="FolderContextMenu_ClearStartupFolder_Click"/>
             <Separator/>

--- a/QuickMail/Views/MainWindow.xaml
+++ b/QuickMail/Views/MainWindow.xaml
@@ -249,6 +249,14 @@
                       AutomationProperties.Name="Use Automatic Archive Folder"
                       Click="FolderContextMenu_ClearArchive_Click"/>
             <Separator/>
+            <!-- #516. Mnemonics: N, M, C, A, u and D are taken above, so S and the u in "Start_up". -->
+            <MenuItem Header="Set as _Startup Folder"
+                      AutomationProperties.Name="Set as Startup Folder"
+                      Click="FolderContextMenu_SetStartupFolder_Click"/>
+            <MenuItem Header="Clear Start_up Folder"
+                      AutomationProperties.Name="Clear Startup Folder"
+                      Click="FolderContextMenu_ClearStartupFolder_Click"/>
+            <Separator/>
             <MenuItem Header="_Delete Folder"
                       AutomationProperties.Name="Delete Folder"
                       Click="FolderContextMenu_DeleteFolder_Click"/>

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -1299,6 +1299,18 @@ public partial class MainWindow : Window
             execute: () => Report(_vm.ClearDefaultCalendar()),
             isAvailable: () => _vm.CalendarVm != null));
 
+        // ── Startup folder (#516) ──
+        // No default key: the folder-tree context menu and Settings > Startup are the primary
+        // entry points. Registered so both are reachable — and rebindable — from the palette.
+        _registry.Register(new CommandDefinition(
+            id: "folder.setStartupFolder", category: "Mail", title: "Set as Startup Folder",
+            execute: SetStartupFolderFromSelection,
+            isAvailable: () => FolderList.IsKeyboardFocusWithin && FolderList.SelectedItem != null));
+
+        _registry.Register(new CommandDefinition(
+            id: "folder.clearStartupFolder", category: "Mail", title: "Clear Startup Folder",
+            execute: () => Report(_vm.ClearStartupFolder())));
+
         // ── Respond to a pending invitation (Enter opens the menu; these are the palette entries) ──
         // No default key: Enter (calendar.openSourceMessage) shows the response menu, which is the
         // primary entry point. These keep the actions discoverable and rebindable in the palette.
@@ -5583,6 +5595,19 @@ public partial class MainWindow : Window
             category: AnnouncementCategory.Result);
         await reload;
     }
+
+    // ── Startup folder (#516) ────────────────────────────────────────────────
+
+    private void FolderContextMenu_SetStartupFolder_Click(object sender, RoutedEventArgs e)
+        => Report(_vm.SetStartupFolder(GetContextMenuFolderNode(sender)));
+
+    private void FolderContextMenu_ClearStartupFolder_Click(object sender, RoutedEventArgs e)
+        => Report(_vm.ClearStartupFolder());
+
+    // Selection-based twins. The context menu must never be the only way to reach an action
+    // (issue #250) — these are what the command palette and any user-assigned hotkey invoke.
+    private void SetStartupFolderFromSelection()
+        => Report(_vm.SetStartupFolder(FolderList.SelectedItem as FolderTreeNode));
 
     // ── Calendar context menu handlers (issue #497) ──────────────────────────
 

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -5885,16 +5885,8 @@ public partial class MainWindow : Window
                 vm.StartupFolder,
                 Guid.TryParse(vm.StartupFolderAccount, out var acct) ? acct : null);
             picker.Owner = dialog;
-            if (picker.ShowDialog() != true || picker.SelectedFolder is not { } folder) return null;
-
-            // A virtual aggregate is stored without the NUL sentinel prefix and with no account —
-            // it spans all of them. A real folder carries its owning account, because folder names
-            // collide across accounts and the pair is what resolves at startup.
-            var isVirtual = folder.FullName.Length > 0 && folder.FullName[0] == '\0';
-            return new SettingsViewModel.StartupFolderChoice(
-                isVirtual ? folder.FullName[1..] : folder.FullName,
-                isVirtual ? string.Empty : folder.AccountId.ToString(),
-                folder.DisplayName);
+            // Hand back the folder itself; converting it to storage form is the VM's job.
+            return picker.ShowDialog() == true ? picker.SelectedFolder : null;
         };
 
         if (dialog.ShowDialog() == true)
@@ -6232,6 +6224,10 @@ public partial class MainWindow : Window
             foreach (var (accountId, folders) in _vm.CachedFolders)
             {
                 if (accountScope is { } scope && accountId != scope) continue;
+                // Since #516 the folder cache is restored from disk at launch, so an entry here no
+                // longer implies the account connected. The fail-closed rule below depends on
+                // "couldn't resolve an Inbox" meaning "not connected", so ask directly.
+                if (!_vm.IsAccountReady(accountId)) continue;
                 var inbox = folders.FirstOrDefault(f =>
                     f.Kind == SpecialFolderKind.Inbox ||
                     string.Equals(f.FullName, "INBOX", StringComparison.OrdinalIgnoreCase));

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -5873,6 +5873,30 @@ public partial class MainWindow : Window
         var vm = new SettingsViewModel(_configService, _registry, _themeService, fontNames,
             (Application.Current as App)?.ScreenshotCapture);
         var dialog = new SettingsDialog(vm) { Owner = this };
+
+        // Picking a startup folder needs a window, which is the View's job — the VM asks and gets a
+        // plain record back (#516). Wired here rather than in SettingsDialog because this is where
+        // the accounts and the folder cache live. The picker is a ShowDialog over the Settings
+        // dialog, which hosts no WebView2, so the modal-nesting rule does not bite.
+        vm.PickStartupFolderRequested = () =>
+        {
+            var picker = FolderPickerWindow.ForStartupFolder(
+                _vm.Accounts, _vm.CachedFolders, MainViewModel.AllVirtualFolders,
+                vm.StartupFolder,
+                Guid.TryParse(vm.StartupFolderAccount, out var acct) ? acct : null);
+            picker.Owner = dialog;
+            if (picker.ShowDialog() != true || picker.SelectedFolder is not { } folder) return null;
+
+            // A virtual aggregate is stored without the NUL sentinel prefix and with no account —
+            // it spans all of them. A real folder carries its owning account, because folder names
+            // collide across accounts and the pair is what resolves at startup.
+            var isVirtual = folder.FullName.Length > 0 && folder.FullName[0] == '\0';
+            return new SettingsViewModel.StartupFolderChoice(
+                isVirtual ? folder.FullName[1..] : folder.FullName,
+                isVirtual ? string.Empty : folder.AccountId.ToString(),
+                folder.DisplayName);
+        };
+
         if (dialog.ShowDialog() == true)
         {
             // The dialog's message loop is dead here, so ApplySettings may safely

--- a/QuickMail/Views/SettingsDialog.xaml
+++ b/QuickMail/Views/SettingsDialog.xaml
@@ -531,6 +531,74 @@
             </TabItem>
 
             <!-- Windowing Tab -->
+            <!-- Startup Tab (#516) -->
+            <TabItem Header="Start_up" AutomationProperties.Name="Startup settings">
+                <ScrollViewer VerticalScrollBarVisibility="Auto">
+                    <StackPanel Margin="10">
+                        <!-- Startup folder -->
+                        <GroupBox Header="Startup _Folder" Padding="10" Margin="0,0,0,15"
+                                  AutomationProperties.Name="Startup folder settings">
+                            <StackPanel>
+                                <TextBlock TextWrapping="Wrap" Margin="0,0,0,8"
+                                           Foreground="{DynamicResource Theme.TextSecondary}" FontSize="{DynamicResource Theme.FontSizeSmall}"
+                                           Text="Where QuickMail opens each time it starts. You can also set this from the folder tree: select a folder, open its context menu, and choose Set as Startup Folder."/>
+                                <Label x:Name="StartupFolderLabelControl"
+                                       Content="Opens _in:"
+                                       Target="{Binding ElementName=StartupFolderBox}"
+                                       FontWeight="SemiBold"/>
+                                <!-- Read-only rather than disabled: a disabled TextBox is skipped by Tab,
+                                     so the value would be unreachable to a keyboard or screen-reader user. -->
+                                <TextBox x:Name="StartupFolderBox"
+                                         Text="{Binding StartupFolderDisplay, Mode=OneWay}"
+                                         IsReadOnly="True"
+                                         AutomationProperties.LabeledBy="{Binding ElementName=StartupFolderLabelControl}"/>
+                                <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+                                    <Button Content="_Choose…"
+                                            Command="{Binding ChooseStartupFolderCommand}"
+                                            AutomationProperties.Name="Choose startup folder"
+                                            MinWidth="90" Margin="0,0,8,0"/>
+                                    <Button Content="C_lear"
+                                            Command="{Binding ClearStartupFolderCommand}"
+                                            AutomationProperties.Name="Clear startup folder"
+                                            MinWidth="90"/>
+                                </StackPanel>
+                            </StackPanel>
+                        </GroupBox>
+
+                        <!-- Startup sync -->
+                        <GroupBox Header="Startup _Sync" Padding="10" Margin="0,0,0,15"
+                                  AutomationProperties.Name="Startup sync settings">
+                            <StackPanel>
+                                <TextBlock TextWrapping="Wrap" Margin="0,0,0,8"
+                                           Foreground="{DynamicResource Theme.TextSecondary}" FontSize="{DynamicResource Theme.FontSizeSmall}"
+                                           Text="How much mail to check when QuickMail starts. Whatever you choose, QuickMail keeps checking every folder in the background afterwards, and new mail still arrives in your inboxes right away."/>
+                                <StackPanel KeyboardNavigation.TabNavigation="Once"
+                                            KeyboardNavigation.DirectionalNavigation="Cycle"
+                                            helpers:RadioGroupNavigation.SelectionFollowsFocus="True">
+                                    <RadioButton Content="Just my start_up folder (recommended)"
+                                                 IsChecked="{Binding IsStartupSyncScopeStartupFolder, Mode=TwoWay}"
+                                                 GroupName="StartupSyncScope"
+                                                 AutomationProperties.Name="Just my startup folder"
+                                                 AutomationProperties.HelpText="Fastest start. Checks only the folders your startup folder shows. If that is All Mail, this checks everything."
+                                                 Margin="0,0,0,4"/>
+                                    <RadioButton Content="Every account's _inbox"
+                                                 IsChecked="{Binding IsStartupSyncScopeInboxes, Mode=TwoWay}"
+                                                 GroupName="StartupSyncScope"
+                                                 AutomationProperties.Name="Every account's inbox"
+                                                 AutomationProperties.HelpText="Checks each account's inbox at startup, whatever folder you open in."
+                                                 Margin="0,0,0,4"/>
+                                    <RadioButton Content="_Every folder"
+                                                 IsChecked="{Binding IsStartupSyncScopeAll, Mode=TwoWay}"
+                                                 GroupName="StartupSyncScope"
+                                                 AutomationProperties.Name="Every folder"
+                                                 AutomationProperties.HelpText="Checks every folder on every account before settling. Slowest start, and how QuickMail behaved before this setting existed."/>
+                                </StackPanel>
+                            </StackPanel>
+                        </GroupBox>
+                    </StackPanel>
+                </ScrollViewer>
+            </TabItem>
+
             <TabItem Header="_Windowing" AutomationProperties.Name="Windowing settings">
                 <ScrollViewer VerticalScrollBarVisibility="Auto">
                     <StackPanel Margin="10">

--- a/QuickMail/Views/SettingsDialog.xaml
+++ b/QuickMail/Views/SettingsDialog.xaml
@@ -530,7 +530,6 @@
                 </Grid>
             </TabItem>
 
-            <!-- Windowing Tab -->
             <!-- Startup Tab (#516) -->
             <TabItem Header="Start_up" AutomationProperties.Name="Startup settings">
                 <ScrollViewer VerticalScrollBarVisibility="Auto">
@@ -553,7 +552,7 @@
                                          IsReadOnly="True"
                                          AutomationProperties.LabeledBy="{Binding ElementName=StartupFolderLabelControl}"/>
                                 <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
-                                    <Button Content="_Choose…"
+                                    <Button Content="C_hoose…"
                                             Command="{Binding ChooseStartupFolderCommand}"
                                             AutomationProperties.Name="Choose startup folder"
                                             MinWidth="90" Margin="0,0,8,0"/>
@@ -566,28 +565,32 @@
                         </GroupBox>
 
                         <!-- Startup sync -->
-                        <GroupBox Header="Startup _Sync" Padding="10" Margin="0,0,0,15"
+                        <!-- Access keys across this whole dialog: G A K U W P (tabs), S (Save),
+                             C (Cancel). This tab therefore uses F I H L Y J X D, all otherwise
+                             unused. WPF cycles between duplicates rather than activating, so a
+                             collision costs the user the keystroke entirely. -->
+                        <GroupBox Header="Startup S_ync" Padding="10" Margin="0,0,0,15"
                                   AutomationProperties.Name="Startup sync settings">
                             <StackPanel>
                                 <TextBlock TextWrapping="Wrap" Margin="0,0,0,8"
                                            Foreground="{DynamicResource Theme.TextSecondary}" FontSize="{DynamicResource Theme.FontSizeSmall}"
-                                           Text="How much mail to check when QuickMail starts. Whatever you choose, QuickMail keeps checking every folder in the background afterwards, and new mail still arrives in your inboxes right away."/>
+                                           Text="How much mail to check when QuickMail starts. New mail still arrives in your inboxes right away whichever you choose. Other folders are caught up by the background check on the General tab — if you have set that to Off, they are only checked when you open them."/>
                                 <StackPanel KeyboardNavigation.TabNavigation="Once"
                                             KeyboardNavigation.DirectionalNavigation="Cycle"
                                             helpers:RadioGroupNavigation.SelectionFollowsFocus="True">
-                                    <RadioButton Content="Just my start_up folder (recommended)"
+                                    <RadioButton Content="_Just my startup folder (recommended)"
                                                  IsChecked="{Binding IsStartupSyncScopeStartupFolder, Mode=TwoWay}"
                                                  GroupName="StartupSyncScope"
                                                  AutomationProperties.Name="Just my startup folder"
                                                  AutomationProperties.HelpText="Fastest start. Checks only the folders your startup folder shows. If that is All Mail, this checks everything."
                                                  Margin="0,0,0,4"/>
-                                    <RadioButton Content="Every account's _inbox"
+                                    <RadioButton Content="Every account's inbo_x"
                                                  IsChecked="{Binding IsStartupSyncScopeInboxes, Mode=TwoWay}"
                                                  GroupName="StartupSyncScope"
                                                  AutomationProperties.Name="Every account's inbox"
                                                  AutomationProperties.HelpText="Checks each account's inbox at startup, whatever folder you open in."
                                                  Margin="0,0,0,4"/>
-                                    <RadioButton Content="_Every folder"
+                                    <RadioButton Content="Every fol_der"
                                                  IsChecked="{Binding IsStartupSyncScopeAll, Mode=TwoWay}"
                                                  GroupName="StartupSyncScope"
                                                  AutomationProperties.Name="Every folder"

--- a/QuickMail/Views/UiProbeDriver.cs
+++ b/QuickMail/Views/UiProbeDriver.cs
@@ -133,6 +133,14 @@ internal sealed class UiProbeDriver
                     w => w is SettingsDialog, path,
                     prepare: w => SelectTabByHeader((SettingsDialog)w, "ppearance"));
 
+            // #516. Its own surface rather than riding on settings-appearance: the Startup tab is
+            // the only Settings pane combining a read-only field, a button row, and a radio group,
+            // and none of that is visible in a capture of a different tab.
+            case "settings-startup":
+                return await CaptureChildWindowAsync(() => _window.ShowSettingsDialogForProbe(),
+                    w => w is SettingsDialog, path,
+                    prepare: w => SelectTabByHeader((SettingsDialog)w, "tart"));
+
             case "command-palette":
                 return await CaptureChildWindowAsync(() => _window.OpenCommandPaletteForProbe(),
                     w => w is CommandPaletteWindow, path);
@@ -146,7 +154,7 @@ internal sealed class UiProbeDriver
                     w => w is RowFieldsWindow, path);
 
             default:
-                LogService.Log($"ui-probe: unknown surface \"{surface}\". Known: inbox, reading-pane, calendar, compose, theme-manager, address-book, rules, saved-views, settings-appearance, command-palette, folder-picker, row-fields.");
+                LogService.Log($"ui-probe: unknown surface \"{surface}\". Known: inbox, reading-pane, calendar, compose, theme-manager, address-book, rules, saved-views, settings-appearance, settings-startup, command-palette, folder-picker, row-fields.");
                 return false;
         }
     }

--- a/QuickMail/Views/ViewManagerWindow.xaml
+++ b/QuickMail/Views/ViewManagerWindow.xaml
@@ -209,13 +209,10 @@
                                    Text="days"/>
                     </Grid>
 
-                    <!-- Options -->
-                    <TextBlock Style="{StaticResource SectionLabel}" Text="Options"
-                               Visibility="{Binding ShowEditPanel, Converter={StaticResource BoolToVis}}"/>
-                    <CheckBox Content="_Default view (applied on startup)"
-                              IsChecked="{Binding EditIsDefault}"
-                              AutomationProperties.Name="Set as default view"
-                              Visibility="{Binding ShowEditPanel, Converter={StaticResource BoolToVis}}"/>
+                    <!-- The "Default view (applied on startup)" checkbox lived here until #516. Setting
+                         a startup folder no longer needs a saved view at all: use the folder tree's
+                         "Set as Startup Folder", or Tools > Settings > Startup. The whole Options
+                         section went with it, being that checkbox and nothing else. -->
 
                     <!-- Name (last before Save — shown after day limit so the suggestion already includes it) -->
                     <TextBlock Style="{StaticResource SectionLabel}" Text="Name"

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -1013,7 +1013,7 @@ Also under **Tools → Settings → Startup**, **Startup Sync** controls how muc
 - **Every account's inbox** — checks each account's inbox, whichever folder you open in.
 - **Every folder** — checks everything before settling. This is how QuickMail behaved before this setting existed.
 
-Whichever you choose, nothing is skipped for long: QuickMail keeps checking every folder in the background afterwards, and new mail still arrives in your inboxes straight away, so notifications are unaffected.
+New mail still arrives in your inboxes straight away whichever you choose, so notifications are unaffected. Other folders are caught up by the background check — the **Check for new mail every** setting on the **General** tab. If you have set that to **Off**, other folders are only checked when you open them.
 
 ---
 

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -985,11 +985,35 @@ Open the **View Manager** from the **View** menu or the command palette. Create 
 
 Press the assigned hotkey from anywhere in the main window to switch to that view immediately.
 
-### Choose what opens at startup
+---
 
-By default QuickMail opens to **All Mail**. To make it open somewhere else — your Inbox, a specific folder, or any saved view — select the **Default view (applied on startup)** checkbox for that view in the View Manager. QuickMail then opens to that view, and the folder it targets, each time it starts. Only one view can be the default at a time; choosing a new default clears the previous one.
+## Startup
 
-So to open directly into a particular folder on launch: navigate to that folder, choose **Save View…** from the **View** menu, then mark the new view as the default in the View Manager.
+By default QuickMail opens to **All Mail**. You can tell it to open anywhere you like instead — one account's Inbox, a project folder, or **All Inboxes**.
+
+### Choose your startup folder
+
+The quickest way is from the folder tree itself:
+
+1. Move to the folder you want (**Ctrl+1** puts you in the folder tree).
+2. Press the **Applications** key, or **Shift+F10**, to open the folder's context menu.
+3. Choose **Set as Startup Folder**.
+
+QuickMail confirms the change, and opens there every time it starts from then on.
+
+You can also do it from **Tools → Settings → Startup**, where the **Opens in** field shows your current choice. Select **Choose…** to pick a different folder from the folder tree, or **Clear** to go back to All Mail. **Clear Startup Folder** in the folder context menu does the same thing.
+
+If the folder later disappears — you delete it, rename it, or remove the account — QuickMail opens in All Mail and tells you why. Nothing is lost and nothing needs repairing.
+
+### Choose how much is checked at startup
+
+Also under **Tools → Settings → Startup**, **Startup Sync** controls how much mail QuickMail checks while it is starting. This matters most if you have several accounts and a lot of folders.
+
+- **Just my startup folder** (recommended) — checks only what your startup folder shows. If your startup folder is All Inboxes, that is every inbox; if it is All Mail, that is everything.
+- **Every account's inbox** — checks each account's inbox, whichever folder you open in.
+- **Every folder** — checks everything before settling. This is how QuickMail behaved before this setting existed.
+
+Whichever you choose, nothing is skipped for long: QuickMail keeps checking every folder in the background afterwards, and new mail still arrives in your inboxes straight away, so notifications are unaffected.
 
 ---
 

--- a/docs/planning/startup-improvements-pm-dev-spec.md
+++ b/docs/planning/startup-improvements-pm-dev-spec.md
@@ -1,421 +1,244 @@
 # Startup Improvements — PM + Dev Spec
 
-**GitHub issue:** [#144 Improve QuickMail startup](https://github.com/kellylford/QuickMail/issues/144)
+**GitHub issues:** [#144 Improve QuickMail startup](https://github.com/kellylford/QuickMail/issues/144) (closed — Phase 1)
+· [#516 Startup folder as a first-class setting, and a configurable startup sync scope](https://github.com/kellylford/QuickMail/issues/516)
+· resolves [#498](https://github.com/kellylford/QuickMail/issues/498)
 
 ## Status
 
 | Phase | Description | Status |
 |---|---|---|
-| 1 | Inbox-first parallel sync in `SyncService` | ✅ Complete — shipped in v0.7.6 |
-| 2 | `ConfigModel.StartupFolder` + `ConfigService` persistence | ⬜ Not started |
-| 3 | Apply `StartupFolder` in `InitialLoadAsync` | ⬜ Not started |
-| 4 | Settings UI — read-only field + "Choose…" button (tree-view picker) | ⬜ Not started |
+| 1 | Inbox-first parallel sync in `SyncService` | ✅ Shipped in v0.7.6 |
+| 2 | Persist the folder list in SQLite | ✅ #516 |
+| 3 | `StartupFolder` config keys | ✅ #516 |
+| 4 | Resolve and apply the startup folder in `InitialLoadAsync` | ✅ #516 |
+| 5 | Retire `SavedView.IsDefault`, with migration | ✅ #516 |
+| 6 | Folder-tree context menu + commands | ✅ #516 |
+| 7 | Settings → Startup | ✅ #516 |
+| 8 | Startup sync scope | ✅ #516 |
 
-**Resume at Phase 2.** Start a new implementation session with: *"Implement Phases 2–4 of `docs/planning/startup-improvements-pm-dev-spec.md`. Phase 1 is complete. Read the spec in full before writing any code."*
+> **This spec was rewritten for #516.** The original Phases 2–4 (a `StartupFolder` limited to
+> virtual folders and saved views, applied *after* the saved-view default, chosen from a flat
+> ComboBox) were never built and are superseded. Their central assumption was wrong: see §2.
 
 ---
 
 ## Section 1: Executive Summary
 
-For users with many email accounts and many folders, QuickMail's startup can feel slow: the cached message list appears immediately, but new mail from the server doesn't show until every folder across every account has been synced — a sequential process that can take 20–40 seconds or more. This spec addresses startup latency through two complementary strategies: (1) smarter sync ordering that prioritizes Inbox folders so new inbox mail surfaces quickly, and (2) a configurable startup folder/view so users choose what they see at launch rather than always landing on "All Mail." Together these changes make the first 5–10 seconds of use feel much more responsive without changing behavior for users who are happy with the current defaults.
+Users kept asking to open QuickMail in a folder of their choosing. The only route was to navigate
+there, save a view, open the View Manager, and tick **Default view (applied on startup)** — three
+surfaces and a permanent saved-view artifact to express one preference. #516 makes the startup
+folder a first-class setting, reachable from the folder tree's context menu or Settings → Startup,
+and removes the saved-view mechanism entirely.
+
+The same change lets users cap how much QuickMail syncs at launch, which matters for anyone with
+several accounts and a deep folder tree.
 
 ---
 
-## Section 2: User Problem & Opportunity
+## Section 2: What the original spec got wrong
 
-### 2.1 Current state (verified)
+The 2026 spec assumed the startup folder was a small config-plus-UI job. It is not, because of one
+fact it did not record:
 
-| Surface | Today | Pain | Who feels it |
-|---|---|---|---|
-| Startup folder | Always "All Mail" (`AllMailFolder` sentinel, hardcoded at `MainViewModel.cs:1301`) | Users who mostly live in their inbox see a big "All Mail" list that then changes again after sync | Multi-account users, inbox-focused users |
-| Sync ordering | All accounts synced sequentially, all folders per account before moving to next account (`SyncService.cs:50-88`) | New inbox mail doesn't appear until every sent/trash/bulk folder for every account is done | Anyone with more than ~2 accounts or 20+ folders |
-| Default view override | Requires creating a saved view and marking it IsDefault | User-hostile: a persistent UI artifact just to control startup destination | Power users, accessibility users |
-| Startup folder setting | Does not exist | No way to say "start me in All Inboxes" without creating a saved view | All users |
+**The folder list was never persisted.** `MainViewModel._cachedFolders` was in-memory only, filled
+by `GetFoldersAsync` after connect. So at launch nothing knew which folders existed, let alone which
+were Inboxes. That made "open me in All Inboxes" unimplementable before the network came up — which
+is exactly why the saved-view default was applied *post-connect* and why users saw All Mail first
+and a switch a few seconds later. Issue #57 had already moved that application from post-sync to
+post-connect; it shortened the flash without removing it.
 
-**Code-verified facts:**
-- `InitialLoadAsync()` (`MainViewModel.cs:1299`) hardcodes `SelectedFolder = AllMailFolder`.
-- `SyncAllAccountsAsync()` (`SyncService.cs:33`) iterates accounts sequentially, then folders within each account sequentially. No prioritization.
-- A saved-view default IS applied, but only after `ConnectAllAccountsAsync()` completes (`MainViewModel.cs:1407`). This typically means ~5–15s after launch before the default view is applied.
-- `ConfigModel` has no `StartupFolder` or startup-destination property.
+It is also why the folder tree at launch showed only the eight virtual aggregates, and the root
+cause behind [#451](https://github.com/kellylford/QuickMail/issues/451).
 
-### 2.2 Target personas
+So #516 starts by persisting folder metadata, and everything else builds on it.
 
-**Alex — 4-account power user.** Has work IMAP, personal IMAP, a newsletter account, and a list account. Each has 40+ folders. Startup sync takes 45 seconds. By the time new mail appears, Alex has given up and checked the phone instead.
-
-**Sam — single account, lots of folders.** Uses aggressive sub-folder filing. Has 80+ folders. Starting in "All Mail" dumps 2,000+ cached messages that reload again after sync. Sam just wants to see their inbox.
-
-**Jordan — screen reader user.** The long sync with announcements every 10 folders creates many "Synced X of Y folders" announcements before the real mail is visible. Jordan wants the inbox-relevant mail announced first.
-
-**Casey — new user.** Has 2 accounts, all mail in inbox. The default "All Mail" view is confusing — shows duplicates of inbox mail alongside sent, and Casey doesn't understand the difference from "All Inboxes."
-
-**Morgan — rules-heavy user.** Has mail rules that move everything out of inbox into folders. "All Mail" is the right default for Morgan. A configurable setting lets Morgan keep the current behavior while others change theirs.
-
-### 2.3 Why now
-
-- The saved-view default mechanism (issue #57 fix) is already in place — this builds on top of it.
-- Sync infrastructure is stable; inbox-first ordering is a targeted change to `SyncService`.
-- No external dependencies. No schema changes to SQLite.
+Two further corrections to the original text: the settings dialog is `Views/SettingsDialog.xaml`
+(there is no `SettingsWindow.xaml`), and its line references were stale by roughly 800 lines.
 
 ---
 
-## Section 3: Design Principles
+## Section 3: Design principles
 
-1. **Zero behavior change for existing users who don't opt in.** The default startup folder stays "All Mail" to match today's behavior. Inbox-first sync is a transparent optimization with no user-visible change except speed.
-2. **The setting is simple: one choice, not a tree.** The startup folder picker presents a flat list of options (virtual folders + saved views), not the full folder tree.
-3. **Fast path for the common case.** Inbox-first sync must reduce time-to-new-mail for inbox-focused users even if they never touch the setting.
-4. **Respect the existing saved-view default.** If a user has set a saved view as default, that takes precedence over the new `StartupFolder` setting.
-
----
-
-## Section 4: Feature Scope & Acceptance Criteria
-
-### 4.1 In scope (v1)
-
-| Feature | Setting / Location | Default | Notes |
-|---|---|---|---|
-| Startup folder setting | `StartupFolder` in `[startup]` section of config.ini | `"AllMail"` (current behavior) | Accepts: `"AllMail"`, `"AllInboxes"`, `"AllDrafts"`, `"AllSent"`, `"AllTrash"`, or a saved-view name |
-| Startup folder UI | **Settings → General → Startup folder** — read-only field + "Choose…" button | All Mail | Opens `FolderPickerWindow` (tree-view) scoped to virtual folders and saved views; keyboard-friendly |
-| Inbox-first sync ordering | Internal to `SyncService`; no UI | On (transparent) | Inbox/Inbox-kind folders across all accounts sync first, then remaining folders |
-| Parallel account sync | Internal to `SyncService`; no UI | On (transparent) | Accounts sync concurrently (capped at N connections per account, already enforced by `ImapMailService`) |
-| Change default from All Mail to All Inboxes | Opt-in via setting | No change (stays All Mail) | Recommended in onboarding/docs, not enforced |
-
-### 4.2 Explicitly out of scope (v1)
-
-- Per-account startup folder (one global setting only).
-- Startup folder set to a specific real IMAP folder (e.g. "work/Projects"). Only virtual folders and saved views in v1.
-- Persisting startup folder across profile directories.
-- Startup folder in the first-run tutorial UI (can be added later).
-- Changing `SyncDays` or `InitialSyncCount` as a startup-speed lever (already exposed; out of scope here).
-- Background/idle sync scheduling changes.
+1. **The startup folder is applied from cache, before any connect.** CLAUDE.md's startup rule
+   requires it, and applying it later is the defect being fixed, not an implementation detail.
+2. **One concept, not two.** A startup folder is a folder. Saved views remain what they always
+   were — named filters with hotkeys — and no longer double as a startup mechanism.
+3. **Set it where you already are.** The folder tree is the primary entry point; Settings is where
+   you see and change it.
+4. **Falling back is normal, and it is explained.** A startup folder that no longer resolves opens
+   All Mail and says so. Never a dialog, never a crash.
+5. **Nothing is skipped permanently.** Every sync scope still leaves the periodic sweep visiting
+   every folder and the live watchers covering every Inbox.
 
 ---
 
-## Section 5: Architecture & Technical Decisions
+## Section 4: Scope
 
-### 5.1 Key architectural decisions
+### In scope
 
-**Decision A: Inbox-first sync ordering inside `SyncService`.**
+| Feature | Location | Default |
+|---|---|---|
+| Folder metadata persistence | `Folder` table in `mail.db` | Always on |
+| `StartupFolder` / `StartupFolderAccount` / `StartupFolderLabel` | `[global]` in `config.ini` | Empty = All Mail |
+| `StartupSyncScope` | `[global]` in `config.ini` | `startupFolder` |
+| Set / Clear from the folder tree | `FolderContextMenu` + `folder.setStartupFolder`, `folder.clearStartupFolder` | No default hotkey |
+| Settings → Startup | `SettingsDialog.xaml`, sixth tab | — |
+| Migration off `SavedView.IsDefault` | `StartupFolderMigration`, run once in `App.OnStartup` | — |
 
-Reorder `SyncAllAccountsAsync` to iterate in two passes:
-1. Pass 1: For each account, sync only folders with `SpecialFolderKind.Inbox` (i.e., where `folder.Kind == SpecialFolderKind.Inbox`). Accounts can run in parallel in this pass.
-2. Pass 2: For each account, sync all remaining non-Inbox folders that aren't excluded (`!folder.ExcludeFromAllMail`). Accounts can run in parallel.
-3. After both passes, fire `FolderSynced` and let `StartBackgroundSyncAsync` call `RefreshAsync` as today.
+### Out of scope
 
-**Alternatives:**
-1. Keep sequential, but put Inbox first per account. Pro: simpler, no concurrency. Con: still slow for many accounts — account 1's inbox syncs, then all of account 1's folders, then account 2's inbox, etc.
-2. Full parallelism (all folders, all accounts concurrently). Pro: fastest. Con: can exhaust IMAP connections; harder to reason about; more complex error handling.
-
-**Rationale:** Two-pass with per-account parallelism gives the biggest win with manageable complexity. Each account still uses its own IMAP client (already isolated in `ImapMailService`); parallelism across accounts is safe. `MaxImapConnectionsPerAccount` already caps connections.
-
----
-
-**Decision B: `StartupFolder` stored in `config.ini` as a string key.**
-
-Use the same sentinel naming scheme as virtual folders (e.g., `"AllMail"`, `"AllInboxes"`) plus saved-view names. Saved views are identified by `SavedView.Name` (not Guid, for readability).
-
-**Alternatives:**
-1. Store a Guid for saved views, sentinel string for virtuals. Pro: rename-safe. Con: config file is unreadable; Guid lookup needed on every startup.
-2. Store a JSON blob. Pro: extensible. Con: over-engineered for one setting.
-
-**Rationale:** String keys match how saved views are already serialized (`VirtualFolderKey` in `SavedView`). Renames are an acceptable edge case — if a saved view is renamed, startup falls back to "All Mail" gracefully.
+Per-account startup folders. Launching QuickMail with Windows (#129). Remembering the last folder
+used. Per-folder sync opt-in/opt-out. Scoping the *periodic* sweep (#462). The observable-property
+half of #451 — persisting folders removes its root cause, but re-stamping already-displayed rows is
+a separate change.
 
 ---
 
-**Decision C: `StartupFolder` setting takes lower precedence than the saved-view `IsDefault` flag.**
+## Section 5: Architecture
 
-The existing "Mark as default" saved-view mechanism stays and takes precedence. `StartupFolder` is the new baseline when no saved view is marked default.
+### 5.1 The `Folder` table
 
-**Rationale:** Backwards compatibility. Users who have relied on the saved-view default mechanism since issue #57 see no change. `StartupFolder` is additive.
+`account_id, full_name, display_name, parent_id, kind, exclude_from_all_mail, unread_count,
+message_count, sort_order`, primary key `(account_id, full_name)`. Created with
+`CREATE TABLE IF NOT EXISTS`, so no `user_version` bump — the same treatment `CalendarEvent` got.
+`SuppressUnreadCount` is not stored; it is derived from `Kind`.
 
----
+Written replace-all per account after each discovery, so a folder deleted or renamed on the server
+disappears locally. Read once in `InitialLoadAsync`; purged for unknown accounts there and on
+account deletion.
 
-**Decision D: Parallel account sync uses `Task.WhenAll` with one task per account.**
+### 5.2 The `_cachedFolders` / `_connectedAccountIds` split — the load-bearing decision
 
-Each account runs its Inbox-pass folders concurrently via `Task.WhenAll`. Exception handling: a faulted account task logs and continues; it does not cancel others.
+`_cachedFolders` used to mean *"accounts connected this session"*: an account appeared there only
+after `GetFoldersAsync` succeeded, and eleven call sites relied on that. Pre-filling it from SQLite
+would have made every one of them report "connected" for accounts that never came up — the full
+sync firing at unreachable servers, watchers starting for them, the status bar claiming connections
+that did not exist, and `AccountsNeedingConnect` no longer reconnecting them.
 
-**Rationale:** `ImapMailService.GetOrReconnectAsync` is account-scoped and thread-safe for concurrent calls on different accounts. Same pattern used elsewhere in the codebase.
+Connection state therefore has its own home, `_connectedAccountIds`. **Anything asking "did we
+connect?" must use the set; anything asking "what folders do we know about?" uses the dictionary.**
+Sites moved to the set: the sync guard, the sync account list, the periodic sweep, `WireUpWatchers`,
+`IsAccountReady`, the All Mail IMAP fetch phase, `AccountsNeedingConnect`, and the connected-count
+labels.
 
----
+This is the first thing to check if a startup or connection bug appears near this code.
 
-### 5.2 Runtime mode compatibility
+### 5.3 Startup folder resolution
 
-| Mode | Behavior |
+`ConfigModel.StartupFolder` holds one of four things:
+
+| Value | Meaning |
 |---|---|
-| Normal | Full feature: inbox-first sync, startup folder applied from config |
-| `--online` | No sync at all today; startup folder still applies (controls which virtual folder is selected before the IMAP fetch) |
-| `--profileDir <path>` | Uses alternate config.ini — `StartupFolder` read from that profile's config |
+| empty | All Mail (the default, and today's behaviour) |
+| `AllInboxes`, `AllMail`, … | A virtual aggregate. Stored without the NUL sentinel prefix — an INI file cannot carry one — matching the `SavedView.VirtualFolderKey` convention. |
+| a folder's `FullName` + `StartupFolderAccount` | A real folder. The account is required: folder names collide across accounts, and the pair is what resolves. |
+| `view:{guid}` | A migrated multi-folder saved view. **Written only by the migration**; no picker offers or can create it. |
 
-### 5.3 Code reuse and duplication risks
+`StartupFolderLabel` is display-only, stored rather than derived because a Microsoft Graph
+`FullName` is an opaque server id with nothing human-readable to fall back on.
 
-- `FetchVirtualAsync(AllMailFolder)` is currently called in three places when online mode or no default view: at `InitialLoadAsync` for the cache, and again in `StartBackgroundSyncAsync`. The startup-folder selection needs to call the right fetch method for each virtual folder type. Use the existing `RefreshAsync()` (which already handles all sentinel types) rather than duplicating dispatch logic.
+Anything unresolvable falls back to All Mail with the reason in the status bar and one
+`AnnouncementCategory.Status` announce.
 
-### 5.4 Shared component audit
+`--online` never initializes the local store, so it resolves against config alone
+(`ResolveOnlineStartupFolder`) and its background path calls `RefreshAsync` instead of a hardcoded
+All Mail fetch. The setting was previously ignored entirely on that path.
 
-| Component | File | Other consumers | Change needed | Risk |
-|---|---|---|---|---|
-| `SyncService.SyncAllAccountsAsync` | `Services/SyncService.cs` | `StartBackgroundSyncAsync` in `MainViewModel` | Add two-pass inbox-first + parallel account sync | Progress counter math changes; `SyncProgressChanged` must still fire accurately. Tests must cover new ordering. |
-| `ConfigModel` | `Models/ConfigModel.cs` | `ConfigService`, every settings VM | Add `StartupFolder` string property | Additive only; no existing consumers affected. |
-| `ConfigService` | `Services/ConfigService.cs` | All settings read/write | Read/write `StartupFolder` from `[startup]` section | Well-isolated INI section; no risk to other sections. |
-| `MainViewModel.InitialLoadAsync` | `ViewModels/MainViewModel.cs` | `App.xaml.cs` (called once on startup) | Apply `StartupFolder` setting instead of hardcoded `AllMailFolder` | Must fall back to `AllMailFolder` if setting is invalid or no match. |
-| `SettingsViewModel` | `ViewModels/SettingsViewModel.cs` | `SettingsWindow` | Add `StartupFolder` property + picker options | No other consumers of `SettingsViewModel`. |
-| `SettingsWindow.xaml` | `Views/SettingsWindow.xaml` | — | Add ComboBox for Startup folder | XAML parse test covers this. |
-| `ISyncService` | `Services/ISyncService.cs` | `MainViewModel`, `StubServices` (tests) | `SyncAllAccountsAsync` signature unchanged | `StubSyncService` in tests needs no change if signature unchanged. |
+### 5.4 Startup sync scope
 
----
+`SyncAllAccountsAsync` has exactly one caller, so it *is* the startup sync and reads the scope from
+config itself — keeping it off `ISyncService` and out of the five test stubs.
 
-## Section 6: Keyboard Walkthrough
+`startupFolder` mirrors what the startup folder shows. **Note the consequence:** with no startup
+folder configured, that is All Mail, which spans everything, so those users still get the full
+sweep. A narrower sync would leave stale rows on the screen they are looking at. The saving is
+opted into by choosing a narrower place to start; `inboxes` is there for anyone who wants it
+unconditionally.
 
-### Path A: Change startup folder in settings
+Cases that cannot be resolved narrowly sync wide: a startup folder that no longer exists (startup
+itself falls back to All Mail), an unparseable account id, and `view:{guid}`. Under-syncing what the
+user is looking at is the worse failure.
 
-1. User opens Settings (Ctrl+,). **Expected:** Settings window opens, focus on first tab.
-2. User navigates to the "General" tab. **Expected:** General settings pane is visible.
-3. User presses Tab to reach the "Startup folder" read-only text field. **Expected:** Screen reader announces "Startup folder" label then field value (e.g. "All Mail").
-4. User presses Tab to the "Choose…" button and activates it. **Expected:** Folder picker window opens — using `FolderPickerWindow` (tree-view) scoped to virtual folders and saved views. Focus lands on the folder tree. Screen reader announces the current selection (e.g. "All Mail").
-5. User presses Down arrow to move to "All Inboxes". **Expected:** Screen reader announces "All Inboxes".
-6. User presses Enter to confirm. **Expected:** Picker closes, "Startup folder" field in Settings updates to "All Inboxes". Change is not yet saved.
-7. User activates "Save" button. **Expected:** Settings window closes, setting written to config.ini. No restart required.
-8. User restarts QuickMail. **Expected:** App opens with "All Inboxes" selected in the folder tree, "All Inboxes" messages loaded from cache immediately.
-
-### Path B: Startup with "All Inboxes" selected (user has set it)
-
-1. App launches. **Expected:** Folder tree visible, "All Inboxes" is the selected folder. Cache shows inbox messages immediately. Status bar says "N messages (cached — syncing…)".
-2. Sync runs (inbox-first pass). **Expected:** After a few seconds (inbox folders only), message list updates with new inbox mail. Screen reader announces "N messages loaded." (when `AnnounceStatus` is on).
-3. Sync continues (remaining folders in background). **Expected:** No UI change to the message list (user is in All Inboxes; non-inbox folders don't affect this view). Status bar updates to "N messages." when sync completes.
-
-### Path C: Inbox-first sync (transparent, no setting changed)
-
-1. App launches with default "All Mail" setting. **Expected:** Cached messages shown immediately as today.
-2. Inbox folders across all accounts sync first. **Expected:** New inbox messages appear in the All Mail list within a few seconds of launch (much sooner than today).
-3. Remaining folders sync. **Expected:** Additional non-inbox messages trickle in as each folder completes, exactly as today.
-4. Sync completes. **Expected:** Status bar and announcement as today.
-
-### Path D: Saved view default (existing behavior, unchanged)
-
-1. User has saved view "Work Inbox" marked as default. **Expected:** After connections ready (~5s), "Work Inbox" view is applied. `StartupFolder` setting is ignored (saved-view default takes precedence).
-
-### Path E: Edge case — saved view referenced by StartupFolder is deleted
-
-1. User had saved view "My View" set as startup folder. User then deleted "My View". **Expected:** App falls back to "All Mail" silently. No crash. No error dialog.
+The `SyncProgressChanged` denominator comes from the same filtered set, or the progress announcement
+names a total the sync never reaches and "Sync complete" never fires.
 
 ---
 
-## Section 7: Accessibility Checklist
+## Section 6: Keyboard walkthrough
 
-- **`AutomationProperties.Name`:** The read-only text field gets its name from a `<Label Target="{Binding ElementName=StartupFolderField}">` binding (matching the existing settings UI pattern). The "Choose…" button gets `AutomationProperties.Name="Choose startup folder"`. `FolderPickerWindow` already has its own accessible names — no new ones needed there.
-- **Announcements:** No new `AccessibilityHelper.Announce` calls needed. The existing "N messages loaded" `AnnouncementCategory.Status` announcement at end of sync covers the startup-folder case. Inbox-first sync is transparent — no new announcement.
-- **Focus restoration:** The Settings ComboBox is in the existing tab order; no special focus restoration needed.
-- **F6 ring:** No new panes. No F6 changes.
-- **Radio/checkbox groups:** No new grouped controls; the ComboBox is a single control.
-- **Color-only information:** None.
+### Path A — set it from the folder tree
 
----
+1. **Ctrl+1** moves focus to the folder tree.
+2. Arrow to the folder. The screen reader announces the folder and its unread count.
+3. Press the **Applications** key (or **Shift+F10**). Announced: "Folder actions".
+4. Arrow to **Set as Startup Folder**, press **Enter**. The menu closes, focus returns to the
+   folder, and a `Result` announcement says "QuickMail will open in Projects." The status bar shows
+   the same sentence.
 
-## Section 8: Acceptance Walkthrough
+### Path B — set it from Settings
 
-### Scenario 1: Change startup folder to All Inboxes
+1. **Ctrl+,** opens Settings.
+2. **Ctrl+Tab** to the **Startup** tab. Announced: "Startup settings".
+3. **Tab** reaches the read-only **Opens in** field, which reads its current value ("All Mail" when
+   nothing is configured). It is read-only rather than disabled so Tab still reaches it.
+4. **Tab** to **Choose…**, **Enter**. The folder tree picker opens with the current startup folder
+   already selected — never nothing.
+5. Arrow to the folder, **Enter**. The picker closes; the field updates.
+6. **Tab** to the **Startup Sync** radio group: one tab stop, arrows move and select together.
+7. **Tab** to **Save**, **Enter**.
 
-**Setup:** App running. At least 2 accounts configured with mail in Inbox. Current startup folder is "All Mail" (default).
+### Path C — launching
 
-1. Open Settings (Ctrl+,). **Verify:** Settings window opens.
-2. Navigate to General tab. **Verify:** "Startup folder" field is present showing "All Mail", and a "Choose…" button is beside it.
-3. Activate "Choose…", navigate to "All Inboxes" in the tree picker, press Enter. Activate "Save". **Verify:** Settings closes, config.ini `[startup]` section contains `StartupFolder=AllInboxes`.
-4. Restart app. **Verify:** Folder tree shows "All Inboxes" selected, message list shows inbox messages from cache. Message count status bar visible.
-5. Wait for sync to complete. **Verify:** Message list updates with new inbox mail. No "All Mail" messages visible.
+The app opens with the startup folder selected and its cached messages already listed. No All Mail
+flash. The folder tree is fully populated from cache before any connect. Status bar:
+"N messages in Projects (cached — syncing…)".
 
-### Scenario 2: Inbox-first sync speed improvement
+### Path D — the folder is gone
 
-**Setup:** App configured with 2+ accounts, each with 10+ folders. Observer: watch the message list update during startup.
-
-1. Launch app (default All Mail startup folder). **Verify:** Cached messages appear immediately.
-2. Watch first message list update after sync begins. **Verify:** New messages arrive in the list within ~5 seconds (inbox folders complete first, before sent/trash/bulk). Previously this took longer.
-3. Continue watching. **Verify:** Additional messages arrive as other folders complete. No regression in final message count.
-
-### Scenario 3: Saved-view default takes precedence over StartupFolder
-
-**Setup:** A saved view "Work" is marked as default (IsDefault = true). StartupFolder is set to "AllInboxes" in config.
-
-1. Launch app. **Verify:** After connections ready, "Work" saved view is applied — not "All Inboxes". The saved-view default wins.
-
-### Scenario 4: Invalid StartupFolder falls back gracefully
-
-**Setup:** Manually set `StartupFolder=NonExistentView` in config.ini.
-
-1. Launch app. **Verify:** App starts normally with "All Mail" selected. No crash, no error dialog.
-
-### Scenario 5: Settings — screen reader
-
-**Setup:** Screen reader active.
-
-1. Tab to "Startup folder" ComboBox in Settings. **Verify:** Screen reader announces "Startup folder" and current value (e.g., "All Mail").
-2. Open dropdown and navigate options. **Verify:** Each option name is announced as focus moves.
-3. Save with changed selection. **Verify:** No unexpected announcements. Settings closes.
-
-### Scenario 6: `--online` mode
-
-**Setup:** Launch with `--online` flag. StartupFolder set to "AllInboxes".
-
-1. Launch app. **Verify:** "All Inboxes" is selected at startup. IMAP fetch runs for All Inboxes virtual folder. No crash.
+The app opens in All Mail. Status bar and one `Status` announcement: "Startup folder 'Projects' was
+not found — showing All Mail." No dialog.
 
 ---
 
-## Section 9: Success Metrics
+## Section 7: Infrastructure changes
 
-- **Primary happy path works:** User sets StartupFolder to "AllInboxes", restarts, lands in All Inboxes with cached messages visible immediately.
-- **Speed improvement is perceptible:** On a 3-account × 30-folder setup, new inbox mail appears in the list within 5–10 seconds (inbox-first pass) rather than 30–45 seconds (after all folders).
-- **No regression:** Existing behavior for users with a saved-view default is unchanged. `IsDefault` saved view still overrides StartupFolder.
-- **Invalid config handled:** Deleting a referenced saved view does not crash on startup.
-- **Keyboard-only:** All new settings UI operable with Tab, arrow keys, Enter, Escape.
-- **`--online` mode compatible:** Feature works correctly under `--online`.
-
----
-
-## Section 10: Implementation Phases
-
-### Phase 1: Inbox-first parallel sync in SyncService ✅ Complete (v0.7.6)
-
-**Goal:** `SyncAllAccountsAsync` runs Inbox folders first (all accounts concurrently), then all remaining folders (all accounts concurrently). Progress reporting still accurate.
-
-**Deliverables:**
-- Modify `QuickMail/Services/SyncService.cs`: restructure `SyncAllAccountsAsync` into two `Task.WhenAll` passes.
-- Pass 1: one `Task` per account, each syncing only `folder.Kind == SpecialFolderKind.Inbox` folders.
-- Pass 2: one `Task` per account, each syncing remaining non-excluded folders.
-- `SyncProgressChanged` fires from within each task; total count stays the same.
-
-**Tests:**
-- `SyncServiceTests` (new): verify inbox folders complete before non-inbox folders using a controllable stub. Verify `SyncProgressChanged` fires the correct total count. Verify an exception in one account task does not prevent other accounts from completing.
-
-**Risk:** Race in `SyncProgressChanged` counter across parallel tasks — use `Interlocked.Increment` on `completedFolders`. Medium probability, Medium impact. Mitigation: unit test with two concurrent accounts.
-
-**Duration:** 2–3 hours
+- **F6 ring:** unchanged. No new panes.
+- **Commands:** `folder.setStartupFolder` and `folder.clearStartupFolder`, category `Mail`, no
+  default hotkeys. Both registered in `MainWindow.xaml.cs`.
+- **`AutomationProperties.Name` added:** "Startup settings", "Startup folder settings", "Startup
+  sync settings", "Choose startup folder", "Clear startup folder", "Set as Startup Folder", "Clear
+  Startup Folder", and one per sync-scope radio.
+- **Announcements added:** the set/clear/refusal sentences via `Report(...)`
+  (`AnnouncementCategory.Result`), and the startup fallback sentence
+  (`AnnouncementCategory.Status`). No new announcement categories.
+- **Removed:** `SavedView.IsDefault`, `ViewManagerViewModel.EditIsDefault`, the View Manager's
+  Options group, and the post-connect `ApplyViewAsync` call in `StartBackgroundSyncAsync`.
+- **VM state:** `MainViewModel._connectedAccountIds` is new and is now the authority on connection
+  state (§5.2).
+- **Test registries touched:** `RadioGroupWiringTests.RadioGroupSites` gains `StartupSyncScope`.
+  No new `Selector`-bound type, so `SelectorItemAccessibilityTests` and `TypeAheadWiringTests` are
+  unaffected.
 
 ---
 
-### Phase 2: ConfigModel + ConfigService for StartupFolder
+## Section 8: Tests
 
-**Goal:** `ConfigModel.StartupFolder` property reads from and writes to `[startup]` section of config.ini.
-
-**Deliverables:**
-- Modify `QuickMail/Models/ConfigModel.cs`: add `public string StartupFolder { get; set; } = "AllMail";`
-- Modify `QuickMail/Services/ConfigService.cs`: read/write `StartupFolder` from `[startup]` section (new section).
-
-**Tests:**
-- `SettingsViewModelTests` or a new `ConfigServiceStartupTests`: round-trip read/write of `StartupFolder`. Test default (key absent from config.ini returns `"AllMail"`). Test unknown value round-trips as-is.
-
-**Risk:** New INI section parsing — low risk given existing pattern. Low probability, Minor impact.
-
-**Duration:** 1–2 hours
+| Suite | Covers |
+|---|---|
+| `FolderStoreTests` | Folder table round-trip, replace-on-save, per-account isolation, purge, idempotent `Initialize` |
+| `ConfigServiceSaveTests` | All four keys through a real INI, fresh-config defaults, scope normalisation |
+| `MainViewModelStartupTests` | Resolution for each form, every fallback, `--online` |
+| `StartupFolderMigrationTests` | Each `IsDefault` shape, malformed JSON, never overwriting an explicit choice |
+| `StartupFolderCommandTests` | The context-menu guard, including the aggregates it must accept and the sentinels it must refuse |
+| `StartupSyncScopeTests` | Which folders each scope actually visits; the progress denominator |
+| `StartupSettingsTests` | Settings round-trip, Choose/Clear, and call-site guards on the picker |
 
 ---
 
-### Phase 3: Apply StartupFolder in InitialLoadAsync
+## Section 9: Known limitation
 
-**Goal:** `InitialLoadAsync` selects the startup folder based on `ConfigModel.StartupFolder`, falling back to `AllMailFolder` for unrecognized values.
-
-**Deliverables:**
-- Modify `QuickMail/ViewModels/MainViewModel.cs` `InitialLoadAsync()`:
-  - Read `_configService.Load().StartupFolder`.
-  - Map the value to the correct `MailFolderModel` sentinel (using existing sentinel constants: `AllMailFolder`, `AllInboxesFolder`, `AllDraftsFolder`, `AllSentFolder`, `AllTrashFolder`, or a matching saved view).
-  - Fall back to `AllMailFolder` if no match.
-  - Set `SelectedFolder` to the resolved folder.
-  - Load cache for that folder (for virtual folders: `LoadAllSummariesAsync` already loads everything from SQLite, which is correct for any virtual view — no change needed there).
-
-**Tests:**
-- `MainViewModelStartupTests` (new or extend existing): verify `InitialLoadAsync` selects the correct `SelectedFolder` for each valid `StartupFolder` value; verify fallback to `AllMailFolder` for unknown value.
-
-**Risk:** If `SavedViews` is not yet populated when `InitialLoadAsync` runs (saved views load async from store), the saved-view lookup may fail to match. Mitigation: load saved views synchronously during `InitialLoadAsync` before the folder lookup, or accept that saved-view startup folder may silently fall back to "All Mail" on first launch (acceptable — saved views are populated before display in normal flow).
-
-**Duration:** 1–2 hours
-
----
-
-### Phase 4: Settings UI
-
-**Goal:** Users can select their startup folder in Settings → General.
-
-**Deliverables:**
-- Modify `QuickMail/ViewModels/SettingsViewModel.cs`: add `StartupFolder` string property (two-way bound to config). Add `StartupFolderOptions` list populated from virtual folder names + current saved views.
-- Modify `QuickMail/Views/SettingsWindow.xaml`: add Label + ComboBox in General section, bound to `StartupFolder` and `StartupFolderOptions`.
-- Options list: "All Mail", "All Inboxes", "All Drafts", "All Sent", "All Trash", then each saved view by name.
-
-**Tests:**
-- `XamlParseTests`: `SettingsWindow` XAML loads without error (catches XAML binding mistakes).
-- `SettingsViewModelTests`: verify `StartupFolderOptions` contains at least the 5 virtual folder options; verify `StartupFolder` property round-trips through config.
-
-**Risk:** `SettingsViewModel` currently has no dependency on `ISavedViewService` or the saved views list. Options: (a) inject saved views at construction (preferred), (b) derive options from `_viewService.GetSavedViews()`. Verify that existing `SettingsViewModelTests` compile and pass with the new injection.
-
-**Duration:** 2–3 hours
-
----
-
-## Section 11: Files to Create / Modify
-
-### Files to Modify
-
-| File | Changes | Lines changed (est.) |
-|---|---|---|
-| `Services/SyncService.cs` | Restructure `SyncAllAccountsAsync` into two-pass parallel; `Interlocked.Increment` for progress counter | +40, -20 |
-| `Models/ConfigModel.cs` | Add `StartupFolder` string property with default `"AllMail"` | +5 |
-| `Services/ConfigService.cs` | Read/write `[startup]` section; parse `StartupFolder` | +15 |
-| `ViewModels/MainViewModel.cs` | `InitialLoadAsync`: resolve startup folder from config | +20 |
-| `ViewModels/SettingsViewModel.cs` | Add `StartupFolder`, `StartupFolderOptions` | +30 |
-| `Views/SettingsWindow.xaml` | Add Label, read-only TextBlock, and "Choose…" button for startup folder in General tab | +15 |
-
-### Files to Create
-
-None. All changes extend existing files.
-
----
-
-## Section 12: Tests to Add
-
-| Test Class | Test Methods | Coverage |
-|---|---|---|
-| `SyncServiceTests` (new) | `InboxFoldersCompleteBeforeOtherFolders`, `ExceptionInOneAccountDoesNotCancelOthers`, `ProgressCounterAccurateWithParallelAccounts` | Sync ordering, error isolation, progress reporting |
-| `ConfigServiceStartupTests` (new or extend `SettingsViewModelTests`) | `StartupFolder_DefaultIsAllMail`, `StartupFolder_RoundTrip`, `StartupFolder_AbsentKeyReturnsDefault` | Config persistence |
-| `MainViewModelStartupTests` (new or extend `ViewModelConstructionTests`) | `InitialLoad_DefaultStartupFolder_SelectsAllMail`, `InitialLoad_AllInboxesStartupFolder`, `InitialLoad_UnknownStartupFolder_FallsBackToAllMail` | Startup folder resolution |
-| `SettingsViewModelTests` (extend) | `StartupFolderOptions_ContainsVirtualFolders`, `StartupFolder_BindsToConfig` | Settings persistence |
-| `XamlParseTests` (extend) | `SettingsWindow_ParsesWithoutError` (already exists, covers new XAML) | XAML correctness |
-
----
-
-## Section 13: Known Risks & Open Questions
-
-### 13.1 Risks
-
-| Risk | Probability | Impact | Mitigation |
-|---|---|---|---|
-| `Interlocked.Increment` race in `SyncProgressChanged` counter with parallel accounts | Medium | Minor (cosmetic: incorrect progress count) | Use `Interlocked.Increment`; unit test with two concurrent accounts |
-| Saved-view lookup in `InitialLoadAsync` fails because views not yet loaded from SQLite | Medium | Minor (silent fallback to All Mail) | Acceptable for v1; document in Phase 3 implementation note |
-| Parallel account sync reveals hidden concurrency bug in `ImapMailService` | Low | Major | Each account already has its own IMAP client stack; concurrent calls on *different* accounts are safe. Test with 3+ accounts. |
-| `SyncService` progress total count changes if Inbox-pass and remaining-pass overlap | Low | Minor | Count all non-excluded folders once at the start, same as today; the two-pass split doesn't change total. |
-
-### 13.2 Open questions
-
-All resolved before implementation:
-
-- **Q: Should parallel account sync be capped?** No additional cap needed — each account's IMAP connections are already limited by `MaxImapConnectionsPerAccount`. `Task.WhenAll` over accounts is safe.
-- **Q: What if a user's saved view is named "AllMail" — does it shadow the virtual folder?** The virtual folders are matched first by sentinel name; saved views are matched second. "AllMail" (no sentinel prefix) would only shadow if we search saved views before virtuals. Implementation must check sentinel names first.
-- **Q: Should "All Inboxes" become the new default instead of "All Mail"?** No — keep "All Mail" as the default for v1 to avoid surprising existing users. The user guide can recommend "All Inboxes" as the better default for inbox-focused users. This can be revisited for v2.
-
----
-
-## Section 14: Implementation Guidance for AI
-
-### 14.1 Adjustments you're expected to make
-
-- The spec describes `Task.WhenAll` over accounts. If you discover that `ImapMailService.GetOrReconnectAsync` is NOT thread-safe for concurrent calls on *different* account IDs (e.g., a shared dictionary without locking), fall back to sequential account processing but keep the inbox-first folder ordering within each account. Document the deviation.
-- `StartupFolderOptions` in `SettingsViewModel` requires access to saved views. Inject the saved views list via the constructor or a method. Choose whichever approach is consistent with how `SettingsViewModel` currently gets other dynamic data.
-- The ComboBox in `SettingsWindow.xaml` should use `DisplayMemberPath` or an item template that shows the display name. The stored value should be the sentinel/name string, not an index.
-
-### 14.2 When to ask for clarification
-
-- If `ImapMailService` has a shared lock or synchronization concern that makes parallel account access risky, stop and ask before proceeding with Phase 1.
-- If saved views are not available at the time `SettingsViewModel` is constructed (because they load async), stop and ask how to populate `StartupFolderOptions`.
-
-### 14.3 Acceptance walkthrough preview
-
-After implementation, the highest-risk steps to verify are:
-
-1. **Scenario 2, step 2** — inbox messages appear in the list faster than today (subjective but perceptible on a multi-account setup).
-2. **Scenario 3** — saved-view default still overrides `StartupFolder`. This is the most likely regression.
-3. **Scenario 4** — unknown `StartupFolder` value does not crash on startup.
+The periodic sweep is unscoped: it visits every folder every `MailSyncPollMinutes` (default 5). So
+work skipped at launch still happens shortly after. This moves load out of the critical window
+rather than removing it. Scoping the sweep is [#462](https://github.com/kellylford/QuickMail/issues/462)
+and was deliberately left out of #516.

--- a/scripts/ui-probe-plan.json
+++ b/scripts/ui-probe-plan.json
@@ -22,6 +22,11 @@
       "scale": 100
     },
     {
+      "surface": "settings-startup",
+      "theme": "parchment",
+      "scale": 100
+    },
+    {
       "surface": "theme-manager",
       "theme": "parchment",
       "scale": 100
@@ -77,6 +82,11 @@
       "scale": 100
     },
     {
+      "surface": "settings-startup",
+      "theme": "dark",
+      "scale": 100
+    },
+    {
       "surface": "theme-manager",
       "theme": "dark",
       "scale": 100
@@ -128,6 +138,11 @@
     },
     {
       "surface": "settings-appearance",
+      "theme": "parchment",
+      "scale": 150
+    },
+    {
+      "surface": "settings-startup",
       "theme": "parchment",
       "scale": 150
     },


### PR DESCRIPTION
Closes #516. Resolves #498. Removes the root cause behind #451.

Opening QuickMail in a chosen folder no longer requires creating a saved view. Set it from the folder tree's context menu or **Tools → Settings → Startup**.

## What changed

| | |
|---|---|
| **Folder list persisted to SQLite** | The load-bearing prerequisite. It was in-memory only, filled after connect, so nothing at launch knew which folders existed — let alone which were Inboxes. That is why a startup folder could not be honoured before the network came up, and why the tree showed only the aggregates. |
| **Startup folder applied in `InitialLoadAsync`** | From cache, before any connect. #57 moved the old default-view application from post-sync to post-connect, which shortened the All Mail flash without removing it. |
| **`SavedView.IsDefault` retired** | With a one-time migration covering virtual-folder, single-folder and multi-folder default views. |
| **Context menu + Settings** | `folder.setStartupFolder` / `folder.clearStartupFolder`, and a sixth Settings tab. |
| **Startup sync scope** | `startupFolder` (new default) / `inboxes` / `all`. |

## The load-bearing change to watch

`_cachedFolders` used to mean *"accounts connected this session"*, and eleven call sites relied on it. Pre-filling it from SQLite breaks that meaning, so connection state now has its own home, `_connectedAccountIds`. **Anything asking "did we connect?" must use the set; anything asking "what folders do we know about?" uses the dictionary.**

## Independent review

Three reviewers went over the branch. Seven real bugs, two of them data loss — all fixed here, with regression tests. Notably the Settings picker silently dropped every virtual aggregate (so All Inboxes was unselectable) while the test that claimed to cover it only grepped MainWindow's source for a string. Full list in https://github.com/kellylford/QuickMail/issues/516#issuecomment-5240062331.

## One decision worth knowing

`startupFolder` scope syncs what the startup folder *shows*. With none configured that is All Mail, which spans everything — so a user who has not chosen one still gets the full sweep. Syncing narrower than the view would leave visibly stale rows on screen. One line in `BuildStartupScopeFilter` if the default should be lighter for everyone.

## Verification

2804 tests pass. Visual probe run and reviewed in parchment and dark at 100%, parchment at 150%. ARM64 installer built from this branch (run 31387349303) and smoke-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)