### PR TITLE
Honor an explicit Graph choice for personal Microsoft accounts (#527)

### DIFF
--- a/QuickMail.Tests/PersonalGraphBackendChoiceTests.cs
+++ b/QuickMail.Tests/PersonalGraphBackendChoiceTests.cs
@@ -1,0 +1,62 @@
+using System.Linq;
+using System.Threading.Tasks;
+using QuickMail.Models;
+using QuickMail.Services;
+using QuickMail.ViewModels;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// Pins #527: a personal Microsoft account gets to Graph when the user picks it by hand. The
+/// post-sign-in correction (`OnMicrosoftSignInCompleted`) exists to undo an <em>auto-inferred</em>
+/// Graph choice on a vanity domain once the tenant id proves the account is personal — but it must
+/// honor a choice the user made deliberately in Advanced, the same way `ChooseBackendForMicrosoftAccount`
+/// already does. Its missing `_backendUserChosen` guard was the bug: it left personal-on-Graph
+/// unreachable through the UI.
+/// </summary>
+public class PersonalGraphBackendChoiceTests
+{
+    private static AddAccountViewModel Make(StubOAuthService oauth) =>
+        new(new StubFeatureGate { [FeatureFlag.GraphBackend] = true },
+            new StubImapMailService(), oauth, new ProviderCatalog());
+
+    [Fact]
+    public async Task PersonalAccount_UserPicksGraphByHand_SignInKeepsGraph()
+    {
+        var oauth = new StubOAuthService { SignInUsername = "me@outlook.com", SignInIsPersonalAccount = true };
+        var vm = Make(oauth);
+        vm.SelectedProvider = new ProviderCatalog().ById(ProviderCatalog.MicrosoftId);
+        vm.Username = "me@outlook.com";
+
+        // The user deliberately switches the connection method to Microsoft 365 (Graph) in Advanced.
+        vm.SelectedBackend = vm.AvailableBackends.First(b => b.Kind == BackendKind.MicrosoftGraph);
+        Assert.Equal(BackendKind.MicrosoftGraph, vm.BackendKind);
+
+        await vm.SignInMicrosoftCommand.ExecuteAsync(null);
+
+        // #527: a hand-picked Graph choice for a personal account survives sign-in — not reverted to IMAP.
+        Assert.True(vm.IsPersonalMicrosoftAccount);
+        Assert.Equal(BackendKind.MicrosoftGraph, vm.BackendKind);
+    }
+
+    [Fact]
+    public async Task PersonalAccount_GraphAutoInferredFromDomain_SignInStillRevertsToImap()
+    {
+        var oauth = new StubOAuthService { SignInUsername = "me@myvanitydomain.com", SignInIsPersonalAccount = true };
+        var vm = Make(oauth);
+        vm.Username = "me@myvanitydomain.com";
+        vm.SelectedProvider = new ProviderCatalog().ById(ProviderCatalog.MicrosoftId);
+
+        // A vanity domain is not on the consumer list, so the address inference moves it to Graph on
+        // its own (internal, NOT user-chosen) — the exact case the post-sign-in correction is for.
+        vm.CommitUsername();
+        Assert.Equal(BackendKind.MicrosoftGraph, vm.BackendKind);
+
+        await vm.SignInMicrosoftCommand.ExecuteAsync(null);
+
+        // Sign-in reveals a personal account → the auto-inferred Graph is corrected back to IMAP.
+        // This behavior is unchanged by #527; only a hand-picked choice is now spared.
+        Assert.Equal(BackendKind.ImapSmtp, vm.BackendKind);
+    }
+}

--- a/QuickMail/ViewModels/AddAccountViewModel.cs
+++ b/QuickMail/ViewModels/AddAccountViewModel.cs
@@ -235,16 +235,22 @@ public partial class AddAccountViewModel : AccountEditorViewModel, IDisposable
 
     /// <summary>
     /// Sign-in answered the question the domain could only guess at. A personal Microsoft account
-    /// on a vanity domain looks exactly like a work tenant from the address alone, so it had been
-    /// moved to Graph; put it back on IMAP, the path such accounts worked on before the guess
-    /// existed. This overrides a hand-picked connection method deliberately: the tenant id is
-    /// ground truth about the account, not an inference from its domain.
+    /// on a vanity domain looks exactly like a work tenant from the address alone, so the domain
+    /// guess had moved it to Graph; the tenant id from sign-in is ground truth, so put an
+    /// <em>auto-inferred</em> Graph choice back on IMAP.
+    ///
+    /// But a connection method the user picked BY HAND in Advanced is honored — the same
+    /// <see cref="_backendUserChosen"/> guard <see cref="ChooseBackendForMicrosoftAccount"/> already
+    /// uses. Its absence here was the #527 bug: an explicit "Microsoft 365 (Graph)" pick for a
+    /// personal account survived the address-commit step and was then silently reverted after sign-in,
+    /// leaving no way to reach Graph for a personal account through the UI at all.
     /// </summary>
     protected override void OnMicrosoftSignInCompleted(bool isPersonalAccount)
     {
         if (!isPersonalAccount) return;
         if (SelectedProvider is not { } provider || provider.Id != ProviderCatalog.MicrosoftId) return;
         if (BackendKind != BackendKind.MicrosoftGraph) return;
+        if (_backendUserChosen) return;   // the user deliberately chose Graph — don't override it (#527)
 
         MoveToBackend(BackendKind.ImapSmtp);
     }


### PR DESCRIPTION
Fixes #527. Part of the #529 plan (the unflagged correctness step — step 2).

## The bug

When adding a Microsoft account, `AddAccountViewModel.OnMicrosoftSignInCompleted` reverts a **personal** account from the Graph backend to IMAP after sign-in. That is correct for a Graph choice the **domain guess auto-inferred** on a vanity domain — the tenant id from sign-in is ground truth, and a personal account under-delivers on Graph with work scopes.

But it lacked the `_backendUserChosen` guard that `ChooseBackendForMicrosoftAccount` already uses (`AddAccountViewModel.cs:229`), so it *also* reverted a connection method the user picked **by hand** in Advanced → *"Microsoft 365 (Graph)."* The result: an explicit Graph pick for a personal account survived the address-commit step and was then silently undone after sign-in, leaving **personal-on-Graph unreachable through the UI entirely.**

## The fix

Add the same guard to `OnMicrosoftSignInCompleted`:

```csharp
if (_backendUserChosen) return;   // the user deliberately chose Graph — don't override it (#527)
```

- An **auto-inferred** Graph choice (domain guess, `_backendUserChosen == false`) is still corrected to IMAP after sign-in — unchanged.
- A **hand-picked** Graph choice (`_backendUserChosen == true`) is honored.

The stale `<summary>` that described the revert as *"overrides a hand-picked connection method deliberately"* is rewritten to the corrected behavior.

## Tests

`PersonalGraphBackendChoiceTests` drives the real `SignInMicrosoftCommand` with a personal sign-in result and pins both paths:
- Hand-picked Graph → stays Graph after sign-in (fails without this fix).
- Auto-inferred Graph (via `CommitUsername` on a vanity domain) → still reverts to IMAP (fails if the guard were unconditional).

Full suite green (the pre-existing STA focus flakes aside); 0 CA analyzer warnings in a Release build. A hand-picked personal-Graph account carries `IsPersonalMicrosoftAccount = true`, so it requests `GraphMailScopesPersonal` — the correct read/write scopes, no under-delivery.

## Scope

Unflagged, as agreed on #529: this changes nothing for anyone who doesn't open Advanced and pick Graph. It's the prerequisite that makes personal-Graph reachable so it can be tested by hand before the default-flip (which lands behind a feature flag).
