### PR TITLE
Fix #528: arrow keys reach every Settings tab, whatever row it is on

### DIFF
--- a/QuickMail.Tests/TabStripNavigationTests.cs
+++ b/QuickMail.Tests/TabStripNavigationTests.cs
@@ -1,0 +1,254 @@
+// Regression tests for issue #528: Left and Right on the Settings tab headers did not reach all
+// six tabs.
+//
+// The cause was geometry, not the keys. TabPanel wraps headers onto as many rows as it needs and
+// then moves the row holding the selected tab to the bottom; Settings wraps to two rows of three.
+// WPF's directional navigation looks for the nearest focusable element in the direction pressed,
+// so Left and Right only ever found the other tabs on the same row — General, Advanced and
+// Keyboard Shortcuts cycled among themselves and Startup, Windowing and Appearance could not be
+// reached with the arrow keys at all.
+//
+// The tests feed real KeyEventArgs through the class handler rather than synthesizing keystrokes,
+// so they are deterministic and do not need QUICKMAIL_RUN_INPUT_TESTS. Logical focus is tracked
+// through FocusManager for the reason recorded on TabOrderWalker: keyboard focus is only granted
+// in the active window, which a test cannot rely on owning.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+using QuickMail.Helpers;
+using QuickMail.Services;
+using QuickMail.ViewModels;
+using QuickMail.Views;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+[Collection("WpfTests")]
+public class TabStripNavigationTests
+{
+    private static void EnsureApplication()
+    {
+        lock (typeof(Application))
+        {
+            if (Application.Current == null)
+                new Application { ShutdownMode = ShutdownMode.OnExplicitShutdown };
+            const string stylesUri = "pack://application:,,,/QuickMail;component/Styles/AccessibleStyles.xaml";
+            var uri = new Uri(stylesUri, UriKind.Absolute);
+            if (Application.Current!.Resources.MergedDictionaries.All(d => d.Source != uri))
+                Application.Current.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = uri });
+        }
+        TabStripNavigation.Install();
+    }
+
+    /// <summary>A tab strip in a shown window, so the containers and layout are real.</summary>
+    private static (Window window, TabControl tabs, TabItem[] items) BuildStrip(int count = 4)
+    {
+        var tabs = new TabControl();
+        var items = Enumerable.Range(0, count)
+            .Select(i => new TabItem { Header = $"Tab {i}", Content = new TextBox() })
+            .ToArray();
+        foreach (var item in items) tabs.Items.Add(item);
+
+        var window = new Window { Width = 400, Height = 300, ShowActivated = false, Content = tabs };
+        window.Show();
+        TabOrderWalker.Drain();
+        return (window, tabs, items);
+    }
+
+    /// <summary>Puts focus on <paramref name="from"/> and presses <paramref name="key"/> there.</summary>
+    private static void Press(Window window, DependencyObject from, Key key)
+    {
+        if (from is IInputElement focusable)
+        {
+            FocusManager.SetFocusedElement(window, focusable);
+            (from as FrameworkElement)?.Focus();
+            TabOrderWalker.Drain();
+        }
+
+        var args = new KeyEventArgs(Keyboard.PrimaryDevice, PresentationSource.FromVisual(window)!, 0, key)
+        {
+            RoutedEvent = UIElement.PreviewKeyDownEvent,
+            Source      = from,
+        };
+        ((UIElement)from).RaiseEvent(args);
+        TabOrderWalker.Drain();
+    }
+
+    private static string? Header(object? tab) => (tab as TabItem)?.Header?.ToString();
+
+    [StaFact]
+    public void RightArrow_MovesToTheNextTab_AndSelectsIt()
+    {
+        EnsureApplication();
+        var (window, tabs, items) = BuildStrip();
+        try
+        {
+            Press(window, items[0], Key.Right);
+
+            Assert.Equal("Tab 1", Header(tabs.SelectedItem));
+            Assert.Same(items[1], FocusManager.GetFocusedElement(window));
+        }
+        finally { window.Close(); }
+    }
+
+    [StaFact]
+    public void RightArrow_FromTheLastTab_WrapsToTheFirst()
+    {
+        EnsureApplication();
+        var (window, tabs, items) = BuildStrip();
+        try
+        {
+            Press(window, items[^1], Key.Right);
+
+            Assert.Equal("Tab 0", Header(tabs.SelectedItem));
+        }
+        finally { window.Close(); }
+    }
+
+    [StaFact]
+    public void LeftArrow_FromTheFirstTab_WrapsToTheLast()
+    {
+        EnsureApplication();
+        var (window, tabs, items) = BuildStrip();
+        try
+        {
+            Press(window, items[0], Key.Left);
+
+            Assert.Equal("Tab 3", Header(tabs.SelectedItem));
+        }
+        finally { window.Close(); }
+    }
+
+    [StaFact]
+    public void HomeAndEnd_GoToTheFirstAndLastTab()
+    {
+        EnsureApplication();
+        var (window, tabs, items) = BuildStrip();
+        try
+        {
+            Press(window, items[1], Key.End);
+            Assert.Equal("Tab 3", Header(tabs.SelectedItem));
+            Assert.Same(items[3], FocusManager.GetFocusedElement(window));
+
+            Press(window, items[3], Key.Home);
+            Assert.Equal("Tab 0", Header(tabs.SelectedItem));
+            Assert.Same(items[0], FocusManager.GetFocusedElement(window));
+        }
+        finally { window.Close(); }
+    }
+
+    [StaFact]
+    public void DisabledTabs_AreSkipped()
+    {
+        EnsureApplication();
+        var (window, tabs, items) = BuildStrip();
+        try
+        {
+            items[1].IsEnabled = false;
+            TabOrderWalker.Drain();
+
+            Press(window, items[0], Key.Right);
+
+            Assert.Equal("Tab 2", Header(tabs.SelectedItem));
+        }
+        finally { window.Close(); }
+    }
+
+    [StaFact]
+    public void ArrowsInTheTabsContent_AreLeftAlone()
+    {
+        // The behaviour must never take an arrow key away from a text box, list or combo box that
+        // happens to live inside the selected tab.
+        EnsureApplication();
+        var (window, tabs, items) = BuildStrip();
+        try
+        {
+            var box = (TextBox)items[0].Content;
+            Press(window, box, Key.Right);
+
+            Assert.Equal("Tab 0", Header(tabs.SelectedItem));
+        }
+        finally { window.Close(); }
+    }
+
+    [StaFact]
+    public void CtrlTab_IsLeftToTheFramework()
+    {
+        // TabControl implements Ctrl+Tab itself; a modified key must fall straight through.
+        EnsureApplication();
+        var (window, tabs, items) = BuildStrip();
+        try
+        {
+            var args = new KeyEventArgs(Keyboard.PrimaryDevice, PresentationSource.FromVisual(window)!, 0, Key.Right)
+            {
+                RoutedEvent = UIElement.PreviewKeyDownEvent,
+                Source      = items[0],
+            };
+            // A real Ctrl+Right cannot be simulated without holding the key down, so assert the
+            // narrower thing the handler actually checks: an already-handled event is not touched.
+            args.Handled = true;
+            items[0].RaiseEvent(args);
+            TabOrderWalker.Drain();
+
+            Assert.Equal("Tab 0", Header(tabs.SelectedItem));
+        }
+        finally { window.Close(); }
+    }
+
+    [StaFact]
+    public void SettingsDialog_EveryTabIsReachableWithTheArrowKeys()
+    {
+        // The regression #528 reported, against the real dialog: its six tabs wrap onto two rows,
+        // which is what broke geometric navigation. Pressing Right once per tab must visit every
+        // one of them and come back to where it started.
+        EnsureApplication();
+        var vm     = new SettingsViewModel(new StubConfigService(), new StubCommandRegistry());
+        var dialog = new SettingsDialog(vm) { ShowActivated = false };
+        dialog.Show();
+        TabOrderWalker.Drain();
+        try
+        {
+            var tabs = FindTabControl(dialog);
+            Assert.NotNull(tabs);
+            var items = tabs!.Items.Cast<TabItem>().ToArray();
+            Assert.True(items.Length >= 4, "the dialog should still have its tabs");
+
+            // Guards the premise: if the headers ever stop wrapping this test still passes, but a
+            // reader should know the two-row layout is what the fix is for.
+            var rows = items.Select(i => Math.Round(i.TransformToAncestor(dialog).Transform(default).Y))
+                            .Distinct().Count();
+            Assert.True(rows >= 1);
+
+            var visited = new List<string?>();
+            var current = items[0];
+            for (var i = 0; i < items.Length; i++)
+            {
+                Press(dialog, current, Key.Right);
+                current = (TabItem)FocusManager.GetFocusedElement(dialog)!;
+                visited.Add(Header(tabs.SelectedItem));
+            }
+
+            // Every tab, in order, ending back at the first.
+            var expected = items.Skip(1).Select(i => Header(i)).Append(Header(items[0])).ToList();
+            Assert.Equal(expected, visited);
+        }
+        finally { dialog.Close(); }
+    }
+
+    private static TabControl? FindTabControl(DependencyObject root)
+    {
+        if (root is TabControl found) return found;
+        var count = VisualTreeHelper.GetChildrenCount(root);
+        for (var i = 0; i < count; i++)
+        {
+            var child = FindTabControl(VisualTreeHelper.GetChild(root, i));
+            if (child != null) return child;
+        }
+        return null;
+    }
+}

--- a/QuickMail/App.xaml.cs
+++ b/QuickMail/App.xaml.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using System.Windows;
+using QuickMail.Helpers;
 using QuickMail.Models;
 using QuickMail.Services;
 using QuickMail.ViewModels;
@@ -220,6 +221,10 @@ public partial class App : Application
         }
         if (onlineMode)
             LogService.Log("Online mode enabled — SQLite cache bypassed.");
+
+        // Left/Right/Home/End through a wrapped tab strip (#528). A class handler so a window
+        // with tabs added later cannot be left out.
+        TabStripNavigation.Install();
 
         // Debug screenshot capture (#175): the real engine exists only under /debug;
         // otherwise a null object keeps the feature structurally unreachable. One

--- a/QuickMail/Helpers/TabStripNavigation.cs
+++ b/QuickMail/Helpers/TabStripNavigation.cs
@@ -1,0 +1,117 @@
+using System.Collections.Generic;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+
+namespace QuickMail.Helpers;
+
+/// <summary>
+/// Makes Left/Right/Home/End on a tab header move through the tabs in <em>declaration order</em>
+/// rather than by where the headers happen to sit on screen (issue #528).
+///
+/// <para>
+/// WPF navigates a tab strip with the same geometric directional navigation it uses everywhere
+/// else: Right looks for the nearest focusable thing to the right, on roughly the same line. That
+/// is fine while the headers form one row, and wrong the moment they do not. <c>TabPanel</c> wraps
+/// the headers onto as many rows as it needs, and then moves the row holding the selected tab to
+/// the bottom. Settings has six tabs and wraps to two rows of three, so Left and Right cycled
+/// General → Advanced → Keyboard Shortcuts → General for ever; Startup, Windowing and Appearance
+/// could not be reached with the arrow keys at all. Which tabs are stranded depends on the window
+/// width, the font size and the text-scaling setting, so this is not something a wider dialog or
+/// shorter headers can be relied on to fix.
+/// </para>
+///
+/// <para>
+/// Selection follows focus, which is how a tab control behaves everywhere on Windows: arrowing to
+/// a tab shows it. The tab is selected <em>before</em> it is focused so the state the platform
+/// reports for the newly focused header is already the new one. Nothing is announced here —
+/// focusing a tab header and reporting its state is the platform's job.
+/// </para>
+///
+/// <para>
+/// Home and End were already handled by <c>TabControl</c> itself; they are handled here too so
+/// that all four keys come from one place with one set of rules (skip disabled and collapsed
+/// tabs), and so the behaviour is covered by tests rather than by an implementation detail of the
+/// framework.
+/// </para>
+/// </summary>
+public static class TabStripNavigation
+{
+    private static bool _installed;
+
+    /// <summary>
+    /// Registers the behaviour for every <see cref="TabControl"/> in the process. Called once from
+    /// application startup: a class handler cannot be forgotten when a new window with tabs is
+    /// added, which a per-control attached property can. Idempotent, so tests can call it too.
+    /// </summary>
+    public static void Install()
+    {
+        if (_installed) return;
+        _installed = true;
+
+        // Tunnelling, so the TabControl sees the key before anything inside it. The OriginalSource
+        // check below is what keeps that safe: a key pressed in the tab's *content* — an arrow in
+        // a text box, a list, a combo box — is not touched.
+        EventManager.RegisterClassHandler(
+            typeof(TabControl), UIElement.PreviewKeyDownEvent, new KeyEventHandler(OnPreviewKeyDown));
+    }
+
+    private static void OnPreviewKeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.Handled || sender is not TabControl tabControl) return;
+
+        // The event's own device state, not the global Keyboard.Modifiers: the latter reports
+        // whatever is physically held right now, which is not necessarily what produced this key.
+        // Ctrl+Tab and Ctrl+Shift+Tab are TabControl's own and must be left alone.
+        if (e.KeyboardDevice.Modifiers != ModifierKeys.None) return;
+
+        // Only when focus is on a tab header of this tab control. For a keyboard event
+        // OriginalSource is the focused element; Keyboard.FocusedElement is the fallback for
+        // synthesized events that carry a different source.
+        var current = e.OriginalSource as TabItem ?? Keyboard.FocusedElement as TabItem;
+        if (current is null || !ReferenceEquals(ItemsControl.ItemsControlFromItemContainer(current), tabControl))
+            return;
+
+        var tabs = SelectableTabs(tabControl);
+        var index = tabs.IndexOf(current);
+        if (index < 0 || tabs.Count < 2) return;
+
+        var target = e.Key switch
+        {
+            Key.Right => tabs[(index + 1) % tabs.Count],
+            Key.Left  => tabs[(index - 1 + tabs.Count) % tabs.Count],
+            Key.Home  => tabs[0],
+            Key.End   => tabs[^1],
+            _         => null,
+        };
+        if (target is null) return;
+
+        // Handled either way: Home on the first tab and Left on it both mean "the strip dealt with
+        // this", and letting the key fall through to geometric navigation would move focus out of
+        // the strip entirely.
+        e.Handled = true;
+        if (ReferenceEquals(target, current)) return;
+
+        // SetCurrentValue rather than an assignment: it does not overwrite a binding on IsSelected.
+        target.SetCurrentValue(TabItem.IsSelectedProperty, true);
+        target.Focus();
+    }
+
+    private static List<TabItem> SelectableTabs(TabControl tabControl)
+    {
+        var tabs = new List<TabItem>();
+        for (var i = 0; i < tabControl.Items.Count; i++)
+        {
+            // ContainerFromIndex covers tabs generated from an ItemsSource; tabs declared in XAML
+            // are their own containers, so fall back to the item before the containers exist.
+            var tab = tabControl.ItemContainerGenerator.ContainerFromIndex(i) as TabItem
+                      ?? tabControl.Items[i] as TabItem;
+
+            // Visibility rather than IsVisible: IsVisible is false for anything not yet rendered,
+            // which would make the strip empty in a window that has not been shown.
+            if (tab is { IsEnabled: true, Visibility: Visibility.Visible })
+                tabs.Add(tab);
+        }
+        return tabs;
+    }
+}

--- a/docs/KEYBOARD-SHORTCUTS.md
+++ b/docs/KEYBOARD-SHORTCUTS.md
@@ -164,3 +164,25 @@ These are **deliberately not registered in `CommandRegistry`**. They are in-fiel
 Stepping and free-text parsing live in `Helpers/DateTimeFieldParser.cs` (pure, unit-tested in `DateTimeFieldParserTests`). A time field holds a full instant, not a `TimeSpan`, so stepping past midnight carries into the date instead of wrapping. `TryParseTime` uses an explicit format list and **rejects date-shaped text**: `DateTime.TryParse("8/3")` succeeds with a `TimeOfDay` of zero, which used to turn a date typed into the time box into a silent midnight.
 
 **Automation surface — do not change without listening first.** The control is a plain `TextBox` with no automation peer of its own. Three shapes were built and evaluated with three screen readers before this one was chosen: an edit field, an edit field claiming `AutomationControlType.Spinner`, and a purpose-built spinner control implementing `IValueProvider` and `IRangeValueProvider`. All three announced correctly, so the one that invents nothing won — replacing `TextBox.Text` raises the UIA value-change event screen readers already act on. There is **no** `AccessibilityHelper.Announce` in the stepping path, and there must not be: a programmatic announcement is filtered by the user's announcement settings, while a native value change is not.
+
+## Tab strips
+
+Left, Right, Home and End on a tab header move through the tabs of any `TabControl` in the app, in
+declaration order, wrapping at both ends; selection follows focus, so arrowing to a tab shows it.
+`Helpers/TabStripNavigation.cs` installs this once, from `App.OnStartup`, as a class handler on
+`TabControl` — a per-control attached property can be forgotten when a window with tabs is added,
+a class handler cannot.
+
+WPF's own arrow handling here is **geometric**: Right finds the nearest focusable element to the
+right, on roughly the same line. `TabPanel` wraps headers onto as many rows as they need and then
+moves the row holding the selected tab to the bottom, so on a wrapped strip the arrows can only
+ever reach the tabs sharing a row. Settings has six tabs, wraps to two rows of three, and stranded
+Startup, Windowing and Appearance completely (issue #528). How many rows a strip takes depends on
+the window width, the font and the text-scaling setting, so a wider dialog or shorter headers is
+not a fix. Covered by `TabStripNavigationTests`, which includes a walk over the real
+`SettingsDialog`.
+
+Like the date-field stepping keys above, these are **deliberately not registered in
+`CommandRegistry`**: they are in-control navigation keys, the same kind as the arrow keys inside a
+list box, and they do nothing outside a tab header. `Ctrl+Tab` / `Ctrl+Shift+Tab` remain
+`TabControl`'s own — the handler ignores any key pressed with a modifier.

--- a/docs/release-notes-v0.8.40.md
+++ b/docs/release-notes-v0.8.40.md
@@ -17,6 +17,16 @@ All downloads include the .NET 8 runtime — you do not need to install .NET sep
 
 ---
 
+## Fixed: the arrow keys skipped half the Settings tabs
+
+In **File → Settings** (Ctrl+comma), Left and Right on the tab headers only ever reached three of the six tabs — pressing Right from General went to Advanced, then Keyboard Shortcuts, then straight back to General. Startup, Windowing and Appearance could not be reached with the arrow keys at all.
+
+The cause was that the six headers do not fit on one line, so they are laid out on two, and the arrow keys were finding the next tab by *where it sits on screen* rather than by its place in the list. That meant they never crossed from one line to the other.
+
+Left and Right now move through the tabs in order, whatever the layout, and wrap around at both ends. **Home** goes to the first tab and **End** to the last. Arrowing to a tab shows it, as it does in any tabbed window on Windows, and **Ctrl+Tab** and **Ctrl+Shift+Tab** work as before. Every tabbed window in QuickMail gets this, not just Settings. ([#528](https://github.com/kellylford/QuickMail/issues/528))
+
+---
+
 ## Reporting Issues
 
 Found a problem or have a suggestion? There are three ways to reach us — pick the one that fits:


### PR DESCRIPTION
Closes #528. Stacked on #531 (the 0.8.40 bump), because the release-notes entry goes in that file. Retarget to `main` once #531 lands.

## What was wrong

Left and Right on the Settings tab headers reached three of the six tabs: General → Advanced → Keyboard Shortcuts → General, for ever. Startup, Windowing and Appearance could not be reached with the arrow keys at all.

## Why

Geometry, not keys. WPF navigates a tab strip with the directional navigation it uses everywhere else — Right looks for the nearest focusable element to the right, on roughly the same line. `TabPanel` wraps headers onto as many rows as they need, then moves the row holding the selected tab to the bottom. Settings wraps to two rows of three, so the arrows could only ever find tabs sharing a row.

Measured against the real dialog with a throwaway probe rather than reasoned about:

```
_General:            at=10,41.96      _Keyboard Shortcuts: at=296.68,41.96
_Advanced:           at=147.55,41.96  Start_up:            at=10,10
_Windowing:          at=156.64,10     A_ppearance:         at=325.48,10

Right: _General -> _Advanced -> _Keyboard Shortcuts -> _General -> ...
Left:  _General -> _Keyboard Shortcuts -> _Advanced -> _General -> ...
```

How many rows a strip takes depends on window width, font and text scaling, so widening the dialog or shortening the headers is not a fix — it only changes which tabs get stranded.

## The fix

`Helpers/TabStripNavigation.cs` navigates by declaration order:

- **Left / Right** step one tab and wrap at both ends.
- **Home / End** go to the first and last tab.
- Disabled and collapsed tabs are skipped.
- Selection follows focus, as a tab control does everywhere on Windows. The tab is selected *before* it is focused, so the state reported for the newly focused header is already the new one. Nothing is announced — a tab header being focused is the platform's to report.

Installed once from `App.OnStartup` as a class handler on `TabControl`, so a window with tabs added later cannot be left out (the Address Book gets it too). It tunnels, and acts only when the key came from a tab header of that tab control with **no modifier held** — an arrow pressed inside a tab's content, and `Ctrl+Tab`, are untouched.

Home and End already worked through `TabControl`'s own handling. They are here so all four keys come from one place with one set of rules, and so they are covered by tests rather than by a framework detail.

Not registered in `CommandRegistry`, for the same reason the date-field stepping keys are not: in-control navigation, not an application command. Documented in `docs/KEYBOARD-SHORTCUTS.md` under a new "Tab strips" section.

## Verification

- `TabStripNavigationTests` — 8 tests: stepping, wrapping both ways, Home/End, disabled tabs skipped, arrows in tab content left alone, an already-handled key left alone, and a walk over the real `SettingsDialog` asserting every tab is visited in order. **Six of the eight fail without the fix** (verified by stubbing out `Install()`).
- Full suite green: 2870 passed, 3 skipped, 0 failed, run with `--blame-hang`.
- Release build: 0 warnings, 0 errors.

No `Views/`, `Styles/` or `Themes/` changes, so no ui-probe run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)