### PR TITLE
Docs: menu paths pointed at Tools, but Settings is on File

### DIFF
--- a/QuickMail/Services/ConfigService.cs
+++ b/QuickMail/Services/ConfigService.cs
@@ -704,7 +704,7 @@ public class ConfigService : IConfigService
         sb.AppendLine($"StartupFolder = {config.StartupFolder}");
         sb.AppendLine("# The folder QuickMail opens in. Empty means All Mail.");
         sb.AppendLine("# Set it from the folder tree's context menu (\"Set as Startup Folder\") or");
-        sb.AppendLine("# under Tools > Settings > Startup. A virtual folder is stored by name, e.g.");
+        sb.AppendLine("# under File > Settings > Startup. A virtual folder is stored by name, e.g.");
         sb.AppendLine("# AllInboxes; a real folder is stored as its server name plus the account");
         sb.AppendLine("# below. A folder that no longer exists falls back to All Mail at launch.");
         sb.AppendLine();

--- a/QuickMail/Views/ViewManagerWindow.xaml
+++ b/QuickMail/Views/ViewManagerWindow.xaml
@@ -211,7 +211,7 @@
 
                     <!-- The "Default view (applied on startup)" checkbox lived here until #516. Setting
                          a startup folder no longer needs a saved view at all: use the folder tree's
-                         "Set as Startup Folder", or Tools > Settings > Startup. The whole Options
+                         "Set as Startup Folder", or File > Settings > Startup. The whole Options
                          section went with it, being that checkbox and nothing else. -->
 
                     <!-- Name (last before Save — shown after day limit so the suggestion already includes it) -->

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -123,7 +123,7 @@ Remove QuickMail from **Settings → Apps** as usual. After the app is removed, 
 
 ## Accounts
 
-Adding an account, changing one, testing it, and removing it all happen in **Manage Accounts**. Open it from **File → Manage Accounts…**, from the **Accounts** button on the toolbar, or from the Command Palette (**Ctrl+Shift+P**) by choosing **Manage Accounts**. It has no keyboard shortcut of its own to begin with; you can give it one under **Settings → Keyboard Shortcuts**.
+Adding an account, changing one, testing it, and removing it all happen in **Manage Accounts**. Open it from **File → Manage Accounts…**, from the **Accounts** button on the toolbar, or from the Command Palette (**Ctrl+Shift+P**) by choosing **Manage Accounts**. It has no keyboard shortcut of its own to begin with; you can give it one under **File → Settings → Keyboard Shortcuts**.
 
 Manage Accounts opens with focus on the first entry in the **Accounts** list, so you can arrow through your accounts straight away. **New**, **Delete**, and **Set Default** sit below the list; the settings for whichever account is selected fill the rest of the window; **Save**, **Test Connection**, and **Close** are at the bottom. When you have no accounts yet there is nothing to land on, so focus goes to **New** instead.
 
@@ -259,7 +259,7 @@ App passwords are not offered if your account is enrolled in Google's Advanced P
 
 Google stopped granting QuickMail new authorizations, so for most people the sign-in route can only end in a refusal — which is why QuickMail no longer offers it by default. If your Google account was authorized before that happened, it still works, and you can turn the option back on:
 
-1. Open **Tools → Settings**, go to the **Advanced** tab, and check **Sign in with Google for Gmail accounts**. Select **Save**.
+1. Open **File → Settings**, go to the **Advanced** tab, and check **Sign in with Google for Gmail accounts**. Select **Save**.
 2. Restart QuickMail. The setting is read at startup.
 
 You now have a **Gmail (sign in with Google)** entry in the **Provider** list, sitting directly below plain **Gmail**, and a **Google OAuth (Gmail)** choice under **Advanced settings** → **Authentication**.
@@ -425,7 +425,7 @@ Two things worth knowing. QuickMail groups a conversation by its subject, ignori
 
 If you would like each row to say whether its conversation is watched, turn on the **Watched** field in [Message List Fields](#message-list-fields). It is off to begin with.
 
-**To see what you are watching**, choose **Message → Watched Conversations…**. The window lists every watch with how many cached messages it has collected and when you started it. Press **Enter** on one to jump to that conversation, **Delete** to stop watching it, or **Rename** to give it a clearer label. Renaming changes the label only — which messages the watch collects is decided by the subject and does not change. Type a letter to jump down the list. The window stays open while you work, so you can leave it up and keep going; **Escape** closes it.
+**To see what you are watching**, choose **Tools → Watched Conversations…**. The window lists every watch with how many cached messages it has collected and when you started it. Press **Enter** on one to jump to that conversation, **Delete** to stop watching it, or **Rename** to give it a clearer label. Renaming changes the label only — which messages the watch collects is decided by the subject and does not change. Type a letter to jump down the list. The window stays open while you work, so you can leave it up and keep going; **Escape** closes it.
 
 **To be told when a reply arrives**, turn on **Settings → Notifications → Show a notification when a watched conversation gets a reply**. Unlike the ordinary new-mail notification, this one applies to every folder rather than just the inbox, because a watched thread's next message can land anywhere. The two settings are independent; if a message is both new inbox mail and part of a watched conversation you get one notification, the watched one.
 
@@ -528,7 +528,7 @@ Press **Ctrl+Shift+P** to open the command palette. Type any part of a command n
 
 ### Keyboard Customization
 
-Open **Settings → Keyboard** to reassign any shortcut to a different key. Select a command's field and press the key combination you want — QuickMail captures it, shows you what it heard, and asks you to confirm with **OK**, pick another with **Change**, or **Cancel**. If the combination is already assigned to something else, a warning names the existing command so you can decide whether to reassign it. Changes take effect immediately and survive restarts.
+Open **File → Settings → Keyboard Shortcuts** to reassign any shortcut to a different key. Select a command's field and press the key combination you want — QuickMail captures it, shows you what it heard, and asks you to confirm with **OK**, pick another with **Change**, or **Cancel**. If the combination is already assigned to something else, a warning names the existing command so you can decide whether to reassign it. Changes take effect immediately and survive restarts.
 
 **Bare keys as shortcuts.** You can assign a shortcut with no modifier key using **Delete, Backspace, Insert, or any function key (F1–F24)** — for example, bare **Delete** to delete a message, or **F5** to sync. (Bare **Delete** ships as a default binding for exactly this reason.) Plain letters, digits, and the Spacebar cannot be bound on their own — they would swallow ordinary typing — so pair them with **Ctrl**, **Alt**, or **Shift**. **Enter**, **Escape**, and **Tab** are reserved for navigating dialogs and are never captured as shortcuts.
 
@@ -632,7 +632,7 @@ Press **Delete**. Deleted messages go to Trash. Press `Ctrl+Shift+E` to empty th
 
 Press **Ctrl+Shift+M** to archive the selected message — move it to your account's Archive folder instead of deleting it. Use this for mail you want out of your inbox but want to keep. **Delete** is unchanged and still moves messages to Trash.
 
-The command is named **Move to Archive** — it is on the message menu and the message context menu (Shift+F10), and in the command palette. Archiving works from every view. In the **From**, **To**, and **Conversations** groupings, archiving a group moves the whole group at once, the same way Delete does. The **Ctrl+Shift+M** shortcut can be changed in **Settings → Keyboard**.
+The command is named **Move to Archive** — it is on the message menu and the message context menu (Shift+F10), and in the command palette. Archiving works from every view. In the **From**, **To**, and **Conversations** groupings, archiving a group moves the whole group at once, the same way Delete does. The **Ctrl+Shift+M** shortcut can be changed in **File → Settings → Keyboard Shortcuts**.
 
 **Each account archives to its own folder** — there is no single shared Archive folder. QuickMail uses the folder your provider marks as the Archive folder automatically, so most accounts need no setup. To choose a different folder, select a folder in the folder tree, open its context menu (Shift+F10), and choose **Set as Archive Folder**; choose **Use Automatic Archive Folder** to return to the automatic one.
 
@@ -768,7 +768,7 @@ Inline navigation wraps around the message so it always finds misspellings where
 
 When a screen reader is active, QuickMail announces each misspelling along with up to three suggestions. By default, each suggestion is numbered — for example: "Misspelling: teh. 1: the, 2: then, 3: them." Press `Alt+1`, `Alt+2`, or `Alt+3` to replace the misspelled word with that numbered suggestion without leaving the compose area.
 
-Control announcement behavior in **Settings → Screen Reader Announcements**:
+Control announcement behavior in **File → Settings → General → Screen Reader Announcements**:
 
 - **Announce spelling suggestions** — turn off to hear only the misspelled word without suggestions.
 - **Spelling Suggestions Verbosity** — choose **Numbers with suggestions** (default) to hear "1: the, 2: then" so `Alt+1/2/3` maps directly to what is spoken, or **Just suggestions** to hear "the, then, them" without numbers.
@@ -841,7 +841,7 @@ From the contact list, you can pull up everything a person sent you, or everythi
 2. Choose **Find mail from this contact** or **Find mail to this contact**.
 3. The address book closes and the message list fills with the matches, newest first. Focus moves to the message list and the count is announced — for example, "12 messages from Bob Baker." The window title shows **Mail from Bob Baker** so you can tell the results apart from a folder.
 
-Both actions are also in the address book's Command Palette (**Ctrl+Shift+P**) as **Find Mail From Contact** and **Find Mail To Contact**. Commands that live inside the address book are not listed in Settings → Keyboard, which covers the main window's commands; reach them from the palette.
+Both actions are also in the address book's Command Palette (**Ctrl+Shift+P**) as **Find Mail From Contact** and **Find Mail To Contact**. Commands that live inside the address book are not listed in File → Settings → Keyboard Shortcuts, which covers the main window's commands; reach them from the palette.
 
 Press **Escape** with focus in the message list to close the results and go back to the folder you started from; the folder name and its message count are announced. A **Close** button at the top of the results does the same, and **Close Contact Mail Results** is in the Command Palette. Selecting any folder in the folder tree also leaves the results.
 
@@ -1039,13 +1039,13 @@ The quickest way is from the folder tree itself:
 
 QuickMail confirms the change, and opens there every time it starts from then on.
 
-You can also do it from **Tools → Settings → Startup**, where the **Opens in** field shows your current choice. Select **Choose…** to pick a different folder from the folder tree, or **Clear** to go back to All Mail. **Clear Startup Folder** in the folder context menu does the same thing.
+You can also do it from **File → Settings → Startup**, where the **Opens in** field shows your current choice. Select **Choose…** to pick a different folder from the folder tree, or **Clear** to go back to All Mail. **Clear Startup Folder** in the folder context menu does the same thing.
 
 If the folder later disappears — you delete it, rename it, or remove the account — QuickMail opens in All Mail and tells you why. Nothing is lost and nothing needs repairing.
 
 ### Choose how much is checked at startup
 
-Also under **Tools → Settings → Startup**, **Startup Sync** controls how much mail QuickMail checks while it is starting. This matters most if you have several accounts and a lot of folders.
+Also under **File → Settings → Startup**, **Startup Sync** controls how much mail QuickMail checks while it is starting. This matters most if you have several accounts and a lot of folders.
 
 - **Just my startup folder** (recommended) — checks only what your startup folder shows. If your startup folder is All Inboxes, that is every inbox; if it is All Mail, that is everything.
 - **Every account's inbox** — checks each account's inbox, whichever folder you open in.
@@ -1099,7 +1099,7 @@ Two things this does not do. It does not change which events you are *looking at
 
 **All Calendars** cannot be the default, because it is several calendars at once and so names no single place to save to. If you choose it, QuickMail says so and leaves your existing default alone.
 
-Both commands are also in the Command Palette (**Ctrl+Shift+P**) — as **Use as Default Calendar for New Appointments** and **Clear Default Calendar** — and you can assign them keys in **Settings → Keyboard**.
+Both commands are also in the Command Palette (**Ctrl+Shift+P**) — as **Use as Default Calendar for New Appointments** and **Clear Default Calendar** — and you can assign them keys in **File → Settings → Keyboard Shortcuts**.
 
 ### The four views
 
@@ -1244,7 +1244,7 @@ There is a single reminder lead time for all appointments; per-appointment remin
 
 ### Exporting an appointment
 
-To share an appointment as a standard calendar file, select it and choose **Export Appointment as .ics** from the command palette (**Ctrl+Shift+P**) or the toolbar/menu. QuickMail writes a `.ics` file you can send to someone or import elsewhere. (Exporting one occurrence of a repeating appointment exports the whole series.) This action has no default keyboard shortcut, but you can assign one in **Settings → Keyboard**.
+To share an appointment as a standard calendar file, select it and choose **Export Appointment as .ics** from the command palette (**Ctrl+Shift+P**) or the toolbar/menu. QuickMail writes a `.ics` file you can send to someone or import elsewhere. (Exporting one occurrence of a repeating appointment exports the whole series.) This action has no default keyboard shortcut, but you can assign one in **File → Settings → Keyboard Shortcuts**.
 
 ### Searching your appointments
 
@@ -1384,7 +1384,7 @@ The **Tools** menu is always available from the main window menu bar and groups 
 - **Rules…** (`Ctrl+Shift+L`) — opens the [Rules Manager](#mail-rules).
 - **Command Palette…** (`Ctrl+Shift+P`)
 
-**Choosing how QuickMail looks and reads is on the View menu**, not here — **Manage Themes…** opens the [Theme Manager](#themes), **Density** sets [message list density](#message-list-density), and **Message List Fields…** opens the [field chooser](#message-list-fields). **Next Theme** and **Previous Theme** have no menu items; run them from the Command Palette, or give them a key of your own in **Settings → Keyboard**.
+**Choosing how QuickMail looks and reads is on the View menu**, not here — **Manage Themes…** opens the [Theme Manager](#themes), **Density** sets [message list density](#message-list-density), and **Message List Fields…** opens the [field chooser](#message-list-fields). **Next Theme** and **Previous Theme** have no menu items; run them from the Command Palette, or give them a key of your own in **File → Settings → Keyboard Shortcuts**.
 
 ---
 
@@ -1611,7 +1611,7 @@ Choose **Manage Themes…** from the **View** menu, or open the Command Palette 
 
 Below the theme list and actions, a read-only **Theme description** box always shows a plain-language account of the currently selected theme — its overall look, its fonts, and every individual color together with where in the app that color is used. This box is there so you can understand and compare themes by ear or by reading, without needing to see the colors. See [Built-in Themes](#built-in-themes) below for the description of each theme that ships with QuickMail.
 
-The Command Palette also offers **Next Theme** and **Previous Theme** to cycle through themes, and a **Theme: [name]** command for each theme. None of these have a default keyboard shortcut — assign one in **Settings → Keyboard** if you want direct access.
+The Command Palette also offers **Next Theme** and **Previous Theme** to cycle through themes, and a **Theme: [name]** command for each theme. None of these have a default keyboard shortcut — assign one in **File → Settings → Keyboard Shortcuts** if you want direct access.
 
 **Editing a theme by hand:** a theme is a plain, documented JSON text file. Duplicate a built-in theme, choose **Open themes folder**, and edit the copy in any text editor. Colors are hex values like `#3D5A80`; any color you leave out is filled in from the built-in Light or Dark theme (whichever the file's `base` names). A typical minimal theme:
 
@@ -1655,7 +1655,7 @@ The four light themes are close cousins. Ember, Fjord, and Heather each change o
 
 ## Message List Fields
 
-Each row in a message list is spoken as a single line — sender, subject, date, and so on. **View → Message List Fields…** lets you decide which of those pieces are spoken and in what order. It is also in the command palette as **Message List Fields…**. It has no keyboard shortcut of its own; assign one in **Settings → Keyboard** if you want one.
+Each row in a message list is spoken as a single line — sender, subject, date, and so on. **View → Message List Fields…** lets you decide which of those pieces are spoken and in what order. It is also in the command palette as **Message List Fields…**. It has no keyboard shortcut of its own; assign one in **File → Settings → Keyboard Shortcuts** if you want one.
 
 Open it and you get a list of every available field, each one a real check box. Check a field to have it spoken, uncheck it to leave it out, and move it to change where it falls in the line.
 
@@ -1772,7 +1772,7 @@ Every announcement is optional and controlled by the settings above. No custom s
 | `Shift+.` | Last message in group |
 | `Escape` | Close contact mail results (message list focus) |
 
-**Move to Folder…** and **Copy to Folder…** are available from the context menu (Shift+F10) or the command palette; they have no default keyboard shortcut. **Manage Themes**, **Next Theme**, **Previous Theme**, **Message List Fields…**, **Density: Comfortable**, **Density: Compact**, **Manage Flags…**, and **Report a Bug** likewise have no default key — reach them from the menus or the command palette, or assign a shortcut yourself in Settings → Keyboard.
+**Move to Folder…** and **Copy to Folder…** are available from the context menu (Shift+F10) or the command palette; they have no default keyboard shortcut. **Manage Themes**, **Next Theme**, **Previous Theme**, **Message List Fields…**, **Density: Comfortable**, **Density: Compact**, **Manage Flags…**, and **Report a Bug** likewise have no default key — reach them from the menus or the command palette, or assign a shortcut yourself in File → Settings → Keyboard Shortcuts.
 
 `Ctrl+1`, `Ctrl+2`, and `Ctrl+3` jump to a pane when no message tabs are open; with tabs open they select tab 1, 2, and 3 instead. **`Ctrl+Alt+1`, `Ctrl+Alt+2`, and `Ctrl+Alt+3` always** go to the account list, folder tree, and message list, whatever else is open. `Ctrl+0` moves to the toolbar.
 

--- a/docs/release-notes-v0.8.39.md
+++ b/docs/release-notes-v0.8.39.md
@@ -21,9 +21,9 @@ All downloads include the .NET 8 runtime — you do not need to install .NET sep
 
 QuickMail has always opened in **All Mail**. If you wanted it to open somewhere else, the only way was to save a view of that folder and then mark it as the default in the View Manager — four steps, and a saved view left behind that you never wanted. Several people have asked for something simpler.
 
-Now you set it where you already are. In the folder tree, move to the folder you want, open its context menu with **Shift+F10** or the Applications key, and choose **Set as Startup Folder**. That is it. **Clear Startup Folder** on the same menu goes back to All Mail, and both are in the Command Palette (**Ctrl+Shift+P**) and can be given keys in **Settings → Keyboard**.
+Now you set it where you already are. In the folder tree, move to the folder you want, open its context menu with **Shift+F10** or the Applications key, and choose **Set as Startup Folder**. That is it. **Clear Startup Folder** on the same menu goes back to All Mail, and both are in the Command Palette (**Ctrl+Shift+P**) and can be given keys in **File → Settings → Keyboard Shortcuts**.
 
-There is also a new **Startup** tab in **Tools → Settings**, where **Opens in** shows your current choice and **Choose…** opens the folder tree to pick a different one.
+There is also a new **Startup** tab in **File → Settings**, where **Opens in** shows your current choice, **Choose…** opens the folder tree to pick a different one, and **Clear** goes back to All Mail.
 
 You can pick any folder — one account's Inbox, a project folder buried a few levels down, or one of the views at the top of the tree such as **All Inboxes** or **All Mail**.
 
@@ -35,19 +35,19 @@ If the folder later disappears — you delete it, rename it, or remove the accou
 
 Because a startup folder is now a folder, the **Default view (applied on startup)** checkbox in the View Manager has been removed, along with the Options section that held it.
 
-If you were using it, QuickMail converts your choice to the new setting the first time it starts — including a view over several folders, which it keeps working as it did. Check **Tools → Settings → Startup** if you want to see what it picked. Your saved views themselves are untouched: they are still named filters with hotkeys, and everything else about them works as before. ([#516](https://github.com/kellylford/QuickMail/issues/516))
+If you were using it, QuickMail converts your choice to the new setting the first time it starts — including a view over several folders, which it keeps working as it did. Check **File → Settings → Startup** if you want to see what it picked. Your saved views themselves are untouched: they are still named filters with hotkeys, and everything else about them works as before. ([#516](https://github.com/kellylford/QuickMail/issues/516))
 
 ## New: choose how much mail is checked at startup
 
 If you have several accounts and a lot of folders, QuickMail used to check every one of them while starting, whether or not you were going to look at them.
 
-**Tools → Settings → Startup** now has **Startup Sync** with three choices:
+**File → Settings → Startup** now has **Startup Sync** with three choices:
 
 - **Just my startup folder** (the new default) — checks only what your startup folder shows. If your startup folder is All Inboxes that means every inbox; if it is All Mail, that still means everything, because All Mail shows everything.
 - **Every account's inbox** — checks each account's inbox whichever folder you open in.
 - **Every folder** — how QuickMail behaved before this setting existed.
 
-New mail still arrives in your inboxes straight away whichever you choose, so notifications are unaffected. Other folders are caught up by the background check — the **Check for new mail every** setting on the **General** tab. If you have that set to **Off**, other folders are only checked when you open them. ([#516](https://github.com/kellylford/QuickMail/issues/516))
+New mail still arrives in your inboxes straight away whichever you choose, so notifications are unaffected. Other folders are caught up by the background check — the **Check for new mail every** setting on the **General** tab of Settings. If you have that set to **Off**, other folders are only checked when you open them. ([#516](https://github.com/kellylford/QuickMail/issues/516))
 
 ## New: each folder remembers how you left it
 
@@ -57,7 +57,7 @@ Now the choice is per folder. Change the view mode, filter, or sort in a folder 
 
 A folder you have never changed follows the **Display mode** on the **General** tab of Settings, which also tracks the last choice you made anywhere — so a folder you open for the first time looks like the last one you set up, and one change makes it its own.
 
-**Reset Folder View**, on the **View → Views** menu and in the Command Palette, hands a folder back to the default. To turn the whole behaviour off, clear **Remember view settings for each folder** in **Settings → General**; your per-folder choices are kept, so switching it back on restores them. ([#520](https://github.com/kellylford/QuickMail/issues/520))
+**Reset Folder View**, on the **View → Views** menu and in the Command Palette, hands a folder back to the default. To turn the whole behaviour off, clear **Remember view settings for each folder** in **File → Settings → General**; your per-folder choices are kept, so switching it back on restores them. ([#520](https://github.com/kellylford/QuickMail/issues/520))
 
 ## Fixed: leaving a view left some of it behind
 


### PR DESCRIPTION
Review of the v0.8.39 release notes against the code. One class of error, plus two more found while checking every menu path in the User Guide.

## Wrong

- **"Tools → Settings" ×3 in the release notes, ×3 in the User Guide.** Settings is on **File**. Tools holds Address Book, Rules, Watched Conversations and the Command Palette.
- **"Settings → Keyboard" ×10 in the User Guide.** The tab is named **Keyboard Shortcuts**.
- **"Message → Watched Conversations…"** — that manager is on **Tools**. Only *Watch Conversation*, which acts on the selected message, is on Message.
- **"Settings → Screen Reader Announcements"** — a group on the **General** tab, not a tab.
- **`config.ini` header comment** said "Tools > Settings > Startup". This is written into every user profile.
- **`ViewManagerWindow.xaml` comment** recording where the retired default-view checkbox went, same error.
- The release notes' Startup tab entry omitted the **Clear** button, the documented way back to All Mail from Settings.

## Verified correct, no change

Both startup-folder context menu commands and their palette registrations (no default key, so "can be given keys" holds); the Settings tab and control labels; the three Startup Sync options, their descriptions and the new default; the migration of the retired `SavedView.IsDefault`, including the multi-folder case; the folder-list cache that lets the startup folder resolve before any network call; the fallback-with-a-reason when the folder is gone; and all four #520 entries, including the "two restored, four left behind" accounting. Nothing user-visible is missing from the notes — the only other commit since v0.8.38 is shared-mailbox PR 1, which is feature-gated off.

## Tests

Build clean, 0 warnings. Local suite: 2527 passed, 0 failed, then the test host crashed mid-run — the known partial-run condition, unrelated to a diff of comment text and Markdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)