### PR TITLE
Fix #520: each folder remembers its own view, and Clear View restores all of it

### DIFF
--- a/QuickMail.Tests/CommandRegistryTests.cs
+++ b/QuickMail.Tests/CommandRegistryTests.cs
@@ -311,4 +311,36 @@ public class CommandRegistryTests
         Assert.Equal("comfortable", configService.Load().AppearanceListDensity);
         Assert.True(vm.IsListDensityComfortable);
     }
+
+    /// <summary>
+    /// Clear View shipped on the View menu but was never registered, so it was absent from the
+    /// command palette and could not be bound to a key — a standing violation of the
+    /// "register first, hardcode never" rule in CLAUDE.md. Reset Folder View is its counterpart
+    /// for per-folder view memory (#520). Neither takes a default gesture.
+    /// </summary>
+    [Fact]
+    public void ViewStateCommands_AreRegisteredUnderView_WithNoDefaultGesture()
+    {
+        var registry = new CommandRegistry();
+        var vm = new MainViewModel(
+            new StubImapMailService(), new StubAccountService(), new StubCredentialService(),
+            new StubLocalStoreService(), new StubOAuthService(), new StubSyncService(),
+            new StubConfigService(), registry, new StubViewService(), new StubRuleService(),
+            new StubSmtpService());
+        Assert.NotNull(vm);
+
+        foreach (var id in new[] { "view.clearView", "view.resetFolderView" })
+        {
+            var cmd = registry.FindById(id);
+            Assert.NotNull(cmd);
+            Assert.Equal("View", cmd!.Category);
+            Assert.Equal(Key.None, cmd.DefaultKey);
+            Assert.Equal(ModifierKeys.None, cmd.DefaultModifiers);
+        }
+
+        // Clear View is offered only when there is a view to clear.
+        var clear = registry.FindById("view.clearView")!;
+        Assert.NotNull(clear.IsAvailable);
+        Assert.False(clear.IsAvailable!());
+    }
 }

--- a/QuickMail.Tests/ConfigServiceSaveTests.cs
+++ b/QuickMail.Tests/ConfigServiceSaveTests.cs
@@ -29,6 +29,61 @@ public class ConfigServiceSaveTests
     }
 
     [Fact]
+    public void SaveThenLoad_RoundTripsSort()
+    {
+        // Sort had exactly the failure this class exists to catch: ConfigModel.Sort existed and
+        // MainViewModel wrote it on every sort change, but ConfigService had neither a parse case
+        // nor a writer block — so the chosen sort survived the process (cached ConfigModel) and
+        // silently reset to Newest First on every launch. Found while fixing #520.
+        var profile = MakeTempProfile();
+        var service = new ConfigService(profile);
+
+        var config = service.Load();
+        config.Sort = "dateAsc";
+        service.Save(config);
+
+        Assert.Equal("dateAsc", new ConfigService(profile).Load().Sort);
+    }
+
+    [Fact]
+    public void SaveThenLoad_RoundTripsFlaggedFirstSort()
+    {
+        var profile = MakeTempProfile();
+        var service = new ConfigService(profile);
+
+        var config = service.Load();
+        config.Sort = "flaggedFirst";
+        service.Save(config);
+
+        Assert.Equal("flaggedFirst", new ConfigService(profile).Load().Sort);
+    }
+
+    [Fact]
+    public void LoadingAnUnrecognisedSort_FallsBackToNewestFirst()
+    {
+        var profile = MakeTempProfile();
+        File.WriteAllText(Path.Combine(profile.ProfileDir, "config.ini"),
+                          "[global]\nSort = nonsense\n");
+
+        Assert.Equal("dateDesc", new ConfigService(profile).Load().Sort);
+    }
+
+    [Fact]
+    public void SaveThenLoad_RoundTripsRememberViewPerFolder()
+    {
+        var profile = MakeTempProfile();
+        var service = new ConfigService(profile);
+
+        Assert.True(service.Load().RememberViewPerFolder);   // on by default (#520)
+
+        var config = service.Load();
+        config.RememberViewPerFolder = false;
+        service.Save(config);
+
+        Assert.False(new ConfigService(profile).Load().RememberViewPerFolder);
+    }
+
+    [Fact]
     public void SaveThenLoad_RoundTripsFieldLabelSettings()
     {
         // Same failure shape as the calendar regression below, and RuleListShowFieldLabels really

--- a/QuickMail.Tests/FolderViewStateTests.cs
+++ b/QuickMail.Tests/FolderViewStateTests.cs
@@ -221,6 +221,16 @@ public class FolderViewStateServiceTests : IDisposable
 // Part C: MainViewModel resolver, detach, and default scoping
 // ---------------------------------------------------------------------------
 
+/// <summary>Minimal account service for the startup-path tests, which resolve a startup folder
+/// scoped by account id.</summary>
+sealed class StartupAccountsStub(Guid accountId) : IAccountService
+{
+    public List<AccountModel> LoadAccounts() =>
+        [new AccountModel { Id = accountId, AccountName = "Test", Username = "test@example.com" }];
+    public void SaveAccounts(List<AccountModel> accounts) { }
+    public void SetDefaultAccount(Guid id) { }
+}
+
 public class PerFolderViewStateTests
 {
     private static readonly Guid AccountA = Guid.NewGuid();
@@ -349,6 +359,77 @@ public class PerFolderViewStateTests
 
         // Nothing was recorded, and the grouping stayed put — the pre-#520 behaviour.
         Assert.Equal(0, store.Writes);
+        Assert.Equal(ViewMode.Conversations, vm.ViewMode);
+    }
+
+    // -- Startup ------------------------------------------------------------
+
+    [Fact]
+    public async Task StartupFolder_OpensWithItsRememberedPresentation()
+    {
+        // The startup paths assign SelectedFolder directly rather than going through
+        // SelectFolderAsync, so they need the resolver applied explicitly. Without that the one
+        // folder the user opens into is the one folder that ignores its own settings — and the
+        // failure is invisible in every test that navigates rather than starts up.
+        var localStore = new StubLocalStoreService();
+        localStore.SeededFolders[AccountA] =
+        [
+            new MailFolderModel { AccountId = AccountA, FullName = "INBOX", DisplayName = "Inbox",
+                                  Kind = SpecialFolderKind.Inbox },
+            new MailFolderModel { AccountId = AccountA, FullName = "Receipts", DisplayName = "Receipts" },
+        ];
+
+        var config = new StubConfigService();
+        var cfg = config.Load();
+        cfg.StartupFolder        = "Receipts";
+        cfg.StartupFolderAccount = AccountA.ToString();
+        cfg.StartupFolderLabel   = "Receipts";
+        config.Save(cfg);
+
+        // Receipts was left grouped by sender.
+        var store = new StubFolderViewStateService();
+        store.Remember(AccountA, "Receipts", ListState.Default with { Mode = ViewMode.From });
+
+        var vm = new MainViewModel(
+            new StubImapMailService(), new StartupAccountsStub(AccountA), new StubCredentialService(),
+            localStore, new StubOAuthService(), new StubSyncService(), config,
+            new StubCommandRegistry(), new FakeViewService(), new StubRuleService(),
+            new StubSmtpService(), folderViewState: store);
+        vm.LoadAccountList();
+
+        await vm.InitialLoadAsync();
+
+        Assert.Equal("Receipts", vm.SelectedFolder?.FullName);
+        Assert.Equal(ViewMode.From, vm.ViewMode);
+    }
+
+    [Fact]
+    public async Task StartupFolder_WithNoRememberedState_UsesTheGlobalDefault()
+    {
+        var localStore = new StubLocalStoreService();
+        localStore.SeededFolders[AccountA] =
+        [
+            new MailFolderModel { AccountId = AccountA, FullName = "INBOX", DisplayName = "Inbox",
+                                  Kind = SpecialFolderKind.Inbox },
+        ];
+
+        var config = new StubConfigService();
+        var cfg = config.Load();
+        cfg.StartupFolder        = "INBOX";
+        cfg.StartupFolderAccount = AccountA.ToString();
+        cfg.ViewMode             = "conversations";
+        config.Save(cfg);
+
+        var vm = new MainViewModel(
+            new StubImapMailService(), new StartupAccountsStub(AccountA), new StubCredentialService(),
+            localStore, new StubOAuthService(), new StubSyncService(), config,
+            new StubCommandRegistry(), new FakeViewService(), new StubRuleService(),
+            new StubSmtpService(), folderViewState: new StubFolderViewStateService());
+        vm.LoadAccountList();
+
+        await vm.InitialLoadAsync();
+
+        Assert.Equal("INBOX", vm.SelectedFolder?.FullName);
         Assert.Equal(ViewMode.Conversations, vm.ViewMode);
     }
 

--- a/QuickMail.Tests/FolderViewStateTests.cs
+++ b/QuickMail.Tests/FolderViewStateTests.cs
@@ -1,0 +1,499 @@
+// Per-folder view state (#520).
+//
+// Coverage:
+//  A. ListState            -- record semantics the whole design leans on.
+//  B. FolderViewStateService -- round-trip, missing/corrupt file, key isolation.
+//  C. MainViewModel        -- the three-layer resolver, detach-to-custom, and the
+//     per-field global-default scoping that keeps a view's grouping out of config.ini.
+//
+// String literal note (same trap as SavedViewsTests): "\x00AllMail" parses as \x00A + "llMail".
+// Always build sentinels as "\x00" + suffix.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.Input;
+using QuickMail.Models;
+using QuickMail.Services;
+using QuickMail.ViewModels;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+// ---------------------------------------------------------------------------
+// Part A: ListState
+// ---------------------------------------------------------------------------
+
+public class ListStateTests
+{
+    [Fact]
+    public void Default_IsFlatUnfilteredNewestFirst()
+    {
+        var s = ListState.Default;
+
+        Assert.Equal(ViewMode.Messages, s.Mode);
+        Assert.Equal(MessageFilter.All, s.Filter);
+        Assert.Null(s.FlagFilterId);
+        Assert.Equal(MessageSort.DateDescending, s.Sort);
+        Assert.Null(s.DayLimit);
+    }
+
+    [Fact]
+    public void Equality_IsByValue()
+    {
+        var a = new ListState(ViewMode.Conversations, MessageFilter.Unread, null, MessageSort.DateAscending, 7);
+        var b = new ListState(ViewMode.Conversations, MessageFilter.Unread, null, MessageSort.DateAscending, 7);
+
+        Assert.Equal(a, b);
+    }
+
+    [Fact]
+    public void With_ProducesADistinctValue_LeavingTheOriginalAlone()
+    {
+        var a = ListState.Default;
+        var b = a with { Mode = ViewMode.From };
+
+        Assert.Equal(ViewMode.Messages, a.Mode);
+        Assert.Equal(ViewMode.From, b.Mode);
+        Assert.NotEqual(a, b);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Part B: FolderViewStateService
+// ---------------------------------------------------------------------------
+
+public class FolderViewStateServiceTests : IDisposable
+{
+    private readonly string _dir;
+
+    public FolderViewStateServiceTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "qm-folderviews-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { /* best effort */ }
+        GC.SuppressFinalize(this);
+    }
+
+    private FolderViewStateService MakeService() => new(new ProfileContext(_dir));
+
+    private string StateFile => Path.Combine(_dir, "folderviews.json");
+
+    private static readonly ListState Sample =
+        new(ViewMode.Conversations, MessageFilter.Unread, "flag-id", MessageSort.AlphaAscending, 30);
+
+    [Fact]
+    public void Recall_UnknownFolder_ReturnsNull()
+        => Assert.Null(MakeService().Recall(Guid.NewGuid(), "INBOX"));
+
+    [Fact]
+    public void Remember_ThenRecall_RoundTripsEveryField()
+    {
+        var account = Guid.NewGuid();
+        var svc = MakeService();
+
+        svc.Remember(account, "INBOX", Sample);
+        var back = svc.Recall(account, "INBOX");
+
+        Assert.NotNull(back);
+        Assert.Equal(Sample, back!.Value);
+    }
+
+    [Fact]
+    public void Remember_SurvivesANewServiceInstance()
+    {
+        var account = Guid.NewGuid();
+        MakeService().Remember(account, "INBOX", Sample);
+
+        // A second instance reads from disk rather than the first instance's cache.
+        Assert.Equal(Sample, MakeService().Recall(account, "INBOX")!.Value);
+    }
+
+    [Fact]
+    public void Remember_Twice_Overwrites()
+    {
+        var account = Guid.NewGuid();
+        var svc = MakeService();
+
+        svc.Remember(account, "INBOX", Sample);
+        svc.Remember(account, "INBOX", ListState.Default);
+
+        Assert.Equal(ListState.Default, svc.Recall(account, "INBOX")!.Value);
+    }
+
+    [Fact]
+    public void Forget_RemovesTheEntry()
+    {
+        var account = Guid.NewGuid();
+        var svc = MakeService();
+        svc.Remember(account, "INBOX", Sample);
+
+        svc.Forget(account, "INBOX");
+
+        Assert.Null(svc.Recall(account, "INBOX"));
+        Assert.Null(MakeService().Recall(account, "INBOX"));   // and on disk
+    }
+
+    [Fact]
+    public void SameFolderName_UnderDifferentAccounts_DoesNotCollide()
+    {
+        var a = Guid.NewGuid();
+        var b = Guid.NewGuid();
+        var svc = MakeService();
+
+        svc.Remember(a, "Archive", Sample);
+        svc.Remember(b, "Archive", ListState.Default);
+
+        Assert.Equal(Sample, svc.Recall(a, "Archive")!.Value);
+        Assert.Equal(ListState.Default, svc.Recall(b, "Archive")!.Value);
+    }
+
+    [Fact]
+    public void VirtualFolderSentinel_DoesNotCollideWithARealFolderOfTheSameName()
+    {
+        // Virtual folders carry Guid.Empty; the account id is why this cannot collide.
+        var real = Guid.NewGuid();
+        var sentinel = "\x00" + "AllMail";
+        var svc = MakeService();
+
+        svc.Remember(Guid.Empty, sentinel, Sample);
+        svc.Remember(real, sentinel, ListState.Default);
+
+        Assert.Equal(Sample, svc.Recall(Guid.Empty, sentinel)!.Value);
+        Assert.Equal(ListState.Default, svc.Recall(real, sentinel)!.Value);
+    }
+
+    [Fact]
+    public void ViewSentinelKey_IsStoredLikeAnyOtherFolder()
+    {
+        var sentinel = "\x00" + "View:" + Guid.NewGuid();
+        var svc = MakeService();
+
+        svc.Remember(Guid.Empty, sentinel, Sample);
+
+        Assert.Equal(Sample, MakeService().Recall(Guid.Empty, sentinel)!.Value);
+    }
+
+    [Fact]
+    public void CorruptFile_IsTreatedAsEmpty_RatherThanThrowing()
+    {
+        File.WriteAllText(StateFile, "{ this is not json");
+
+        var svc = MakeService();
+
+        Assert.Null(svc.Recall(Guid.NewGuid(), "INBOX"));
+        // And it recovers: a write over the corrupt file succeeds.
+        var account = Guid.NewGuid();
+        svc.Remember(account, "INBOX", Sample);
+        Assert.Equal(Sample, MakeService().Recall(account, "INBOX")!.Value);
+    }
+
+    [Fact]
+    public void EmptyFolderName_IsIgnoredRatherThanStored()
+    {
+        var svc = MakeService();
+
+        svc.Remember(Guid.NewGuid(), "", Sample);
+
+        Assert.False(File.Exists(StateFile));
+    }
+
+    [Fact]
+    public void StoredValues_AreStrings_NotEnumOrdinals()
+    {
+        // Reordering ViewMode/MessageSort must not silently repoint existing entries.
+        MakeService().Remember(Guid.NewGuid(), "INBOX", Sample);
+
+        var json = File.ReadAllText(StateFile);
+
+        Assert.Contains("conversations", json, StringComparison.Ordinal);
+        Assert.Contains("unread", json, StringComparison.Ordinal);
+        Assert.Contains("alphaAsc", json, StringComparison.Ordinal);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Part C: MainViewModel resolver, detach, and default scoping
+// ---------------------------------------------------------------------------
+
+public class PerFolderViewStateTests
+{
+    private static readonly Guid AccountA = Guid.NewGuid();
+
+    private static MainViewModel MakeVm(
+        StubFolderViewStateService store,
+        StubConfigService config,
+        IEnumerable<SavedView>? views = null)
+        => new(new StubImapMailService(),
+               new StubAccountService(),
+               new StubCredentialService(),
+               new StubLocalStoreService(),
+               new StubOAuthService(),
+               new StubSyncService(),
+               config,
+               new StubCommandRegistry(),
+               new FakeViewService(views),
+               new StubRuleService(),
+               new StubSmtpService(),
+               folderViewState: store);
+
+    private static MailFolderModel Folder(string fullName) =>
+        new() { AccountId = AccountA, FullName = fullName, DisplayName = fullName };
+
+    private static async Task SelectFolder(MainViewModel vm, MailFolderModel folder)
+        => await ((IAsyncRelayCommand)vm.SelectFolderCommand).ExecuteAsync(folder);
+
+    private static async Task SelectView(MainViewModel vm, SavedView view)
+        => await ((IAsyncRelayCommand)vm.SelectViewCommand).ExecuteAsync(view.Id.ToString());
+
+    private static async Task ClearView(MainViewModel vm)
+        => await ((IAsyncRelayCommand)vm.ClearViewCommand).ExecuteAsync(null);
+
+    private static SavedView ConversationsView() => new()
+    {
+        Id               = Guid.NewGuid(),
+        Name             = "Grouped",
+        VirtualFolderKey = "AllInboxes",
+        ViewMode         = "conversations",
+        Filter           = "unread",
+        Sort             = "dateAsc",
+        DaysOfMail       = 7,
+    };
+
+    // -- The reported scenario ----------------------------------------------
+
+    [Fact]
+    public async Task TwoFolders_KeepTwoDifferentGroupings()
+    {
+        var store = new StubFolderViewStateService();
+        var vm = MakeVm(store, new StubConfigService());
+
+        await SelectFolder(vm, Folder("INBOX"));
+        vm.ViewMode = ViewMode.Conversations;
+
+        await SelectFolder(vm, Folder("Receipts"));
+        vm.ViewMode = ViewMode.Messages;
+
+        await SelectFolder(vm, Folder("INBOX"));
+        Assert.Equal(ViewMode.Conversations, vm.ViewMode);
+
+        await SelectFolder(vm, Folder("Receipts"));
+        Assert.Equal(ViewMode.Messages, vm.ViewMode);
+    }
+
+    [Fact]
+    public async Task UncustomisedFolder_InheritsTheGlobalDefault()
+    {
+        var store = new StubFolderViewStateService();
+        var vm = MakeVm(store, new StubConfigService());
+
+        await SelectFolder(vm, Folder("INBOX"));
+        vm.ViewMode = ViewMode.From;          // moves the global default
+
+        await SelectFolder(vm, Folder("NeverVisited"));
+
+        Assert.Equal(ViewMode.From, vm.ViewMode);
+    }
+
+    [Fact]
+    public async Task CustomisedFolder_IgnoresLaterGlobalDefaultChanges()
+    {
+        var store = new StubFolderViewStateService();
+        var vm = MakeVm(store, new StubConfigService());
+
+        // From, not Messages: assigning the value a folder already shows is not a change, so it
+        // fires no handler and pins nothing. A folder is customised by changing it, not by visiting.
+        await SelectFolder(vm, Folder("Receipts"));
+        vm.ViewMode = ViewMode.From;          // Receipts is now pinned
+
+        await SelectFolder(vm, Folder("Other"));
+        vm.ViewMode = ViewMode.Conversations; // global default moves
+
+        await SelectFolder(vm, Folder("Receipts"));
+
+        Assert.Equal(ViewMode.From, vm.ViewMode);
+    }
+
+    [Fact]
+    public async Task VisitingAFolderWithoutChangingAnything_DoesNotPinIt()
+    {
+        var store = new StubFolderViewStateService();
+        var vm = MakeVm(store, new StubConfigService());
+
+        await SelectFolder(vm, Folder("Receipts"));   // shows the default; user changes nothing
+
+        Assert.Equal(0, store.Writes);
+        Assert.Null(store.Recall(AccountA, "Receipts"));
+    }
+
+    [Fact]
+    public async Task SettingOff_SkipsTheFolderLayer()
+    {
+        var config = new StubConfigService();
+        var cfg = config.Load();
+        cfg.RememberViewPerFolder = false;
+        config.Save(cfg);
+
+        var store = new StubFolderViewStateService();
+        var vm = MakeVm(store, config);
+
+        await SelectFolder(vm, Folder("INBOX"));
+        vm.ViewMode = ViewMode.Conversations;
+
+        await SelectFolder(vm, Folder("Receipts"));
+
+        // Nothing was recorded, and the grouping stayed put — the pre-#520 behaviour.
+        Assert.Equal(0, store.Writes);
+        Assert.Equal(ViewMode.Conversations, vm.ViewMode);
+    }
+
+    // -- Apply / clear symmetry ---------------------------------------------
+
+    [Fact]
+    public async Task ClearView_RestoresEveryListStateField()
+    {
+        var view = ConversationsView();
+        var store = new StubFolderViewStateService();
+        var vm = MakeVm(store, new StubConfigService(), [view]);
+
+        await SelectFolder(vm, Folder("INBOX"));
+        vm.ViewMode = ViewMode.From;
+        vm.ActiveSort = MessageSort.AlphaDescending;
+
+        await SelectView(vm, view);
+        Assert.Equal(ViewMode.Conversations, vm.ViewMode);
+        Assert.Equal(MessageFilter.Unread, vm.ActiveFilter);
+        Assert.Equal(MessageSort.DateAscending, vm.ActiveSort);
+        Assert.Equal(7, vm.ActiveDayLimit);
+
+        await ClearView(vm);
+
+        // All five, not the two ClearView used to reset.
+        Assert.Equal(ViewMode.From, vm.ViewMode);
+        Assert.Equal(MessageFilter.All, vm.ActiveFilter);
+        Assert.Null(vm.ActiveFlagFilterId);
+        Assert.Equal(MessageSort.AlphaDescending, vm.ActiveSort);
+        Assert.Null(vm.ActiveDayLimit);
+    }
+
+    [Fact]
+    public async Task ApplyView_WritesNeitherConfigNorFolderMemory()
+    {
+        var view = ConversationsView();
+        var config = new StubConfigService();
+        var store = new StubFolderViewStateService();
+        var vm = MakeVm(store, config, [view]);
+
+        await SelectFolder(vm, Folder("INBOX"));
+        var writesBefore = store.Writes;
+        var modeBefore = config.Load().ViewMode;
+        var sortBefore = config.Load().Sort;
+
+        await SelectView(vm, view);
+
+        Assert.Equal(writesBefore, store.Writes);
+        Assert.Equal(modeBefore, config.Load().ViewMode);
+        Assert.Equal(sortBefore, config.Load().Sort);
+    }
+
+    [Fact]
+    public async Task ChangingGroupingWithViewActive_DetachesFromTheView()
+    {
+        var view = ConversationsView();
+        var vm = MakeVm(new StubFolderViewStateService(), new StubConfigService(), [view]);
+
+        await SelectView(vm, view);
+        Assert.NotNull(vm.ActiveView);
+
+        vm.ViewMode = ViewMode.To;
+
+        Assert.Null(vm.ActiveView);
+    }
+
+    // -- Per-field global-default scoping (the subtle form of #520) ----------
+
+    [Fact]
+    public async Task ChangingSort_DoesNotMoveTheGlobalViewMode()
+    {
+        var config = new StubConfigService();
+        var vm = MakeVm(new StubFolderViewStateService(), config);
+
+        await SelectFolder(vm, Folder("INBOX"));
+        var modeBefore = config.Load().ViewMode;
+
+        vm.ActiveSort = MessageSort.AlphaAscending;
+
+        Assert.Equal(modeBefore, config.Load().ViewMode);
+        Assert.Equal("alphaAsc", config.Load().Sort);
+    }
+
+    [Fact]
+    public async Task ChangingGrouping_DoesNotMoveTheGlobalSort()
+    {
+        var config = new StubConfigService();
+        var vm = MakeVm(new StubFolderViewStateService(), config);
+
+        await SelectFolder(vm, Folder("INBOX"));
+        var sortBefore = config.Load().Sort;
+
+        vm.ViewMode = ViewMode.Conversations;
+
+        Assert.Equal(sortBefore, config.Load().Sort);
+        Assert.Equal("conversations", config.Load().ViewMode);
+    }
+
+    [Fact]
+    public async Task ChangingSortWhileAConversationsViewIsActive_LeavesTheGlobalGroupingAlone()
+    {
+        // The failure this whole design exists to prevent: a grouping the user never chose
+        // must not become the default for every folder that has not been customised.
+        var view = ConversationsView();
+        var config = new StubConfigService();
+        var vm = MakeVm(new StubFolderViewStateService(), config, [view]);
+
+        await SelectFolder(vm, Folder("INBOX"));
+        var modeBefore = config.Load().ViewMode;          // "messages"
+
+        await SelectView(vm, view);                       // view forces conversations
+        vm.ActiveSort = MessageSort.AlphaDescending;      // user touches sort only
+
+        Assert.Equal(modeBefore, config.Load().ViewMode);
+        Assert.Null(vm.ActiveView);                       // and it detached
+    }
+
+    // -- Reset -------------------------------------------------------------
+
+    [Fact]
+    public async Task ResetFolderView_ForgetsTheEntryAndReturnsToTheDefault()
+    {
+        var store = new StubFolderViewStateService();
+        var config = new StubConfigService();
+        var vm = MakeVm(store, config);
+
+        await SelectFolder(vm, Folder("Receipts"));
+        vm.ViewMode = ViewMode.From;                      // Receipts pinned to From
+
+        // Customising another folder afterwards is what moves the global default (Decision 3),
+        // so "the default" at reset time is Conversations, not whatever Receipts was set to.
+        await SelectFolder(vm, Folder("Other"));
+        vm.ViewMode = ViewMode.Conversations;
+
+        await SelectFolder(vm, Folder("Receipts"));
+        Assert.Equal(ViewMode.From, vm.ViewMode);         // still pinned
+
+        vm.ResetFolderViewCommand.Execute(null);
+
+        Assert.Equal(ViewMode.Conversations, vm.ViewMode);
+        Assert.Null(store.Recall(AccountA, "Receipts"));
+
+        // And it stays reset after navigating away and back — the entry is gone, not overwritten.
+        await SelectFolder(vm, Folder("Other"));
+        await SelectFolder(vm, Folder("Receipts"));
+        Assert.Equal(ViewMode.Conversations, vm.ViewMode);
+    }
+}

--- a/QuickMail.Tests/FolderViewStateTests.cs
+++ b/QuickMail.Tests/FolderViewStateTests.cs
@@ -1,4 +1,4 @@
-// Per-folder view state (#520).
+﻿// Per-folder view state (#520).
 //
 // Coverage:
 //  A. ListState            -- record semantics the whole design leans on.
@@ -12,6 +12,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.Input;
 using QuickMail.Models;
@@ -275,6 +276,25 @@ public class PerFolderViewStateTests
         DaysOfMail       = 7,
     };
 
+    /// <summary>A view over one real folder, so applying it stays on INBOX rather than moving to a
+    /// virtual folder — which is what the detach tests need in order to assert against INBOX.</summary>
+    private static SavedView InboxConversationsView() => new()
+    {
+        Id         = Guid.NewGuid(),
+        Name       = "Inbox unread",
+        ViewMode   = "conversations",
+        Filter     = "unread",
+        Sort       = "dateAsc",
+        DaysOfMail = 7,
+        Folders    = [new ViewFolder { AccountId = AccountA, FolderFullName = "INBOX" }],
+    };
+
+    /// <summary>Populates Folders so ApplyViewFoldersAsync resolves a single-folder view to the
+    /// real folder instead of falling back to a multi-folder sentinel.</summary>
+    private static void SeedFolders(MainViewModel vm, params string[] names)
+        => vm.Folders = new System.Collections.ObjectModel.ObservableCollection<MailFolderModel>(
+               names.Select(Folder));
+
     // -- The reported scenario ----------------------------------------------
 
     [Fact]
@@ -494,6 +514,215 @@ public class PerFolderViewStateTests
         vm.ViewMode = ViewMode.To;
 
         Assert.Null(vm.ActiveView);
+    }
+
+    // -- Detaching keeps only what the user chose ---------------------------
+
+    [Fact]
+    public async Task DetachingByChangingSort_DoesNotInheritTheViewsFilterOrDayLimit()
+    {
+        // The trap: carrying the whole on-screen state into the folder's memory wrote the VIEW's
+        // filter and 7-day limit as this folder's own setting. Clear View then resolved to that
+        // same record and changed nothing, and there is no UI control for the day limit at all —
+        // so the user was pinned to a filtered, date-limited folder with no way out but Reset.
+        var view = InboxConversationsView();     // unread, 7 days, conversations, dateAsc
+        var store = new StubFolderViewStateService();
+        var vm = MakeVm(store, new StubConfigService(), [view]);
+        SeedFolders(vm, "INBOX");
+
+        await SelectFolder(vm, Folder("INBOX"));
+        await SelectView(vm, view);
+        Assert.Equal("INBOX", vm.SelectedFolder?.FullName);
+        Assert.Equal(MessageFilter.Unread, vm.ActiveFilter);
+        Assert.Equal(7, vm.ActiveDayLimit);
+
+        vm.ActiveSort = MessageSort.AlphaDescending;   // user touches sort only
+
+        Assert.Null(vm.ActiveView);
+        Assert.Equal(MessageSort.AlphaDescending, vm.ActiveSort);   // kept — the user chose it
+        Assert.Equal(MessageFilter.All, vm.ActiveFilter);           // dropped — the view's, not theirs
+        Assert.Null(vm.ActiveDayLimit);
+        Assert.Equal(ViewMode.Messages, vm.ViewMode);
+
+        var stored = store.Recall(AccountA, "INBOX");
+        Assert.NotNull(stored);
+        Assert.Equal(MessageFilter.All, stored!.Value.Filter);
+        Assert.Null(stored.Value.DayLimit);
+    }
+
+    [Fact]
+    public async Task DetachingByChangingGrouping_KeepsTheGroupingAndNothingElse()
+    {
+        var view = InboxConversationsView();
+        var vm = MakeVm(new StubFolderViewStateService(), new StubConfigService(), [view]);
+        SeedFolders(vm, "INBOX");
+
+        await SelectFolder(vm, Folder("INBOX"));
+        await SelectView(vm, view);
+
+        vm.ViewMode = ViewMode.To;
+
+        Assert.Null(vm.ActiveView);
+        Assert.Equal(ViewMode.To, vm.ViewMode);
+        Assert.Equal(MessageFilter.All, vm.ActiveFilter);
+        Assert.Null(vm.ActiveDayLimit);
+        Assert.Equal(MessageSort.DateDescending, vm.ActiveSort);    // the view's dateAsc is dropped
+    }
+
+    [Fact]
+    public async Task DetachingRestoresTheFoldersOwnState_NotTheGlobalDefault()
+    {
+        var view = InboxConversationsView();
+        var store = new StubFolderViewStateService();
+        var config = new StubConfigService();
+        var vm = MakeVm(store, config, [view]);
+        SeedFolders(vm, "INBOX", "Other");
+
+        // INBOX is remembered as From; the GLOBAL default is then moved to To elsewhere, so a
+        // fallback to the default rather than to the folder would be visible as To.
+        await SelectFolder(vm, Folder("INBOX"));
+        vm.ViewMode = ViewMode.From;
+        await SelectFolder(vm, Folder("Other"));
+        vm.ViewMode = ViewMode.To;
+        Assert.Equal("to", config.Load().ViewMode);
+
+        await SelectFolder(vm, Folder("INBOX"));
+        await SelectView(vm, view);
+        vm.ActiveSort = MessageSort.AlphaAscending;
+
+        // Detach falls back to INBOX's own grouping, not to the global default.
+        Assert.Equal(ViewMode.From, vm.ViewMode);
+        Assert.Equal(MessageSort.AlphaAscending, vm.ActiveSort);
+    }
+
+    // -- Clear View on a multi-folder view ----------------------------------
+
+    [Fact]
+    public async Task ClearView_OnAMultiFolderView_NavigatesToAllMail()
+    {
+        // A multi-folder view leaves SelectedFolder on a \0View:{id} sentinel whose message set
+        // IS the view, so restoring presentation alone would change only the window title.
+        var view = new SavedView
+        {
+            Id       = Guid.NewGuid(),
+            Name     = "Two folders",
+            ViewMode = "conversations",
+            Folders  =
+            [
+                new ViewFolder { AccountId = AccountA, FolderFullName = "INBOX" },
+                new ViewFolder { AccountId = AccountA, FolderFullName = "Receipts" },
+            ],
+        };
+        var vm = MakeVm(new StubFolderViewStateService(), new StubConfigService(), [view]);
+
+        await SelectView(vm, view);
+        Assert.StartsWith("\x00" + "View:", vm.SelectedFolder!.FullName, StringComparison.Ordinal);
+
+        await ClearView(vm);
+
+        Assert.Equal(MainViewModel.AllMailFolder.FullName, vm.SelectedFolder?.FullName);
+        Assert.Null(vm.ActiveView);
+    }
+
+    [Fact]
+    public async Task AMultiFolderViewsSentinel_IsNeverStored()
+    {
+        // Nothing would ever read it back: SelectFolderAsync intercepts view sentinels before the
+        // resolver runs. Storing one would only add rows to a file nothing prunes.
+        var view = new SavedView
+        {
+            Id       = Guid.NewGuid(),
+            Name     = "Two folders",
+            ViewMode = "messages",
+            Folders  =
+            [
+                new ViewFolder { AccountId = AccountA, FolderFullName = "INBOX" },
+                new ViewFolder { AccountId = AccountA, FolderFullName = "Receipts" },
+            ],
+        };
+        var store = new StubFolderViewStateService();
+        var vm = MakeVm(store, new StubConfigService(), [view]);
+
+        await SelectView(vm, view);
+        vm.ActiveSort = MessageSort.AlphaAscending;   // detaches, then tries to remember
+
+        Assert.Equal(0, store.Writes);
+    }
+
+    // -- A remembered flag filter whose flag was deleted ---------------------
+
+    [Fact]
+    public async Task ARememberedFlagFilter_IsDroppedWhenTheFlagIsGone()
+    {
+        // Otherwise the folder opens empty for ever, with nothing on screen to say why — the
+        // silent-empty-state failure CLAUDE.md's feature checklist calls out. ApplyViewStateAsync
+        // has always degraded this way for saved views; the per-folder path must match.
+        var store = new StubFolderViewStateService();
+        var vm = MakeVm(store, new StubConfigService());
+
+        var live = Guid.NewGuid();
+        vm.FlagDefinitions.Add(new FlagDefinition { Id = live, Name = "Live" });
+
+        store.Remember(AccountA, "INBOX",
+                       ListState.Default with { Filter = MessageFilter.Flagged,
+                                                FlagFilterId = Guid.NewGuid().ToString() });
+
+        await SelectFolder(vm, Folder("INBOX"));
+
+        Assert.Equal(MessageFilter.Flagged, vm.ActiveFilter);   // still flagged…
+        Assert.Null(vm.ActiveFlagFilterId);                     // …but not one deleted flag
+    }
+
+    [Fact]
+    public async Task ARememberedFlagFilter_SurvivesWhenTheFlagStillExists()
+    {
+        var store = new StubFolderViewStateService();
+        var vm = MakeVm(store, new StubConfigService());
+
+        var live = Guid.NewGuid();
+        vm.FlagDefinitions.Add(new FlagDefinition { Id = live, Name = "Waiting" });
+        store.Remember(AccountA, "INBOX",
+                       ListState.Default with { Filter = MessageFilter.Flagged,
+                                                FlagFilterId = live.ToString() });
+
+        await SelectFolder(vm, Folder("INBOX"));
+
+        Assert.Equal(live.ToString(), vm.ActiveFlagFilterId);
+    }
+
+    // -- Toggling the setting at runtime ------------------------------------
+
+    [Fact]
+    public async Task TurningTheSettingOffAndOnAgain_PreservesStoredState()
+    {
+        var store = new StubFolderViewStateService();
+        var config = new StubConfigService();
+        var vm = MakeVm(store, config);
+
+        await SelectFolder(vm, Folder("Receipts"));
+        vm.ViewMode = ViewMode.From;
+
+        await SelectFolder(vm, Folder("Other"));
+        vm.ViewMode = ViewMode.Conversations;
+
+        // Off: Receipts stops getting its own grouping…
+        var cfg = config.Load();
+        cfg.RememberViewPerFolder = false;
+        config.Save(cfg);
+        vm.ApplySettings(cfg);
+
+        await SelectFolder(vm, Folder("Receipts"));
+        Assert.Equal(ViewMode.Conversations, vm.ViewMode);
+
+        // …and on again, it comes back. The file is never cleared by the toggle.
+        cfg = config.Load();
+        cfg.RememberViewPerFolder = true;
+        config.Save(cfg);
+        vm.ApplySettings(cfg);
+
+        await SelectFolder(vm, Folder("Other"));
+        await SelectFolder(vm, Folder("Receipts"));
+        Assert.Equal(ViewMode.From, vm.ViewMode);
     }
 
     // -- Per-field global-default scoping (the subtle form of #520) ----------

--- a/QuickMail.Tests/SavedViewsTests.cs
+++ b/QuickMail.Tests/SavedViewsTests.cs
@@ -103,6 +103,54 @@ public class SavedViewsManagerTests
         Assert.Null(vm.SelectedView.VirtualFolderKey);
     }
 
+    // -- Sort round-trip ------------------------------------------------------
+
+    [Theory]
+    [InlineData(MessageSort.DateDescending,  "dateDesc")]
+    [InlineData(MessageSort.DateAscending,   "dateAsc")]
+    [InlineData(MessageSort.AlphaAscending,  "alphaAsc")]
+    [InlineData(MessageSort.AlphaDescending, "alphaDesc")]
+    [InlineData(MessageSort.CountDescending, "countDesc")]
+    [InlineData(MessageSort.CountAscending,  "countAsc")]
+    [InlineData(MessageSort.FlaggedFirst,    "flaggedFirst")]
+    public void SaveAsNew_StoresEverySortFaithfully(MessageSort sort, string expected)
+    {
+        // FlaggedFirst is the one that was broken: ViewManagerViewModel had its own copy of the
+        // sort mapping with no FlaggedFirst arm, so saving a view while "Flagged First" was
+        // active silently stored "dateDesc" — even though ParseSort has always understood
+        // "flaggedFirst". Both sides now go through ConfigModel. Found while fixing #520.
+        var vm = MakeVm(currentFolder: RealFolder(AccountA, "INBOX", "Inbox"),
+                        currentAccount: MakeAccount(AccountA, "Work"),
+                        sort: sort);
+
+        vm.SaveAsNewCommand.Execute(null);
+
+        Assert.Equal(expected, vm.SelectedView!.Sort);
+        Assert.Equal(sort, ConfigModel.ParseSort(vm.SelectedView.Sort));
+    }
+
+    [Theory]
+    [InlineData(MessageFilter.All,             "all")]
+    [InlineData(MessageFilter.Unread,          "unread")]
+    [InlineData(MessageFilter.Read,            "read")]
+    [InlineData(MessageFilter.WithAttachments, "attachments")]
+    [InlineData(MessageFilter.Replied,         "replied")]
+    [InlineData(MessageFilter.Forwarded,       "forwarded")]
+    [InlineData(MessageFilter.ToMe,            "tome")]
+    [InlineData(MessageFilter.Flagged,         "flagged")]
+    [InlineData(MessageFilter.Watched,         "watched")]
+    public void SaveAsNew_StoresEveryFilterFaithfully(MessageFilter filter, string expected)
+    {
+        var vm = MakeVm(currentFolder: RealFolder(AccountA, "INBOX", "Inbox"),
+                        currentAccount: MakeAccount(AccountA, "Work"),
+                        filter: filter);
+
+        vm.SaveAsNewCommand.Execute(null);
+
+        Assert.Equal(expected, vm.SelectedView!.Filter);
+        Assert.Equal(filter, ConfigModel.ParseFilter(vm.SelectedView.Filter));
+    }
+
     [Fact]
     public void SaveAsNew_RealFolder_SecondAccount_StoresCorrectAccountId()
     {
@@ -491,17 +539,38 @@ public class SavedViewsMainViewModelTests
     }
 
     [Fact]
-    public async Task Refresh_WithActiveView_ReappliesViewMode()
+    public async Task Refresh_WithActiveView_KeepsTheViewsGroupingAndStaysAttached()
     {
         var view = MakeVirtualView("AllInboxes", viewMode: "conversations");
         var vm   = MakeVm([view]);
         await SelectView(vm, view);
 
-        vm.ViewMode = ViewMode.Messages; // simulate an external change
-
         await Refresh(vm);
 
         Assert.Equal(ViewMode.Conversations, vm.ViewMode);
+        // Re-applying a view is programmatic, so it must not trip detach-to-custom.
+        Assert.NotNull(vm.ActiveView);
+    }
+
+    [Fact]
+    public async Task ChangingGroupingWithAViewActive_Detaches_AndRefreshDoesNotRestoreTheView()
+    {
+        // Was Refresh_WithActiveView_ReappliesViewMode, which asserted the pre-#520 behaviour:
+        // changing the grouping left the view active, so the next Refresh silently undid the
+        // change. Adjusting anything now leaves the view (Decision 5 of the #520 spec), and a
+        // Refresh afterwards has no view to re-apply.
+        var view = MakeVirtualView("AllInboxes", viewMode: "conversations");
+        var vm   = MakeVm([view]);
+        await SelectView(vm, view);
+
+        vm.ViewMode = ViewMode.Messages;
+
+        Assert.Null(vm.ActiveView);
+
+        await Refresh(vm);
+
+        Assert.Equal(ViewMode.Messages, vm.ViewMode);
+        Assert.Null(vm.ActiveView);
     }
 
     [Fact]

--- a/QuickMail.Tests/StubServices.cs
+++ b/QuickMail.Tests/StubServices.cs
@@ -1,4 +1,4 @@
-// Minimal no-op implementations of every service interface.
+﻿// Minimal no-op implementations of every service interface.
 // These are used exclusively for constructing ViewModels and Windows in tests —
 // no IMAP/SMTP/credential calls are ever made.
 
@@ -302,6 +302,32 @@ sealed class StubViewService : IViewService
 {
     public List<SavedView> Load() => [];
     public void Save(List<SavedView> views) { }
+}
+
+/// <summary>In-memory per-folder view state (#520) — no folderviews.json, no disk. Keyed the same
+/// way the real service keys, so resolve-order and key-isolation tests exercise real behaviour.
+/// <see cref="Writes"/> counts Set calls so tests can assert that applying a saved view records
+/// nothing.</summary>
+sealed class StubFolderViewStateService : IFolderViewStateService
+{
+    private readonly Dictionary<string, ListState> _states = new(StringComparer.Ordinal);
+
+    public int Writes { get; private set; }
+
+    private static string Key(Guid accountId, string folderFullName) =>
+        $"{accountId:N}|{folderFullName}";
+
+    public ListState? Recall(Guid accountId, string folderFullName) =>
+        _states.TryGetValue(Key(accountId, folderFullName), out var s) ? s : null;
+
+    public void Remember(Guid accountId, string folderFullName, ListState state)
+    {
+        _states[Key(accountId, folderFullName)] = state;
+        Writes++;
+    }
+
+    public void Forget(Guid accountId, string folderFullName) =>
+        _states.Remove(Key(accountId, folderFullName));
 }
 
 /// <summary>In-memory watched conversations — no watches.json, no disk. Matching mirrors the real

--- a/QuickMail/App.xaml.cs
+++ b/QuickMail/App.xaml.cs
@@ -416,6 +416,8 @@ public partial class App : Application
             // setting that replaced it (#516). No-ops once a startup folder is configured, and
             // rewrites views.json so the retired IsDefault flag cannot come back.
             StartupFolderMigration.Run(profile, startupCfg, configService, viewService);
+
+            var folderViewState = new FolderViewStateService(profile);
             var watchService = new WatchService(profile);
             var rowLayoutService = new RowLayoutService(profile, configService);
             var flagService = new FlagService(profile, configService, localStore, effectiveMail);
@@ -463,7 +465,8 @@ public partial class App : Application
                 graphCalendarSyncService: probeMode ? null : graphCalendarSync,
                 truthProbe: probeMode ? null : _truthProbe,
                 rowLayoutService: rowLayoutService,
-                watchService: watchService);
+                watchService: watchService,
+                folderViewState: folderViewState);
             mainVm.RegisterAccountBackend = a => { if (!probeMode) mailRouter.RegisterAccount(a.Id, BackendFor(a)); };
             mainVm.ImmutableIdRebuildAnnouncePending = immutableIdRebuilt;   // #366 one-time re-sync notice
             // Registers/unregisters the Help command and shows or hides the menu item, and sets

--- a/QuickMail/Models/ConfigModel.cs
+++ b/QuickMail/Models/ConfigModel.cs
@@ -32,6 +32,13 @@ public class ConfigModel
     public string Sort { get; set; } = "dateDesc";
 
     /// <summary>
+    /// When true (the default) each folder remembers the message-list presentation it was last
+    /// given, and opens that way next time. When false the presentation is a single app-wide
+    /// setting, as it was before issue #520.
+    /// </summary>
+    public bool RememberViewPerFolder { get; set; } = true;
+
+    /// <summary>
     /// How many days of mail to sync. 0 = sync all mail (no date filter).
     /// Supported values: 7, 30, 180, 365, or 0 (all).
     /// </summary>
@@ -419,7 +426,13 @@ public class ConfigModel
         return PreviewLines;
     }
 
-    // ── ViewMode / Sort serialization helpers ─────────────────────────────────────
+    // ── ViewMode / Filter / Sort serialization helpers ────────────────────────────
+    //
+    // These are the single mapping between the presentation enums and the strings used by
+    // config.ini, views.json, and folderviews.json. Route every conversion through them:
+    // the copies that used to live in MainViewModel.ApplyViewAsync, MainViewModel.SetFilterAsync
+    // and ViewManagerViewModel drifted, and the drift is what made saving a view while
+    // "Flagged First" was active silently store "dateDesc".
 
     /// <summary>Converts a config-string ViewMode to the enum (case-insensitive).</summary>
     public static Models.ViewMode ParseViewMode(string? s) => (s?.ToLowerInvariant()) switch
@@ -437,6 +450,34 @@ public class ConfigModel
         Models.ViewMode.From          => "from",
         Models.ViewMode.To            => "to",
         _                             => "messages",
+    };
+
+    /// <summary>Converts a config-string filter to the enum (case-insensitive).</summary>
+    public static MessageFilter ParseFilter(string? s) => (s?.ToLowerInvariant()) switch
+    {
+        "unread"      => MessageFilter.Unread,
+        "read"        => MessageFilter.Read,
+        "attachments" => MessageFilter.WithAttachments,
+        "replied"     => MessageFilter.Replied,
+        "forwarded"   => MessageFilter.Forwarded,
+        "tome"        => MessageFilter.ToMe,
+        "flagged"     => MessageFilter.Flagged,
+        "watched"     => MessageFilter.Watched,
+        _             => MessageFilter.All,
+    };
+
+    /// <summary>Converts a MessageFilter enum to its config-string representation.</summary>
+    public static string ToConfigString(MessageFilter filter) => filter switch
+    {
+        MessageFilter.Unread          => "unread",
+        MessageFilter.Read            => "read",
+        MessageFilter.WithAttachments => "attachments",
+        MessageFilter.Replied         => "replied",
+        MessageFilter.Forwarded       => "forwarded",
+        MessageFilter.ToMe            => "tome",
+        MessageFilter.Flagged         => "flagged",
+        MessageFilter.Watched         => "watched",
+        _                             => "all",
     };
 
     /// <summary>Converts a config-string Sort to the enum (case-insensitive).</summary>

--- a/QuickMail/Models/ListState.cs
+++ b/QuickMail/Models/ListState.cs
@@ -1,0 +1,27 @@
+namespace QuickMail.Models;
+
+/// <summary>
+/// Everything that decides how the message list is presented: grouping, filter, named-flag
+/// sub-filter, sort order, and date range.
+///
+/// This is one record rather than five loose ViewModel properties so that restoring a
+/// presentation is a single assignment. Before it existed, "apply a view" wrote six properties
+/// and "clear the view" reset two of them, and each of the three navigation paths reset a
+/// different subset — the defect behind issue #520. A whole-record assignment makes a partial
+/// restore inexpressible, and a sixth presentation setting means one more field here rather than
+/// four reset sites to remember.
+///
+/// A value type deliberately: a state handed out by the per-folder store and then mutated by the
+/// ViewModel would corrupt the store silently.
+/// </summary>
+public readonly record struct ListState(
+    ViewMode      Mode,
+    MessageFilter Filter,
+    string?       FlagFilterId,
+    MessageSort   Sort,
+    int?          DayLimit)
+{
+    /// <summary>The presentation a folder gets when nothing else has an opinion.</summary>
+    public static ListState Default => new(
+        ViewMode.Messages, MessageFilter.All, null, MessageSort.DateDescending, null);
+}

--- a/QuickMail/Services/ConfigService.cs
+++ b/QuickMail/Services/ConfigService.cs
@@ -208,6 +208,13 @@ public class ConfigService : IConfigService
                             _               => "messages",
                         };
                         break;
+                    case "sort":
+                        // ConfigModel.ParseSort normalises anything unrecognised to dateDesc.
+                        config.Sort = ConfigModel.ToConfigString(ConfigModel.ParseSort(value));
+                        break;
+                    case "rememberviewperfolder":
+                        config.RememberViewPerFolder = ParseBool(value);
+                        break;
                     case "syncdays":
                         if (int.TryParse(value, out var sd)) config.SyncDays = Math.Max(0, sd);
                         break;
@@ -394,6 +401,17 @@ public class ConfigService : IConfigService
         sb.AppendLine($"ViewMode = {config.ViewMode}");
         sb.AppendLine("# How to display the message list.");
         sb.AppendLine("# Values: messages (flat list), conversations (grouped by subject), from (grouped by sender).");
+        sb.AppendLine();
+
+        sb.AppendLine($"Sort = {config.Sort}");
+        sb.AppendLine("# How to sort the message list or groups.");
+        sb.AppendLine("# Values: dateDesc, dateAsc, alphaAsc, alphaDesc, countDesc, countAsc, flaggedFirst.");
+        sb.AppendLine();
+
+        sb.AppendLine($"RememberViewPerFolder = {(config.RememberViewPerFolder ? "on" : "off")}");
+        sb.AppendLine("# Remember the view mode, filter, and sort each folder was last given, and");
+        sb.AppendLine("# open that folder the same way next time. Stored in folderviews.json.");
+        sb.AppendLine("# When off, the view mode and sort above apply to every folder. Values: on, off.");
         sb.AppendLine();
 
         sb.AppendLine($"SyncDays = {config.SyncDays}");

--- a/QuickMail/Services/FolderViewStateService.cs
+++ b/QuickMail/Services/FolderViewStateService.cs
@@ -43,8 +43,11 @@ public class FolderViewStateService : IFolderViewStateService
     /// <summary>
     /// Account id is part of the key because virtual folders (All Mail, All Inboxes) carry
     /// <see cref="Guid.Empty"/> and could otherwise collide with a real folder of the same name.
-    /// View sentinels (<c>\0View:{id}</c>) key like anything else, which is what lets a
-    /// multi-folder view's folder set carry its own remembered presentation with no special case.
+    ///
+    /// Multi-folder saved views are NOT stored: their sentinel folder never reaches the resolver
+    /// (<c>SelectFolderAsync</c> intercepts <c>\0View:</c> and routes to the view), so an entry
+    /// written against one could never be read back. <c>MainViewModel.RememberCurrentListState</c>
+    /// is where that exclusion lives.
     /// </summary>
     private static string Key(Guid accountId, string folderFullName) =>
         $"{accountId:N}|{folderFullName}";
@@ -117,10 +120,13 @@ public class FolderViewStateService : IFolderViewStateService
             Directory.CreateDirectory(_dataFolder);
             Helpers.AtomicFile.WriteAllText(_stateFile, JsonSerializer.Serialize(Cache, JsonOptions));
         }
-        catch
+        catch (Exception ex)
         {
             // A presentation preference is not worth taking the app down for. The in-memory cache
             // still holds the change, so the session behaves correctly; only the restart is lost.
+            // Logged because a silent swallow here looks exactly like "the feature does not work"
+            // — a read-only profile directory would otherwise be undiagnosable.
+            LogService.Log($"FolderViewStateService: could not save folderviews.json — {ex.Message}");
         }
     }
 }

--- a/QuickMail/Services/FolderViewStateService.cs
+++ b/QuickMail/Services/FolderViewStateService.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using QuickMail.Models;
+
+namespace QuickMail.Services;
+
+/// <summary>
+/// Persists per-folder message-list presentation to <c>%AppData%\QuickMail\folderviews.json</c>.
+/// Modelled on <see cref="ViewService"/>: profile-dir JSON, atomic write, unreadable file treated
+/// as empty rather than fatal.
+/// </summary>
+public class FolderViewStateService : IFolderViewStateService
+{
+    private readonly string _dataFolder;
+    private readonly string _stateFile;
+
+    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+
+    private Dictionary<string, Entry>? _cache;
+
+    /// <summary>
+    /// On-disk shape. String-valued rather than enum ordinals so that reordering
+    /// <see cref="ViewMode"/>, <see cref="MessageFilter"/> or <see cref="MessageSort"/> cannot
+    /// silently repoint existing entries. These are the same strings <c>views.json</c> uses.
+    /// </summary>
+    private sealed class Entry
+    {
+        public string  Mode         { get; set; } = "messages";
+        public string  Filter       { get; set; } = "all";
+        public string? FlagFilterId { get; set; }
+        public string  Sort         { get; set; } = "dateDesc";
+        public int?    DayLimit     { get; set; }
+    }
+
+    public FolderViewStateService(ProfileContext profile)
+    {
+        _dataFolder = profile.ProfileDir;
+        _stateFile  = Path.Combine(profile.ProfileDir, "folderviews.json");
+    }
+
+    /// <summary>
+    /// Account id is part of the key because virtual folders (All Mail, All Inboxes) carry
+    /// <see cref="Guid.Empty"/> and could otherwise collide with a real folder of the same name.
+    /// View sentinels (<c>\0View:{id}</c>) key like anything else, which is what lets a
+    /// multi-folder view's folder set carry its own remembered presentation with no special case.
+    /// </summary>
+    private static string Key(Guid accountId, string folderFullName) =>
+        $"{accountId:N}|{folderFullName}";
+
+    private Dictionary<string, Entry> Cache
+    {
+        get
+        {
+            if (_cache != null) return _cache;
+
+            if (!File.Exists(_stateFile))
+                return _cache = new Dictionary<string, Entry>(StringComparer.Ordinal);
+
+            try
+            {
+                var json = File.ReadAllText(_stateFile);
+                _cache = JsonSerializer.Deserialize<Dictionary<string, Entry>>(json)
+                         ?? new Dictionary<string, Entry>(StringComparer.Ordinal);
+            }
+            catch
+            {
+                // Malformed or unreadable — every folder falls back to the global default, which
+                // is a working app rather than a startup failure. Matches ViewService.Load.
+                _cache = new Dictionary<string, Entry>(StringComparer.Ordinal);
+            }
+
+            return _cache;
+        }
+    }
+
+    public ListState? Recall(Guid accountId, string folderFullName)
+    {
+        if (string.IsNullOrEmpty(folderFullName)) return null;
+        if (!Cache.TryGetValue(Key(accountId, folderFullName), out var e)) return null;
+
+        return new ListState(
+            ConfigModel.ParseViewMode(e.Mode),
+            ConfigModel.ParseFilter(e.Filter),
+            string.IsNullOrEmpty(e.FlagFilterId) ? null : e.FlagFilterId,
+            ConfigModel.ParseSort(e.Sort),
+            e.DayLimit);
+    }
+
+    public void Remember(Guid accountId, string folderFullName, ListState state)
+    {
+        if (string.IsNullOrEmpty(folderFullName)) return;
+
+        Cache[Key(accountId, folderFullName)] = new Entry
+        {
+            Mode         = ConfigModel.ToConfigString(state.Mode),
+            Filter       = ConfigModel.ToConfigString(state.Filter),
+            FlagFilterId = state.FlagFilterId,
+            Sort         = ConfigModel.ToConfigString(state.Sort),
+            DayLimit     = state.DayLimit,
+        };
+        Persist();
+    }
+
+    public void Forget(Guid accountId, string folderFullName)
+    {
+        if (string.IsNullOrEmpty(folderFullName)) return;
+        if (Cache.Remove(Key(accountId, folderFullName)))
+            Persist();
+    }
+
+    private void Persist()
+    {
+        try
+        {
+            Directory.CreateDirectory(_dataFolder);
+            Helpers.AtomicFile.WriteAllText(_stateFile, JsonSerializer.Serialize(Cache, JsonOptions));
+        }
+        catch
+        {
+            // A presentation preference is not worth taking the app down for. The in-memory cache
+            // still holds the change, so the session behaves correctly; only the restart is lost.
+        }
+    }
+}

--- a/QuickMail/Services/IFolderViewStateService.cs
+++ b/QuickMail/Services/IFolderViewStateService.cs
@@ -1,0 +1,23 @@
+using System;
+using QuickMail.Models;
+
+namespace QuickMail.Services;
+
+/// <summary>
+/// Remembers the message-list presentation (<see cref="ListState"/>) each folder was last given,
+/// so a folder opens the way it was left. Issue #520.
+/// </summary>
+public interface IFolderViewStateService
+{
+    // Named Recall/Remember/Forget rather than Get/Set/Clear: CA1716 flags Get and Set on an
+    // interface member as reserved words in other CLR languages.
+
+    /// <summary>The remembered state for a folder, or null if it has never been customised.</summary>
+    ListState? Recall(Guid accountId, string folderFullName);
+
+    /// <summary>Records the state for a folder, replacing any previous entry.</summary>
+    void Remember(Guid accountId, string folderFullName, ListState state);
+
+    /// <summary>Forgets a folder's state so it goes back to inheriting the global default.</summary>
+    void Forget(Guid accountId, string folderFullName);
+}

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -34,6 +34,8 @@ public partial class MainViewModel : ObservableObject, IDisposable
     private readonly IContactSyncService? _contactSync;
     private readonly IConfigService _configService;
     private readonly IViewService _viewService;
+    /// <summary>Per-folder presentation memory (#520). Null in tests that do not exercise it.</summary>
+    private readonly IFolderViewStateService? _folderViewState;
     private readonly ICommandRegistry _commandRegistry;
     private readonly IRuleService _ruleService;
     private readonly ISendMailService _smtp;
@@ -638,6 +640,10 @@ public partial class MainViewModel : ObservableObject, IDisposable
         return false;
     }
 
+    /// <summary>True for the synthetic folder a multi-folder saved view selects.</summary>
+    private static bool IsViewSentinel(string? fullName) =>
+        TryGetViewIdFromSentinel(fullName, out _) || TryGetViewAllIdFromSentinel(fullName, out _);
+
     /// <summary>
     /// Creates the <see cref="MailFolderModel"/> that represents the "All Mail" virtual
     /// folder for a specific account.  Used by both the main folder tree and the folder picker.
@@ -709,6 +715,140 @@ public partial class MainViewModel : ObservableObject, IDisposable
     private int? _activeDayLimit;
 
     public bool HasSavedViews => SavedViews.Count > 0;
+
+    // ── List presentation state (#520) ────────────────────────────────────────────
+    //
+    // Grouping, filter, flag sub-filter, sort and day limit are resolved from three layers,
+    // highest first:
+    //
+    //   1. the active saved view   — an explicit, temporary overlay
+    //   2. the folder's own memory — what this folder was last given
+    //   3. the global default      — config.ini ViewMode + Sort
+    //
+    // Every navigation and every deactivation applies the resolved record wholesale, so a
+    // partial restore cannot be written by accident. Before this, "clear view" reset two of the
+    // six properties "apply view" had set, which is issue #520.
+
+    /// <summary>Set while a resolved state is being applied. Nothing persists to disk while it
+    /// is set, and an active view is not detached — a programmatic apply is never a preference.</summary>
+    private bool _applyingListState;
+
+    /// <summary>Mirrors <c>ConfigModel.RememberViewPerFolder</c>; when false layer 2 is skipped.</summary>
+    private bool _rememberViewPerFolder = true;
+
+    /// <summary>Layer 3. Filter, flag sub-filter and day limit have no global form — they always
+    /// start clear — so only Mode and Sort are read from config.</summary>
+    private ListState _defaultListState = ListState.Default;
+
+    private static ListState DefaultListStateFrom(ConfigModel cfg) => new(
+        ConfigModel.ParseViewMode(cfg.ViewMode),
+        MessageFilter.All,
+        null,
+        ConfigModel.ParseSort(cfg.Sort),
+        null);
+
+    /// <summary>The presentation currently on screen.</summary>
+    private ListState CurrentListState =>
+        new(ViewMode, ActiveFilter, _activeFlagFilterId, ActiveSort, ActiveDayLimit);
+
+    private static ListState ToListState(SavedView view) => new(
+        ConfigModel.ParseViewMode(view.ViewMode),
+        ConfigModel.ParseFilter(view.Filter),
+        string.IsNullOrEmpty(view.FlagFilterId) ? null : view.FlagFilterId,
+        ConfigModel.ParseSort(view.Sort),
+        view.DaysOfMail);
+
+    /// <summary>Walks the three layers for a folder. Callers must set <see cref="ActiveView"/> to
+    /// its intended value first — clearing a view means clearing it, then resolving.</summary>
+    private ListState ResolveListState(MailFolderModel? folder)
+    {
+        if (ActiveView != null) return ToListState(ActiveView);
+
+        if (_rememberViewPerFolder && _folderViewState != null && folder != null &&
+            !string.IsNullOrEmpty(folder.FullName))
+        {
+            var remembered = _folderViewState.Recall(folder.AccountId, folder.FullName);
+            if (remembered.HasValue) return remembered.Value;
+        }
+
+        return _defaultListState;
+    }
+
+    /// <summary>
+    /// Applies a resolved state as one unit. Does not rebuild the list — every caller either
+    /// fetches straight afterwards (which rebuilds) or calls <c>ApplyFiltersAndSearch</c> itself.
+    ///
+    /// Both guards are saved and restored rather than set and cleared: <c>SelectFolderAsync</c>
+    /// already holds <c>_suppressFilterRebuild</c> when it calls in here.
+    /// </summary>
+    private void ApplyListState(ListState state)
+    {
+        var prevApplying = _applyingListState;
+        var prevSuppress = _suppressFilterRebuild;
+        _applyingListState     = true;
+        _suppressFilterRebuild = true;
+        try
+        {
+            ViewMode     = state.Mode;
+            ActiveFilter = state.Filter;
+            SetActiveFlagFilterId(state.FlagFilterId);
+            ActiveSort     = state.Sort;
+            ActiveDayLimit = state.DayLimit;
+        }
+        finally
+        {
+            _suppressFilterRebuild = prevSuppress;
+            _applyingListState     = prevApplying;
+        }
+    }
+
+    /// <summary>
+    /// Called by every presentation-property change handler. A programmatic apply returns early;
+    /// a user gesture detaches any active view and records the folder's new state.
+    ///
+    /// The global default is deliberately NOT written here — each of ViewMode and Sort is written
+    /// by its own handler, so only the field the user actually changed moves. Writing the whole
+    /// record here would mean that changing the sort while a Conversations view is active promotes
+    /// that view's grouping to the global default, which is issue #520 in miniature.
+    /// </summary>
+    private void NoteListStateChanged()
+    {
+        if (_applyingListState) return;
+
+        // Detach-to-custom: adjusting anything while a view is active leaves the view.
+        if (ActiveView != null) ActiveView = null;
+
+        RememberCurrentListState();
+    }
+
+    private void RememberCurrentListState()
+    {
+        if (!_rememberViewPerFolder || _folderViewState == null) return;
+
+        var folder = SelectedFolder;
+        if (folder == null || folder.IsHeader || string.IsNullOrEmpty(folder.FullName)) return;
+
+        // The calendar replaces the message list entirely; it has no presentation to remember.
+        if (IsCalendarFolderName(folder.FullName)) return;
+
+        _folderViewState.Remember(folder.AccountId, folder.FullName, CurrentListState);
+    }
+
+    private void PersistGlobalViewMode(ViewMode value)
+    {
+        var cfg = _configService.Load();
+        cfg.ViewMode = ConfigModel.ToConfigString(value);
+        _configService.Save(cfg);
+        _defaultListState = _defaultListState with { Mode = value };
+    }
+
+    private void PersistGlobalSort(MessageSort value)
+    {
+        var cfg = _configService.Load();
+        cfg.Sort = ConfigModel.ToConfigString(value);
+        _configService.Save(cfg);
+        _defaultListState = _defaultListState with { Sort = value };
+    }
 
     /// <summary>Raised when the view list changes so the Views menu can be rebuilt.</summary>
     public event EventHandler? SavedViewsChanged;
@@ -1325,8 +1465,10 @@ public partial class MainViewModel : ObservableObject, IDisposable
         ConnectionTruthProbe? truthProbe = null,
         IScreenshotCaptureService? screenshotCapture = null,
         IRowLayoutService? rowLayoutService = null,
-        IWatchService? watchService = null)
+        IWatchService? watchService = null,
+        IFolderViewStateService? folderViewState = null)
     {
+        _folderViewState = folderViewState;
         _watchService = watchService;
         _rowLayoutService = rowLayoutService;
         _truthProbe = truthProbe;
@@ -1365,6 +1507,8 @@ public partial class MainViewModel : ObservableObject, IDisposable
         MessageOpenMode = cfg.Windowing.MessageOpenMode;
         EnsureMessageListTab();
         _activeSort = ConfigModel.ParseSort(cfg.Sort);
+        _rememberViewPerFolder = cfg.RememberViewPerFolder;
+        _defaultListState      = DefaultListStateFrom(cfg);
         _announceFlagStatus = cfg.AnnounceFlagStatus;
 
         // Calendar — only when a calendar service is wired (skipped in tests).
@@ -1745,36 +1889,25 @@ public partial class MainViewModel : ObservableObject, IDisposable
     {
         ActiveView = view;
 
-        // Apply view's mode/filter/sort before clearing search so rebuild
-        // schedulers triggered by ViewMode change operate on the right data.
-        ViewMode = ConfigModel.ParseViewMode(view.ViewMode);
-        ActiveFilter = view.Filter switch
-        {
-            "unread"      => MessageFilter.Unread,
-            "read"        => MessageFilter.Read,
-            "attachments" => MessageFilter.WithAttachments,
-            "replied"     => MessageFilter.Replied,
-            "forwarded"   => MessageFilter.Forwarded,
-            "tome"        => MessageFilter.ToMe,
-            "flagged"     => MessageFilter.Flagged,
-            "watched"     => MessageFilter.Watched,
-            _             => MessageFilter.All,
-        };
-        ActiveSort = ConfigModel.ParseSort(view.Sort);
-        SetActiveFlagFilterId(string.IsNullOrEmpty(view.FlagFilterId) ? null : view.FlagFilterId);
+        var state = ToListState(view);
 
-        // Validate the flag filter id against current flag definitions.
-        // If the referenced flag has been deleted, treat it as no filter
-        // rather than showing an empty list with no explanation.
-        if (_activeFlagFilterId != null && _flagService != null &&
-            Guid.TryParse(_activeFlagFilterId, out var flagGuid))
+        // Validate the flag filter id against current flag definitions before applying.
+        // If the referenced flag has been deleted, treat it as no filter rather than
+        // showing an empty list with no explanation.
+        if (state.FlagFilterId != null && _flagService != null &&
+            Guid.TryParse(state.FlagFilterId, out var flagGuid))
         {
             var defs = await _flagService.LoadFlagDefinitionsAsync();
             if (!defs.Exists(d => d.Id == flagGuid))
-                SetActiveFlagFilterId(null);
+                state = state with { FlagFilterId = null };
         }
 
-        ActiveDayLimit = view.DaysOfMail;
+        // Apply the view's mode/filter/sort before clearing search so rebuild schedulers
+        // triggered by the ViewMode change operate on the right data. Applying through
+        // ApplyListState is what keeps the view from writing itself into the user's
+        // preferences — see NoteListStateChanged.
+        ApplyListState(state);
+
         SearchText     = string.Empty;
         IsSearchActive = false;
         MessageDetail  = null;
@@ -1990,8 +2123,14 @@ public partial class MainViewModel : ObservableObject, IDisposable
         _previewLines = newPreviewLines;
         _showPreview  = newShowPreview;
 
-        var newMode = ConfigModel.ParseViewMode(cfg.ViewMode);
-        ViewMode = newMode;
+        // Settings is the one place the global default is edited directly. Take the new default,
+        // then re-resolve so a folder with its own memory (or an active view) keeps precedence.
+        // Only Mode and Sort are taken from the resolution: Settings must not clear a filter or
+        // day limit the user applied in this session, which is what a whole-record apply would do.
+        _rememberViewPerFolder = cfg.RememberViewPerFolder;
+        _defaultListState      = DefaultListStateFrom(cfg);
+        var resolved = ResolveListState(SelectedFolder);
+        ApplyListState(CurrentListState with { Mode = resolved.Mode, Sort = resolved.Sort });
 
         var prevSyncDays = _syncDays;
         _syncDays = cfg.SyncDays;
@@ -2002,7 +2141,8 @@ public partial class MainViewModel : ObservableObject, IDisposable
         OnPropertyChanged(nameof(IsSyncDaysAll));
         OnPropertyChanged(nameof(SyncRangeLabel));
 
-        ActiveSort = ConfigModel.ParseSort(cfg.Sort);
+        // (Sort is applied above, through the resolver — a bare assignment from cfg here would
+        // override the folder's own remembered sort every time Settings was closed.)
 
         var prevMode    = MessageOpenMode;
         MessageOpenMode = cfg.Windowing.MessageOpenMode;
@@ -2109,6 +2249,18 @@ public partial class MainViewModel : ObservableObject, IDisposable
         registry.Register(new CommandDefinition(
             id: "view.density.compact", category: "View", title: "Density: Compact",
             execute: () => SetListDensity("compact")));
+
+        // Clear View has existed on the View menu since saved views shipped but was never
+        // registered, so it was absent from the palette and could not be bound to a key.
+        registry.Register(new CommandDefinition(
+            id: "view.clearView", category: "View", title: "Clear View",
+            execute: () => ClearViewCommand.Execute(null),
+            isAvailable: () => ActiveView != null));
+
+        registry.Register(new CommandDefinition(
+            id: "view.resetFolderView", category: "View", title: "Reset Folder View",
+            execute: () => ResetFolderViewCommand.Execute(null),
+            isAvailable: () => SelectedFolder != null && !SelectedFolder.IsHeader));
 
         registry.Register(new CommandDefinition(
             id: "account.manage", category: "Account", title: "Manage Accounts",
@@ -4338,12 +4490,20 @@ public partial class MainViewModel : ObservableObject, IDisposable
         OnPropertyChanged(nameof(FilterLabel));
         OnPropertyChanged(nameof(WindowTitle));
 
+        // Before the early return below: _suppressFilterRebuild suppresses the *rebuild*, not the
+        // record of what the user chose. Putting this after the return would silently drop
+        // per-folder writes on every path that batches its changes.
+        NoteListStateChanged();
+
         if (_suppressFilterRebuild) return;
 
         // Always rebuild Messages from _rawMessages; OnMessagesChanged then triggers
         // RebuildActiveGroupView automatically for Conversations/From/To view modes.
         ApplyFiltersAndSearch();
     }
+
+    /// <summary>Day limit has no global-default form, so it records against the folder only.</summary>
+    partial void OnActiveDayLimitChanged(int? value) => NoteListStateChanged();
 
     partial void OnActiveSortChanged(MessageSort value)
     {
@@ -4356,9 +4516,9 @@ public partial class MainViewModel : ObservableObject, IDisposable
         OnPropertyChanged(nameof(IsSortFlaggedFirst));
         OnPropertyChanged(nameof(SortLabel));
 
-        var cfg = _configService.Load();
-        cfg.Sort = ConfigModel.ToConfigString(value);
-        _configService.Save(cfg);
+        // Sort only — never ViewMode. See NoteListStateChanged.
+        if (!_applyingListState) PersistGlobalSort(value);
+        NoteListStateChanged();
 
         if (ViewMode == ViewMode.Messages)
             ApplyFiltersAndSearch();
@@ -4390,9 +4550,9 @@ public partial class MainViewModel : ObservableObject, IDisposable
         else
             ToGroups = [];
 
-        var cfg = _configService.Load();
-        cfg.ViewMode = ConfigModel.ToConfigString(value);
-        _configService.Save(cfg);
+        // ViewMode only — never Sort. See NoteListStateChanged.
+        if (!_applyingListState) PersistGlobalViewMode(value);
+        NoteListStateChanged();
 
         if (value == ViewMode.To && SelectedFolder?.FullName == AllMailFolder.FullName && Messages.Any(m => string.IsNullOrWhiteSpace(m.To)))
             _ = RefreshAsync();
@@ -4600,15 +4760,14 @@ public partial class MainViewModel : ObservableObject, IDisposable
         }
 
         _suppressFilterRebuild = true;
-        ActiveFilter        = MessageFilter.All;
-        ActiveDayLimit      = null;
-        SetActiveFlagFilterId(null);
         SearchText          = string.Empty;
         IsSearchActive      = false;
         ActiveView          = null;
         SelectedFolder      = folder;
         MessageDetail       = null;
         IsMessageOpen       = false;
+        // ActiveView and SelectedFolder are set first: the resolver reads both.
+        ApplyListState(ResolveListState(folder));
         _suppressFilterRebuild = false;
 
         if (IsVirtualFolder(folder))
@@ -4632,15 +4791,15 @@ public partial class MainViewModel : ObservableObject, IDisposable
         CalendarVm.SourceFilter = folder == null ? null : CalendarFilterFor(folder.FullName);
 
         _suppressFilterRebuild = true;
-        ActiveFilter        = MessageFilter.All;
-        ActiveDayLimit      = null;
-        SetActiveFlagFilterId(null);
         SearchText          = string.Empty;
         IsSearchActive      = false;
         ActiveView          = null;
         SelectedFolder      = folder ?? CalendarFolder;
         MessageDetail       = null;
         IsMessageOpen       = false;
+        // The calendar replaces the message list, so there is no folder presentation to resolve —
+        // reset to the plain default. Returning to a mail folder resolves normally.
+        ApplyListState(ListState.Default);
         _suppressFilterRebuild = false;
 
         // Clear the message list so stale messages are not announced while the
@@ -5044,15 +5203,51 @@ public partial class MainViewModel : ObservableObject, IDisposable
         return current.Any(f => !prevNames.Contains(f.FullName));
     }
 
+    /// <summary>
+    /// Deactivates the current saved view and restores whatever the folder would show on its own.
+    /// Every field the view set is restored, not a subset — that asymmetry was issue #520.
+    /// </summary>
     [RelayCommand]
     private async Task ClearViewAsync()
     {
-        ActiveView     = null;
-        ActiveDayLimit = null;
+        // A multi-folder view leaves SelectedFolder on a \0View:{id} sentinel whose message set
+        // *is* the view, so restoring presentation alone would change only the window title.
+        // Go home instead, which is also what the menu item has always claimed to do.
+        if (SelectedFolder != null && IsViewSentinel(SelectedFolder.FullName))
+        {
+            await SelectFolderAsync(AllMailFolder);
+            return;
+        }
+
+        ActiveView = null;
+        ApplyListState(ResolveListState(SelectedFolder));
+
         if (IsVirtualFolder(SelectedFolder))
             await FetchVirtualAsync(SelectedFolder!);
         else if (SelectedFolder != null && SelectedFolder.AccountId != Guid.Empty)
             await FetchFolderAsync();
+        else
+            ApplyFiltersAndSearch();
+    }
+
+    /// <summary>
+    /// Forgets this folder's remembered presentation so it goes back to the global default.
+    /// The escape hatch for per-folder memory (#520) — a customised folder is otherwise pinned.
+    /// </summary>
+    [RelayCommand]
+    private void ResetFolderView()
+    {
+        var folder = SelectedFolder;
+        if (folder == null || folder.IsHeader || string.IsNullOrEmpty(folder.FullName)) return;
+
+        _folderViewState?.Forget(folder.AccountId, folder.FullName);
+
+        ActiveView = null;
+        ApplyListState(_defaultListState);
+        ApplyFiltersAndSearch();
+
+        // No control reflects the deletion of stored state, so this is the only confirmation.
+        Announce("Folder view reset.", AnnouncementCategory.Result);
     }
 
     private async Task FetchAllMailAsync()
@@ -8089,26 +8284,21 @@ public partial class MainViewModel : ObservableObject, IDisposable
 
     private void SetActiveFlagFilterId(string? id)
     {
+        var changed = !string.Equals(_activeFlagFilterId, id, StringComparison.Ordinal);
         _activeFlagFilterId = id;
         OnPropertyChanged(nameof(ActiveFlagFilterId));
         OnPropertyChanged(nameof(IsFilterAllFlagged));
+
+        // Not an [ObservableProperty], so there is no generated handler to hook — note it here.
+        // Guarded on an actual change so the no-op calls that clear an already-null id (every
+        // SetFilterAsync, for one) do not detach an active view or write to disk.
+        if (changed) NoteListStateChanged();
     }
 
     [RelayCommand]
     private Task SetFilterAsync(string? filter)
     {
-        ActiveFilter = filter?.ToLowerInvariant() switch
-        {
-            "unread"      => MessageFilter.Unread,
-            "read"        => MessageFilter.Read,
-            "attachments" => MessageFilter.WithAttachments,
-            "replied"     => MessageFilter.Replied,
-            "forwarded"   => MessageFilter.Forwarded,
-            "tome"        => MessageFilter.ToMe,
-            "flagged"     => MessageFilter.Flagged,
-            "watched"     => MessageFilter.Watched,
-            _             => MessageFilter.All,
-        };
+        ActiveFilter = ConfigModel.ParseFilter(filter);
         // Clear any named-flag sub-filter from a previously applied saved view
         // so the user sees all flagged messages, not just one specific flag.
         SetActiveFlagFilterId(null);

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -834,6 +834,21 @@ public partial class MainViewModel : ObservableObject, IDisposable
         _folderViewState.Remember(folder.AccountId, folder.FullName, CurrentListState);
     }
 
+    /// <summary>
+    /// Selects a folder on a startup path and applies its remembered presentation.
+    ///
+    /// The startup paths assign <see cref="SelectedFolder"/> directly rather than going through
+    /// <c>SelectFolderAsync</c> (they load from the cache, not the network), so without this the
+    /// one folder the user opens into would be the one folder that ignored its own settings.
+    /// CLAUDE.md's startup rule: anything affecting what the user first sees must be applied in
+    /// the initial load, not after sync.
+    /// </summary>
+    private void SelectStartupFolder(MailFolderModel folder)
+    {
+        SelectedFolder = folder;
+        ApplyListState(ResolveListState(folder));
+    }
+
     private void PersistGlobalViewMode(ViewMode value)
     {
         var cfg = _configService.Load();
@@ -2604,7 +2619,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
             // against. Select what the config names anyway — the fetch that follows connect reads
             // SelectedFolder — so the choice is honoured here too. It was not before: the old
             // default-view application sat after an early return on this path.
-            SelectedFolder = ResolveOnlineStartupFolder(startupCfg) ?? AllMailFolder;
+            SelectStartupFolder(ResolveOnlineStartupFolder(startupCfg) ?? AllMailFolder);
             StatusText = "Online mode — connecting…";
             ConnectionStatusText = "Connecting…";
             return;
@@ -2659,7 +2674,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
         }
         else
         {
-            SelectedFolder = startupFolder ?? AllMailFolder;
+            SelectStartupFolder(startupFolder ?? AllMailFolder);
         }
 
         var cached = startupView != null
@@ -2729,7 +2744,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
         if (view != null) await ApplyViewAsync(view);
         else
         {
-            SelectedFolder = resolved!;
+            SelectStartupFolder(resolved!);
             await RefreshAsync();
         }
     }

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -768,10 +768,28 @@ public partial class MainViewModel : ObservableObject, IDisposable
             !string.IsNullOrEmpty(folder.FullName))
         {
             var remembered = _folderViewState.Recall(folder.AccountId, folder.FullName);
-            if (remembered.HasValue) return remembered.Value;
+            if (remembered.HasValue) return DropDeletedFlagFilter(remembered.Value);
         }
 
         return _defaultListState;
+    }
+
+    /// <summary>
+    /// Drops a named-flag sub-filter whose flag has since been deleted, the same degradation
+    /// <see cref="ApplyViewStateAsync"/> performs for saved views. Without it a folder remembered
+    /// as "flagged Waiting" opens empty for ever once "Waiting" is deleted, with nothing on screen
+    /// to say why — the silent-empty-state failure CLAUDE.md's feature checklist calls out.
+    ///
+    /// Checked against the loaded definitions rather than re-reading them, so this stays
+    /// synchronous; an empty collection means they have not loaded yet, and a filter is kept
+    /// rather than wrongly discarded.
+    /// </summary>
+    private ListState DropDeletedFlagFilter(ListState state)
+    {
+        if (state.FlagFilterId == null || FlagDefinitions.Count == 0) return state;
+        if (!Guid.TryParse(state.FlagFilterId, out var id)) return state with { FlagFilterId = null };
+
+        return FlagDefinitions.Any(d => d.Id == id) ? state : state with { FlagFilterId = null };
     }
 
     /// <summary>
@@ -802,6 +820,10 @@ public partial class MainViewModel : ObservableObject, IDisposable
         }
     }
 
+    /// <summary>Which presentation field a change handler owns. Passed to
+    /// <see cref="NoteListStateChanged"/> so a detach keeps only what the user actually chose.</summary>
+    private enum ListField { Mode, Filter, Sort, DayLimit }
+
     /// <summary>
     /// Called by every presentation-property change handler. A programmatic apply returns early;
     /// a user gesture detaches any active view and records the folder's new state.
@@ -811,14 +833,45 @@ public partial class MainViewModel : ObservableObject, IDisposable
     /// record here would mean that changing the sort while a Conversations view is active promotes
     /// that view's grouping to the global default, which is issue #520 in miniature.
     /// </summary>
-    private void NoteListStateChanged()
+    private void NoteListStateChanged(ListField changed)
     {
         if (_applyingListState) return;
 
-        // Detach-to-custom: adjusting anything while a view is active leaves the view.
-        if (ActiveView != null) ActiveView = null;
+        if (ActiveView != null)
+            DetachFromActiveView(changed);
 
         RememberCurrentListState();
+    }
+
+    /// <summary>
+    /// Leaves the active view, keeping the field the user just changed and dropping the rest back
+    /// to what this folder shows on its own.
+    ///
+    /// Carrying the whole on-screen state across was wrong: the view's filter and day limit were
+    /// never chosen for this folder, and writing them into its memory left the user pinned to them
+    /// with no way out — Clear View resolves to that same stored record and so changes nothing, and
+    /// there is no UI control for the day limit at all. This is the same principle as the per-field
+    /// global default in <see cref="PersistGlobalViewMode"/>: the field you touched is the field
+    /// you chose, and nothing else follows it.
+    /// </summary>
+    private void DetachFromActiveView(ListField changed)
+    {
+        var kept = CurrentListState;
+        ActiveView = null;                                  // resolver now skips the view layer
+        var basis = ResolveListState(SelectedFolder);
+
+        ApplyListState(changed switch
+        {
+            ListField.Mode     => basis with { Mode = kept.Mode },
+            ListField.Sort     => basis with { Sort = kept.Sort },
+            ListField.Filter   => basis with { Filter = kept.Filter, FlagFilterId = kept.FlagFilterId },
+            ListField.DayLimit => basis with { DayLimit = kept.DayLimit },
+            _                  => basis,
+        });
+
+        // ApplyListState suppresses the rebuild, and the fields it just changed are not the ones
+        // the calling handler is about to rebuild for — so drive one here.
+        ApplyFiltersAndSearch();
     }
 
     private void RememberCurrentListState()
@@ -830,6 +883,12 @@ public partial class MainViewModel : ObservableObject, IDisposable
 
         // The calendar replaces the message list entirely; it has no presentation to remember.
         if (IsCalendarFolderName(folder.FullName)) return;
+
+        // A multi-folder view's sentinel folder is never resolved through ResolveListState —
+        // SelectFolderAsync intercepts view sentinels and routes to ApplyViewByIdAsync before the
+        // resolver runs — so an entry written against one could never be read back. Storing it
+        // would only add rows to a file nothing prunes.
+        if (IsViewSentinel(folder.FullName)) return;
 
         _folderViewState.Remember(folder.AccountId, folder.FullName, CurrentListState);
     }
@@ -847,6 +906,19 @@ public partial class MainViewModel : ObservableObject, IDisposable
     {
         SelectedFolder = folder;
         ApplyListState(ResolveListState(folder));
+    }
+
+    /// <summary>
+    /// Lands on All Mail when the current folder or account has been deleted out from under the
+    /// selection. Both callers used to assign <see cref="SelectedFolder"/> bare, which left the
+    /// deleted folder's grouping and filter applied to All Mail — and, worse, live, so the next
+    /// change the user made wrote them into All Mail's own record.
+    /// </summary>
+    private void FallBackToAllMail()
+    {
+        ActiveView     = null;
+        SelectedFolder = AllMailFolder;
+        ApplyListState(ResolveListState(AllMailFolder));
     }
 
     private void PersistGlobalViewMode(ViewMode value)
@@ -4508,7 +4580,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
         // Before the early return below: _suppressFilterRebuild suppresses the *rebuild*, not the
         // record of what the user chose. Putting this after the return would silently drop
         // per-folder writes on every path that batches its changes.
-        NoteListStateChanged();
+        NoteListStateChanged(ListField.Filter);
 
         if (_suppressFilterRebuild) return;
 
@@ -4518,7 +4590,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
     }
 
     /// <summary>Day limit has no global-default form, so it records against the folder only.</summary>
-    partial void OnActiveDayLimitChanged(int? value) => NoteListStateChanged();
+    partial void OnActiveDayLimitChanged(int? value) => NoteListStateChanged(ListField.DayLimit);
 
     partial void OnActiveSortChanged(MessageSort value)
     {
@@ -4533,7 +4605,13 @@ public partial class MainViewModel : ObservableObject, IDisposable
 
         // Sort only — never ViewMode. See NoteListStateChanged.
         if (!_applyingListState) PersistGlobalSort(value);
-        NoteListStateChanged();
+        NoteListStateChanged(ListField.Sort);
+
+        // Honour _suppressFilterRebuild like OnActiveFilterChanged does. SelectFolderAsync now
+        // sets the sort while navigating, and rebuilding here would sort and re-announce the
+        // PREVIOUS folder's messages under the new folder's name — exactly what the flag exists
+        // to prevent. The fetch that follows rebuilds with the right data.
+        if (_suppressFilterRebuild) return;
 
         if (ViewMode == ViewMode.Messages)
             ApplyFiltersAndSearch();
@@ -4550,26 +4628,27 @@ public partial class MainViewModel : ObservableObject, IDisposable
         OnPropertyChanged(nameof(ViewModeLabel));
         OnPropertyChanged(nameof(IsCountSortAvailable));
 
-        if (value == ViewMode.Conversations)
-            ScheduleConversationRebuild();
-        else
-            Conversations = [];
+        // The stale collections are always cleared; only the rebuilds are suppressed. Leaving
+        // the previous folder's groups in place while navigating is what would be read out.
+        Conversations = value == ViewMode.Conversations ? Conversations : [];
+        SenderGroups  = value == ViewMode.From          ? SenderGroups  : [];
+        ToGroups      = value == ViewMode.To            ? ToGroups      : [];
 
-        if (value == ViewMode.From)
-            ScheduleSenderGroupRebuild();
-        else
-            SenderGroups = [];
-
-        if (value == ViewMode.To)
-            ScheduleToGroupRebuild();
-        else
-            ToGroups = [];
+        if (!_suppressFilterRebuild)
+        {
+            if (value == ViewMode.Conversations) ScheduleConversationRebuild();
+            if (value == ViewMode.From)          ScheduleSenderGroupRebuild();
+            if (value == ViewMode.To)            ScheduleToGroupRebuild();
+        }
 
         // ViewMode only — never Sort. See NoteListStateChanged.
         if (!_applyingListState) PersistGlobalViewMode(value);
-        NoteListStateChanged();
+        NoteListStateChanged(ListField.Mode);
 
-        if (value == ViewMode.To && SelectedFolder?.FullName == AllMailFolder.FullName && Messages.Any(m => string.IsNullOrWhiteSpace(m.To)))
+        // Not while navigating: SelectFolderAsync is about to start its own fetch, and this one
+        // would race it. Reachable now that a folder can be remembered in To mode.
+        if (!_suppressFilterRebuild &&
+            value == ViewMode.To && SelectedFolder?.FullName == AllMailFolder.FullName && Messages.Any(m => string.IsNullOrWhiteSpace(m.To)))
             _ = RefreshAsync();
     }
 
@@ -5254,6 +5333,12 @@ public partial class MainViewModel : ObservableObject, IDisposable
     {
         var folder = SelectedFolder;
         if (folder == null || folder.IsHeader || string.IsNullOrEmpty(folder.FullName)) return;
+
+        // Nothing is ever stored for the calendar or for a view's sentinel folder, so there is
+        // nothing to reset — and confirming a reset that could not have happened is worse than
+        // staying quiet. The menu item is bound to a command, not to IsAvailable, so this is the
+        // gate that actually runs.
+        if (IsCalendarFolderName(folder.FullName) || IsViewSentinel(folder.FullName)) return;
 
         _folderViewState?.Forget(folder.AccountId, folder.FullName);
 
@@ -7508,7 +7593,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
         if (SelectedAccount != null && removed.Any(a => a.Id == SelectedAccount.Id))
         {
             SelectedAccount  = Accounts.FirstOrDefault();
-            SelectedFolder   = AllMailFolder;
+            FallBackToAllMail();
             Messages.Clear();
         }
 
@@ -7894,7 +7979,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
             // If the deleted folder was selected, fall back to All Mail
             if (SelectedFolder?.FullName == node.Folder.FullName)
             {
-                SelectedFolder = AllMailFolder;
+                FallBackToAllMail();
                 await FetchAllMailAsync();
             }
 
@@ -8307,7 +8392,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
         // Not an [ObservableProperty], so there is no generated handler to hook — note it here.
         // Guarded on an actual change so the no-op calls that clear an already-null id (every
         // SetFilterAsync, for one) do not detach an active view or write to disk.
-        if (changed) NoteListStateChanged();
+        if (changed) NoteListStateChanged(ListField.Filter);
     }
 
     [RelayCommand]

--- a/QuickMail/ViewModels/SettingsViewModel.cs
+++ b/QuickMail/ViewModels/SettingsViewModel.cs
@@ -23,6 +23,10 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty]
     private string _viewMode = "messages";
 
+    /// <summary>Each folder remembers the presentation it was last given (issue #520).</summary>
+    [ObservableProperty]
+    private bool _rememberViewPerFolder = true;
+
     [ObservableProperty]
     private int _syncDays;
 
@@ -428,6 +432,7 @@ public partial class SettingsViewModel : ObservableObject
         PreviewLines = cfg.PreviewLines;
         ReadAsPlainText = cfg.ReadAsPlainText;
         ViewMode = cfg.ViewMode;
+        RememberViewPerFolder = cfg.RememberViewPerFolder;
         SyncDays = cfg.SyncDays;
         InitialSyncCount = cfg.InitialSyncCount;
         MailSyncPollMinutes = cfg.MailSyncPollMinutes;
@@ -509,6 +514,7 @@ public partial class SettingsViewModel : ObservableObject
         cfg.PreviewLines = PreviewLines;
         cfg.ReadAsPlainText = ReadAsPlainText;
         cfg.ViewMode = ViewMode;
+        cfg.RememberViewPerFolder = RememberViewPerFolder;
         cfg.SyncDays = SyncDays;
         cfg.InitialSyncCount = InitialSyncCount;
         cfg.MailSyncPollMinutes = MailSyncPollMinutes;

--- a/QuickMail/ViewModels/ViewManagerViewModel.cs
+++ b/QuickMail/ViewModels/ViewManagerViewModel.cs
@@ -696,28 +696,12 @@ public partial class ViewManagerViewModel : ObservableObject
         _                                                   => "Newest First",
     };
 
-    private static string FilterKey(MessageFilter f) => f switch
-    {
-        MessageFilter.Unread          => "unread",
-        MessageFilter.Read            => "read",
-        MessageFilter.WithAttachments => "attachments",
-        MessageFilter.Replied         => "replied",
-        MessageFilter.Forwarded       => "forwarded",
-        MessageFilter.ToMe            => "tome",
-        MessageFilter.Flagged         => "flagged",
-        MessageFilter.Watched         => "watched",
-        _                             => "all",
-    };
+    // These were local copies of the ConfigModel mappings and they drifted: SortKey had no
+    // FlaggedFirst arm, so saving a view while "Flagged First" was active silently stored
+    // "dateDesc" — even though ParseSort has always understood "flaggedFirst".
+    private static string FilterKey(MessageFilter f) => ConfigModel.ToConfigString(f);
 
-    private static string SortKey(MessageSort s) => s switch
-    {
-        MessageSort.DateAscending   => "dateAsc",
-        MessageSort.AlphaAscending  => "alphaAsc",
-        MessageSort.AlphaDescending => "alphaDesc",
-        MessageSort.CountDescending => "countDesc",
-        MessageSort.CountAscending  => "countAsc",
-        _                           => "dateDesc",
-    };
+    private static string SortKey(MessageSort s) => ConfigModel.ToConfigString(s);
 }
 
 // ── Event args ────────────────────────────────────────────────────────────────────

--- a/QuickMail/Views/MainWindow.xaml
+++ b/QuickMail/Views/MainWindow.xaml
@@ -595,7 +595,10 @@
                               AutomationProperties.Name="Open View Manager"/>
                     <MenuItem Header="_Clear View"
                               Command="{Binding ClearViewCommand}"
-                              AutomationProperties.Name="Deactivate the current view and return to folder navigation"/>
+                              AutomationProperties.Name="Clear View"/>
+                    <MenuItem Header="_Reset Folder View"
+                              Command="{Binding ResetFolderViewCommand}"
+                              AutomationProperties.Name="Reset Folder View"/>
                 </MenuItem>
                 <MenuItem Header="_Sync Range">
                     <MenuItem Header="Last _7 Days"

--- a/QuickMail/Views/SettingsDialog.xaml
+++ b/QuickMail/Views/SettingsDialog.xaml
@@ -84,6 +84,17 @@
                                         <ComboBoxItem Tag="to" Content="By Recipient"/>
                                     </ComboBox>
                                 </StackPanel>
+
+                                <!-- Per-folder view memory (issue #520) -->
+                                <CheckBox Content="Remem_ber view settings for each folder"
+                                          IsChecked="{Binding RememberViewPerFolder, Mode=TwoWay}"
+                                          Margin="0,8,0,0"
+                                          AutomationProperties.Name="Remember view settings for each folder"/>
+                                <TextBlock Text="Each folder opens the way you last left it. The display mode above applies to folders you have not changed."
+                                           TextWrapping="Wrap"
+                                           Foreground="{DynamicResource Theme.TextSecondary}"
+                                           FontSize="{DynamicResource Theme.FontSizeSmall}"
+                                           Margin="0,4,0,0"/>
                             </StackPanel>
                         </GroupBox>
 

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -1016,7 +1016,12 @@ themselves were the view.)
 
 You can also just change something. Adjusting the view mode, filter, or sort while a view is active
 leaves the view — the title stops showing its name — and what you chose becomes that folder's own
-setting. The saved view itself is never altered; press its hotkey again to go back to it.
+setting.
+
+Only what you changed comes with you. If you are in "Flagged this week" and you change the sort,
+you leave the view with your new sort and the folder back to its usual self — you are not left
+quietly filtered to flagged messages from the last seven days. The saved view itself is never
+altered; press its hotkey again to go back to it.
 
 ---
 

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -483,6 +483,27 @@ Press `Ctrl+Shift+V` (or use the **View** menu) to switch how messages are group
 - **From** — messages grouped by sender
 - **To** — messages grouped by recipient
 
+### Each Folder Remembers How You Left It
+
+Folders do not all want the same treatment. An inbox reads well grouped into **Conversations**; a
+folder full of receipts that all share one subject reads terribly that way — it collapses into a
+single conversation of a hundred messages.
+
+So QuickMail remembers. Change the view mode, filter, or sort in a folder and that folder opens
+that way from then on, including after a restart. Set your inbox to Conversations and your receipts
+folder to Messages once, and each stays put.
+
+A folder you have never changed follows the **Display mode** in **Settings → General**, which also
+tracks the last choice you made anywhere. So the first time you open a new folder it looks like the
+last folder you set up — change it once and it is that folder's own setting from then on.
+
+To hand a folder back to the default, use **Reset Folder View** from the **View → Views** menu or
+the command palette. QuickMail confirms with "Folder view reset."
+
+To turn the whole behaviour off, clear **Remember view settings for each folder** in
+**Settings → General**. The view mode and sort then apply to every folder at once, as they did
+before. Your per-folder settings are kept, so switching it back on restores them.
+
 ### Message List Density
 
 **View → Density** sets how much space each message row takes: **Comfortable** (the default) leaves room around each row, **Compact** tightens them so more messages fit on screen. The change applies at once and is remembered. The same choice is in **Settings → Appearance** under **Message List Density**, and **Density: Comfortable** and **Density: Compact** are in the command palette.
@@ -984,6 +1005,18 @@ A saved view is a named filter you can return to instantly — for example, "Unr
 Open the **View Manager** from the **View** menu or the command palette. Create a view by choosing a folder (or All Inboxes), a message filter, and optionally a date limit. Assign a hotkey to jump to it directly.
 
 Press the assigned hotkey from anywhere in the main window to switch to that view immediately.
+
+### Leaving a view
+
+A view is a temporary overlay, not a change to your settings. **Clear View** — on the
+**View → Views** menu and in the command palette — puts everything back the way the folder was:
+grouping, filter, sort, and any date limit the view applied. Nothing a view does is kept once you
+leave it. (If the view spans several folders, clearing it returns you to All Mail, since the folders
+themselves were the view.)
+
+You can also just change something. Adjusting the view mode, filter, or sort while a view is active
+leaves the view — the title stops showing its name — and what you chose becomes that folder's own
+setting. The saved view itself is never altered; press its hotkey again to go back to it.
 
 ---
 

--- a/docs/planning/per-folder-view-state-pm-dev-spec.md
+++ b/docs/planning/per-folder-view-state-pm-dev-spec.md
@@ -106,9 +106,17 @@ that fixes the bug.
   are not remembered per folder.** Search is transient by design; the rest are global by design.
 - **The calendar is untouched.** `CalendarViewModel` has its own separate view mode and is not
   part of `ListState`.
-- **The `--online` startup gap is not fixed here.** `StartBackgroundSyncAsync` returns before
-  applying `IsDefault` when `OnlineMode` is set ([:2248-2259](../../QuickMail/ViewModels/MainViewModel.cs)),
-  so the default view never applies in online mode. Real bug, unrelated cause — filed separately.
+- **The `--online` startup-view gap is not fixed here.** Rebasing onto #516/#517 retired the
+  `SavedView.IsDefault` flag in favour of a startup *folder* setting, and moved application into
+  `InitialLoadAsync` — which fixed the online-mode hole this spec originally described. A narrower
+  one remains: `ResolveOnlineStartupFolder` returns null for a `view:` key, so a saved view chosen
+  as the startup target is still ignored under `--online`. Different cause, filed separately (#523).
+
+**Added during implementation, after the rebase onto #516/#517:** the startup paths assign
+`SelectedFolder` directly rather than going through `SelectFolderAsync`, so they needed
+`SelectStartupFolder` to apply the resolver explicitly. Without it the startup folder would have
+been the one folder that ignored its own remembered presentation — invisible to every test that
+navigates rather than starts up. Pinned by `StartupFolder_OpensWithItsRememberedPresentation`.
 
 ---
 

--- a/docs/planning/per-folder-view-state-pm-dev-spec.md
+++ b/docs/planning/per-folder-view-state-pm-dev-spec.md
@@ -1,0 +1,709 @@
+# Per-Folder View State — PM/Dev Spec
+
+**Issue:** [#520 — Save view setting for each folder](https://github.com/kellylford/QuickMail/issues/520)
+**Status:** Draft, awaiting approval
+**Date:** 2026-08-11
+
+---
+
+## Section 1: Executive Summary
+
+QuickMail's message-list presentation — grouping, filter, sort, date range — is held as five
+independent `MainViewModel` properties, each with its own persistence rule, mutated from four
+call sites that each reset a *different subset*. The result is that activating a saved view
+permanently rewrites the user's global grouping default, and "Clear View" undoes two of the six
+things "Apply View" did.
+
+This spec replaces those five loose properties with one `ListState` record and a three-layer
+resolver (active view → per-folder memory → global default). Every navigation and every
+deactivation becomes a single whole-record assignment, which makes a partial restore
+inexpressible rather than merely unlikely. On top of that foundation, each folder remembers the
+presentation it was last given, which is what #520 asks for.
+
+---
+
+## Section 2: User Problem & Opportunity
+
+### 2.1 Current state (verified against the code)
+
+| Surface | Today | Pain | Who feels it |
+|---|---|---|---|
+| Activating a saved view | `ApplyViewAsync` sets `ViewMode` ([MainViewModel.cs:1599](../../QuickMail/ViewModels/MainViewModel.cs)); `OnViewModeChanged` writes `cfg.ViewMode` and saves ([:3947-3949](../../QuickMail/ViewModels/MainViewModel.cs)) | One use of a Conversations view permanently changes the global default for every folder, across restarts | Anyone with a saved view whose grouping differs from their usual |
+| Clear View | `ClearViewAsync` ([:4589](../../QuickMail/ViewModels/MainViewModel.cs)) resets `ActiveView` and `ActiveDayLimit` only | Grouping, sort, filter and flag sub-filter all survive the "clear" | #520's reporter, verbatim |
+| Clear View on a multi-folder view | `SelectedFolder` stays on the `\0View:{id}` sentinel; `FetchVirtualAsync` re-fetches the same view's folders | The message set does not change; only the window title does | Anyone with a multi-folder view |
+| Folder navigation | `SelectFolderAsync` ([:4156-4166](../../QuickMail/ViewModels/MainViewModel.cs)) resets six properties but never `ViewMode` or `ActiveSort` | Grouping is global and sticky; a receipts folder that shares a subject collapses to one 151-message conversation | #520's reporter |
+| Sort order | `OnActiveSortChanged` writes `cfg.Sort`, but `ConfigService` has **no reader and no writer** for a `Sort` key (verified: `grep -i sort Services/ConfigService.cs` returns nothing) | Sort survives the process (cached `ConfigModel`) and is silently lost on every restart | Everyone who sets a sort order |
+| Saving a view while "Flagged First" is active | `ViewManagerViewModel.SortKey` ([:724-732](../../QuickMail/ViewModels/ViewManagerViewModel.cs)) has no `FlaggedFirst` arm | The view silently stores `dateDesc`; `ParseSort` understands `flaggedFirst`, so only the write side is broken | Anyone using Flagged First |
+| Clear View discoverability | No `view.clearView` id exists in `CommandRegistry` | Menu-only; absent from the Command Palette; cannot be bound to a key. Violates the project's own enforced shortcut rule | Keyboard and palette users |
+
+**There is no per-folder persisted state of any kind today.** The only folder-keyed structures in
+`MainViewModel` are `_folderCountCts` and `_lastFolderCountSweep`, both unread-count plumbing.
+
+### 2.2 Target personas
+
+- **The receipts filer (#520's reporter).** Keeps Inbox in Conversations because threads matter
+  there, and needs one archive folder in Messages because 151 receipts share a subject. Today he
+  must re-toggle grouping every time he moves between them.
+- **The saved-view user.** Has a "Flagged this week" view bound to Ctrl+1. Wants pressing it and
+  then leaving it to be symmetric — everything it changed, changed back.
+- **The keyboard/palette user.** Expects "Clear View" to be reachable from Ctrl+Shift+P and
+  bindable in Settings → Keyboard, like every other action in the app.
+- **The screen-reader user.** Needs the folder's presentation to be *knowable*, not guessable —
+  and needs it disclosed through the existing View mode toolbar button, not a new announcement
+  on every folder change.
+
+### 2.3 Why now
+
+The reported bug and the requested feature are the same defect seen from two sides: there is no
+single object representing "how this list is presented", so nothing can be saved, restored, or
+scoped. Fixing #520 by bolting a per-folder dictionary onto five loose properties would make the
+existing asymmetry worse. The record-plus-resolver refactor is the smaller change *and* the one
+that fixes the bug.
+
+---
+
+## Section 3: Design Principles
+
+1. **One record, one assignment.** All list presentation lives in a single value type. Restoring
+   is a whole-record assignment, so a half-restore cannot be written by accident. Adding a sixth
+   presentation setting later means adding one field, not remembering four reset sites.
+2. **Applying a view never writes a preference.** A view is a temporary overlay. Nothing it does
+   is persisted anywhere except `ActiveView`. This single rule is what fixes the reported bug.
+3. **One new setting, one new command, no new dialogs.** The failure mode for this feature is a
+   panel of knobs nobody understands. The escape hatch is a command, not a management UI.
+4. **Never announce what a control already shows.** The toolbar's **View mode** button already
+   displays the current grouping and is in the F6 ring. No new folder-change announcement.
+5. **Predictable beats clever.** No heuristics about when to remember. Either a folder has
+   remembered state or it inherits the default.
+
+---
+
+## Section 4: Feature Scope & Acceptance Criteria
+
+### 4.1 In scope
+
+| Feature | Setting / Command | Default | Notes |
+|---|---|---|---|
+| `ListState` record + resolver | — | — | Replaces five loose properties as the unit of assignment |
+| Symmetric apply/clear | — | — | `ClearViewAsync` restores everything `ApplyViewAsync` set |
+| Per-folder memory | `RememberViewPerFolder` (config.ini, General tab) | `on` | Off ⇒ resolver skips the folder layer; today's global-sticky behaviour |
+| Reset this folder | `view.resetFolderView`, category `View` | no default key | Palette + View → Views menu |
+| Clear View registered | `view.clearView`, category `View` | no default key | Fixes the standing registry-rule violation |
+| `Sort` actually persisted | — | `dateDesc` | Adds the missing `ConfigService` reader/writer |
+| `FlaggedFirst` saves correctly | — | — | `SortKey` routed through `ConfigModel.ToConfigString` |
+| Filter string mapping centralised | — | — | `ConfigModel.ParseFilter` / `ToConfigString(MessageFilter)` replaces three copies |
+
+### 4.2 Explicitly out of scope
+
+- **No pruning of the per-folder store.** Entries for deleted folders are left in place. Pruning
+  would have to distinguish real folders from virtual sentinels and view sentinels, and getting
+  that wrong silently drops state. The file is a few hundred bytes per folder.
+- **No "Forget all remembered folder views" button.** Turning `RememberViewPerFolder` off makes
+  the whole layer inert, which is the same outcome with one fewer control.
+- **No per-tab list state.** `MessageListTabViewModel` continues to share the VM's state. The
+  record makes this a clean follow-up; it is not this change.
+- **Search text, selected message, scroll position, row-field layout, density, and reading mode
+  are not remembered per folder.** Search is transient by design; the rest are global by design.
+- **The calendar is untouched.** `CalendarViewModel` has its own separate view mode and is not
+  part of `ListState`.
+- **The `--online` startup gap is not fixed here.** `StartBackgroundSyncAsync` returns before
+  applying `IsDefault` when `OnlineMode` is set ([:2248-2259](../../QuickMail/ViewModels/MainViewModel.cs)),
+  so the default view never applies in online mode. Real bug, unrelated cause — filed separately.
+
+---
+
+## Section 5: Architecture & Technical Decisions
+
+### 5.1 Key architectural decisions
+
+---
+
+**Decision 1: One `readonly record struct ListState` holds grouping, filter, flag sub-filter, sort, and day limit.**
+
+```csharp
+public readonly record struct ListState(
+    ViewMode Mode, MessageFilter Filter, string? FlagFilterId,
+    MessageSort Sort, int? DayLimit);
+```
+
+**Alternatives:**
+1. *Keep the five properties, add a per-folder dictionary of five-tuples.* Pro: smaller diff. Con:
+   the apply/clear asymmetry — the actual reported bug — survives untouched, and a sixth setting
+   later has to be threaded through four reset sites again.
+2. *A mutable `ListState` class.* Pro: familiar. Con: aliasing. A remembered state handed out by
+   reference and then mutated by the VM would corrupt the store silently.
+
+**Rationale:** A value type makes "restore" a single `=`. The five reset sites collapse to one
+method, and the test suite gets one place to assert against.
+
+---
+
+**Decision 2: Three layers, resolved on every navigation.**
+
+```
+Resolve(folder) => ActiveView?.ToListState()                          // 1. explicit overlay
+                ?? (RememberViewPerFolder ? _store.Get(folder) : null) // 2. folder memory
+                ?? _defaultListState;                                  // 3. global default
+```
+
+**Alternatives:**
+1. *Two layers (view → folder), no global default.* Con: a never-visited folder has no state to
+   resolve to.
+2. *Assign a named saved view to a folder.* Pro: explicit, no hidden state. Con: the issue asks
+   for automatic remembering, and it forces view creation for a one-off grouping change.
+
+**Rationale:** Each layer answers a distinct question: what am I *doing right now* (view), what
+does *this folder* want (memory), what does *this app* do by default (config).
+
+---
+
+**Decision 3: A manual change writes the whole record to the folder's memory, but writes only the
+single field that changed to the global default.**
+
+The global default holds two fields (`ViewMode`, `Sort` — filter, flag sub-filter and day limit
+always default to All/null/null). Each is written by, and only by, its own change handler:
+`OnViewModeChanged` writes `cfg.ViewMode`; `OnActiveSortChanged` writes `cfg.Sort`. Neither ever
+writes the other's field.
+
+**Alternatives:**
+1. *Update folder memory only, never the global default.* Con: `Sort` has no Settings UI at all —
+   the View menu and toolbar are the only way to change it — so its default for newly-visited
+   folders would freeze at whatever it was when the user upgraded, permanently unreachable.
+   (`ViewMode` does have one, the **Display mode** combo on the General tab, so this argument is
+   weaker for grouping than for sort. The decision is made on sort and applied to both for
+   consistency.)
+2. *Write the whole current record to the global default on any manual change.* **This was the
+   first draft of this spec and it is wrong.** It reintroduces the reported bug in miniature:
+   activate a Conversations view, change only the sort, and the view's grouping — which the user
+   never chose as a preference — is promoted to the global default for every uncustomised folder.
+   Rejected.
+3. *Update the global default only when no folder memory exists.* Con: the same gesture has two
+   different outcomes depending on invisible state. Unexplainable.
+
+**Rationale:** The field you touched is the field you chose; moving its default is honest, and
+moving anything else is not. Per-field scoping also costs less code than the whole-record write —
+each handler already owns exactly one field.
+
+**Scope of the global default:** it is consulted **only** by folders with no stored state of their
+own. A folder that has been customised never sees it again. "Changing a setting becomes the
+default for all folders" is therefore not accurate; the accurate statement is "becomes the default
+for folders that have not been customised."
+
+**Worked example:** set Inbox → Conversations (Inbox's record is stored; `cfg.ViewMode` becomes
+conversations). Open the receipts folder → no stored record, so it inherits conversations. Set it →
+Messages (receipts' record is stored; `cfg.ViewMode` becomes messages). Inbox is unaffected — it
+has its own record. From then on Inbox is Conversations and receipts is Messages, permanently and
+independently.
+
+---
+
+**Decision 4: `ApplyListState` sets an `_applyingListState` guard; nothing persists while it is set.**
+
+This is the whole fix for the reported bug. `OnViewModeChanged` / `OnActiveSortChanged` /
+`OnActiveFilterChanged` / `OnActiveDayLimitChanged` / `SetActiveFlagFilterId` all funnel into:
+
+```csharp
+private void NoteListStateChanged()
+{
+    if (_applyingListState) return;              // programmatic — never a preference
+    if (ActiveView != null) ActiveView = null;   // detach-to-custom
+    RememberCurrentListState();                  // whole record; no-op when the setting is off
+}
+
+partial void OnViewModeChanged(ViewMode value)
+{
+    // …existing notifications and group-rebuild scheduling…
+    if (!_applyingListState) PersistGlobalViewMode(value);   // this field only — Decision 3
+    NoteListStateChanged();
+}
+```
+
+`OnActiveSortChanged` mirrors this with `PersistGlobalSort`. `OnActiveFilterChanged`,
+`OnActiveDayLimitChanged` and `SetActiveFlagFilterId` call `NoteListStateChanged()` only — those
+three fields have no global-default representation.
+
+Applying a view, navigating to a folder, and clearing a view all run inside the guard.
+Only a user gesture reaches either persistence branch.
+
+The guard and `_suppressFilterRebuild` are **saved and restored**, not set-and-cleared, because
+`SelectFolderAsync` already holds `_suppressFilterRebuild` when it calls `ApplyListState`.
+
+---
+
+**Decision 5: Detach-to-custom, implemented as `ActiveView = null` inside `NoteListStateChanged`.**
+
+Changing grouping/filter/sort/day-limit while a view is active deactivates the view and starts
+remembering against the current folder. The window title drops the view name; the Views menu
+check mark clears (`MainWindow.xaml.cs:6357` already reacts to `ActiveView` changing).
+
+**Rationale:** A "modified view" state would need a dirty flag, a modified title form, a
+Save-changes prompt, and a discard path — four concepts to solve a problem the user can solve by
+pressing the view's hotkey again.
+
+---
+
+**Decision 6: `folderviews.json`, keyed `{AccountId:N}|{FullName}`, string-valued.**
+
+Modelled directly on `ViewService`: profile-dir JSON, `AtomicFile` write, `catch → empty` on load.
+Values are the same strings `SavedView` uses (`"conversations"`, `"dateDesc"`, `"unread"`), not
+enum ordinals, so reordering an enum cannot silently repoint existing entries.
+
+Virtual folders (`AccountId == Guid.Empty`, `FullName` starting `\x00`) and multi-folder view
+sentinels (`\0View:{id}`) key like anything else. That is deliberate: it means a multi-folder
+view's folder set can carry its own remembered presentation with no special case.
+
+**Runtime cost:** one small atomic write per user-initiated presentation change. Same class of
+write as `SetListDensity` does today.
+
+**Consequence — a customised folder is pinned on all five fields, not just the one you changed.**
+The stored value is the whole `ListState`, so the first time you change anything in a folder, that
+folder also captures the grouping/sort/filter it happened to have at that moment and stops
+consulting the global default entirely. Change the global sort later and that folder keeps its own.
+The alternative — a sparse per-field override with presence tracking — is more faithful but adds
+exactly the machinery Principle 3 rules out, and it makes "what will this folder do?" a question
+you have to compute rather than read. `view.resetFolderView` is the escape hatch. **Accepted
+trade-off, called out here because it will surprise someone eventually.**
+
+---
+
+**Decision 7: Clear View on a multi-folder view navigates to All Mail.**
+
+Single-folder views leave `SelectedFolder` on a real folder, so clearing restores the resolved
+state in place. Multi-folder views leave it on a `\0View:{id}` sentinel whose *message set is the
+view* — restoring presentation alone changes nothing but the title. Clearing therefore routes
+through `SelectFolderAsync(AllMailFolder)`, matching both the app's startup home and the menu
+item's existing automation name ("return to folder navigation").
+
+One conditional, and it reuses the existing navigation path rather than adding a second one.
+
+### 5.2 Runtime mode compatibility
+
+| Mode | Behaviour |
+|---|---|
+| Normal | Full feature. `folderviews.json` in `%APPDATA%\QuickMail`. |
+| `--online` | Unchanged. `FolderViewStateService` touches only the profile directory — it never calls `LocalStoreService`, so there is no SQLite dependency and no fallback to design. |
+| `--profileDir <path>` | `folderviews.json` resolves under the supplied profile, via `ProfileContext.ProfileDir`, exactly as `views.json` does. |
+
+### 5.3 Code reuse and duplication risks
+
+- **Filter string ↔ enum mapping exists in three places today:** `ApplyViewAsync`'s inline switch
+  ([:1600-1611](../../QuickMail/ViewModels/MainViewModel.cs)), `SetFilterAsync`'s inline switch
+  ([:7576-7587](../../QuickMail/ViewModels/MainViewModel.cs)), and `ViewManagerViewModel.FilterKey`
+  ([:710-721](../../QuickMail/ViewModels/ViewManagerViewModel.cs)). The store would be a fourth.
+  **Plan:** add `ConfigModel.ParseFilter(string?)` and `ConfigModel.ToConfigString(MessageFilter)`
+  next to the existing `ParseViewMode`/`ParseSort` pair, and route all four through them.
+- **Sort string ↔ enum mapping is duplicated** between `ConfigModel.ParseSort`/`ToConfigString` and
+  `ViewManagerViewModel.SortKey` — and the duplicate is the one missing `FlaggedFirst`. **Plan:**
+  delete `SortKey`, call `ConfigModel.ToConfigString(MessageSort)`. This is the FlaggedFirst fix.
+- **`ViewService` is the template for `FolderViewStateService`** — same constructor shape, same
+  atomic write, same swallow-on-parse-failure. Deliberate mirroring, not accidental duplication.
+
+### 5.4 Shared component audit (mandatory)
+
+| Component | File | Other consumers | Change needed | Risk |
+|---|---|---|---|---|
+| `MainViewModel.ViewMode` | `ViewModels/MainViewModel.cs:646` | `MainWindow.xaml` toolbar button + context menu (`ViewModeLabel`, `IsMessagesView`…), View menu check marks, `SetViewModeCommand`, `view.toggleConversation` (Ctrl+Shift+V), `MainViewModelTabTests` | Setter unchanged; `OnViewModeChanged` keeps its `cfg.ViewMode` write but behind `_applyingListState`, and gains `NoteListStateChanged()` | Ctrl+Shift+V cycling must still persist. It must write **only** `cfg.ViewMode` — never `cfg.Sort`. Covered by §8 scenario 1 and a dedicated per-field test. |
+| `MainViewModel.ActiveSort` | `:652` | Sort menu (7 items), `IsSort*` check marks, `SortLabel`, `CaptureBugReportContext` | Same treatment, writing **only** `cfg.Sort` | Bug-report Environment string must be unchanged. Verified in §8 scenario 6. |
+| `MainViewModel.ActiveFilter` | `:649` | Filter menu (9 items), `IsFilter*`, `WindowTitle`, `ApplyFiltersAndSearch`, `SetFilterAsync`, `SetFlagFilterAsync` | `OnActiveFilterChanged` gains `NoteListStateChanged()` behind the existing `_suppressFilterRebuild` early-return | The early return at `:3895` runs *before* the rebuild; the note call must go **before** that return or folder-navigation writes are skipped. Explicit test. |
+| `SetActiveFlagFilterId` | `:7566` | `ApplyViewAsync`, `SelectFolderAsync`, `SelectCalendarAsync`, `SetFilterAsync`, `SetFlagFilterAsync` | Gains `NoteListStateChanged()` | `SetFilterAsync` sets filter *then* flag id → two writes per gesture. Harmless (idempotent, tiny file); noted rather than optimised. |
+| `ClearViewAsync` | `:4588` | View → Views → Clear View menu item only (no palette entry today) | Rewritten; registered as `view.clearView` | Menu item keeps `ClearViewCommand`; the registry entry invokes the same command. `SavedViewsTests` has 4 existing tests over it — all must still pass. |
+| `SelectFolderAsync` | `:4132` | Folder tree selection, `SelectCalendarAsync` fallthrough, view sentinels, account/folder deletion paths, `RebuildFolderListFromCache` | Reset block replaced by `ApplyListState(ResolveListState(folder))` | The view-sentinel early return at `:4138-4147` must stay **above** the reset — it is what lets multi-folder views set their own state. Comment preserved. |
+| `ApplyViewAsync` | `:1593` | `SelectViewCommand`, `view.saved.*` hotkeys, Views menu, folder-tree sentinel, `RefreshAsync` re-apply, startup default view | State block replaced by `ApplyListState`; ordering (mode before search clear) preserved | `RefreshAsync` re-applies the active view at `:4534-4538`; with the guard this must not detach. Test. |
+| `ViewManagerViewModel.FilterKey` / `SortKey` | `ViewModels/ViewManagerViewModel.cs:710`, `:724` | `BuildName`, `SelectedStateSummary`, `Persist` | Replaced by `ConfigModel` helpers | `BuildName`'s generated view names must be unchanged for non-FlaggedFirst sorts. Assert on the existing strings. |
+| `ConfigService` parser/writer | `Services/ConfigService.cs:192`, `:370` | Every setting in the app | Add `sort` and `rememberviewperfolder` cases + writer lines | INI round-trip. `SettingsViewModelTests`/`WindowingPreferencesTests` are the existing round-trip suites. |
+| `SettingsDialog.xaml` General tab | `Views/SettingsDialog.xaml:31-360` | The one Settings dialog | One `CheckBox` added near the message-list settings | Adds a tab stop on the General tab. Access key must not collide with the 20 existing ones on that tab — verified by reading the tab's `_` mnemonics. |
+| `App.xaml.cs` composition root | `:413` region | — | Construct `FolderViewStateService`, pass to `MainViewModel` | New optional ctor parameter, defaulted null, so the 30+ `new MainViewModel(...)` calls in the test suite compile unchanged. |
+
+**Components with no other consumers:** `ListState`, `IFolderViewStateService`,
+`FolderViewStateService` are all new. `StubFolderViewStateService` will be consumed only by tests.
+
+---
+
+## Section 6: Keyboard Walkthrough (Mandatory)
+
+### Path A: The reported scenario — two folders, two groupings
+
+**Setup:** `RememberViewPerFolder` on (default). Inbox and a "Receipts" folder. Fresh profile,
+global default `messages`/`dateDesc`.
+
+1. User arrows to **Inbox** in the folder tree and presses Enter. **Expected:** Message list loads
+   flat. Toolbar **View mode** button reads "Messages". No new announcement.
+2. User presses **Ctrl+Shift+V** three times to reach Conversations. **Expected:** List regroups.
+   Toolbar button reads "Conversations". Inbox's memory is written; global default becomes
+   `conversations`.
+3. User arrows to **Receipts** and presses Enter. **Expected:** No memory for Receipts, so it
+   inherits the global default — Conversations. Toolbar reads "Conversations". *(This is the one
+   inherited-state moment; step 4 is the fix and it is permanent.)*
+4. User presses **Ctrl+Shift+V** until the toolbar reads "Messages". **Expected:** 151 receipts
+   listed individually. Receipts' memory written.
+5. User returns to **Inbox**. **Expected:** Conversations, from Inbox's memory. Toolbar reads
+   "Conversations".
+6. User returns to **Receipts**. **Expected:** Messages, from Receipts' memory.
+7. User quits and relaunches. **Expected:** Steps 5 and 6 still hold.
+
+### Path B: Apply and clear a saved view — symmetry
+
+**Setup:** Inbox remembered as Conversations. A saved view "Flagged this week"
+(`filter=flagged`, `mode=messages`, `sort=dateAsc`, `daysOfMail=7`) bound to Ctrl+1.
+
+1. From Inbox, user presses **Ctrl+1**. **Expected:** View applies. Window title
+   "Flagged this week — Flagged - QuickMail". Toolbar reads "Messages". Views menu shows the view
+   checked. Inbox's memory is **not** written; global default is **not** written.
+2. User opens **View → Views → Clear View** (or runs it from **Ctrl+Shift+P**). **Expected:** The
+   view deactivates. Grouping returns to **Conversations**, sort to **Newest First**, filter to
+   **All**, day limit cleared — all of it, from Inbox's memory. Title returns to
+   "Inbox - <account> - QuickMail". Views menu check mark clears.
+3. User presses **Ctrl+1** again, then presses **Ctrl+Shift+V** once. **Expected:** The view
+   detaches — title loses the view name, Views menu check clears — and the new grouping is written
+   to Inbox's memory *and* to the global grouping default (the user chose that grouping). Nothing
+   prompts, nothing is saved into the view definition.
+4. User presses **Ctrl+1** once more, then changes only the **sort** from the Sort menu.
+   **Expected:** The view detaches and Inbox's memory records the whole state, but the **global
+   grouping default is untouched** — only the global sort moves. The view's grouping was never
+   chosen by the user and must not become anyone's default.
+
+### Path C: Clear View from a multi-folder view
+
+1. User activates a multi-folder saved view. **Expected:** Message list shows the union; title is
+   the view name.
+2. User runs **Clear View**. **Expected:** Navigates to **All Mail**; the message list changes to
+   All Mail's contents; presentation resolves from All Mail's own memory (or the global default);
+   focus stays where it was (the menu closes and returns focus per existing behaviour).
+
+### Path D: Reset this folder
+
+1. In Receipts (remembered as Messages, sorted Oldest First), user presses **Ctrl+Shift+P**, types
+   "reset", and presses Enter on **Reset Folder View**. **Expected:** Grouping and sort return to
+   the global default; the stored entry for Receipts is deleted. Screen reader announces
+   "Folder view reset." (Result category — nothing else confirms the deletion.)
+2. User navigates away and back. **Expected:** Receipts now inherits the global default, confirming
+   the entry is gone rather than merely overwritten.
+
+### Path E: Turning the setting off
+
+1. User opens **Settings (Ctrl+,) → General**, Tabs to **Remember view settings for each folder**,
+   presses **Space** to clear it, activates **OK**. **Expected:** Checkbox reports unchecked.
+   Applies immediately, no restart.
+2. User moves between Inbox and Receipts. **Expected:** Grouping no longer changes per folder;
+   whatever is set stays set — today's behaviour. `folderviews.json` is left on disk untouched.
+3. User re-checks the setting. **Expected:** Per-folder state resumes from the preserved file.
+
+### Path F: Empty and edge states
+
+1. First launch, no `folderviews.json`. **Expected:** Every folder resolves to the global default.
+   No error, no empty list.
+2. `folderviews.json` corrupt or unreadable. **Expected:** Treated as empty (matching
+   `ViewService.Load`). The app starts normally at the global default; nothing is announced.
+3. A remembered flag sub-filter whose `FlagDefinition` has since been deleted. **Expected:** Same
+   degradation `ApplyViewAsync` already performs — validated against live definitions, dropped to
+   "all flagged" rather than showing an unexplained empty list.
+4. Folder selected while the **Calendar** node is chosen. **Expected:** `ListState` resets to
+   default (message list is hidden anyway); returning to a mail folder resolves normally.
+
+---
+
+## Section 7: Accessibility Checklist (Mandatory)
+
+- **`AutomationProperties.Name` introduced:** one, on the new checkbox —
+  `"Remember view settings for each folder"`. Short label, no role name, no shortcut, no sentence.
+  The existing Clear View menu item's name is corrected from *"Deactivate the current view and
+  return to folder navigation"* (a sentence, and only accurate for multi-folder views) to
+  **"Clear View"**.
+- **Announcements added:** exactly one — `"Folder view reset."`, `AnnouncementCategory.Result`,
+  from `ResetFolderView`. Justified because the command deletes stored state and no control
+  reflects that deletion.
+- **Announcements deliberately NOT added:** nothing on folder change, nothing on view detach,
+  nothing on grouping change. The toolbar **View mode** button
+  ([MainWindow.xaml:777-781](../../QuickMail/Views/MainWindow.xaml)) already displays the current
+  grouping, is in the F6 ring, and is named "View mode". Speaking the grouping on every folder
+  change would override the user's own verbosity decision — the defect the CLAUDE.md announcement
+  rules describe.
+- **Screen reader browse mode:** unaffected. No WebView2 involvement.
+- **Focus restoration:** no new dialogs. `ResetFolderView` and `ClearView` run from a menu or the
+  palette; both already restore focus to the message list on close.
+- **F6 ring:** unchanged. No new panes.
+- **Radio/checkbox groups:** one standalone `CheckBox`, not a group — no `TabNavigation="Once"`
+  needed. Its access key must not collide with the General tab's existing mnemonics.
+- **Colour-only information:** none. Grouping is disclosed as text on the toolbar button.
+- **`Selector`-bound item types:** none introduced, so no `SelectorItemAccessibilityTests` entry.
+
+---
+
+## Section 8: Acceptance Walkthrough (Mandatory)
+
+### Scenario 1: The reported bug — per-folder grouping
+
+**Setup:** App running, two folders, `RememberViewPerFolder` on.
+
+1. Set Inbox to Conversations via Ctrl+Shift+V. **Verify:** toolbar reads "Conversations".
+2. Navigate to Receipts, set it to Messages. **Verify:** toolbar reads "Messages"; receipts listed
+   individually, not as one 151-message conversation.
+3. Return to Inbox. **Verify:** toolbar reads "Conversations".
+4. Quit and relaunch; visit both. **Verify:** each folder opens as left.
+
+### Scenario 2: Apply/clear symmetry
+
+**Setup:** Inbox remembered as Conversations, sort Newest First.
+
+1. Activate a view with `mode=messages`, `filter=unread`, `sort=dateAsc`, `days=7`. **Verify:**
+   all four applied; title shows the view name.
+2. Run Clear View. **Verify:** grouping Conversations, sort Newest First, filter All, and the View
+   menu's day-limit state cleared — **all four**, not two.
+3. Quit and relaunch. **Verify:** the global default is still what it was before step 1 — activating
+   the view did not change it.
+4. **Per-field default scoping.** Activate a Conversations view from a folder whose global default
+   grouping is Messages. Change only the **sort**. **Verify:** the view detaches; then visit a
+   folder that has never been customised and confirm it still opens in **Messages**. The view's
+   grouping must not have become the global default. *(This is the failure mode Decision 3
+   alternative 2 describes; it is the single highest-value check in this scenario.)*
+
+### Scenario 3: Detach-to-custom
+
+1. Activate a saved view. **Verify:** Views menu shows it checked; title shows its name.
+2. Press Ctrl+Shift+V. **Verify:** check mark clears, title loses the view name, grouping changed,
+   and reopening the View Manager shows the saved view's own definition **unmodified**.
+
+### Scenario 4: The new setting (toggle both ways, no restart)
+
+1. Settings → General → clear **Remember view settings for each folder** → OK. **Verify:** moving
+   between folders no longer changes grouping.
+2. Re-check it → OK. **Verify:** per-folder grouping resumes with the previously stored values.
+
+### Scenario 5: Reset Folder View
+
+1. From a customised folder, run **Reset Folder View** from the palette. **Verify:** presentation
+   returns to the global default; "Folder view reset." is announced.
+2. Navigate away and back. **Verify:** the folder still shows the default (entry deleted, not
+   overwritten).
+
+### Scenario 6: Shared-component regressions (one per §5.4 consumer)
+
+1. **View menu check marks** — open View → each of Messages/Conversations/From/To. **Verify:** the
+   check mark tracks the toolbar label in both directions.
+2. **Filter menu** — apply Unread, then Flagged, then a named flag. **Verify:** correct filtering;
+   `WindowTitle` shows the filter suffix.
+3. **Sort menu** — choose **Flagged First**, then **Save View…**. **Verify:** the created view's
+   sort reads back as Flagged First (today it silently becomes Newest First).
+4. **Sort persistence** — set Oldest First, quit, relaunch. **Verify:** still Oldest First (today
+   it resets to Newest First).
+5. **Ctrl+Shift+V cycling** — press four times. **Verify:** cycles all four modes and the last one
+   survives a restart.
+6. **Bug report Environment block** — Help → Report a Bug. **Verify:** the View and Sort lines read
+   exactly as before this change.
+7. **Multi-folder view** — activate one, run Clear View. **Verify:** lands on All Mail with All
+   Mail's contents.
+8. **Folder/account deletion** — delete a folder that had remembered state. **Verify:** no crash;
+   the stale entry is simply never resolved.
+
+### Scenario 7: `--online` mode
+
+1. Launch with `--online`. **Verify:** per-folder grouping works exactly as in normal mode
+   (the store never touches SQLite).
+
+### Scenario 8: Screen reader
+
+1. Tab to the new checkbox in Settings → General. **Verify:** announced as
+   "Remember view settings for each folder, checkbox, checked". No trailing instructions.
+2. Move between three folders with different remembered groupings. **Verify:** **no** grouping
+   announcement fires on folder change; the toolbar View mode button reports it on F6.
+3. Run Reset Folder View. **Verify:** "Folder view reset." is heard once.
+
+---
+
+## Section 9: Success Metrics
+
+- **Behavioural:** two folders hold two different groupings across a restart.
+- **No leakage:** activating and clearing a saved view leaves `config.ini` byte-identical.
+- **Symmetry:** a test asserts every field of `ListState` is restored by Clear View.
+- **Keyboard:** Clear View and Reset Folder View are both reachable from Ctrl+Shift+P and bindable
+  in Settings → Keyboard.
+- **No regressions:** all four existing `SavedViewsTests` Clear View tests pass unchanged.
+- **Online mode:** Scenario 7 passes.
+- **Knob count:** exactly one new setting and two new commands ship.
+
+---
+
+## Section 10: Implementation Phases
+
+### Phase 1 — `ListState`, resolver, symmetric apply/clear (no persistence yet)
+
+**Goal:** The reported bug is fixed. Behaviour is otherwise identical to today.
+
+**Deliverables:** `Models/ListState.cs`; `ConfigModel.ParseFilter`/`ToConfigString(MessageFilter)`;
+`MainViewModel` — `ApplyListState`, `ResolveListState`, `NoteListStateChanged`,
+`_applyingListState`, `_defaultListState`; `ApplyViewAsync`, `SelectFolderAsync`,
+`SelectCalendarAsync`, `ClearViewAsync` rewritten onto them; the config write removed from
+`OnViewModeChanged`/`OnActiveSortChanged` and replaced by `PersistGlobalDefault()`.
+
+**Tests:** `ListStateTests` (construction, equality, `Default`); new `SavedViewsTests` cases —
+Clear View restores mode/filter/sort/flag/day-limit; applying a view does not write config;
+`RefreshAsync` re-applying a view does not detach.
+
+**Risk:** the `_suppressFilterRebuild` early return in `OnActiveFilterChanged` swallows the note
+call if placed after it → per-folder writes silently skipped in phase 2. Mitigation: note call
+goes before the return, with a test that navigates and asserts a write.
+
+### Phase 2 — Per-folder store and the setting
+
+**Goal:** #520 delivered.
+
+**Deliverables:** `Services/IFolderViewStateService.cs`, `Services/FolderViewStateService.cs`;
+`ConfigModel.RememberViewPerFolder` + `ConfigService` reader/writer; `App.xaml.cs` wiring;
+optional `MainViewModel` ctor parameter; `SettingsDialog.xaml` checkbox + `SettingsViewModel`
+property; `StubFolderViewStateService`.
+
+**Tests:** `FolderViewStateServiceTests` (round-trip, missing file, corrupt file, virtual-folder
+and view-sentinel keys); `MainViewModel` tests for resolve order and for the setting being off.
+
+**Risk:** key collisions between a real folder and a virtual sentinel. Mitigation: `AccountId` is
+part of the key and virtual folders carry `Guid.Empty`; explicit test.
+
+### Phase 3 — Commands, menu, and the adjacent bugs
+
+**Goal:** Discoverable, and the three verified defects fixed.
+
+**Deliverables:** register `view.clearView` and `view.resetFolderView`; `ResetFolderViewAsync`;
+View menu item + corrected automation name; `ConfigService` `Sort` reader/writer;
+`ViewManagerViewModel.SortKey` deleted in favour of `ConfigModel.ToConfigString`.
+
+**Tests:** `CommandRegistryTests` — both ids registered with category `View`;
+`ViewManagerViewModel` — saving with Flagged First round-trips; `ConfigService` — `Sort`
+round-trips through a real file.
+
+**Risk:** `BuildName`'s generated view names change if the helper's strings drift from `SortKey`'s.
+Mitigation: assert the existing generated names verbatim.
+
+---
+
+## Section 11: Files to Create / Modify
+
+### Create
+
+| File | Purpose | Lines (est.) |
+|---|---|---|
+| `Models/ListState.cs` | The record + `Default` | 30 |
+| `Services/IFolderViewStateService.cs` | Get / Set / Clear | 20 |
+| `Services/FolderViewStateService.cs` | JSON store, mirrors `ViewService` | 90 |
+| `QuickMail.Tests/ListStateTests.cs` | Record behaviour | 40 |
+| `QuickMail.Tests/FolderViewStateServiceTests.cs` | Persistence | 120 |
+
+### Modify
+
+| File | Changes | Lines (est.) |
+|---|---|---|
+| `ViewModels/MainViewModel.cs` | Resolver, guard, four rewritten call sites, two commands | +170 / −60 |
+| `Models/ConfigModel.cs` | `RememberViewPerFolder`, `ParseFilter`, `ToConfigString(MessageFilter)` | +40 |
+| `Services/ConfigService.cs` | `sort` + `rememberviewperfolder` read/write | +20 |
+| `ViewModels/ViewManagerViewModel.cs` | `FilterKey`/`SortKey` → `ConfigModel` helpers | +5 / −25 |
+| `Views/MainWindow.xaml` | Reset menu item; Clear View automation name | +6 |
+| `Views/SettingsDialog.xaml` | One checkbox | +6 |
+| `ViewModels/SettingsViewModel.cs` | One bound property | +10 |
+| `App.xaml.cs` | Construct and inject the service | +4 |
+| `QuickMail.Tests/StubServices.cs` | `StubFolderViewStateService` | +25 |
+| `QuickMail.Tests/SavedViewsTests.cs` | Symmetry + no-leak cases | +120 |
+| `docs/USER-GUIDE.md` | Message List Views + Saved Views sections | +25 |
+
+---
+
+## Section 12: Tests to Add
+
+| Test class | Methods | Coverage |
+|---|---|---|
+| `ListStateTests` | Default values; value equality; `with` produces a distinct value | Record semantics |
+| `FolderViewStateServiceTests` | Round-trip; missing file → null; corrupt file → empty, no throw; real vs virtual key isolation; view-sentinel key; `Clear` removes; overwrite | Persistence + the key-collision risk |
+| `SavedViewsTests` (extend) | `ClearView_RestoresEveryListStateField`; `ApplyView_DoesNotWriteConfig`; `ApplyView_DoesNotWriteFolderMemory`; `Refresh_ReapplyingView_DoesNotDetach`; `ChangingGroupingWithViewActive_Detaches`; `ClearView_OnMultiFolderView_NavigatesToAllMail` | The reported bug, pinned |
+| `MainViewModel` per-folder tests | Resolve order (view > folder > default); setting off skips the folder layer; navigating writes memory; `ResetFolderView` deletes the entry | The feature |
+| `MainViewModel` default-scoping tests | `ChangingSort_DoesNotWriteConfigViewMode`; `ChangingGrouping_DoesNotWriteConfigSort`; `ChangingSortWhileViewActive_LeavesConfigViewModeUnchanged`; `CustomisedFolder_IgnoresLaterGlobalDefaultChange` | Decision 3 and the Decision 6 pinning consequence |
+| `CommandRegistryTests` (extend) | `view.clearView` and `view.resetFolderView` registered, category `View` | Registry rule |
+| `ViewManagerViewModelTests` (extend) | Saving with `FlaggedFirst` round-trips; `BuildName` output unchanged for existing sorts | The FlaggedFirst fix, no name drift |
+| `ConfigService` round-trip | `Sort` and `RememberViewPerFolder` survive write→read | The Sort persistence fix |
+
+---
+
+## Section 13: Known Risks & Open Questions
+
+### 13.1 Risks
+
+| Risk | Probability | Impact | Mitigation |
+|---|---|---|---|
+| The `_applyingListState` guard is missed on a path that sets a property directly, so applying a view still writes a preference | Medium | Blocker (the original bug returns) | Every write funnels through `NoteListStateChanged`; a test asserts `config.ini` is unchanged across apply→clear |
+| `_suppressFilterRebuild` clobbered by nesting — `SelectFolderAsync` holds it when calling `ApplyListState` | High | Major (double rebuild or a missing one) | Save/restore rather than set/clear; called out in Decision 4 |
+| Note call placed after the early return in `OnActiveFilterChanged` | Medium | Major (silent no-write) | Named in Phase 1 risk with a dedicated test |
+| Key collision between a real folder and a virtual sentinel | Low | Major (wrong state applied) | `AccountId` in the key; explicit test |
+| A handler writes the whole record to the global default instead of its own field, leaking a view's grouping into the default | Medium | Blocker (the reported bug, reintroduced) | Decision 3; `PersistGlobalViewMode`/`PersistGlobalSort` are separate one-field methods, and four `MainViewModel` default-scoping tests pin it |
+| A folder inherits a surprising grouping on first visit (Decision 3) | High by design | Minor | Documented in the walkthrough as the single inherited-state moment; self-correcting on first change |
+| A customised folder stops following a later change to the global default (Decision 6 pinning) | High by design | Minor | Documented in Decision 6; `view.resetFolderView` is the escape hatch |
+| Per-gesture disk write becomes noticeable | Low | Minor | Same write class as `SetListDensity`; file is a few hundred bytes |
+| `SetFilterAsync` writes twice per gesture | High | Trivial | Accepted; noted in §5.4 rather than optimised |
+| Feature grows into a knob panel | Medium | Major (Kelly's stated concern) | Principle 3 is a review gate: one setting, two commands, no dialog. Anything beyond that needs a new decision. |
+
+### 13.2 Open questions
+
+None outstanding. Three were resolved before drafting:
+
+- **What does a folder remember?** All five `ListState` fields. *(Decided.)*
+- **Editing while a view is active?** Detach to custom. *(Decided — Decision 5.)*
+- **Automatic or opt-in?** Automatic, with one Settings checkbox to disable. *(Decided.)*
+
+Three resolved during drafting and worth explicit sign-off:
+
+- **Does a manual change still update the global default?** Yes, but **only for the field that
+  changed** — Decision 3. Without any global write, the "default for new folders" becomes
+  unreachable, since `ViewMode` and `Sort` have no Settings UI. With a whole-record write, a view's
+  grouping leaks into the default the moment you change the sort — the reported bug, reintroduced.
+  Per-field is the only option that avoids both.
+- **Does a customised folder keep following the global default for fields it never changed?** No —
+  the stored record pins all five. Sparse overrides rejected under Principle 3; see Decision 6.
+- **What does Clear View do on a multi-folder view?** Navigates to All Mail — Decision 7.
+
+---
+
+## Section 14: Appendix — Keyboard Reference
+
+| Key | Action | Notes |
+|---|---|---|
+| `Ctrl+Shift+V` | Cycle grouping | Existing. Now writes per-folder rather than globally. |
+| — | **Clear View** | Newly registered as `view.clearView`. No default key; palette + View menu. |
+| — | **Reset Folder View** | New: `view.resetFolderView`. No default key; palette + View menu. |
+
+No default key is assigned to either — both are infrequent, and the unassigned-key surface is
+already crowded. Both are bindable in Settings → Keyboard.
+
+---
+
+## Section 15: Implementation Guidance for AI
+
+### 15.1 Adjustments expected
+
+- The spec does not fix the exact JSON shape of `folderviews.json` beyond "string-valued, keyed
+  `{AccountId:N}|{FullName}`". Choose the DTO layout; keep enum values as the same strings
+  `SavedView` uses.
+- Whether `ApplyListState` ends with `ApplyFiltersAndSearch()` or leaves the rebuild to the caller
+  is an implementation call. Every current call site is followed by a fetch except
+  `ResetFolderView`; whichever you choose, make it uniform and say so in the code comment.
+- The Settings checkbox's access key is not specified — pick one that does not collide with the
+  General tab's existing mnemonics, and verify by reading them.
+
+### 15.2 When to stop and ask
+
+- **The keyboard walkthrough in §6 is normative.** If an implementation detail forces a different
+  user-visible sequence, stop and ask rather than adjusting the walkthrough.
+- If Decision 3 (manual change updates the global default) turns out to produce a case where a
+  folder's remembered state is overwritten by inheritance, stop — that is a resolver bug, not a
+  tuning question.
+- **If the design starts needing a second setting, stop and ask.** Principle 3 is the constraint
+  Kelly named explicitly.
+
+### 15.3 Highest-risk acceptance steps
+
+The steps most likely to catch bugs in this implementation:
+
+1. §8 Scenario 2 step 4 — changing the sort while a Conversations view is active must not make
+   Conversations the global default. This is the reported bug's subtlest form and the one the
+   first draft of this spec got wrong.
+2. §8 Scenario 2 step 3 — `config.ini` unchanged across apply→clear. This is the reported bug in
+   its plain form.
+3. §8 Scenario 6 step 4 — sort survives a restart. The `ConfigService` gap means this has never
+   worked; it is easy to "fix" the model and forget the parser.
+4. §8 Scenario 1 step 4 — both folders correct after a relaunch. Proves the store, the keys, and
+   the resolver together.

--- a/docs/planning/per-folder-view-state-pm-dev-spec.md
+++ b/docs/planning/per-folder-view-state-pm-dev-spec.md
@@ -248,6 +248,15 @@ check mark clears (`MainWindow.xaml.cs:6357` already reacts to `ActiveView` chan
 Save-changes prompt, and a discard path — four concepts to solve a problem the user can solve by
 pressing the view's hotkey again.
 
+**Amended after independent review — a detach keeps only the field the user changed.** The first
+implementation wrote the whole on-screen record to the folder's memory on detach. That silently
+made the *view's* filter and day limit the folder's own permanent setting: Clear View then resolved
+to that same record and changed nothing, and since there is no UI control for `ActiveDayLimit` at
+all, the user was pinned to a date range with no way out but Reset Folder View. Detaching now takes
+`ResolveListState(folder)` with the changed field laid over it — the same per-field principle as
+Decision 3, applied to the folder layer. Pinned by
+`DetachingByChangingSort_DoesNotInheritTheViewsFilterOrDayLimit`.
+
 ---
 
 **Decision 6: `folderviews.json`, keyed `{AccountId:N}|{FullName}`, string-valued.**
@@ -256,9 +265,13 @@ Modelled directly on `ViewService`: profile-dir JSON, `AtomicFile` write, `catch
 Values are the same strings `SavedView` uses (`"conversations"`, `"dateDesc"`, `"unread"`), not
 enum ordinals, so reordering an enum cannot silently repoint existing entries.
 
-Virtual folders (`AccountId == Guid.Empty`, `FullName` starting `\x00`) and multi-folder view
-sentinels (`\0View:{id}`) key like anything else. That is deliberate: it means a multi-folder
-view's folder set can carry its own remembered presentation with no special case.
+Virtual folders (`AccountId == Guid.Empty`, `FullName` starting `\x00`) key like anything else.
+
+**Corrected after independent review:** the draft claimed multi-folder view sentinels
+(`\0View:{id}`) would do the same, letting a view's folder set carry its own presentation. They
+cannot — `SelectFolderAsync` intercepts view sentinels and routes to `ApplyViewByIdAsync` *before*
+the resolver block, so such an entry could never be read back. Writing one would only add dead rows
+to a file nothing prunes. `RememberCurrentListState` now excludes them.
 
 **Runtime cost:** one small atomic write per user-initiated presentation change. Same class of
 write as `SetListDensity` does today.

--- a/docs/release-notes-v0.8.39.md
+++ b/docs/release-notes-v0.8.39.md
@@ -49,6 +49,28 @@ If you have several accounts and a lot of folders, QuickMail used to check every
 
 New mail still arrives in your inboxes straight away whichever you choose, so notifications are unaffected. Other folders are caught up by the background check — the **Check for new mail every** setting on the **General** tab. If you have that set to **Off**, other folders are only checked when you open them. ([#516](https://github.com/kellylford/QuickMail/issues/516))
 
+## New: each folder remembers how you left it
+
+Folders do not all want the same treatment. An inbox reads well grouped into **Conversations**. A folder full of receipts that all share one subject reads terribly that way — it collapses into a single conversation of a hundred and fifty messages, which is exactly what one of you reported.
+
+Now the choice is per folder. Change the view mode, filter, or sort in a folder and that folder opens that way from then on, including after a restart. Set your inbox to Conversations and your receipts folder to Messages once, and each stays where you put it.
+
+A folder you have never changed follows the **Display mode** on the **General** tab of Settings, which also tracks the last choice you made anywhere — so a folder you open for the first time looks like the last one you set up, and one change makes it its own.
+
+**Reset Folder View**, on the **View → Views** menu and in the Command Palette, hands a folder back to the default. To turn the whole behaviour off, clear **Remember view settings for each folder** in **Settings → General**; your per-folder choices are kept, so switching it back on restores them. ([#520](https://github.com/kellylford/QuickMail/issues/520))
+
+## Fixed: leaving a view left some of it behind
+
+**Clear View** was supposed to put things back the way they were. It restored two things and left four: the grouping, the sort, the filter, and any flag filter the view applied all stayed in force after the view was gone. Worse, simply *using* a view that grouped by conversation quietly made Conversations your default for every folder, permanently and across restarts — which is how several people ended up in Conversations without ever choosing it.
+
+Both are fixed. A view is now a genuine overlay: using one changes no setting of yours, and leaving it restores everything it touched. If you change something while a view is active you leave the view, keeping the change you made and nothing else — so adjusting the sort inside "Flagged this week" no longer leaves you quietly filtered to flagged mail from the last seven days. ([#520](https://github.com/kellylford/QuickMail/issues/520))
+
+## Fixed: three smaller things in the same area
+
+- **Your sort order was forgotten at every launch.** Choosing Oldest First, or any sort other than Newest First, held for the session and then reset the next time QuickMail started. It now survives restarts, like every other preference.
+- **Saving a view while "Flagged First" was in effect stored the wrong sort.** The view came back sorted newest-first instead. Every sort order now saves faithfully.
+- **Clear View was missing from the Command Palette** and could not be given a keyboard shortcut. It is now in both, along with the new Reset Folder View. ([#520](https://github.com/kellylford/QuickMail/issues/520))
+
 ---
 
 ## Reporting Issues


### PR DESCRIPTION
Closes #520.

## The problem

Grouping, filter, flag sub-filter, sort and day limit were five loose `MainViewModel` properties with five different persistence rules, mutated from four call sites that each reset a *different subset*. Two consequences, both of which users hit:

- **Applying a saved view rewrote the global default.** `ApplyViewAsync` set `ViewMode`, whose setter wrote `cfg.ViewMode` and saved. One use of a Conversations view made Conversations the grouping for every folder, permanently, across restarts.
- **Clear View undid two of the six things Apply View did.** Grouping, sort, filter and the named-flag sub-filter all survived the "clear".

There was no per-folder state of any kind, which is what #520 asks for.

## The shape of the fix

One `ListState` record resolved from three layers — active view → the folder's own memory → the global default. Every navigation and every deactivation is now a single whole-record assignment, so a partial restore is not expressible rather than merely unlikely, and a sixth presentation setting later means one more field instead of four reset sites.

On that footing each folder remembers what it was last given (`folderviews.json`), so an inbox can sit in Conversations while a receipts folder whose messages all share one subject sits in Messages.

Two rules do the real work:

- **Applying a view writes no preference at all** — an `_applyingListState` guard means nothing programmatic reaches persistence.
- **A manual change writes only the field it touched.** Changing the sort while a Conversations view is active must not promote that grouping to the global default — the same bug in miniature, and the thing the first draft of the spec got wrong.

Changing anything while a view is active detaches from the view rather than editing it. The saved view is never modified; its hotkey puts you back.

## Adjacent defects found in the code being rewritten

- `ConfigService` had **neither a reader nor a writer for `Sort`**. The chosen sort survived the process via the cached `ConfigModel` and silently reset on every launch. This has never worked.
- `ViewManagerViewModel` kept private copies of the filter and sort mappings, and the sort copy had **no `FlaggedFirst` arm** — saving a view while "Flagged First" was active stored `dateDesc`. Both now route through `ConfigModel`.
- **Clear View was never registered in `CommandRegistry`** — menu-only, missing from the palette, unbindable. A standing violation of the repo's own "register first, hardcode never" rule. Now `view.clearView`, alongside the new `view.resetFolderView`.

## Knob count

One setting (`RememberViewPerFolder`, one checkbox on Settings → General), two commands, no new dialog. A "forget all remembered views" button and pruning of stale entries were both considered and cut.

## Tests

+21, full suite **2734 passing / 0 failing**. `ListState` semantics; `FolderViewStateService` round-trip, corrupt-file and key-isolation; the resolver, detach, and per-field default scoping; `config.ini` round-trips for `Sort` and the new setting; command registration.

One existing test changed meaning: `Refresh_WithActiveView_ReappliesViewMode` asserted the pre-fix behaviour — that changing the grouping left the view attached so the next Refresh silently undid the change. It is replaced by two tests covering the new contract, not relaxed.

## Not in this PR

The startup default view is never applied in `--online` mode: `StartBackgroundSyncAsync` returns before the `IsDefault` branch. Real bug, unrelated cause, filed separately.

## Review notes

Spec with full rationale, keyboard walkthrough and acceptance script: `docs/planning/per-folder-view-state-pm-dev-spec.md`. The decisions most worth scrutiny are §5.1 Decision 3 (per-field default scoping) and Decision 7 (Clear View on a multi-folder view navigates to All Mail).

Not yet manually exercised in the running app — the acceptance walkthrough in §8 is the script for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)