### PR TITLE
Explicit Graph scopes are the permanent design, not a bridge (#529)

### DIFF
--- a/QuickMail.Tests/OAuthServiceScopeSelectionTests.cs
+++ b/QuickMail.Tests/OAuthServiceScopeSelectionTests.cs
@@ -6,15 +6,16 @@ using Xunit;
 namespace QuickMail.Tests;
 
 /// <summary>
-/// Locks the per-account scope selection (#217/#218, #511/#529): personal Microsoft accounts get the
+/// Locks the per-account scope selection (#217/#218, #511): personal Microsoft accounts get the
 /// explicit personal Graph scopes, work/school Graph accounts get the explicit work/school Graph scopes
-/// (the #529 bridge — so a Graph sign-in never validates the Exchange entitlement, #511), and IMAP
-/// always uses the IMAP scopes. Guards against a future refactor silently reverting the routing.
+/// (so a Graph sign-in never validates the Exchange entitlement, #511), and IMAP always uses the IMAP
+/// scopes. Guards against a future refactor silently reverting the routing — including a well-meaning
+/// "restore `.default` for work/school", which #529 ruled out for good (see OAuthService).
 /// </summary>
 public class OAuthServiceScopeSelectionTests
 {
     // A work-or-school Microsoft address on Graph asks for explicit Graph scopes, NOT `.default`
-    // (#511/#529 bridge). `.default` requested the whole declared set, dragging the Exchange IMAP/SMTP
+    // (#511). `.default` requested the whole declared set, dragging the Exchange IMAP/SMTP
     // permissions into every fresh Graph consent — whose flaky validation produced the intermittent
     // AADSTS65006. The explicit list requests only the Graph mail permissions, so the Exchange
     // entitlement is never touched by a Graph sign-in.

--- a/QuickMail/Services/Graph/GraphClient.cs
+++ b/QuickMail/Services/Graph/GraphClient.cs
@@ -269,8 +269,8 @@ public sealed class GraphClient : IDisposable
         for (int attempt = 0; ; attempt++)
         {
             // Default (scopes == null): per-account default scopes (DefaultScopesFor) — explicit Graph
-            // mail scopes for BOTH personal (#217) and work/school (the #511/#529 bridge; `.default` is
-            // no longer used on the mail path until the Exchange perms are removed). An explicit scope
+            // mail scopes for BOTH personal (#217) and work/school (#511; `.default` is no longer used
+            // on the mail path at all, and is not coming back — see OAuthService). An explicit scope
             // set is passed only by contact sync (Graph Contacts.Read/People.Read), which also asks for
             // silent-only acquisition so it never opens an interactive window.
             var token = scopes is null

--- a/QuickMail/Services/OAuthService.cs
+++ b/QuickMail/Services/OAuthService.cs
@@ -36,13 +36,24 @@ public class OAuthService : IOAuthService
     // Microsoft's validation of that legacy Exchange entitlement went intermittently bad, `.default`
     // consent failed with AADSTS65006 (reproducible on every fresh consent, not tenant-side). #511.
     //
-    // BRIDGE for the Graph-only migration (#529): request EXPLICIT Graph mail scopes instead, so a Graph
-    // sign-in only ever validates the Graph permissions it needs and never touches the Exchange
-    // entitlement. Contacts and calendar are NOT here — they run through their own incremental consent
-    // flows (RequestContactsConsentAsync / RequestCalendarConsentAsync), same as personal accounts, so
-    // this list is mail only. This is temporary: once the Exchange permissions are removed from the app
-    // registration (last step of #529), `.default` is Exchange-free and this reverts to it (restoring the
-    // zero-maintenance #208 behavior). See docs/planning/oauth-default-scope-pm-dev-spec.md.
+    // FIX (#511): request EXPLICIT Graph mail scopes instead, so a Graph sign-in only ever validates the
+    // Graph permissions it needs and never touches the Exchange entitlement. Contacts and calendar are
+    // NOT here — they run through their own incremental consent flows (RequestContactsConsentAsync /
+    // RequestCalendarConsentAsync), same as personal accounts, so this list is mail only.
+    //
+    // THIS IS PERMANENT — do NOT "restore" `.default` here. It was originally written as a temporary
+    // bridge, on the plan that Microsoft IMAP would be dropped and the Exchange permissions deleted from
+    // the app registration. That plan was settled the other way (#529): Microsoft IMAP is RETAINED as a
+    // documented fallback while the open Graph defects (#491/#462/#454/#31) stand, so the Exchange
+    // permissions must stay declared, so `.default` would drag them back into Graph consent and
+    // reintroduce the AADSTS65006. The registration cleanup and the `.default` revert are off the table.
+    //
+    // The cost of that decision lands here: this list is HAND-MAINTAINED. Adding a work/school Graph mail
+    // capability means adding its scope to this array AND declaring it on the registration — miss the
+    // array and the call 403s at runtime. That is the accepted trade (a dev-time-diagnosable 403 beats
+    // anything that touches users' machines); it is not an oversight to be optimized away by going back
+    // to `.default`. See docs/planning/oauth-default-scope-pm-dev-spec.md for the superseded `.default`
+    // design and #529 for why it stays superseded.
     // Only scopes the work/school MAIL path actually calls. Deliberately NOT `User.ReadBasic.All`
     // (a `/users` directory permission with no call site — it's a forward declaration on the app
     // registration, see docs/ENTRA-APP-REGISTRATION.md): restrictive tenants gate directory reads
@@ -84,9 +95,11 @@ public class OAuthService : IOAuthService
 
     // Calendar read/write scope for Graph calendar sync (full-calendar spec, M4). Explicit scope so
     // it works for BOTH personal and work/school accounts — same reasoning as GraphContactScopes.
-    // Requested only when the user adds a Microsoft calendar. NOTE: work/school accounts sign in with
-    // `.default`, so for them Calendars.ReadWrite must ALSO be declared on the app registration (see
-    // docs/ENTRA-APP-REGISTRATION.md §3); this explicit array is what personal (MSA) accounts request.
+    // Requested only when the user adds a Microsoft calendar. NOTE: Calendars.ReadWrite must ALSO be
+    // declared on the app registration (see docs/ENTRA-APP-REGISTRATION.md §3) so a work/school tenant
+    // can admin-consent it; this explicit array is what the calendar consent flow requests, for personal
+    // and work/school alike. (This note used to say work/school "sign in with `.default`" — no longer
+    // true since #511, and it was never the reason the declaration is needed.)
     // In use by GraphCalendarSyncService (#282): reads /me/calendars and /me/events and creates
     // events, so the ReadWrite (not just Read) scope is required.
     public static readonly string[] GraphCalendarScopes =
@@ -121,9 +134,9 @@ public class OAuthService : IOAuthService
     {
         if (account.BackendKind != BackendKind.MicrosoftGraph)
             return ImapSmtpScopes;
-        // Both personal and work/school use explicit Graph scopes now — personal for write access
-        // (#217), work/school as the #529 bridge so a Graph sign-in never validates the Exchange
-        // entitlement (#511). Prefer the persisted, tenant-derived flag; fall back to the email-domain
+        // Both personal and work/school use explicit Graph scopes — personal for write access (#217),
+        // work/school so a Graph sign-in never validates the Exchange entitlement (#511).
+        // Prefer the persisted, tenant-derived flag; fall back to the email-domain
         // guess only when the account hasn't been detected yet (first sign-in, or added before detection).
         var isPersonal = account.IsPersonalMicrosoftAccount ?? IsPersonalMicrosoftDomain(account.Username);
         return isPersonal ? GraphMailScopesPersonal : GraphMailScopesWorkSchool;
@@ -135,10 +148,10 @@ public class OAuthService : IOAuthService
     // permissions are never consented and mail calls then 403 (#391, Microsoft docs "`.default`"
     // Example 3). Prompt.Consent makes the admin/user approve the full declared set once, up front.
     //
-    // #511/#529: with EXPLICIT scopes (not `.default`) that workaround does not apply — requesting
+    // #511: with EXPLICIT scopes (not `.default`) that workaround does not apply — requesting
     // `Mail.ReadWrite` IS the consent trigger, and AAD shows consent only when it isn't already granted.
     // Forcing it there just re-prompts an already-consented org on every add (the #207/#208 symptom seen
-    // when the bridge first went in). So force consent only on the `.default` path; explicit-scope adds
+    // when explicit scopes first went in). So force consent only on the `.default` path; explicit adds
     // fall through to the normal prompt, which lets AAD skip consent when the org has already granted it.
     //
     // Re-auth (an already-added account whose token expired) uses the normal prompt either way — that
@@ -281,7 +294,7 @@ public class OAuthService : IOAuthService
 
     // Add-account entry point. firstConnect=true; the prompt then depends on the scopes: the `.default`
     // path still forces consent (#391), while the explicit-scope paths (personal, and work/school since
-    // the #529 bridge) let AAD decide, so an already-consented org isn't re-prompted. See PromptForSignIn.
+    // #511) let AAD decide, so an already-consented org isn't re-prompted. See PromptForSignIn.
     public Task<OAuthResult> SignInInteractiveAsync(AccountModel account, CancellationToken ct = default)
         => SignInInteractiveAsync(account, DefaultScopesFor(account), firstConnect: true, ct);
 

--- a/docs/ENTRA-APP-REGISTRATION.md
+++ b/docs/ENTRA-APP-REGISTRATION.md
@@ -67,9 +67,15 @@ scope requested at sign-in can dead-end onboarding on a consent-restricted tenan
 > into every fresh Graph consent. When Microsoft's validation of that legacy Exchange entitlement went
 > intermittently bad, `.default` consent failed with `AADSTS65006` on every fresh work/school Graph
 > onboarding (#511). Explicit Graph scopes never touch the Exchange entitlement, so Graph sign-in is
-> clean. This is the **bridge** for the Graph-only migration (#529); once the Exchange permissions are
-> removed from this registration (last step of #529), work/school reverts to `.default` (Exchange-free,
-> zero-maintenance). The Graph permissions below must still be declared for AAD either way.
+> clean. The Graph permissions below must still be declared for AAD either way.
+>
+> **This is permanent — work/school does not go back to `.default`.** It was first written as a
+> temporary bridge, assuming Microsoft IMAP would be dropped and the Exchange permissions deleted from
+> this registration. #529 settled the opposite: Microsoft IMAP is **retained** as a documented fallback
+> while the open Graph defects stand, so the Exchange permissions stay declared, so `.default` would
+> drag them back into Graph consent and bring back the `AADSTS65006`. Removing the Exchange permissions
+> and reverting to `.default` are both off the table. The price is that
+> `OAuthService.GraphMailScopesWorkSchool` is a hand-maintained list — see the §6 note.
 
 > **`.default` is not the whole story.** Contact sync and calendar sync run **separate,
 > incremental consent flows** (`RequestContactsConsentAsync` / `RequestCalendarConsentAsync`) that
@@ -114,15 +120,17 @@ declared scopes). Both must still be declared here.
 | `SMTP.Send` | SMTP send (XOAUTH2) |
 
 Plus `offline_access` (refresh tokens) — a standard OIDC scope that **MSAL adds automatically** for
-the public-client desktop flow, so refresh tokens still issue even though the code now requests only
-`.default` (verified live). It is not listed in `OAuthService.cs` and needs no separate portal entry.
+the public-client desktop flow, so refresh tokens still issue even though the code never requests it
+(verified live). It is not listed in `OAuthService.cs` and needs no separate portal entry.
 
-> For scopes reached through **`.default`** (the mail path), adding a permission is **entirely a
-> registration action**: declare it in this list **and** re-grant admin consent in each
-> admin-consent tenant. There is no code scope list to update, and a permission the code needs but
-> that is not declared+granted here surfaces as a feature-level `403`. Declaring a new scope
-> **before** GA (while no account has consented yet) means the first consent captures it and no one
-> is ever re-prompted.
+> **No mail path goes through `.default` any more (#511).** Work/school Graph mail requests
+> `GraphMailScopesWorkSchool`, personal Graph mail requests `GraphMailScopesPersonal`, and IMAP/SMTP
+> requests its two explicit Exchange scopes — so adding a mail permission is **never** a
+> registration-only action. Declare it in this list, re-grant admin consent in each admin-consent
+> tenant, **and** add it to the matching array in `OAuthService.cs`; a permission that is declared and
+> granted but missing from the code array is simply never requested, and the feature `403`s. Declaring
+> a new scope **before** GA (while no account has consented yet) means the first consent captures it
+> and no one is ever re-prompted.
 >
 > **The explicitly-requested scopes behave differently and fail differently.** For contacts and
 > calendar (see the callout above), an undeclared or un-consented scope surfaces as a **consent
@@ -323,7 +331,9 @@ un-granted permission blocks sign-in only if that build's scope list actually re
 that is merely *declared* on the registration but not in the code list (e.g. `User.ReadBasic.All`, a
 forward declaration) does **not** block sign-in. Conversely, adding a new work/school mail permission
 now requires editing `GraphMailScopesWorkSchool` **and** the registration, not the registration alone.
-(This reverts to `.default` at the end of the #529 migration, once the Exchange perms are removed.)
+This is the standing arrangement, not a transitional one — #529 settled on retaining Microsoft IMAP,
+which keeps the Exchange permissions declared, which is exactly why work/school cannot go back to
+`.default`.
 
 ### Server-rules write fails with `403` even though sign-in worked
 The account's cached token predates a newly-added scope, or the tenant granted only part of the set.


### PR DESCRIPTION
Follow-up to #530, agreed in [#529](https://github.com/kellylford/QuickMail/issues/529#issuecomment-5288511130).

## The problem

#530 shipped the explicit work/school Graph mail scopes and described them, in code comments and in `docs/ENTRA-APP-REGISTRATION.md`, as a **temporary bridge** that reverts to `.default` once the Office 365 Exchange Online permissions are removed from the app registration.

#529 then settled the opposite way. **Microsoft IMAP is retained** as a documented fallback while the open Graph defects (#491, #462, #454, #31) stand. So the Exchange permissions stay declared. So `.default` — which requests the app's entire declared set — would drag them straight back into Graph consent and reintroduce the `AADSTS65006` that #511 reported. The registration cleanup and the `.default` revert are both off the table.

That leaves `main` carrying comments that instruct the next reader to undo the fix, next to the code that implements it. This rewrites them as the standing design, and states the reason so the conclusion survives without the issue thread: the scope list is hand-maintained **because** Microsoft IMAP is retained, and that is the accepted trade — a dev-time-diagnosable 403 beats anything that touches users' machines.

## Two stale claims fixed while here

Same class of defect, both found by sweeping for the pattern rather than by the report:

- **`GraphCalendarScopes`** said work/school accounts "sign in with `.default`" as the reason `Calendars.ReadWrite` must also be declared on the registration. Untrue since #511 — and it was never the real reason. The declaration is what lets a tenant admin-consent the scope; that is still required, so only the stated reasoning was wrong.
- **The Entra doc** told readers that for the mail path, adding a permission is "**entirely a registration action**" with "no code scope list to update". No mail path goes through `.default` any more — work/school, personal, and IMAP all request explicit scopes — so every one of them needs the matching `OAuthService` array updated too. Following the old text gets you a declared, granted, admin-consented permission that the code never requests, surfacing as a feature-level 403 with nothing obviously wrong in the portal.

## Scope

Comments and documentation only. **No behavior change** — no scope array values, no control flow, no test assertions altered. Release build clean (0 errors, warnings all pre-existing); the 20 `OAuthService`/`ContactSyncScope` scope-selection tests pass.

The test-class summary now also names the specific refactor it guards against — a well-meaning "restore `.default` for work/school" — since that is exactly what the old comments invited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)