### PR TITLE
Fix #128: POP3/SMTP backend, rebuilt on current main and tested

### DIFF
--- a/QuickMail.IntegrationTests/GreenMailFixture.cs
+++ b/QuickMail.IntegrationTests/GreenMailFixture.cs
@@ -28,14 +28,23 @@ public sealed class GreenMailFixture
     public const int SmtpPort = 3025;
     public const int ImapPort = 3143;
 
+    /// <summary>
+    /// GreenMail's POP3 port (#128). It serves the same INBOX as IMAP, which is what lets a POP3
+    /// test seed its mailbox over SMTP exactly as the IMAP tests do.
+    /// </summary>
+    public const int Pop3Port = 3110;
+
     /// <summary>Domain for test users; resolves nowhere, mailboxes exist only inside GreenMail.</summary>
     public const string MailDomain = "greenmail.test";
 
     private readonly bool _serversAvailable;
 
+    private readonly bool _pop3Available;
+
     public GreenMailFixture()
     {
         _serversAvailable = IsPortOpen(Host, SmtpPort) && IsPortOpen(Host, ImapPort);
+        _pop3Available    = IsPortOpen(Host, Pop3Port);
     }
 
     /// <summary>
@@ -55,6 +64,42 @@ public sealed class GreenMailFixture
         Assert.Skip(
             $"GreenMail is not running on {Host}:{SmtpPort}/{ImapPort}. " +
             "Start it with scripts/start-test-servers.ps1 (see docs/TESTING-INTEGRATION.md).");
+    }
+
+    /// <summary>
+    /// Call first in every POP3 test. Same contract as <see cref="RequireServers"/>, plus the POP3
+    /// port: a harness started before POP3 was added to the script would otherwise fail these tests
+    /// with a connection error instead of saying what is missing.
+    /// </summary>
+    public void RequirePop3()
+    {
+        RequireServers();
+        if (_pop3Available) return;
+
+        if (Environment.GetEnvironmentVariable("QUICKMAIL_IT_SERVERS") == "1")
+            throw new InvalidOperationException(
+                $"QUICKMAIL_IT_SERVERS=1 but GreenMail's POP3 port {Host}:{Pop3Port} is not open. " +
+                "The harness must start it with -Dgreenmail.setup.test.pop3.");
+
+        Assert.Skip(
+            $"GreenMail is running but its POP3 port {Host}:{Pop3Port} is not open. " +
+            "Restart the harness with scripts/start-test-servers.ps1 (it now asks for POP3 too).");
+    }
+
+    /// <summary>
+    /// Creates a password-auth POP3/SMTP account pointed at GreenMail, with a unique user.
+    /// <paramref name="leaveOnServer"/> mirrors the account setting that decides whether collected
+    /// mail is removed from the server.
+    /// </summary>
+    public AccountModel CreatePop3Account(string userPrefix, bool leaveOnServer = true)
+    {
+        var account = CreateAccount(userPrefix);
+        account.BackendKind           = BackendKind.Pop3Smtp;
+        account.Pop3Host              = Host;
+        account.Pop3Port              = Pop3Port;
+        account.Pop3UseSsl            = false;
+        account.Pop3LeaveMailOnServer = leaveOnServer;
+        return account;
     }
 
     /// <summary>Creates a password-auth IMAP/SMTP account pointed at GreenMail, with a unique user.</summary>

--- a/QuickMail.IntegrationTests/Pop3ProtocolTests.cs
+++ b/QuickMail.IntegrationTests/Pop3ProtocolTests.cs
@@ -96,6 +96,151 @@ public sealed class Pop3ProtocolTests : IDisposable
     }
 
     [Fact]
+    public async Task DeletedMail_StaysDeleted_WhileTheServerStillListsIt()
+    {
+        // Leave-on-server (the shipped default) keeps the UIDL listed after collection. Deleting
+        // the message moves its row out of the Inbox — and dedupe keyed on Inbox rows alone then
+        // re-downloaded it as new mail on every later sync, forever. The collected-UIDL ledger is
+        // what this pins: delete once, and the message never comes back.
+        _greenMail.RequirePop3();
+        var ct      = TestContext.Current.CancellationToken;
+        var account = _greenMail.CreatePop3Account("pop-resurrect", leaveOnServer: true);
+        await SeedAsync(account.Username, "Delete me", "Body.", ct);
+
+        var store = NewStore();
+        using var pop = new Pop3MailService(store);
+        await pop.ConnectAsync(account, "pw", ct);
+        var downloaded = await WaitForDownloadAsync(pop, account.Id, expected: 1, ct);
+        var uidl = downloaded.Single().MessageId;
+
+        await pop.MoveToTrashAsync(account.Id, "Inbox", uidl, ct);
+
+        // The next sync must not re-collect it, and the listing must not offer it to the sweep as
+        // an arrival (which is what made hasNew fire and fetch phantom mail every cycle).
+        Assert.Equal(0, await pop.PollAsync(account.Id, "Inbox", ct));
+        Assert.Empty(await store.GetAllMessageIdsAsync(account.Id, "Inbox"));
+        var listing = await pop.GetFolderMessageIdDatesAsync(account.Id, "Inbox", ct);
+        Assert.DoesNotContain(listing, l => l.Id == uidl);
+
+        // Still exactly one copy, in Trash — and still on the server, as leave-on-server promises.
+        Assert.Single(await store.GetAllMessageIdsAsync(account.Id, "Trash"));
+        Assert.Equal(1, await ServerMessageCountAsync(account, ct));
+    }
+
+    [Fact]
+    public async Task EmptiedTrash_StaysEmpty_WhileTheServerStillListsTheUidl()
+    {
+        // Empty Trash removes the rows entirely; with leave-on-server on there is no DELE, so only
+        // the ledger stands between "permanently deleted" and the mail returning next sync.
+        _greenMail.RequirePop3();
+        var ct      = TestContext.Current.CancellationToken;
+        var account = _greenMail.CreatePop3Account("pop-empty-trash", leaveOnServer: true);
+        await SeedAsync(account.Username, "Destroy me", "Body.", ct);
+
+        var store = NewStore();
+        using var pop = new Pop3MailService(store);
+        await pop.ConnectAsync(account, "pw", ct);
+        var downloaded = await WaitForDownloadAsync(pop, account.Id, expected: 1, ct);
+        var uidl = downloaded.Single().MessageId;
+
+        await pop.MoveToTrashAsync(account.Id, "Inbox", uidl, ct);
+        Assert.Equal(1, await pop.EmptyTrashAsync(account.Id, ct));
+
+        Assert.Equal(0, await pop.PollAsync(account.Id, "Inbox", ct));
+        Assert.Empty(await store.GetAllMessageIdsAsync(account.Id, "Inbox"));
+        Assert.Empty(await store.GetAllMessageIdsAsync(account.Id, "Trash"));
+
+        // Leave-on-server means QuickMail never touches the server copy, even on Empty Trash —
+        // another client may not have collected it yet. Destroyed here, kept there.
+        Assert.Equal(1, await ServerMessageCountAsync(account, ct));
+    }
+
+    [Fact]
+    public async Task AnArrivalWithAnOldDateHeader_IsStillReturnedAsAnArrival()
+    {
+        // The sweep's window test reads the message's own Date header, and a message arriving today
+        // can carry an old one — delayed delivery, resent mail, spam forging its date. Filtering
+        // the fetch's return by header date alone downloaded and stored such a message while
+        // permanently hiding it from rules, the toast and the open list.
+        _greenMail.RequirePop3();
+        var ct      = TestContext.Current.CancellationToken;
+        var account = _greenMail.CreatePop3Account("pop-old-date", leaveOnServer: true);
+        var window  = DateTime.UtcNow.AddDays(-30);
+
+        var store = NewStore();
+        using var pop = new Pop3MailService(store);
+        await pop.ConnectAsync(account, "pw", ct);
+
+        // First collection: seed and collect one ordinary message so the account leaves the
+        // deliberately-quiet first-collection state.
+        await SeedAsync(account.Username, "Ordinary", "Body.", ct);
+        await WaitForDownloadAsync(pop, account.Id, expected: 1, ct);
+
+        // Steady state: a new arrival dated far outside the sync window.
+        await SeedAsync(account.Username, "Backdated spam", "Body.", ct,
+            date: DateTimeOffset.UtcNow.AddDays(-90));
+
+        List<MailMessageSummary> returned = [];
+        var stopwatch = Stopwatch.StartNew();
+        while (stopwatch.Elapsed < TimeSpan.FromSeconds(20))
+        {
+            returned = await pop.GetMessagesSinceDateAsync(account.Id, "Inbox", window, ct);
+            if (returned.Any(m => m.Subject == "Backdated spam")) break;
+            await Task.Delay(250, ct);
+        }
+
+        // Downloaded, stored — and RETURNED, which is what reaches rules and the live list.
+        Assert.Contains(returned, m => m.Subject == "Backdated spam");
+        Assert.Equal(2, (await store.GetAllMessageIdsAsync(account.Id, "Inbox")).Count);
+    }
+
+    [Fact]
+    public async Task ADeleRolledBackByALostConnection_IsReissuedOnTheNextSync()
+    {
+        // DELEs only commit at QUIT: a connection lost mid-collection rolls them all back
+        // (RFC 1939) while the messages are already committed to the store one by one. Those
+        // UIDLs are in the seen set, so without an explicit re-issue the stale server copies
+        // would survive every later sync, forever, despite delete-on-collect.
+        _greenMail.RequirePop3();
+        var ct      = TestContext.Current.CancellationToken;
+        var account = _greenMail.CreatePop3Account("pop-redele", leaveOnServer: false);
+        await SeedAsync(account.Username, "Stored but not DELEd", "Body.", ct);
+
+        var store = NewStore();
+        using var pop = new Pop3MailService(store);
+        await pop.ConnectAsync(account, "pw", ct);
+
+        // Reproduce the post-rollback state directly: the message is in the store (it was
+        // committed before the drop) but still on the server (the DELE was discarded with the
+        // session). The UIDL comes from the listing, which stamps unseen server ids as arriving.
+        var listing = await WaitForListingAsync(pop, account.Id, ct);
+        var uidl = listing.Single().Id;
+        await store.UpsertSummariesAsync([new MailMessageSummary
+        {
+            MessageId = uidl, AccountId = account.Id, FolderName = "Inbox",
+            From = "Sender <sender@example.test>", To = account.Username,
+            Subject = "Stored but not DELEd", Date = DateTimeOffset.UtcNow,
+        }]);
+
+        // The next sync downloads nothing (already stored) — and clears the stale server copy.
+        Assert.Equal(0, await pop.PollAsync(account.Id, "Inbox", ct));
+        await WaitForServerCountAsync(account, 0, ct);
+    }
+
+    private static async Task<IReadOnlyList<(string Id, DateTimeOffset ReceivedUtc, bool IsRead)>> WaitForListingAsync(
+        Pop3MailService pop, Guid accountId, CancellationToken ct)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        while (stopwatch.Elapsed < TimeSpan.FromSeconds(20))
+        {
+            var listing = await pop.GetFolderMessageIdDatesAsync(accountId, "Inbox", ct);
+            if (listing.Count > 0) return listing;
+            await Task.Delay(250, ct);
+        }
+        throw new TimeoutException("Expected the server to list at least one UIDL.");
+    }
+
+    [Fact]
     public async Task LeaveOnServer_KeepsTheServerCopy()
     {
         _greenMail.RequirePop3();
@@ -374,12 +519,13 @@ public sealed class Pop3ProtocolTests : IDisposable
 
     private static async Task SeedAsync(
         string recipient, string subject, string body, CancellationToken ct,
-        Action<BodyBuilder>? customize = null)
+        Action<BodyBuilder>? customize = null, DateTimeOffset? date = null)
     {
         var message = new MimeMessage();
         message.From.Add(new MailboxAddress("Sender", "sender@example.test"));
         message.To.Add(MailboxAddress.Parse(recipient));
         message.Subject = subject;
+        if (date is not null) message.Date = date.Value;
 
         var builder = new BodyBuilder { TextBody = body };
         customize?.Invoke(builder);

--- a/QuickMail.IntegrationTests/Pop3ProtocolTests.cs
+++ b/QuickMail.IntegrationTests/Pop3ProtocolTests.cs
@@ -1,0 +1,393 @@
+using System.Diagnostics;
+using System.IO;
+using MailKit.Net.Pop3;
+using MailKit.Security;
+using MimeKit;
+using QuickMail.Models;
+using QuickMail.Services;
+
+namespace QuickMail.IntegrationTests;
+
+/// <summary>
+/// The POP3 backend (#128) against a real POP3 server. This is the half the unit tests cannot
+/// reach: RETR, UIDL deduplication across sessions, and DELE — including the case that decides
+/// whether a user keeps their mail, where the server has dropped every message QuickMail holds.
+///
+/// <para>Everything runs against the real <see cref="LocalStoreService"/> on a temp profile,
+/// because for POP3 the store is not a cache of the mailbox — it is the mailbox.</para>
+/// </summary>
+[Collection(GreenMailCollection.Name)]
+public sealed class Pop3ProtocolTests : IDisposable
+{
+    private readonly GreenMailFixture _greenMail;
+    private readonly string _profileDir;
+
+    public Pop3ProtocolTests(GreenMailFixture greenMail)
+    {
+        _greenMail  = greenMail;
+        _profileDir = Path.Combine(Path.GetTempPath(), $"QuickMailPop3IT-{Guid.NewGuid():N}");
+    }
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_profileDir)) Directory.Delete(_profileDir, recursive: true); }
+        catch { /* a temp dir left behind is not a test failure */ }
+    }
+
+    private LocalStoreService NewStore()
+    {
+        var store = new LocalStoreService(new ProfileContext(
+            Path.Combine(_profileDir, Guid.NewGuid().ToString("N"))));
+        store.Initialize();
+        return store;
+    }
+
+    // ── Collecting mail ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Sync_DownloadsMailIntoTheLocalStore()
+    {
+        _greenMail.RequirePop3();
+        var ct      = TestContext.Current.CancellationToken;
+        var account = _greenMail.CreatePop3Account("pop-download");
+        await SeedAsync(account.Username, "First message", "Body of the first message.", ct);
+        await SeedAsync(account.Username, "Second message", "Body of the second message.", ct);
+
+        var store = NewStore();
+        using var pop = new Pop3MailService(store);
+        await pop.ConnectAsync(account, "pw", ct);
+
+        Assert.True(pop.IsConnected(account.Id));
+
+        var downloaded = await WaitForDownloadAsync(pop, account.Id, expected: 2, ct);
+
+        Assert.Equal(2, downloaded.Count);
+        Assert.Contains(downloaded, m => m.Subject == "First message");
+
+        // The whole message is stored, not just a header: opening it later must not need the server.
+        var summary = downloaded.First(m => m.Subject == "First message");
+        var detail  = await pop.GetMessageDetailAsync(account.Id, "Inbox", summary.MessageId, ct);
+        Assert.Contains("first message", detail.PlainTextBody, StringComparison.OrdinalIgnoreCase);
+        Assert.False(summary.IsRead);
+    }
+
+    [Fact]
+    public async Task Resync_DownloadsNothingTwice()
+    {
+        // UIDL deduplication is the property POP3 correctness rests on: the protocol has no
+        // high-water mark, so without it every sync would re-download the whole mailbox.
+        _greenMail.RequirePop3();
+        var ct      = TestContext.Current.CancellationToken;
+        var account = _greenMail.CreatePop3Account("pop-dedup");
+        await SeedAsync(account.Username, "Only message", "Body.", ct);
+
+        var store = NewStore();
+        using var pop = new Pop3MailService(store);
+        await pop.ConnectAsync(account, "pw", ct);
+
+        await WaitForDownloadAsync(pop, account.Id, expected: 1, ct);
+
+        var second = await pop.GetMessagesSinceAsync(account.Id, "Inbox", "0", 50, ct);
+        var third  = await pop.PollAsync(account.Id, "Inbox", ct);
+
+        Assert.Empty(second);
+        Assert.Equal(0, third);
+        Assert.Single(await store.GetAllMessageIdsAsync(account.Id, "Inbox"));
+    }
+
+    [Fact]
+    public async Task LeaveOnServer_KeepsTheServerCopy()
+    {
+        _greenMail.RequirePop3();
+        var ct      = TestContext.Current.CancellationToken;
+        var account = _greenMail.CreatePop3Account("pop-leave", leaveOnServer: true);
+        await SeedAsync(account.Username, "Keep me", "Body.", ct);
+
+        using var pop = new Pop3MailService(NewStore());
+        await pop.ConnectAsync(account, "pw", ct);
+        await WaitForDownloadAsync(pop, account.Id, expected: 1, ct);
+
+        // The default must never remove the user's mail from the server — another client, or the
+        // provider's webmail, is still the copy they expect to find.
+        Assert.Equal(1, await ServerMessageCountAsync(account, ct));
+    }
+
+    [Fact]
+    public async Task LeaveOnServerOff_RemovesTheServerCopyOnceItIsStored()
+    {
+        _greenMail.RequirePop3();
+        var ct      = TestContext.Current.CancellationToken;
+        var account = _greenMail.CreatePop3Account("pop-remove", leaveOnServer: false);
+        await SeedAsync(account.Username, "Collect me", "Body.", ct);
+
+        var store = NewStore();
+        using var pop = new Pop3MailService(store);
+        await pop.ConnectAsync(account, "pw", ct);
+        await WaitForDownloadAsync(pop, account.Id, expected: 1, ct);
+
+        Assert.Equal(0, await ServerMessageCountAsync(account, ct));
+        // ...and the local copy — now the only one — survived the deletion.
+        Assert.Single(await store.GetAllMessageIdsAsync(account.Id, "Inbox"));
+    }
+
+    // ── The sync contract, against a server that really has dropped the mail ─────
+
+    [Fact]
+    public async Task AfterTheServerDropsEverything_TheSweepStillCannotDeleteTheLocalCopies()
+    {
+        // The failure this guards against destroys mail: SyncService's id-diff sweep deletes cached
+        // ids the backend's listing omits, and with leave-on-server off the server legitimately
+        // lists nothing at all a moment after collection.
+        _greenMail.RequirePop3();
+        var ct      = TestContext.Current.CancellationToken;
+        var account = _greenMail.CreatePop3Account("pop-sweep", leaveOnServer: false);
+        await SeedAsync(account.Username, "Vanishing message", "Body.", ct);
+
+        var store = NewStore();
+        using var pop = new Pop3MailService(store);
+        await pop.ConnectAsync(account, "pw", ct);
+        await WaitForDownloadAsync(pop, account.Id, expected: 1, ct);
+        Assert.Equal(0, await ServerMessageCountAsync(account, ct));
+
+        var cached  = await store.GetAllMessageIdsAsync(account.Id, "Inbox");
+        var listing = await pop.GetFolderMessageIdDatesAsync(account.Id, "Inbox", ct);
+        var listed  = listing.Select(l => l.Id).ToHashSet();
+
+        // This subtraction IS the sweep's deletion reconcile (SyncService.ReconcileDeletionsAsync).
+        Assert.Empty(cached.Except(listed));
+
+        // The same for the older reconcile path.
+        var ids = await pop.GetFolderMessageIdsAsync(account.Id, "Inbox", ct);
+        Assert.Empty(cached.Except(ids));
+    }
+
+    [Fact]
+    public async Task ANewServerMessageIsReportedAsSomethingToFetch()
+    {
+        // The other half of the contract: the listing must make genuinely new mail visible to the
+        // sweep, or POP3 accounts would only ever collect when the user opens the folder.
+        _greenMail.RequirePop3();
+        var ct      = TestContext.Current.CancellationToken;
+        var account = _greenMail.CreatePop3Account("pop-newmail");
+
+        var store = NewStore();
+        using var pop = new Pop3MailService(store);
+        await pop.ConnectAsync(account, "pw", ct);
+        await SeedAsync(account.Username, "Fresh mail", "Body.", ct);
+        await WaitForServerCountAsync(account, 1, ct);
+
+        var listing = await pop.GetFolderMessageIdDatesAsync(account.Id, "Inbox", ct);
+        var fresh   = Assert.Single(listing);
+
+        // Reported as arriving now, so it falls inside the sweep's window and triggers the fetch.
+        Assert.True(fresh.ReceivedUtc > DateTimeOffset.UtcNow.AddMinutes(-5));
+        Assert.False(fresh.IsRead);
+
+        // And the fetch the sweep then makes is what actually downloads it.
+        var fetched = await pop.GetMessagesSinceDateAsync(account.Id, "Inbox", DateTime.UtcNow.AddDays(-30), ct);
+        Assert.Contains(fetched, m => m.Subject == "Fresh mail");
+    }
+
+    // ── Deleting ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task PermanentDelete_RemovesTheRightMessageFromTheServer()
+    {
+        _greenMail.RequirePop3();
+        var ct      = TestContext.Current.CancellationToken;
+        var account = _greenMail.CreatePop3Account("pop-delete", leaveOnServer: true);
+        await SeedAsync(account.Username, "Delete me", "Body.", ct);
+        await SeedAsync(account.Username, "Keep me",   "Body.", ct);
+
+        var store = NewStore();
+        using var pop = new Pop3MailService(store);
+        await pop.ConnectAsync(account, "pw", ct);
+        var downloaded = await WaitForDownloadAsync(pop, account.Id, expected: 2, ct);
+
+        var doomed = downloaded.First(m => m.Subject == "Delete me");
+        var keeper = downloaded.First(m => m.Subject == "Keep me");
+
+        // Deleting is two steps: to local Trash, then permanently. Only the second reaches the
+        // server, and only for an account set to remove collected mail.
+        await pop.MoveToTrashAsync(account.Id, "Inbox", doomed.MessageId, ct);
+        Assert.Equal(2, await ServerMessageCountAsync(account, ct));
+
+        account.Pop3LeaveMailOnServer = false;   // the user changes their mind in Account Manager
+        await pop.ConnectAsync(account, "pw", ct);
+        await pop.PermanentlyDeleteBatchAsync(account.Id, "Trash", [doomed.MessageId], ct);
+
+        // Exactly one message gone, and it is the right one — DELE takes a session-scoped index, so
+        // resolving it against a stale listing would delete a message the user meant to keep.
+        var remaining = await ServerUidlsAsync(account, ct);
+        Assert.Single(remaining);
+        Assert.Equal(keeper.MessageId, remaining[0]);
+        Assert.Empty(await store.GetAllMessageIdsAsync(account.Id, "Trash"));
+    }
+
+    [Fact]
+    public async Task PermanentDelete_OfAMessageTheServerNoLongerHas_TouchesNothing()
+    {
+        // The UIDL safety check. Another client collected the message with delete-on-collect, so the
+        // id QuickMail holds is gone; deleting by position instead would destroy someone else's mail.
+        _greenMail.RequirePop3();
+        var ct      = TestContext.Current.CancellationToken;
+        var account = _greenMail.CreatePop3Account("pop-safety", leaveOnServer: false);
+        await SeedAsync(account.Username, "Still here", "Body.", ct);
+        await WaitForServerCountAsync(account, 1, ct);
+
+        var store = NewStore();
+        using var pop = new Pop3MailService(store);
+        await pop.ConnectAsync(account, "pw", ct);
+
+        await pop.PermanentlyDeleteBatchAsync(account.Id, "Trash", ["uidl-that-is-not-on-this-server"], ct);
+
+        Assert.Equal(1, await ServerMessageCountAsync(account, ct));
+    }
+
+    // ── Sending from a POP3 account ──────────────────────────────────────────────
+
+    [Fact]
+    public async Task APop3AccountSendsOverSmtp_AndFilesItsOwnCopyInSent()
+    {
+        // POP3 is receive-only, so send goes through the ordinary SmtpService path. Worth proving
+        // end to end: the account carries POP3 host settings, and nothing in the send path may take
+        // those for the outgoing server.
+        _greenMail.RequirePop3();
+        var ct        = TestContext.Current.CancellationToken;
+        var sender    = _greenMail.CreatePop3Account("pop-sender");
+        var recipient = _greenMail.CreatePop3Account("pop-recipient");
+
+        var store = NewStore();
+        using var pop = new Pop3MailService(store);
+        await pop.ConnectAsync(sender, "pw", ct);
+
+        var compose = new ComposeModel
+        {
+            To      = recipient.Username,
+            Subject = "Sent from POP3",
+            Body    = "Outgoing mail from an account that receives over POP3.",
+        };
+
+        var smtp = new SmtpService(new NoOpOAuthService(), new NoOpGraphSendService());
+        await smtp.SendAsync(compose, sender, "pw", ct);
+
+        // Sent mail has no server folder to land in, so QuickMail files its own copy locally.
+        await pop.AppendToSentAsync(sender.Id, compose, ct);
+        var sent = await store.LoadFolderSummariesAsync(sender.Id, "Sent");
+        Assert.Equal("Sent from POP3", sent.Single().Subject);
+
+        // And it really arrived: collect it as the recipient.
+        using var recipientPop = new Pop3MailService(NewStore());
+        await recipientPop.ConnectAsync(recipient, "pw", ct);
+        var delivered = await WaitForDownloadAsync(recipientPop, recipient.Id, expected: 1, ct);
+        Assert.Equal("Sent from POP3", delivered[0].Subject);
+    }
+
+    // ── Attachments ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task AnAttachmentSurvivesTheRoundTrip_AndOpensWithoutTheServer()
+    {
+        _greenMail.RequirePop3();
+        var ct      = TestContext.Current.CancellationToken;
+        var account = _greenMail.CreatePop3Account("pop-attach", leaveOnServer: false);
+        var payload = new byte[3000];
+        for (var i = 0; i < payload.Length; i++) payload[i] = (byte)(i % 251);
+
+        await SeedAsync(account.Username, "With attachment", "See attached.", ct, builder =>
+            builder.Attachments.Add("report.bin", payload, new ContentType("application", "octet-stream")));
+
+        var store = NewStore();
+        using var pop = new Pop3MailService(store);
+        await pop.ConnectAsync(account, "pw", ct);
+        var downloaded = await WaitForDownloadAsync(pop, account.Id, expected: 1, ct);
+
+        var detail = await pop.GetMessageDetailAsync(account.Id, "Inbox", downloaded[0].MessageId, ct);
+        var attachment = Assert.Single(detail.Attachments);
+        Assert.Equal("report.bin", attachment.FileName);
+        Assert.Equal(payload.Length, attachment.FileSize);
+
+        // The server has already dropped the message (leaveOnServer: false), so this can only come
+        // from the bytes stored at download time.
+        Assert.Equal(0, await ServerMessageCountAsync(account, ct));
+        var bytes = await pop.DownloadAttachmentAsync(
+            account.Id, "Inbox", downloaded[0].MessageId, attachment.PartSpecifier!, ct);
+        Assert.Equal(payload, bytes);
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Collects until the expected number of messages has arrived. SMTP delivery is asynchronous, so
+    /// a single sync can legitimately run before GreenMail has filed the message.
+    /// </summary>
+    private static async Task<List<MailMessageSummary>> WaitForDownloadAsync(
+        Pop3MailService pop, Guid accountId, int expected, CancellationToken ct)
+    {
+        var collected = new List<MailMessageSummary>();
+        var stopwatch = Stopwatch.StartNew();
+        while (stopwatch.Elapsed < TimeSpan.FromSeconds(20))
+        {
+            collected.AddRange(await pop.GetMessagesSinceAsync(accountId, "Inbox", "0", 50, ct));
+            if (collected.Count >= expected) return collected;
+            await Task.Delay(250, ct);
+        }
+        throw new TimeoutException(
+            $"Expected {expected} message(s) to arrive over POP3; collected {collected.Count}.");
+    }
+
+    private static async Task WaitForServerCountAsync(AccountModel account, int expected, CancellationToken ct)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        while (stopwatch.Elapsed < TimeSpan.FromSeconds(20))
+        {
+            if (await ServerMessageCountAsync(account, ct) >= expected) return;
+            await Task.Delay(250, ct);
+        }
+        throw new TimeoutException($"GreenMail never held {expected} message(s) for {account.Username}.");
+    }
+
+    /// <summary>Message count straight from the server, bypassing QuickMail entirely.</summary>
+    private static async Task<int> ServerMessageCountAsync(AccountModel account, CancellationToken ct)
+    {
+        using var client = await OpenAsync(account, ct);
+        var count = client.Count;
+        await client.DisconnectAsync(quit: false, ct);
+        return count;
+    }
+
+    private static async Task<IList<string>> ServerUidlsAsync(AccountModel account, CancellationToken ct)
+    {
+        using var client = await OpenAsync(account, ct);
+        var uidls = client.Count == 0 ? new List<string>() : await client.GetMessageUidsAsync(ct);
+        await client.DisconnectAsync(quit: false, ct);
+        return uidls;
+    }
+
+    private static async Task<Pop3Client> OpenAsync(AccountModel account, CancellationToken ct)
+    {
+        var client = new Pop3Client();
+        await client.ConnectAsync(GreenMailFixture.Host, GreenMailFixture.Pop3Port, SecureSocketOptions.None, ct);
+        await client.AuthenticateAsync(account.Username, "pw", ct);
+        return client;
+    }
+
+    private static async Task SeedAsync(
+        string recipient, string subject, string body, CancellationToken ct,
+        Action<BodyBuilder>? customize = null)
+    {
+        var message = new MimeMessage();
+        message.From.Add(new MailboxAddress("Sender", "sender@example.test"));
+        message.To.Add(MailboxAddress.Parse(recipient));
+        message.Subject = subject;
+
+        var builder = new BodyBuilder { TextBody = body };
+        customize?.Invoke(builder);
+        message.Body = builder.ToMessageBody();
+
+        using var smtp = new MailKit.Net.Smtp.SmtpClient();
+        await smtp.ConnectAsync(GreenMailFixture.Host, GreenMailFixture.SmtpPort, SecureSocketOptions.None, ct);
+        await smtp.SendAsync(message, ct);
+        await smtp.DisconnectAsync(quit: true, ct);
+    }
+}

--- a/QuickMail.Tests/FlagServiceTests.cs
+++ b/QuickMail.Tests/FlagServiceTests.cs
@@ -149,6 +149,9 @@ sealed class RecordingFlagStore : ILocalStoreService
     public Task<MailMessageDetail?> LoadDetailAsync(Guid accountId, string folderName, string messageId) => Task.FromResult<MailMessageDetail?>(null);
     public Task StoreMimeBytesAsync(Guid accountId, string folderName, string messageId, byte[]? mimeBytes) => Task.CompletedTask;
     public Task<byte[]?> LoadMimeBytesAsync(Guid accountId, string folderName, string messageId) => Task.FromResult<byte[]?>(null);
+    public Task<HashSet<string>> LoadPop3CollectedUidlsAsync(Guid accountId) => Task.FromResult(new HashSet<string>());
+    public Task AddPop3CollectedUidlsAsync(Guid accountId, IEnumerable<string> uidls) => Task.CompletedTask;
+    public Task RemovePop3CollectedUidlsAsync(Guid accountId, IEnumerable<string> uidls) => Task.CompletedTask;
     public Task<string> GetMaxMessageKeyAsync(Guid accountId, string folderName) => Task.FromResult("0");
     public Task<HashSet<string>> GetAllMessageIdsAsync(Guid accountId, string folderName) => Task.FromResult(new HashSet<string>());
     public Task<Dictionary<string, bool>> LoadFolderReadStatesAsync(Guid accountId, string folderName) => Task.FromResult(new Dictionary<string, bool>());

--- a/QuickMail.Tests/FlagServiceTests.cs
+++ b/QuickMail.Tests/FlagServiceTests.cs
@@ -147,6 +147,8 @@ sealed class RecordingFlagStore : ILocalStoreService
     public Task<bool> HasSummariesMissingRecipientsAsync() => Task.FromResult(false);
     public Task UpsertDetailAsync(MailMessageDetail detail) => Task.CompletedTask;
     public Task<MailMessageDetail?> LoadDetailAsync(Guid accountId, string folderName, string messageId) => Task.FromResult<MailMessageDetail?>(null);
+    public Task StoreMimeBytesAsync(Guid accountId, string folderName, string messageId, byte[]? mimeBytes) => Task.CompletedTask;
+    public Task<byte[]?> LoadMimeBytesAsync(Guid accountId, string folderName, string messageId) => Task.FromResult<byte[]?>(null);
     public Task<string> GetMaxMessageKeyAsync(Guid accountId, string folderName) => Task.FromResult("0");
     public Task<HashSet<string>> GetAllMessageIdsAsync(Guid accountId, string folderName) => Task.FromResult(new HashSet<string>());
     public Task<Dictionary<string, bool>> LoadFolderReadStatesAsync(Guid accountId, string folderName) => Task.FromResult(new Dictionary<string, bool>());

--- a/QuickMail.Tests/GraphBackendGateTests.cs
+++ b/QuickMail.Tests/GraphBackendGateTests.cs
@@ -64,9 +64,29 @@ public class AddAccountViewModelGateTests
     }
 
     [Fact]
+    public void GraphIsNotOffered_UnlessTheProviderIsMicrosoft()
+    {
+        // Graph is the Microsoft 365 API. Offering it for other providers let a Gmail account be
+        // saved bound to Microsoft OAuth with no hosts — nothing downstream validates the pairing
+        // (IsReadyToSave has nothing to check for Graph), so the combo must not offer it.
+        var vm = Make(graphEnabled: true);
+        var catalog = new ProviderCatalog();
+
+        vm.SelectedProvider = catalog.ById(ProviderCatalog.GmailId);
+        Assert.DoesNotContain(vm.AvailableBackends, b => b.Kind == BackendKind.MicrosoftGraph);
+
+        vm.SelectedProvider = catalog.Other;
+        Assert.DoesNotContain(vm.AvailableBackends, b => b.Kind == BackendKind.MicrosoftGraph);
+
+        vm.SelectedProvider = catalog.ById(ProviderCatalog.MicrosoftId);
+        Assert.Contains(vm.AvailableBackends, b => b.Kind == BackendKind.MicrosoftGraph);
+    }
+
+    [Fact]
     public void SelectingGraph_ForcesOAuthAndClearsImapFields()
     {
-        var vm = Make(graphEnabled: true);
+        // Through the Microsoft provider — the only one Graph is offered for.
+        var vm = MakeMicrosoft(graphEnabled: true);
         vm.ImapHost = "imap.example.com";
         vm.SmtpHost = "smtp.example.com";
 
@@ -83,7 +103,7 @@ public class AddAccountViewModelGateTests
     [Fact]
     public void ToAccountModel_CarriesBackendKind()
     {
-        var vm = Make(graphEnabled: true);
+        var vm = MakeMicrosoft(graphEnabled: true);
         vm.SelectedBackend = vm.AvailableBackends.First(b => b.Kind == BackendKind.MicrosoftGraph);
         Assert.Equal(BackendKind.MicrosoftGraph, vm.ToAccountModel().BackendKind);
 

--- a/QuickMail.Tests/MainViewModelFlagTests.cs
+++ b/QuickMail.Tests/MainViewModelFlagTests.cs
@@ -236,6 +236,9 @@ sealed class FilterableStoreForFlags : ILocalStoreService
     public Task<MailMessageDetail?> LoadDetailAsync(Guid accountId, string folderName, string messageId) => Task.FromResult<MailMessageDetail?>(null);
     public Task StoreMimeBytesAsync(Guid accountId, string folderName, string messageId, byte[]? mimeBytes) => Task.CompletedTask;
     public Task<byte[]?> LoadMimeBytesAsync(Guid accountId, string folderName, string messageId) => Task.FromResult<byte[]?>(null);
+    public Task<HashSet<string>> LoadPop3CollectedUidlsAsync(Guid accountId) => Task.FromResult(new HashSet<string>());
+    public Task AddPop3CollectedUidlsAsync(Guid accountId, IEnumerable<string> uidls) => Task.CompletedTask;
+    public Task RemovePop3CollectedUidlsAsync(Guid accountId, IEnumerable<string> uidls) => Task.CompletedTask;
     public Task<string> GetMaxMessageKeyAsync(Guid accountId, string folderName) => Task.FromResult("0");
     public Task<HashSet<string>> GetAllMessageIdsAsync(Guid accountId, string folderName) => Task.FromResult(new HashSet<string>());
     public Task<Dictionary<string, bool>> LoadFolderReadStatesAsync(Guid accountId, string folderName) => Task.FromResult(new Dictionary<string, bool>());

--- a/QuickMail.Tests/MainViewModelFlagTests.cs
+++ b/QuickMail.Tests/MainViewModelFlagTests.cs
@@ -234,6 +234,8 @@ sealed class FilterableStoreForFlags : ILocalStoreService
     public Task<bool> HasSummariesMissingRecipientsAsync() => Task.FromResult(false);
     public Task UpsertDetailAsync(MailMessageDetail detail) => Task.CompletedTask;
     public Task<MailMessageDetail?> LoadDetailAsync(Guid accountId, string folderName, string messageId) => Task.FromResult<MailMessageDetail?>(null);
+    public Task StoreMimeBytesAsync(Guid accountId, string folderName, string messageId, byte[]? mimeBytes) => Task.CompletedTask;
+    public Task<byte[]?> LoadMimeBytesAsync(Guid accountId, string folderName, string messageId) => Task.FromResult<byte[]?>(null);
     public Task<string> GetMaxMessageKeyAsync(Guid accountId, string folderName) => Task.FromResult("0");
     public Task<HashSet<string>> GetAllMessageIdsAsync(Guid accountId, string folderName) => Task.FromResult(new HashSet<string>());
     public Task<Dictionary<string, bool>> LoadFolderReadStatesAsync(Guid accountId, string folderName) => Task.FromResult(new Dictionary<string, bool>());

--- a/QuickMail.Tests/MarkReadOnOpenTests.cs
+++ b/QuickMail.Tests/MarkReadOnOpenTests.cs
@@ -123,6 +123,9 @@ public class MarkReadOnOpenTests
                 FolderName = folderName,
             });
 
+        public Task StoreMimeBytesAsync(Guid accountId, string folderName, string messageId, byte[]? mimeBytes) => Task.CompletedTask;
+        public Task<byte[]?> LoadMimeBytesAsync(Guid accountId, string folderName, string messageId) => Task.FromResult<byte[]?>(null);
+
         public void Initialize() { }
         public Task UpsertSummariesAsync(IEnumerable<MailMessageSummary> summaries) => Task.CompletedTask;
         public Task<List<MailMessageSummary>> LoadAllSummariesAsync() => Task.FromResult(new List<MailMessageSummary>());

--- a/QuickMail.Tests/MarkReadOnOpenTests.cs
+++ b/QuickMail.Tests/MarkReadOnOpenTests.cs
@@ -125,6 +125,9 @@ public class MarkReadOnOpenTests
 
         public Task StoreMimeBytesAsync(Guid accountId, string folderName, string messageId, byte[]? mimeBytes) => Task.CompletedTask;
         public Task<byte[]?> LoadMimeBytesAsync(Guid accountId, string folderName, string messageId) => Task.FromResult<byte[]?>(null);
+        public Task<HashSet<string>> LoadPop3CollectedUidlsAsync(Guid accountId) => Task.FromResult(new HashSet<string>());
+        public Task AddPop3CollectedUidlsAsync(Guid accountId, IEnumerable<string> uidls) => Task.CompletedTask;
+        public Task RemovePop3CollectedUidlsAsync(Guid accountId, IEnumerable<string> uidls) => Task.CompletedTask;
 
         public void Initialize() { }
         public Task UpsertSummariesAsync(IEnumerable<MailMessageSummary> summaries) => Task.CompletedTask;

--- a/QuickMail.Tests/MessageFilterTests.cs
+++ b/QuickMail.Tests/MessageFilterTests.cs
@@ -46,6 +46,9 @@ public class MessageFilterTests
         public Task<MailMessageDetail?> LoadDetailAsync(Guid accountId, string folderName, string messageId) => Task.FromResult<MailMessageDetail?>(null);
         public Task StoreMimeBytesAsync(Guid accountId, string folderName, string messageId, byte[]? mimeBytes) => Task.CompletedTask;
         public Task<byte[]?> LoadMimeBytesAsync(Guid accountId, string folderName, string messageId) => Task.FromResult<byte[]?>(null);
+        public Task<HashSet<string>> LoadPop3CollectedUidlsAsync(Guid accountId) => Task.FromResult(new HashSet<string>());
+        public Task AddPop3CollectedUidlsAsync(Guid accountId, IEnumerable<string> uidls) => Task.CompletedTask;
+        public Task RemovePop3CollectedUidlsAsync(Guid accountId, IEnumerable<string> uidls) => Task.CompletedTask;
         public Task<string> GetMaxMessageKeyAsync(Guid accountId, string folderName) => Task.FromResult("0");
         public Task<HashSet<string>> GetAllMessageIdsAsync(Guid accountId, string folderName) => Task.FromResult(new HashSet<string>());
         public Task<Dictionary<string, bool>> LoadFolderReadStatesAsync(Guid accountId, string folderName) => Task.FromResult(new Dictionary<string, bool>());

--- a/QuickMail.Tests/MessageFilterTests.cs
+++ b/QuickMail.Tests/MessageFilterTests.cs
@@ -44,6 +44,8 @@ public class MessageFilterTests
         public Task<bool> HasSummariesMissingRecipientsAsync() => Task.FromResult(false);
         public Task UpsertDetailAsync(MailMessageDetail detail) => Task.CompletedTask;
         public Task<MailMessageDetail?> LoadDetailAsync(Guid accountId, string folderName, string messageId) => Task.FromResult<MailMessageDetail?>(null);
+        public Task StoreMimeBytesAsync(Guid accountId, string folderName, string messageId, byte[]? mimeBytes) => Task.CompletedTask;
+        public Task<byte[]?> LoadMimeBytesAsync(Guid accountId, string folderName, string messageId) => Task.FromResult<byte[]?>(null);
         public Task<string> GetMaxMessageKeyAsync(Guid accountId, string folderName) => Task.FromResult("0");
         public Task<HashSet<string>> GetAllMessageIdsAsync(Guid accountId, string folderName) => Task.FromResult(new HashSet<string>());
         public Task<Dictionary<string, bool>> LoadFolderReadStatesAsync(Guid accountId, string folderName) => Task.FromResult(new Dictionary<string, bool>());

--- a/QuickMail.Tests/Pop3AccountSetupTests.cs
+++ b/QuickMail.Tests/Pop3AccountSetupTests.cs
@@ -1,0 +1,355 @@
+using System;
+using System.Linq;
+using QuickMail.Models;
+using QuickMail.Services;
+using QuickMail.ViewModels;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// Adding and editing a POP3 account (#128): the feature gate that decides whether POP3 is offered
+/// at all, what selecting it does to the form, and what reaches <see cref="AccountModel"/>.
+/// </summary>
+public class Pop3AddAccountTests
+{
+    private static AddAccountViewModel Make(bool pop3Enabled, bool graphEnabled = true)
+    {
+        var gate = new StubFeatureGate
+        {
+            [FeatureFlag.GraphBackend] = graphEnabled,
+            [FeatureFlag.Pop3Backend]  = pop3Enabled,
+        };
+        return new AddAccountViewModel(gate, new StubImapMailService(), new StubOAuthService(), new ProviderCatalog());
+    }
+
+    private static BackendKindOption Pop3Option(AddAccountViewModel vm) =>
+        vm.AvailableBackends.First(b => b.Kind == BackendKind.Pop3Smtp);
+
+    [Fact]
+    public void GateOff_Pop3IsNotOffered()
+    {
+        var vm = Make(pop3Enabled: false);
+        Assert.DoesNotContain(vm.AvailableBackends, b => b.Kind == BackendKind.Pop3Smtp);
+    }
+
+    [Fact]
+    public void GateOn_Pop3IsOffered()
+    {
+        var vm = Make(pop3Enabled: true);
+        Assert.Contains(vm.AvailableBackends, b => b.Kind == BackendKind.Pop3Smtp);
+        // Still IMAP by default — enabling the option must not move new accounts onto POP3.
+        Assert.Equal(BackendKind.ImapSmtp, vm.BackendKind);
+    }
+
+    [Fact]
+    public void GateOn_TheConnectionMethodComboIsReachableForAnyProvider()
+    {
+        // IMAP-versus-Graph is a Microsoft-only question, so the combo used to appear only there.
+        // POP3 is offered for every provider — and is usually wanted by someone whose provider
+        // QuickMail has never heard of — so hiding the combo would make it unreachable.
+        var vm = Make(pop3Enabled: true);
+        var catalog = new ProviderCatalog();
+
+        vm.SelectedProvider = catalog.Other;
+        Assert.True(vm.ShowConnectionMethod);
+
+        vm.SelectedProvider = catalog.ById(ProviderCatalog.GmailId);
+        Assert.True(vm.ShowConnectionMethod);
+    }
+
+    [Fact]
+    public void GateOff_TheComboIsStillMicrosoftOnly()
+    {
+        var vm = Make(pop3Enabled: false);
+        vm.SelectedProvider = new ProviderCatalog().ById(ProviderCatalog.GmailId);
+        Assert.False(vm.ShowConnectionMethod);
+    }
+
+    [Fact]
+    public void SelectingPop3_ForcesPasswordAuthAndShowsTheServerFields()
+    {
+        var vm = Make(pop3Enabled: true);
+        vm.SelectedBackend = Pop3Option(vm);
+
+        Assert.Equal(BackendKind.Pop3Smtp, vm.BackendKind);
+        Assert.True(vm.IsPop3Backend);
+        Assert.False(vm.IsImapBackend);
+        Assert.False(vm.IsGraphBackend);
+        // There is no OAuth path through the POP3 backend.
+        Assert.Equal(AuthType.Password, vm.AuthType);
+        // Both host-based backends need the server block: POP3 to receive, SMTP to send.
+        Assert.True(vm.ShowServerSettings);
+        Assert.Equal("POP3", vm.IncomingHostLabel);
+    }
+
+    [Fact]
+    public void SelectingPop3_FillsInAKnownProvidersPop3Host()
+    {
+        var vm = Make(pop3Enabled: true);
+        vm.SelectedProvider = new ProviderCatalog().ById(ProviderCatalog.GmailId);
+        vm.SelectedBackend = Pop3Option(vm);
+
+        Assert.Equal("pop.gmail.com", vm.Pop3Host);
+        Assert.Equal(995, vm.Pop3Port);
+        Assert.True(vm.Pop3UseSsl);
+        // Sending is unchanged — POP3 accounts still send over the provider's SMTP host.
+        Assert.Equal("smtp.gmail.com", vm.SmtpHost);
+    }
+
+    [Fact]
+    public void MovingFromGraphToPop3_PutsTheHostsBack()
+    {
+        // Graph clears the host fields, and the POP3 branch has to restore them or the account is
+        // saved with no way to send and no way to receive.
+        var vm = Make(pop3Enabled: true);
+        vm.SelectedProvider = new ProviderCatalog().ById(ProviderCatalog.MicrosoftId);
+        vm.SelectedBackend = vm.AvailableBackends.First(b => b.Kind == BackendKind.MicrosoftGraph);
+        Assert.Equal(string.Empty, vm.SmtpHost);
+
+        vm.SelectedBackend = Pop3Option(vm);
+
+        Assert.Equal("outlook.office365.com", vm.Pop3Host);
+        Assert.Equal("smtp-mail.outlook.com", vm.SmtpHost);
+    }
+
+    [Fact]
+    public void AProviderWithNoPop3Service_LeavesTheHostForTheUserToType()
+    {
+        // iCloud is IMAP-only. Pre-filling a guessed host would hand the user a server that never
+        // answers; an empty box plus the IsReadyToSave message is the honest outcome.
+        var vm = Make(pop3Enabled: true);
+        vm.SelectedProvider = new ProviderCatalog().ById(ProviderCatalog.ICloudId);
+        vm.SelectedBackend = Pop3Option(vm);
+
+        Assert.Equal(string.Empty, vm.Pop3Host);
+
+        vm.Username = "someone@icloud.com";
+        vm.Password = "app-specific";
+        Assert.False(vm.IsReadyToSave(out var error));
+        Assert.Contains("POP3", error);
+    }
+
+    [Fact]
+    public void TypingTheAddressDoesNotUndoAHandPickedPop3()
+    {
+        // Typing an address matches a provider and re-applies its default connection method. That
+        // used to throw away a POP3 choice made moments earlier — invisibly, because the combo is
+        // inside the collapsed Advanced expander.
+        var vm = Make(pop3Enabled: true);
+        vm.SelectedBackend = Pop3Option(vm);
+
+        vm.Username = "kelly@gmail.com";
+        vm.CommitUsername();
+
+        Assert.Equal(BackendKind.Pop3Smtp, vm.BackendKind);
+        Assert.Equal(AuthType.Password, vm.AuthType);
+        // The provider still applies everything else about itself, including its POP3 host.
+        Assert.Equal(ProviderCatalog.GmailId, vm.SelectedProvider?.Id);
+        Assert.Equal("pop.gmail.com", vm.Pop3Host);
+    }
+
+    [Fact]
+    public void AProviderChangeStillMovesAnAccountOffGraph()
+    {
+        // The mirror of the test above, and the reason only POP3 is preserved: Graph belongs to the
+        // Microsoft provider, so picking a different provider must be free to move off it.
+        var vm = Make(pop3Enabled: true);
+        vm.SelectedProvider = new ProviderCatalog().ById(ProviderCatalog.MicrosoftId);
+        vm.SelectedBackend = vm.AvailableBackends.First(b => b.Kind == BackendKind.MicrosoftGraph);
+        Assert.Equal(BackendKind.MicrosoftGraph, vm.BackendKind);
+
+        vm.SelectedProvider = new ProviderCatalog().ById(ProviderCatalog.GmailId);
+
+        Assert.Equal(BackendKind.ImapSmtp, vm.BackendKind);
+    }
+
+    [Fact]
+    public void PickingAnOAuthProviderWhileOnPop3_KeepsPasswordAuth()
+    {
+        // POP3 has no OAuth path here, so taking the provider's OAuth default would leave the
+        // account unable to authenticate at all.
+        var vm = Make(pop3Enabled: true);
+        vm.SelectedBackend = Pop3Option(vm);
+
+        vm.SelectedProvider = new ProviderCatalog().ById(ProviderCatalog.MicrosoftId);
+
+        Assert.Equal(BackendKind.Pop3Smtp, vm.BackendKind);
+        Assert.Equal(AuthType.Password, vm.AuthType);
+    }
+
+    [Fact]
+    public void SaveIsRefusedUntilThePop3HostIsFilledIn_AndTheImapHostIsIrrelevant()
+    {
+        var vm = Make(pop3Enabled: true);
+        vm.SelectedBackend = Pop3Option(vm);
+        vm.Username = "kelly@example.com";
+        vm.Password = "secret";
+        vm.SmtpHost = "smtp.example.com";
+        vm.ImapHost = "imap.example.com";   // must not stand in for the POP3 host
+
+        Assert.False(vm.IsReadyToSave(out var error));
+        Assert.Contains("POP3", error);
+
+        vm.Pop3Host = "pop.example.com";
+        Assert.True(vm.IsReadyToSave(out _));
+    }
+
+    [Fact]
+    public void ToAccountModel_CarriesEveryPop3Setting()
+    {
+        var vm = Make(pop3Enabled: true);
+        vm.SelectedBackend = Pop3Option(vm);
+        vm.Username = "kelly@example.com";
+        vm.Pop3Host = "pop.example.com";
+        vm.Pop3Port = 110;
+        vm.Pop3UseSsl = false;
+        vm.Pop3AcceptInvalidCert = true;
+        vm.Pop3LeaveMailOnServer = false;
+
+        var account = vm.ToAccountModel();
+
+        Assert.Equal(BackendKind.Pop3Smtp, account.BackendKind);
+        Assert.Equal("pop.example.com", account.Pop3Host);
+        Assert.Equal(110, account.Pop3Port);
+        Assert.False(account.Pop3UseSsl);
+        Assert.True(account.Pop3AcceptInvalidCert);
+        Assert.False(account.Pop3LeaveMailOnServer);
+    }
+
+    [Fact]
+    public void LeaveMailOnServer_DefaultsToKeepingIt()
+    {
+        // The local store becomes the only copy the moment this is off, so the safe setting is the
+        // default and turning it off is a deliberate act.
+        Assert.True(Make(pop3Enabled: true).Pop3LeaveMailOnServer);
+        Assert.True(new AccountModel().Pop3LeaveMailOnServer);
+    }
+}
+
+/// <summary>Editing an existing POP3 account in the Account Manager round-trips its settings.</summary>
+public class Pop3AccountManagerTests
+{
+    private static AccountManagerViewModel NewVm() => new(
+        new StubAccountService(), new StubCredentialService(), new StubImapMailService(),
+        new StubOAuthService(), new StubLocalStoreService(), new StubConfigService(),
+        new StubFeatureGate(), new ProviderCatalog());
+
+    private static AccountModel Pop3Account() => new()
+    {
+        Id = Guid.NewGuid(),
+        AccountName = "POP account",
+        Username = "kelly@example.com",
+        AuthType = AuthType.Password,
+        BackendKind = BackendKind.Pop3Smtp,
+        Pop3Host = "pop.example.com",
+        Pop3Port = 995,
+        Pop3UseSsl = true,
+        Pop3LeaveMailOnServer = true,
+        SmtpHost = "smtp.example.com",
+    };
+
+    [Fact]
+    public void SelectingAPop3Account_LoadsItsSettingsAndShowsTheRightSection()
+    {
+        var vm = NewVm();
+        var account = Pop3Account();
+        vm.Accounts.Add(account);
+        vm.SelectedAccount = account;
+
+        Assert.True(vm.IsPop3Backend);
+        Assert.False(vm.IsImapBackend);
+        Assert.True(vm.ShowServerSettings);
+        Assert.Equal("pop.example.com", vm.Pop3Host);
+        Assert.Equal(995, vm.Pop3Port);
+        Assert.True(vm.Pop3LeaveMailOnServer);
+    }
+
+    [Fact]
+    public void EditingLeaveMailOnServer_IsSaved()
+    {
+        var vm = NewVm();
+        var account = Pop3Account();
+        vm.Accounts.Add(account);
+        vm.SelectedAccount = account;
+
+        vm.Pop3LeaveMailOnServer = false;
+        vm.Pop3Host = "pop3.example.net";
+        vm.SaveAccountCommand.Execute(null);
+
+        Assert.False(account.Pop3LeaveMailOnServer);
+        Assert.Equal("pop3.example.net", account.Pop3Host);
+    }
+}
+
+/// <summary>The POP3 half of the provider catalog.</summary>
+public class Pop3ProviderCatalogTests
+{
+    private readonly ProviderCatalog _catalog = new();
+
+    [Theory]
+    [InlineData(ProviderCatalog.GmailId,     "pop.gmail.com")]
+    [InlineData(ProviderCatalog.MicrosoftId, "outlook.office365.com")]
+    [InlineData(ProviderCatalog.YahooId,     "pop.mail.yahoo.com")]
+    public void KnownProvidersCarryTheirPop3Host(string providerId, string expectedHost)
+    {
+        var provider = _catalog.ById(providerId);
+        Assert.NotNull(provider);
+        Assert.True(provider!.SupportsPop3);
+        Assert.Equal(expectedHost, provider.Pop3Host);
+        Assert.Equal(995, provider.Pop3Port);
+    }
+
+    [Fact]
+    public void ICloudDoesNotClaimPop3() // iCloud Mail serves IMAP only
+    {
+        var provider = _catalog.ById(ProviderCatalog.ICloudId);
+        Assert.NotNull(provider);
+        Assert.False(provider!.SupportsPop3);
+    }
+
+    [Fact]
+    public void OtherDoesNotClaimPop3()
+        => Assert.False(_catalog.Other.SupportsPop3);
+}
+
+/// <summary>The <c>Pop3Backend</c> gate itself.</summary>
+public class Pop3FeatureGateTests
+{
+    [Fact]
+    public void DefaultsOff() // opt-in until it has run against real servers
+        => Assert.False(new ConfigFeatureGate(new ConfigModel(), Array.Empty<string>())
+            .IsEnabled(FeatureFlag.Pop3Backend));
+
+    [Fact]
+    public void ConfigTurnsItOn()
+    {
+        var config = new ConfigModel();
+        config.Features["Pop3Backend"] = "true";
+        Assert.True(new ConfigFeatureGate(config, Array.Empty<string>()).IsEnabled(FeatureFlag.Pop3Backend));
+    }
+
+    [Fact]
+    public void CommandLineTurnsItOn()
+        => Assert.True(new ConfigFeatureGate(new ConfigModel(), new[] { "Pop3Backend" })
+            .IsEnabled(FeatureFlag.Pop3Backend));
+}
+
+/// <summary>
+/// A shared mailbox reads through a parent account's mailbox access. POP3 has no such concept — one
+/// maildrop, no folders, no delegation — so a POP3 account must not be offered as a parent (#31/#128).
+/// </summary>
+public class Pop3SharedMailboxTests
+{
+    [Fact]
+    public void APop3AccountIsNotOfferedAsAParent()
+    {
+        var imap = new AccountModel { Id = Guid.NewGuid(), AccountName = "IMAP", BackendKind = BackendKind.ImapSmtp };
+        var pop3 = new AccountModel { Id = Guid.NewGuid(), AccountName = "POP3", BackendKind = BackendKind.Pop3Smtp };
+
+        var vm = new AddSharedMailboxViewModel([imap, pop3]);
+
+        Assert.Contains(vm.ParentOptions, a => a.Id == imap.Id);
+        Assert.DoesNotContain(vm.ParentOptions, a => a.Id == pop3.Id);
+    }
+}

--- a/QuickMail.Tests/Pop3AccountSetupTests.cs
+++ b/QuickMail.Tests/Pop3AccountSetupTests.cs
@@ -282,6 +282,74 @@ public class Pop3AccountManagerTests
     }
 }
 
+/// <summary>
+/// The incoming leg reported per backend (#128). Code that asks "which server does this account
+/// receive from" used to read the IMAP fields directly, which describes a POP3 account as the empty
+/// host on port 993 — the same root cause as the blank server the Account Properties window showed.
+/// </summary>
+public class AccountIncomingLegTests
+{
+    [Fact]
+    public void APop3AccountReportsItsPop3Server()
+    {
+        var account = new AccountModel
+        {
+            BackendKind = BackendKind.Pop3Smtp,
+            Pop3Host = "mail.example.com", Pop3Port = 995, Pop3UseSsl = true, Pop3AcceptInvalidCert = true,
+            ImapHost = string.Empty, ImapPort = 993, ImapUseSsl = true,   // untouched defaults
+        };
+
+        Assert.Equal("mail.example.com", account.IncomingHost);
+        Assert.Equal(995, account.IncomingPort);
+        Assert.True(account.IncomingUseSsl);
+        Assert.True(account.IncomingAcceptInvalidCert);
+    }
+
+    [Fact]
+    public void AnImapAccountIsUnchanged()
+    {
+        var account = new AccountModel
+        {
+            BackendKind = BackendKind.ImapSmtp,
+            ImapHost = "imap.example.com", ImapPort = 143, ImapUseSsl = false,
+        };
+
+        Assert.Equal("imap.example.com", account.IncomingHost);
+        Assert.Equal(143, account.IncomingPort);
+        Assert.False(account.IncomingUseSsl);
+    }
+
+    [Fact]
+    public void AGraphAccountHasNoIncomingServer()
+    {
+        var account = new AccountModel { BackendKind = BackendKind.MicrosoftGraph, ImapPort = 993 };
+
+        Assert.Equal(string.Empty, account.IncomingHost);
+        Assert.Equal(0, account.IncomingPort);
+    }
+
+    [Fact]
+    public void TwoPop3AccountsOnDifferentServersAreNotTheSameHost()
+    {
+        // Connect-time grouping serializes accounts that share a host, which matters more for POP3
+        // than IMAP: RFC 1939 locks the maildrop for the session. Grouping on the IMAP field put
+        // every POP3 account in one bucket — both of these looked like the same empty host.
+        var first  = new AccountModel { BackendKind = BackendKind.Pop3Smtp, Pop3Host = "pop.one.example" };
+        var second = new AccountModel { BackendKind = BackendKind.Pop3Smtp, Pop3Host = "pop.two.example" };
+
+        Assert.NotEqual(first.IncomingHost, second.IncomingHost);
+    }
+
+    [Fact]
+    public void APop3AccountAndAnImapAccountOnOneHostShareIt()
+    {
+        var pop3 = new AccountModel { BackendKind = BackendKind.Pop3Smtp, Pop3Host = "mail.example.com" };
+        var imap = new AccountModel { BackendKind = BackendKind.ImapSmtp, ImapHost = "mail.example.com" };
+
+        Assert.Equal(pop3.IncomingHost, imap.IncomingHost);
+    }
+}
+
 /// <summary>The POP3 half of the provider catalog.</summary>
 public class Pop3ProviderCatalogTests
 {

--- a/QuickMail.Tests/Pop3DialogTests.cs
+++ b/QuickMail.Tests/Pop3DialogTests.cs
@@ -85,6 +85,43 @@ public class Pop3DialogTests
         return string.Empty;   // unreachable; Assert.Fail throws
     }
 
+    /// <summary>
+    /// Asserts a field is labelled the way the Accessibility Checklist requires, in the two halves
+    /// that can break independently:
+    ///
+    /// <list type="number">
+    /// <item>the field's <c>AutomationProperties.LabeledBy</c> resolves to the intended Label — the
+    /// ElementName binding that #168 is about, and the half that renders perfectly when broken;</item>
+    /// <item>that Label's own automation peer carries the expected text.</item>
+    /// </list>
+    ///
+    /// <para>Both come from real automation peers, never from the XAML. Split because the composite
+    /// read (the field's peer, which delegates to the Label's) returned empty on the CI runner while
+    /// passing here, and an empty string does not say which half was missing.</para>
+    /// </summary>
+    private static void AssertLabelled(Window window, string fieldName, string labelName, string expected)
+    {
+        var field = Named<FrameworkElement>(window, fieldName);
+        var label = Named<Label>(window, labelName);
+
+        Assert.True(ReferenceEquals(AutomationProperties.GetLabeledBy(field), label),
+            $"{fieldName} is not labelled by {labelName}: LabeledBy resolved to " +
+            $"{AutomationProperties.GetLabeledBy(field)?.GetType().Name ?? "null"}. " +
+            "A field whose label binding fails looks perfect on screen and announces nothing.");
+
+        Assert.Equal(expected, SettledPeerName(label));
+
+        // The field's own peer delegates to the label's, and is what a screen reader actually reads.
+        // Reported rather than asserted a second time: when the two halves above hold and this does
+        // not, the cause is WPF's delegation in that environment, not this dialog's wiring.
+        var viaField = SettledPeerName(field);
+        Assert.True(viaField == expected,
+            $"{fieldName} is labelled by {labelName} (which reads '{expected}'), but the field's own " +
+            $"peer reads '{viaField}'. LabeledBy delegation did not resolve. " +
+            $"field: IsVisible={field.IsVisible} IsLoaded={field.IsLoaded}; " +
+            $"label: IsVisible={label.IsVisible} IsLoaded={label.IsLoaded} ActualWidth={label.ActualWidth}.");
+    }
+
     [StaFact]
     public void ChoosingPop3_ShowsThePop3FieldsAndHidesTheImapOnes()
     {
@@ -125,10 +162,10 @@ public class Pop3DialogTests
             window.UpdateLayout();
             Drain();
 
-            // Read from the automation peer, not from the XAML: a Label whose Target failed to bind
-            // renders perfectly and announces nothing (#168).
-            Assert.Equal("POP3 host:", SettledPeerName(Named<TextBox>(window, "Pop3HostBox")));
-            Assert.Equal("POP3 port:", SettledPeerName(Named<TextBox>(window, "Pop3PortBox")));
+            // What a screen reader reads, checked in the two independent halves it is made of, so a
+            // failure names the broken one instead of just reporting an empty string (#168).
+            AssertLabelled(window, "Pop3HostBox", "LblPop3Host", "POP3 host:");
+            AssertLabelled(window, "Pop3PortBox", "LblPop3Port", "POP3 port:");
 
             // A short label, with no instruction baked in — the consequence of clearing it is a Hint.
             var keep = SettledPeerName(Named<CheckBox>(window, "Pop3LeaveOnServerCheckBox"));

--- a/QuickMail.Tests/Pop3DialogTests.cs
+++ b/QuickMail.Tests/Pop3DialogTests.cs
@@ -1,0 +1,208 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using System.Windows.Automation.Peers;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Threading;
+using QuickMail.Models;
+using QuickMail.Services;
+using QuickMail.ViewModels;
+using QuickMail.Views;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// The POP3 settings as they actually render (#128). QuickMail is built by someone who cannot see
+/// the screen, so "the fields are there" is asserted against the real visual tree and the real
+/// automation peers — never eyeballed, and never inferred from the XAML text.
+/// </summary>
+[Collection("WpfTests")]
+public class Pop3DialogTests
+{
+    private static void Drain()
+    {
+        var frame = new DispatcherFrame();
+        Dispatcher.CurrentDispatcher.BeginInvoke(
+            DispatcherPriority.SystemIdle, new Action(() => frame.Continue = false));
+        Dispatcher.PushFrame(frame);
+    }
+
+    private static T Named<T>(Window window, string name) where T : class
+    {
+        var element = window.FindName(name) as T;
+        Assert.True(element is not null, $"{name} is missing from {window.GetType().Name}.");
+        return element!;
+    }
+
+    private static AddAccountViewModel NewAddVm() =>
+        new(new StubFeatureGate { [FeatureFlag.GraphBackend] = true, [FeatureFlag.Pop3Backend] = true },
+            new StubImapMailService(), new StubOAuthService(), new ProviderCatalog());
+
+    private static AddAccountDialog ShowAddDialog(AddAccountViewModel vm)
+    {
+        var window = new AddAccountDialog(vm)
+        {
+            WindowStyle = WindowStyle.None, ShowInTaskbar = false, ShowActivated = false,
+        };
+        window.Show();
+        return window;
+    }
+
+    /// <summary>The accessible name a screen reader would read for this element.</summary>
+    private static string PeerName(UIElement element) =>
+        UIElementAutomationPeer.CreatePeerForElement(element)?.GetName() ?? string.Empty;
+
+    [StaFact]
+    public void ChoosingPop3_ShowsThePop3FieldsAndHidesTheImapOnes()
+    {
+        var vm = NewAddVm();
+        var window = ShowAddDialog(vm);
+        try
+        {
+            vm.IsAdvancedExpanded = true;
+            vm.SelectedBackend = vm.AvailableBackends.First(b => b.Kind == BackendKind.Pop3Smtp);
+            window.UpdateLayout();
+            Drain();
+
+            // IsVisible, not Visibility: an element inside a collapsed panel keeps its own
+            // Visibility.Visible, so asserting on that would pass whatever the section did.
+            Assert.True(Named<TextBox>(window, "Pop3HostBox").IsVisible);
+            Assert.True(Named<TextBox>(window, "Pop3PortBox").IsVisible);
+            Assert.True(Named<CheckBox>(window, "Pop3LeaveOnServerCheckBox").IsVisible);
+
+            // The two incoming sections are mutually exclusive; showing both would offer the user a
+            // host box that the account they are creating will never dial.
+            Assert.False(Named<TextBox>(window, "ImapHostBox").IsVisible);
+
+            // SMTP stays: a POP3 account still sends.
+            Assert.True(Named<TextBox>(window, "SmtpHostBox").IsVisible);
+        }
+        finally { window.Close(); }
+    }
+
+    [StaFact]
+    public void ThePop3FieldsAreLabelledForAScreenReader()
+    {
+        var vm = NewAddVm();
+        var window = ShowAddDialog(vm);
+        try
+        {
+            vm.IsAdvancedExpanded = true;
+            vm.SelectedBackend = vm.AvailableBackends.First(b => b.Kind == BackendKind.Pop3Smtp);
+            window.UpdateLayout();
+            Drain();
+
+            // Read from the automation peer, not from the XAML: a Label whose Target failed to bind
+            // renders perfectly and announces nothing (#168).
+            Assert.Equal("POP3 host:", PeerName(Named<TextBox>(window, "Pop3HostBox")));
+            Assert.Equal("POP3 port:", PeerName(Named<TextBox>(window, "Pop3PortBox")));
+
+            // A short label, with no instruction baked in — the consequence of clearing it is a Hint.
+            var keep = PeerName(Named<CheckBox>(window, "Pop3LeaveOnServerCheckBox"));
+            Assert.Equal("Keep mail on the server after downloading", keep);
+        }
+        finally { window.Close(); }
+    }
+
+    [StaFact]
+    public void TheKeepMailCheckboxSpeaksWhatClearingItCosts()
+    {
+        var vm = NewAddVm();
+        var window = ShowAddDialog(vm);
+        var heard = new List<(string Text, AnnouncementCategory Category)>();
+        AccessibilityHelper.AnnouncementObserver = (text, category) => heard.Add((text, category));
+        try
+        {
+            vm.IsAdvancedExpanded = true;
+            vm.SelectedBackend = vm.AvailableBackends.First(b => b.Kind == BackendKind.Pop3Smtp);
+            window.UpdateLayout();
+            Drain();
+
+            heard.Clear();
+            var checkbox = Named<CheckBox>(window, "Pop3LeaveOnServerCheckBox");
+            checkbox.Focus();
+            Keyboard.Focus(checkbox);
+            Drain();
+
+            var hint = heard.FirstOrDefault(h => h.Category == AnnouncementCategory.Hint);
+            Assert.False(string.IsNullOrWhiteSpace(hint.Text),
+                "focusing the keep-mail checkbox produced no hint. Heard: "
+                + (heard.Count == 0 ? "(nothing)" : string.Join(" | ", heard.Select(h => $"{h.Category}: {h.Text}"))));
+            // It must say what is at stake, not merely restate the label.
+            Assert.Contains("only copy", hint.Text, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            AccessibilityHelper.AnnouncementObserver = null;
+            window.Close();
+        }
+    }
+
+    [StaFact]
+    public void TheConnectionMethodComboOffersPop3ByItsDisplayName()
+    {
+        var vm = NewAddVm();
+        var window = ShowAddDialog(vm);
+        try
+        {
+            vm.IsAdvancedExpanded = true;
+            window.UpdateLayout();
+            Drain();
+
+            var combo = Named<ComboBox>(window, "BackendComboBox");
+            Assert.True(combo.IsVisible);
+
+            // A Selector item's accessible name comes from ToString(), not DisplayMemberPath — the
+            // bug that shipped in the theme combo and looks perfect on screen.
+            var names = combo.Items.Cast<object>().Select(i => i.ToString()).ToList();
+            Assert.Contains("POP3/SMTP", names);
+            Assert.DoesNotContain(names, n => n?.Contains("BackendKindOption", StringComparison.Ordinal) == true);
+        }
+        finally { window.Close(); }
+    }
+
+    [StaFact]
+    public void AnExistingPop3AccountShowsItsSettingsInTheAccountManager()
+    {
+        var vm = new AccountManagerViewModel(
+            new StubAccountService(), new StubCredentialService(), new StubImapMailService(),
+            new StubOAuthService(), new StubLocalStoreService(), new StubConfigService(),
+            new StubFeatureGate(), new ProviderCatalog());
+
+        var account = new AccountModel
+        {
+            Id = Guid.NewGuid(),
+            AccountName = "POP account",
+            Username = "kelly@example.com",
+            AuthType = AuthType.Password,
+            BackendKind = BackendKind.Pop3Smtp,
+            Pop3Host = "pop.example.com",
+            SmtpHost = "smtp.example.com",
+        };
+        vm.Accounts.Add(account);
+        vm.SelectedAccount = account;
+
+        var window = new AccountManagerDialog(vm)
+        {
+            WindowStyle = WindowStyle.None, ShowInTaskbar = false, ShowActivated = false,
+        };
+        window.Show();
+        try
+        {
+            vm.IsAdvancedExpanded = true;
+            window.UpdateLayout();
+            Drain();
+
+            // The gate hides the OFFER of POP3 in Add Account; an account already using it must still
+            // show its own settings, whatever the flag is set to.
+            var host = Named<TextBox>(window, "Pop3HostBox");
+            Assert.True(host.IsVisible);
+            Assert.Equal("pop.example.com", host.Text);
+            Assert.False(Named<TextBox>(window, "ImapHostBox").IsVisible);
+        }
+        finally { window.Close(); }
+    }
+}

--- a/QuickMail.Tests/Pop3DialogTests.cs
+++ b/QuickMail.Tests/Pop3DialogTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
+using System.Windows.Automation;
 using System.Windows.Automation.Peers;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -55,6 +56,35 @@ public class Pop3DialogTests
     private static string PeerName(UIElement element) =>
         UIElementAutomationPeer.CreatePeerForElement(element)?.GetName() ?? string.Empty;
 
+    /// <summary>
+    /// The accessible name once WPF has settled.
+    ///
+    /// <para><c>AutomationProperties.LabeledBy</c> is an <c>ElementName</c> binding, and ElementName
+    /// resolution is asynchronous — WPF retries it as the tree loads. A single dispatcher drain is
+    /// enough on a fast machine and was not on the CI runner, where this read came back empty
+    /// (build job of PR 538). Draining until the name appears makes the test measure the wiring
+    /// rather than the machine; a name that never appears still fails, with the diagnosis attached.</para>
+    /// </summary>
+    private static string SettledPeerName(FrameworkElement element)
+    {
+        for (var attempt = 0; attempt < 20; attempt++)
+        {
+            var name = PeerName(element);
+            if (!string.IsNullOrEmpty(name)) return name;
+            Drain();
+        }
+
+        // Empty after settling is a real failure. Say which half of the wiring is missing: a null
+        // LabeledBy means the ElementName never resolved (#168's failure mode), while a resolved
+        // LabeledBy with no name means the label itself carries no content.
+        var labeledBy = AutomationProperties.GetLabeledBy(element);
+        Assert.Fail(
+            $"{element.Name} has no accessible name after settling. " +
+            $"LabeledBy={(labeledBy is null ? "null (ElementName never resolved)" : labeledBy.GetType().Name)}, " +
+            $"IsVisible={element.IsVisible}, IsLoaded={element.IsLoaded}.");
+        return string.Empty;   // unreachable; Assert.Fail throws
+    }
+
     [StaFact]
     public void ChoosingPop3_ShowsThePop3FieldsAndHidesTheImapOnes()
     {
@@ -97,11 +127,11 @@ public class Pop3DialogTests
 
             // Read from the automation peer, not from the XAML: a Label whose Target failed to bind
             // renders perfectly and announces nothing (#168).
-            Assert.Equal("POP3 host:", PeerName(Named<TextBox>(window, "Pop3HostBox")));
-            Assert.Equal("POP3 port:", PeerName(Named<TextBox>(window, "Pop3PortBox")));
+            Assert.Equal("POP3 host:", SettledPeerName(Named<TextBox>(window, "Pop3HostBox")));
+            Assert.Equal("POP3 port:", SettledPeerName(Named<TextBox>(window, "Pop3PortBox")));
 
             // A short label, with no instruction baked in — the consequence of clearing it is a Hint.
-            var keep = PeerName(Named<CheckBox>(window, "Pop3LeaveOnServerCheckBox"));
+            var keep = SettledPeerName(Named<CheckBox>(window, "Pop3LeaveOnServerCheckBox"));
             Assert.Equal("Keep mail on the server after downloading", keep);
         }
         finally { window.Close(); }

--- a/QuickMail.Tests/Pop3MailServiceTests.cs
+++ b/QuickMail.Tests/Pop3MailServiceTests.cs
@@ -127,7 +127,7 @@ public class Pop3MailServiceTests
         var account = Guid.NewGuid();
         var cached  = new[] { Msg(account, "uidl-1", "Inbox"), Msg(account, "uidl-2", "Inbox") };
 
-        var merged = Pop3MailService.MergeListing(cached, [], DateTimeOffset.UtcNow);
+        var merged = Pop3MailService.MergeListing(cached, [], new HashSet<string>(), DateTimeOffset.UtcNow);
 
         Assert.Equal(["uidl-1", "uidl-2"], merged.Select(m => m.Id));
     }
@@ -139,7 +139,7 @@ public class Pop3MailServiceTests
         var now     = DateTimeOffset.UtcNow;
         var cached  = new[] { Msg(account, "known", "Inbox", now.AddDays(-2), isRead: true) };
 
-        var merged = Pop3MailService.MergeListing(cached, ["known", "brand-new"], now);
+        var merged = Pop3MailService.MergeListing(cached, ["known", "brand-new"], new HashSet<string>(), now);
 
         // The known id appears once, with its own date and read state.
         var known = Assert.Single(merged.Where(m => m.Id == "known"));
@@ -161,12 +161,134 @@ public class Pop3MailServiceTests
         var account = Guid.NewGuid();
         var cached  = new[] { Msg(account, "collected-1", "Inbox"), Msg(account, "collected-2", "Inbox") };
 
-        var merged = Pop3MailService.MergeListing(cached, ["a-totally-different-uidl"], DateTimeOffset.UtcNow);
+        var merged = Pop3MailService.MergeListing(cached, ["a-totally-different-uidl"], new HashSet<string>(), DateTimeOffset.UtcNow);
         var listed = merged.Select(m => m.Id).ToHashSet();
 
         Assert.Contains("collected-1", listed);
         Assert.Contains("collected-2", listed);
         Assert.Contains("a-totally-different-uidl", listed);
+    }
+
+    [Fact]
+    public void MergeListing_NeverReportsACollectedUidl_AsANewArrival()
+    {
+        // Leave-on-server keeps a UIDL listed forever. Once the user deletes the message (row moves
+        // to Trash) or empties Trash (row gone entirely), the UIDL is no longer cached in the Inbox
+        // — but it is in the collected ledger. Reporting it as "arriving now" is what made deleted
+        // mail resurrect on every sweep: hasNew fired, and the fetch re-downloaded it.
+        var account   = Guid.NewGuid();
+        var now       = DateTimeOffset.UtcNow;
+        var cached    = new[] { Msg(account, "still-in-inbox", "Inbox") };
+        var collected = new HashSet<string>(["still-in-inbox", "deleted-by-user", "emptied-from-trash"]);
+
+        var merged = Pop3MailService.MergeListing(
+            cached, ["still-in-inbox", "deleted-by-user", "emptied-from-trash", "genuinely-new"], collected, now);
+
+        var ids = merged.Select(m => m.Id).ToList();
+        Assert.Contains("still-in-inbox", ids);      // cached rows always survive
+        Assert.Contains("genuinely-new", ids);        // real arrivals still surface
+        Assert.DoesNotContain("deleted-by-user", ids);
+        Assert.DoesNotContain("emptied-from-trash", ids);
+    }
+
+    [Fact]
+    public async Task PermanentDelete_RecordsTheUidl_SoItIsNeverCollectedAgain()
+    {
+        // Empty Trash with leave-on-server on (the shipped default): no DELE is sent, so only the
+        // ledger stands between "permanently deleted" and the same message re-downloading into the
+        // Inbox on the very next sweep.
+        var store   = NewStore();
+        var account = Guid.NewGuid();
+        var pop     = new Pop3MailService(store);
+
+        await store.UpsertSummariesAsync([Msg(account, "uidl-1", "Trash"), Msg(account, "local-abc", "Trash")]);
+        await pop.PermanentlyDeleteBatchAsync(account, "Trash", ["uidl-1", "local-abc"]);
+
+        var ledger = await store.LoadPop3CollectedUidlsAsync(account);
+        Assert.Contains("uidl-1", ledger);
+        // Locally-authored ids were never on the server; remembering them would be noise.
+        Assert.DoesNotContain("local-abc", ledger);
+    }
+
+    [Fact]
+    public async Task MoveToAFolderThatDoesNotExist_IsRefused_NotSilentlyFiled()
+    {
+        // A rule created against an IMAP account, or a mixed-account move, can hand the POP3 backend
+        // any folder name. Filing rows under a name GetFoldersAsync never returns strands them
+        // invisibly — and this store may hold the only copy.
+        var store   = NewStore();
+        var account = Guid.NewGuid();
+        var pop     = new Pop3MailService(store);
+
+        await store.UpsertSummariesAsync([Msg(account, "uidl-1", "Inbox")]);
+
+        await Assert.ThrowsAsync<NotSupportedException>(
+            () => pop.MoveMessagesAsync(account, "Inbox", ["uidl-1"], "Archive"));
+
+        // The message is exactly where it was.
+        var inbox = await store.LoadFolderSummariesAsync(account, "Inbox");
+        Assert.Equal(["uidl-1"], inbox.Select(m => m.MessageId));
+    }
+
+    [Fact]
+    public async Task MoveBetweenSyntheticFolders_IsCaseInsensitive_AndFilesUnderTheCanonicalName()
+    {
+        var store   = NewStore();
+        var account = Guid.NewGuid();
+        var pop     = new Pop3MailService(store);
+
+        await store.UpsertSummariesAsync([Msg(account, "uidl-1", "Inbox")]);
+        await pop.MoveMessagesAsync(account, "Inbox", ["uidl-1"], "TRASH");
+
+        // Accepted case-insensitively, but stored under the name GetFoldersAsync actually lists —
+        // the store's folder lookups compare exactly, so "TRASH" rows would be invisible.
+        Assert.Empty(await store.LoadFolderSummariesAsync(account, "Inbox"));
+        Assert.Equal(["uidl-1"], (await store.LoadFolderSummariesAsync(account, "Trash")).Select(m => m.MessageId));
+    }
+
+    [Fact]
+    public async Task AForwardedMessageAttachment_IsListed_AndComesBackAsEml()
+    {
+        // A forwarded email attached as message/rfc822 is a MessagePart, not a MimePart. It must be
+        // both listed AND openable: the stored bytes are the only copy POP3 will ever have, so
+        // "visible but throws on open" strands the content permanently. IMAP serves the same part
+        // as a serialized .eml; POP3 must answer identically.
+        var inner = new MimeMessage();
+        inner.From.Add(new MailboxAddress("Original Sender", "orig@example.com"));
+        inner.To.Add(new MailboxAddress("Original Recipient", "rcpt@example.com"));
+        inner.Subject = "The forwarded original";
+        inner.Body = new TextPart("plain") { Text = "Original body." };
+
+        var outer = BuildMime(subject: "FW: The forwarded original", customize: msg =>
+        {
+            msg.Body = new Multipart("mixed")
+            {
+                new TextPart("plain") { Text = "See attached." },
+                new MessagePart { Message = inner,
+                    ContentDisposition = new ContentDisposition(ContentDisposition.Attachment) },
+            };
+        });
+
+        var account = Guid.NewGuid();
+        var detail = Pop3MailService.BuildDetail(account, "uidl-1", outer, "Inbox", isRead: false);
+        var att = Assert.Single(detail.Attachments);
+        Assert.True(att.FileSize > 0);   // DecodedSize measures the serialized .eml, not 0
+        Assert.NotNull(att.PartSpecifier);
+
+        var store = NewStore();
+        // Mirror StoreMessageAsync's order: the bytes column lives on the MessageDetail row, so the
+        // detail is upserted first and the bytes update targets it.
+        await store.UpsertDetailAsync(detail);
+        using var ms = new MemoryStream();
+        outer.WriteTo(ms);
+        await store.StoreMimeBytesAsync(account, "Inbox", "uidl-1", ms.ToArray());
+
+        var pop = new Pop3MailService(store);
+        var bytes = await pop.DownloadAttachmentAsync(account, "Inbox", "uidl-1", att.PartSpecifier);
+
+        using var loaded = new MemoryStream(bytes);
+        var roundTripped = MimeMessage.Load(loaded);
+        Assert.Equal("The forwarded original", roundTripped.Subject);
     }
 
     [Fact]

--- a/QuickMail.Tests/Pop3MailServiceTests.cs
+++ b/QuickMail.Tests/Pop3MailServiceTests.cs
@@ -1,0 +1,764 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using MimeKit;
+using QuickMail.Models;
+using QuickMail.Services;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// POP3 backend (#128) behavior that does not need a server: the local half of the protocol — how a
+/// downloaded message maps onto QuickMail's models, how the synthetic folders behave, and above all
+/// the sync contract that keeps <c>SyncService</c> from deleting mail that exists nowhere else.
+///
+/// <para>These run against the REAL <see cref="LocalStoreService"/> on a temp profile rather than a
+/// stub. That is deliberate: the flag and read-state semantics under test are enforced by the
+/// upsert SQL, so a hand-written fake store would happily pass tests the shipping code fails.</para>
+///
+/// <para>The protocol half — RETR, UIDL dedup across sessions, DELE — is covered against a real
+/// server in QuickMail.IntegrationTests/Pop3ProtocolTests.cs.</para>
+/// </summary>
+public class Pop3MailServiceTests
+{
+    private static LocalStoreService NewStore()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), $"QuickMailPop3-{Guid.NewGuid():N}");
+        var store = new LocalStoreService(new ProfileContext(dir));
+        store.Initialize();
+        return store;
+    }
+
+    private static MailMessageSummary Msg(Guid account, string id, string folder,
+                                          DateTimeOffset? date = null, bool isRead = false) => new()
+    {
+        MessageId  = id,
+        AccountId  = account,
+        FolderName = folder,
+        From       = "Sender <sender@example.com>",
+        To         = "me@example.com",
+        Subject    = $"Message {id}",
+        Date       = date ?? DateTimeOffset.UtcNow,
+        IsRead     = isRead,
+        Preview    = "preview text",
+    };
+
+    private static MimeMessage BuildMime(
+        string subject = "Hello",
+        string? text = "Line one\nLine two",
+        string? html = null,
+        string? messageId = "<abc@example.com>",
+        Action<MimeMessage>? customize = null)
+    {
+        var msg = new MimeMessage();
+        msg.From.Add(new MailboxAddress("Kelly Ford", "kelly@example.com"));
+        msg.To.Add(new MailboxAddress("Recipient Name", "recipient@example.com"));
+        msg.Subject = subject;
+        msg.Date = new DateTimeOffset(2026, 8, 1, 9, 30, 0, TimeSpan.Zero);
+        if (messageId is not null) msg.MessageId = messageId.Trim('<', '>');
+
+        var body = new BodyBuilder();
+        if (text is not null) body.TextBody = text;
+        if (html is not null) body.HtmlBody = html;
+        msg.Body = body.ToMessageBody();
+
+        customize?.Invoke(msg);
+        return msg;
+    }
+
+    // ── The sync contract (#462) ─────────────────────────────────────────────────
+    // SyncService routes every POP3 folder through its id-diff sweep, which deletes cached ids the
+    // backend's listing does not mention. For POP3 the cache is the only copy of the mail, so these
+    // are the tests that stand between the sweep and a user's mailbox.
+
+    [Fact]
+    public async Task IdDateListing_IncludesEveryCachedId_SoTheDeletionReconcileCanNeverPurge()
+    {
+        var store   = NewStore();
+        var account = Guid.NewGuid();
+        var pop     = new Pop3MailService(store);
+
+        await store.UpsertSummariesAsync([
+            Msg(account, "uidl-1", "Inbox"),
+            Msg(account, "uidl-2", "Inbox"),
+        ]);
+
+        // No ConnectAsync, so the server half contributes nothing — exactly the state a POP3 server
+        // that has already dropped the mail would produce.
+        var listing = await pop.GetFolderMessageIdDatesAsync(account, "Inbox");
+
+        var listed = listing.Select(l => l.Id).ToHashSet();
+        Assert.Contains("uidl-1", listed);
+        Assert.Contains("uidl-2", listed);
+
+        // The sweep's deletion reconcile is (cached ids) minus (listed ids). It must come out empty.
+        var cached = await store.GetAllMessageIdsAsync(account, "Inbox");
+        Assert.Empty(cached.Except(listed));
+    }
+
+    [Fact]
+    public async Task IdDateListing_ReportsCachedReadState_SoTheReadReconcileIsANoOp()
+    {
+        var store   = NewStore();
+        var account = Guid.NewGuid();
+        var pop     = new Pop3MailService(store);
+
+        await store.UpsertSummariesAsync([
+            Msg(account, "read-one",   "Inbox", isRead: true),
+            Msg(account, "unread-one", "Inbox", isRead: false),
+        ]);
+
+        var listing = await pop.GetFolderMessageIdDatesAsync(account, "Inbox");
+
+        // POP3 has no server-side read state. Reporting anything but the cached value would make the
+        // sweep "reconcile" a message the user has read straight back to unread on every cycle.
+        Assert.True(listing.Single(l => l.Id == "read-one").IsRead);
+        Assert.False(listing.Single(l => l.Id == "unread-one").IsRead);
+    }
+
+    [Fact]
+    public void MergeListing_KeepsEveryCachedId_EvenWhenTheServerListsNothing()
+    {
+        // The listing the sweep consumes, exercised directly — the service-level test above cannot
+        // reach the merge without a live server, so this is what pins the arithmetic.
+        var account = Guid.NewGuid();
+        var cached  = new[] { Msg(account, "uidl-1", "Inbox"), Msg(account, "uidl-2", "Inbox") };
+
+        var merged = Pop3MailService.MergeListing(cached, [], DateTimeOffset.UtcNow);
+
+        Assert.Equal(["uidl-1", "uidl-2"], merged.Select(m => m.Id));
+    }
+
+    [Fact]
+    public void MergeListing_AddsUnseenServerIdsAsArrivingNow()
+    {
+        var account = Guid.NewGuid();
+        var now     = DateTimeOffset.UtcNow;
+        var cached  = new[] { Msg(account, "known", "Inbox", now.AddDays(-2), isRead: true) };
+
+        var merged = Pop3MailService.MergeListing(cached, ["known", "brand-new"], now);
+
+        // The known id appears once, with its own date and read state.
+        var known = Assert.Single(merged.Where(m => m.Id == "known"));
+        Assert.True(known.IsRead);
+        Assert.Equal(now.AddDays(-2), known.ReceivedUtc);
+
+        // The unseen one is stamped now and unread, so it lands inside the sweep's window and gets
+        // fetched. Its real date is inside the message, which POP3 cannot show without downloading it.
+        var fresh = Assert.Single(merged.Where(m => m.Id == "brand-new"));
+        Assert.Equal(now, fresh.ReceivedUtc);
+        Assert.False(fresh.IsRead);
+    }
+
+    [Fact]
+    public void MergeListing_NeverDropsACachedIdTheServerHasForgotten()
+    {
+        // With leave-on-server off, this is the steady state seconds after collection: the server
+        // lists nothing QuickMail holds. Dropping those ids here is what would delete the mail.
+        var account = Guid.NewGuid();
+        var cached  = new[] { Msg(account, "collected-1", "Inbox"), Msg(account, "collected-2", "Inbox") };
+
+        var merged = Pop3MailService.MergeListing(cached, ["a-totally-different-uidl"], DateTimeOffset.UtcNow);
+        var listed = merged.Select(m => m.Id).ToHashSet();
+
+        Assert.Contains("collected-1", listed);
+        Assert.Contains("collected-2", listed);
+        Assert.Contains("a-totally-different-uidl", listed);
+    }
+
+    [Fact]
+    public async Task FolderMessageIds_ComeFromTheStore_NotTheServer()
+    {
+        var store   = NewStore();
+        var account = Guid.NewGuid();
+        var pop     = new Pop3MailService(store);
+
+        await store.UpsertSummariesAsync([Msg(account, "uidl-1", "Inbox")]);
+
+        // ReconcileFolderAsync (the pre-#462 path, taken when a server issues numeric UIDLs) diffs
+        // the cache against this. Store-backed means it diffs the cache against itself.
+        var ids = await pop.GetFolderMessageIdsAsync(account, "Inbox");
+        Assert.Equal(["uidl-1"], ids);
+    }
+
+    [Fact]
+    public async Task SyncFetch_RestatesLocalFlags_SoASweepDoesNotClearThem()
+    {
+        // UpsertSummariesAsync derives the stored flag from IsServerFlagged — an IMAP rule, where the
+        // server is the authority. SyncService upserts whatever a fetch returns, so a POP3 fetch that
+        // returned rows with IsServerFlagged=false would clear the user's flags on every sweep.
+        var store   = NewStore();
+        var account = Guid.NewGuid();
+        var pop     = new Pop3MailService(store);
+
+        await store.UpsertSummariesAsync([Msg(account, "uidl-1", "Sent")]);
+        await store.UpdateFlagIdAsync(account, "Sent", "uidl-1", FlagDefinition.BuiltInFlagId.ToString());
+
+        // Sent is a synthetic folder, so this reads the store without touching a server.
+        var fetched = await pop.GetMessagesSinceDateAsync(account, "Sent", DateTime.UtcNow.AddDays(-30));
+
+        Assert.True(fetched.Single().IsServerFlagged);
+
+        // Simulate what SyncService does with the batch, then confirm the flag survived.
+        await store.UpsertSummariesAsync(fetched);
+        var reloaded = await store.LoadFolderSummariesAsync(account, "Sent");
+        Assert.Equal(FlagDefinition.BuiltInFlagId.ToString(), reloaded.Single().FlagId);
+    }
+
+    [Fact]
+    public async Task SyncFetch_HonoursTheWindow()
+    {
+        var store   = NewStore();
+        var account = Guid.NewGuid();
+        var pop     = new Pop3MailService(store);
+
+        await store.UpsertSummariesAsync([
+            Msg(account, "recent", "Sent", DateTimeOffset.UtcNow.AddDays(-1)),
+            Msg(account, "old",    "Sent", DateTimeOffset.UtcNow.AddDays(-90)),
+        ]);
+
+        var fetched = await pop.GetMessagesSinceDateAsync(account, "Sent", DateTime.UtcNow.AddDays(-30));
+
+        // Old mail stays in the store and stays visible in the folder; it is simply not announced as
+        // an arrival, so a backlog does not produce a toast per message.
+        Assert.Equal(["recent"], fetched.Select(f => f.MessageId));
+        Assert.Equal(2, (await store.GetAllMessageIdsAsync(account, "Sent")).Count);
+    }
+
+    // ── Synthetic folders ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Folders_AreTheFourSyntheticOnes_WithCountsFromTheStore()
+    {
+        var store   = NewStore();
+        var account = Guid.NewGuid();
+        var pop     = new Pop3MailService(store);
+
+        await store.UpsertSummariesAsync([
+            Msg(account, "a", "Inbox", isRead: false),
+            Msg(account, "b", "Inbox", isRead: true),
+            Msg(account, "c", "Trash", isRead: false),
+        ]);
+
+        var folders = await pop.GetFoldersAsync(account);
+
+        Assert.Equal(["Inbox", "Sent", "Drafts", "Trash"], folders.Select(f => f.FullName));
+        Assert.Equal(SpecialFolderKind.Inbox,  folders[0].Kind);
+        Assert.Equal(SpecialFolderKind.Sent,   folders[1].Kind);
+        Assert.Equal(SpecialFolderKind.Drafts, folders[2].Kind);
+        Assert.Equal(SpecialFolderKind.Trash,  folders[3].Kind);
+
+        // Counts come from the store because there is no server-side STATUS to ask.
+        Assert.Equal(2, folders[0].MessageCount);
+        Assert.Equal(1, folders[0].UnreadCount);
+        Assert.Equal(1, folders[3].MessageCount);
+
+        // Everything but the Inbox is excluded from the All Mail aggregate, as on IMAP.
+        Assert.False(folders[0].ExcludeFromAllMail);
+        Assert.True(folders.Skip(1).All(f => f.ExcludeFromAllMail));
+    }
+
+    [Fact]
+    public async Task FolderCrud_IsRefused()
+    {
+        var pop = new Pop3MailService(NewStore());
+        var id  = Guid.NewGuid();
+
+        await Assert.ThrowsAsync<NotSupportedException>(() => pop.CreateFolderAsync(id, null, "New"));
+        await Assert.ThrowsAsync<NotSupportedException>(() => pop.DeleteFolderAsync(id, "Inbox"));
+        await Assert.ThrowsAsync<NotSupportedException>(() => pop.RenameFolderAsync(id, "Inbox", "X", null));
+        await Assert.ThrowsAsync<NotSupportedException>(() => pop.CopyFolderAsync(id, "Inbox", null));
+    }
+
+    // ── Local move / copy ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task MoveToTrash_MovesTheWholeMessage_AndKeepsItsFlag()
+    {
+        var store   = NewStore();
+        var account = Guid.NewGuid();
+        var pop     = new Pop3MailService(store);
+        var flag    = Guid.NewGuid().ToString();   // a named flag, not the built-in one
+
+        await store.UpsertSummariesAsync([Msg(account, "uidl-1", "Inbox")]);
+        await store.UpsertDetailAsync(new MailMessageDetail
+        {
+            MessageId = "uidl-1", AccountId = account, FolderName = "Inbox",
+            PlainTextBody = "the body", Attachments = [new AttachmentModel { FileName = "a.pdf", PartSpecifier = "0" }],
+        });
+        await store.StoreMimeBytesAsync(account, "Inbox", "uidl-1", [1, 2, 3]);
+        await store.UpdateFlagIdAsync(account, "Inbox", "uidl-1", flag);
+
+        await pop.MoveToTrashAsync(account, "Inbox", "uidl-1");
+
+        Assert.Empty(await store.GetAllMessageIdsAsync(account, "Inbox"));
+        var trashed = (await store.LoadFolderSummariesAsync(account, "Trash")).Single();
+        Assert.Equal("uidl-1", trashed.MessageId);
+        // A named flag survives the move: the upsert can only carry the built-in id, so the service
+        // restates it explicitly.
+        Assert.Equal(flag, trashed.FlagId);
+
+        var detail = await store.LoadDetailAsync(account, "Trash", "uidl-1");
+        Assert.NotNull(detail);
+        Assert.Equal("the body", detail!.PlainTextBody);
+        // The raw bytes travel too, or the attachment becomes unopenable by being filed.
+        Assert.Equal([1, 2, 3], await store.LoadMimeBytesAsync(account, "Trash", "uidl-1"));
+    }
+
+    [Fact]
+    public async Task Copy_LeavesTheSourceInPlace()
+    {
+        var store   = NewStore();
+        var account = Guid.NewGuid();
+        var pop     = new Pop3MailService(store);
+
+        await store.UpsertSummariesAsync([Msg(account, "uidl-1", "Inbox")]);
+        await pop.CopyMessagesAsync(account, "Inbox", ["uidl-1"], "Sent");
+
+        Assert.Single(await store.GetAllMessageIdsAsync(account, "Inbox"));
+        Assert.Single(await store.GetAllMessageIdsAsync(account, "Sent"));
+    }
+
+    [Fact]
+    public async Task PermanentDelete_RemovesFromTheStore_WhenTheServerIsNotInvolved()
+    {
+        var store   = NewStore();
+        var account = Guid.NewGuid();
+        var pop     = new Pop3MailService(store);
+
+        await store.UpsertSummariesAsync([Msg(account, "uidl-1", "Trash")]);
+
+        // The account is not registered, so there is no server leg to run — and no exception either:
+        // the local delete must still happen.
+        await pop.PermanentlyDeleteBatchAsync(account, "Trash", ["uidl-1"]);
+
+        Assert.Empty(await store.GetAllMessageIdsAsync(account, "Trash"));
+    }
+
+    [Fact]
+    public async Task EmptyTrash_ReportsWhatItRemoved()
+    {
+        var store   = NewStore();
+        var account = Guid.NewGuid();
+        var pop     = new Pop3MailService(store);
+
+        await store.UpsertSummariesAsync([Msg(account, "a", "Trash"), Msg(account, "b", "Trash")]);
+
+        Assert.Equal(2, await pop.CountTrashMessagesAsync(account));
+        Assert.Equal(2, await pop.EmptyTrashAsync(account));
+        Assert.Equal(0, await pop.CountTrashMessagesAsync(account));
+    }
+
+    // ── Local mail (sent, drafts) ────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Draft_IsStoredLocally_UnderAnIdThatIsNotAUidl()
+    {
+        var store   = NewStore();
+        var account = Guid.NewGuid();
+        var pop     = new Pop3MailService(store);
+
+        var id = await pop.AppendDraftAsync(account, new ComposeModel
+        {
+            To = "someone@example.com", Subject = "Draft subject", Body = "draft body",
+        }, replaceMessageId: null);
+
+        Assert.StartsWith(Pop3MailService.LocalIdPrefix, id);
+        var drafts = await store.LoadFolderSummariesAsync(account, "Drafts");
+        Assert.Equal("Draft subject", drafts.Single().Subject);
+        // Locally-authored mail is not unread mail — it would otherwise inflate the Drafts badge.
+        Assert.True(drafts.Single().IsRead);
+    }
+
+    [Fact]
+    public async Task ReplacingADraft_LeavesOnlyTheNewOne()
+    {
+        var store   = NewStore();
+        var account = Guid.NewGuid();
+        var pop     = new Pop3MailService(store);
+
+        var first  = await pop.AppendDraftAsync(account, new ComposeModel { Subject = "v1" }, null);
+        var second = await pop.AppendDraftAsync(account, new ComposeModel { Subject = "v2" }, first);
+
+        var drafts = await store.LoadFolderSummariesAsync(account, "Drafts");
+        Assert.Equal(second, drafts.Single().MessageId);
+        Assert.Equal("v2", drafts.Single().Subject);
+    }
+
+    [Fact]
+    public async Task SentMail_LandsInTheSyntheticSentFolder()
+    {
+        var store   = NewStore();
+        var account = Guid.NewGuid();
+        var pop     = new Pop3MailService(store);
+
+        await pop.AppendToSentAsync(account, new ComposeModel
+        {
+            To = "someone@example.com", Subject = "Sent subject", Body = "sent body",
+        });
+
+        Assert.Equal("Sent subject", (await store.LoadFolderSummariesAsync(account, "Sent")).Single().Subject);
+    }
+
+    // ── Reading ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task OpeningAMessageThatWasNeverDownloaded_SaysSo()
+    {
+        var pop = new Pop3MailService(NewStore());
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => pop.GetMessageDetailAsync(Guid.NewGuid(), "Inbox", "uidl-1"));
+
+        // Never a silent empty state: the message says what is wrong.
+        Assert.Contains("local store", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task MarkRead_AndFlag_AreLocalOnly()
+    {
+        var store   = NewStore();
+        var account = Guid.NewGuid();
+        var pop     = new Pop3MailService(store);
+
+        await store.UpsertSummariesAsync([Msg(account, "uidl-1", "Inbox")]);
+
+        await pop.MarkReadAsync(account, "Inbox", "uidl-1");
+        await pop.SetMessageFlaggedAsync(account, "Inbox", "uidl-1", flagged: true);
+
+        var row = (await store.LoadFolderSummariesAsync(account, "Inbox")).Single();
+        Assert.True(row.IsRead);
+        Assert.Equal(FlagDefinition.BuiltInFlagId.ToString(), row.FlagId);
+
+        await pop.SetMessageFlaggedAsync(account, "Inbox", "uidl-1", flagged: false);
+        Assert.Null((await store.LoadFolderSummariesAsync(account, "Inbox")).Single().FlagId);
+    }
+
+    [Fact]
+    public async Task InboxStatus_AndPreviews_ComeFromTheStore()
+    {
+        var store   = NewStore();
+        var account = Guid.NewGuid();
+        var pop     = new Pop3MailService(store);
+
+        await store.UpsertSummariesAsync([
+            Msg(account, "a", "Inbox", isRead: true),
+            Msg(account, "b", "Inbox", isRead: false),
+        ]);
+
+        Assert.Equal((2, 1), await pop.GetInboxStatusAsync(account));
+
+        var previews = await pop.FetchPreviewsAsync(account, "Inbox", ["a", "b"], maxLines: 3);
+        Assert.Equal("preview text", previews["a"]);
+    }
+
+    [Fact]
+    public async Task NoOp_DoesNothing_AndDisposeIsSafe()
+    {
+        var pop = new Pop3MailService(NewStore());
+        await pop.NoOpAsync(Guid.NewGuid());   // no persistent connection to keep alive
+        pop.Dispose();
+        pop.Dispose();                          // idempotent
+    }
+
+    [Fact]
+    public void IsConnected_IsFalseUntilTheAccountAuthenticates()
+        => Assert.False(new Pop3MailService(NewStore()).IsConnected(Guid.NewGuid()));
+
+    [Fact]
+    public async Task Connect_WithoutAPassword_SaysWhatIsMissing()
+    {
+        var pop = new Pop3MailService(NewStore());
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => pop.ConnectAsync(new AccountModel { Username = "me@example.com" }, password: null));
+
+        Assert.Contains("password", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ── Mapping a downloaded message onto the models ─────────────────────────────
+
+    [Fact]
+    public void Summary_MatchesTheImapBackendsConventions()
+    {
+        var account = Guid.NewGuid();
+        var msg     = BuildMime(subject: "Quarterly report");
+
+        var summary = Pop3MailService.BuildSummary(account, "uidl-1", msg, "Inbox", isRead: false);
+
+        Assert.Equal("uidl-1", summary.MessageId);
+        // Display name in the list, like ImapMailService.SummaryToModel.
+        Assert.Equal("Kelly Ford", summary.From);
+        Assert.Equal("Quarterly report", summary.Subject);
+        // Carried so aggregate views can collapse duplicates and a reply can thread (#220).
+        Assert.Equal("abc@example.com", summary.InternetMessageId);
+        Assert.Equal("Line one Line two", summary.Preview);
+        Assert.False(summary.IsRead);
+    }
+
+    [Fact]
+    public void Summary_FallsBackForAMessageWithNoSubjectAndNoDate()
+    {
+        var msg = BuildMime(subject: "");
+        msg.Date = default;
+
+        var summary = Pop3MailService.BuildSummary(Guid.NewGuid(), "uidl-1", msg, "Inbox", isRead: false);
+
+        Assert.Equal("(no subject)", summary.Subject);
+        // Not DateTimeOffset.MinValue: an undated message sorts to the top and counts as arriving
+        // now, which is what the sweep's window test needs it to be.
+        Assert.True(summary.Date > DateTimeOffset.UtcNow.AddMinutes(-5));
+    }
+
+    [Fact]
+    public void Summary_DetectsAMailingList()
+    {
+        var msg = BuildMime(customize: m => m.Headers.Add("List-Id", "<quickmail.example.com>"));
+        Assert.True(Pop3MailService.BuildSummary(Guid.NewGuid(), "u", msg, "Inbox", false).IsMailingList);
+        Assert.False(Pop3MailService.BuildSummary(Guid.NewGuid(), "u", BuildMime(), "Inbox", false).IsMailingList);
+    }
+
+    [Fact]
+    public void Preview_FallsBackToTheHtmlBody()
+    {
+        var msg = BuildMime(text: null, html: "<p>Hello <b>there</b></p>");
+        var preview = Pop3MailService.BuildSummary(Guid.NewGuid(), "u", msg, "Inbox", false).Preview;
+
+        Assert.Contains("Hello", preview);
+        Assert.DoesNotContain("<p>", preview);
+    }
+
+    [Fact]
+    public void Detail_CarriesFullAddresses_AndTheComposeMode()
+    {
+        var msg = BuildMime(customize: m =>
+        {
+            m.Cc.Add(new MailboxAddress("Cc Person", "cc@example.com"));
+            m.ReplyTo.Add(new MailboxAddress("Reply Person", "reply@example.com"));
+            m.Headers.Add("X-QuickMail-Compose-Mode", "markdown");
+        });
+
+        var detail = Pop3MailService.BuildDetail(Guid.NewGuid(), "u", msg, "Drafts", isRead: true);
+
+        Assert.Contains("kelly@example.com", detail.From);
+        Assert.Contains("cc@example.com", detail.Cc);
+        Assert.Contains("reply@example.com", detail.ReplyTo);
+        Assert.Equal(ComposeMode.Markdown, detail.DraftComposeMode);
+    }
+
+    [Fact]
+    public void Detail_MeasuresAttachmentsAndIndexesThemForLaterExtraction()
+    {
+        var payload = new byte[5000];
+        Array.Fill(payload, (byte)7);
+
+        var msg = BuildMime(customize: m =>
+        {
+            var builder = new BodyBuilder { TextBody = "see attached" };
+            builder.Attachments.Add("report.pdf", payload, new ContentType("application", "pdf"));
+            m.Body = builder.ToMessageBody();
+        });
+
+        var detail = Pop3MailService.BuildDetail(Guid.NewGuid(), "u", msg, "Inbox", isRead: false);
+
+        var attachment = Assert.Single(detail.Attachments);
+        Assert.Equal("report.pdf", attachment.FileName);
+        // The DECODED size. Reporting the base64 length would overstate the file by a third.
+        Assert.Equal(payload.Length, attachment.FileSize);
+        // Index into MimeMessage.Attachments, which is what DownloadAttachmentAsync walks.
+        Assert.Equal("0", attachment.PartSpecifier);
+        Assert.True(detail.HasAttachments);
+    }
+
+    [Fact]
+    public void Detail_ParsesACalendarInvite()
+    {
+        const string ics = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            METHOD:REQUEST
+            BEGIN:VEVENT
+            UID:invite-1
+            SUMMARY:Design review
+            DTSTART:20260901T150000Z
+            DTEND:20260901T160000Z
+            END:VEVENT
+            END:VCALENDAR
+            """;
+
+        var msg = BuildMime(customize: m =>
+        {
+            var mixed = new Multipart("mixed") { new TextPart("plain") { Text = "invite" } };
+            mixed.Add(new TextPart("calendar") { Text = ics });
+            m.Body = mixed;
+        });
+
+        var detail = Pop3MailService.BuildDetail(Guid.NewGuid(), "u", msg, "Inbox", isRead: false);
+
+        // The raw ICS is what gets cached, and for POP3 the cache is the only copy — an invite whose
+        // card came only from a live parse would vanish the moment it was stored (#297).
+        Assert.Contains("Design review", detail.CalendarIcs);
+        Assert.NotNull(detail.CalendarInvite);
+    }
+
+    [Fact]
+    public async Task Attachment_IsExtractedFromTheStoredBytes()
+    {
+        var store   = NewStore();
+        var account = Guid.NewGuid();
+        var pop     = new Pop3MailService(store);
+        var payload = new byte[] { 10, 20, 30, 40 };
+
+        var msg = BuildMime(customize: m =>
+        {
+            var builder = new BodyBuilder { TextBody = "see attached" };
+            builder.Attachments.Add("data.bin", payload, new ContentType("application", "octet-stream"));
+            m.Body = builder.ToMessageBody();
+        });
+
+        await store.UpsertDetailAsync(Pop3MailService.BuildDetail(account, "uidl-1", msg, "Inbox", false));
+        using (var ms = new MemoryStream())
+        {
+            await msg.WriteToAsync(ms);
+            await store.StoreMimeBytesAsync(account, "Inbox", "uidl-1", ms.ToArray());
+        }
+
+        var extracted = await pop.DownloadAttachmentAsync(account, "Inbox", "uidl-1", "0");
+        Assert.Equal(payload, extracted);
+    }
+
+    [Fact]
+    public async Task Attachment_WithNoStoredBytes_SaysWhyItCannotBeFetched()
+    {
+        var pop = new Pop3MailService(NewStore());
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => pop.DownloadAttachmentAsync(Guid.NewGuid(), "Inbox", "uidl-1", "0"));
+
+        Assert.Contains("re-fetch", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ── --online mode (no local store) ───────────────────────────────────────────
+
+    [Fact]
+    public async Task OnlineMode_ReadsAreEmptyRatherThanAStoreError()
+    {
+        // --online skips LocalStoreService.Initialize(), so every table is missing. Reading anyway
+        // put "SqliteException: no such table: MessageSummary" in the log on every aggregate load —
+        // seen for real when the app was run with --online and a POP3 account (#128).
+        var store   = NewStore();
+        var account = Guid.NewGuid();
+        var pop     = new Pop3MailService(store, onlineMode: true);
+
+        Assert.Empty(await pop.GetMessageSummariesAsync(account, "Inbox", 50));
+        Assert.Empty(await pop.GetMessagesSinceDateAsync(account, "Inbox", DateTime.UtcNow.AddDays(-30)));
+        Assert.Empty(await pop.GetMessagesSinceAsync(account, "Inbox", "0", 50));
+        Assert.Empty(await pop.GetFolderMessageIdsAsync(account, "Inbox"));
+        Assert.Empty(await pop.GetFolderMessageIdDatesAsync(account, "Inbox"));
+        Assert.Empty(await pop.FetchPreviewsAsync(account, "Inbox", ["a"], 3));
+        Assert.Equal((0, 0), await pop.GetInboxStatusAsync(account));
+        Assert.Equal(0, await pop.CountTrashMessagesAsync(account));
+        Assert.Equal(0, await pop.EmptyTrashAsync(account));
+    }
+
+    [Fact]
+    public async Task OnlineMode_StillListsTheFolders_SoTheAccountIsNotAnEmptyNode()
+    {
+        var pop = new Pop3MailService(NewStore(), onlineMode: true);
+        var folders = await pop.GetFoldersAsync(Guid.NewGuid());
+
+        Assert.Equal(["Inbox", "Sent", "Drafts", "Trash"], folders.Select(f => f.FullName));
+        Assert.All(folders, f => Assert.Equal(0, f.MessageCount));
+    }
+
+    [Fact]
+    public async Task OnlineMode_MutationsAreNoOps_AndReadsSayWhy()
+    {
+        var pop     = new Pop3MailService(NewStore(), onlineMode: true);
+        var account = Guid.NewGuid();
+
+        // No throw: a mark-read on a message that cannot exist is simply nothing to do.
+        await pop.MarkReadAsync(account, "Inbox", "uidl-1");
+        await pop.MarkReadBatchAsync(account, "Inbox", ["uidl-1"]);
+        await pop.SetMessageFlaggedAsync(account, "Inbox", "uidl-1", flagged: true);
+        await pop.MoveToTrashAsync(account, "Inbox", "uidl-1");
+        await pop.PermanentlyDeleteBatchAsync(account, "Trash", ["uidl-1"]);
+        await pop.AppendToSentAsync(account, new ComposeModel { Subject = "sent" });
+
+        // Opening one, though, has to explain itself rather than fail as a database error.
+        var open = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => pop.GetMessageDetailAsync(account, "Inbox", "uidl-1"));
+        Assert.Contains("--online", open.Message, StringComparison.Ordinal);
+
+        var attach = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => pop.DownloadAttachmentAsync(account, "Inbox", "uidl-1", "0"));
+        Assert.Contains("--online", attach.Message, StringComparison.Ordinal);
+
+        var draft = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => pop.AppendDraftAsync(account, new ComposeModel { Subject = "draft" }, null));
+        Assert.Contains("--online", draft.Message, StringComparison.Ordinal);
+    }
+
+    // ── The store columns POP3 depends on ────────────────────────────────────────
+
+    [Fact]
+    public async Task StoredMessageBytes_RoundTrip_AndAreDroppedWithTheMessage()
+    {
+        var store   = NewStore();
+        var account = Guid.NewGuid();
+        var bytes   = new byte[] { 1, 2, 3, 4, 5 };
+
+        await store.UpsertSummariesAsync([Msg(account, "uidl-1", "Inbox")]);
+        await store.UpsertDetailAsync(new MailMessageDetail
+        {
+            MessageId = "uidl-1", AccountId = account, FolderName = "Inbox", PlainTextBody = "body",
+        });
+
+        await store.StoreMimeBytesAsync(account, "Inbox", "uidl-1", bytes);
+        Assert.Equal(bytes, await store.LoadMimeBytesAsync(account, "Inbox", "uidl-1"));
+
+        // The bytes live on the detail row, so deleting the message takes them with it rather than
+        // leaving orphaned blobs in the database.
+        await store.DeleteSummariesAsync(account, "Inbox", ["uidl-1"]);
+        Assert.Null(await store.LoadMimeBytesAsync(account, "Inbox", "uidl-1"));
+    }
+
+    [Fact]
+    public async Task NoStoredBytes_ReadsAsNull_ForIMapAndGraphMessages()
+    {
+        var store   = NewStore();
+        var account = Guid.NewGuid();
+
+        await store.UpsertDetailAsync(new MailMessageDetail
+        {
+            MessageId = "42", AccountId = account, FolderName = "INBOX", PlainTextBody = "body",
+        });
+
+        Assert.Null(await store.LoadMimeBytesAsync(account, "INBOX", "42"));
+    }
+
+    [Fact]
+    public async Task CachedDetail_CarriesTheMessageId_SoAReplyThreads()
+    {
+        // ComposeViewModel puts MailMessageDetail.InternetMessageId in In-Reply-To. A cache-served
+        // open used to hand it an empty string; for POP3 the cache is the only copy, so nothing
+        // would ever fill it in later.
+        var store   = NewStore();
+        var account = Guid.NewGuid();
+
+        var summary = Msg(account, "uidl-1", "Inbox");
+        summary.InternetMessageId = "original@example.com";
+        await store.UpsertSummariesAsync([summary]);
+        await store.UpsertDetailAsync(new MailMessageDetail
+        {
+            MessageId = "uidl-1", AccountId = account, FolderName = "Inbox", PlainTextBody = "body",
+        });
+
+        var loaded = await store.LoadDetailAsync(account, "Inbox", "uidl-1");
+
+        Assert.NotNull(loaded);
+        Assert.Equal("original@example.com", loaded!.InternetMessageId);
+    }
+}

--- a/QuickMail.Tests/PropertiesBuilderTests.cs
+++ b/QuickMail.Tests/PropertiesBuilderTests.cs
@@ -275,6 +275,97 @@ public class AccountPropertiesBuilderTests
             i.Label == "Authentication" && i.Value.Contains("iCloud"));
     }
 
+    // ── Incoming section follows the backend (#128) ─────────────────────────
+    // Reading the IMAP fields regardless described the wrong protocol for every account that does
+    // not speak IMAP: a POP3 account showed a blank server on port 993, which is what sent this
+    // back for a second look after it was first tried.
+
+    private static AccountModel MakePop3Account() => new()
+    {
+        AccountName           = "POP mail",
+        Username              = "kelly@example.com",
+        AuthType              = AuthType.Password,
+        BackendKind           = BackendKind.Pop3Smtp,
+        Pop3Host              = "mail.example.com",
+        Pop3Port              = 995,
+        Pop3UseSsl            = true,
+        Pop3LeaveMailOnServer = true,
+        SmtpHost              = "mail.example.com",
+        SmtpPort              = 465,
+        SmtpUseSsl            = true,
+        // Left at their defaults, exactly as a real POP3 account has them — and precisely what must
+        // not be reported.
+        ImapPort              = 993,
+    };
+
+    [Fact]
+    public void Build_Pop3Account_DescribesPop3NotImap()
+    {
+        var (_, sections) = AccountPropertiesBuilder.Build(MakePop3Account(), null);
+
+        Assert.DoesNotContain(sections, s => s.Header.Contains("IMAP", StringComparison.Ordinal));
+
+        var incoming = sections.First(s => s.Header == "Incoming (POP3)");
+        Assert.Contains(incoming.Items, i => i.Label == "Server" && i.Value == "mail.example.com");
+        Assert.Contains(incoming.Items, i => i.Label == "Port"   && i.Value == "995");
+
+        // The unused IMAP default must not appear anywhere.
+        Assert.DoesNotContain(sections.SelectMany(s => s.Items), i => i.Value == "993");
+    }
+
+    [Fact]
+    public void Build_Pop3Account_SaysWhetherMailIsKeptOnTheServer()
+    {
+        var keeping = AccountPropertiesBuilder.Build(MakePop3Account(), null).Sections
+            .First(s => s.Header == "Incoming (POP3)");
+        Assert.Contains(keeping.Items, i => i.Label == "Mail on server" && i.Value.Contains("Kept", StringComparison.Ordinal));
+
+        var account = MakePop3Account();
+        account.Pop3LeaveMailOnServer = false;
+        var removing = AccountPropertiesBuilder.Build(account, null).Sections
+            .First(s => s.Header == "Incoming (POP3)");
+        Assert.Contains(removing.Items, i => i.Label == "Mail on server" && i.Value.Contains("Removed", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Build_Pop3Account_StillSendsOverSmtp()
+    {
+        var (_, sections) = AccountPropertiesBuilder.Build(MakePop3Account(), null);
+
+        var outgoing = sections.First(s => s.Header == "Outgoing (SMTP)");
+        Assert.Contains(outgoing.Items, i => i.Label == "Server" && i.Value == "mail.example.com");
+        Assert.Contains(outgoing.Items, i => i.Label == "Port"   && i.Value == "465");
+    }
+
+    [Fact]
+    public void Build_GraphAccount_DoesNotInventServerSettings()
+    {
+        // Graph clears the host fields, so this had the same defect as POP3: a blank server on
+        // port 993 for an account that has no servers at all.
+        var acct = MakeAccount(AuthType.OAuth2Microsoft);
+        acct.BackendKind = BackendKind.MicrosoftGraph;
+        acct.ImapHost = string.Empty;
+        acct.SmtpHost = string.Empty;
+
+        var (_, sections) = AccountPropertiesBuilder.Build(acct, null);
+
+        Assert.DoesNotContain(sections, s => s.Header.Contains("IMAP", StringComparison.Ordinal));
+        Assert.DoesNotContain(sections, s => s.Header.Contains("SMTP", StringComparison.Ordinal));
+        Assert.DoesNotContain(sections.SelectMany(s => s.Items), i => i.Value is "993" or "587");
+        Assert.Contains(sections.SelectMany(s => s.Items),
+            i => i.Label == "Connection" && i.Value.Contains("Graph", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Build_ImapAccount_IsUnchanged()
+    {
+        var (_, sections) = AccountPropertiesBuilder.Build(MakeAccount(), null);
+
+        var incoming = sections.First(s => s.Header == "Incoming (IMAP)");
+        Assert.Contains(incoming.Items, i => i.Label == "Server" && i.Value == "imap.work.com");
+        Assert.Contains(incoming.Items, i => i.Label == "Port"   && i.Value == "993");
+    }
+
     [Fact]
     public void Build_NeverExposeCredential()
     {

--- a/QuickMail.Tests/SavedViewsTests.cs
+++ b/QuickMail.Tests/SavedViewsTests.cs
@@ -914,6 +914,9 @@ public class SavedViewsMainViewModelTests
         public Task<MailMessageDetail?> LoadDetailAsync(Guid accountId, string folderName, string messageId) => Task.FromResult<MailMessageDetail?>(null);
         public Task StoreMimeBytesAsync(Guid accountId, string folderName, string messageId, byte[]? mimeBytes) => Task.CompletedTask;
         public Task<byte[]?> LoadMimeBytesAsync(Guid accountId, string folderName, string messageId) => Task.FromResult<byte[]?>(null);
+        public Task<HashSet<string>> LoadPop3CollectedUidlsAsync(Guid accountId) => Task.FromResult(new HashSet<string>());
+        public Task AddPop3CollectedUidlsAsync(Guid accountId, IEnumerable<string> uidls) => Task.CompletedTask;
+        public Task RemovePop3CollectedUidlsAsync(Guid accountId, IEnumerable<string> uidls) => Task.CompletedTask;
         public Task<string> GetMaxMessageKeyAsync(Guid accountId, string folderName) => Task.FromResult("0");
         public Task<HashSet<string>> GetAllMessageIdsAsync(Guid accountId, string folderName) => Task.FromResult(new HashSet<string>());
         public Task<Dictionary<string, bool>> LoadFolderReadStatesAsync(Guid accountId, string folderName) => Task.FromResult(new Dictionary<string, bool>());

--- a/QuickMail.Tests/SavedViewsTests.cs
+++ b/QuickMail.Tests/SavedViewsTests.cs
@@ -912,6 +912,8 @@ public class SavedViewsMainViewModelTests
         public Task<bool> HasSummariesMissingRecipientsAsync() => Task.FromResult(false);
         public Task UpsertDetailAsync(MailMessageDetail detail) => Task.CompletedTask;
         public Task<MailMessageDetail?> LoadDetailAsync(Guid accountId, string folderName, string messageId) => Task.FromResult<MailMessageDetail?>(null);
+        public Task StoreMimeBytesAsync(Guid accountId, string folderName, string messageId, byte[]? mimeBytes) => Task.CompletedTask;
+        public Task<byte[]?> LoadMimeBytesAsync(Guid accountId, string folderName, string messageId) => Task.FromResult<byte[]?>(null);
         public Task<string> GetMaxMessageKeyAsync(Guid accountId, string folderName) => Task.FromResult("0");
         public Task<HashSet<string>> GetAllMessageIdsAsync(Guid accountId, string folderName) => Task.FromResult(new HashSet<string>());
         public Task<Dictionary<string, bool>> LoadFolderReadStatesAsync(Guid accountId, string folderName) => Task.FromResult(new Dictionary<string, bool>());

--- a/QuickMail.Tests/SessionFeaturesTests.cs
+++ b/QuickMail.Tests/SessionFeaturesTests.cs
@@ -106,6 +106,9 @@ public class PreviewSuppressionTests
         public Task<MailMessageDetail?> LoadDetailAsync(Guid accountId, string folderName, string messageId) => Task.FromResult<MailMessageDetail?>(null);
         public Task StoreMimeBytesAsync(Guid accountId, string folderName, string messageId, byte[]? mimeBytes) => Task.CompletedTask;
         public Task<byte[]?> LoadMimeBytesAsync(Guid accountId, string folderName, string messageId) => Task.FromResult<byte[]?>(null);
+        public Task<HashSet<string>> LoadPop3CollectedUidlsAsync(Guid accountId) => Task.FromResult(new HashSet<string>());
+        public Task AddPop3CollectedUidlsAsync(Guid accountId, IEnumerable<string> uidls) => Task.CompletedTask;
+        public Task RemovePop3CollectedUidlsAsync(Guid accountId, IEnumerable<string> uidls) => Task.CompletedTask;
         public Task<string> GetMaxMessageKeyAsync(Guid accountId, string folderName) => Task.FromResult("0");
         public Task<HashSet<string>> GetAllMessageIdsAsync(Guid accountId, string folderName) => Task.FromResult(new HashSet<string>());
         public Task<Dictionary<string, bool>> LoadFolderReadStatesAsync(Guid accountId, string folderName) => Task.FromResult(new Dictionary<string, bool>());

--- a/QuickMail.Tests/SessionFeaturesTests.cs
+++ b/QuickMail.Tests/SessionFeaturesTests.cs
@@ -104,6 +104,8 @@ public class PreviewSuppressionTests
         public Task<bool> HasSummariesMissingRecipientsAsync() => Task.FromResult(false);
         public Task UpsertDetailAsync(MailMessageDetail detail) => Task.CompletedTask;
         public Task<MailMessageDetail?> LoadDetailAsync(Guid accountId, string folderName, string messageId) => Task.FromResult<MailMessageDetail?>(null);
+        public Task StoreMimeBytesAsync(Guid accountId, string folderName, string messageId, byte[]? mimeBytes) => Task.CompletedTask;
+        public Task<byte[]?> LoadMimeBytesAsync(Guid accountId, string folderName, string messageId) => Task.FromResult<byte[]?>(null);
         public Task<string> GetMaxMessageKeyAsync(Guid accountId, string folderName) => Task.FromResult("0");
         public Task<HashSet<string>> GetAllMessageIdsAsync(Guid accountId, string folderName) => Task.FromResult(new HashSet<string>());
         public Task<Dictionary<string, bool>> LoadFolderReadStatesAsync(Guid accountId, string folderName) => Task.FromResult(new Dictionary<string, bool>());

--- a/QuickMail.Tests/SettingsViewModelTests.cs
+++ b/QuickMail.Tests/SettingsViewModelTests.cs
@@ -43,6 +43,43 @@ public class SettingsViewModelTests
     }
 
     [Fact]
+    public void OfferPop3_RoundTripsThroughTheFeatureFlag()
+    {
+        // The checkbox exists so nobody has to hand-edit config.ini to try POP3 (#128). It is stored
+        // as the Pop3Backend feature flag, not as a setting of its own: --feature Pop3Backend is the
+        // same switch, and two spellings of one flag would disagree the moment a user set both.
+        var configService = new StubConfigService();
+        var registry = new StubCommandRegistry();
+
+        Assert.False(new SettingsViewModel(configService, registry).OfferPop3);
+
+        var cfg = new ConfigModel();
+        cfg.Features["Pop3Backend"] = "true";
+        configService.Save(cfg);
+        var vm = new SettingsViewModel(configService, registry);
+        Assert.True(vm.OfferPop3);
+
+        vm.OfferPop3 = false;
+        vm.SaveCommand.Execute(null);
+
+        // Written as an explicit "false" rather than removed, so a user who turns it back off stays
+        // off if the built-in default ever changes — the rule the Google flag already follows.
+        Assert.Equal("false", configService.Load().Features["Pop3Backend"]);
+        Assert.False(new ConfigFeatureGate(configService.Load(), []).IsEnabled(FeatureFlag.Pop3Backend));
+    }
+
+    [Fact]
+    public void OfferPop3_TurnedOn_ReachesTheFeatureGate()
+    {
+        // The whole point of the checkbox: what it writes is what the gate reads at the next start.
+        var configService = new StubConfigService();
+        var vm = new SettingsViewModel(configService, new StubCommandRegistry()) { OfferPop3 = true };
+        vm.SaveCommand.Execute(null);
+
+        Assert.True(new ConfigFeatureGate(configService.Load(), []).IsEnabled(FeatureFlag.Pop3Backend));
+    }
+
+    [Fact]
     public void ListDensity_RoundTripsThroughConfig_AndRadiosStayExclusive()
     {
         var configService = new StubConfigService();

--- a/QuickMail.Tests/StubServices.cs
+++ b/QuickMail.Tests/StubServices.cs
@@ -244,6 +244,18 @@ sealed class StubLocalStoreService : ILocalStoreService
     /// stand in for a cached invite email); otherwise it returns null like the real cache-miss path.</summary>
     public MailMessageDetail? SeededDetail { get; set; }
     public Task<MailMessageDetail?> LoadDetailAsync(Guid accountId, string folderName, string messageId) => Task.FromResult(SeededDetail);
+
+    /// <summary>Raw POP3 message bytes (#128), kept so a test can assert what was stored.</summary>
+    public Dictionary<(Guid AccountId, string Folder, string MessageId), byte[]?> MimeBytes { get; } = new();
+
+    public Task StoreMimeBytesAsync(Guid accountId, string folderName, string messageId, byte[]? mimeBytes)
+    {
+        MimeBytes[(accountId, folderName, messageId)] = mimeBytes;
+        return Task.CompletedTask;
+    }
+
+    public Task<byte[]?> LoadMimeBytesAsync(Guid accountId, string folderName, string messageId) =>
+        Task.FromResult(MimeBytes.TryGetValue((accountId, folderName, messageId), out var bytes) ? bytes : null);
     public Task<string> GetMaxMessageKeyAsync(Guid accountId, string folderName) => Task.FromResult("0");
     public Task<HashSet<string>> GetAllMessageIdsAsync(Guid accountId, string folderName) => Task.FromResult(new HashSet<string>());
     public Task<Dictionary<string, bool>> LoadFolderReadStatesAsync(Guid accountId, string folderName) => Task.FromResult(new Dictionary<string, bool>());

--- a/QuickMail.Tests/StubServices.cs
+++ b/QuickMail.Tests/StubServices.cs
@@ -256,6 +256,25 @@ sealed class StubLocalStoreService : ILocalStoreService
 
     public Task<byte[]?> LoadMimeBytesAsync(Guid accountId, string folderName, string messageId) =>
         Task.FromResult(MimeBytes.TryGetValue((accountId, folderName, messageId), out var bytes) ? bytes : null);
+
+    /// <summary>Functional in-memory POP3 collected-UIDL ledger, so backend tests exercise the real
+    /// record/prune arithmetic rather than a silent no-op.</summary>
+    public Dictionary<Guid, HashSet<string>> Pop3Uidls { get; } = [];
+    public Task<HashSet<string>> LoadPop3CollectedUidlsAsync(Guid accountId)
+        => Task.FromResult(Pop3Uidls.TryGetValue(accountId, out var set)
+            ? new HashSet<string>(set, StringComparer.Ordinal) : new HashSet<string>(StringComparer.Ordinal));
+    public Task AddPop3CollectedUidlsAsync(Guid accountId, IEnumerable<string> uidls)
+    {
+        if (!Pop3Uidls.TryGetValue(accountId, out var set))
+            Pop3Uidls[accountId] = set = new HashSet<string>(StringComparer.Ordinal);
+        set.UnionWith(uidls);
+        return Task.CompletedTask;
+    }
+    public Task RemovePop3CollectedUidlsAsync(Guid accountId, IEnumerable<string> uidls)
+    {
+        if (Pop3Uidls.TryGetValue(accountId, out var set)) set.ExceptWith(uidls);
+        return Task.CompletedTask;
+    }
     public Task<string> GetMaxMessageKeyAsync(Guid accountId, string folderName) => Task.FromResult("0");
     public Task<HashSet<string>> GetAllMessageIdsAsync(Guid accountId, string folderName) => Task.FromResult(new HashSet<string>());
     public Task<Dictionary<string, bool>> LoadFolderReadStatesAsync(Guid accountId, string folderName) => Task.FromResult(new Dictionary<string, bool>());

--- a/QuickMail.Tests/SyncServiceRuleApplicationTests.cs
+++ b/QuickMail.Tests/SyncServiceRuleApplicationTests.cs
@@ -93,9 +93,18 @@ public class SyncServiceRuleApplicationTests : IDisposable
         public List<MailMessageSummary> Batch { get; }
         public FetchStubMailService(List<MailMessageSummary> batch) => Batch = batch;
 
+        // POP3's fetches persist every download into the store BEFORE returning (the store is the
+        // only copy). Setting this reproduces that shape, which is what silently disabled rules:
+        // the chokepoint's post-fetch store snapshot read every arrival as already-known.
+        public Func<List<MailMessageSummary>, Task>? PersistOnFetch { get; set; }
+
         // The only method the IDLE paths call to fetch.
-        public Task<List<MailMessageSummary>> GetMessagesSinceAsync(Guid a, string f, string sinceId, int count, CancellationToken ct = default)
-            => Task.FromResult(Batch.Select(Clone).ToList());
+        public async Task<List<MailMessageSummary>> GetMessagesSinceAsync(Guid a, string f, string sinceId, int count, CancellationToken ct = default)
+        {
+            var batch = Batch.Select(Clone).ToList();
+            if (PersistOnFetch is not null) await PersistOnFetch(batch);
+            return batch;
+        }
 
         private static MailMessageSummary Clone(MailMessageSummary m) => new()
         {
@@ -114,10 +123,12 @@ public class SyncServiceRuleApplicationTests : IDisposable
         // assert the id-diff sweep skips the window fetch entirely when nothing is new, and pulls the
         // whole SyncDays window when there IS a new server id (#462).
         public DateTime? LastSinceDate { get; private set; }
-        public Task<List<MailMessageSummary>> GetMessagesSinceDateAsync(Guid a, string f, DateTime since, CancellationToken ct = default)
+        public async Task<List<MailMessageSummary>> GetMessagesSinceDateAsync(Guid a, string f, DateTime since, CancellationToken ct = default)
         {
             LastSinceDate = since;
-            return Task.FromResult(Batch.Select(Clone).ToList());
+            var batch = Batch.Select(Clone).ToList();
+            if (PersistOnFetch is not null) await PersistOnFetch(batch);
+            return batch;
         }
         public Task<MailMessageDetail> GetMessageDetailAsync(Guid a, string f, string id, CancellationToken ct = default) => Task.FromResult(new MailMessageDetail());
         public Task<MailMessageDetail> PrefetchMessageDetailAsync(Guid a, string f, string id, CancellationToken ct = default) => Task.FromResult(new MailMessageDetail());
@@ -172,6 +183,68 @@ public class SyncServiceRuleApplicationTests : IDisposable
         => new(imap, _store, new StubConfigService(), rules);
 
     // ── The verifications ────────────────────────────────────────────────────────
+
+    // ── POP3-shaped fetches (#128): the backend persists inside the fetch ─────────
+    // These three pin the pre-fetch snapshot plumbing. Without it, a backend that stores its
+    // downloads before returning (POP3 — the store is its only copy) made every arrival read as
+    // already-known at the chokepoint, and client rules silently never ran on that account.
+
+    [Fact]
+    public async Task Pop3ShapedSweep_PersistsInsideTheFetch_RulesStillRunOnTheArrival()
+    {
+        var known = Message("p0");
+        await _store.UpsertSummariesAsync([known]);   // steady state: the folder has cached mail
+
+        var arrival = Message("p1", read: false);
+        var imap = new FetchStubMailService([known, arrival])
+        {
+            PersistOnFetch = batch => _store.UpsertSummariesAsync(batch),
+            ServerIdDates  = [(known.MessageId, known.Date, known.IsRead), (arrival.MessageId, arrival.Date, false)],
+        };
+        var rules = new CapturingRuleService();
+
+        await Build(imap, rules).SyncFolderFullAsync(Account(), _inbox, CancellationToken.None);
+
+        // Only the arrival reaches the engine — not the cached message the window re-returned.
+        var call = Assert.Single(rules.Calls);
+        Assert.Equal([arrival.MessageId], call.Select(m => m.MessageId));
+    }
+
+    [Fact]
+    public async Task Pop3ShapedSweep_FirstSyncOfAnEmptyFolder_TreatsTheWholeFetchAsArrivals()
+    {
+        var arrival = Message("p1", read: false);
+        var imap = new FetchStubMailService([arrival])
+        {
+            PersistOnFetch = batch => _store.UpsertSummariesAsync(batch),
+        };
+        var rules = new CapturingRuleService();
+
+        await Build(imap, rules).SyncFolderFullAsync(Account(), _inbox, CancellationToken.None);
+
+        var call = Assert.Single(rules.Calls);
+        Assert.Equal([arrival.MessageId], call.Select(m => m.MessageId));
+    }
+
+    [Fact]
+    public async Task Pop3ShapedIdleSync_RunsRulesOnItsFreshDownloads()
+    {
+        // The targeted-sync path (delete/archive reconciliation): POP3's incremental fetch returns
+        // ONLY what it just downloaded and stored, so the whole batch is new by construction.
+        var arrival = Message("p1", read: false);
+        var imap = new FetchStubMailService([arrival])
+        {
+            PersistOnFetch = batch => _store.UpsertSummariesAsync(batch),
+        };
+        var rules = new CapturingRuleService();
+        var account = Account();
+        account.BackendKind = BackendKind.Pop3Smtp;
+
+        await Build(imap, rules).SyncOneFolderAsync(account, _inbox, CancellationToken.None);
+
+        var call = Assert.Single(rules.Calls);
+        Assert.Equal([arrival.MessageId], call.Select(m => m.MessageId));
+    }
 
     [Fact]
     public async Task LiveIdleSync_AppliesRulesToNewArrival()

--- a/QuickMail/App.xaml.cs
+++ b/QuickMail/App.xaml.cs
@@ -43,6 +43,7 @@ public partial class App : Application
     private GraphChangeNotifier? _graphNotifier;
     private ImapMailService? _imapBackend;
     private GraphMailService? _graphBackend;
+    private Pop3MailService? _pop3Backend;
     private UpdateCheckService? _updateCheckService;
     private ThemeService? _themeService;
     private BugReportService? _bugReportService;
@@ -269,14 +270,29 @@ public partial class App : Application
             _graphSendMail        = new GraphSendMailService(msOAuthService);
             var smtpService       = new SmtpService(oauthService, _graphSendMail);
 
+            // The local store is built before the backends because the POP3 backend reads and writes
+            // it directly: a POP3 mailbox has no server-side state to consult, so the store is not a
+            // cache of the account but the account itself.
+            var localStore = new LocalStoreService(profile);
+            if (!onlineMode)
+                localStore.Initialize();
+
+            _pop3Backend          = new Pop3MailService(localStore, onlineMode);
+            var pop3Backend       = _pop3Backend;
+
             // Per-account mail backend router. Each account is registered to the backend its
-            // BackendKind selects (IMAP by default, Graph for Microsoft 365 accounts).
-            IMailService BackendFor(AccountModel a)
-                => a.BackendKind == BackendKind.MicrosoftGraph ? graphBackend : imapBackend;
+            // BackendKind selects (IMAP by default, Graph for Microsoft 365 accounts, POP3 for
+            // POP3/SMTP accounts).
+            IMailService BackendFor(AccountModel a) => a.BackendKind switch
+            {
+                BackendKind.MicrosoftGraph => graphBackend,
+                BackendKind.Pop3Smtp       => pop3Backend,
+                _                          => imapBackend,
+            };
             // BackendFor is also handed to the router so an account it has never been told about —
             // the throwaway probe account Test Connection builds, for instance — is routed by its
             // BackendKind rather than defaulting to IMAP.
-            var mailRouter = new MailServiceRouter(new IMailService[] { imapBackend, graphBackend }, BackendFor);
+            var mailRouter = new MailServiceRouter(new IMailService[] { imapBackend, graphBackend, pop3Backend }, BackendFor);
 
             // ui-probe (#180 Decision D): network hard-off at the DI root. EVERY
             // consumer of the mail/send/oauth services gets the offline no-op —
@@ -287,10 +303,6 @@ public partial class App : Application
             IMailService effectiveMail = probeMode ? new ProbeOfflineMailService() : mailRouter;
             ISendMailService effectiveSmtp = probeMode ? new ProbeOfflineSendMailService() : smtpService;
             IOAuthService effectiveOAuth = probeMode ? new ProbeOfflineOAuthService() : oauthService;
-
-            var localStore = new LocalStoreService(profile);
-            if (!onlineMode)
-                localStore.Initialize();
 
             // Change-notification router (new-mail + reachability). IMAP's strategy is a held IDLE
             // connection, implemented by ImapMailService itself because it is bound to the IMAP
@@ -510,6 +522,7 @@ public partial class App : Application
         _graphNotifier?.Dispose();  // disposes the Graph poll CTS (StopWatchers already ran; idempotent)
         _imapBackend?.Dispose();    // closes connection pools (StopWatchers already ran, and is idempotent)
         _graphBackend?.Dispose();   // releases GraphClient/HttpClient; after the notifiers, which poll through its client
+        _pop3Backend?.Dispose();    // releases the per-account session locks (POP3 holds no open connection)
         _graphSendMail?.Dispose();
         _googlePeopleClient?.Dispose();
         _googleCalendarClient?.Dispose();

--- a/QuickMail/Helpers/AccountPropertiesBuilder.cs
+++ b/QuickMail/Helpers/AccountPropertiesBuilder.cs
@@ -20,23 +20,56 @@ public static class AccountPropertiesBuilder
             new("Email address",  account.Username),
         };
 
-        var imap = new List<PropertyItem>
+        // Incoming: whichever protocol this account actually receives over. Reading the IMAP fields
+        // regardless was wrong for every account that does not speak IMAP — a POP3 or Graph account
+        // showed a blank server on port 993, which is not a description of anything (#128).
+        var (incomingHeader, incoming) = account.BackendKind switch
         {
-            new("Server",   account.ImapHost),
-            new("Port",     account.ImapPort.ToString()),
-            new("Security", account.ImapUseSsl ? "SSL/TLS" : "STARTTLS"),
-            // AuthUsername, not Username: these two rows describe how the account CONNECTS, so on an
-            // account with a separate login name they must show the name actually sent (#396).
-            new("Username", account.AuthUsername),
+            BackendKind.Pop3Smtp => ("Incoming (POP3)", new List<PropertyItem>
+            {
+                new("Server",   account.Pop3Host),
+                new("Port",     account.Pop3Port.ToString()),
+                new("Security", account.Pop3UseSsl ? "SSL/TLS" : "STARTTLS"),
+                new("Username", account.AuthUsername),
+                // The setting with consequences: cleared, this computer holds the only copy.
+                new("Mail on server", account.Pop3LeaveMailOnServer
+                    ? "Kept after downloading"
+                    : "Removed once downloaded"),
+            }),
+
+            BackendKind.MicrosoftGraph => ("Incoming (Microsoft 365)", new List<PropertyItem>
+            {
+                new("Connection", "Microsoft Graph"),
+                new("Server",     "None — Graph uses the Microsoft 365 API"),
+                new("Username",   account.Username),
+            }),
+
+            _ => ("Incoming (IMAP)", new List<PropertyItem>
+            {
+                new("Server",   account.ImapHost),
+                new("Port",     account.ImapPort.ToString()),
+                new("Security", account.ImapUseSsl ? "SSL/TLS" : "STARTTLS"),
+                // AuthUsername, not Username: these two rows describe how the account CONNECTS, so on
+                // an account with a separate login name they must show the name actually sent (#396).
+                new("Username", account.AuthUsername),
+            }),
         };
 
-        var smtp = new List<PropertyItem>
-        {
-            new("Server",   account.SmtpHost),
-            new("Port",     account.SmtpPort.ToString()),
-            new("Security", account.SmtpUseSsl ? "SSL/TLS" : "STARTTLS"),
-            new("Username", account.AuthUsername),
-        };
+        // Outgoing: POP3 accounts send over SMTP exactly like IMAP ones, so only Graph differs.
+        var (outgoingHeader, outgoing) = account.BackendKind == BackendKind.MicrosoftGraph
+            ? ("Outgoing (Microsoft 365)", new List<PropertyItem>
+            {
+                new("Connection", "Microsoft Graph"),
+                new("Server",     "None — Graph uses the Microsoft 365 API"),
+                new("Username",   account.Username),
+            })
+            : ("Outgoing (SMTP)", new List<PropertyItem>
+            {
+                new("Server",   account.SmtpHost),
+                new("Port",     account.SmtpPort.ToString()),
+                new("Security", account.SmtpUseSsl ? "SSL/TLS" : "STARTTLS"),
+                new("Username", account.AuthUsername),
+            });
 
         var auth = new List<PropertyItem>
         {
@@ -57,10 +90,10 @@ public static class AccountPropertiesBuilder
 
         var sections = new List<PropertySection>
         {
-            new("Identity",        identity),
-            new("Incoming (IMAP)", imap),
-            new("Outgoing (SMTP)", smtp),
-            new("Authentication",  auth),
+            new("Identity",       identity),
+            new(incomingHeader,   incoming),
+            new(outgoingHeader,   outgoing),
+            new("Authentication", auth),
         };
 
         // Add Sync section if cache information is available (not in --online mode).

--- a/QuickMail/Models/AccountModel.cs
+++ b/QuickMail/Models/AccountModel.cs
@@ -92,6 +92,48 @@ public partial class AccountModel : ObservableObject
     /// </summary>
     public bool Pop3LeaveMailOnServer { get; set; } = true;
 
+    // ── The incoming leg, whichever protocol serves it ───────────────────────────
+    // Code that cares about "the server this account receives from" — grouping accounts by host at
+    // connect time, deciding whether a reconfigured account still describes the same connection —
+    // must not reach for the IMAP fields directly. A POP3 account leaves those at their defaults, so
+    // an IMAP-only reading sees every POP3 account as the same empty host on port 993 (#128).
+
+    /// <summary>The host this account receives mail from. Empty for Graph, which has no server.</summary>
+    [JsonIgnore]
+    public string IncomingHost => BackendKind switch
+    {
+        BackendKind.Pop3Smtp       => Pop3Host,
+        BackendKind.MicrosoftGraph => string.Empty,
+        _                          => ImapHost,
+    };
+
+    /// <summary>The port that goes with <see cref="IncomingHost"/>. 0 for Graph.</summary>
+    [JsonIgnore]
+    public int IncomingPort => BackendKind switch
+    {
+        BackendKind.Pop3Smtp       => Pop3Port,
+        BackendKind.MicrosoftGraph => 0,
+        _                          => ImapPort,
+    };
+
+    /// <summary>Implicit TLS on the incoming connection. False for Graph, which has none.</summary>
+    [JsonIgnore]
+    public bool IncomingUseSsl => BackendKind switch
+    {
+        BackendKind.Pop3Smtp       => Pop3UseSsl,
+        BackendKind.MicrosoftGraph => false,
+        _                          => ImapUseSsl,
+    };
+
+    /// <summary>Whether the incoming connection accepts an invalid certificate.</summary>
+    [JsonIgnore]
+    public bool IncomingAcceptInvalidCert => BackendKind switch
+    {
+        BackendKind.Pop3Smtp       => Pop3AcceptInvalidCert,
+        BackendKind.MicrosoftGraph => false,
+        _                          => ImapAcceptInvalidCert,
+    };
+
     // SMTP
     public string SmtpHost { get; set; } = string.Empty;
     public int SmtpPort { get; set; } = 587;

--- a/QuickMail/Models/AccountModel.cs
+++ b/QuickMail/Models/AccountModel.cs
@@ -75,6 +75,23 @@ public partial class AccountModel : ObservableObject
     public bool ImapUseSsl { get; set; } = true;
     public bool ImapAcceptInvalidCert { get; set; } = false;
 
+    // POP3
+    public string Pop3Host { get; set; } = string.Empty;
+    public int Pop3Port { get; set; } = 995;
+    public bool Pop3UseSsl { get; set; } = true;
+    public bool Pop3AcceptInvalidCert { get; set; } = false;
+
+    /// <summary>
+    /// When true (the default), downloaded messages are left on the server so other clients can
+    /// still collect them. When false, a message is deleted from the server once it is stored
+    /// locally — the classic POP3 behavior.
+    /// <para>QuickMail still files deletes through a local Trash folder either way: a message the
+    /// user deletes is moved to Trash and only removed from the server when Trash is emptied or the
+    /// message is permanently deleted. Because the local store is the only copy of POP3 mail, that
+    /// second step is the point of no return.</para>
+    /// </summary>
+    public bool Pop3LeaveMailOnServer { get; set; } = true;
+
     // SMTP
     public string SmtpHost { get; set; } = string.Empty;
     public int SmtpPort { get; set; } = 587;

--- a/QuickMail/Models/BackendKind.cs
+++ b/QuickMail/Models/BackendKind.cs
@@ -11,4 +11,11 @@ public enum BackendKind
 
     /// <summary>Microsoft Graph for receive + send. Used for M365 / Outlook.com.</summary>
     MicrosoftGraph,
+
+    /// <summary>
+    /// POP3 for receive + SMTP for send. Messages are downloaded in full at sync time and live in
+    /// the local store — which is the only copy once the server drops them, so nothing in the app
+    /// may delete cached POP3 mail on the strength of a server listing.
+    /// </summary>
+    Pop3Smtp,
 }

--- a/QuickMail/Models/FeatureFlag.cs
+++ b/QuickMail/Models/FeatureFlag.cs
@@ -52,4 +52,18 @@ public enum FeatureFlag
     /// launch. Flips to true by default once the feature is complete.
     /// </summary>
     SharedMailboxes,
+
+    /// <summary>
+    /// Offers POP3/SMTP as a connection method in the Add Account dialog (#128).
+    ///
+    /// Only the OFFER is gated, exactly as with <see cref="GoogleAuth"/>: an account already saved
+    /// with <see cref="QuickMail.Models.BackendKind.Pop3Smtp"/> connects, syncs and sends normally
+    /// whatever this is set to, and the Account Manager still shows its POP3 server settings. Turning
+    /// the flag off after adding an account therefore hides the option without stranding the mail.
+    ///
+    /// Default: false. POP3 puts the only copy of a message in the local store, so it stays opt-in
+    /// until it has run against real servers. Turn it on with Pop3Backend=true under [features] in
+    /// config.ini, or --feature Pop3Backend at launch.
+    /// </summary>
+    Pop3Backend,
 }

--- a/QuickMail/Models/MailProvider.cs
+++ b/QuickMail/Models/MailProvider.cs
@@ -26,6 +26,13 @@ namespace QuickMail.Models;
 /// than the account password. Null means no hint.
 /// </param>
 /// <param name="AppPasswordUrl">Where the user generates that app password. Null when there is none.</param>
+/// <param name="Pop3Host">
+/// This provider's POP3 host, for the users who choose POP3 as the connection method (#128). Null
+/// when the provider offers no POP3 service (iCloud) or when POP3 is not a sensible route to it —
+/// the POP3 host box is then left for the user to fill in rather than pre-filled with a guess.
+/// Optional and trailing so every existing construction site is untouched.
+/// </param>
+/// <param name="Pop3Port">POP3 port to go with <paramref name="Pop3Host"/>. 995 is implicit TLS.</param>
 public sealed record MailProvider(
     string Id,
     string DisplayName,
@@ -40,8 +47,13 @@ public sealed record MailProvider(
     bool SupportsOAuth,
     BackendKind DefaultBackend,
     string? AppPasswordHint,
-    string? AppPasswordUrl)
+    string? AppPasswordUrl,
+    string? Pop3Host = null,
+    int Pop3Port = 995)
 {
+    /// <summary>True when QuickMail knows a POP3 host for this provider.</summary>
+    public bool SupportsPop3 => !string.IsNullOrEmpty(Pop3Host);
+
     /// <summary>The catch-all entry: no known settings, user fills in Advanced settings by hand.</summary>
     public bool IsOther => Domains.Length == 0;
 

--- a/QuickMail/Services/ConfigFeatureGate.cs
+++ b/QuickMail/Services/ConfigFeatureGate.cs
@@ -27,6 +27,10 @@ public class ConfigFeatureGate : IFeatureGate
         // sole creation path, stays hidden until the feature is whole. Set SharedMailboxes=true under
         // [features] to test.
         [FeatureFlag.SharedMailboxes] = false,
+        // Off until POP3 (#128) has run against real servers. The local store holds the only copy of
+        // POP3 mail, so the cost of a wrong assumption is a user's mail, not a re-sync. Set
+        // Pop3Backend=true under [features] to test.
+        [FeatureFlag.Pop3Backend] = false,
     };
 
     private readonly Dictionary<string, string> _configFlags;

--- a/QuickMail/Services/ILocalStoreService.cs
+++ b/QuickMail/Services/ILocalStoreService.cs
@@ -65,6 +65,22 @@ public interface ILocalStoreService
     Task UpsertDetailAsync(MailMessageDetail detail);
     Task<MailMessageDetail?> LoadDetailAsync(Guid accountId, string folderName, string messageId);
 
+    // ── POP3 raw message bytes (#128) ────────────────────────────────────────────
+
+    /// <summary>
+    /// Stores the raw RFC 5322 bytes of a POP3 message so its attachments can be extracted later
+    /// without a second download — POP3 has no per-part fetch, so the bytes are the only way back to
+    /// the parts. Pass null to clear. Called only by <c>Pop3MailService</c>, and only after
+    /// <see cref="UpsertDetailAsync"/>; IMAP and Graph messages leave this null.
+    /// </summary>
+    Task StoreMimeBytesAsync(Guid accountId, string folderName, string messageId, byte[]? mimeBytes);
+
+    /// <summary>
+    /// Returns the bytes previously stored by <see cref="StoreMimeBytesAsync"/>, or null if none
+    /// were stored (IMAP/Graph messages, and POP3 messages with no attachments).
+    /// </summary>
+    Task<byte[]?> LoadMimeBytesAsync(Guid accountId, string folderName, string messageId);
+
     /// <summary>
     /// Returns the highest message key stored for this folder, or "0" if none. For the IMAP
     /// backend this is the numeric high-water UID, computed as MAX(CAST(unique_id AS INTEGER))

--- a/QuickMail/Services/ILocalStoreService.cs
+++ b/QuickMail/Services/ILocalStoreService.cs
@@ -81,6 +81,25 @@ public interface ILocalStoreService
     /// </summary>
     Task<byte[]?> LoadMimeBytesAsync(Guid accountId, string folderName, string messageId);
 
+    // ── POP3 collected-UIDL ledger (#128) ────────────────────────────────────────
+    // The persistent memory of which server UIDLs this profile has ever collected or destroyed.
+    // Message rows cannot carry this: a row moves out of the Inbox (delete, rule, manual filing) or
+    // leaves the store entirely (Empty Trash), and with leave-on-server on the UIDL is still listed
+    // by the server — without the ledger every one of those messages is re-downloaded into the
+    // Inbox as new mail on the next sweep, forever.
+
+    /// <summary>Every UIDL ever recorded for this account by <see cref="AddPop3CollectedUidlsAsync"/>.</summary>
+    Task<HashSet<string>> LoadPop3CollectedUidlsAsync(Guid accountId);
+
+    /// <summary>Records UIDLs as collected (or deliberately destroyed). Idempotent.</summary>
+    Task AddPop3CollectedUidlsAsync(Guid accountId, IEnumerable<string> uidls);
+
+    /// <summary>
+    /// Forgets UIDLs the server no longer lists. Pruning only — a UIDL absent from the server can
+    /// never be offered again, so remembering it buys nothing.
+    /// </summary>
+    Task RemovePop3CollectedUidlsAsync(Guid accountId, IEnumerable<string> uidls);
+
     /// <summary>
     /// Returns the highest message key stored for this folder, or "0" if none. For the IMAP
     /// backend this is the numeric high-water UID, computed as MAX(CAST(unique_id AS INTEGER))

--- a/QuickMail/Services/ImapMailService.cs
+++ b/QuickMail/Services/ImapMailService.cs
@@ -1878,7 +1878,10 @@ public class ImapMailService : IMailService, IChangeNotifier, IConnectionProbe
 
     private static readonly string[] _mailingListHeaders = { "List-Id" };
 
-    private static ComposeMode ParseComposeMode(string? header) => header?.ToLowerInvariant() switch
+    /// <summary>Shared with <see cref="Pop3MailService"/>, which reads the same header off a
+    /// downloaded <c>MimeMessage</c> so a QuickMail-authored draft reopens in the mode it was
+    /// written in whichever backend fetched it.</summary>
+    internal static ComposeMode ParseComposeMode(string? header) => header?.ToLowerInvariant() switch
     {
         "markdown" => ComposeMode.Markdown,
         "html"     => ComposeMode.Html,

--- a/QuickMail/Services/LocalStoreService.cs
+++ b/QuickMail/Services/LocalStoreService.cs
@@ -164,6 +164,12 @@ public class LocalStoreService : ILocalStoreService
                 sort_order            INTEGER NOT NULL DEFAULT 0,
                 PRIMARY KEY (account_id, full_name)
             );
+
+            CREATE TABLE IF NOT EXISTS Pop3CollectedUidl (
+                account_id TEXT NOT NULL,
+                uidl       TEXT NOT NULL,
+                PRIMARY KEY (account_id, uidl)
+            );
             """;
         cmd.ExecuteNonQuery();
 
@@ -508,10 +514,11 @@ public class LocalStoreService : ILocalStoreService
         await using var tx   = await conn.BeginTransactionAsync();
         await using var cmd  = conn.CreateCommand();
         cmd.CommandText =
-            "DELETE FROM MessageDetail  WHERE account_id = $aid;" +
-            "DELETE FROM MessageSummary WHERE account_id = $aid;" +
-            "DELETE FROM CalendarEvent  WHERE account_id = $aid;" +
-            "DELETE FROM Folder         WHERE account_id = $aid;";
+            "DELETE FROM MessageDetail     WHERE account_id = $aid;" +
+            "DELETE FROM MessageSummary    WHERE account_id = $aid;" +
+            "DELETE FROM CalendarEvent     WHERE account_id = $aid;" +
+            "DELETE FROM Folder            WHERE account_id = $aid;" +
+            "DELETE FROM Pop3CollectedUidl WHERE account_id = $aid;";
         cmd.Parameters.AddWithValue("$aid", accountId.ToString());
         await cmd.ExecuteNonQueryAsync();
         await tx.CommitAsync();
@@ -992,6 +999,60 @@ public class LocalStoreService : ILocalStoreService
         while (await r.ReadAsync())
             result.Add(r.GetString(0));
         return result;
+    }
+
+    public async Task<HashSet<string>> LoadPop3CollectedUidlsAsync(Guid accountId)
+    {
+        await using var conn = await OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT uidl FROM Pop3CollectedUidl WHERE account_id=$aid;";
+        cmd.Parameters.AddWithValue("$aid", accountId.ToString());
+        var result = new HashSet<string>(StringComparer.Ordinal);
+        await using var r = await cmd.ExecuteReaderAsync();
+        while (await r.ReadAsync())
+            result.Add(r.GetString(0));
+        return result;
+    }
+
+    public async Task AddPop3CollectedUidlsAsync(Guid accountId, IEnumerable<string> uidls)
+    {
+        var list = uidls as IReadOnlyList<string> ?? uidls.ToList();
+        if (list.Count == 0) return;
+
+        await using var conn = await OpenAsync();
+        await using var tx = (SqliteTransaction)await conn.BeginTransactionAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.Transaction = tx;
+        cmd.CommandText =
+            "INSERT OR IGNORE INTO Pop3CollectedUidl (account_id, uidl) VALUES ($aid, $uidl);";
+        var aid  = cmd.Parameters.AddWithValue("$aid", accountId.ToString());
+        var uidl = cmd.Parameters.AddWithValue("$uidl", string.Empty);
+        foreach (var u in list)
+        {
+            uidl.Value = u;
+            await cmd.ExecuteNonQueryAsync();
+        }
+        await tx.CommitAsync();
+    }
+
+    public async Task RemovePop3CollectedUidlsAsync(Guid accountId, IEnumerable<string> uidls)
+    {
+        var list = uidls as IReadOnlyList<string> ?? uidls.ToList();
+        if (list.Count == 0) return;
+
+        await using var conn = await OpenAsync();
+        await using var tx = (SqliteTransaction)await conn.BeginTransactionAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.Transaction = tx;
+        cmd.CommandText = "DELETE FROM Pop3CollectedUidl WHERE account_id=$aid AND uidl=$uidl;";
+        var aid  = cmd.Parameters.AddWithValue("$aid", accountId.ToString());
+        var uidl = cmd.Parameters.AddWithValue("$uidl", string.Empty);
+        foreach (var u in list)
+        {
+            uidl.Value = u;
+            await cmd.ExecuteNonQueryAsync();
+        }
+        await tx.CommitAsync();
     }
 
     public async Task<Dictionary<string, bool>> LoadFolderReadStatesAsync(Guid accountId, string folderName)

--- a/QuickMail/Services/LocalStoreService.cs
+++ b/QuickMail/Services/LocalStoreService.cs
@@ -168,6 +168,19 @@ public class LocalStoreService : ILocalStoreService
         cmd.ExecuteNonQuery();
 
         RunDataMigrations(conn);
+
+        // Raw RFC 5322 bytes of a POP3 message, stored only when the message has attachments (#128).
+        // POP3 has no equivalent of IMAP's fetch-one-body-part, so an attachment has to come back out
+        // of the message we already downloaded; keeping the bytes is what makes it openable later
+        // without a second full download. NULL for every IMAP and Graph row, and for POP3 messages
+        // with no attachments — which is why this is a nullable column on the existing detail table
+        // rather than a table of its own: DeleteSummariesAsync already drops the MessageDetail row,
+        // so the bytes cascade with the message instead of leaking.
+        //
+        // Deliberately AFTER RunDataMigrations, unlike the ALTERs above: the 1→2 migration rebuilds
+        // MessageDetail by CREATE/INSERT/DROP/RENAME against a fixed column list, so a column added
+        // before it would be dropped again and stay missing for the rest of the session.
+        RunMigration(conn, "ALTER TABLE MessageDetail ADD COLUMN mime_bytes BLOB DEFAULT NULL;");
     }
 
     // SQLite's PRAGMA user_version stores a single integer per database. We use it as a
@@ -869,7 +882,8 @@ public class LocalStoreService : ILocalStoreService
         // INNER JOIN returns nothing.
         cmd.CommandText = """
             SELECT d.to_addr, d.cc, d.reply_to, d.plain_body, d.html_body,
-                   s.from_disp, s.subject, s.date_ticks, s.is_read, d.attachments_json, d.calendar_ics
+                   s.from_disp, s.subject, s.date_ticks, s.is_read, d.attachments_json, d.calendar_ics,
+                   s.internet_message_id
             FROM MessageDetail d
             LEFT JOIN MessageSummary s USING (unique_id, account_id, folder_name)
             WHERE d.unique_id=$uid AND d.account_id=$aid AND d.folder_name=$fn;
@@ -916,10 +930,53 @@ public class LocalStoreService : ILocalStoreService
             Subject       = r.IsDBNull(6) ? "(no subject)" : r.GetString(6),
             Date          = r.IsDBNull(7) ? DateTimeOffset.MinValue : new DateTimeOffset(r.GetInt64(7), TimeSpan.Zero),
             IsRead        = !r.IsDBNull(8) && r.GetInt64(8) != 0,
+            // Carried from the summary row so a reply composed from a cached message still threads:
+            // ComposeViewModel puts this in In-Reply-To, and until now a cache-served open handed it
+            // an empty string. POP3 makes that permanent rather than incidental — the cache is the
+            // only copy, so there is no server fetch that would fill it in later.
+            InternetMessageId = r.IsDBNull(11) ? string.Empty : r.GetString(11),
             Attachments   = attachments,
             CalendarIcs   = calendarIcs,
             CalendarInvite = string.IsNullOrWhiteSpace(calendarIcs) ? null : IcsModel.Parse(calendarIcs),
         };
+    }
+
+    /// <summary>
+    /// Stores (or clears, when <paramref name="mimeBytes"/> is null) the raw message bytes on an
+    /// existing MessageDetail row. Only <c>Pop3MailService</c> calls this, and only after
+    /// <see cref="UpsertDetailAsync"/> has created the row — an UPDATE against a missing row is a
+    /// silent no-op, which is the right outcome for a message that is no longer cached.
+    /// </summary>
+    public async Task StoreMimeBytesAsync(Guid accountId, string folderName, string messageId, byte[]? mimeBytes)
+    {
+        await using var conn = await OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText =
+            "UPDATE MessageDetail SET mime_bytes=$bytes " +
+            "WHERE unique_id=$uid AND account_id=$aid AND folder_name=$fn;";
+        cmd.Parameters.AddWithValue("$bytes", (object?)mimeBytes ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("$uid",   messageId);
+        cmd.Parameters.AddWithValue("$aid",   accountId.ToString());
+        cmd.Parameters.AddWithValue("$fn",    folderName);
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    /// <summary>
+    /// Returns the raw message bytes previously stored by <see cref="StoreMimeBytesAsync"/>, or null
+    /// when none were stored (every IMAP/Graph message, and POP3 messages with no attachments).
+    /// </summary>
+    public async Task<byte[]?> LoadMimeBytesAsync(Guid accountId, string folderName, string messageId)
+    {
+        await using var conn = await OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText =
+            "SELECT mime_bytes FROM MessageDetail " +
+            "WHERE unique_id=$uid AND account_id=$aid AND folder_name=$fn;";
+        cmd.Parameters.AddWithValue("$uid", messageId);
+        cmd.Parameters.AddWithValue("$aid", accountId.ToString());
+        cmd.Parameters.AddWithValue("$fn",  folderName);
+        var result = await cmd.ExecuteScalarAsync();
+        return result as byte[];
     }
 
     public async Task<HashSet<string>> GetAllMessageIdsAsync(Guid accountId, string folderName)

--- a/QuickMail/Services/MailSecurity.cs
+++ b/QuickMail/Services/MailSecurity.cs
@@ -19,6 +19,10 @@ internal static class MailSecurity
     public static SecureSocketOptions ForImap(AccountModel account) =>
         Select(account.ImapUseSsl, account.RequireStartTls);
 
+    /// <summary>Connect option for this account's incoming (POP3) connection.</summary>
+    public static SecureSocketOptions ForPop3(AccountModel account) =>
+        Select(account.Pop3UseSsl, account.RequireStartTls);
+
     /// <summary>Connect option for this account's outgoing (SMTP) connection.</summary>
     public static SecureSocketOptions ForSmtp(AccountModel account) =>
         Select(account.SmtpUseSsl, account.RequireStartTls);

--- a/QuickMail/Services/Pop3MailService.cs
+++ b/QuickMail/Services/Pop3MailService.cs
@@ -1,0 +1,881 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MailKit.Net.Pop3;
+using MimeKit;
+using QuickMail.Models;
+
+namespace QuickMail.Services;
+
+/// <summary>
+/// <see cref="IMailService"/> implementation for POP3/SMTP accounts (#128). Send goes through the
+/// ordinary <see cref="SmtpService"/> path — only receive is POP3.
+///
+/// <para>How it differs from <see cref="ImapMailService"/>, and why the difference is structural
+/// rather than incidental:</para>
+/// <list type="bullet">
+/// <item>POP3 has one mailbox drop, no folders, no server-side per-message state, and no way to
+/// fetch part of a message. So every message is downloaded whole at sync time and everything the
+/// user does to it afterwards — read/unread, flags, move, delete-to-Trash — is local.</item>
+/// <item><b>The local store is the only copy.</b> Once a message is collected (and, with
+/// leave-on-server off, dropped from the server) nothing can fetch it again. That single fact drives
+/// the sync contract below: no code path may delete cached mail because a server listing did not
+/// mention it.</item>
+/// <item>Four synthetic folders are exposed — Inbox, Sent, Drafts, Trash — and only the Inbox is
+/// backed by the server. Folder CRUD throws <see cref="NotSupportedException"/>; callers gate on
+/// <see cref="BackendKind.Pop3Smtp"/> rather than catching.</item>
+/// </list>
+///
+/// <para><b>The sync contract (#462).</b> <c>SyncService</c> routes any folder whose max message key
+/// is "0" — which is every POP3 folder, since UIDLs are not numeric — through its id-diff sweep. That
+/// sweep asks a backend three things, and each answer here is chosen so the sweep behaves correctly
+/// against a mailbox the server keeps deleting from:</para>
+/// <list type="number">
+/// <item><see cref="GetFolderMessageIdDatesAsync"/> returns the UNION of the server's UIDLs and the
+/// ids already cached. The union is what makes the sweep's deletion reconcile a no-op: cached ids
+/// are never "missing from the server", so collected mail is never purged. Cached rows report their
+/// cached read state (so the read reconcile is a no-op too — POP3 has no server-side read state to
+/// reconcile against), and UIDLs we have never seen are reported as arriving now, which is what
+/// tells the sweep there is something to fetch.</item>
+/// <item><see cref="GetMessagesSinceDateAsync"/> is therefore the download trigger, not a store
+/// read: the sweep calls it when the listing showed something new, and the messages it returns are
+/// what reaches rules, the message list and the new-mail toast.</item>
+/// <item><see cref="GetFolderMessageIdsAsync"/> answers from the store alone, so the older
+/// <c>ReconcileFolderAsync</c> path (taken when a server happens to issue numeric UIDLs, giving the
+/// folder a real high-water mark) also diffs the cache against itself and deletes nothing.</item>
+/// </list>
+/// </summary>
+public class Pop3MailService : IMailService
+{
+    internal const string InboxFolder  = "Inbox";
+    internal const string SentFolder   = "Sent";
+    internal const string DraftsFolder = "Drafts";
+    internal const string TrashFolder  = "Trash";
+
+    /// <summary>Prefix for the synthetic ids of locally-authored messages (sent mail, drafts).
+    /// A real UIDL never collides with it, and <see cref="PermanentlyDeleteBatchAsync"/> uses it to
+    /// know an id was never on the server.</summary>
+    internal const string LocalIdPrefix = "local-";
+
+    private readonly ILocalStoreService _store;
+    private readonly bool _onlineMode;
+
+    private readonly ConcurrentDictionary<Guid, AccountModel> _accounts  = new();
+    private readonly ConcurrentDictionary<Guid, string>       _passwords = new();
+
+    /// <summary>
+    /// One POP3 session per account at a time. Not an optimization: RFC 1939 gives the server an
+    /// exclusive-access lock on the maildrop for the life of a session, so a second concurrent
+    /// connection is refused outright by most servers. The sweep can call the listing and the
+    /// download back to back, so this is load-bearing.
+    /// </summary>
+    private readonly ConcurrentDictionary<Guid, SemaphoreSlim> _locks = new();
+
+    private bool _disposed;
+
+    public Pop3MailService(ILocalStoreService store, bool onlineMode = false)
+    {
+        _store      = store;
+        _onlineMode = onlineMode;
+    }
+
+    // ── Connect / Disconnect ──────────────────────────────────────────────────
+
+    public async Task ConnectAsync(AccountModel account, string? password = null, CancellationToken ct = default)
+    {
+        ThrowIfDisposed();
+
+        if (string.IsNullOrEmpty(password))
+            throw new InvalidOperationException(
+                $"POP3 account {account.AuthUsername} has no password. POP3 accounts authenticate with a password; " +
+                "OAuth is not offered for this backend.");
+
+        // Probe first, register second, so a failed sign-in does not leave the account looking
+        // connected to IsConnected (and so the router never dispatches work at a bad credential).
+        using (var client = await OpenConnectionAsync(account, password, ct))
+            await client.DisconnectAsync(quit: false, ct);
+
+        _accounts[account.Id]  = account;
+        _passwords[account.Id] = password;
+        _locks.GetOrAdd(account.Id, _ => new SemaphoreSlim(1, 1));
+    }
+
+    public Task DisconnectAsync(Guid accountId, CancellationToken ct = default)
+    {
+        _accounts.TryRemove(accountId, out _);
+        _passwords.TryRemove(accountId, out _);
+        if (_locks.TryRemove(accountId, out var sem))
+            sem.Dispose();
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// True once <see cref="ConnectAsync"/> has authenticated successfully. POP3 holds no persistent
+    /// connection — a session is opened per operation — so registration, not a live socket, is the
+    /// analogue of IMAP's connection pool.
+    /// </summary>
+    public bool IsConnected(Guid accountId) => _accounts.ContainsKey(accountId);
+
+    // ── Folders ───────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The four synthetic folders, with counts read from the local store so the folder tree shows
+    /// real unread numbers (there is no server-side STATUS to ask).
+    /// </summary>
+    public async Task<List<MailFolderModel>> GetFoldersAsync(Guid accountId, CancellationToken ct = default)
+    {
+        var folders = new List<MailFolderModel>
+        {
+            new() { AccountId = accountId, FullName = InboxFolder,  DisplayName = "Inbox",  Kind = SpecialFolderKind.Inbox },
+            new() { AccountId = accountId, FullName = SentFolder,   DisplayName = "Sent",   Kind = SpecialFolderKind.Sent,   ExcludeFromAllMail = true },
+            new() { AccountId = accountId, FullName = DraftsFolder, DisplayName = "Drafts", Kind = SpecialFolderKind.Drafts, ExcludeFromAllMail = true },
+            new() { AccountId = accountId, FullName = TrashFolder,  DisplayName = "Trash",  Kind = SpecialFolderKind.Trash,  ExcludeFromAllMail = true },
+        };
+
+        if (_onlineMode) return folders;
+
+        foreach (var f in folders)
+        {
+            try
+            {
+                var readStates = await _store.LoadFolderReadStatesAsync(accountId, f.FullName);
+                f.MessageCount = readStates.Count;
+                f.UnreadCount  = readStates.Count(kv => !kv.Value);
+            }
+            catch (Exception ex)
+            {
+                // Counts are cosmetic; a store hiccup must not cost the user their folder list.
+                LogService.Log($"POP3: failed to count {f.FullName} for account {accountId}", ex);
+            }
+        }
+        return folders;
+    }
+
+    // ── Message fetch ─────────────────────────────────────────────────────────
+
+    public async Task<List<MailMessageSummary>> GetMessageSummariesAsync(
+        Guid accountId, string folderName, int maxMessages, CancellationToken ct = default)
+        => await LoadFromStoreAsync(accountId, folderName, maxMessages);
+
+    /// <summary>
+    /// The sweep's fetch, and therefore the download trigger — see the sync contract on the class.
+    /// Collects anything new from the server first, then returns the folder's messages inside the
+    /// window so the sweep surfaces them through the ordinary arrivals path (rules, list, toast).
+    /// <para>Mail older than the window is still downloaded and stored; it is simply not announced
+    /// as an arrival. That matters on a first sync of a mailbox holding a long backlog: the user
+    /// gets all of it in the Inbox, without a toast per message.</para>
+    /// </summary>
+    public async Task<List<MailMessageSummary>> GetMessagesSinceDateAsync(
+        Guid accountId, string folderName, DateTime since, CancellationToken ct = default)
+    {
+        if (IsInbox(folderName))
+            await DownloadNewMessagesAsync(accountId, ct);
+
+        var all = await LoadFromStoreAsync(accountId, folderName);
+        var sinceUtc = since.Kind == DateTimeKind.Unspecified
+            ? DateTime.SpecifyKind(since, DateTimeKind.Utc)
+            : since.ToUniversalTime();
+        return all.Where(m => m.Date.UtcDateTime >= sinceUtc).ToList();
+    }
+
+    /// <summary>
+    /// Incremental fetch. <paramref name="sinceMessageId"/> is ignored — POP3 has no high-water mark
+    /// and UIDLs carry no order, so the local store's id set is what decides which messages are new.
+    /// Returns only the messages actually downloaded on this call.
+    /// </summary>
+    public async Task<List<MailMessageSummary>> GetMessagesSinceAsync(
+        Guid accountId, string folderName, string sinceMessageId, int initialCount, CancellationToken ct = default)
+        => IsInbox(folderName)
+            ? await DownloadNewMessagesAsync(accountId, ct)
+            : [];
+
+    public async Task<MailMessageDetail> GetMessageDetailAsync(
+        Guid accountId, string folderName, string messageId, CancellationToken ct = default)
+    {
+        if (_onlineMode)
+            throw new InvalidOperationException(OnlineModeExplanation);
+
+        var detail = await _store.LoadDetailAsync(accountId, folderName, messageId);
+        if (detail is null)
+            throw new InvalidOperationException(
+                $"POP3 message {messageId} is not in the local store. POP3 messages are only readable " +
+                "after they have been downloaded by a sync.");
+        return detail;
+    }
+
+    public Task<MailMessageDetail> PrefetchMessageDetailAsync(
+        Guid accountId, string folderName, string messageId, CancellationToken ct = default)
+        => GetMessageDetailAsync(accountId, folderName, messageId, ct);
+
+    // ── State mutations (local-only) ──────────────────────────────────────────
+
+    public async Task MarkReadAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default)
+    {
+        if (_onlineMode) return;
+        await _store.UpdateIsReadAsync(accountId, folderName, messageId, isRead: true);
+    }
+
+    public async Task MarkReadBatchAsync(Guid accountId, string folderName, IList<string> messageIds, CancellationToken ct = default)
+    {
+        if (_onlineMode) return;
+        await _store.UpdateIsReadBatchAsync(messageIds.Select(id => (accountId, folderName, id)), isRead: true);
+    }
+
+    public async Task SetMessageFlaggedAsync(Guid accountId, string folderName, string messageId, bool flagged, CancellationToken ct = default)
+    {
+        if (_onlineMode) return;
+        await _store.UpdateFlagIdAsync(accountId, folderName, messageId,
+            flagged ? FlagDefinition.BuiltInFlagId.ToString() : null);
+    }
+
+    // ── Delete (local Trash, then the server) ─────────────────────────────────
+
+    public Task MoveToTrashAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default)
+        => MoveLocalAsync(accountId, folderName, TrashFolder, [messageId], copy: false);
+
+    public Task MoveToTrashBatchAsync(Guid accountId, string folderName, IList<string> messageIds, CancellationToken ct = default)
+        => MoveLocalAsync(accountId, folderName, TrashFolder, messageIds, copy: false);
+
+    /// <summary>
+    /// Removes messages from the local store, and — only when the account is set to remove collected
+    /// mail from the server — issues the matching DELEs.
+    /// <para>The DELE is addressed by index, and indexes are only meaningful within one session, so
+    /// every id is re-resolved against a fresh UIDL listing first. An id no longer listed (another
+    /// client collected it) is skipped rather than deleted by position: deleting the wrong message
+    /// off a POP3 server destroys the only copy.</para>
+    /// </summary>
+    public async Task PermanentlyDeleteBatchAsync(
+        Guid accountId, string folderName, IList<string> messageIds, CancellationToken ct = default)
+    {
+        if (_onlineMode) return;   // nothing was ever collected; see LoadFromStoreAsync
+
+        await _store.DeleteSummariesAsync(accountId, folderName, messageIds);
+
+        if (!_accounts.TryGetValue(accountId, out var account) || account.Pop3LeaveMailOnServer)
+            return;
+
+        // Locally-authored mail (sent, drafts) was never on the server; nothing to delete there.
+        var serverIds = messageIds.Where(id => !id.StartsWith(LocalIdPrefix, StringComparison.Ordinal)).ToList();
+        if (serverIds.Count == 0) return;
+
+        var wanted = new HashSet<string>(serverIds, StringComparer.Ordinal);
+        var sem = _locks.GetOrAdd(accountId, _ => new SemaphoreSlim(1, 1));
+        await sem.WaitAsync(ct);
+        try
+        {
+            using var client = await OpenConnectionAsync(accountId, ct);
+            var uidls = await client.GetMessageUidsAsync(ct);
+
+            bool anyDeleted = false;
+            for (int i = 0; i < uidls.Count; i++)
+            {
+                if (!wanted.Contains(uidls[i])) continue;
+                await client.DeleteMessageAsync(i, ct);
+                anyDeleted = true;
+            }
+
+            // QUIT is what commits the DELEs; a plain disconnect abandons them.
+            await client.DisconnectAsync(quit: anyDeleted, ct);
+            LogService.Log($"POP3 [{account.AccountLabel}]: permanently deleted {serverIds.Count} message(s) locally, {(anyDeleted ? "and on the server" : "none still on the server")}.");
+        }
+        finally
+        {
+            sem.Release();
+        }
+    }
+
+    public async Task<int> EmptyTrashAsync(Guid accountId, CancellationToken ct = default)
+    {
+        if (_onlineMode) return 0;
+
+        var trashIds = await _store.GetAllMessageIdsAsync(accountId, TrashFolder);
+        if (trashIds.Count == 0) return 0;
+        await PermanentlyDeleteBatchAsync(accountId, TrashFolder, trashIds.ToList(), ct);
+        return trashIds.Count;
+    }
+
+    public async Task<int> CountTrashMessagesAsync(Guid accountId, CancellationToken ct = default)
+        => _onlineMode ? 0 : (await _store.GetAllMessageIdsAsync(accountId, TrashFolder)).Count;
+
+    // ── Sent / Drafts (local-only) ────────────────────────────────────────────
+
+    public async Task AppendToSentAsync(Guid accountId, ComposeModel sent, CancellationToken ct = default)
+    {
+        // The message has already been sent over SMTP by the time this is called; with no store there
+        // is simply nowhere to file the copy, which is the same bargain --online makes for IMAP.
+        if (_onlineMode) return;
+
+        _accounts.TryGetValue(accountId, out var account);
+        var msg = MimeMessageBuilder.Build(sent, account ?? new AccountModel { Id = accountId }, null);
+        var id  = NewLocalId();
+        await StoreMessageAsync(accountId, id, msg, SentFolder, isRead: true, ct);
+    }
+
+    public async Task<string> AppendDraftAsync(
+        Guid accountId, ComposeModel draft, string? replaceMessageId, CancellationToken ct = default)
+    {
+        if (_onlineMode)
+            throw new InvalidOperationException(OnlineModeExplanation);
+
+        if (replaceMessageId is not null)
+            await _store.DeleteSummariesAsync(accountId, DraftsFolder, [replaceMessageId]);
+
+        _accounts.TryGetValue(accountId, out var account);
+        var msg = MimeMessageBuilder.Build(draft, account ?? new AccountModel { Id = accountId }, null);
+        var id  = NewLocalId();
+        await StoreMessageAsync(accountId, id, msg, DraftsFolder, isRead: true, ct);
+        return id;
+    }
+
+    public Task<string?> FindDraftsFolderNameAsync(Guid accountId, CancellationToken ct = default)
+        => Task.FromResult<string?>(DraftsFolder);
+
+    // ── Attachments (served from the stored message bytes) ────────────────────
+
+    public async Task<byte[]> DownloadAttachmentAsync(
+        Guid accountId, string folderName, string messageId, string partSpecifier, CancellationToken ct = default)
+    {
+        if (_onlineMode)
+            throw new InvalidOperationException(OnlineModeExplanation);
+
+        var mimeBytes = await _store.LoadMimeBytesAsync(accountId, folderName, messageId)
+            ?? throw new InvalidOperationException(
+                $"No stored message bytes for POP3 message {messageId} in {folderName}, so its attachment " +
+                "cannot be extracted. POP3 cannot re-fetch a single part from the server.");
+
+        using var ms = new MemoryStream(mimeBytes);
+        var message  = await MimeMessage.LoadAsync(ms, ct);
+        var parts    = message.Attachments.ToList();
+
+        if (!int.TryParse(partSpecifier, out var idx) || idx < 0 || idx >= parts.Count)
+            throw new InvalidOperationException(
+                $"Attachment '{partSpecifier}' is out of range for POP3 message {messageId} ({parts.Count} attachment(s)).");
+
+        if (parts[idx] is not MimePart part || part.Content is null)
+            throw new InvalidOperationException(
+                $"Attachment {idx} of POP3 message {messageId} is not a decodable MIME part.");
+
+        using var buf = new MemoryStream();
+        await part.Content.DecodeToAsync(buf, ct);
+        return buf.ToArray();
+    }
+
+    // ── Poll / keepalive / status ─────────────────────────────────────────────
+
+    public async Task<int> PollAsync(Guid accountId, string folderName, CancellationToken ct = default)
+        => (await DownloadNewMessagesAsync(accountId, ct)).Count;
+
+    /// <summary>No-op: POP3 keeps no connection open between operations, so there is nothing to keep alive.</summary>
+    public Task NoOpAsync(Guid accountId, CancellationToken ct = default) => Task.CompletedTask;
+
+    public async Task<(int Total, int Unread)> GetInboxStatusAsync(Guid accountId, CancellationToken ct = default)
+    {
+        if (_onlineMode) return (0, 0);
+
+        var readStates = await _store.LoadFolderReadStatesAsync(accountId, InboxFolder);
+        return (readStates.Count, readStates.Count(kv => !kv.Value));
+    }
+
+    // ── Id listings (the sweep's input — see the sync contract on the class) ──
+
+    /// <summary>
+    /// Store-backed by design. The deletion reconcile diffs the cache against this, so answering
+    /// from the server would delete every message the server has already dropped — which, with
+    /// leave-on-server off, is all of them.
+    /// </summary>
+    public async Task<IList<string>> GetFolderMessageIdsAsync(
+        Guid accountId, string folderName, CancellationToken ct = default)
+        => _onlineMode ? [] : (await _store.GetAllMessageIdsAsync(accountId, folderName)).ToList();
+
+    /// <summary>
+    /// The union of what the server lists and what the cache holds — see the sync contract on the
+    /// class for why each half is there.
+    /// <para>Cached rows carry their cached date and read state. Server UIDLs we have not seen are
+    /// reported as received now: their real date is inside the message, which POP3 cannot show us
+    /// without downloading it, and "now" is the answer that puts them inside the sweep's window so
+    /// the fetch actually happens.</para>
+    /// <para>Only the Inbox contacts the server; the synthetic folders have no server side, and in
+    /// <c>--online</c> mode there is no store, so both answer from what they have.</para>
+    /// </summary>
+    public async Task<IReadOnlyList<(string Id, DateTimeOffset ReceivedUtc, bool IsRead)>> GetFolderMessageIdDatesAsync(
+        Guid accountId, string folderName, CancellationToken ct = default)
+    {
+        var cached = await LoadFromStoreAsync(accountId, folderName);
+
+        if (!IsInbox(folderName) || _onlineMode || !_accounts.ContainsKey(accountId))
+            return MergeListing(cached, [], DateTimeOffset.UtcNow);
+
+        IList<string> serverUidls;
+        try
+        {
+            serverUidls = await ListServerUidlsAsync(accountId, ct);
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex)
+        {
+            // An unreachable server means "nothing new to report", never "the cache is stale".
+            // Reporting the cached half alone keeps the sweep's reconciles no-ops.
+            LogService.Log($"POP3: UIDL listing failed for account {accountId}", ex);
+            serverUidls = [];
+        }
+
+        return MergeListing(cached, serverUidls, DateTimeOffset.UtcNow);
+    }
+
+    /// <summary>
+    /// The sync contract's arithmetic, in one place so it can be tested directly: every cached
+    /// message, plus every server UIDL not already cached.
+    ///
+    /// <para>Cached rows keep their own date and read state — the sweep's read reconcile compares
+    /// against them, and POP3 has no server-side read state that could disagree. Unseen UIDLs are
+    /// stamped <paramref name="now"/> and unread, which is what puts them inside the sweep's window
+    /// so it fetches them.</para>
+    ///
+    /// <para>Cached ids are never dropped, whatever the server says. That is the whole point: the
+    /// sweep deletes cached ids missing from this list, and a POP3 server legitimately stops listing
+    /// a message the moment it is collected.</para>
+    /// </summary>
+    internal static IReadOnlyList<(string Id, DateTimeOffset ReceivedUtc, bool IsRead)> MergeListing(
+        IReadOnlyList<MailMessageSummary> cached, IEnumerable<string> serverUidls, DateTimeOffset now)
+    {
+        var result = cached
+            .Select(m => (Id: m.MessageId, ReceivedUtc: m.Date, m.IsRead))
+            .ToList();
+
+        var known = new HashSet<string>(result.Select(r => r.Id), StringComparer.Ordinal);
+        foreach (var uidl in serverUidls)
+            if (known.Add(uidl))
+                result.Add((uidl, now, false));
+
+        return result;
+    }
+
+    /// <summary>
+    /// Previews are built at download time and live in the store, so this needs no server round trip.
+    /// </summary>
+    public async Task<IReadOnlyDictionary<string, string>> FetchPreviewsAsync(
+        Guid accountId, string folderName, IList<string> messageIds,
+        int maxLines, CancellationToken ct = default)
+    {
+        if (_onlineMode) return new Dictionary<string, string>();
+
+        var wanted = new HashSet<string>(messageIds, StringComparer.Ordinal);
+        var summaries = await _store.LoadFolderSummariesAsync(accountId, folderName);
+        return summaries
+            .Where(s => wanted.Contains(s.MessageId) && !string.IsNullOrEmpty(s.Preview))
+            .ToDictionary(s => s.MessageId, s => s.Preview, StringComparer.Ordinal);
+    }
+
+    // ── Copy / Move (between the synthetic folders) ───────────────────────────
+
+    public Task CopyMessagesAsync(
+        Guid accountId, string folderName, IList<string> messageIds, string destinationFolder, CancellationToken ct = default)
+        => MoveLocalAsync(accountId, folderName, destinationFolder, messageIds, copy: true);
+
+    public Task MoveMessagesAsync(
+        Guid accountId, string folderName, IList<string> messageIds, string destinationFolder, CancellationToken ct = default)
+        => MoveLocalAsync(accountId, folderName, destinationFolder, messageIds, copy: false);
+
+    // ── Folder CRUD — not supported ───────────────────────────────────────────
+    // POP3 has no folder namespace. Callers gate on BackendKind (see MainViewModel's folder
+    // commands) so the user never reaches these; they throw rather than silently doing nothing.
+
+    public Task CreateFolderAsync(Guid accountId, string? parentFolderName, string name, CancellationToken ct = default)
+        => throw new NotSupportedException("POP3 accounts have no server folders, so folders cannot be created.");
+
+    public Task DeleteFolderAsync(Guid accountId, string folderName, CancellationToken ct = default)
+        => throw new NotSupportedException("POP3 accounts have no server folders, so folders cannot be deleted.");
+
+    public Task RenameFolderAsync(Guid accountId, string folderName, string newName, string? newParentFolderName, CancellationToken ct = default)
+        => throw new NotSupportedException("POP3 accounts have no server folders, so folders cannot be renamed or moved.");
+
+    public Task CopyFolderAsync(Guid accountId, string folderName, string? destinationParentName, CancellationToken ct = default)
+        => throw new NotSupportedException("POP3 accounts have no server folders, so folders cannot be copied.");
+
+    // ── Download ──────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Collects every UIDL the server holds that the store does not, storing each message whole.
+    /// Returns the messages downloaded on this call (empty when there is nothing new).
+    /// <para>Deduplication is by UIDL against the store, which is what makes this safe to call from
+    /// several sync paths — the sweep, a poll, an account's first load — without re-downloading.</para>
+    /// </summary>
+    private async Task<List<MailMessageSummary>> DownloadNewMessagesAsync(Guid accountId, CancellationToken ct)
+    {
+        var downloaded = new List<MailMessageSummary>();
+
+        if (_onlineMode)
+        {
+            // POP3 keeps mail nowhere but the store, so with no store there is nothing to sync into.
+            LogService.Log($"POP3: skipping sync for account {accountId} — --online mode has no local store.");
+            return downloaded;
+        }
+
+        if (!_accounts.TryGetValue(accountId, out var account))
+            return downloaded;
+
+        var seen = await _store.GetAllMessageIdsAsync(accountId, InboxFolder);
+
+        var sem = _locks.GetOrAdd(accountId, _ => new SemaphoreSlim(1, 1));
+        await sem.WaitAsync(ct);
+        try
+        {
+            using var client = await OpenConnectionAsync(accountId, ct);
+            if (client.Count == 0)
+            {
+                await client.DisconnectAsync(quit: false, ct);
+                return downloaded;
+            }
+
+            // Index into this list is the session-scoped message number the RETR/DELE commands take.
+            var uidls = await client.GetMessageUidsAsync(ct);
+            bool anyDeleted = false;
+
+            for (int i = 0; i < uidls.Count; i++)
+            {
+                ct.ThrowIfCancellationRequested();
+                var uidl = uidls[i];
+                if (seen.Contains(uidl)) continue;
+
+                MimeMessage msg;
+                try
+                {
+                    msg = await client.GetMessageAsync(i, ct);
+                }
+                catch (OperationCanceledException) { throw; }
+                catch (Exception ex)
+                {
+                    // One unreadable message must not stop the rest of the mailbox from arriving.
+                    LogService.Log($"POP3 [{account.AccountLabel}]: failed to download UIDL {uidl}", ex);
+                    continue;
+                }
+
+                var summary = await StoreMessageAsync(accountId, uidl, msg, InboxFolder, isRead: false, ct);
+                downloaded.Add(summary);
+
+                if (!account.Pop3LeaveMailOnServer)
+                {
+                    // Only after the message is committed to the store. DELEs take effect at QUIT.
+                    await client.DeleteMessageAsync(i, ct);
+                    anyDeleted = true;
+                }
+            }
+
+            await client.DisconnectAsync(quit: anyDeleted, ct);
+
+            if (downloaded.Count > 0)
+                LogService.Log($"POP3 [{account.AccountLabel}]: downloaded {downloaded.Count} new message(s)" +
+                               (anyDeleted ? ", removed from the server" : ", left on the server") + ".");
+            return downloaded;
+        }
+        finally
+        {
+            sem.Release();
+        }
+    }
+
+    /// <summary>Lists the server's UIDLs without retrieving anything. One short session.</summary>
+    private async Task<IList<string>> ListServerUidlsAsync(Guid accountId, CancellationToken ct)
+    {
+        var sem = _locks.GetOrAdd(accountId, _ => new SemaphoreSlim(1, 1));
+        await sem.WaitAsync(ct);
+        try
+        {
+            using var client = await OpenConnectionAsync(accountId, ct);
+            IList<string> uidls = client.Count == 0
+                ? new List<string>()
+                : await client.GetMessageUidsAsync(ct);
+            await client.DisconnectAsync(quit: false, ct);
+            return uidls;
+        }
+        finally
+        {
+            sem.Release();
+        }
+    }
+
+    // ── Storage ───────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Writes one downloaded (or locally authored) message to the store as summary + detail, keeping
+    /// the raw bytes when it has attachments so they can be extracted later.
+    /// </summary>
+    private async Task<MailMessageSummary> StoreMessageAsync(
+        Guid accountId, string messageId, MimeMessage msg, string folderName, bool isRead, CancellationToken ct)
+    {
+        var summary = BuildSummary(accountId, messageId, msg, folderName, isRead);
+        var detail  = BuildDetail(accountId, messageId, msg, folderName, isRead);
+
+        await _store.UpsertSummariesAsync([summary]);
+        await _store.UpsertDetailAsync(detail);
+
+        if (detail.Attachments.Count > 0)
+        {
+            using var ms = new MemoryStream();
+            await msg.WriteToAsync(ms, ct);
+            await _store.StoreMimeBytesAsync(accountId, folderName, messageId, ms.ToArray());
+        }
+
+        return summary;
+    }
+
+    /// <summary>
+    /// Loads a folder from the store for a caller on a sync path.
+    /// <para>The stamp matters: <c>SyncService</c> upserts whatever a fetch returns, and
+    /// <c>UpsertSummariesAsync</c> derives the stored flag from <see cref="MailMessageSummary.IsServerFlagged"/>
+    /// — an IMAP-shaped rule where the server is the authority on flags. POP3 has no server flag
+    /// state, so the local flag IS the state of record; without restating it, every sweep would
+    /// re-upsert these rows as unflagged and silently clear the user's flags.</para>
+    /// </summary>
+    private async Task<List<MailMessageSummary>> LoadFromStoreAsync(Guid accountId, string folderName, int? limit = null)
+    {
+        // --online skips LocalStoreService.Initialize(), so the tables do not exist. Reading anyway
+        // raises "no such table: MessageSummary" from every aggregate load — an error in the log for
+        // a supported configuration. A POP3 account in --online mode simply has no mail.
+        if (_onlineMode) return [];
+
+        var summaries = await _store.LoadFolderSummariesAsync(accountId, folderName, limit);
+        foreach (var s in summaries)
+            s.IsServerFlagged = s.IsFlagged;
+        return summaries;
+    }
+
+    /// <summary>
+    /// Copies or moves messages between the synthetic folders, carrying everything that makes the
+    /// message what it is: the stored row itself (so no field is lost when the model gains one), its
+    /// flag, its body and its raw bytes.
+    /// </summary>
+    private async Task MoveLocalAsync(
+        Guid accountId, string fromFolder, string toFolder, IList<string> messageIds, bool copy)
+    {
+        if (_onlineMode) return;   // no store, so there is nothing filed anywhere to move
+        if (string.Equals(fromFolder, toFolder, StringComparison.OrdinalIgnoreCase)) return;
+
+        var byId = (await _store.LoadFolderSummariesAsync(accountId, fromFolder))
+            .ToDictionary(s => s.MessageId, StringComparer.Ordinal);
+
+        foreach (var id in messageIds)
+        {
+            if (!byId.TryGetValue(id, out var summary)) continue;
+
+            var detail    = await _store.LoadDetailAsync(accountId, fromFolder, id);
+            var mimeBytes = await _store.LoadMimeBytesAsync(accountId, fromFolder, id);
+            var flagId    = summary.FlagId;
+
+            // Re-file the loaded rows rather than projecting them field by field — these instances
+            // came from the store, not from the UI, so retargeting them is safe and cannot drop a
+            // column that the model gains later.
+            summary.FolderName      = toFolder;
+            summary.IsServerFlagged = flagId is not null;   // see LoadFromStoreAsync
+            await _store.UpsertSummariesAsync([summary]);
+
+            // The upsert writes the built-in flag id at most; a named flag has to be restated.
+            if (flagId is not null)
+                await _store.UpdateFlagIdAsync(accountId, toFolder, id, flagId);
+
+            if (detail is not null)
+            {
+                detail.FolderName = toFolder;
+                await _store.UpsertDetailAsync(detail);
+                if (mimeBytes is not null)
+                    await _store.StoreMimeBytesAsync(accountId, toFolder, id, mimeBytes);
+            }
+
+            if (!copy)
+                await _store.DeleteSummariesAsync(accountId, fromFolder, [id]);
+        }
+    }
+
+    // ── Model building ────────────────────────────────────────────────────────
+
+    // BuildSummary/BuildDetail are internal rather than private so the mapping from a downloaded
+    // MimeMessage to QuickMail's models can be tested directly, without standing up a POP3 server.
+    internal static MailMessageSummary BuildSummary(
+        Guid accountId, string messageId, MimeMessage msg, string folderName, bool isRead) =>
+        new()
+        {
+            MessageId         = messageId,
+            AccountId         = accountId,
+            FolderName        = folderName,
+            InternetMessageId = msg.MessageId ?? string.Empty,
+            // Display form in the summary, full addresses in the detail — matching ImapMailService,
+            // so the message list reads the same whichever backend fetched the message.
+            From              = FormatAddressesDisplay(msg.From),
+            To                = FormatAddresses(msg.To),
+            Subject           = string.IsNullOrEmpty(msg.Subject) ? "(no subject)" : msg.Subject,
+            Date              = NormalizeDate(msg.Date),
+            IsRead            = isRead,
+            Preview           = BuildPreview(msg),
+            HasAttachments    = msg.Attachments.Any(),
+            IsMailingList     = !string.IsNullOrEmpty(msg.Headers["List-Id"]),
+        };
+
+    internal static MailMessageDetail BuildDetail(
+        Guid accountId, string messageId, MimeMessage msg, string folderName, bool isRead)
+    {
+        var attachments = new List<AttachmentModel>();
+        int idx = 0;
+        foreach (var part in msg.Attachments)
+        {
+            attachments.Add(new AttachmentModel
+            {
+                FileName    = part.ContentDisposition?.FileName
+                              ?? part.ContentType?.Name
+                              ?? $"attachment{idx}",
+                ContentType = part.ContentType?.MimeType ?? "application/octet-stream",
+                FileSize    = DecodedSize(part),
+                // Index into MimeMessage.Attachments — the same enumeration DownloadAttachmentAsync
+                // walks when it re-parses the stored bytes, so the two always agree.
+                PartSpecifier = idx.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            });
+            idx++;
+        }
+
+        var detail = new MailMessageDetail
+        {
+            MessageId         = messageId,
+            AccountId         = accountId,
+            FolderName        = folderName,
+            InternetMessageId = msg.MessageId ?? string.Empty,
+            From              = FormatAddresses(msg.From),
+            To                = FormatAddresses(msg.To),
+            Cc                = FormatAddresses(msg.Cc),
+            ReplyTo           = FormatAddresses(msg.ReplyTo),
+            Subject           = string.IsNullOrEmpty(msg.Subject) ? "(no subject)" : msg.Subject,
+            Date              = NormalizeDate(msg.Date),
+            IsRead            = isRead,
+            PlainTextBody     = msg.TextBody ?? string.Empty,
+            HtmlBody          = msg.HtmlBody ?? string.Empty,
+            Attachments       = attachments,
+            DraftComposeMode  = ImapMailService.ParseComposeMode(msg.Headers["X-QuickMail-Compose-Mode"]),
+        };
+
+        ImapMailService.PopulateCalendar(detail, FindCalendarText(msg));
+        return detail;
+    }
+
+    /// <summary>
+    /// Decoded byte count for an attachment, measured rather than guessed: the encoded length on the
+    /// wire is what the stream reports, and for base64 that overstates the file by a third.
+    /// </summary>
+    private static long DecodedSize(MimeEntity entity)
+    {
+        if (entity is not MimePart part || part.Content is null) return 0;
+        try
+        {
+            using var measuring = new MimeKit.IO.MeasuringStream();
+            part.Content.DecodeTo(measuring);
+            return measuring.Length;
+        }
+        catch (Exception ex)
+        {
+            LogService.Log($"POP3: could not measure attachment '{part.FileName}'", ex);
+            return 0;
+        }
+    }
+
+    /// <summary>Raw text of the first text/calendar part, or null when the message carries no invite.</summary>
+    private static string? FindCalendarText(MimeMessage msg) =>
+        msg.BodyParts
+            .OfType<TextPart>()
+            .FirstOrDefault(p => p.ContentType.IsMimeType("text", "calendar"))?.Text;
+
+    private static string FormatAddresses(InternetAddressList list) =>
+        list.Count == 0 ? string.Empty : string.Join(", ", list.Select(a => a.ToString()));
+
+    private static string FormatAddressesDisplay(InternetAddressList list) =>
+        list.Count == 0
+            ? string.Empty
+            : string.Join(", ", list.Select(a =>
+                a is MailboxAddress mb && !string.IsNullOrWhiteSpace(mb.Name) ? mb.Name : a.ToString()));
+
+    /// <summary>
+    /// A message with no (or an unparseable) Date header sorts to the top of the list rather than to
+    /// 1/1/0001 at the bottom, and — because the sweep's window test reads this date — is treated as
+    /// having just arrived, which is what it is from this mailbox's point of view.
+    /// </summary>
+    private static DateTimeOffset NormalizeDate(DateTimeOffset date) =>
+        date == default ? DateTimeOffset.UtcNow : date;
+
+    private static string BuildPreview(MimeMessage msg)
+    {
+        var text = msg.TextBody;
+        if (string.IsNullOrWhiteSpace(text))
+            text = Helpers.HtmlStripper.ToPlainText(msg.HtmlBody);
+        if (string.IsNullOrWhiteSpace(text)) return string.Empty;
+
+        var joined = string.Join(" ", text
+            .Split('\n')
+            .Select(l => l.Trim())
+            .Where(l => l.Length > 0)
+            .Take(3));
+        return joined.Length > 200 ? joined[..200] : joined;
+    }
+
+    // ── Connection ────────────────────────────────────────────────────────────
+
+    private Task<Pop3Client> OpenConnectionAsync(Guid accountId, CancellationToken ct)
+    {
+        if (!_accounts.TryGetValue(accountId, out var account))
+            throw new InvalidOperationException($"Account {accountId} is not registered with the POP3 backend.");
+        if (!_passwords.TryGetValue(accountId, out var password) || string.IsNullOrEmpty(password))
+            throw new InvalidOperationException($"No password is available for POP3 account {account.AuthUsername}.");
+        return OpenConnectionAsync(account, password, ct);
+    }
+
+    private static async Task<Pop3Client> OpenConnectionAsync(AccountModel account, string password, CancellationToken ct)
+    {
+        var client = new Pop3Client();
+        try
+        {
+            if (account.Pop3AcceptInvalidCert)
+            {
+#pragma warning disable CA5359 // Accepting an invalid certificate is this account's explicit setting.
+                client.ServerCertificateValidationCallback = (_, _, _, _) => true;
+#pragma warning restore CA5359
+            }
+
+            await client.ConnectAsync(account.Pop3Host, account.Pop3Port, MailSecurity.ForPop3(account), ct);
+            await client.AuthenticateAsync(account.AuthUsername, password, ct);
+            return client;
+        }
+        catch
+        {
+            client.Dispose();
+            throw;
+        }
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Why an operation that needs the local store cannot run. POP3 keeps mail nowhere else, so
+    /// <c>--online</c> — which is defined as "no local store" — leaves a POP3 account with nothing to
+    /// read, file or attach. Said plainly rather than surfaced as a SQLite "no such table" error.
+    /// </summary>
+    private const string OnlineModeExplanation =
+        "POP3 accounts store their mail locally, and --online mode runs without the local store. " +
+        "Restart QuickMail without --online to use this account.";
+
+    private static bool IsInbox(string folderName) =>
+        string.Equals(folderName, InboxFolder, StringComparison.OrdinalIgnoreCase);
+
+    private static string NewLocalId() => LocalIdPrefix + Guid.NewGuid().ToString("N");
+
+    private void ThrowIfDisposed() => ObjectDisposedException.ThrowIf(_disposed, this);
+
+    public void Dispose()
+    {
+        _disposed = true;
+        foreach (var sem in _locks.Values)
+            sem.Dispose();
+        _locks.Clear();
+        _accounts.Clear();
+        _passwords.Clear();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/QuickMail/Services/Pop3MailService.cs
+++ b/QuickMail/Services/Pop3MailService.cs
@@ -61,6 +61,9 @@ public class Pop3MailService : IMailService
     /// know an id was never on the server.</summary>
     internal const string LocalIdPrefix = "local-";
 
+    /// <summary>The complete folder namespace of a POP3 account. Anything else does not exist.</summary>
+    internal static readonly string[] SyntheticFolders = [InboxFolder, SentFolder, DraftsFolder, TrashFolder];
+
     private readonly ILocalStoreService _store;
     private readonly bool _onlineMode;
 
@@ -164,22 +167,39 @@ public class Pop3MailService : IMailService
     /// <summary>
     /// The sweep's fetch, and therefore the download trigger — see the sync contract on the class.
     /// Collects anything new from the server first, then returns the folder's messages inside the
-    /// window so the sweep surfaces them through the ordinary arrivals path (rules, list, toast).
-    /// <para>Mail older than the window is still downloaded and stored; it is simply not announced
-    /// as an arrival. That matters on a first sync of a mailbox holding a long backlog: the user
-    /// gets all of it in the Inbox, without a toast per message.</para>
+    /// window PLUS everything collected on this call, so the sweep surfaces every arrival through
+    /// the ordinary path (rules, list, toast).
+    /// <para>The union matters: the window test reads the message's own Date header, and a message
+    /// arriving today can carry an older one — delayed delivery, resent mail, spam forging its
+    /// date. Filtering the return by header date alone would download and store such a message
+    /// while permanently hiding it from rules and the open list.</para>
+    /// <para>The one deliberate exception is the account's first collection ever, which stays
+    /// window-filtered: a first sync of a mailbox holding a years-long backlog puts all of it in
+    /// the Inbox without announcing each message as a new arrival.</para>
     /// </summary>
     public async Task<List<MailMessageSummary>> GetMessagesSinceDateAsync(
         Guid accountId, string folderName, DateTime since, CancellationToken ct = default)
     {
+        List<MailMessageSummary> downloaded = [];
+        bool firstCollection = false;
         if (IsInbox(folderName))
-            await DownloadNewMessagesAsync(accountId, ct);
+            (downloaded, firstCollection) = await DownloadNewMessagesAsync(accountId, ct);
 
         var all = await LoadFromStoreAsync(accountId, folderName);
         var sinceUtc = since.Kind == DateTimeKind.Unspecified
             ? DateTime.SpecifyKind(since, DateTimeKind.Utc)
             : since.ToUniversalTime();
-        return all.Where(m => m.Date.UtcDateTime >= sinceUtc).ToList();
+        var window = all.Where(m => m.Date.UtcDateTime >= sinceUtc).ToList();
+        if (firstCollection || downloaded.Count == 0) return window;
+
+        // Prefer the store-loaded instance for a message in both sets — LoadFromStoreAsync restated
+        // its flag state, and the sweep upserts whatever this returns.
+        var inWindow = new HashSet<string>(window.Select(m => m.MessageId), StringComparer.Ordinal);
+        var byId = all.ToDictionary(m => m.MessageId, StringComparer.Ordinal);
+        foreach (var d in downloaded)
+            if (!inWindow.Contains(d.MessageId))
+                window.Add(byId.TryGetValue(d.MessageId, out var stored) ? stored : d);
+        return window;
     }
 
     /// <summary>
@@ -190,7 +210,7 @@ public class Pop3MailService : IMailService
     public async Task<List<MailMessageSummary>> GetMessagesSinceAsync(
         Guid accountId, string folderName, string sinceMessageId, int initialCount, CancellationToken ct = default)
         => IsInbox(folderName)
-            ? await DownloadNewMessagesAsync(accountId, ct)
+            ? (await DownloadNewMessagesAsync(accountId, ct)).Downloaded
             : [];
 
     public async Task<MailMessageDetail> GetMessageDetailAsync(
@@ -255,11 +275,17 @@ public class Pop3MailService : IMailService
 
         await _store.DeleteSummariesAsync(accountId, folderName, messageIds);
 
+        // Locally-authored mail (sent, drafts) was never on the server; nothing to delete there.
+        var serverIds = messageIds.Where(id => !id.StartsWith(LocalIdPrefix, StringComparison.Ordinal)).ToList();
+
+        // Record the destruction BEFORE any early return. With leave-on-server on, the server
+        // keeps listing these UIDLs — the ledger is the only thing standing between "Empty Trash"
+        // and the same mail re-downloading into the Inbox on the very next sweep.
+        await _store.AddPop3CollectedUidlsAsync(accountId, serverIds);
+
         if (!_accounts.TryGetValue(accountId, out var account) || account.Pop3LeaveMailOnServer)
             return;
 
-        // Locally-authored mail (sent, drafts) was never on the server; nothing to delete there.
-        var serverIds = messageIds.Where(id => !id.StartsWith(LocalIdPrefix, StringComparison.Ordinal)).ToList();
         if (serverIds.Count == 0) return;
 
         var wanted = new HashSet<string>(serverIds, StringComparer.Ordinal);
@@ -355,6 +381,16 @@ public class Pop3MailService : IMailService
             throw new InvalidOperationException(
                 $"Attachment '{partSpecifier}' is out of range for POP3 message {messageId} ({parts.Count} attachment(s)).");
 
+        // A forwarded email attached as message/rfc822 is a MessagePart, not a MimePart. Serialize
+        // the embedded message as .eml bytes — the same answer ImapMailService gives for this part
+        // type — rather than throwing at the only copy the user will ever have.
+        if (parts[idx] is MessagePart msgPart && msgPart.Message is not null)
+        {
+            using var eml = new MemoryStream();
+            await msgPart.Message.WriteToAsync(eml, ct);
+            return eml.ToArray();
+        }
+
         if (parts[idx] is not MimePart part || part.Content is null)
             throw new InvalidOperationException(
                 $"Attachment {idx} of POP3 message {messageId} is not a decodable MIME part.");
@@ -367,7 +403,7 @@ public class Pop3MailService : IMailService
     // ── Poll / keepalive / status ─────────────────────────────────────────────
 
     public async Task<int> PollAsync(Guid accountId, string folderName, CancellationToken ct = default)
-        => (await DownloadNewMessagesAsync(accountId, ct)).Count;
+        => (await DownloadNewMessagesAsync(accountId, ct)).Downloaded.Count;
 
     /// <summary>No-op: POP3 keeps no connection open between operations, so there is nothing to keep alive.</summary>
     public Task NoOpAsync(Guid accountId, CancellationToken ct = default) => Task.CompletedTask;
@@ -407,7 +443,12 @@ public class Pop3MailService : IMailService
         var cached = await LoadFromStoreAsync(accountId, folderName);
 
         if (!IsInbox(folderName) || _onlineMode || !_accounts.ContainsKey(accountId))
-            return MergeListing(cached, [], DateTimeOffset.UtcNow);
+            return MergeListing(cached, [], new HashSet<string>(), DateTimeOffset.UtcNow);
+
+        // The ledger keeps a collected-then-moved (or deliberately destroyed) UIDL from reading as
+        // a new arrival: it is no longer cached in the Inbox, but it is not new mail either, and
+        // stamping it "now" would make the sweep fetch phantom arrivals every cycle forever.
+        var collected = await _store.LoadPop3CollectedUidlsAsync(accountId);
 
         IList<string> serverUidls;
         try
@@ -423,24 +464,30 @@ public class Pop3MailService : IMailService
             serverUidls = [];
         }
 
-        return MergeListing(cached, serverUidls, DateTimeOffset.UtcNow);
+        return MergeListing(cached, serverUidls, collected, DateTimeOffset.UtcNow);
     }
 
     /// <summary>
     /// The sync contract's arithmetic, in one place so it can be tested directly: every cached
-    /// message, plus every server UIDL not already cached.
+    /// message, plus every server UIDL not already cached and never collected before.
     ///
     /// <para>Cached rows keep their own date and read state — the sweep's read reconcile compares
-    /// against them, and POP3 has no server-side read state that could disagree. Unseen UIDLs are
-    /// stamped <paramref name="now"/> and unread, which is what puts them inside the sweep's window
-    /// so it fetches them.</para>
+    /// against them, and POP3 has no server-side read state that could disagree. Genuinely unseen
+    /// UIDLs are stamped <paramref name="now"/> and unread, which is what puts them inside the
+    /// sweep's window so it fetches them.</para>
+    ///
+    /// <para><paramref name="collectedUidls"/> is the ledger of everything ever collected. A server
+    /// UIDL in it but not in <paramref name="cached"/> is a message the user moved out of this
+    /// folder or destroyed while leave-on-server keeps it listed — reporting it as arriving now
+    /// would make every sweep fetch phantom mail, so it is omitted entirely.</para>
     ///
     /// <para>Cached ids are never dropped, whatever the server says. That is the whole point: the
     /// sweep deletes cached ids missing from this list, and a POP3 server legitimately stops listing
     /// a message the moment it is collected.</para>
     /// </summary>
     internal static IReadOnlyList<(string Id, DateTimeOffset ReceivedUtc, bool IsRead)> MergeListing(
-        IReadOnlyList<MailMessageSummary> cached, IEnumerable<string> serverUidls, DateTimeOffset now)
+        IReadOnlyList<MailMessageSummary> cached, IEnumerable<string> serverUidls,
+        IReadOnlySet<string> collectedUidls, DateTimeOffset now)
     {
         var result = cached
             .Select(m => (Id: m.MessageId, ReceivedUtc: m.Date, m.IsRead))
@@ -448,7 +495,7 @@ public class Pop3MailService : IMailService
 
         var known = new HashSet<string>(result.Select(r => r.Id), StringComparer.Ordinal);
         foreach (var uidl in serverUidls)
-            if (known.Add(uidl))
+            if (!collectedUidls.Contains(uidl) && known.Add(uidl))
                 result.Add((uidl, now, false));
 
         return result;
@@ -481,8 +528,10 @@ public class Pop3MailService : IMailService
         => MoveLocalAsync(accountId, folderName, destinationFolder, messageIds, copy: false);
 
     // ── Folder CRUD — not supported ───────────────────────────────────────────
-    // POP3 has no folder namespace. Callers gate on BackendKind (see MainViewModel's folder
-    // commands) so the user never reaches these; they throw rather than silently doing nothing.
+    // POP3 has no folder namespace. Callers gate on BackendKind (MainWindow's SupportsServerFolders
+    // guards the folder-tree entry points) so the user rarely reaches these; they throw with a plain
+    // reason rather than silently doing nothing, because ungated paths (the folder picker's New
+    // Folder button) surface the thrown message as the explanation.
 
     public Task CreateFolderAsync(Guid accountId, string? parentFolderName, string name, CancellationToken ct = default)
         => throw new NotSupportedException("POP3 accounts have no server folders, so folders cannot be created.");
@@ -499,12 +548,22 @@ public class Pop3MailService : IMailService
     // ── Download ──────────────────────────────────────────────────────────────
 
     /// <summary>
-    /// Collects every UIDL the server holds that the store does not, storing each message whole.
-    /// Returns the messages downloaded on this call (empty when there is nothing new).
-    /// <para>Deduplication is by UIDL against the store, which is what makes this safe to call from
-    /// several sync paths — the sweep, a poll, an account's first load — without re-downloading.</para>
+    /// Collects every UIDL the server holds that this profile has never collected, storing each
+    /// message whole. Returns the messages downloaded on this call (empty when there is nothing
+    /// new) and whether this was the account's first collection ever.
+    /// <para>Deduplication is by UIDL against the collected-UIDL ledger plus every folder's stored
+    /// ids — NOT against the Inbox rows alone. A collected message does not stay in the Inbox: the
+    /// user deletes it (row moves to Trash), a rule files it, Empty Trash removes it entirely — and
+    /// with leave-on-server on the server still lists its UIDL. Only a memory independent of the
+    /// message rows keeps all of those from being re-downloaded into the Inbox as new mail.</para>
+    /// <para>With leave-on-server off, a UIDL we already collected but the server still lists gets
+    /// its DELE re-issued: DELEs only commit at QUIT, so a connection lost mid-collection rolls
+    /// every pending DELE back (RFC 1939), and without this the stale copies would sit on the
+    /// server forever. Never data loss — a UIDL is only in the seen set once its message is in the
+    /// store, or after the user deliberately destroyed it.</para>
     /// </summary>
-    private async Task<List<MailMessageSummary>> DownloadNewMessagesAsync(Guid accountId, CancellationToken ct)
+    private async Task<(List<MailMessageSummary> Downloaded, bool FirstCollection)> DownloadNewMessagesAsync(
+        Guid accountId, CancellationToken ct)
     {
         var downloaded = new List<MailMessageSummary>();
 
@@ -512,65 +571,105 @@ public class Pop3MailService : IMailService
         {
             // POP3 keeps mail nowhere but the store, so with no store there is nothing to sync into.
             LogService.Log($"POP3: skipping sync for account {accountId} — --online mode has no local store.");
-            return downloaded;
+            return (downloaded, false);
         }
 
         if (!_accounts.TryGetValue(accountId, out var account))
-            return downloaded;
+            return (downloaded, false);
 
-        var seen = await _store.GetAllMessageIdsAsync(accountId, InboxFolder);
+        var ledger = await _store.LoadPop3CollectedUidlsAsync(accountId);
+        var seen   = new HashSet<string>(ledger, StringComparer.Ordinal);
+        bool anyServerDerivedRow = false;
+        foreach (var folder in SyntheticFolders)
+        {
+            foreach (var id in await _store.GetAllMessageIdsAsync(accountId, folder))
+            {
+                if (id.StartsWith(LocalIdPrefix, StringComparison.Ordinal)) continue;
+                seen.Add(id);
+                anyServerDerivedRow = true;
+            }
+        }
+
+        // First collection = no ledger and no server-derived row anywhere: this profile has never
+        // taken anything off this maildrop. GetMessagesSinceDateAsync uses it to keep a first-run
+        // backlog quiet while still announcing every later arrival.
+        var firstCollection = ledger.Count == 0 && !anyServerDerivedRow;
 
         var sem = _locks.GetOrAdd(accountId, _ => new SemaphoreSlim(1, 1));
         await sem.WaitAsync(ct);
         try
         {
-            using var client = await OpenConnectionAsync(accountId, ct);
-            if (client.Count == 0)
+            IList<string> uidls;
+            using (var client = await OpenConnectionAsync(accountId, ct))
             {
-                await client.DisconnectAsync(quit: false, ct);
-                return downloaded;
+                // Index into this list is the session-scoped message number the RETR/DELE commands take.
+                uidls = client.Count == 0
+                    ? new List<string>()
+                    : await client.GetMessageUidsAsync(ct);
+                bool anyDeleted = false;
+
+                for (int i = 0; i < uidls.Count; i++)
+                {
+                    ct.ThrowIfCancellationRequested();
+                    var uidl = uidls[i];
+                    if (seen.Contains(uidl))
+                    {
+                        if (!account.Pop3LeaveMailOnServer)
+                        {
+                            // Already collected (or deliberately destroyed) — the server copy should
+                            // be gone under this setting. Covers DELEs rolled back by a lost
+                            // connection, and mail collected before the setting was turned off.
+                            await client.DeleteMessageAsync(i, ct);
+                            anyDeleted = true;
+                        }
+                        continue;
+                    }
+
+                    MimeMessage msg;
+                    try
+                    {
+                        msg = await client.GetMessageAsync(i, ct);
+                    }
+                    catch (OperationCanceledException) { throw; }
+                    catch (Exception ex)
+                    {
+                        // One unreadable message must not stop the rest of the mailbox from arriving.
+                        LogService.Log($"POP3 [{account.AccountLabel}]: failed to download UIDL {uidl}", ex);
+                        continue;
+                    }
+
+                    var summary = await StoreMessageAsync(accountId, uidl, msg, InboxFolder, isRead: false, ct);
+                    downloaded.Add(summary);
+
+                    if (!account.Pop3LeaveMailOnServer)
+                    {
+                        // Only after the message is committed to the store. DELEs take effect at QUIT.
+                        await client.DeleteMessageAsync(i, ct);
+                        anyDeleted = true;
+                    }
+                }
+
+                await client.DisconnectAsync(quit: anyDeleted, ct);
+
+                if (downloaded.Count > 0)
+                    LogService.Log($"POP3 [{account.AccountLabel}]: downloaded {downloaded.Count} new message(s)" +
+                                   (anyDeleted ? ", removed from the server" : ", left on the server") + ".");
             }
 
-            // Index into this list is the session-scoped message number the RETR/DELE commands take.
-            var uidls = await client.GetMessageUidsAsync(ct);
-            bool anyDeleted = false;
+            // Ledger upkeep, after the session so it never extends the maildrop lock's hold time.
+            // Both writes are recoverable if the app dies before them: the messages are already in
+            // the store, so the next sweep's seen set still covers them and re-records here.
+            //   Record: everything downloaded this call, plus store-known UIDLs the ledger lacked
+            //   (rows collected by a build before the ledger existed).
+            //   Prune: ledger entries the server no longer lists — those can never be offered again.
+            var serverSet = new HashSet<string>(uidls, StringComparer.Ordinal);
+            var record = downloaded.Select(m => m.MessageId)
+                .Concat(serverSet.Where(u => seen.Contains(u) && !ledger.Contains(u)))
+                .ToList();
+            await _store.AddPop3CollectedUidlsAsync(accountId, record);
+            await _store.RemovePop3CollectedUidlsAsync(accountId, ledger.Where(u => !serverSet.Contains(u)).ToList());
 
-            for (int i = 0; i < uidls.Count; i++)
-            {
-                ct.ThrowIfCancellationRequested();
-                var uidl = uidls[i];
-                if (seen.Contains(uidl)) continue;
-
-                MimeMessage msg;
-                try
-                {
-                    msg = await client.GetMessageAsync(i, ct);
-                }
-                catch (OperationCanceledException) { throw; }
-                catch (Exception ex)
-                {
-                    // One unreadable message must not stop the rest of the mailbox from arriving.
-                    LogService.Log($"POP3 [{account.AccountLabel}]: failed to download UIDL {uidl}", ex);
-                    continue;
-                }
-
-                var summary = await StoreMessageAsync(accountId, uidl, msg, InboxFolder, isRead: false, ct);
-                downloaded.Add(summary);
-
-                if (!account.Pop3LeaveMailOnServer)
-                {
-                    // Only after the message is committed to the store. DELEs take effect at QUIT.
-                    await client.DeleteMessageAsync(i, ct);
-                    anyDeleted = true;
-                }
-            }
-
-            await client.DisconnectAsync(quit: anyDeleted, ct);
-
-            if (downloaded.Count > 0)
-                LogService.Log($"POP3 [{account.AccountLabel}]: downloaded {downloaded.Count} new message(s)" +
-                               (anyDeleted ? ", removed from the server" : ", left on the server") + ".");
-            return downloaded;
+            return (downloaded, firstCollection);
         }
         finally
         {
@@ -653,6 +752,17 @@ public class Pop3MailService : IMailService
         Guid accountId, string fromFolder, string toFolder, IList<string> messageIds, bool copy)
     {
         if (_onlineMode) return;   // no store, so there is nothing filed anywhere to move
+
+        // A rule created against another account, or a mixed-account move offering an IMAP folder
+        // name, can hand this any string. Filing rows under a name GetFoldersAsync never returns
+        // makes them unreachable from every part of the UI — and this store may hold the only copy
+        // of the message. Refuse loudly instead — and canonicalize the casing, since the store's
+        // folder lookups compare exactly.
+        toFolder = SyntheticFolders.FirstOrDefault(f => string.Equals(f, toFolder, StringComparison.OrdinalIgnoreCase))
+            ?? throw new NotSupportedException(
+                $"POP3 accounts have only the built-in Inbox, Sent, Drafts and Trash folders; " +
+                $"'{toFolder}' does not exist on this account, so the messages were not filed there.");
+
         if (string.Equals(fromFolder, toFolder, StringComparison.OrdinalIgnoreCase)) return;
 
         var byId = (await _store.LoadFolderSummariesAsync(accountId, fromFolder))
@@ -764,16 +874,26 @@ public class Pop3MailService : IMailService
     /// </summary>
     private static long DecodedSize(MimeEntity entity)
     {
-        if (entity is not MimePart part || part.Content is null) return 0;
         try
         {
             using var measuring = new MimeKit.IO.MeasuringStream();
-            part.Content.DecodeTo(measuring);
-            return measuring.Length;
+            switch (entity)
+            {
+                case MimePart { Content: not null } part:
+                    part.Content.DecodeTo(measuring);
+                    return measuring.Length;
+                case MessagePart { Message: not null } msgPart:
+                    // A forwarded email attached as message/rfc822: its size is the serialized .eml,
+                    // which is also exactly what DownloadAttachmentAsync hands back for it.
+                    msgPart.Message.WriteTo(measuring);
+                    return measuring.Length;
+                default:
+                    return 0;
+            }
         }
         catch (Exception ex)
         {
-            LogService.Log($"POP3: could not measure attachment '{part.FileName}'", ex);
+            LogService.Log($"POP3: could not measure attachment '{(entity as MimePart)?.FileName ?? entity.ContentType?.MimeType ?? "attachment"}'", ex);
             return 0;
         }
     }

--- a/QuickMail/Services/ProviderCatalog.cs
+++ b/QuickMail/Services/ProviderCatalog.cs
@@ -42,7 +42,9 @@ public sealed class ProviderCatalog : IProviderCatalog
         DefaultBackend: BackendKind.ImapSmtp,
         AppPasswordHint: "Gmail requires an app password, not your Google account password. "
                        + "Turn on 2-Step Verification first, then create a 16-character app password.",
-        AppPasswordUrl: "https://myaccount.google.com/apppasswords");
+        AppPasswordUrl: "https://myaccount.google.com/apppasswords",
+        // POP3 also has to be switched on in Gmail's own settings before it answers (#128).
+        Pop3Host: "pop.gmail.com", Pop3Port: 995);
 
     /// <summary>
     /// Gmail for the users whose Google authorization still works: QuickMail's Google OAuth client
@@ -81,7 +83,8 @@ public sealed class ProviderCatalog : IProviderCatalog
         // The Graph option remains available as "Connection method" under Advanced settings.
         DefaultBackend: BackendKind.ImapSmtp,
         AppPasswordHint: null,
-        AppPasswordUrl: null);
+        AppPasswordUrl: null,
+        Pop3Host: "outlook.office365.com", Pop3Port: 995);
 
     private static readonly MailProvider YahooProvider = new(
         Id: YahooId,
@@ -94,7 +97,8 @@ public sealed class ProviderCatalog : IProviderCatalog
         DefaultBackend: BackendKind.ImapSmtp,
         AppPasswordHint: "Yahoo requires an app password, not your Yahoo account password. "
                        + "Generate one under Account Security, App passwords.",
-        AppPasswordUrl: "https://login.yahoo.com/account/security");
+        AppPasswordUrl: "https://login.yahoo.com/account/security",
+        Pop3Host: "pop.mail.yahoo.com", Pop3Port: 995);
 
     private static readonly MailProvider ICloudProvider = new(
         Id: ICloudId,
@@ -108,6 +112,8 @@ public sealed class ProviderCatalog : IProviderCatalog
         AppPasswordHint: "iCloud requires an app-specific password, not your Apple ID password. "
                        + "Generate one under Sign-In & Security, App-Specific Passwords.",
         AppPasswordUrl: "https://appleid.apple.com");
+    // No Pop3Host on purpose: iCloud Mail serves IMAP only, so pre-filling a POP3 host here would
+    // hand the user a server that does not answer.
 
     private static readonly MailProvider OtherProvider = new(
         Id: OtherId,

--- a/QuickMail/Services/SyncService.cs
+++ b/QuickMail/Services/SyncService.cs
@@ -154,11 +154,15 @@ public class SyncService : ISyncService
         // int[] so Interlocked.Increment works inside async lambdas (can't use ref locals there).
         int[] completedFolders = { 0 };
 
-        // Group accounts by IMAP host. Accounts on the same server sync sequentially within
-        // their group to avoid hitting per-IP connection limits (which trigger "Server shutting
-        // down" BYEs on shared hosting). Groups on different servers still run in parallel.
+        // Group accounts by incoming host — the server each backend actually receives from, so a
+        // POP3 account groups by its POP3 host, not its (empty) ImapHost. Accounts on the same
+        // server sync sequentially within their group to avoid hitting per-IP connection limits
+        // (which trigger "Server shutting down" BYEs on shared hosting) — and, for POP3, the
+        // RFC 1939 exclusive maildrop lock. Grouping by ImapHost here put every POP3 and Graph
+        // account into one "" bucket (serialized against each other, parallel with an IMAP account
+        // on the same real host — both wrong). Same rationale as MainViewModel's connect grouping.
         var accountsByHost = accountList
-            .GroupBy(a => a.ImapHost, StringComparer.OrdinalIgnoreCase)
+            .GroupBy(a => a.IncomingHost, StringComparer.OrdinalIgnoreCase)
             .ToList();
 
         async Task SyncPassAsync(Func<MailFolderModel, bool> folderFilter)
@@ -260,10 +264,17 @@ public class SyncService : ISyncService
     /// messages from the store, raises <see cref="RulesApplied"/> / <see cref="MessagesRemoved"/>,
     /// and returns the batch with those messages stripped so the UI never shows them in the origin
     /// folder. Callers own <see cref="FolderSynced"/>.
+    ///
+    /// <para><paramref name="preFetchKnownIds"/>: the folder's cached-id set as it stood BEFORE the
+    /// fetch, when the caller has one. The store query below assumes fetching does not persist —
+    /// true for IMAP and Graph, violated by POP3, whose fetch stores every download before
+    /// returning. Querying after such a fetch reads every arrival as already-known and rules
+    /// silently never run, so a caller that snapshotted ids pre-fetch must pass them.</para>
     /// </summary>
     private async Task<List<MailMessageSummary>> ApplyRulesToArrivalsAsync(
         AccountModel account, MailFolderModel folder,
-        List<MailMessageSummary> fetched, bool persisted, bool consumeRebuildBaseline, CancellationToken ct)
+        List<MailMessageSummary> fetched, bool persisted, bool consumeRebuildBaseline, CancellationToken ct,
+        IReadOnlyCollection<string>? preFetchKnownIds = null)
     {
         if (fetched.Count == 0)
         {
@@ -279,11 +290,14 @@ public class SyncService : ISyncService
         // (LoadRules() is cached after first load.) Still persist so the cache/UI reflect the fetch.
         var hasEnabledRules = _rules.LoadRules().Any(r => r.IsEnabled);
 
-        // Persisted dedupe authority is the store — snapshot which fetched ids it already holds,
-        // BEFORE the upsert, so freshly-fetched messages still read as new. A bounded IN over the
+        // Persisted dedupe authority is the store — the caller's pre-fetch snapshot when it has one
+        // (mandatory for backends that persist inside the fetch), otherwise queried here, which is
+        // still BEFORE the upsert so IMAP/Graph fetches read as new. A bounded IN over the
         // batch avoids scanning every id in a large cached folder; the full scan is only cheaper for
         // an unusually large batch (a fresh account's first sync, where the store is empty anyway).
         var knownInStore = !(persisted && hasEnabledRules) ? []
+            : preFetchKnownIds is not null
+                ? new HashSet<string>(preFetchKnownIds)
             : fetched.Count <= 500
                 ? await _store.GetExistingMessageIdsAsync(account.Id, folder.FullName, fetched.Select(m => m.MessageId))
                 : await _store.GetAllMessageIdsAsync(account.Id, folder.FullName);
@@ -429,8 +443,13 @@ public class SyncService : ISyncService
         if (incoming.Count > 0)
         {
             // Upsert + client rules happen inside the shared chokepoint so live-arriving mail is
-            // subject to rules exactly like the full sync.
-            incoming = await ApplyRulesToArrivalsAsync(account, folder, incoming, persisted: true, consumeRebuildBaseline: false, ct);
+            // subject to rules exactly like the full sync. POP3's incremental fetch returns ONLY the
+            // messages it just downloaded (and persisted before returning), so for that backend the
+            // whole batch is new by construction — pass an empty pre-fetch snapshot, or the store
+            // query would read every arrival as already-known and skip rules.
+            IReadOnlyCollection<string>? preFetch = account.BackendKind == BackendKind.Pop3Smtp
+                ? Array.Empty<string>() : null;
+            incoming = await ApplyRulesToArrivalsAsync(account, folder, incoming, persisted: true, consumeRebuildBaseline: false, ct, preFetch);
             _ui.Post(() => FolderSynced?.Invoke(incoming));
         }
         return incoming;
@@ -543,7 +562,10 @@ public class SyncService : ISyncService
         if (cacheReadStates.Count == 0)
         {
             var initial = await _imap.GetMessagesSinceDateAsync(account.Id, folder.FullName, windowStart, ct);
-            return await SurfaceArrivalsAsync(account, folder, initial, ct);
+            // Empty pre-fetch snapshot: the folder held nothing before this fetch, so everything
+            // fetched is an arrival — including for POP3, whose fetch persists before returning
+            // and would otherwise read its own downloads as already-known and skip rules.
+            return await SurfaceArrivalsAsync(account, folder, initial, ct, preFetchKnownIds: Array.Empty<string>());
         }
 
         var serverIdDates = await _imap.GetFolderMessageIdDatesAsync(account.Id, folder.FullName, ct);
@@ -558,8 +580,10 @@ public class SyncService : ISyncService
 
         // Always run the (possibly empty) batch through the chokepoint. An empty batch is a no-op except
         // that it consumes a pending #366 rebuild baseline (F4) — preserving the pre-#462 behavior where
-        // every sweep passed through ApplyRulesToArrivalsAsync.
-        var incoming = await SurfaceArrivalsAsync(account, folder, fetched, ct);
+        // every sweep passed through ApplyRulesToArrivalsAsync. The pre-fetch cached-id set is passed as
+        // the rules dedupe snapshot: it was taken before the fetch, so arrivals a backend persisted
+        // inside the fetch (POP3) still read as new.
+        var incoming = await SurfaceArrivalsAsync(account, folder, fetched, ct, cacheReadStates.Keys);
 
         // ── Read/unread reconcile ── the old full-window re-fetch refreshed read state from the server as
         // a side effect (UpsertSummariesAsync carries is_read = excluded.is_read); with the fetch now
@@ -629,9 +653,10 @@ public class SyncService : ISyncService
     /// consuming a pending rebuild baseline).
     /// </summary>
     private async Task<List<MailMessageSummary>> SurfaceArrivalsAsync(
-        AccountModel account, MailFolderModel folder, List<MailMessageSummary> fetched, CancellationToken ct)
+        AccountModel account, MailFolderModel folder, List<MailMessageSummary> fetched, CancellationToken ct,
+        IReadOnlyCollection<string>? preFetchKnownIds = null)
     {
-        var incoming = await ApplyRulesToArrivalsAsync(account, folder, fetched, persisted: true, consumeRebuildBaseline: true, ct);
+        var incoming = await ApplyRulesToArrivalsAsync(account, folder, fetched, persisted: true, consumeRebuildBaseline: true, ct, preFetchKnownIds);
         if (incoming.Count > 0)
             _ui.Post(() => FolderSynced?.Invoke(incoming));
         return incoming;

--- a/QuickMail/ViewModels/AccountEditorViewModel.cs
+++ b/QuickMail/ViewModels/AccountEditorViewModel.cs
@@ -47,6 +47,18 @@ public abstract partial class AccountEditorViewModel : ObservableObject
     [ObservableProperty] private int    _imapPort = 993;
     [ObservableProperty] private bool   _imapUseSsl = true;
     [ObservableProperty] private bool   _imapAcceptInvalidCert = false;
+    [ObservableProperty] private string _pop3Host = string.Empty;
+    [ObservableProperty] private int    _pop3Port = 995;
+    [ObservableProperty] private bool   _pop3UseSsl = true;
+    [ObservableProperty] private bool   _pop3AcceptInvalidCert = false;
+
+    /// <summary>
+    /// Bound to "Leave mail on the server" in the POP3 settings. On by default, because the
+    /// alternative — the classic POP3 behavior — makes the local store the only copy of the user's
+    /// mail from the moment it is collected.
+    /// </summary>
+    [ObservableProperty] private bool   _pop3LeaveMailOnServer = true;
+
     [ObservableProperty] private string _smtpHost = string.Empty;
     [ObservableProperty] private int    _smtpPort = 587;
     [ObservableProperty] private bool   _smtpUseSsl = false;
@@ -184,6 +196,10 @@ public abstract partial class AccountEditorViewModel : ObservableObject
     /// currently holds keyboard focus removes the focused element from the visual tree and strands
     /// focus on the window with no announcement.
     /// </param>
+    /// <remarks>
+    /// See <see cref="PreserveChosenBackend"/> for the one case where the provider's default backend
+    /// is deliberately not applied.
+    /// </remarks>
     protected bool ApplyProvider(MailProvider? provider, bool collapseAdvanced = true)
     {
         if (provider is null) return false;
@@ -202,8 +218,13 @@ public abstract partial class AccountEditorViewModel : ObservableObject
         {
             // ORDER MATTERS: BackendKind is assigned before AuthType because OnAuthTypeChangedInternal
             // reads BackendKind. This is the same ordering hazard the old backend combo documented.
-            BackendKind = provider.DefaultBackend;
-            AuthType = provider.DefaultAuthType;
+            if (!PreserveChosenBackend)
+                BackendKind = provider.DefaultBackend;
+
+            // POP3 authenticates with a password whatever the provider's default says: there is no
+            // OAuth path through that backend, and taking the provider's OAuth default here would
+            // leave the account unable to sign in at all.
+            AuthType = BackendKind == BackendKind.Pop3Smtp ? AuthType.Password : provider.DefaultAuthType;
 
             if (BackendKind == BackendKind.MicrosoftGraph)
             {
@@ -227,6 +248,14 @@ public abstract partial class AccountEditorViewModel : ObservableObject
                 SmtpPort = provider.SmtpPort;
                 SmtpUseSsl = provider.SmtpUseSsl;
                 SmtpAcceptInvalidCert = false;
+
+                // POP3 fields are filled whichever backend is selected, so switching the connection
+                // method to POP3 finds them already set. A provider with no POP3 service leaves the
+                // host empty rather than guessing one — the user types it, and IsReadyToSave says so.
+                Pop3Host = provider.Pop3Host ?? string.Empty;
+                Pop3Port = provider.Pop3Port;
+                Pop3UseSsl = provider.Pop3Port == 995;
+                Pop3AcceptInvalidCert = false;
             }
 
             if (AuthType != AuthType.Password) ClearPassword();
@@ -267,6 +296,10 @@ public abstract partial class AccountEditorViewModel : ObservableObject
             SmtpPort = 587;
             SmtpUseSsl = false;
             SmtpAcceptInvalidCert = false;
+            Pop3Host = string.Empty;
+            Pop3Port = 995;
+            Pop3UseSsl = true;
+            Pop3AcceptInvalidCert = false;
             // The account name is never touched here — nothing writes it but the user.
         }
         finally
@@ -344,6 +377,9 @@ public abstract partial class AccountEditorViewModel : ObservableObject
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(IsGraphBackend))]
     [NotifyPropertyChangedFor(nameof(IsImapBackend))]
+    [NotifyPropertyChangedFor(nameof(IsPop3Backend))]
+    [NotifyPropertyChangedFor(nameof(IncomingHostLabel))]
+    [NotifyPropertyChangedFor(nameof(ShowServerSettings))]
     private BackendKind _backendKind = BackendKind.ImapSmtp;
 
     /// <summary>True when this account uses the Microsoft Graph backend (drives IMAP/SMTP field visibility).</summary>
@@ -351,6 +387,21 @@ public abstract partial class AccountEditorViewModel : ObservableObject
 
     /// <summary>True when this account uses the standard IMAP/SMTP backend.</summary>
     public bool IsImapBackend => BackendKind == BackendKind.ImapSmtp;
+
+    /// <summary>True when this account receives over POP3 (drives POP3 field visibility).</summary>
+    public bool IsPop3Backend => BackendKind == BackendKind.Pop3Smtp;
+
+    /// <summary>
+    /// Names the incoming protocol in status text, so a failure says which server refused the
+    /// connection rather than naming IMAP for an account that never speaks it.
+    /// </summary>
+    public string IncomingHostLabel => IsPop3Backend ? "POP3" : "IMAP";
+
+    /// <summary>
+    /// Whether the server-settings block is shown at all. Both host-based backends need it (each
+    /// shows its own incoming section, and both send over SMTP); Graph has no hosts to configure.
+    /// </summary>
+    public bool ShowServerSettings => !IsGraphBackend;
 
     [ObservableProperty] private string _statusText = string.Empty;
 
@@ -497,6 +548,9 @@ public abstract partial class AccountEditorViewModel : ObservableObject
     partial void OnSmtpPortChanged(int value) => NoteHostEdit();
     partial void OnImapUseSslChanged(bool value) => NoteHostEdit();
     partial void OnSmtpUseSslChanged(bool value) => NoteHostEdit();
+    partial void OnPop3HostChanged(string value) => NoteHostEdit();
+    partial void OnPop3PortChanged(int value) => NoteHostEdit();
+    partial void OnPop3UseSslChanged(bool value) => NoteHostEdit();
 
     private void NoteHostEdit()
     {
@@ -523,6 +577,20 @@ public abstract partial class AccountEditorViewModel : ObservableObject
     /// <see cref="OnAuthTypeChangedInternal"/> because the generated partial method belongs to this
     /// class and cannot be implemented by a derived one.
     /// </summary>
+    /// <summary>
+    /// True when the connection method the user picked outranks the provider's default, so
+    /// <see cref="ApplyProvider"/> leaves <see cref="BackendKind"/> alone.
+    ///
+    /// <para>Only POP3 qualifies, and the asymmetry is the point. Graph is a property of the
+    /// PROVIDER — only Microsoft accounts have it — so a provider change must be free to move an
+    /// account off it. POP3 is a property of how the user wants to connect, and any provider may
+    /// offer it; without this, choosing POP3 in Advanced settings and then finishing the email
+    /// address put the account silently back on IMAP, because typing the address matches a provider
+    /// and re-applies its default. The user could not see it happen — the combo is inside a
+    /// collapsed expander.</para>
+    /// </summary>
+    protected virtual bool PreserveChosenBackend => false;
+
     protected virtual void OnSelectedProviderChangedInternal(MailProvider? value) { }
 
     partial void OnSelectedProviderChanged(MailProvider? value) => OnSelectedProviderChangedInternal(value);
@@ -710,7 +778,15 @@ public abstract partial class AccountEditorViewModel : ObservableObject
         // Graph carries no host configuration at all; sign-in is what proves the account.
         if (IsGraphBackend) return true;
 
-        if (string.IsNullOrWhiteSpace(ImapHost) || string.IsNullOrWhiteSpace(SmtpHost))
+        if (IsPop3Backend)
+        {
+            if (string.IsNullOrWhiteSpace(Pop3Host) || string.IsNullOrWhiteSpace(SmtpHost))
+            {
+                error = "No server settings for this address. Enter the POP3 and SMTP hosts under Advanced settings.";
+                return false;
+            }
+        }
+        else if (string.IsNullOrWhiteSpace(ImapHost) || string.IsNullOrWhiteSpace(SmtpHost))
         {
             error = "No server settings for this address. Enter the IMAP and SMTP hosts under Advanced settings.";
             return false;
@@ -748,6 +824,11 @@ public abstract partial class AccountEditorViewModel : ObservableObject
         ImapPort = ImapPort,
         ImapUseSsl = ImapUseSsl,
         ImapAcceptInvalidCert = ImapAcceptInvalidCert,
+        Pop3Host = Pop3Host,
+        Pop3Port = Pop3Port,
+        Pop3UseSsl = Pop3UseSsl,
+        Pop3AcceptInvalidCert = Pop3AcceptInvalidCert,
+        Pop3LeaveMailOnServer = Pop3LeaveMailOnServer,
         SmtpHost = SmtpHost,
         SmtpPort = SmtpPort,
         SmtpUseSsl = SmtpUseSsl,
@@ -792,9 +873,12 @@ public abstract partial class AccountEditorViewModel : ObservableObject
             return;
         }
 
-        if (string.IsNullOrWhiteSpace(ImapHost) || string.IsNullOrWhiteSpace(Username))
+        // The incoming host the probe will actually dial — naming IMAP for a POP3 account would send
+        // the user to fill in a box that is not even shown.
+        var incomingHost = IsPop3Backend ? Pop3Host : ImapHost;
+        if (string.IsNullOrWhiteSpace(incomingHost) || string.IsNullOrWhiteSpace(Username))
         {
-            StatusText = "Fill in IMAP host and username first.";
+            StatusText = $"Fill in {IncomingHostLabel} host and username first.";
             return;
         }
 
@@ -807,7 +891,7 @@ public abstract partial class AccountEditorViewModel : ObservableObject
             // Two independent legs, reported independently. Incoming can be perfect while outgoing
             // is wrong — that combination used to pass Test Connection and then fail on first send,
             // because only IMAP was ever probed.
-            var imapResult = await ProbeAsync(ct => MailService.ConnectAsync(account, pwd, ct));
+            var incomingResult = await ProbeAsync(ct => MailService.ConnectAsync(account, pwd, ct));
 
             var smtpResult = string.IsNullOrWhiteSpace(SmtpHost)
                 ? "SMTP not configured."
@@ -815,7 +899,7 @@ public abstract partial class AccountEditorViewModel : ObservableObject
                     ? "SMTP not checked."
                     : await ProbeAsync(ct => SendMailService.VerifyAsync(account, pwd, ct));
 
-            StatusText = $"IMAP: {imapResult} SMTP: {smtpResult}";
+            StatusText = $"{IncomingHostLabel}: {incomingResult} SMTP: {smtpResult}";
         }
         finally
         {

--- a/QuickMail/ViewModels/AccountManagerViewModel.cs
+++ b/QuickMail/ViewModels/AccountManagerViewModel.cs
@@ -157,6 +157,11 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
         ImapPort = value.ImapPort;
         ImapUseSsl = value.ImapUseSsl;
         ImapAcceptInvalidCert = value.ImapAcceptInvalidCert;
+        Pop3Host = value.Pop3Host;
+        Pop3Port = value.Pop3Port;
+        Pop3UseSsl = value.Pop3UseSsl;
+        Pop3AcceptInvalidCert = value.Pop3AcceptInvalidCert;
+        Pop3LeaveMailOnServer = value.Pop3LeaveMailOnServer;
         SmtpHost = value.SmtpHost;
         SmtpPort = value.SmtpPort;
         SmtpUseSsl = value.SmtpUseSsl;
@@ -384,6 +389,13 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
         account.ImapPort = ImapPort;
         account.ImapUseSsl = ImapUseSsl;
         account.ImapAcceptInvalidCert = ImapAcceptInvalidCert;
+        account.Pop3Host = Pop3Host;
+        account.Pop3Port = Pop3Port;
+        account.Pop3UseSsl = Pop3UseSsl;
+        account.Pop3AcceptInvalidCert = Pop3AcceptInvalidCert;
+        // Editable after the fact, and consequential: turning "leave mail on the server" off means
+        // the next collection is the last chance any other client has to see that mail.
+        account.Pop3LeaveMailOnServer = Pop3LeaveMailOnServer;
         account.SmtpHost = SmtpHost;
         account.SmtpPort = SmtpPort;
         account.SmtpUseSsl = SmtpUseSsl;

--- a/QuickMail/ViewModels/AddAccountViewModel.cs
+++ b/QuickMail/ViewModels/AddAccountViewModel.cs
@@ -44,7 +44,7 @@ public partial class AddAccountViewModel : AccountEditorViewModel, IDisposable
         if (gate.IsEnabled(FeatureFlag.Pop3Backend))
             backends.Add(new(BackendKind.Pop3Smtp, "POP3/SMTP"));
 
-        AvailableBackends = backends;
+        _allBackends = backends;
         _selectedBackend = backends[0];
 
         // The Google sign-in provider entry only exists for users who opted in. Everyone else is
@@ -85,6 +85,9 @@ public partial class AddAccountViewModel : AccountEditorViewModel, IDisposable
         ChooseBackendForMicrosoftAccount();
         SyncBackendOptionToBackendKind();
         // Declared on this class, so the base class's [NotifyPropertyChangedFor] can't cover it.
+        // AvailableBackends is provider-dependent (Graph is Microsoft-only), so the combo refreshes
+        // with the provider.
+        OnPropertyChanged(nameof(AvailableBackends));
         OnPropertyChanged(nameof(ShowConnectionMethod));
 
         // Deliberately NOT filling in the account name from the provider. Selecting a provider fires
@@ -99,8 +102,19 @@ public partial class AddAccountViewModel : AccountEditorViewModel, IDisposable
 
     // ── Connection method (Advanced settings) ────────────────────────────────────
 
-    /// <summary>Connection methods offered, derived from the feature gate.</summary>
-    public IReadOnlyList<BackendKindOption> AvailableBackends { get; }
+    private readonly List<BackendKindOption> _allBackends;
+
+    /// <summary>
+    /// Connection methods offered, derived from the feature gate AND the selected provider: Graph
+    /// is the Microsoft 365 API, so it is only offered when the provider is Microsoft. Offering it
+    /// for any provider let a Gmail account be saved bound to Microsoft OAuth with no hosts — a
+    /// dead account nothing later corrects, since <see cref="IsReadyToSave"/> has nothing to check
+    /// for Graph and ChooseBackendForMicrosoftAccount deliberately no-ops for other providers.
+    /// </summary>
+    public IReadOnlyList<BackendKindOption> AvailableBackends =>
+        _allBackends.Where(b => b.Kind != BackendKind.MicrosoftGraph
+                                || SelectedProvider?.Id == ProviderCatalog.MicrosoftId)
+                    .ToList();
 
     /// <summary>
     /// The connection-method choice, shown inside Advanced settings.

--- a/QuickMail/ViewModels/AddAccountViewModel.cs
+++ b/QuickMail/ViewModels/AddAccountViewModel.cs
@@ -41,6 +41,8 @@ public partial class AddAccountViewModel : AccountEditorViewModel, IDisposable
         };
         if (gate.IsEnabled(FeatureFlag.GraphBackend))
             backends.Add(new(BackendKind.MicrosoftGraph, "Microsoft 365 (Graph)"));
+        if (gate.IsEnabled(FeatureFlag.Pop3Backend))
+            backends.Add(new(BackendKind.Pop3Smtp, "POP3/SMTP"));
 
         AvailableBackends = backends;
         _selectedBackend = backends[0];
@@ -101,13 +103,27 @@ public partial class AddAccountViewModel : AccountEditorViewModel, IDisposable
     public IReadOnlyList<BackendKindOption> AvailableBackends { get; }
 
     /// <summary>
-    /// The IMAP-versus-Graph choice, shown only for Microsoft accounts and only inside Advanced
-    /// settings. Every other provider has exactly one connection method, so asking would be noise.
+    /// The connection-method choice, shown inside Advanced settings.
+    ///
+    /// <para>IMAP versus Graph is a Microsoft-only question, so on its own it appears only for
+    /// Microsoft accounts — every other provider has exactly one connection method, and asking would
+    /// be noise. POP3 changes that: it is offered for any provider, so once the POP3 backend is
+    /// enabled the combo is shown throughout. It is the only way to reach POP3, and a user who wants
+    /// it usually has a provider QuickMail has never heard of.</para>
     /// </summary>
     public bool ShowConnectionMethod =>
-        AvailableBackends.Count > 1 && SelectedProvider?.Id == ProviderCatalog.MicrosoftId;
+        AvailableBackends.Count > 1
+        && (_gate.IsEnabled(FeatureFlag.Pop3Backend) || SelectedProvider?.Id == ProviderCatalog.MicrosoftId);
 
     protected override bool IsGoogleAuthEnabled => _gate.IsEnabled(FeatureFlag.GoogleAuth);
+
+    /// <summary>
+    /// A hand-picked POP3 survives a provider change; see the base declaration for why POP3 and not
+    /// Graph. <see cref="_backendUserChosen"/> is what makes it the user's choice rather than one of
+    /// this VM's own inferences.
+    /// </summary>
+    protected override bool PreserveChosenBackend =>
+        _backendUserChosen && BackendKind == BackendKind.Pop3Smtp;
 
     [ObservableProperty]
     private BackendKindOption _selectedBackend;
@@ -150,6 +166,15 @@ public partial class AddAccountViewModel : AccountEditorViewModel, IDisposable
             // Graph accounts authenticate via OAuth and need no IMAP/SMTP host configuration.
             AuthType = AuthType.OAuth2Microsoft;
             ClearHostsForGraph();
+        }
+        else if (BackendKind == BackendKind.Pop3Smtp)
+        {
+            // The POP3 backend authenticates with a password; there is no OAuth path through it.
+            // Coming from Graph, the host fields were cleared and have to be put back — the SMTP
+            // half is still needed to send, and a provider's POP3 host to receive.
+            AuthType = AuthType.Password;
+            if (SelectedProvider is { IsOther: false } popProvider && !HostsUserEdited)
+                ApplyProvider(popProvider, collapseAdvanced: false);
         }
         else if (SelectedProvider is { IsOther: false } provider && !HostsUserEdited)
         {
@@ -420,6 +445,11 @@ public partial class AddAccountViewModel : AccountEditorViewModel, IDisposable
         ImapPort = ImapPort,
         ImapUseSsl = ImapUseSsl,
         ImapAcceptInvalidCert = ImapAcceptInvalidCert,
+        Pop3Host = Pop3Host,
+        Pop3Port = Pop3Port,
+        Pop3UseSsl = Pop3UseSsl,
+        Pop3AcceptInvalidCert = Pop3AcceptInvalidCert,
+        Pop3LeaveMailOnServer = Pop3LeaveMailOnServer,
         SmtpHost = SmtpHost,
         SmtpPort = SmtpPort,
         SmtpUseSsl = SmtpUseSsl,

--- a/QuickMail/ViewModels/AddSharedMailboxViewModel.cs
+++ b/QuickMail/ViewModels/AddSharedMailboxViewModel.cs
@@ -24,9 +24,11 @@ public partial class AddSharedMailboxViewModel : ObservableObject
 
         // Only shared-capable accounts can host a shared mailbox: a work/school Microsoft 365 (Graph)
         // account, or an IMAP account. A personal Microsoft account has no Exchange shared mailboxes,
-        // and a shared account can't itself be a parent.
+        // a POP3 account has no concept of a second mailbox at all (one maildrop, no folders, no
+        // access delegation), and a shared account can't itself be a parent.
         ParentOptions = _allAccounts
             .Where(a => !a.IsShared
+                        && a.BackendKind != BackendKind.Pop3Smtp
                         && !(a.BackendKind == BackendKind.MicrosoftGraph && a.IsPersonalMicrosoftAccount == true))
             .ToList();
 

--- a/QuickMail/ViewModels/ConnectionDiagnosticsViewModel.cs
+++ b/QuickMail/ViewModels/ConnectionDiagnosticsViewModel.cs
@@ -125,7 +125,9 @@ public sealed partial class ConnectionDiagnosticsViewModel : ObservableObject
             {
                 Id    = account.Id,
                 Label = account.AccountLabel,
-                Host  = account.ImapHost ?? "-",
+                // IncomingHost, not ImapHost: a POP3 account's ImapHost is empty, and this window
+                // exists to debug exactly the account whose server would otherwise show blank.
+                Host  = string.IsNullOrEmpty(account.IncomingHost) ? "-" : account.IncomingHost,
             };
             UpdateRow(row, account);
             Accounts.Add(row);

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -1730,11 +1730,14 @@ public partial class MainViewModel : ObservableObject, IDisposable
         left.Username == right.Username &&
         left.LoginUsername == right.LoginUsername &&
         left.AuthType == right.AuthType &&
-        left.ImapHost == right.ImapHost &&
-        left.ImapPort == right.ImapPort &&
-        left.ImapUseSsl == right.ImapUseSsl &&
+        // The INCOMING leg, whichever protocol serves it: reading the IMAP fields directly missed a
+        // repointed POP3 account entirely (its IMAP fields never change), so live "connected" status
+        // was carried over to a connection that no longer existed.
+        left.IncomingHost == right.IncomingHost &&
+        left.IncomingPort == right.IncomingPort &&
+        left.IncomingUseSsl == right.IncomingUseSsl &&
         left.RequireStartTls == right.RequireStartTls &&
-        left.ImapAcceptInvalidCert == right.ImapAcceptInvalidCert;
+        left.IncomingAcceptInvalidCert == right.IncomingAcceptInvalidCert;
 
     // ── Saved-views lifecycle ─────────────────────────────────────────────────────
 
@@ -4118,12 +4121,17 @@ public partial class MainViewModel : ObservableObject, IDisposable
         ConnectionStatusText = "Connecting…";
         IsBusy = true;
 
-        // Group by IMAP host: accounts sharing a server connect sequentially to stay under the
+        // Group by incoming host: accounts sharing a server connect sequentially to stay under the
         // per-IP connection limit shared hosting enforces (same rationale as SyncService); accounts
         // on different hosts still connect in parallel.
+        //
+        // IncomingHost, not ImapHost — a POP3 account's IMAP host is empty, so grouping on it put
+        // every POP3 account in one bucket regardless of its real server, and failed to serialize a
+        // POP3 account against an IMAP account on the same host. Serializing matters more for POP3
+        // than for IMAP: RFC 1939 gives a session an exclusive lock on the maildrop.
         var resultsByHost = await Task.WhenAll(
             Accounts.Where(a => !a.IsShared)   // #31: shared mailboxes are not connected in PR 1 (no own creds)
-                    .GroupBy(a => a.ImapHost, StringComparer.OrdinalIgnoreCase)
+                    .GroupBy(a => a.IncomingHost, StringComparer.OrdinalIgnoreCase)
                     .Select(async hostGroup =>
                     {
                         var groupResults = new List<(Guid Id, List<MailFolderModel>? Folders)>();

--- a/QuickMail/ViewModels/SettingsViewModel.cs
+++ b/QuickMail/ViewModels/SettingsViewModel.cs
@@ -130,6 +130,19 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty]
     private bool _googleSignIn;
 
+    /// <summary>
+    /// Bound to the Advanced tab's POP3 checkbox, and stored as the Pop3Backend flag in the
+    /// config.ini [features] section for the same reason as <see cref="GoogleSignIn"/> — it is the
+    /// same switch as <c>--feature Pop3Backend</c>, and a setting of its own would be a second
+    /// spelling of one flag. Read at startup by ConfigFeatureGate, hence the restart (#128).
+    ///
+    /// <para>Off by default. It gates only the OFFER of POP3 in Add Account: an account already
+    /// using POP3 keeps working whatever this is set to, so turning it back off hides the option
+    /// without stranding anyone's mail.</para>
+    /// </summary>
+    [ObservableProperty]
+    private bool _offerPop3;
+
     // ── Diagnostics (debug-only, #175) ─────────────────────────────────────────────
     // Deliberately NOT [ObservableProperty] over a field: the value lives on the
     // session service, never in ConfigModel/config.ini — non-persistence is the
@@ -460,6 +473,7 @@ public partial class SettingsViewModel : ObservableObject
         AutoUpdate                       = cfg.AutoUpdate;
         ShowUpdateInstalledAlerts        = cfg.ShowUpdateInstalledAlerts;
         GoogleSignIn                     = ReadFeature(cfg, FeatureFlag.GoogleAuth, false);
+        OfferPop3                        = ReadFeature(cfg, FeatureFlag.Pop3Backend, false);
         AutoSaveDrafts                   = cfg.AutoSaveDrafts;
         AutoSaveIntervalSeconds          = cfg.AutoSaveIntervalSeconds;
         DefaultComposeMode = cfg.DefaultComposeMode switch
@@ -543,6 +557,7 @@ public partial class SettingsViewModel : ObservableObject
         // Written both ways round, never removed when false: an explicit "false" in the file is how
         // a user who turns this back off stays off if the built-in default ever changes again.
         cfg.Features[FeatureFlag.GoogleAuth.ToString()] = GoogleSignIn ? "true" : "false";
+        cfg.Features[FeatureFlag.Pop3Backend.ToString()] = OfferPop3 ? "true" : "false";
         if (DesktopShortcut != Helpers.DesktopShortcut.Exists())
         {
             try

--- a/QuickMail/Views/AccountManagerDialog.xaml
+++ b/QuickMail/Views/AccountManagerDialog.xaml
@@ -243,8 +243,9 @@
                             </ComboBox>
                         </StackPanel>
 
-                        <!-- IMAP + SMTP server settings — hidden for Microsoft 365 (Graph) accounts. -->
-                        <StackPanel Visibility="{Binding IsImapBackend, Converter={StaticResource BoolToVisibility}}">
+                        <!-- Server settings — hidden for Microsoft 365 (Graph) accounts, shown for both
+                             host-based backends (each has its own incoming section; both send over SMTP). -->
+                        <StackPanel Visibility="{Binding ShowServerSettings, Converter={StaticResource BoolToVisibility}}">
                             <Separator Margin="0,12"/>
 
                             <!-- Empty for almost every account; filled in when the server logs in
@@ -259,29 +260,64 @@
 
                             <Separator Margin="0,12"/>
 
-                            <TextBlock Text="Incoming Mail (IMAP)" FontWeight="SemiBold" Margin="0,0,0,6"/>
+                            <!-- Exactly one of these two is ever visible, so both use the same access
+                                 keys: the access-key manager only considers visible elements. -->
+                            <StackPanel Visibility="{Binding IsImapBackend, Converter={StaticResource BoolToVisibility}}">
+                                <TextBlock Text="Incoming Mail (IMAP)" FontWeight="SemiBold" Margin="0,0,0,6"/>
 
-                            <Label x:Name="LblImapHost" Content="IMAP _host:" Target="{Binding ElementName=ImapHostBox}" Padding="0" Margin="0,4,0,2"/>
-                            <TextBox x:Name="ImapHostBox"
-                                     Text="{Binding ImapHost, UpdateSourceTrigger=PropertyChanged}"
-                                     AutomationProperties.LabeledBy="{Binding ElementName=LblImapHost}"
-                                    />
+                                <Label x:Name="LblImapHost" Content="IMAP _host:" Target="{Binding ElementName=ImapHostBox}" Padding="0" Margin="0,4,0,2"/>
+                                <TextBox x:Name="ImapHostBox"
+                                         Text="{Binding ImapHost, UpdateSourceTrigger=PropertyChanged}"
+                                         AutomationProperties.LabeledBy="{Binding ElementName=LblImapHost}"
+                                        />
 
-                            <Label x:Name="LblImapPort" Content="IMAP _port:" Target="{Binding ElementName=ImapPortBox}" Padding="0" Margin="0,6,0,2"/>
-                            <TextBox x:Name="ImapPortBox"
-                                     Text="{Binding ImapPort, UpdateSourceTrigger=PropertyChanged}"
-                                     AutomationProperties.LabeledBy="{Binding ElementName=LblImapPort}"
-                                    />
+                                <Label x:Name="LblImapPort" Content="IMAP _port:" Target="{Binding ElementName=ImapPortBox}" Padding="0" Margin="0,6,0,2"/>
+                                <TextBox x:Name="ImapPortBox"
+                                         Text="{Binding ImapPort, UpdateSourceTrigger=PropertyChanged}"
+                                         AutomationProperties.LabeledBy="{Binding ElementName=LblImapPort}"
+                                        />
 
-                            <CheckBox Content="Use _SSL (port 993)"
-                                      IsChecked="{Binding ImapUseSsl}"
-                                      AutomationProperties.Name="IMAP use SSL"
-                                      Margin="0,6"/>
+                                <CheckBox Content="Use _SSL (port 993)"
+                                          IsChecked="{Binding ImapUseSsl}"
+                                          AutomationProperties.Name="IMAP use SSL"
+                                          Margin="0,6"/>
 
-                            <CheckBox Content="Accept _invalid certificates"
-                                      IsChecked="{Binding ImapAcceptInvalidCert}"
-                                      AutomationProperties.Name="IMAP accept invalid SSL certificates"
-                                      Margin="0,0,0,6"/>
+                                <CheckBox Content="Accept _invalid certificates"
+                                          IsChecked="{Binding ImapAcceptInvalidCert}"
+                                          AutomationProperties.Name="IMAP accept invalid SSL certificates"
+                                          Margin="0,0,0,6"/>
+                            </StackPanel>
+
+                            <StackPanel Visibility="{Binding IsPop3Backend, Converter={StaticResource BoolToVisibility}}">
+                                <TextBlock Text="Incoming Mail (POP3)" FontWeight="SemiBold" Margin="0,0,0,6"/>
+
+                                <Label x:Name="LblPop3Host" Content="POP3 _host:" Target="{Binding ElementName=Pop3HostBox}" Padding="0" Margin="0,4,0,2"/>
+                                <TextBox x:Name="Pop3HostBox"
+                                         Text="{Binding Pop3Host, UpdateSourceTrigger=PropertyChanged}"
+                                         AutomationProperties.LabeledBy="{Binding ElementName=LblPop3Host}"
+                                        />
+
+                                <Label x:Name="LblPop3Port" Content="POP3 _port:" Target="{Binding ElementName=Pop3PortBox}" Padding="0" Margin="0,6,0,2"/>
+                                <TextBox x:Name="Pop3PortBox"
+                                         Text="{Binding Pop3Port, UpdateSourceTrigger=PropertyChanged}"
+                                         AutomationProperties.LabeledBy="{Binding ElementName=LblPop3Port}"
+                                        />
+
+                                <CheckBox Content="Use _SSL (port 995)"
+                                          IsChecked="{Binding Pop3UseSsl}"
+                                          AutomationProperties.Name="POP3 use SSL"
+                                          Margin="0,6"/>
+
+                                <CheckBox Content="Accept _invalid certificates"
+                                          IsChecked="{Binding Pop3AcceptInvalidCert}"
+                                          AutomationProperties.Name="POP3 accept invalid SSL certificates"
+                                          Margin="0,0,0,6"/>
+
+                                <CheckBox x:Name="Pop3LeaveOnServerCheckBox"
+                                          Content="_Keep mail on the server after downloading"
+                                          IsChecked="{Binding Pop3LeaveMailOnServer}"
+                                          Margin="0,0,0,6"/>
+                            </StackPanel>
 
                             <Separator Margin="0,6"/>
 

--- a/QuickMail/Views/AccountManagerDialog.xaml.cs
+++ b/QuickMail/Views/AccountManagerDialog.xaml.cs
@@ -155,6 +155,11 @@ public partial class AccountManagerDialog : Window
         // stay a short label.
         if (ReferenceEquals(focused, SmtpImplicitSslCheckBox))
             return "Checked uses port 465. Cleared uses STARTTLS on port 587.";
+        // Same reasoning as the Add Account dialog: what clearing this costs is the point of the
+        // control, and it belongs in a hint rather than in a label that must stay short.
+        if (ReferenceEquals(focused, Pop3LeaveOnServerCheckBox))
+            return "Cleared, mail is removed from the server once QuickMail has downloaded it, "
+                 + "so this computer holds the only copy.";
         if (ReferenceEquals(focused, SignatureBox))
             return "Added to the end of new messages, replies, and forwards.";
         return null;

--- a/QuickMail/Views/AddAccountDialog.xaml
+++ b/QuickMail/Views/AddAccountDialog.xaml
@@ -157,9 +157,11 @@
                             </ComboBox>
                         </StackPanel>
 
-                        <!-- IMAP + SMTP — collapsed for Microsoft Graph accounts, which authenticate
-                             via OAuth and need no host configuration. -->
-                        <StackPanel Visibility="{Binding IsImapBackend, Converter={StaticResource BoolToVisibility}}">
+                        <!-- Server settings — collapsed for Microsoft Graph accounts, which authenticate
+                             via OAuth and need no host configuration. Shown for both host-based
+                             backends: each contributes its own incoming section below, and both send
+                             over SMTP. -->
+                        <StackPanel Visibility="{Binding ShowServerSettings, Converter={StaticResource BoolToVisibility}}">
                             <Separator Margin="0,12"/>
 
                             <!-- Only for servers whose login is not the email address. Advanced,
@@ -178,29 +180,67 @@
 
                             <Separator Margin="0,12"/>
 
-                            <TextBlock Text="Incoming Mail (IMAP)" FontWeight="SemiBold" Margin="0,0,0,6"/>
+                            <!-- Incoming: exactly one of these two is ever visible, which is why both
+                                 use the same access keys — the access-key manager only considers
+                                 visible elements, and h/p/S/i stay where the user learned them. -->
+                            <StackPanel Visibility="{Binding IsImapBackend, Converter={StaticResource BoolToVisibility}}">
+                                <TextBlock Text="Incoming Mail (IMAP)" FontWeight="SemiBold" Margin="0,0,0,6"/>
 
-                            <Label x:Name="LblImapHost" Content="IMAP _host:" Target="{Binding ElementName=ImapHostBox}" Padding="0" Margin="0,4,0,2"/>
-                            <TextBox x:Name="ImapHostBox"
-                                     Text="{Binding ImapHost, UpdateSourceTrigger=PropertyChanged}"
-                                     AutomationProperties.LabeledBy="{Binding ElementName=LblImapHost}"
-                                    />
+                                <Label x:Name="LblImapHost" Content="IMAP _host:" Target="{Binding ElementName=ImapHostBox}" Padding="0" Margin="0,4,0,2"/>
+                                <TextBox x:Name="ImapHostBox"
+                                         Text="{Binding ImapHost, UpdateSourceTrigger=PropertyChanged}"
+                                         AutomationProperties.LabeledBy="{Binding ElementName=LblImapHost}"
+                                        />
 
-                            <Label x:Name="LblImapPort" Content="IMAP _port:" Target="{Binding ElementName=ImapPortBox}" Padding="0" Margin="0,6,0,2"/>
-                            <TextBox x:Name="ImapPortBox"
-                                     Text="{Binding ImapPort, UpdateSourceTrigger=PropertyChanged}"
-                                     AutomationProperties.LabeledBy="{Binding ElementName=LblImapPort}"
-                                    />
+                                <Label x:Name="LblImapPort" Content="IMAP _port:" Target="{Binding ElementName=ImapPortBox}" Padding="0" Margin="0,6,0,2"/>
+                                <TextBox x:Name="ImapPortBox"
+                                         Text="{Binding ImapPort, UpdateSourceTrigger=PropertyChanged}"
+                                         AutomationProperties.LabeledBy="{Binding ElementName=LblImapPort}"
+                                        />
 
-                            <CheckBox Content="Use _SSL (port 993)"
-                                      IsChecked="{Binding ImapUseSsl}"
-                                      AutomationProperties.Name="IMAP use SSL"
-                                      Margin="0,6"/>
+                                <CheckBox Content="Use _SSL (port 993)"
+                                          IsChecked="{Binding ImapUseSsl}"
+                                          AutomationProperties.Name="IMAP use SSL"
+                                          Margin="0,6"/>
 
-                            <CheckBox Content="Accept _invalid certificates"
-                                      IsChecked="{Binding ImapAcceptInvalidCert}"
-                                      AutomationProperties.Name="IMAP accept invalid SSL certificates"
-                                      Margin="0,0,0,6"/>
+                                <CheckBox Content="Accept _invalid certificates"
+                                          IsChecked="{Binding ImapAcceptInvalidCert}"
+                                          AutomationProperties.Name="IMAP accept invalid SSL certificates"
+                                          Margin="0,0,0,6"/>
+                            </StackPanel>
+
+                            <StackPanel Visibility="{Binding IsPop3Backend, Converter={StaticResource BoolToVisibility}}">
+                                <TextBlock Text="Incoming Mail (POP3)" FontWeight="SemiBold" Margin="0,0,0,6"/>
+
+                                <Label x:Name="LblPop3Host" Content="POP3 _host:" Target="{Binding ElementName=Pop3HostBox}" Padding="0" Margin="0,4,0,2"/>
+                                <TextBox x:Name="Pop3HostBox"
+                                         Text="{Binding Pop3Host, UpdateSourceTrigger=PropertyChanged}"
+                                         AutomationProperties.LabeledBy="{Binding ElementName=LblPop3Host}"
+                                        />
+
+                                <Label x:Name="LblPop3Port" Content="POP3 _port:" Target="{Binding ElementName=Pop3PortBox}" Padding="0" Margin="0,6,0,2"/>
+                                <TextBox x:Name="Pop3PortBox"
+                                         Text="{Binding Pop3Port, UpdateSourceTrigger=PropertyChanged}"
+                                         AutomationProperties.LabeledBy="{Binding ElementName=LblPop3Port}"
+                                        />
+
+                                <CheckBox Content="Use _SSL (port 995)"
+                                          IsChecked="{Binding Pop3UseSsl}"
+                                          AutomationProperties.Name="POP3 use SSL"
+                                          Margin="0,6"/>
+
+                                <CheckBox Content="Accept _invalid certificates"
+                                          IsChecked="{Binding Pop3AcceptInvalidCert}"
+                                          AutomationProperties.Name="POP3 accept invalid SSL certificates"
+                                          Margin="0,0,0,6"/>
+
+                                <!-- The consequence of clearing this is spelled out in a focus hint
+                                     (see HintFor) rather than in the label, which stays a short label. -->
+                                <CheckBox x:Name="Pop3LeaveOnServerCheckBox"
+                                          Content="_Keep mail on the server after downloading"
+                                          IsChecked="{Binding Pop3LeaveMailOnServer}"
+                                          Margin="0,0,0,6"/>
+                            </StackPanel>
 
                             <Separator Margin="0,6"/>
 

--- a/QuickMail/Views/AddAccountDialog.xaml.cs
+++ b/QuickMail/Views/AddAccountDialog.xaml.cs
@@ -85,7 +85,10 @@ public partial class AddAccountDialog : Window
 
     /// <summary>
     /// A lookup finished. The message itself is announced by the StatusText handler above; what this
-    /// adds is putting the caret where the work now is — the IMAP host field — when nothing was found.
+    /// adds is putting the caret where the work now is — the incoming host field — when nothing was
+    /// found. Exactly one of the IMAP and POP3 panels is visible, so the host box to focus follows
+    /// the connection method; without the POP3 branch, a POP3 account's error announced the field
+    /// and then stranded focus where it was.
     /// </summary>
     private void OnDiscoveryCompleted(bool found, string message)
     {
@@ -93,12 +96,19 @@ public partial class AddAccountDialog : Window
 
         // Advanced was just expanded by the VM. Let the expander realize its content before focusing
         // into it, or Focus() lands on an element that does not exist yet.
-        Dispatcher.BeginInvoke(new Action(() =>
-        {
-            if (!ImapHostBox.IsVisible) return;
-            ImapHostBox.Focus();
-            Keyboard.Focus(ImapHostBox);
-        }), System.Windows.Threading.DispatcherPriority.Input);
+        Dispatcher.BeginInvoke(new Action(FocusIncomingHostBox),
+            System.Windows.Threading.DispatcherPriority.Input);
+    }
+
+    /// <summary>Focuses whichever incoming-server host box is currently presented.</summary>
+    private void FocusIncomingHostBox()
+    {
+        var box = ImapHostBox.IsVisible ? ImapHostBox
+                : Pop3HostBox.IsVisible ? Pop3HostBox
+                : null;
+        if (box is null) return;
+        box.Focus();
+        Keyboard.Focus(box);
     }
 
     /// <summary>
@@ -265,12 +275,8 @@ public partial class AddAccountDialog : Window
             else
             {
                 _vm.IsAdvancedExpanded = true;
-                Dispatcher.BeginInvoke(new Action(() =>
-                {
-                    if (!ImapHostBox.IsVisible) return;
-                    ImapHostBox.Focus();
-                    Keyboard.Focus(ImapHostBox);
-                }), System.Windows.Threading.DispatcherPriority.Input);
+                Dispatcher.BeginInvoke(new Action(FocusIncomingHostBox),
+                    System.Windows.Threading.DispatcherPriority.Input);
             }
             return;
         }

--- a/QuickMail/Views/AddAccountDialog.xaml.cs
+++ b/QuickMail/Views/AddAccountDialog.xaml.cs
@@ -148,6 +148,12 @@ public partial class AddAccountDialog : Window
         // stay a short label.
         if (ReferenceEquals(focused, SmtpImplicitSslCheckBox))
             return "Checked uses port 465. Cleared uses STARTTLS on port 587.";
+        // POP3 hands the local store the only copy of a message once the server drops it, and that
+        // is what this checkbox decides. It belongs in a hint rather than in the label, which stays
+        // a short label — and in a hint the user's announcement preference still applies.
+        if (ReferenceEquals(focused, Pop3LeaveOnServerCheckBox))
+            return "Cleared, mail is removed from the server once QuickMail has downloaded it, "
+                 + "so this computer holds the only copy.";
         if (ReferenceEquals(focused, SignatureBox))
             return "Added to the end of new messages, replies, and forwards.";
         return null;

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -5476,6 +5476,7 @@ public partial class MainWindow : Window
                           ?? (node != null ? _vm.Accounts.FirstOrDefault(a => a.AccountLabel == node.Label)?.Id : null)
                           ?? _vm.SelectedAccount?.Id;
         if (accountId == null || accountId == Guid.Empty) return;
+        if (!SupportsServerFolders(accountId.Value, "create a folder in")) return;
 
         var dlg = new NewFolderDialog
         {
@@ -5509,6 +5510,22 @@ public partial class MainWindow : Window
         return false;
     }
 
+    /// <summary>
+    /// Refuses folder management on an account whose protocol has no folders — POP3 (#128), whose
+    /// Inbox, Sent, Drafts and Trash are made up by QuickMail and are the only folders there can be.
+    /// Same contract as <see cref="IsMovableFolder"/>: say why, rather than let the command reach a
+    /// backend that throws and surface as "Failed to create folder".
+    /// </summary>
+    private bool SupportsServerFolders(Guid accountId, string verb)
+    {
+        var account = _vm.Accounts.FirstOrDefault(a => a.Id == accountId);
+        if (account?.BackendKind != BackendKind.Pop3Smtp) return true;
+
+        Report($"POP3 accounts have no server folders, so there is nothing to {verb}. "
+             + $"{account.AccountLabel} has only Inbox, Sent, Drafts and Trash.");
+        return false;
+    }
+
     // Status bar for sighted users, announcement for screen-reader users — the pairing
     // FolderContextMenu_SetArchive_Click established for these context-menu outcomes.
     private void Report(string message)
@@ -5521,6 +5538,7 @@ public partial class MainWindow : Window
     {
         var node = GetContextMenuFolderNode(sender);
         if (!IsMovableFolder(node, "move")) return;
+        if (!SupportsServerFolders(node!.Folder!.AccountId, "move")) return;
 
         if (_vm.CachedFolders.Count == 0) return;
         var picker = FolderPickerWindow.ForFolderMoveCopy(
@@ -5542,6 +5560,7 @@ public partial class MainWindow : Window
     {
         var node = GetContextMenuFolderNode(sender);
         if (!IsMovableFolder(node, "copy")) return;
+        if (!SupportsServerFolders(node!.Folder!.AccountId, "copy")) return;
 
         if (_vm.CachedFolders.Count == 0) return;
         var picker = FolderPickerWindow.ForFolderMoveCopy(
@@ -5627,6 +5646,8 @@ public partial class MainWindow : Window
     // tree in place (no rebuild), so the captured neighbour reference stays valid for FocusTreeItem.
     private async Task DeleteFolderWithFocusAsync(FolderTreeNode node)
     {
+        if (node.Folder is { } target && !SupportsServerFolders(target.AccountId, "delete")) return;
+
         var above = FindVisibleFolderNodeAbove(node);
         // Only move focus if the delete actually happened — a cancelled confirmation must leave the
         // user where they were.

--- a/QuickMail/Views/SettingsDialog.xaml
+++ b/QuickMail/Views/SettingsDialog.xaml
@@ -403,6 +403,18 @@
                             </StackPanel>
                         </GroupBox>
 
+                        <!-- Account Types Group (#128) -->
+                        <GroupBox Header="Account T_ypes" Padding="10" Margin="0,0,0,15"
+                                  AutomationProperties.Name="Account type settings">
+                            <StackPanel>
+                                <CheckBox Content="Offer _POP3 when adding an account"
+                                          IsChecked="{Binding OfferPop3, Mode=TwoWay}"
+                                          AutomationProperties.Name="Offer POP3 when adding an account"/>
+                                <TextBlock Text="Adds POP3/SMTP to the Connection method list under Advanced settings in Add Account, for mail services that offer no IMAP. Takes effect the next time QuickMail starts. POP3 downloads each message to this computer and keeps it there — QuickMail's own Inbox, Sent, Drafts and Trash — so the local copy is the only copy once a message leaves the server. Accounts already using POP3 keep working whether this is on or off."
+                                           Foreground="{DynamicResource Theme.TextSecondary}" FontSize="{DynamicResource Theme.FontSizeSmall}" Margin="0,3,0,0" TextWrapping="Wrap"/>
+                            </StackPanel>
+                        </GroupBox>
+
                         <!-- QuickMail Logging Group -->
                         <GroupBox Header="QuickMail _Logging" Padding="10" Margin="0,0,0,15"
                                   AutomationProperties.Name="QuickMail logging settings">

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -335,12 +335,20 @@ your phone, webmail, or anything else you use.
 Clear it and QuickMail removes each message from the server once it is safely stored here — the
 classic POP3 behaviour, and the reason POP3 has the reputation it has. **This computer then holds the
 only copy**, so think about backups before choosing it. You can change the setting later in Manage
-Accounts; it applies from the next collection onwards and never retrieves anything already removed.
+Accounts. Clearing it also applies to mail collected earlier, as POP3 programs have traditionally
+worked: on the next collection QuickMail removes the server copies of messages it already downloaded
+— every one of them is already stored here, so nothing is lost, but if your phone or another program
+has not collected that mailbox yet, leave the setting checked until it has.
 
 Either way, deleting a message in QuickMail is two steps, as it is everywhere else: to Trash, then
 permanently. Only the permanent delete can reach the server, and only for an account set to remove
 collected mail. QuickMail confirms it is deleting the right message first — a message some other
 program has already collected is left alone rather than deleted by position.
+
+With **keep mail on the server** checked, a permanent delete (including emptying the Trash) is local
+and final: the message is gone from QuickMail for good, the server copy stays where it is for
+whatever else reads that mailbox, and QuickMail remembers the deletion so the message is never
+downloaded again.
 
 **Where your POP3 mail lives.** In QuickMail's data folder for that profile (`%APPDATA%\QuickMail` by
 default), in `mail.db`. For an IMAP account that file is a cache and can be deleted safely; for a

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -187,7 +187,8 @@ To turn off steps 2, 3, and 4, set `AutoDiscoverOnline = off` in `config.ini`. T
 Choose **Other**, or open **Advanced settings** for any provider, to enter:
 
 - **Login username** — leave this blank unless your mail server logs in under a different name than your email address. See [When your login is not your email address](#when-your-login-is-not-your-email-address).
-- **IMAP host**, port, **Use SSL** (port 993), and whether to accept invalid certificates
+- **Connection method** — Standard IMAP/SMTP, Microsoft 365 (Graph) for Microsoft accounts, and POP3/SMTP when you have turned POP3 on. The incoming fields below follow whichever you choose; see [POP3 accounts](#pop3-accounts).
+- **IMAP host**, port, **Use SSL** (port 993), and whether to accept invalid certificates — or **POP3 host**, port and **Use SSL** (port 995) for a POP3 account
 - **SMTP host**, port, implicit SSL on connect (port 465 — leave it unchecked for STARTTLS on port 587), and whether to accept invalid certificates
 - **Authentication** — Password or Microsoft, plus Google when you have turned Google sign-in on (or when the account already uses it)
 - Your **Signature**, which is added to the end of new messages, replies, and forwards
@@ -291,6 +292,60 @@ Choose **iCloud Mail** or type your iCloud address (`@icloud.com`, `@me.com`, or
 **App-specific password required.** Apple does not allow third-party apps to use your Apple ID password directly. Generate an app-specific password at **appleid.apple.com** (Sign-In & Security → App-Specific Passwords) and enter it in the Password field. QuickMail shows a reminder above the password box, with a link to that page.
 
 To bring in your iCloud data, check **Sync contacts from this account** and/or **Sync calendar from this account** — QuickMail uses the same app-specific password for both, so there's nothing else to set up. iCloud **contacts** are read-only; iCloud **calendars** you can also add, edit, and delete single (non-repeating) appointments on. See [Syncing Contacts from Your Accounts](#syncing-contacts-from-your-accounts) and the [Calendar](#calendar) section for details.
+
+### POP3 accounts
+
+Some mail services offer POP3 and nothing else. QuickMail can collect mail over POP3 and send over
+SMTP as usual — but POP3 works differently enough from IMAP that it is worth reading this section
+before you choose it.
+
+**Turning it on.** POP3 is off until you ask for it. In **File → Settings** (Ctrl+comma), open the
+**Advanced** tab, and under **Account Types** check **Offer POP3 when adding an account**. It takes
+effect the next time QuickMail starts. (Equivalently, `Pop3Backend = true` under `[features]` in
+`config.ini`, or `--feature Pop3Backend` at launch — they are the same switch, so there is no need to
+set more than one.)
+
+**Adding the account.** Add it as you would any other: **New** in Manage Accounts, then open
+**Advanced settings** and choose **POP3/SMTP** under **Connection method**. The **Incoming Mail
+(POP3)** fields replace the IMAP ones. Gmail, Outlook.com and Yahoo Mail fill in their POP3 server
+for you; for anything else, type the server, port and security yourself. iCloud is not offered a POP3
+server because Apple does not run one — iCloud is IMAP only.
+
+Two things most services require before POP3 will answer at all: POP3 switched on in the service's
+own web settings, and — for Gmail and Yahoo — an app password rather than your account password.
+
+**What is different from IMAP:**
+
+- **Messages are downloaded whole and kept on this computer.** Reading a message, opening its
+  attachments, and searching all work with no network.
+- **Four folders — Inbox, Sent, Drafts and Trash — and they belong to QuickMail.** A POP3 server has
+  no folders to show, so these are QuickMail's own. Creating, renaming, moving and deleting folders
+  are not offered for a POP3 account; QuickMail says so rather than failing at the server.
+- **Read and unread, flags, and moves between those folders stay on this computer.** POP3 has nowhere
+  on the server to record them, so another mail program reading the same mailbox will not see them.
+- **New mail arrives on the sync interval**, not the moment it lands. POP3 has no equivalent of the
+  live connection QuickMail holds open for IMAP, so there is no instant notification.
+- **Sending is unchanged.** A POP3 account sends over SMTP exactly like an IMAP one, and a copy of
+  each sent message is filed in QuickMail's own Sent folder.
+
+**Keep mail on the server after downloading.** This is checked by default, and while it is checked
+QuickMail never deletes anything from your mail service: collect mail here and it is still there for
+your phone, webmail, or anything else you use.
+
+Clear it and QuickMail removes each message from the server once it is safely stored here — the
+classic POP3 behaviour, and the reason POP3 has the reputation it has. **This computer then holds the
+only copy**, so think about backups before choosing it. You can change the setting later in Manage
+Accounts; it applies from the next collection onwards and never retrieves anything already removed.
+
+Either way, deleting a message in QuickMail is two steps, as it is everywhere else: to Trash, then
+permanently. Only the permanent delete can reach the server, and only for an account set to remove
+collected mail. QuickMail confirms it is deleting the right message first — a message some other
+program has already collected is left alone rather than deleted by position.
+
+**Where your POP3 mail lives.** In QuickMail's data folder for that profile (`%APPDATA%\QuickMail` by
+default), in `mail.db`. For an IMAP account that file is a cache and can be deleted safely; for a
+POP3 account with "keep mail on the server" cleared, it is your mail. Back it up accordingly, and see
+[Moving to a new computer](#moving-to-a-new-computer).
 
 ### Editing an account
 
@@ -1332,7 +1387,7 @@ The direction matters, so it is worth being blunt about it: a **two-way** item i
 
 | What | Direction | What that means for you |
 |------|-----------|--------------------------|
-| **Messages** | Two-way | Read and unread, moving between folders, deleting, and sending all go to the server. Another program sees the same state. |
+| **Messages** | Two-way | Read and unread, moving between folders, deleting, and sending all go to the server. Another program sees the same state. **POP3 accounts are the exception** — the protocol has nowhere to record any of it, so everything but sending stays on this computer. See [POP3 accounts](#pop3-accounts). |
 | **The built-in flag** | Two-way | Set or cleared in QuickMail, it shows up everywhere else, and a message flagged elsewhere arrives here already flagged. |
 | **Named flags you create** | This computer only | The name and color exist in QuickMail alone. Other programs, and QuickMail on another computer, will not see them. |
 | **Contacts** | Download only | QuickMail reads your Microsoft, Google, and iCloud contacts and never writes back. Synced contacts cannot be edited or deleted in the address book — [make the change at the account and re-sync](#changing-or-deleting-a-synced-contact). |
@@ -1348,6 +1403,8 @@ That is nearly always a download-only item. QuickMail refreshed from the account
 ### Moving to a new computer
 
 Your mail, your contacts, and your connected calendars come back on their own once you add your accounts again, because they live on the server. The **This computer only** row above does not: rules, flags you named, templates, signatures, saved views, and your settings are stored in QuickMail's data folder (`%APPDATA%\QuickMail`) and need to be copied across if you want them.
+
+**A [POP3 account](#pop3-accounts) is the exception to the first sentence.** If it is set to remove mail from the server once collected, the server has nothing left to give back and `mail.db` in that data folder is your mail — copy it across, or back it up, like any other document.
 
 ---
 
@@ -1518,6 +1575,10 @@ Accounts are not part of Settings — they have a window of their own. Open **Fi
 **Account Sign-In**
 
 - **Sign in with Google for Gmail accounts** — off by default. Google no longer authorizes QuickMail for new accounts, so Gmail normally uses an app password. Turn this on only if your Google authorization predates that change; it adds a **Gmail (sign in with Google)** provider and a Google choice under **Authentication** in the account dialogs. Takes effect the next time QuickMail starts. Gmail accounts already using Google sign-in keep working whether this is on or off. See [Gmail (Google Account)](#gmail-google-account).
+
+**Account Types**
+
+- **Offer POP3 when adding an account** — off by default. Adds **POP3/SMTP** to the **Connection method** list under **Advanced settings** in the account dialogs, for mail services that offer no IMAP. Takes effect the next time QuickMail starts. POP3 downloads each message to this computer and keeps it there, in QuickMail's own Inbox, Sent, Drafts and Trash, so the local copy is the only copy once a message leaves the server — read [POP3 accounts](#pop3-accounts) before turning it on. Accounts already using POP3 keep working whether this is on or off.
 
 **QuickMail Logging**
 

--- a/docs/planning/pop3-pm-dev-spec.md
+++ b/docs/planning/pop3-pm-dev-spec.md
@@ -1,10 +1,45 @@
 # POP3 Backend — PM & Dev Specification
 
-**Status:** Implemented — awaiting testing (see [issue #128](https://github.com/kellylford/QuickMail/issues/128))  
+**Status:** Implemented and tested, behind the `Pop3Backend` flag (see [issue #128](https://github.com/kellylford/QuickMail/issues/128))  
 **Date:** 2026-06-24  
-**Implemented:** 2026-06-26  
+**Implemented:** 2026-06-26 (first cut) / 2026-08-14 (rebuilt on current main, tested)  
 **Target:** v0.8.x (after Graph backend ships)  
 **Scope:** Large (new protocol backend, new service, model changes, UI additions)
+
+---
+
+## 0. What changed after the spec was written
+
+The spec predates the #462 periodic-sweep rework, which is where POP3's real design problem turned
+out to live. Read this section before §5.
+
+**The sweep is the hazard.** `SyncService` routes a folder with no numeric high-water mark through
+`SyncFolderByIdDiffAsync`, and every POP3 folder qualifies (UIDLs are not numbers). That path deletes
+cached ids the backend's listing omits — and a POP3 server legitimately stops listing a message the
+moment it is collected. Left alone it would have deleted the user's only copy of their mail on the
+first sweep after collection.
+
+The resolution keeps `SyncService` backend-agnostic; all three answers live in `Pop3MailService`:
+
+| Sweep asks | POP3 answers | Why |
+|---|---|---|
+| `GetFolderMessageIdDatesAsync` | union of server UIDLs and cached ids; cached rows keep their own date and read state; unseen UIDLs are stamped "now", unread | the union makes the deletion reconcile a no-op; the stamp is what tells the sweep there is new mail to fetch |
+| `GetMessagesSinceDateAsync` | collects from the server first, then returns the window | this is the download trigger, so arrivals reach rules, the list and the toast |
+| `GetFolderMessageIdsAsync` | store only | the older `ReconcileFolderAsync` path diffs the cache against itself |
+
+Two smaller corrections from the same review:
+
+- **Flags.** `UpsertSummariesAsync` derives the stored flag from `IsServerFlagged`, which assumes an
+  IMAP server that owns flag state. POP3 has none, so every sync fetch restates the local flag as the
+  server's — otherwise each sweep cleared the user's flags.
+- **A hand-picked POP3 survives a provider match.** Typing an address selects a provider and applies
+  its default connection method, which silently put the account back on IMAP. Graph still follows the
+  provider (it is a Microsoft-only route); POP3 does not (any provider may offer it).
+
+Also implemented beyond the original spec: POP3 hosts in the provider catalog (Gmail, Outlook.com,
+Yahoo; iCloud has no POP3 service and is deliberately blank), decoded attachment sizes, calendar
+invites and mailing-list detection on downloaded mail, and `internet_message_id` carried on cached
+details so a reply from a POP3 message threads.
 
 ---
 

--- a/docs/release-notes-v0.8.40.md
+++ b/docs/release-notes-v0.8.40.md
@@ -59,10 +59,16 @@ is still there for your phone, or webmail, or whatever else you use.
 
 Clear it and QuickMail removes each message from the server once it has been safely stored here,
 which is the classic POP3 behaviour. That makes this computer the only copy, so keep backups in mind
-before you choose it. Either way, a message you delete only ever leaves the server on a permanent
-delete, never on the way to Trash — and QuickMail checks it is deleting the right message before it
-does, so a message another program has already collected is left alone rather than deleted by
-position.
+before you choose it. Clearing it also applies to mail collected earlier, as POP3 programs have
+traditionally worked: the next collection removes the server copies of messages QuickMail already
+holds, so if another device has not caught up with that mailbox yet, leave the setting on until it
+has.
+
+A message you delete only ever leaves the server on a permanent delete, never on the way to Trash —
+and QuickMail checks it is deleting the right message before it does, so a message another program
+has already collected is left alone rather than deleted by position. With keep-mail on, a permanent
+delete (including emptying the Trash) is local and final: the server copy stays for your other
+devices, and QuickMail remembers the deletion so the message is never downloaded again.
 
 Thanks to the people who have been asking for this since QuickMail's early days.
 ([#128](https://github.com/kellylford/QuickMail/issues/128))

--- a/docs/release-notes-v0.8.40.md
+++ b/docs/release-notes-v0.8.40.md
@@ -17,6 +17,56 @@ All downloads include the .NET 8 runtime — you do not need to install .NET sep
 
 ---
 
+## New: POP3, for mail services that offer no IMAP
+
+Some mail services still hand out POP3 and nothing else, and until now that put QuickMail out of
+reach entirely. It can now collect mail over POP3, and send over SMTP exactly as it always has.
+
+**It is off until you turn it on.** POP3 is new here, and it works differently enough from IMAP to
+be worth choosing deliberately rather than stumbling into. In **File → Settings** (Ctrl+comma),
+**Advanced**, under **Account Types**, tick **Offer POP3 when adding an account**, then restart
+QuickMail. Nothing else about QuickMail changes while it is off — and an account already using POP3
+keeps working whether the setting is on or off, so turning it back off hides the option without
+stranding your mail.
+
+Then add the account as usual: **Accounts → Add Account**, open **Advanced settings**, and choose
+**POP3/SMTP** under **Connection method**. Gmail, Outlook.com and Yahoo fill in their POP3 server for
+you; for anything else you type the server, as you would for IMAP. Most services need POP3 switched
+on in their own web settings first, and Gmail and Yahoo want an app password rather than your account
+password.
+
+### What POP3 means day to day
+
+POP3 has no folders on the server, no shared read or flag state, and no way to fetch part of a
+message. So a POP3 account in QuickMail works like this:
+
+- **Whole messages are downloaded and kept on this computer.** Reading a message, opening its
+  attachments and searching all work with no network at all.
+- **Four folders — Inbox, Sent, Drafts and Trash — and they are QuickMail's own.** There is nothing
+  on a POP3 server to make folders out of, so creating, renaming or moving folders is not offered;
+  ask for it and QuickMail says why rather than failing at the server.
+- **Read and unread, flags, and moves stay on this computer.** POP3 gives them nowhere to go, so
+  another mail program looking at the same mailbox will not see them.
+- **New mail arrives on the sync interval**, not the instant it lands. POP3 has no equivalent of the
+  live connection QuickMail holds open for IMAP.
+- **Deleting is two steps, as everywhere else in QuickMail**: to Trash, then permanently.
+
+### Keep mail on the server
+
+The one setting worth reading twice. **Keep mail on the server after downloading** is on by default,
+and while it is on QuickMail never deletes anything from your mail service — collect mail here and it
+is still there for your phone, or webmail, or whatever else you use.
+
+Clear it and QuickMail removes each message from the server once it has been safely stored here,
+which is the classic POP3 behaviour. That makes this computer the only copy, so keep backups in mind
+before you choose it. Either way, a message you delete only ever leaves the server on a permanent
+delete, never on the way to Trash — and QuickMail checks it is deleting the right message before it
+does, so a message another program has already collected is left alone rather than deleted by
+position.
+
+Thanks to the people who have been asking for this since QuickMail's early days.
+([#128](https://github.com/kellylford/QuickMail/issues/128))
+
 ## New: the folder picker opens where you last filed
 
 Filing is repetitive. You move a message to **Projects/2026**, then the next one, then the one after that — and until now the picker opened each time on the folder the messages were *in*, so you walked the tree to the same destination over and over.

--- a/scripts/start-test-servers.ps1
+++ b/scripts/start-test-servers.ps1
@@ -112,12 +112,14 @@ if (Test-Path $pidFile) {
 }
 
 if (-not $gmAlreadyRunning) {
-    # greenmail.setup.test.smtp / .imap bind 127.0.0.1 at the test-profile ports (3025 / 3143).
-    # greenmail.auth.disabled accepts any credentials and auto-creates mailboxes, so tests can
-    # invent per-run users without any server-side user list.
+    # greenmail.setup.test.smtp / .imap / .pop3 bind 127.0.0.1 at the test-profile ports
+    # (3025 / 3143 / 3110). greenmail.auth.disabled accepts any credentials and auto-creates
+    # mailboxes, so tests can invent per-run users without any server-side user list.
+    # POP3 serves the same INBOX as IMAP, which is what lets a POP3 test seed over SMTP (#128).
     $gmArgs = @(
         "-Dgreenmail.setup.test.smtp",
         "-Dgreenmail.setup.test.imap",
+        "-Dgreenmail.setup.test.pop3",
         "-Dgreenmail.auth.disabled",
         "-Dgreenmail.verbose",
         "-jar", $jar
@@ -134,14 +136,15 @@ if (-not $gmAlreadyRunning) {
         }
         $smtpOk = (Test-NetConnection 127.0.0.1 -Port 3025 -WarningAction SilentlyContinue).TcpTestSucceeded
         $imapOk = (Test-NetConnection 127.0.0.1 -Port 3143 -WarningAction SilentlyContinue).TcpTestSucceeded
-        if ($smtpOk -and $imapOk) { $ready = $true; break }
+        $popOk  = (Test-NetConnection 127.0.0.1 -Port 3110 -WarningAction SilentlyContinue).TcpTestSucceeded
+        if ($smtpOk -and $imapOk -and $popOk) { $ready = $true; break }
         Start-Sleep -Milliseconds 500
     }
 
     if (-not $ready) {
-        Write-Error "GreenMail did not open ports 3025/3143 within 60s. See $logFile / $logFile.err"
+        Write-Error "GreenMail did not open ports 3025/3143/3110 within 60s. See $logFile / $logFile.err"
     }
-    Write-Host "GreenMail ready: SMTP 127.0.0.1:3025, IMAP 127.0.0.1:3143 (pid $($proc.Id))."
+    Write-Host "GreenMail ready: SMTP 127.0.0.1:3025, IMAP 127.0.0.1:3143, POP3 127.0.0.1:3110 (pid $($proc.Id))."
 }
 
 # ── Radicale (CalDAV + CardDAV) ────────────────────────────────────────────────


### PR DESCRIPTION
POP3 receive for accounts that have no IMAP, behind the `Pop3Backend` feature flag (off by default). Send is unchanged — a POP3 account sends over SMTP like any other.

The old `pop3` branch was 515 commits behind. Its 587-line service was the only asset worth keeping, so it was lifted onto current `main` and everything around it rewritten. That mattered: the old branch's code would have compiled, and its behaviour would have deleted people's mail.

## The design problem is the sweep, not the protocol

`SyncService` routes any folder with no numeric high-water mark through its #462 id-diff sweep, and every POP3 folder qualifies (UIDLs are not numbers). That sweep deletes cached ids the backend's listing omits — and a POP3 server legitimately stops listing a message the moment it is collected. Left unaddressed it would have purged the user's only copy of their mail on the first sweep after collection.

All three answers live in `Pop3MailService`, so `SyncService` stays backend-agnostic:

| Sweep asks | POP3 answers | Why |
|---|---|---|
| `GetFolderMessageIdDatesAsync` | union of server UIDLs and cached ids; cached rows keep their own date and read state; unseen UIDLs are stamped "now", unread | the union makes the deletion reconcile a no-op; the stamp is what tells the sweep there is new mail to fetch |
| `GetMessagesSinceDateAsync` | collects from the server first, then returns the window | this is the download trigger, so arrivals reach rules, the list and the toast |
| `GetFolderMessageIdsAsync` | store only | the older `ReconcileFolderAsync` path diffs the cache against itself |

## Two more bugs the tests found

- **Every sweep was clearing the user's flags.** `UpsertSummariesAsync` derives the stored flag from `IsServerFlagged` — an IMAP rule where the server owns flag state. POP3 has none, so each sync fetch now restates the local flag as the server's.
- **Choosing POP3 and then finishing the email address silently reverted to IMAP.** Typing an address matches a provider and re-applies its default connection method. Invisible, because the combo lives inside a collapsed expander. Graph still follows the provider (a Microsoft-only route); POP3 does not, since any provider may offer it.

And one found by running the app: `--online` logged `SQLite Error 1: 'no such table: MessageSummary'` on every aggregate load, because POP3's store reads hit an uninitialised database. It now answers "no mail", and the operations that genuinely need the store explain themselves instead of failing as a database error.

## Also here

POP3 hosts in the provider catalog (Gmail, Outlook.com, Yahoo; iCloud serves IMAP only and is deliberately blank), synthetic Inbox/Sent/Drafts/Trash with counts from the store, local Trash with a UIDL safety check before any DELE, attachments served from stored message bytes, calendar invites and mailing-list detection on downloaded mail, and folder management refused with a spoken reason rather than a backend exception.

`internet_message_id` now comes back with a cached detail, so a reply composed from a cached message threads. That was always a gap; POP3 makes it permanent, because the cache is the only copy.

## Verification

| Evidence | Result |
|---|---|
| 69 POP3 unit tests | pass |
| 10 GreenMail POP3 protocol tests (real RETR / UIDL / DELE) | pass |
| Full unit suite, Release | 2955 passed, 3 skipped |
| Full integration suite | 35 passed, 9 skipped (live-credential and known-blocked) |
| Real app, 3 messages, leave-on-server | `downloaded 3 new message(s), left on the server`; "3 messages loaded"; zero errors |
| Real app, delete-on-collect + mail delivered mid-run | the sweep collected it (`Sweep cycle 0 … 1 new`); the next cycle was `0 new` with **no deletion reconcile**, while the server held nothing |
| Real app, `--online` | clean skip message, zero errors |
| Mutation check | breaking the union failed 5 tests across both levels |

The harness now starts GreenMail's POP3 listener on 3110 (`scripts/start-test-servers.ps1`), so CI covers the protocol tests.

The dialog tests read the real automation peers rather than the XAML — which caught an assertion on `Visibility` (per-element) where `IsVisible` (ancestor-aware) was needed, and had made three assertions vacuous.

## What is not covered

1. **No real provider has been touched.** GreenMail is a faithful POP3 server, but it is not Gmail (POP must be enabled in settings, "recent mode", connection limits), Outlook.com or Yahoo. This is why the flag stays off.
2. **Partial keyboard walkthrough.** Startup, sync and list/tree/account navigation were confirmed from the running app's input log, and the dialogs through automation peers; open-in-Tab-mode, Window mode, the conversation tree and from/to groups were not hand-driven. Those paths are shared with IMAP and store-backed.
3. **`ui-probe` not run** — the two changed dialogs are not in the probe plan, and no new control types or styles were introduced (`ThemedControlCoverageTests` passes).
4. **No user-guide section or release notes** — pre-ship items for when the flag flips.

Known limits worth stating when it ships: a sweep with new mail costs two POP3 sessions (listing, then download); and with delete-on-collect, a connection lost between `RETR` and `QUIT` leaves a stale copy on the server (never data loss — the message is already stored).

## Suggested plan

Merge behind the flag; ship a release with it off; then ask the users on #128 to test with `Pop3Backend=true` under `[features]` in `config.ini`. Flip the default once two or three real providers come back clean.

Note for reading CI: WPF focus/keyboard tests (`RadioGroupNavigation`, `TabStripNavigation`) flake on the machine this was developed on — confirmed identically on unmodified `main`, 8 failures in the same family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
