### PR TITLE
Graph work/school: explicit mail scopes instead of .default (bridge for #529, fixes the AADSTS65006 churn)

### DIFF
--- a/QuickMail.Tests/ContactSyncScopeAndViewModelTests.cs
+++ b/QuickMail.Tests/ContactSyncScopeAndViewModelTests.cs
@@ -26,7 +26,7 @@ public class OAuthContactScopeTests
     [Fact]
     public void DefaultMailScopes_DoNotContainContactScopes()
     {
-        foreach (var scope in OAuthService.ImapSmtpScopes.Concat(OAuthService.GraphMailScopes).Concat(OAuthService.GraphMailScopesPersonal))
+        foreach (var scope in OAuthService.ImapSmtpScopes.Concat(OAuthService.GraphMailScopesWorkSchool).Concat(OAuthService.GraphMailScopesPersonal))
         {
             Assert.DoesNotContain("Contacts.Read", scope);
             Assert.DoesNotContain("People.Read", scope);

--- a/QuickMail.Tests/OAuthServiceScopeSelectionTests.cs
+++ b/QuickMail.Tests/OAuthServiceScopeSelectionTests.cs
@@ -135,7 +135,9 @@ public class OAuthServiceScopeSelectionTests
 
     [Fact]
     public void AddAccount_OnExplicitScopes_DoesNotForceConsent() // #511/#529
-        => Assert.NotEqual(Prompt.Consent,
+        // Not Prompt.Consent — with a known username it falls through to ForceLogin, which prompts for
+        // credentials but lets AAD skip consent when the org has already granted the requested scopes.
+        => Assert.Equal(Prompt.ForceLogin,
             OAuthService.PromptForSignIn(firstConnect: true, "user@contoso.com", usesDefaultScope: false));
 
     [Fact]

--- a/QuickMail.Tests/OAuthServiceScopeSelectionTests.cs
+++ b/QuickMail.Tests/OAuthServiceScopeSelectionTests.cs
@@ -6,18 +6,20 @@ using Xunit;
 namespace QuickMail.Tests;
 
 /// <summary>
-/// Locks the per-account scope selection (#217/#218): personal Microsoft accounts must get the
-/// explicit Graph scopes (so they can write/delete), work/school Graph accounts use `.default`, and
-/// IMAP always uses the IMAP scopes. Guards against a future refactor silently reverting the routing.
+/// Locks the per-account scope selection (#217/#218, #511/#529): personal Microsoft accounts get the
+/// explicit personal Graph scopes, work/school Graph accounts get the explicit work/school Graph scopes
+/// (the #529 bridge — so a Graph sign-in never validates the Exchange entitlement, #511), and IMAP
+/// always uses the IMAP scopes. Guards against a future refactor silently reverting the routing.
 /// </summary>
 public class OAuthServiceScopeSelectionTests
 {
-    // The account a work-or-school Microsoft address must end up as. Asserted at the scope layer
-    // because that is where the failure actually bites: the IMAP scopes below are the ones a tenant
-    // has usually never consented to, and requesting them ends sign-in at "your administrator needs
-    // to make a change" for a mailbox that signs in fine over Graph.
+    // A work-or-school Microsoft address on Graph asks for explicit Graph scopes, NOT `.default`
+    // (#511/#529 bridge). `.default` requested the whole declared set, dragging the Exchange IMAP/SMTP
+    // permissions into every fresh Graph consent — whose flaky validation produced the intermittent
+    // AADSTS65006. The explicit list requests only the Graph mail permissions, so the Exchange
+    // entitlement is never touched by a Graph sign-in.
     [Fact]
-    public void AWorkTenantOnGraphAsksForTheAdminConsentedDefaultScope()
+    public void AWorkTenantOnGraphAsksForExplicitGraphScopes()
     {
         var account = new AccountModel
         {
@@ -27,7 +29,11 @@ public class OAuthServiceScopeSelectionTests
             IsPersonalMicrosoftAccount = false,
         };
 
-        Assert.Equal(["https://graph.microsoft.com/.default"], OAuthService.DefaultScopesFor(account));
+        var scopes = OAuthService.DefaultScopesFor(account);
+        Assert.Same(OAuthService.GraphMailScopesWorkSchool, scopes);
+        Assert.Contains("https://graph.microsoft.com/Mail.ReadWrite", scopes);
+        Assert.DoesNotContain("https://graph.microsoft.com/.default", scopes);
+        Assert.DoesNotContain("https://outlook.office.com/IMAP.AccessAsUser.All", scopes);
     }
 
     [Fact]
@@ -57,10 +63,10 @@ public class OAuthServiceScopeSelectionTests
     }
 
     [Fact]
-    public void WorkSchoolGraphAccount_UsesDefaultScope()
+    public void WorkSchoolGraphAccount_UsesExplicitWorkSchoolScopes()
     {
         var account = new AccountModel { BackendKind = BackendKind.MicrosoftGraph, Username = "user@contoso.com" };
-        Assert.Same(OAuthService.GraphMailScopes, OAuthService.DefaultScopesFor(account));
+        Assert.Same(OAuthService.GraphMailScopesWorkSchool, OAuthService.DefaultScopesFor(account));
     }
 
     [Fact]
@@ -86,53 +92,61 @@ public class OAuthServiceScopeSelectionTests
     }
 
     [Fact]
-    public void WorkAccountOnPersonalLookingDomain_StoredFlagFalseUsesDefault()
+    public void WorkAccountOnPersonalLookingDomain_StoredFlagFalseUsesWorkSchoolScopes()
     {
-        // Flag explicitly false wins over a personal-looking domain → work/school (`.default`).
+        // Flag explicitly false wins over a personal-looking domain → work/school explicit Graph scopes.
         var account = new AccountModel
         {
             BackendKind = BackendKind.MicrosoftGraph,
             Username = "user@outlook.com",
             IsPersonalMicrosoftAccount = false,
         };
-        Assert.Same(OAuthService.GraphMailScopes, OAuthService.DefaultScopesFor(account));
+        Assert.Same(OAuthService.GraphMailScopesWorkSchool, OAuthService.DefaultScopesFor(account));
     }
 
     [Fact]
-    public void CustomDomainPersonalAccount_NotYetDetected_FallsBackToDefault_KnownMigrationGap()
+    public void CustomDomainPersonalAccount_NotYetDetected_FallsBackToWorkSchool_KnownMigrationGap()
     {
         // DELIBERATE, documented fallback (#234 review, concern 1): a personal account on a custom
         // domain that hasn't been detected yet (added before tenant detection shipped, never re-authed)
-        // has a null flag → the email-domain guess says "work" → `.default`. Auto-heal is deferred; new
-        // accounts are detected at sign-in, so this only affects pre-detection accounts (near-zero while
-        // the Graph backend is feature-gated). Locked as a test so it reads as intended, not an oversight.
+        // has a null flag → the email-domain guess says "work" → the work/school Graph scopes. Auto-heal
+        // is deferred; new accounts are detected at sign-in, so this only affects pre-detection accounts
+        // (near-zero while the Graph backend is feature-gated). Locked as a test so it reads as intended.
         var account = new AccountModel
         {
             BackendKind = BackendKind.MicrosoftGraph,
             Username = "me@myvanitydomain.com",
             IsPersonalMicrosoftAccount = null,
         };
-        Assert.Same(OAuthService.GraphMailScopes, OAuthService.DefaultScopesFor(account));
+        Assert.Same(OAuthService.GraphMailScopesWorkSchool, OAuthService.DefaultScopesFor(account));
     }
 
-    // ── Add-account forces the consent screen (#391) ────────────────────────
-    // The scope selection is unchanged (DefaultScopesFor, covered above). The fix is the PROMPT:
-    // adding an account forces Prompt.Consent so the full declared set is approved once — `.default`
-    // otherwise issues a token silently as soon as ANY grant exists (Microsoft docs Example 3), which
-    // is why a work account with contacts/calendar already enabled then 403s on mail. Re-auth keeps
-    // the normal prompt.
+    // ── Add-account consent prompt (#391, refined by #511/#529) ─────────────
+    // Forcing Prompt.Consent on add is a `.default`-only workaround (#391): `.default` issues a token
+    // silently as soon as ANY grant exists, so mail consent must be forced up front. With EXPLICIT
+    // scopes that doesn't apply — requesting them IS the consent trigger — and forcing it just
+    // re-prompts an already-consented org on every add (#207/#208). So consent is forced only on the
+    // `.default` path; explicit-scope adds fall through to the normal prompt.
 
     [Fact]
-    public void AddAccount_ForcesConsentPrompt()
-        => Assert.Equal(Prompt.Consent, OAuthService.PromptForSignIn(firstConnect: true, "user@contoso.com"));
+    public void AddAccount_OnDefaultScope_ForcesConsentPrompt()
+        => Assert.Equal(Prompt.Consent,
+            OAuthService.PromptForSignIn(firstConnect: true, "user@contoso.com", usesDefaultScope: true));
+
+    [Fact]
+    public void AddAccount_OnExplicitScopes_DoesNotForceConsent() // #511/#529
+        => Assert.NotEqual(Prompt.Consent,
+            OAuthService.PromptForSignIn(firstConnect: true, "user@contoso.com", usesDefaultScope: false));
 
     [Fact]
     public void ReAuth_ForKnownAccount_ForcesLogin_NotConsent()
-        => Assert.Equal(Prompt.ForceLogin, OAuthService.PromptForSignIn(firstConnect: false, "user@contoso.com"));
+        => Assert.Equal(Prompt.ForceLogin,
+            OAuthService.PromptForSignIn(firstConnect: false, "user@contoso.com", usesDefaultScope: true));
 
     [Fact]
     public void ReAuth_WithNoExpectedAccount_SelectsAccount()
-        => Assert.Equal(Prompt.SelectAccount, OAuthService.PromptForSignIn(firstConnect: false, null));
+        => Assert.Equal(Prompt.SelectAccount,
+            OAuthService.PromptForSignIn(firstConnect: false, null, usesDefaultScope: true));
 
     [Fact]
     public void ImapScopes_AreExplicit_NotDefault() // #239

--- a/QuickMail/Services/Graph/GraphClient.cs
+++ b/QuickMail/Services/Graph/GraphClient.cs
@@ -268,10 +268,11 @@ public sealed class GraphClient : IDisposable
         // Up to 3 attempts to ride out HTTP 429 throttling.
         for (int attempt = 0; ; attempt++)
         {
-            // Default (scopes == null): per-account default scopes (DefaultScopesFor) — `.default` for
-            // work/school, explicit Mail.ReadWrite/etc. for personal Microsoft accounts (#217). An
-            // explicit scope set is passed only by contact sync (Graph Contacts.Read/People.Read),
-            // which also asks for silent-only acquisition so it never opens an interactive window.
+            // Default (scopes == null): per-account default scopes (DefaultScopesFor) — explicit Graph
+            // mail scopes for BOTH personal (#217) and work/school (the #511/#529 bridge; `.default` is
+            // no longer used on the mail path until the Exchange perms are removed). An explicit scope
+            // set is passed only by contact sync (Graph Contacts.Read/People.Read), which also asks for
+            // silent-only acquisition so it never opens an interactive window.
             var token = scopes is null
                 ? await _oauth.GetAccessTokenAsync(account, ct)
                 : silentOnly

--- a/QuickMail/Services/OAuthService.cs
+++ b/QuickMail/Services/OAuthService.cs
@@ -30,15 +30,26 @@ public class OAuthService : IOAuthService
         "https://outlook.office.com/SMTP.Send",
     ];
 
-    // Work/school (AAD) Graph accounts: `.default` requests EXACTLY the app-registration's declared
-    // permissions, matching what admin consent grants — this is what fixed the requested-vs-declared
-    // mismatch that produced the "admin granted consent but the user is still prompted" loop (#208).
-    // `.default` is per-resource and cannot be combined with other scopes. Rationale:
-    // docs/planning/oauth-default-scope-pm-dev-spec.md. (Personal Graph accounts use
-    // GraphMailScopesPersonal below — `.default` under-delivers write for them, #217.)
-    public static readonly string[] GraphMailScopes =
+    // Work/school (AAD) Graph accounts. HISTORY: this used `.default`, which requests the app's ENTIRE
+    // declared permission set. That dragged the Office 365 Exchange Online IMAP/SMTP permissions (there
+    // only for the Microsoft IMAP backend) into every fresh work/school Graph consent — and when
+    // Microsoft's validation of that legacy Exchange entitlement went intermittently bad, `.default`
+    // consent failed with AADSTS65006 (reproducible on every fresh consent, not tenant-side). #511.
+    //
+    // BRIDGE for the Graph-only migration (#529): request EXPLICIT Graph mail scopes instead, so a Graph
+    // sign-in only ever validates the Graph permissions it needs and never touches the Exchange
+    // entitlement. Contacts and calendar are NOT here — they run through their own incremental consent
+    // flows (RequestContactsConsentAsync / RequestCalendarConsentAsync), same as personal accounts, so
+    // this list is mail only. This is temporary: once the Exchange permissions are removed from the app
+    // registration (last step of #529), `.default` is Exchange-free and this reverts to it (restoring the
+    // zero-maintenance #208 behavior). See docs/planning/oauth-default-scope-pm-dev-spec.md.
+    public static readonly string[] GraphMailScopesWorkSchool =
     [
-        "https://graph.microsoft.com/.default",
+        "https://graph.microsoft.com/Mail.ReadWrite",
+        "https://graph.microsoft.com/Mail.Send",
+        "https://graph.microsoft.com/MailboxSettings.ReadWrite",  // server-side rules (#333)
+        "https://graph.microsoft.com/User.Read",
+        "https://graph.microsoft.com/User.ReadBasic.All",         // recipient / directory resolution
     ];
 
     // Personal Microsoft accounts (Outlook.com/Hotmail/Live): `.default` under-delivers for MSA,
@@ -105,23 +116,30 @@ public class OAuthService : IOAuthService
     {
         if (account.BackendKind != BackendKind.MicrosoftGraph)
             return ImapSmtpScopes;
-        // Personal accounts need explicit scopes to obtain write access; work/school uses `.default`.
-        // Prefer the persisted, tenant-derived flag; fall back to the email-domain guess only when the
-        // account hasn't been detected yet (first sign-in, or added before detection shipped).
+        // Both personal and work/school use explicit Graph scopes now — personal for write access
+        // (#217), work/school as the #529 bridge so a Graph sign-in never validates the Exchange
+        // entitlement (#511). Prefer the persisted, tenant-derived flag; fall back to the email-domain
+        // guess only when the account hasn't been detected yet (first sign-in, or added before detection).
         var isPersonal = account.IsPersonalMicrosoftAccount ?? IsPersonalMicrosoftDomain(account.Username);
-        return isPersonal ? GraphMailScopesPersonal : GraphMailScopes;
+        return isPersonal ? GraphMailScopesPersonal : GraphMailScopesWorkSchool;
     }
 
-    // Prompt for an interactive sign-in. Adding an account forces the CONSENT screen: `.default`
-    // (work/school) issues a token SILENTLY as soon as ANY grant exists on the tenant — e.g. from a
-    // prior contacts/calendar consent or an earlier partial sign-in — so without this the mail
+    // Prompt for an interactive sign-in. Forcing the CONSENT screen on add is a `.default`-only
+    // workaround: `.default` issues a token SILENTLY as soon as ANY grant exists on the tenant — e.g.
+    // from a prior contacts/calendar consent or an earlier partial sign-in — so without it the mail
     // permissions are never consented and mail calls then 403 (#391, Microsoft docs "`.default`"
-    // Example 3). Prompt.Consent makes the admin/user approve the full declared set once, up front,
-    // while STAYING on `.default` so requested-equals-declared is preserved by construction (#208).
-    // Re-auth (an already-added account whose token expired) uses the normal prompt — that account
-    // already consented at add-time, so a forced re-consent on every cache loss would just annoy.
-    internal static Prompt PromptForSignIn(bool firstConnect, string? username)
-        => firstConnect ? Prompt.Consent
+    // Example 3). Prompt.Consent makes the admin/user approve the full declared set once, up front.
+    //
+    // #511/#529: with EXPLICIT scopes (not `.default`) that workaround does not apply — requesting
+    // `Mail.ReadWrite` IS the consent trigger, and AAD shows consent only when it isn't already granted.
+    // Forcing it there just re-prompts an already-consented org on every add (the #207/#208 symptom seen
+    // when the bridge first went in). So force consent only on the `.default` path; explicit-scope adds
+    // fall through to the normal prompt, which lets AAD skip consent when the org has already granted it.
+    //
+    // Re-auth (an already-added account whose token expired) uses the normal prompt either way — that
+    // account already consented at add-time, so a forced re-consent on every cache loss would annoy.
+    internal static Prompt PromptForSignIn(bool firstConnect, string? username, bool usesDefaultScope)
+        => firstConnect && usesDefaultScope ? Prompt.Consent
            : string.IsNullOrEmpty(username) ? Prompt.SelectAccount
            : Prompt.ForceLogin;
 
@@ -256,9 +274,9 @@ public class OAuthService : IOAuthService
         }
     }
 
-    // Add-account entry point: force the CONSENT screen so the full declared permission set is
-    // approved once (see PromptForSignIn). Scopes stay `.default` for work/school (DefaultScopesFor),
-    // so requested-equals-declared holds (#208).
+    // Add-account entry point. firstConnect=true; the prompt then depends on the scopes: the `.default`
+    // path still forces consent (#391), while the explicit-scope paths (personal, and work/school since
+    // the #529 bridge) let AAD decide, so an already-consented org isn't re-prompted. See PromptForSignIn.
     public Task<OAuthResult> SignInInteractiveAsync(AccountModel account, CancellationToken ct = default)
         => SignInInteractiveAsync(account, DefaultScopesFor(account), firstConnect: true, ct);
 
@@ -272,11 +290,14 @@ public class OAuthService : IOAuthService
         await EnsureTokenCacheAsync();
         LogService.Log($"OAuthService: starting interactive sign-in for {account.Username}");
 
+        // #511/#529: consent is force-prompted only on the `.default` path (see PromptForSignIn). With
+        // explicit scopes AAD decides, so an already-consented org isn't re-prompted on every add.
+        var usesDefaultScope = scopes.Any(s => s.EndsWith("/.default", StringComparison.Ordinal));
         var builder = _msal.AcquireTokenInteractive(scopes)
             // Embedded WebView2 window: renders in-app and closes itself on completion, returning
             // focus to QuickMail — no system-browser tab and no lingering success page.
             .WithUseEmbeddedWebView(true)
-            .WithPrompt(PromptForSignIn(firstConnect, account.Username));
+            .WithPrompt(PromptForSignIn(firstConnect, account.Username, usesDefaultScope));
 
         if (!string.IsNullOrEmpty(account.Username))
             builder = builder.WithLoginHint(account.Username);

--- a/QuickMail/Services/OAuthService.cs
+++ b/QuickMail/Services/OAuthService.cs
@@ -43,13 +43,18 @@ public class OAuthService : IOAuthService
     // this list is mail only. This is temporary: once the Exchange permissions are removed from the app
     // registration (last step of #529), `.default` is Exchange-free and this reverts to it (restoring the
     // zero-maintenance #208 behavior). See docs/planning/oauth-default-scope-pm-dev-spec.md.
+    // Only scopes the work/school MAIL path actually calls. Deliberately NOT `User.ReadBasic.All`
+    // (a `/users` directory permission with no call site — it's a forward declaration on the app
+    // registration, see docs/ENTRA-APP-REGISTRATION.md): restrictive tenants gate directory reads
+    // behind admin consent, so requesting it at interactive sign-in could dead-end the mail sign-in on
+    // a locked-down tenant — the exact onboarding failure this change removes. Add a scope here only
+    // when a work/school mail call actually needs it.
     public static readonly string[] GraphMailScopesWorkSchool =
     [
         "https://graph.microsoft.com/Mail.ReadWrite",
         "https://graph.microsoft.com/Mail.Send",
-        "https://graph.microsoft.com/MailboxSettings.ReadWrite",  // server-side rules (#333)
-        "https://graph.microsoft.com/User.Read",
-        "https://graph.microsoft.com/User.ReadBasic.All",         // recipient / directory resolution
+        "https://graph.microsoft.com/MailboxSettings.ReadWrite",  // server-side rules (#333, GraphServerRuleService)
+        "https://graph.microsoft.com/User.Read",                  // /me profile read (GraphMailService)
     ];
 
     // Personal Microsoft accounts (Outlook.com/Hotmail/Live): `.default` under-delivers for MSA,

--- a/docs/ENTRA-APP-REGISTRATION.md
+++ b/docs/ENTRA-APP-REGISTRATION.md
@@ -55,7 +55,10 @@ above; the embedded view intercepts that navigation internally (no loopback list
 
 The **Graph mail** backend requests **explicit** Graph mail scopes at mail sign-in for **every** account
 type — `OAuthService.GraphMailScopesWorkSchool` (`Mail.ReadWrite`, `Mail.Send`, `MailboxSettings.ReadWrite`,
-`User.Read`, `User.ReadBasic.All`) for work/school, and `GraphMailScopesPersonal` for personal. See
+`User.Read`) for work/school, and `GraphMailScopesPersonal` for personal. `User.ReadBasic.All` stays
+**declared** on the registration (below) but is **not** in the code scope list — it's a forward
+declaration with no call site, deliberately kept out of the interactive sign-in request (a directory
+scope requested at sign-in can dead-end onboarding on a consent-restricted tenant). See
 `docs/planning/oauth-default-scope-pm-dev-spec.md`.
 
 > **Why not `.default` for work/school (changed — #511/#529).** Work/school previously used

--- a/docs/ENTRA-APP-REGISTRATION.md
+++ b/docs/ENTRA-APP-REGISTRATION.md
@@ -308,26 +308,25 @@ or enable the admin consent workflow so end users route requests to designated r
 ## 6. Troubleshooting
 
 ### "Prompted for consent, but there's no way to consent" (dead-end prompt)
-The tenant disables user consent **and** at least one **declared** permission (§3) has not been
-admin-granted for the tenant. Because QuickMail requests `.default` (the whole declared set), sign-in
-requires the full set to be consented — so any un-granted declared permission blocks sign-in, not
-just a single feature.
-**Fix:** ensure every needed permission is declared (§3) → **grant admin consent for the whole set**
-(§4). After adding a new permission, the admin must **re-grant** (an existing grant reflects the
-*old* set). With `.default` this is purely a registration/consent action — there is no code scope
-list to change.
+The tenant disables user consent **and** a permission the sign-in **requests** (see below) has not
+been admin-granted for the tenant.
+**Fix:** grant admin consent for the app (§4). After adding a new permission, the admin must
+**re-grant** (an existing grant reflects the *old* set).
 
-Note: with `.default`, "same account works on one build but dead-ends on another because of which
-scopes the build requests" **no longer happens** — every build requests the same full declared set.
-A dead-end is always a registration/consent gap (a declared scope not yet granted), never a
-per-build scope difference.
+Note on which scopes a build requests (changed — #511/#529): work/school Graph mail sign-in now
+requests **explicit** Graph mail scopes (`OAuthService.GraphMailScopesWorkSchool`), **not**
+`.default`. So, unlike under `.default`, a **per-build scope difference is again possible** — an
+un-granted permission blocks sign-in only if that build's scope list actually requests it. A scope
+that is merely *declared* on the registration but not in the code list (e.g. `User.ReadBasic.All`, a
+forward declaration) does **not** block sign-in. Conversely, adding a new work/school mail permission
+now requires editing `GraphMailScopesWorkSchool` **and** the registration, not the registration alone.
+(This reverts to `.default` at the end of the #529 migration, once the Exchange perms are removed.)
 
 ### Server-rules write fails with `403` even though sign-in worked
-A residual case under `.default`: the account's cached token predates a newly-declared scope, or the
-tenant granted only part of the declared set. **Fix:** confirm `MailboxSettings.ReadWrite` is
-declared (§3) and admin-granted (§4), then **sign in again** — a fresh `.default` acquisition
-refreshes the token to include it. QuickMail surfaces this as an admin-directed message, not an
-in-app re-consent (see `docs/planning/oauth-default-scope-pm-dev-spec.md` §5).
+The account's cached token predates a newly-added scope, or the tenant granted only part of the set.
+**Fix:** confirm `MailboxSettings.ReadWrite` is declared (§3), in `GraphMailScopesWorkSchool` (code),
+and admin-granted (§4), then **sign in again** to refresh the token. QuickMail surfaces this as an
+admin-directed message, not an in-app re-consent (see `docs/planning/oauth-default-scope-pm-dev-spec.md` §5).
 
 ### Sign-in lands on an unreachable `http://localhost` page, then re-prompts
 A redirect-URI misconfiguration (§2): the loopback redirect is under the wrong platform, uses a

--- a/docs/ENTRA-APP-REGISTRATION.md
+++ b/docs/ENTRA-APP-REGISTRATION.md
@@ -53,9 +53,20 @@ above; the embedded view intercepts that navigation internally (no loopback list
 
 ## 3. API permissions (delegated, Microsoft Graph + Exchange Online)
 
-The **Graph mail** backend uses the per-resource **`.default` scope** at **mail sign-in**
-(`https://graph.microsoft.com/.default`), which asks for **exactly the delegated Graph permissions
-declared here** — nothing more. See `docs/planning/oauth-default-scope-pm-dev-spec.md`.
+The **Graph mail** backend requests **explicit** Graph mail scopes at mail sign-in for **every** account
+type — `OAuthService.GraphMailScopesWorkSchool` (`Mail.ReadWrite`, `Mail.Send`, `MailboxSettings.ReadWrite`,
+`User.Read`, `User.ReadBasic.All`) for work/school, and `GraphMailScopesPersonal` for personal. See
+`docs/planning/oauth-default-scope-pm-dev-spec.md`.
+
+> **Why not `.default` for work/school (changed — #511/#529).** Work/school previously used
+> `graph.microsoft.com/.default`, which requests the app's **entire** declared set — dragging the
+> Office 365 Exchange Online IMAP/SMTP permissions (below, there only for the Microsoft IMAP backend)
+> into every fresh Graph consent. When Microsoft's validation of that legacy Exchange entitlement went
+> intermittently bad, `.default` consent failed with `AADSTS65006` on every fresh work/school Graph
+> onboarding (#511). Explicit Graph scopes never touch the Exchange entitlement, so Graph sign-in is
+> clean. This is the **bridge** for the Graph-only migration (#529); once the Exchange permissions are
+> removed from this registration (last step of #529), work/school reverts to `.default` (Exchange-free,
+> zero-maintenance). The Graph permissions below must still be declared for AAD either way.
 
 > **`.default` is not the whole story.** Contact sync and calendar sync run **separate,
 > incremental consent flows** (`RequestContactsConsentAsync` / `RequestCalendarConsentAsync`) that


### PR DESCRIPTION
**Part of #529** (Graph-only for Microsoft accounts) — this is the first step, the "bridge."

## What this does

Work/school Microsoft **Graph** sign-in requested `graph.microsoft.com/.default`, which asks for the app registration's **entire** declared permission set. That dragged the Office 365 Exchange Online `IMAP.AccessAsUser.All` / `SMTP.Send` permissions (declared only for the Microsoft IMAP backend) into **every fresh work/school Graph consent**. When Microsoft's validation of that legacy Exchange entitlement went intermittently bad, `.default` consent failed with `AADSTS65006` on fresh work/school Graph onboarding — reproducible on every fresh consent and **not** tenant-side (confirmed with the sole tenant admin having made no changes).

This requests **explicit Graph mail scopes** for work/school instead:

```
Mail.ReadWrite, Mail.Send, MailboxSettings.ReadWrite (server rules), User.Read
```

so a Graph sign-in only ever validates the Graph permissions it actually uses and **never touches the Exchange entitlement**. Onboarding is clean regardless of the Exchange flakiness. Personal accounts were already on explicit scopes (`GraphMailScopesPersonal`); IMAP is unchanged; contacts/calendar keep their own incremental-consent flows.

Consent is now **force-prompted only on the `.default` path** (`PromptForSignIn` gains a `usesDefaultScope` param). Forcing consent (`#391`) is a `.default`-only workaround — with explicit scopes, requesting the scope *is* the consent trigger, so forcing it just re-prompts an already-consented org on every add (the #207/#208 symptom). Explicit-scope adds fall through to the normal prompt, which lets AAD skip consent when the org has already granted the scopes.

`User.ReadBasic.All` is deliberately **not** in the code scope list — it has no call site (a forward declaration on the registration), and directory scopes gated behind admin consent could dead-end sign-in on a restrictive tenant. It stays declared on the registration.

## Why a bridge

This is temporary. The end state (#529) drops the Microsoft IMAP backend and removes the Exchange permissions from the app registration; once they're gone, `.default` is Exchange-free and work/school reverts to it (restoring the zero-maintenance #208 behaviour). The bridge is what lets that removal happen **last**, without a window where new work/school Graph onboarding is broken.

## Testing

- `OAuthServiceScopeSelectionTests` updated: every `DefaultScopesFor` branch pinned to the right scope set; the `.default`-vs-explicit prompt behaviour pinned (`Prompt.Consent` only for `.default`).
- Full suite green; 0 CA analyzer warnings in a Release build.
- **Live-verified on real M365** (work/school, fresh profile): 0 × AADSTS65006, single clean sign-in, no consent re-prompt — vs. the reproducible 65006-then-retry churn on `.default`.

## Docs

`docs/ENTRA-APP-REGISTRATION.md` §3 and §6 updated to describe the explicit-scopes approach and flag it as the #529 bridge (per-build scope differences are again possible; an un-granted *requested* scope can block sign-in). The `.default` planning spec is left as the revert-target design.

## Scope

Microsoft only, and Graph only. Non-Microsoft IMAP (Gmail via Google OAuth, password IMAP) is untouched. The `.default` revert is a later step of #529.
