### PR TITLE
Fix #540: POP3 backend cleanup — shared helpers, SQL-side store work, capability gates

### DIFF
--- a/QuickMail.Tests/AddAccountViewModelProviderTests.cs
+++ b/QuickMail.Tests/AddAccountViewModelProviderTests.cs
@@ -877,6 +877,64 @@ public class AddAccountViewModelProviderTests
         Assert.Equal(ProviderCatalog.YahooId, Catalog.Resolve(account).Id);
     }
 
+    [Fact]
+    public void ToAccountModelCarriesEveryServerField_OnBothIncomingProtocols()
+    {
+        // One list of connection fields, shared by the probe account, this method and the Account
+        // Manager's load and save (AccountEditorViewModel.WriteServerFieldsTo). It used to be four
+        // hand-maintained copies, and a field missed in any one of them is silent — the dialog shows
+        // it, the account saves without it.
+        var vm = NewVm();
+        vm.SelectedProvider = Catalog.Other;
+        vm.Username = "kelly@example.com";
+
+        vm.ImapHost = "imap.example.com"; vm.ImapPort = 1143; vm.ImapUseSsl = false; vm.ImapAcceptInvalidCert = true;
+        vm.Pop3Host = "pop.example.com";  vm.Pop3Port = 1110; vm.Pop3UseSsl = false; vm.Pop3AcceptInvalidCert = true;
+        vm.Pop3LeaveMailOnServer = false;
+        vm.SmtpHost = "smtp.example.com"; vm.SmtpPort = 1587; vm.SmtpUseSsl = true;  vm.SmtpAcceptInvalidCert = true;
+
+        var account = vm.ToAccountModel();
+
+        Assert.Equal("imap.example.com", account.ImapHost);
+        Assert.Equal(1143, account.ImapPort);
+        Assert.False(account.ImapUseSsl);
+        Assert.True(account.ImapAcceptInvalidCert);
+
+        Assert.Equal("pop.example.com", account.Pop3Host);
+        Assert.Equal(1110, account.Pop3Port);
+        Assert.False(account.Pop3UseSsl);
+        Assert.True(account.Pop3AcceptInvalidCert);
+        // The one with consequences: cleared, the next collection is the last chance any other
+        // client has to see that mail.
+        Assert.False(account.Pop3LeaveMailOnServer);
+
+        Assert.Equal("smtp.example.com", account.SmtpHost);
+        Assert.Equal(1587, account.SmtpPort);
+        Assert.True(account.SmtpUseSsl);
+        Assert.True(account.SmtpAcceptInvalidCert);
+    }
+
+    [Fact]
+    public void APop3ProvidersTransportSecurityComesFromTheCatalog_NotFromItsPortNumber()
+    {
+        // Pop3UseSsl is stated by the catalog entry, the shape ImapUseSsl and SmtpUseSsl already
+        // have. Inferring it from "is the port 995?" silently downgrades a provider that offers
+        // implicit TLS on any other port to STARTTLS, at the moment its settings are filled in.
+        var vm = NewVm();
+        vm.SelectedProvider = Catalog.ById(ProviderCatalog.GmailId);
+
+        Assert.Equal("pop.gmail.com", vm.Pop3Host);
+        Assert.True(vm.Pop3UseSsl);
+
+        var onANonStandardPort = new MailProvider(
+            "test", "Test", ["test.example"], "imap.test.example", 993, true,
+            "smtp.test.example", 587, false, AuthType.Password, false, BackendKind.ImapSmtp,
+            null, null, Pop3Host: "pop.test.example", Pop3Port: 1995, Pop3UseSsl: true);
+
+        Assert.True(onANonStandardPort.Pop3UseSsl);
+        Assert.True(onANonStandardPort.SupportsPop3);
+    }
+
     // ── Transport security (who chose the servers decides the fallback) ──────────
 
     [Fact]

--- a/QuickMail.Tests/FlagServiceTests.cs
+++ b/QuickMail.Tests/FlagServiceTests.cs
@@ -123,59 +123,15 @@ public class FlagServiceTests
 }
 
 /// <summary>Records UpdateFlagIdAsync calls so tests can assert without a WPF dispatcher.</summary>
-sealed class RecordingFlagStore : ILocalStoreService
+sealed class RecordingFlagStore : StubLocalStoreService
 {
     public int UpdateFlagCalls { get; private set; }
     public string? LastFlagId  { get; private set; }
 
-    public void Initialize() { }
-    public Task UpsertSummariesAsync(IEnumerable<MailMessageSummary> summaries) => Task.CompletedTask;
-    public Task<List<MailMessageSummary>> LoadAllSummariesAsync() => Task.FromResult(new List<MailMessageSummary>());
-    public Task<List<MailMessageSummary>> LoadAllSummariesAsync(Guid accountId) => Task.FromResult(new List<MailMessageSummary>());
-    public Task<List<MailMessageSummary>> LoadFolderSummariesAsync(Guid accountId, string folderName, int? limit = null) => Task.FromResult(new List<MailMessageSummary>());
-    public Task DeleteSummariesAsync(Guid accountId, string folderName, IEnumerable<string> messageIds) => Task.CompletedTask;
-    public Task DeleteAccountDataAsync(Guid accountId) => Task.CompletedTask;
-    public Task ClearCachedMailAsync(System.Collections.Generic.IEnumerable<System.Guid> accountIds) => Task.CompletedTask;
-    public Task PurgeCalendarEventsForUnknownAccountsAsync(IReadOnlyCollection<Guid> knownAccountIds) => Task.CompletedTask;
-    public Task SaveFoldersAsync(Guid accountId, IReadOnlyList<MailFolderModel> folders) => Task.CompletedTask;
-    public Task<Dictionary<Guid, List<MailFolderModel>>> LoadFoldersAsync() => Task.FromResult(new Dictionary<Guid, List<MailFolderModel>>());
-    public Task PurgeFoldersForUnknownAccountsAsync(IReadOnlyCollection<Guid> knownAccountIds) => Task.CompletedTask;
-    public Task UpdateIsReadAsync(Guid accountId, string folderName, string messageId, bool isRead) => Task.CompletedTask;
-    public Task UpdateIsReadBatchAsync(IEnumerable<(Guid AccountId, string FolderName, string MessageId)> items, bool isRead) => Task.CompletedTask;
-    public Task UpdatePreviewAsync(Guid accountId, string folderName, string messageId, string preview) => Task.CompletedTask;
-    public Task UpdatePreviewsBatchAsync(Guid accountId, string folderName, IEnumerable<(string MessageId, string Preview)> updates) => Task.CompletedTask;
-    public Task<bool> HasSummariesMissingRecipientsAsync() => Task.FromResult(false);
-    public Task UpsertDetailAsync(MailMessageDetail detail) => Task.CompletedTask;
-    public Task<MailMessageDetail?> LoadDetailAsync(Guid accountId, string folderName, string messageId) => Task.FromResult<MailMessageDetail?>(null);
-    public Task StoreMimeBytesAsync(Guid accountId, string folderName, string messageId, byte[]? mimeBytes) => Task.CompletedTask;
-    public Task<byte[]?> LoadMimeBytesAsync(Guid accountId, string folderName, string messageId) => Task.FromResult<byte[]?>(null);
-    public Task<HashSet<string>> LoadPop3CollectedUidlsAsync(Guid accountId) => Task.FromResult(new HashSet<string>());
-    public Task AddPop3CollectedUidlsAsync(Guid accountId, IEnumerable<string> uidls) => Task.CompletedTask;
-    public Task RemovePop3CollectedUidlsAsync(Guid accountId, IEnumerable<string> uidls) => Task.CompletedTask;
-    public Task<string> GetMaxMessageKeyAsync(Guid accountId, string folderName) => Task.FromResult("0");
-    public Task<HashSet<string>> GetAllMessageIdsAsync(Guid accountId, string folderName) => Task.FromResult(new HashSet<string>());
-    public Task<Dictionary<string, bool>> LoadFolderReadStatesAsync(Guid accountId, string folderName) => Task.FromResult(new Dictionary<string, bool>());
-    public Task<HashSet<string>> GetExistingMessageIdsAsync(Guid accountId, string folderName, IEnumerable<string> messageIds) => Task.FromResult(new HashSet<string>());
-    public Task<int> CountSummariesAsync(Guid accountId) => Task.FromResult(0);
-    public Task<Dictionary<string, int>> CountSummariesByFolderAsync(Guid accountId) => Task.FromResult(new Dictionary<string, int>());
-    public Task<DateTimeOffset?> GetOldestMessageDateAsync(Guid accountId) => Task.FromResult<DateTimeOffset?>(null);
-    public Task UpdateFlagIdAsync(Guid accountId, string folderName, string messageId, string? flagId)
+    public override Task UpdateFlagIdAsync(Guid accountId, string folderName, string messageId, string? flagId)
     {
         UpdateFlagCalls++;
         LastFlagId = flagId;
         return Task.CompletedTask;
     }
-    public Task UpdateFlagIdBatchAsync(IEnumerable<(Guid AccountId, string FolderName, string MessageId)> items, string? flagId) => Task.CompletedTask;
-    public Task UpsertCalendarEventAsync(CalendarEvent evt) => Task.CompletedTask;
-    public Task<List<CalendarEvent>> LoadCalendarEventsAsync() => Task.FromResult(new List<CalendarEvent>());
-    public Task<IReadOnlyList<(Guid AccountId, string CalendarId, string CalendarName)>> LoadCalendarSourcesAsync()
-        => Task.FromResult<IReadOnlyList<(Guid, string, string)>>(new List<(Guid, string, string)>());
-    public Task UpdateCalendarResponseStatusAsync(string uid, Guid accountId, CalendarResponseStatus status) => Task.CompletedTask;
-    public Task DeleteCalendarEventAsync(string uid, Guid accountId) => Task.CompletedTask;
-    public Task<List<(Guid AccountId, string FolderName, string MessageId, string IcsText)>> LoadAllCalendarIcsAsync()
-        => Task.FromResult(new List<(Guid, string, string, string)>());
-    public Task ClearOrphanedCalendarSourceLinksAsync() => Task.CompletedTask;
-    public Task ReplaceGraphCalendarEventsAsync(Guid accountId, IReadOnlyList<CalendarEvent> events) => Task.CompletedTask;
-    public Task<string?> GetDeltaTokenAsync(Guid accountId, string folderId) => Task.FromResult<string?>(null);
-    public Task SetDeltaTokenAsync(Guid accountId, string folderId, string deltaToken) => Task.CompletedTask;
 }

--- a/QuickMail.Tests/HtmlStripperTests.cs
+++ b/QuickMail.Tests/HtmlStripperTests.cs
@@ -30,6 +30,24 @@ public class HtmlStripperTests
     }
 
     [Fact]
+    public void Strip_ForAPreview_DropsTheLinkTargetButKeepsTheText()
+    {
+        // A preview is one line the user reads — or hears — to decide whether to open the message,
+        // and marketing mail routinely opens with a logo wrapped in a tracking link. With the target
+        // included, the first thing in the preview is a hundred characters of query string.
+        var text = HtmlStripper.ToPlainText(
+            "<a href=\"https://click.e.example.com/u/?qs=8a7f3c2b1d\"><img alt=\"Acme\"></a> Spring sale",
+            includeLinkTargets: false);
+
+        Assert.Equal("[Acme] Spring sale", text);
+
+        // The body conversion — the compose path, where losing the destination loses the only way to
+        // reach it — is unchanged, and is still the default.
+        Assert.Contains("https://example.com",
+            HtmlStripper.ToPlainText("<a href=\"https://example.com\">Click here</a>"));
+    }
+
+    [Fact]
     public void Strip_Link_TextEqualsUrl_NoDuplicateParens()
     {
         var text = HtmlStripper.ToPlainText("<a href=\"https://example.com/\">https://example.com/</a>");

--- a/QuickMail.Tests/MainViewModelFlagTests.cs
+++ b/QuickMail.Tests/MainViewModelFlagTests.cs
@@ -208,56 +208,16 @@ public class MainViewModelFlagTests
 }
 
 /// <summary>Local store stub that serves a fixed set of messages for flag filter tests.</summary>
-sealed class FilterableStoreForFlags : ILocalStoreService
+sealed class FilterableStoreForFlags : StubLocalStoreService
 {
     private readonly List<MailMessageSummary> _messages;
 
     public FilterableStoreForFlags(IEnumerable<MailMessageSummary> messages)
         => _messages = new List<MailMessageSummary>(messages);
 
-    public void Initialize() { }
-    public Task UpsertSummariesAsync(IEnumerable<MailMessageSummary> summaries) => Task.CompletedTask;
-    public Task<List<MailMessageSummary>> LoadAllSummariesAsync() => Task.FromResult(new List<MailMessageSummary>(_messages));
-    public Task<List<MailMessageSummary>> LoadAllSummariesAsync(Guid accountId) => Task.FromResult(new List<MailMessageSummary>(_messages));
-    public Task<List<MailMessageSummary>> LoadFolderSummariesAsync(Guid accountId, string folderName, int? limit = null) => Task.FromResult(new List<MailMessageSummary>(_messages));
-    public Task DeleteSummariesAsync(Guid accountId, string folderName, IEnumerable<string> messageIds) => Task.CompletedTask;
-    public Task DeleteAccountDataAsync(Guid accountId) => Task.CompletedTask;
-    public Task ClearCachedMailAsync(System.Collections.Generic.IEnumerable<System.Guid> accountIds) => Task.CompletedTask;
-    public Task PurgeCalendarEventsForUnknownAccountsAsync(IReadOnlyCollection<Guid> knownAccountIds) => Task.CompletedTask;
-    public Task SaveFoldersAsync(Guid accountId, IReadOnlyList<MailFolderModel> folders) => Task.CompletedTask;
-    public Task<Dictionary<Guid, List<MailFolderModel>>> LoadFoldersAsync() => Task.FromResult(new Dictionary<Guid, List<MailFolderModel>>());
-    public Task PurgeFoldersForUnknownAccountsAsync(IReadOnlyCollection<Guid> knownAccountIds) => Task.CompletedTask;
-    public Task UpdateIsReadAsync(Guid accountId, string folderName, string messageId, bool isRead) => Task.CompletedTask;
-    public Task UpdateIsReadBatchAsync(IEnumerable<(Guid AccountId, string FolderName, string MessageId)> items, bool isRead) => Task.CompletedTask;
-    public Task UpdatePreviewAsync(Guid accountId, string folderName, string messageId, string preview) => Task.CompletedTask;
-    public Task UpdatePreviewsBatchAsync(Guid accountId, string folderName, IEnumerable<(string MessageId, string Preview)> updates) => Task.CompletedTask;
-    public Task<bool> HasSummariesMissingRecipientsAsync() => Task.FromResult(false);
-    public Task UpsertDetailAsync(MailMessageDetail detail) => Task.CompletedTask;
-    public Task<MailMessageDetail?> LoadDetailAsync(Guid accountId, string folderName, string messageId) => Task.FromResult<MailMessageDetail?>(null);
-    public Task StoreMimeBytesAsync(Guid accountId, string folderName, string messageId, byte[]? mimeBytes) => Task.CompletedTask;
-    public Task<byte[]?> LoadMimeBytesAsync(Guid accountId, string folderName, string messageId) => Task.FromResult<byte[]?>(null);
-    public Task<HashSet<string>> LoadPop3CollectedUidlsAsync(Guid accountId) => Task.FromResult(new HashSet<string>());
-    public Task AddPop3CollectedUidlsAsync(Guid accountId, IEnumerable<string> uidls) => Task.CompletedTask;
-    public Task RemovePop3CollectedUidlsAsync(Guid accountId, IEnumerable<string> uidls) => Task.CompletedTask;
-    public Task<string> GetMaxMessageKeyAsync(Guid accountId, string folderName) => Task.FromResult("0");
-    public Task<HashSet<string>> GetAllMessageIdsAsync(Guid accountId, string folderName) => Task.FromResult(new HashSet<string>());
-    public Task<Dictionary<string, bool>> LoadFolderReadStatesAsync(Guid accountId, string folderName) => Task.FromResult(new Dictionary<string, bool>());
-    public Task<HashSet<string>> GetExistingMessageIdsAsync(Guid accountId, string folderName, IEnumerable<string> messageIds) => Task.FromResult(new HashSet<string>());
-    public Task<int> CountSummariesAsync(Guid accountId) => Task.FromResult(0);
-    public Task<Dictionary<string, int>> CountSummariesByFolderAsync(Guid accountId) => Task.FromResult(new Dictionary<string, int>());
-    public Task<DateTimeOffset?> GetOldestMessageDateAsync(Guid accountId) => Task.FromResult<DateTimeOffset?>(null);
-    public Task UpdateFlagIdAsync(Guid accountId, string folderName, string messageId, string? flagId) => Task.CompletedTask;
-    public Task UpdateFlagIdBatchAsync(IEnumerable<(Guid AccountId, string FolderName, string MessageId)> items, string? flagId) => Task.CompletedTask;
-    public Task UpsertCalendarEventAsync(CalendarEvent evt) => Task.CompletedTask;
-    public Task<List<CalendarEvent>> LoadCalendarEventsAsync() => Task.FromResult(new List<CalendarEvent>());
-    public Task<IReadOnlyList<(Guid AccountId, string CalendarId, string CalendarName)>> LoadCalendarSourcesAsync()
-        => Task.FromResult<IReadOnlyList<(Guid, string, string)>>(new List<(Guid, string, string)>());
-    public Task UpdateCalendarResponseStatusAsync(string uid, Guid accountId, CalendarResponseStatus status) => Task.CompletedTask;
-    public Task DeleteCalendarEventAsync(string uid, Guid accountId) => Task.CompletedTask;
-    public Task<List<(Guid AccountId, string FolderName, string MessageId, string IcsText)>> LoadAllCalendarIcsAsync()
-        => Task.FromResult(new List<(Guid, string, string, string)>());
-    public Task ClearOrphanedCalendarSourceLinksAsync() => Task.CompletedTask;
-    public Task ReplaceGraphCalendarEventsAsync(Guid accountId, IReadOnlyList<CalendarEvent> events) => Task.CompletedTask;
-    public Task<string?> GetDeltaTokenAsync(Guid accountId, string folderId) => Task.FromResult<string?>(null);
-    public Task SetDeltaTokenAsync(Guid accountId, string folderId, string deltaToken) => Task.CompletedTask;
+    // One list, served whatever account or folder is asked for — the tests here are about how the
+    // ViewModel treats a set of messages, not about where they were filed.
+    public override Task<List<MailMessageSummary>> LoadAllSummariesAsync() => Task.FromResult(new List<MailMessageSummary>(_messages));
+    public override Task<List<MailMessageSummary>> LoadAllSummariesAsync(Guid accountId) => Task.FromResult(new List<MailMessageSummary>(_messages));
+    public override Task<List<MailMessageSummary>> LoadFolderSummariesAsync(Guid accountId, string folderName, int? limit = null) => Task.FromResult(new List<MailMessageSummary>(_messages));
 }

--- a/QuickMail.Tests/MarkReadOnOpenTests.cs
+++ b/QuickMail.Tests/MarkReadOnOpenTests.cs
@@ -113,60 +113,15 @@ public class MarkReadOnOpenTests
     }
 
     /// <summary>Local store whose LoadDetailAsync always returns a detail — the cache-hit path.</summary>
-    private sealed class CacheHitStore : ILocalStoreService
+    private sealed class CacheHitStore : StubLocalStoreService
     {
-        public Task<MailMessageDetail?> LoadDetailAsync(Guid accountId, string folderName, string messageId)
+        // Always a cache hit, so opening a message never falls through to the backend.
+        public override Task<MailMessageDetail?> LoadDetailAsync(Guid accountId, string folderName, string messageId)
             => Task.FromResult<MailMessageDetail?>(new MailMessageDetail
             {
                 MessageId  = messageId,
                 AccountId  = accountId,
                 FolderName = folderName,
             });
-
-        public Task StoreMimeBytesAsync(Guid accountId, string folderName, string messageId, byte[]? mimeBytes) => Task.CompletedTask;
-        public Task<byte[]?> LoadMimeBytesAsync(Guid accountId, string folderName, string messageId) => Task.FromResult<byte[]?>(null);
-        public Task<HashSet<string>> LoadPop3CollectedUidlsAsync(Guid accountId) => Task.FromResult(new HashSet<string>());
-        public Task AddPop3CollectedUidlsAsync(Guid accountId, IEnumerable<string> uidls) => Task.CompletedTask;
-        public Task RemovePop3CollectedUidlsAsync(Guid accountId, IEnumerable<string> uidls) => Task.CompletedTask;
-
-        public void Initialize() { }
-        public Task UpsertSummariesAsync(IEnumerable<MailMessageSummary> summaries) => Task.CompletedTask;
-        public Task<List<MailMessageSummary>> LoadAllSummariesAsync() => Task.FromResult(new List<MailMessageSummary>());
-        public Task<List<MailMessageSummary>> LoadAllSummariesAsync(Guid accountId) => Task.FromResult(new List<MailMessageSummary>());
-        public Task<List<MailMessageSummary>> LoadFolderSummariesAsync(Guid accountId, string folderName, int? limit = null) => Task.FromResult(new List<MailMessageSummary>());
-        public Task DeleteSummariesAsync(Guid accountId, string folderName, IEnumerable<string> messageIds) => Task.CompletedTask;
-        public Task DeleteAccountDataAsync(Guid accountId) => Task.CompletedTask;
-        public Task ClearCachedMailAsync(System.Collections.Generic.IEnumerable<System.Guid> accountIds) => Task.CompletedTask;
-        public Task PurgeCalendarEventsForUnknownAccountsAsync(IReadOnlyCollection<Guid> knownAccountIds) => Task.CompletedTask;
-        public Task SaveFoldersAsync(Guid accountId, IReadOnlyList<MailFolderModel> folders) => Task.CompletedTask;
-        public Task<Dictionary<Guid, List<MailFolderModel>>> LoadFoldersAsync() => Task.FromResult(new Dictionary<Guid, List<MailFolderModel>>());
-        public Task PurgeFoldersForUnknownAccountsAsync(IReadOnlyCollection<Guid> knownAccountIds) => Task.CompletedTask;
-        public Task UpdateIsReadAsync(Guid accountId, string folderName, string messageId, bool isRead) => Task.CompletedTask;
-        public Task UpdateIsReadBatchAsync(IEnumerable<(Guid AccountId, string FolderName, string MessageId)> items, bool isRead) => Task.CompletedTask;
-        public Task UpdatePreviewAsync(Guid accountId, string folderName, string messageId, string preview) => Task.CompletedTask;
-        public Task UpdatePreviewsBatchAsync(Guid accountId, string folderName, IEnumerable<(string MessageId, string Preview)> updates) => Task.CompletedTask;
-        public Task<bool> HasSummariesMissingRecipientsAsync() => Task.FromResult(false);
-        public Task UpsertDetailAsync(MailMessageDetail detail) => Task.CompletedTask;
-        public Task<string> GetMaxMessageKeyAsync(Guid accountId, string folderName) => Task.FromResult("0");
-        public Task<HashSet<string>> GetAllMessageIdsAsync(Guid accountId, string folderName) => Task.FromResult(new HashSet<string>());
-        public Task<Dictionary<string, bool>> LoadFolderReadStatesAsync(Guid accountId, string folderName) => Task.FromResult(new Dictionary<string, bool>());
-        public Task<HashSet<string>> GetExistingMessageIdsAsync(Guid accountId, string folderName, IEnumerable<string> messageIds) => Task.FromResult(new HashSet<string>());
-        public Task<int> CountSummariesAsync(Guid accountId) => Task.FromResult(0);
-        public Task<Dictionary<string, int>> CountSummariesByFolderAsync(Guid accountId) => Task.FromResult(new Dictionary<string, int>());
-        public Task<DateTimeOffset?> GetOldestMessageDateAsync(Guid accountId) => Task.FromResult<DateTimeOffset?>(null);
-        public Task UpdateFlagIdAsync(Guid accountId, string folderName, string messageId, string? flagId) => Task.CompletedTask;
-        public Task UpdateFlagIdBatchAsync(IEnumerable<(Guid AccountId, string FolderName, string MessageId)> items, string? flagId) => Task.CompletedTask;
-        public Task UpsertCalendarEventAsync(CalendarEvent evt) => Task.CompletedTask;
-        public Task<List<CalendarEvent>> LoadCalendarEventsAsync() => Task.FromResult(new List<CalendarEvent>());
-        public Task<IReadOnlyList<(Guid AccountId, string CalendarId, string CalendarName)>> LoadCalendarSourcesAsync()
-            => Task.FromResult<IReadOnlyList<(Guid, string, string)>>(new List<(Guid, string, string)>());
-        public Task UpdateCalendarResponseStatusAsync(string uid, Guid accountId, CalendarResponseStatus status) => Task.CompletedTask;
-        public Task DeleteCalendarEventAsync(string uid, Guid accountId) => Task.CompletedTask;
-        public Task<List<(Guid AccountId, string FolderName, string MessageId, string IcsText)>> LoadAllCalendarIcsAsync()
-            => Task.FromResult(new List<(Guid, string, string, string)>());
-        public Task ClearOrphanedCalendarSourceLinksAsync() => Task.CompletedTask;
-        public Task ReplaceGraphCalendarEventsAsync(Guid accountId, IReadOnlyList<CalendarEvent> events) => Task.CompletedTask;
-        public Task<string?> GetDeltaTokenAsync(Guid accountId, string folderId) => Task.FromResult<string?>(null);
-        public Task SetDeltaTokenAsync(Guid accountId, string folderId, string deltaToken) => Task.CompletedTask;
     }
 }

--- a/QuickMail.Tests/MessageFilterTests.cs
+++ b/QuickMail.Tests/MessageFilterTests.cs
@@ -18,58 +18,18 @@ public class MessageFilterTests
 {
     // ── Configurable stub ───────────────────────────────────────────────────
 
-    sealed class FilterableStore : ILocalStoreService
+    sealed class FilterableStore : StubLocalStoreService
     {
         private readonly List<MailMessageSummary> _messages;
 
         public FilterableStore(IEnumerable<MailMessageSummary> messages)
             => _messages = new List<MailMessageSummary>(messages);
 
-        public void Initialize() { }
-        public Task UpsertSummariesAsync(IEnumerable<MailMessageSummary> summaries) => Task.CompletedTask;
-        public Task<List<MailMessageSummary>> LoadAllSummariesAsync() => Task.FromResult(new List<MailMessageSummary>(_messages));
-        public Task<List<MailMessageSummary>> LoadAllSummariesAsync(Guid accountId) => Task.FromResult(new List<MailMessageSummary>(_messages));
-        public Task<List<MailMessageSummary>> LoadFolderSummariesAsync(Guid accountId, string folderName, int? limit = null) => Task.FromResult(new List<MailMessageSummary>(_messages));
-        public Task DeleteSummariesAsync(Guid accountId, string folderName, IEnumerable<string> messageIds) => Task.CompletedTask;
-        public Task DeleteAccountDataAsync(Guid accountId) => Task.CompletedTask;
-        public Task ClearCachedMailAsync(System.Collections.Generic.IEnumerable<System.Guid> accountIds) => Task.CompletedTask;
-        public Task PurgeCalendarEventsForUnknownAccountsAsync(IReadOnlyCollection<Guid> knownAccountIds) => Task.CompletedTask;
-        public Task SaveFoldersAsync(Guid accountId, IReadOnlyList<MailFolderModel> folders) => Task.CompletedTask;
-        public Task<Dictionary<Guid, List<MailFolderModel>>> LoadFoldersAsync() => Task.FromResult(new Dictionary<Guid, List<MailFolderModel>>());
-        public Task PurgeFoldersForUnknownAccountsAsync(IReadOnlyCollection<Guid> knownAccountIds) => Task.CompletedTask;
-        public Task UpdateIsReadAsync(Guid accountId, string folderName, string messageId, bool isRead) => Task.CompletedTask;
-        public Task UpdateIsReadBatchAsync(IEnumerable<(Guid AccountId, string FolderName, string MessageId)> items, bool isRead) => Task.CompletedTask;
-        public Task UpdatePreviewAsync(Guid accountId, string folderName, string messageId, string preview) => Task.CompletedTask;
-        public Task UpdatePreviewsBatchAsync(Guid accountId, string folderName, IEnumerable<(string MessageId, string Preview)> updates) => Task.CompletedTask;
-        public Task<bool> HasSummariesMissingRecipientsAsync() => Task.FromResult(false);
-        public Task UpsertDetailAsync(MailMessageDetail detail) => Task.CompletedTask;
-        public Task<MailMessageDetail?> LoadDetailAsync(Guid accountId, string folderName, string messageId) => Task.FromResult<MailMessageDetail?>(null);
-        public Task StoreMimeBytesAsync(Guid accountId, string folderName, string messageId, byte[]? mimeBytes) => Task.CompletedTask;
-        public Task<byte[]?> LoadMimeBytesAsync(Guid accountId, string folderName, string messageId) => Task.FromResult<byte[]?>(null);
-        public Task<HashSet<string>> LoadPop3CollectedUidlsAsync(Guid accountId) => Task.FromResult(new HashSet<string>());
-        public Task AddPop3CollectedUidlsAsync(Guid accountId, IEnumerable<string> uidls) => Task.CompletedTask;
-        public Task RemovePop3CollectedUidlsAsync(Guid accountId, IEnumerable<string> uidls) => Task.CompletedTask;
-        public Task<string> GetMaxMessageKeyAsync(Guid accountId, string folderName) => Task.FromResult("0");
-        public Task<HashSet<string>> GetAllMessageIdsAsync(Guid accountId, string folderName) => Task.FromResult(new HashSet<string>());
-        public Task<Dictionary<string, bool>> LoadFolderReadStatesAsync(Guid accountId, string folderName) => Task.FromResult(new Dictionary<string, bool>());
-        public Task<HashSet<string>> GetExistingMessageIdsAsync(Guid accountId, string folderName, IEnumerable<string> messageIds) => Task.FromResult(new HashSet<string>());
-        public Task<int> CountSummariesAsync(Guid accountId) => Task.FromResult(0);
-        public Task<Dictionary<string, int>> CountSummariesByFolderAsync(Guid accountId) => Task.FromResult(new Dictionary<string, int>());
-        public Task<DateTimeOffset?> GetOldestMessageDateAsync(Guid accountId) => Task.FromResult<DateTimeOffset?>(null);
-        public Task UpdateFlagIdAsync(Guid accountId, string folderName, string messageId, string? flagId) => Task.CompletedTask;
-        public Task UpdateFlagIdBatchAsync(IEnumerable<(Guid AccountId, string FolderName, string MessageId)> items, string? flagId) => Task.CompletedTask;
-        public Task UpsertCalendarEventAsync(CalendarEvent evt) => Task.CompletedTask;
-        public Task<List<CalendarEvent>> LoadCalendarEventsAsync() => Task.FromResult(new List<CalendarEvent>());
-        public Task<IReadOnlyList<(Guid AccountId, string CalendarId, string CalendarName)>> LoadCalendarSourcesAsync()
-            => Task.FromResult<IReadOnlyList<(Guid, string, string)>>(new List<(Guid, string, string)>());
-        public Task UpdateCalendarResponseStatusAsync(string uid, Guid accountId, CalendarResponseStatus status) => Task.CompletedTask;
-        public Task DeleteCalendarEventAsync(string uid, Guid accountId) => Task.CompletedTask;
-        public Task<List<(Guid AccountId, string FolderName, string MessageId, string IcsText)>> LoadAllCalendarIcsAsync()
-            => Task.FromResult(new List<(Guid, string, string, string)>());
-        public Task ClearOrphanedCalendarSourceLinksAsync() => Task.CompletedTask;
-        public Task ReplaceGraphCalendarEventsAsync(Guid accountId, IReadOnlyList<CalendarEvent> events) => Task.CompletedTask;
-        public Task<string?> GetDeltaTokenAsync(Guid accountId, string folderId) => Task.FromResult<string?>(null);
-        public Task SetDeltaTokenAsync(Guid accountId, string folderId, string deltaToken) => Task.CompletedTask;
+        // One list, served whatever account or folder is asked for — the tests here are about how the
+        // ViewModel treats a set of messages, not about where they were filed.
+        public override Task<List<MailMessageSummary>> LoadAllSummariesAsync() => Task.FromResult(new List<MailMessageSummary>(_messages));
+        public override Task<List<MailMessageSummary>> LoadAllSummariesAsync(Guid accountId) => Task.FromResult(new List<MailMessageSummary>(_messages));
+        public override Task<List<MailMessageSummary>> LoadFolderSummariesAsync(Guid accountId, string folderName, int? limit = null) => Task.FromResult(new List<MailMessageSummary>(_messages));
     }
 
     // ── Helpers ─────────────────────────────────────────────────────────────

--- a/QuickMail.Tests/Pop3MailServiceTests.cs
+++ b/QuickMail.Tests/Pop3MailServiceTests.cs
@@ -744,6 +744,21 @@ public class Pop3MailServiceTests
     }
 
     [Fact]
+    public void Preview_DoesNotReadOutATrackingUrl()
+    {
+        // Both backends build previews through HtmlStripper now, so both have to suppress link
+        // targets. Marketing mail opens with a logo wrapped in a tracking link; included, the whole
+        // preview line is query string, which for a screen-reader user is what gets spoken.
+        var msg = BuildMime(text: null,
+            html: "<p><a href=\"https://click.e.example.com/u/?qs=8a7f3c2b1d\">Acme</a> Spring sale</p>");
+        var preview = Pop3MailService.BuildSummary(Guid.NewGuid(), "u", msg, "Inbox", false).Preview;
+
+        Assert.DoesNotContain("click.e.example.com", preview);
+        Assert.Contains("Acme", preview);
+        Assert.Contains("Spring sale", preview);
+    }
+
+    [Fact]
     public void Detail_CarriesFullAddresses_AndTheComposeMode()
     {
         var msg = BuildMime(customize: m =>

--- a/QuickMail.Tests/Pop3MailServiceTests.cs
+++ b/QuickMail.Tests/Pop3MailServiceTests.cs
@@ -46,6 +46,11 @@ public class Pop3MailServiceTests
         Preview    = "preview text",
     };
 
+    /// <summary>A cached row as the id listing sees it — id, date, read state, and nothing else.</summary>
+    private static (string Id, DateTimeOffset Date, bool IsRead) Cached(
+        string id, DateTimeOffset? date = null, bool isRead = false)
+        => (id, date ?? DateTimeOffset.UtcNow, isRead);
+
     private static MimeMessage BuildMime(
         string subject = "Hello",
         string? text = "Line one\nLine two",
@@ -124,8 +129,7 @@ public class Pop3MailServiceTests
     {
         // The listing the sweep consumes, exercised directly — the service-level test above cannot
         // reach the merge without a live server, so this is what pins the arithmetic.
-        var account = Guid.NewGuid();
-        var cached  = new[] { Msg(account, "uidl-1", "Inbox"), Msg(account, "uidl-2", "Inbox") };
+        var cached = new[] { Cached("uidl-1"), Cached("uidl-2") };
 
         var merged = Pop3MailService.MergeListing(cached, [], new HashSet<string>(), DateTimeOffset.UtcNow);
 
@@ -135,9 +139,8 @@ public class Pop3MailServiceTests
     [Fact]
     public void MergeListing_AddsUnseenServerIdsAsArrivingNow()
     {
-        var account = Guid.NewGuid();
-        var now     = DateTimeOffset.UtcNow;
-        var cached  = new[] { Msg(account, "known", "Inbox", now.AddDays(-2), isRead: true) };
+        var now    = DateTimeOffset.UtcNow;
+        var cached = new[] { Cached("known", now.AddDays(-2), isRead: true) };
 
         var merged = Pop3MailService.MergeListing(cached, ["known", "brand-new"], new HashSet<string>(), now);
 
@@ -158,8 +161,7 @@ public class Pop3MailServiceTests
     {
         // With leave-on-server off, this is the steady state seconds after collection: the server
         // lists nothing QuickMail holds. Dropping those ids here is what would delete the mail.
-        var account = Guid.NewGuid();
-        var cached  = new[] { Msg(account, "collected-1", "Inbox"), Msg(account, "collected-2", "Inbox") };
+        var cached = new[] { Cached("collected-1"), Cached("collected-2") };
 
         var merged = Pop3MailService.MergeListing(cached, ["a-totally-different-uidl"], new HashSet<string>(), DateTimeOffset.UtcNow);
         var listed = merged.Select(m => m.Id).ToHashSet();
@@ -176,9 +178,8 @@ public class Pop3MailServiceTests
         // to Trash) or empties Trash (row gone entirely), the UIDL is no longer cached in the Inbox
         // — but it is in the collected ledger. Reporting it as "arriving now" is what made deleted
         // mail resurrect on every sweep: hasNew fired, and the fetch re-downloaded it.
-        var account   = Guid.NewGuid();
         var now       = DateTimeOffset.UtcNow;
-        var cached    = new[] { Msg(account, "still-in-inbox", "Inbox") };
+        var cached    = new[] { Cached("still-in-inbox") };
         var collected = new HashSet<string>(["still-in-inbox", "deleted-by-user", "emptied-from-trash"]);
 
         var merged = Pop3MailService.MergeListing(
@@ -395,6 +396,25 @@ public class Pop3MailServiceTests
         await Assert.ThrowsAsync<NotSupportedException>(() => pop.CopyFolderAsync(id, "Inbox", null));
     }
 
+    [Fact]
+    public void FolderCrud_IsRefusedByCapability_NotByReachingTheBackendAndCatchingIt()
+    {
+        // What the UI asks before it opens a folder dialog. The throws above are the last line of
+        // defence; this is the one that keeps the user from being offered the action at all.
+        Assert.False(new AccountModel { BackendKind = BackendKind.Pop3Smtp }.SupportsFolderCrud);
+        Assert.True(new AccountModel { BackendKind = BackendKind.ImapSmtp }.SupportsFolderCrud);
+        Assert.True(new AccountModel { BackendKind = BackendKind.MicrosoftGraph }.SupportsFolderCrud);
+    }
+
+    [Fact]
+    public void ListingIsNotAuthoritativeForDeletions_SoTheSweepCanSeeTheInvariant()
+    {
+        // The sweep asks this before it reconciles deletions. MergeListing's union makes the
+        // arithmetic a no-op as well, but that is the backend defending itself against a caller that
+        // cannot see the invariant — this is the invariant, stated where the caller can read it.
+        Assert.False(new Pop3MailService(NewStore()).ListingIsAuthoritativeForDeletions(Guid.NewGuid()));
+    }
+
     // ── Local move / copy ────────────────────────────────────────────────────────
 
     [Fact]
@@ -419,8 +439,9 @@ public class Pop3MailServiceTests
         Assert.Empty(await store.GetAllMessageIdsAsync(account, "Inbox"));
         var trashed = (await store.LoadFolderSummariesAsync(account, "Trash")).Single();
         Assert.Equal("uidl-1", trashed.MessageId);
-        // A named flag survives the move: the upsert can only carry the built-in id, so the service
-        // restates it explicitly.
+        // A named flag survives the move. The row is re-filed whole in SQL, so flag_id travels with
+        // it rather than being re-derived from IsServerFlagged by an upsert built for a backend
+        // where the server owns flags.
         Assert.Equal(flag, trashed.FlagId);
 
         var detail = await store.LoadDetailAsync(account, "Trash", "uidl-1");
@@ -442,6 +463,76 @@ public class Pop3MailServiceTests
 
         Assert.Single(await store.GetAllMessageIdsAsync(account, "Inbox"));
         Assert.Single(await store.GetAllMessageIdsAsync(account, "Sent"));
+    }
+
+    [Fact]
+    public async Task Copy_DuplicatesTheBodyAndTheRawBytes_NotJustTheSummaryRow()
+    {
+        // The copy is an INSERT … SELECT over the live column list, so what makes the copy a message
+        // rather than a row — its body and the bytes its attachments are extracted from — has to
+        // arrive with it. A copy that is only a summary opens blank and cannot yield an attachment.
+        var store   = NewStore();
+        var account = Guid.NewGuid();
+        var pop     = new Pop3MailService(store);
+
+        await store.UpsertSummariesAsync([Msg(account, "uidl-1", "Inbox")]);
+        await store.UpsertDetailAsync(new MailMessageDetail
+        {
+            MessageId = "uidl-1", AccountId = account, FolderName = "Inbox", PlainTextBody = "the body",
+        });
+        await store.StoreMimeBytesAsync(account, "Inbox", "uidl-1", [7, 8, 9]);
+
+        await pop.CopyMessagesAsync(account, "Inbox", ["uidl-1"], "Sent");
+
+        var copied = await store.LoadDetailAsync(account, "Sent", "uidl-1");
+        Assert.Equal("the body", copied?.PlainTextBody);
+        Assert.Equal([7, 8, 9], await store.LoadMimeBytesAsync(account, "Sent", "uidl-1"));
+
+        // …and the original is untouched, bytes included.
+        Assert.Equal([7, 8, 9], await store.LoadMimeBytesAsync(account, "Inbox", "uidl-1"));
+    }
+
+    [Fact]
+    public async Task MovingAMessageIntoAnAlreadyOccupiedId_ReplacesItRatherThanFailing()
+    {
+        // Copy to Sent, then move the original there too. Without UPDATE OR REPLACE the second
+        // operation collides with the destination's primary key and aborts — taking the whole
+        // transaction, and with it the message, nowhere.
+        var store   = NewStore();
+        var account = Guid.NewGuid();
+        var pop     = new Pop3MailService(store);
+
+        await store.UpsertSummariesAsync([Msg(account, "uidl-1", "Inbox")]);
+        await pop.CopyMessagesAsync(account, "Inbox", ["uidl-1"], "Sent");
+        await pop.MoveMessagesAsync(account, "Inbox", ["uidl-1"], "Sent");
+
+        Assert.Empty(await store.GetAllMessageIdsAsync(account, "Inbox"));
+        Assert.Single(await store.GetAllMessageIdsAsync(account, "Sent"));
+    }
+
+    [Fact]
+    public async Task MovingAHarvestedInvite_TakesItsCalendarBackLinkWithIt()
+    {
+        // The event's "open the invitation" link records a folder. Filing the message elsewhere used
+        // to clear the link (the old move deleted the source row, and DeleteSummariesAsync clears
+        // links); moving the row in SQL must retarget it instead, or the link points at a folder the
+        // message has left and the calendar dead-ends.
+        var store   = NewStore();
+        var account = Guid.NewGuid();
+        var pop     = new Pop3MailService(store);
+
+        await store.UpsertSummariesAsync([Msg(account, "uidl-1", "Inbox")]);
+        await store.UpsertCalendarEventAsync(new CalendarEvent
+        {
+            Uid = "evt-1", AccountId = account, Summary = "Standup",
+            SourceMessageId = "uidl-1", SourceFolder = "Inbox",
+        });
+
+        await pop.MoveMessagesAsync(account, "Inbox", ["uidl-1"], "Trash");
+
+        var evt = (await store.LoadCalendarEventsAsync()).Single(e => e.Uid == "evt-1");
+        Assert.Equal("Trash", evt.SourceFolder);
+        Assert.Equal("uidl-1", evt.SourceMessageId);
     }
 
     [Fact]

--- a/QuickMail.Tests/SavedViewsTests.cs
+++ b/QuickMail.Tests/SavedViewsTests.cs
@@ -889,55 +889,18 @@ public class SavedViewsMainViewModelTests
         public void Dispose() { }
     }
 
-    sealed class DatedStore : ILocalStoreService
+    sealed class DatedStore : StubLocalStoreService
     {
         private readonly List<MailMessageSummary> _messages;
-        public DatedStore(IEnumerable<MailMessageSummary> messages) => _messages = new(messages);
-        public void Initialize() { }
-        public Task UpsertSummariesAsync(IEnumerable<MailMessageSummary> summaries) => Task.CompletedTask;
-        public Task<List<MailMessageSummary>> LoadAllSummariesAsync() => Task.FromResult(new List<MailMessageSummary>(_messages));
-        public Task<List<MailMessageSummary>> LoadAllSummariesAsync(Guid accountId) => Task.FromResult(new List<MailMessageSummary>(_messages));
-        public Task<List<MailMessageSummary>> LoadFolderSummariesAsync(Guid accountId, string folderName, int? limit = null) => Task.FromResult(new List<MailMessageSummary>(_messages));
-        public Task DeleteSummariesAsync(Guid accountId, string folderName, IEnumerable<string> messageIds) => Task.CompletedTask;
-        public Task DeleteAccountDataAsync(Guid accountId) => Task.CompletedTask;
-        public Task ClearCachedMailAsync(System.Collections.Generic.IEnumerable<System.Guid> accountIds) => Task.CompletedTask;
-        public Task PurgeCalendarEventsForUnknownAccountsAsync(IReadOnlyCollection<Guid> knownAccountIds) => Task.CompletedTask;
-        public Task SaveFoldersAsync(Guid accountId, IReadOnlyList<MailFolderModel> folders) => Task.CompletedTask;
-        public Task<Dictionary<Guid, List<MailFolderModel>>> LoadFoldersAsync() => Task.FromResult(new Dictionary<Guid, List<MailFolderModel>>());
-        public Task PurgeFoldersForUnknownAccountsAsync(IReadOnlyCollection<Guid> knownAccountIds) => Task.CompletedTask;
-        public Task UpdateIsReadAsync(Guid accountId, string folderName, string messageId, bool isRead) => Task.CompletedTask;
-        public Task UpdateIsReadBatchAsync(IEnumerable<(Guid AccountId, string FolderName, string MessageId)> items, bool isRead) => Task.CompletedTask;
-        public Task UpdatePreviewAsync(Guid accountId, string folderName, string messageId, string preview) => Task.CompletedTask;
-        public Task UpdatePreviewsBatchAsync(Guid accountId, string folderName, IEnumerable<(string MessageId, string Preview)> updates) => Task.CompletedTask;
-        public Task<bool> HasSummariesMissingRecipientsAsync() => Task.FromResult(false);
-        public Task UpsertDetailAsync(MailMessageDetail detail) => Task.CompletedTask;
-        public Task<MailMessageDetail?> LoadDetailAsync(Guid accountId, string folderName, string messageId) => Task.FromResult<MailMessageDetail?>(null);
-        public Task StoreMimeBytesAsync(Guid accountId, string folderName, string messageId, byte[]? mimeBytes) => Task.CompletedTask;
-        public Task<byte[]?> LoadMimeBytesAsync(Guid accountId, string folderName, string messageId) => Task.FromResult<byte[]?>(null);
-        public Task<HashSet<string>> LoadPop3CollectedUidlsAsync(Guid accountId) => Task.FromResult(new HashSet<string>());
-        public Task AddPop3CollectedUidlsAsync(Guid accountId, IEnumerable<string> uidls) => Task.CompletedTask;
-        public Task RemovePop3CollectedUidlsAsync(Guid accountId, IEnumerable<string> uidls) => Task.CompletedTask;
-        public Task<string> GetMaxMessageKeyAsync(Guid accountId, string folderName) => Task.FromResult("0");
-        public Task<HashSet<string>> GetAllMessageIdsAsync(Guid accountId, string folderName) => Task.FromResult(new HashSet<string>());
-        public Task<Dictionary<string, bool>> LoadFolderReadStatesAsync(Guid accountId, string folderName) => Task.FromResult(new Dictionary<string, bool>());
-        public Task<HashSet<string>> GetExistingMessageIdsAsync(Guid accountId, string folderName, IEnumerable<string> messageIds) => Task.FromResult(new HashSet<string>());
-        public Task<int> CountSummariesAsync(Guid accountId) => Task.FromResult(0);
-        public Task<Dictionary<string, int>> CountSummariesByFolderAsync(Guid accountId) => Task.FromResult(new Dictionary<string, int>());
-        public Task<DateTimeOffset?> GetOldestMessageDateAsync(Guid accountId) => Task.FromResult<DateTimeOffset?>(null);
-        public Task UpdateFlagIdAsync(Guid accountId, string folderName, string messageId, string? flagId) => Task.CompletedTask;
-        public Task UpdateFlagIdBatchAsync(IEnumerable<(Guid AccountId, string FolderName, string MessageId)> items, string? flagId) => Task.CompletedTask;
-        public Task UpsertCalendarEventAsync(CalendarEvent evt) => Task.CompletedTask;
-        public Task<List<CalendarEvent>> LoadCalendarEventsAsync() => Task.FromResult(new List<CalendarEvent>());
-        public Task<IReadOnlyList<(Guid AccountId, string CalendarId, string CalendarName)>> LoadCalendarSourcesAsync()
-            => Task.FromResult<IReadOnlyList<(Guid, string, string)>>(new List<(Guid, string, string)>());
-        public Task UpdateCalendarResponseStatusAsync(string uid, Guid accountId, CalendarResponseStatus status) => Task.CompletedTask;
-        public Task DeleteCalendarEventAsync(string uid, Guid accountId) => Task.CompletedTask;
-        public Task<List<(Guid AccountId, string FolderName, string MessageId, string IcsText)>> LoadAllCalendarIcsAsync()
-            => Task.FromResult(new List<(Guid, string, string, string)>());
-        public Task ClearOrphanedCalendarSourceLinksAsync() => Task.CompletedTask;
-        public Task ReplaceGraphCalendarEventsAsync(Guid accountId, IReadOnlyList<CalendarEvent> events) => Task.CompletedTask;
-        public Task<string?> GetDeltaTokenAsync(Guid accountId, string folderId) => Task.FromResult<string?>(null);
-        public Task SetDeltaTokenAsync(Guid accountId, string folderId, string deltaToken) => Task.CompletedTask;
+
+        public DatedStore(IEnumerable<MailMessageSummary> messages)
+            => _messages = new List<MailMessageSummary>(messages);
+
+        // One list, served whatever account or folder is asked for — the tests here are about how the
+        // ViewModel treats a set of messages, not about where they were filed.
+        public override Task<List<MailMessageSummary>> LoadAllSummariesAsync() => Task.FromResult(new List<MailMessageSummary>(_messages));
+        public override Task<List<MailMessageSummary>> LoadAllSummariesAsync(Guid accountId) => Task.FromResult(new List<MailMessageSummary>(_messages));
+        public override Task<List<MailMessageSummary>> LoadFolderSummariesAsync(Guid accountId, string folderName, int? limit = null) => Task.FromResult(new List<MailMessageSummary>(_messages));
     }
 
     private static MainViewModel MakeVmWithStore(IEnumerable<SavedView> views, ILocalStoreService store, IMailService? imap = null)

--- a/QuickMail.Tests/SessionFeaturesTests.cs
+++ b/QuickMail.Tests/SessionFeaturesTests.cs
@@ -80,56 +80,18 @@ public class PreviewSuppressionTests
         public void Save(ConfigModel config) { }
     }
 
-    sealed class PreviewStore : ILocalStoreService
+    sealed class PreviewStore : StubLocalStoreService
     {
         private readonly List<MailMessageSummary> _messages;
-        public PreviewStore(IEnumerable<MailMessageSummary> messages) => _messages = new(messages);
 
-        public void Initialize() { }
-        public Task UpsertSummariesAsync(IEnumerable<MailMessageSummary> summaries) => Task.CompletedTask;
-        public Task<List<MailMessageSummary>> LoadAllSummariesAsync() => Task.FromResult(new List<MailMessageSummary>(_messages));
-        public Task<List<MailMessageSummary>> LoadAllSummariesAsync(Guid accountId) => Task.FromResult(new List<MailMessageSummary>(_messages));
-        public Task<List<MailMessageSummary>> LoadFolderSummariesAsync(Guid accountId, string folderName, int? limit = null) => Task.FromResult(new List<MailMessageSummary>(_messages));
-        public Task DeleteSummariesAsync(Guid accountId, string folderName, IEnumerable<string> messageIds) => Task.CompletedTask;
-        public Task DeleteAccountDataAsync(Guid accountId) => Task.CompletedTask;
-        public Task ClearCachedMailAsync(System.Collections.Generic.IEnumerable<System.Guid> accountIds) => Task.CompletedTask;
-        public Task PurgeCalendarEventsForUnknownAccountsAsync(IReadOnlyCollection<Guid> knownAccountIds) => Task.CompletedTask;
-        public Task SaveFoldersAsync(Guid accountId, IReadOnlyList<MailFolderModel> folders) => Task.CompletedTask;
-        public Task<Dictionary<Guid, List<MailFolderModel>>> LoadFoldersAsync() => Task.FromResult(new Dictionary<Guid, List<MailFolderModel>>());
-        public Task PurgeFoldersForUnknownAccountsAsync(IReadOnlyCollection<Guid> knownAccountIds) => Task.CompletedTask;
-        public Task UpdateIsReadAsync(Guid accountId, string folderName, string messageId, bool isRead) => Task.CompletedTask;
-        public Task UpdateIsReadBatchAsync(IEnumerable<(Guid AccountId, string FolderName, string MessageId)> items, bool isRead) => Task.CompletedTask;
-        public Task UpdatePreviewAsync(Guid accountId, string folderName, string messageId, string preview) => Task.CompletedTask;
-        public Task UpdatePreviewsBatchAsync(Guid accountId, string folderName, IEnumerable<(string MessageId, string Preview)> updates) => Task.CompletedTask;
-        public Task<bool> HasSummariesMissingRecipientsAsync() => Task.FromResult(false);
-        public Task UpsertDetailAsync(MailMessageDetail detail) => Task.CompletedTask;
-        public Task<MailMessageDetail?> LoadDetailAsync(Guid accountId, string folderName, string messageId) => Task.FromResult<MailMessageDetail?>(null);
-        public Task StoreMimeBytesAsync(Guid accountId, string folderName, string messageId, byte[]? mimeBytes) => Task.CompletedTask;
-        public Task<byte[]?> LoadMimeBytesAsync(Guid accountId, string folderName, string messageId) => Task.FromResult<byte[]?>(null);
-        public Task<HashSet<string>> LoadPop3CollectedUidlsAsync(Guid accountId) => Task.FromResult(new HashSet<string>());
-        public Task AddPop3CollectedUidlsAsync(Guid accountId, IEnumerable<string> uidls) => Task.CompletedTask;
-        public Task RemovePop3CollectedUidlsAsync(Guid accountId, IEnumerable<string> uidls) => Task.CompletedTask;
-        public Task<string> GetMaxMessageKeyAsync(Guid accountId, string folderName) => Task.FromResult("0");
-        public Task<HashSet<string>> GetAllMessageIdsAsync(Guid accountId, string folderName) => Task.FromResult(new HashSet<string>());
-        public Task<Dictionary<string, bool>> LoadFolderReadStatesAsync(Guid accountId, string folderName) => Task.FromResult(new Dictionary<string, bool>());
-        public Task<HashSet<string>> GetExistingMessageIdsAsync(Guid accountId, string folderName, IEnumerable<string> messageIds) => Task.FromResult(new HashSet<string>());
-        public Task<int> CountSummariesAsync(Guid accountId) => Task.FromResult(0);
-        public Task<Dictionary<string, int>> CountSummariesByFolderAsync(Guid accountId) => Task.FromResult(new Dictionary<string, int>());
-        public Task<DateTimeOffset?> GetOldestMessageDateAsync(Guid accountId) => Task.FromResult<DateTimeOffset?>(null);
-        public Task UpdateFlagIdAsync(Guid accountId, string folderName, string messageId, string? flagId) => Task.CompletedTask;
-        public Task UpdateFlagIdBatchAsync(IEnumerable<(Guid AccountId, string FolderName, string MessageId)> items, string? flagId) => Task.CompletedTask;
-        public Task UpsertCalendarEventAsync(CalendarEvent evt) => Task.CompletedTask;
-        public Task<List<CalendarEvent>> LoadCalendarEventsAsync() => Task.FromResult(new List<CalendarEvent>());
-        public Task<IReadOnlyList<(Guid AccountId, string CalendarId, string CalendarName)>> LoadCalendarSourcesAsync()
-            => Task.FromResult<IReadOnlyList<(Guid, string, string)>>(new List<(Guid, string, string)>());
-        public Task UpdateCalendarResponseStatusAsync(string uid, Guid accountId, CalendarResponseStatus status) => Task.CompletedTask;
-        public Task DeleteCalendarEventAsync(string uid, Guid accountId) => Task.CompletedTask;
-        public Task<List<(Guid AccountId, string FolderName, string MessageId, string IcsText)>> LoadAllCalendarIcsAsync()
-            => Task.FromResult(new List<(Guid, string, string, string)>());
-        public Task ClearOrphanedCalendarSourceLinksAsync() => Task.CompletedTask;
-        public Task ReplaceGraphCalendarEventsAsync(Guid accountId, IReadOnlyList<CalendarEvent> events) => Task.CompletedTask;
-        public Task<string?> GetDeltaTokenAsync(Guid accountId, string folderId) => Task.FromResult<string?>(null);
-        public Task SetDeltaTokenAsync(Guid accountId, string folderId, string deltaToken) => Task.CompletedTask;
+        public PreviewStore(IEnumerable<MailMessageSummary> messages)
+            => _messages = new List<MailMessageSummary>(messages);
+
+        // One list, served whatever account or folder is asked for — the tests here are about how the
+        // ViewModel treats a set of messages, not about where they were filed.
+        public override Task<List<MailMessageSummary>> LoadAllSummariesAsync() => Task.FromResult(new List<MailMessageSummary>(_messages));
+        public override Task<List<MailMessageSummary>> LoadAllSummariesAsync(Guid accountId) => Task.FromResult(new List<MailMessageSummary>(_messages));
+        public override Task<List<MailMessageSummary>> LoadFolderSummariesAsync(Guid accountId, string folderName, int? limit = null) => Task.FromResult(new List<MailMessageSummary>(_messages));
     }
 
     // Property (not field) so each test gets fresh instances — tests mutate Preview in place.

--- a/QuickMail.Tests/StubServices.cs
+++ b/QuickMail.Tests/StubServices.cs
@@ -293,6 +293,10 @@ class StubLocalStoreService : ILocalStoreService
     /// <c>FolderName</c>.</para></summary>
     public virtual Task<int> RefileMessagesAsync(Guid accountId, string fromFolder, string toFolder, IEnumerable<string> messageIds, bool copy)
     {
+        // Same-folder is a no-op in the real store. Without this the stub would find source and
+        // destination to be the same list and remove the row from it — the fake destroying mail the
+        // shipping code leaves alone is exactly the wrong direction for a fake to be wrong in.
+        if (string.Equals(fromFolder, toFolder, StringComparison.Ordinal)) return Task.FromResult(0);
         if (!SeededSummaries.TryGetValue((accountId, fromFolder), out var source)) return Task.FromResult(0);
         var wanted = new HashSet<string>(messageIds, StringComparer.Ordinal);
         var moving = source.Where(m => wanted.Contains(m.MessageId)).ToList();

--- a/QuickMail.Tests/StubServices.cs
+++ b/QuickMail.Tests/StubServices.cs
@@ -191,10 +191,10 @@ sealed class StubOAuthService : IOAuthService
     public Task SignOutAsync(AccountModel account) => Task.CompletedTask;
 }
 
-sealed class StubLocalStoreService : ILocalStoreService
+class StubLocalStoreService : ILocalStoreService
 {
-    public void Initialize() { }
-    public Task UpsertSummariesAsync(IEnumerable<MailMessageSummary> summaries) => Task.CompletedTask;
+    public virtual void Initialize() { }
+    public virtual Task UpsertSummariesAsync(IEnumerable<MailMessageSummary> summaries) => Task.CompletedTask;
 
     /// <summary>Cached rows keyed by (account, folder). Empty by default, so every existing test that
     /// never seeds it keeps seeing an empty cache; seed it to exercise a cache-first load such as the
@@ -204,98 +204,136 @@ sealed class StubLocalStoreService : ILocalStoreService
     private static List<MailMessageSummary> Newest(IEnumerable<MailMessageSummary> rows)
         => [.. rows.OrderByDescending(m => m.Date)];
 
-    public Task<List<MailMessageSummary>> LoadAllSummariesAsync()
+    public virtual Task<List<MailMessageSummary>> LoadAllSummariesAsync()
         => Task.FromResult(Newest(SeededSummaries.Values.SelectMany(v => v)));
-    public Task<List<MailMessageSummary>> LoadAllSummariesAsync(Guid accountId)
+    public virtual Task<List<MailMessageSummary>> LoadAllSummariesAsync(Guid accountId)
         => Task.FromResult(Newest(SeededSummaries.Where(kv => kv.Key.AccountId == accountId).SelectMany(kv => kv.Value)));
-    public Task<List<MailMessageSummary>> LoadFolderSummariesAsync(Guid accountId, string folderName, int? limit = null)
+    public virtual Task<List<MailMessageSummary>> LoadFolderSummariesAsync(Guid accountId, string folderName, int? limit = null)
         => Task.FromResult(SeededSummaries.TryGetValue((accountId, folderName), out var rows)
             ? Newest(rows) : []);
-    public Task DeleteSummariesAsync(Guid accountId, string folderName, IEnumerable<string> messageIds) => Task.CompletedTask;
-    public Task DeleteAccountDataAsync(Guid accountId) => Task.CompletedTask;
-    public Task ClearCachedMailAsync(System.Collections.Generic.IEnumerable<System.Guid> accountIds) => Task.CompletedTask;
-    public Task PurgeCalendarEventsForUnknownAccountsAsync(IReadOnlyCollection<Guid> knownAccountIds) => Task.CompletedTask;
+    public virtual Task<List<MailMessageSummary>> LoadFolderSummariesSinceAsync(Guid accountId, string folderName, DateTimeOffset since)
+        => Task.FromResult(SeededSummaries.TryGetValue((accountId, folderName), out var rows)
+            ? Newest(rows.Where(m => m.Date >= since)) : []);
+    public virtual Task DeleteSummariesAsync(Guid accountId, string folderName, IEnumerable<string> messageIds) => Task.CompletedTask;
+    public virtual Task DeleteAccountDataAsync(Guid accountId) => Task.CompletedTask;
+    public virtual Task ClearCachedMailAsync(System.Collections.Generic.IEnumerable<System.Guid> accountIds) => Task.CompletedTask;
+    public virtual Task PurgeCalendarEventsForUnknownAccountsAsync(IReadOnlyCollection<Guid> knownAccountIds) => Task.CompletedTask;
 
     /// <summary>Folders the stub hands back from <see cref="LoadFoldersAsync"/> — seed this to stand in
     /// for a persisted folder list at startup (#516). <see cref="SaveFoldersAsync"/> writes into it too,
     /// so a save/load round-trip works without a real database.</summary>
     public Dictionary<Guid, List<MailFolderModel>> SeededFolders { get; } = [];
-    public Task SaveFoldersAsync(Guid accountId, IReadOnlyList<MailFolderModel> folders)
+    public virtual Task SaveFoldersAsync(Guid accountId, IReadOnlyList<MailFolderModel> folders)
     {
         SeededFolders[accountId] = [.. folders.Where(f => !f.IsHeader && f.FullName.Length > 0)];
         return Task.CompletedTask;
     }
-    public Task<Dictionary<Guid, List<MailFolderModel>>> LoadFoldersAsync()
+    public virtual Task<Dictionary<Guid, List<MailFolderModel>>> LoadFoldersAsync()
         => Task.FromResult(SeededFolders.ToDictionary(kv => kv.Key, kv => new List<MailFolderModel>(kv.Value)));
-    public Task PurgeFoldersForUnknownAccountsAsync(IReadOnlyCollection<Guid> knownAccountIds)
+    public virtual Task PurgeFoldersForUnknownAccountsAsync(IReadOnlyCollection<Guid> knownAccountIds)
     {
         foreach (var id in SeededFolders.Keys.Where(k => !knownAccountIds.Contains(k)).ToList())
             SeededFolders.Remove(id);
         return Task.CompletedTask;
     }
 
-    public Task UpdateIsReadAsync(Guid accountId, string folderName, string messageId, bool isRead) => Task.CompletedTask;
-    public Task UpdateIsReadBatchAsync(IEnumerable<(Guid AccountId, string FolderName, string MessageId)> items, bool isRead) => Task.CompletedTask;
-    public Task UpdatePreviewAsync(Guid accountId, string folderName, string messageId, string preview) => Task.CompletedTask;
-    public Task UpdatePreviewsBatchAsync(Guid accountId, string folderName, IEnumerable<(string MessageId, string Preview)> updates) => Task.CompletedTask;
-    public Task<bool> HasSummariesMissingRecipientsAsync() => Task.FromResult(false);
-    public Task UpsertDetailAsync(MailMessageDetail detail) => Task.CompletedTask;
+    public virtual Task UpdateIsReadAsync(Guid accountId, string folderName, string messageId, bool isRead) => Task.CompletedTask;
+    public virtual Task UpdateIsReadBatchAsync(IEnumerable<(Guid AccountId, string FolderName, string MessageId)> items, bool isRead) => Task.CompletedTask;
+    public virtual Task UpdatePreviewAsync(Guid accountId, string folderName, string messageId, string preview) => Task.CompletedTask;
+    public virtual Task UpdatePreviewsBatchAsync(Guid accountId, string folderName, IEnumerable<(string MessageId, string Preview)> updates) => Task.CompletedTask;
+    public virtual Task<bool> HasSummariesMissingRecipientsAsync() => Task.FromResult(false);
+    public virtual Task UpsertDetailAsync(MailMessageDetail detail) => Task.CompletedTask;
     /// <summary>When set, <see cref="LoadDetailAsync"/> returns this seeded detail (tests use it to
     /// stand in for a cached invite email); otherwise it returns null like the real cache-miss path.</summary>
     public MailMessageDetail? SeededDetail { get; set; }
-    public Task<MailMessageDetail?> LoadDetailAsync(Guid accountId, string folderName, string messageId) => Task.FromResult(SeededDetail);
+    public virtual Task<MailMessageDetail?> LoadDetailAsync(Guid accountId, string folderName, string messageId) => Task.FromResult(SeededDetail);
 
     /// <summary>Raw POP3 message bytes (#128), kept so a test can assert what was stored.</summary>
     public Dictionary<(Guid AccountId, string Folder, string MessageId), byte[]?> MimeBytes { get; } = new();
 
-    public Task StoreMimeBytesAsync(Guid accountId, string folderName, string messageId, byte[]? mimeBytes)
+    public virtual Task StoreMimeBytesAsync(Guid accountId, string folderName, string messageId, byte[]? mimeBytes)
     {
         MimeBytes[(accountId, folderName, messageId)] = mimeBytes;
         return Task.CompletedTask;
     }
 
-    public Task<byte[]?> LoadMimeBytesAsync(Guid accountId, string folderName, string messageId) =>
+    public virtual Task<byte[]?> LoadMimeBytesAsync(Guid accountId, string folderName, string messageId) =>
         Task.FromResult(MimeBytes.TryGetValue((accountId, folderName, messageId), out var bytes) ? bytes : null);
 
     /// <summary>Functional in-memory POP3 collected-UIDL ledger, so backend tests exercise the real
     /// record/prune arithmetic rather than a silent no-op.</summary>
     public Dictionary<Guid, HashSet<string>> Pop3Uidls { get; } = [];
-    public Task<HashSet<string>> LoadPop3CollectedUidlsAsync(Guid accountId)
+    public virtual Task<HashSet<string>> LoadPop3CollectedUidlsAsync(Guid accountId)
         => Task.FromResult(Pop3Uidls.TryGetValue(accountId, out var set)
             ? new HashSet<string>(set, StringComparer.Ordinal) : new HashSet<string>(StringComparer.Ordinal));
-    public Task AddPop3CollectedUidlsAsync(Guid accountId, IEnumerable<string> uidls)
+    public virtual Task AddPop3CollectedUidlsAsync(Guid accountId, IEnumerable<string> uidls)
     {
         if (!Pop3Uidls.TryGetValue(accountId, out var set))
             Pop3Uidls[accountId] = set = new HashSet<string>(StringComparer.Ordinal);
         set.UnionWith(uidls);
         return Task.CompletedTask;
     }
-    public Task RemovePop3CollectedUidlsAsync(Guid accountId, IEnumerable<string> uidls)
+    public virtual Task RemovePop3CollectedUidlsAsync(Guid accountId, IEnumerable<string> uidls)
     {
         if (Pop3Uidls.TryGetValue(accountId, out var set)) set.ExceptWith(uidls);
         return Task.CompletedTask;
     }
-    public Task<string> GetMaxMessageKeyAsync(Guid accountId, string folderName) => Task.FromResult("0");
-    public Task<HashSet<string>> GetAllMessageIdsAsync(Guid accountId, string folderName) => Task.FromResult(new HashSet<string>());
-    public Task<Dictionary<string, bool>> LoadFolderReadStatesAsync(Guid accountId, string folderName) => Task.FromResult(new Dictionary<string, bool>());
-    public Task<HashSet<string>> GetExistingMessageIdsAsync(Guid accountId, string folderName, IEnumerable<string> messageIds) => Task.FromResult(new HashSet<string>());
-    public Task<int> CountSummariesAsync(Guid accountId) => Task.FromResult(0);
-    public Task<Dictionary<string, int>> CountSummariesByFolderAsync(Guid accountId) => Task.FromResult(new Dictionary<string, int>());
-    public Task<DateTimeOffset?> GetOldestMessageDateAsync(Guid accountId) => Task.FromResult<DateTimeOffset?>(null);
-    public Task UpdateFlagIdAsync(Guid accountId, string folderName, string messageId, string? flagId) => Task.CompletedTask;
-    public Task UpdateFlagIdBatchAsync(IEnumerable<(Guid AccountId, string FolderName, string MessageId)> items, string? flagId) => Task.CompletedTask;
-    public Task UpsertCalendarEventAsync(CalendarEvent evt) => Task.CompletedTask;
-    public Task<List<CalendarEvent>> LoadCalendarEventsAsync() => Task.FromResult(new List<CalendarEvent>());
-    public Task<IReadOnlyList<(Guid AccountId, string CalendarId, string CalendarName)>> LoadCalendarSourcesAsync()
+    public virtual Task<string> GetMaxMessageKeyAsync(Guid accountId, string folderName) => Task.FromResult("0");
+    public virtual Task<HashSet<string>> GetAllMessageIdsAsync(Guid accountId, string folderName) => Task.FromResult(new HashSet<string>());
+    public virtual Task<Dictionary<string, bool>> LoadFolderReadStatesAsync(Guid accountId, string folderName) => Task.FromResult(new Dictionary<string, bool>());
+    public virtual Task<IReadOnlyList<(string Id, DateTimeOffset Date, bool IsRead)>> LoadFolderMessageStatesAsync(Guid accountId, string folderName)
+        => Task.FromResult<IReadOnlyList<(string, DateTimeOffset, bool)>>(
+            SeededSummaries.TryGetValue((accountId, folderName), out var rows)
+                ? [.. rows.Select(m => (m.MessageId, m.Date, m.IsRead))] : []);
+
+    /// <summary>Functional enough to be worth asserting on: the seeded rows really are moved (or
+    /// copied) between folders, so a POP3 re-file test sees the outcome rather than a no-op.
+    /// <para>A copy shares the row instance with the source rather than cloning it — the seeded lists
+    /// are keyed by folder, so membership is the thing to assert on, not the copy's
+    /// <c>FolderName</c>.</para></summary>
+    public virtual Task<int> RefileMessagesAsync(Guid accountId, string fromFolder, string toFolder, IEnumerable<string> messageIds, bool copy)
+    {
+        if (!SeededSummaries.TryGetValue((accountId, fromFolder), out var source)) return Task.FromResult(0);
+        var wanted = new HashSet<string>(messageIds, StringComparer.Ordinal);
+        var moving = source.Where(m => wanted.Contains(m.MessageId)).ToList();
+        if (moving.Count == 0) return Task.FromResult(0);
+
+        if (!SeededSummaries.TryGetValue((accountId, toFolder), out var destination))
+            SeededSummaries[(accountId, toFolder)] = destination = [];
+        foreach (var m in moving)
+        {
+            destination.RemoveAll(d => d.MessageId == m.MessageId);
+            destination.Add(m);
+            if (!copy)
+            {
+                source.Remove(m);
+                m.FolderName = toFolder;
+            }
+        }
+        return Task.FromResult(moving.Count);
+    }
+    public virtual Task<HashSet<string>> GetExistingMessageIdsAsync(Guid accountId, string folderName, IEnumerable<string> messageIds) => Task.FromResult(new HashSet<string>());
+    public virtual Task<int> CountSummariesAsync(Guid accountId) => Task.FromResult(0);
+    public virtual Task<Dictionary<string, int>> CountSummariesByFolderAsync(Guid accountId) => Task.FromResult(new Dictionary<string, int>());
+    public virtual Task<Dictionary<string, (int Total, int Unread)>> CountMessagesByFolderAsync(Guid accountId)
+        => Task.FromResult(SeededSummaries
+            .Where(kv => kv.Key.AccountId == accountId)
+            .ToDictionary(kv => kv.Key.Folder, kv => (kv.Value.Count, kv.Value.Count(m => !m.IsRead))));
+    public virtual Task<DateTimeOffset?> GetOldestMessageDateAsync(Guid accountId) => Task.FromResult<DateTimeOffset?>(null);
+    public virtual Task UpdateFlagIdAsync(Guid accountId, string folderName, string messageId, string? flagId) => Task.CompletedTask;
+    public virtual Task UpdateFlagIdBatchAsync(IEnumerable<(Guid AccountId, string FolderName, string MessageId)> items, string? flagId) => Task.CompletedTask;
+    public virtual Task UpsertCalendarEventAsync(CalendarEvent evt) => Task.CompletedTask;
+    public virtual Task<List<CalendarEvent>> LoadCalendarEventsAsync() => Task.FromResult(new List<CalendarEvent>());
+    public virtual Task<IReadOnlyList<(Guid AccountId, string CalendarId, string CalendarName)>> LoadCalendarSourcesAsync()
         => Task.FromResult<IReadOnlyList<(Guid, string, string)>>(new List<(Guid, string, string)>());
-    public Task UpdateCalendarResponseStatusAsync(string uid, Guid accountId, CalendarResponseStatus status) => Task.CompletedTask;
-    public Task DeleteCalendarEventAsync(string uid, Guid accountId) => Task.CompletedTask;
-    public Task<List<(Guid AccountId, string FolderName, string MessageId, string IcsText)>> LoadAllCalendarIcsAsync()
+    public virtual Task UpdateCalendarResponseStatusAsync(string uid, Guid accountId, CalendarResponseStatus status) => Task.CompletedTask;
+    public virtual Task DeleteCalendarEventAsync(string uid, Guid accountId) => Task.CompletedTask;
+    public virtual Task<List<(Guid AccountId, string FolderName, string MessageId, string IcsText)>> LoadAllCalendarIcsAsync()
         => Task.FromResult(new List<(Guid, string, string, string)>());
-    public Task ClearOrphanedCalendarSourceLinksAsync() => Task.CompletedTask;
-    public Task ReplaceGraphCalendarEventsAsync(Guid accountId, IReadOnlyList<CalendarEvent> events) => Task.CompletedTask;
-    public Task<string?> GetDeltaTokenAsync(Guid accountId, string folderId) => Task.FromResult<string?>(null);
-    public Task SetDeltaTokenAsync(Guid accountId, string folderId, string deltaToken) => Task.CompletedTask;
+    public virtual Task ClearOrphanedCalendarSourceLinksAsync() => Task.CompletedTask;
+    public virtual Task ReplaceGraphCalendarEventsAsync(Guid accountId, IReadOnlyList<CalendarEvent> events) => Task.CompletedTask;
+    public virtual Task<string?> GetDeltaTokenAsync(Guid accountId, string folderId) => Task.FromResult<string?>(null);
+    public virtual Task SetDeltaTokenAsync(Guid accountId, string folderId, string deltaToken) => Task.CompletedTask;
 }
 
 sealed class StubContactService : IContactService

--- a/QuickMail.Tests/SyncServiceRuleApplicationTests.cs
+++ b/QuickMail.Tests/SyncServiceRuleApplicationTests.cs
@@ -146,6 +146,12 @@ public class SyncServiceRuleApplicationTests : IDisposable
         // listing that differs from what a window fetch would return — e.g. a new id the cache lacks, or
         // a cached id the server has dropped.
         public List<string>? ServerIds { get; set; }
+
+        // Cleared to stand in for a POP3 account, whose server drops a message from its listing as
+        // soon as it is collected — after which the local store is the only copy.
+        public bool DeletionAuthority { get; set; } = true;
+        public bool ListingIsAuthoritativeForDeletions(Guid accountId) => DeletionAuthority;
+
         public Task<IList<string>> GetFolderMessageIdsAsync(Guid a, string f, CancellationToken ct = default)
             => Task.FromResult<IList<string>>(ServerIds ?? ServerIdDates?.Select(x => x.Id).ToList()
                                               ?? Batch.Select(m => m.MessageId).ToList());
@@ -494,6 +500,46 @@ public class SyncServiceRuleApplicationTests : IDisposable
         var stored = await _store.GetAllMessageIdsAsync(_accountId, "INBOX");
         Assert.Contains("A", stored);
         Assert.Contains("B", stored);
+    }
+
+    [Fact]
+    public async Task Reconcile_NeverDeletes_WhenTheBackendsListingIsNotAuthoritative()
+    {
+        // POP3 (#128). Its server stops listing a message the moment it is collected, and by then the
+        // local store holds the only copy in existence — so "missing from the listing" must never
+        // mean "delete it". Pop3MailService also unions its cached ids into the listing so the
+        // arithmetic comes out empty either way, but that is the backend defending itself against a
+        // caller that cannot see the invariant. This is the sweep honouring it directly: even handed
+        // a listing that genuinely omits cached mail, it removes nothing.
+        await _store.UpsertSummariesAsync([Message("A"), Message("B")]);
+        var imap = new FetchStubMailService([]) { ServerIds = [], DeletionAuthority = false };
+        var sync = Build(imap, new CapturingRuleService());
+
+        var removed = new List<MailMessageSummary>();
+        sync.MessagesRemoved += list => removed.AddRange(list);
+
+        Assert.Equal(0, await sync.ReconcileFolderAsync(Account(), _inbox, CancellationToken.None));
+        Assert.Empty(removed);
+        var stored = await _store.GetAllMessageIdsAsync(_accountId, "INBOX");
+        Assert.Contains("A", stored);
+        Assert.Contains("B", stored);
+    }
+
+    [Fact]
+    public async Task Reconcile_StillDeletes_WhenTheBackendsListingIsAuthoritative()
+    {
+        // The other half of the gate: an ordinary IMAP/Graph account must keep losing cached mail
+        // that was deleted elsewhere. A capability that turns the reconcile off everywhere would
+        // pass the test above and break every account that is not POP3.
+        await _store.UpsertSummariesAsync([Message("A"), Message("B")]);
+        var imap = new FetchStubMailService([]) { ServerIds = ["A"] };   // B deleted on the server
+        var sync = Build(imap, new CapturingRuleService());
+
+        var removed = new List<MailMessageSummary>();
+        sync.MessagesRemoved += list => removed.AddRange(list);
+
+        Assert.Equal(1, await sync.ReconcileFolderAsync(Account(), _inbox, CancellationToken.None));
+        Assert.Equal(["B"], removed.Select(m => m.MessageId));
     }
 
     [Fact]

--- a/QuickMail.Tests/UnitTest1.cs
+++ b/QuickMail.Tests/UnitTest1.cs
@@ -632,6 +632,91 @@ public class LocalStoreServiceTests
     }
 
     [Fact]
+    public async Task CountMessagesByFolder_ReturnsTotalAndUnread_PerFolder()
+    {
+        // One grouped scan answers what the POP3 folder tree and Inbox status both ask for. Reading
+        // it off LoadFolderReadStatesAsync instead means building a dictionary of every id in each
+        // folder just to count it — a cost that grows with a store nothing prunes.
+        var tempDir = Path.Combine(Path.GetTempPath(), $"QuickMailTests-{Guid.NewGuid():N}");
+        var store   = new LocalStoreService(new ProfileContext(tempDir));
+        store.Initialize();
+
+        var acct = Guid.NewGuid();
+        MailMessageSummary Msg(string id, string folder, bool read) => new()
+        {
+            MessageId = id, AccountId = acct, FolderName = folder, IsRead = read,
+            From = "a@b.com", Subject = "s", Date = DateTimeOffset.UtcNow,
+        };
+        await store.UpsertSummariesAsync([
+            Msg("1", "Inbox", read: false), Msg("2", "Inbox", read: true), Msg("3", "Inbox", read: false),
+            Msg("4", "Trash", read: true),
+        ]);
+
+        var counts = await store.CountMessagesByFolderAsync(acct);
+        Assert.Equal((3, 2), counts["Inbox"]);
+        Assert.Equal((1, 0), counts["Trash"]);
+        Assert.False(counts.ContainsKey("Sent"));                                    // empty folder absent from the map
+        Assert.Empty(await store.CountMessagesByFolderAsync(Guid.NewGuid()));         // different account → empty map
+    }
+
+    [Fact]
+    public async Task LoadFolderSummariesSince_FiltersInSql_OnTheSameBoundaryTheCallerMeans()
+    {
+        // date_ticks is written as Date.UtcTicks, so the bound value has to be UtcTicks: a since
+        // expressed in a local offset, compared as raw Ticks, silently shifts the window by the
+        // offset — which for the POP3 sweep means either missing arrivals or re-announcing old mail.
+        var tempDir = Path.Combine(Path.GetTempPath(), $"QuickMailTests-{Guid.NewGuid():N}");
+        var store   = new LocalStoreService(new ProfileContext(tempDir));
+        store.Initialize();
+
+        var acct   = Guid.NewGuid();
+        var cutoff = new DateTimeOffset(2026, 8, 1, 12, 0, 0, TimeSpan.Zero);
+        MailMessageSummary Msg(string id, DateTimeOffset date) => new()
+        {
+            MessageId = id, AccountId = acct, FolderName = "Inbox", Date = date,
+            From = "a@b.com", Subject = "s",
+        };
+        await store.UpsertSummariesAsync([
+            Msg("older",  cutoff.AddMinutes(-1)),
+            Msg("onTheBoundary", cutoff),
+            Msg("newer",  cutoff.AddMinutes(1)),
+        ]);
+
+        var window = await store.LoadFolderSummariesSinceAsync(acct, "Inbox", cutoff);
+        Assert.Equal(["newer", "onTheBoundary"], window.Select(m => m.MessageId));    // newest first, boundary included
+
+        // The same instant written with a non-zero offset selects the same rows.
+        var shifted = await store.LoadFolderSummariesSinceAsync(acct, "Inbox", cutoff.ToOffset(TimeSpan.FromHours(-5)));
+        Assert.Equal(window.Select(m => m.MessageId), shifted.Select(m => m.MessageId));
+
+        // Full loads are unaffected.
+        Assert.Equal(3, (await store.LoadFolderSummariesAsync(acct, "Inbox")).Count);
+    }
+
+    [Fact]
+    public async Task LoadFolderMessageStates_ReturnsIdDateAndReadState_ForTheWholeFolder()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"QuickMailTests-{Guid.NewGuid():N}");
+        var store   = new LocalStoreService(new ProfileContext(tempDir));
+        store.Initialize();
+
+        var acct = Guid.NewGuid();
+        var when = new DateTimeOffset(2026, 7, 4, 8, 0, 0, TimeSpan.Zero);
+        await store.UpsertSummariesAsync([
+            new() { MessageId = "a", AccountId = acct, FolderName = "Inbox", Date = when, IsRead = true,  From = "x", Subject = "s" },
+            new() { MessageId = "b", AccountId = acct, FolderName = "Inbox", Date = when, IsRead = false, From = "x", Subject = "s" },
+            new() { MessageId = "c", AccountId = acct, FolderName = "Trash", Date = when, IsRead = false, From = "x", Subject = "s" },
+        ]);
+
+        var states = await store.LoadFolderMessageStatesAsync(acct, "Inbox");
+        Assert.Equal(2, states.Count);
+        Assert.True(states.Single(s => s.Id == "a").IsRead);
+        Assert.False(states.Single(s => s.Id == "b").IsRead);
+        Assert.Equal(when, states.Single(s => s.Id == "a").Date);
+        Assert.Empty(await store.LoadFolderMessageStatesAsync(acct, "Sent"));
+    }
+
+    [Fact]
     public async Task HasAttachments_PersistsAndLoads()
     {
         // Regression for §1.10: ReadSummariesAsync used to omit the has_attachments

--- a/QuickMail/Helpers/AccountFieldHints.cs
+++ b/QuickMail/Helpers/AccountFieldHints.cs
@@ -1,0 +1,44 @@
+namespace QuickMail.Helpers;
+
+/// <summary>
+/// Focus hints for the account form fields that Add Account and Account Manager both show.
+///
+/// <para>The two dialogs render the same field stack and so want the same guidance, but each keeps
+/// its own <c>HintFor</c> — the lookup is by control reference, which is per-window. Only the strings
+/// are shared, and they are shared here because a hint that drifts between the two dialogs describes
+/// the same control two different ways depending on which window the user opened it from.</para>
+///
+/// <para>Hints, not <c>AutomationProperties.Name</c>: a name must stay a short label, and delivering
+/// guidance as an <c>AnnouncementCategory.Hint</c> is what keeps the user's announcement preference
+/// in charge of whether they hear it. See the Accessibility Checklist in CLAUDE.md.</para>
+/// </summary>
+internal static class AccountFieldHints
+{
+    public const string AccountName =
+        "Leave blank to use your email address.";
+
+    public const string Password =
+        "Stored in Windows Credential Manager.";
+
+    public const string LoginUsername =
+        "Leave blank unless your mail server logs in under a different name than your email address.";
+
+    public const string SyncCalendar =
+        "Shows this account's calendar in the Calendar view.";
+
+    /// <summary>The ports are in the checkbox's visible Content, but an explicit
+    /// <c>AutomationProperties.Name</c> OVERRIDES that text — so without this the port guidance would
+    /// exist for sighted users only.</summary>
+    public const string SmtpImplicitSsl =
+        "Checked uses port 465. Cleared uses STARTTLS on port 587.";
+
+    /// <summary>POP3 hands the local store the only copy of a message once the server drops it, and
+    /// that is what this checkbox decides — the consequence is the point of the control, so it is
+    /// spelled out rather than left to a label that must stay short.</summary>
+    public const string Pop3LeaveOnServer =
+        "Cleared, mail is removed from the server once QuickMail has downloaded it, " +
+        "so this computer holds the only copy.";
+
+    public const string Signature =
+        "Added to the end of new messages, replies, and forwards.";
+}

--- a/QuickMail/Helpers/AccountPropertiesBuilder.cs
+++ b/QuickMail/Helpers/AccountPropertiesBuilder.cs
@@ -20,6 +20,15 @@ public static class AccountPropertiesBuilder
             new("Email address",  account.Username),
         };
 
+        // Graph has no host, port or security of its own, and describes its incoming and outgoing
+        // legs identically — so the rows are built once rather than written out on both sides.
+        List<PropertyItem> GraphLeg() =>
+        [
+            new("Connection", "Microsoft Graph"),
+            new("Server",     "None — Graph uses the Microsoft 365 API"),
+            new("Username",   account.Username),
+        ];
+
         // Incoming: whichever protocol this account actually receives over. Reading the IMAP fields
         // regardless was wrong for every account that does not speak IMAP — a POP3 or Graph account
         // showed a blank server on port 993, which is not a description of anything (#128).
@@ -37,12 +46,7 @@ public static class AccountPropertiesBuilder
                     : "Removed once downloaded"),
             }),
 
-            BackendKind.MicrosoftGraph => ("Incoming (Microsoft 365)", new List<PropertyItem>
-            {
-                new("Connection", "Microsoft Graph"),
-                new("Server",     "None — Graph uses the Microsoft 365 API"),
-                new("Username",   account.Username),
-            }),
+            BackendKind.MicrosoftGraph => ("Incoming (Microsoft 365)", GraphLeg()),
 
             _ => ("Incoming (IMAP)", new List<PropertyItem>
             {
@@ -57,12 +61,7 @@ public static class AccountPropertiesBuilder
 
         // Outgoing: POP3 accounts send over SMTP exactly like IMAP ones, so only Graph differs.
         var (outgoingHeader, outgoing) = account.BackendKind == BackendKind.MicrosoftGraph
-            ? ("Outgoing (Microsoft 365)", new List<PropertyItem>
-            {
-                new("Connection", "Microsoft Graph"),
-                new("Server",     "None — Graph uses the Microsoft 365 API"),
-                new("Username",   account.Username),
-            })
+            ? ("Outgoing (Microsoft 365)", GraphLeg())
             : ("Outgoing (SMTP)", new List<PropertyItem>
             {
                 new("Server",   account.SmtpHost),

--- a/QuickMail/Helpers/HtmlStripper.cs
+++ b/QuickMail/Helpers/HtmlStripper.cs
@@ -14,7 +14,16 @@ namespace QuickMail.Helpers;
 /// </summary>
 public static class HtmlStripper
 {
-    public static string ToPlainText(string? html)
+    /// <param name="includeLinkTargets">
+    /// Whether a link whose text differs from its href is rendered as <c>text (href)</c>. True for a
+    /// body conversion, where losing the destination loses the only way to reach it.
+    /// <para>False for a message-list preview. A preview is one line the user reads — or hears — to
+    /// decide whether to open the message, and marketing mail routinely opens with a logo wrapped in
+    /// a tracking link, so the first thing in the preview becomes a hundred characters of query
+    /// string. The destination is not lost: it is still in the body, where activating the link is
+    /// what the user would do with it.</para>
+    /// </param>
+    public static string ToPlainText(string? html, bool includeLinkTargets = true)
     {
         if (string.IsNullOrEmpty(html)) return string.Empty;
 
@@ -106,7 +115,8 @@ public static class HtmlStripper
                     {
                         var text = sb.ToString(linkTextStart, sb.Length - linkTextStart).Trim();
                         var decodedHref = WebUtility.HtmlDecode(linkHref);
-                        if (decodedHref.Length > 0
+                        if (includeLinkTargets
+                            && decodedHref.Length > 0
                             && !decodedHref.StartsWith("javascript:", StringComparison.OrdinalIgnoreCase)
                             && !decodedHref.StartsWith("data:", StringComparison.OrdinalIgnoreCase)
                             && !string.Equals(text, decodedHref, StringComparison.OrdinalIgnoreCase)

--- a/QuickMail/Models/AccountModel.cs
+++ b/QuickMail/Models/AccountModel.cs
@@ -98,6 +98,19 @@ public partial class AccountModel : ObservableObject
     // must not reach for the IMAP fields directly. A POP3 account leaves those at their defaults, so
     // an IMAP-only reading sees every POP3 account as the same empty host on port 993 (#128).
 
+    /// <summary>
+    /// Whether folders on this account can be created, renamed, moved, copied or deleted. False only
+    /// for POP3 (#128), whose Inbox, Sent, Drafts and Trash are made up by QuickMail and are the only
+    /// folders there can be.
+    /// <para>A capability the UI asks about, rather than a <see cref="BackendKind"/> comparison
+    /// repeated at each command that needs it: those comparisons are a state decision, they were
+    /// planted at four call sites, and the one place that forgot to make it — the message move/copy
+    /// picker's New Folder button — worked only because the backend's <c>NotSupportedException</c>
+    /// message happened to read well.</para>
+    /// </summary>
+    [JsonIgnore]
+    public bool SupportsFolderCrud => BackendKind != BackendKind.Pop3Smtp;
+
     /// <summary>The host this account receives mail from. Empty for Graph, which has no server.</summary>
     [JsonIgnore]
     public string IncomingHost => BackendKind switch

--- a/QuickMail/Models/MailProvider.cs
+++ b/QuickMail/Models/MailProvider.cs
@@ -33,6 +33,12 @@ namespace QuickMail.Models;
 /// Optional and trailing so every existing construction site is untouched.
 /// </param>
 /// <param name="Pop3Port">POP3 port to go with <paramref name="Pop3Host"/>. 995 is implicit TLS.</param>
+/// <param name="Pop3UseSsl">
+/// Implicit TLS on the POP3 leg, stated by the catalog rather than inferred from the port — the shape
+/// <paramref name="ImapUseSsl"/> and <paramref name="SmtpUseSsl"/> already have. A provider on a
+/// non-standard implicit-TLS port would otherwise be silently downgraded to STARTTLS by the entry
+/// that filled its settings in.
+/// </param>
 public sealed record MailProvider(
     string Id,
     string DisplayName,
@@ -49,7 +55,8 @@ public sealed record MailProvider(
     string? AppPasswordHint,
     string? AppPasswordUrl,
     string? Pop3Host = null,
-    int Pop3Port = 995)
+    int Pop3Port = 995,
+    bool Pop3UseSsl = true)
 {
     /// <summary>True when QuickMail knows a POP3 host for this provider.</summary>
     public bool SupportsPop3 => !string.IsNullOrEmpty(Pop3Host);

--- a/QuickMail/Services/GraphMailService.cs
+++ b/QuickMail/Services/GraphMailService.cs
@@ -269,13 +269,9 @@ public class GraphMailService : IMailService, IConnectionProbe
             var mime = await _client.GetBytesAsync(Account(accountId), $"/me/messages/{messageId}/$value", GraphHeaders.ImmutableId, ct);
             using var stream = new MemoryStream(mime);
             var message = await MimeMessage.LoadAsync(stream, ct);
-            var calendar = message.BodyParts.OfType<TextPart>()
-                .FirstOrDefault(p => p.ContentType.IsMimeType("text", "calendar"));
-            if (calendar != null && !string.IsNullOrWhiteSpace(calendar.Text))
-            {
-                detail.CalendarIcs = calendar.Text;
-                detail.CalendarInvite = IcsModel.Parse(calendar.Text);
-            }
+            // The same part query and the same assignment rule the other two backends use — the
+            // CalendarIcs-with-CalendarInvite invariant is stated once, in PopulateCalendar.
+            ImapMailService.PopulateCalendar(detail, ImapMailService.FindCalendarText(message));
         }
         catch (Exception ex)
         {

--- a/QuickMail/Services/ILocalStoreService.cs
+++ b/QuickMail/Services/ILocalStoreService.cs
@@ -13,6 +13,14 @@ public interface ILocalStoreService
     Task<List<MailMessageSummary>> LoadAllSummariesAsync();
     Task<List<MailMessageSummary>> LoadAllSummariesAsync(Guid accountId);
     Task<List<MailMessageSummary>> LoadFolderSummariesAsync(Guid accountId, string folderName, int? limit = null);
+
+    /// <summary>
+    /// The folder's summaries dated <paramref name="since"/> or later, filtered in SQL rather than in
+    /// memory. The POP3 backend's window fetch is a store read (its mail lives nowhere else), and a
+    /// mailbox that is never pruned by a server grows without bound — so loading every row to discard
+    /// most of them is a cost that grows with the account's whole history, every sweep.
+    /// </summary>
+    Task<List<MailMessageSummary>> LoadFolderSummariesSinceAsync(Guid accountId, string folderName, DateTimeOffset since);
     Task DeleteSummariesAsync(Guid accountId, string folderName, IEnumerable<string> messageIds);
     Task DeleteAccountDataAsync(Guid accountId);
 
@@ -119,6 +127,15 @@ public interface ILocalStoreService
     /// </summary>
     Task<Dictionary<string, bool>> LoadFolderReadStatesAsync(Guid accountId, string folderName);
 
+    /// <summary>
+    /// Id, date and read state for every message in the folder — the three columns an id listing is
+    /// made of, and nothing else. The POP3 backend answers <c>GetFolderMessageIdDatesAsync</c> from
+    /// the cache, which otherwise means materialising every fifteen-column summary in the folder
+    /// (bodies excepted) on every sweep, to project three fields out of each.
+    /// </summary>
+    Task<IReadOnlyList<(string Id, DateTimeOffset Date, bool IsRead)>> LoadFolderMessageStatesAsync(
+        Guid accountId, string folderName);
+
     /// <summary>Which of <paramref name="messageIds"/> already exist in the folder (bounded lookup).</summary>
     Task<HashSet<string>> GetExistingMessageIdsAsync(Guid accountId, string folderName, IEnumerable<string> messageIds);
 
@@ -134,6 +151,29 @@ public interface ILocalStoreService
     /// the measurement's own cost off the timed region and off the per-folder hot path.
     /// </summary>
     Task<Dictionary<string, int>> CountSummariesByFolderAsync(Guid accountId);
+
+    /// <summary>
+    /// Total and unread message counts per folder for one account, in a single <c>GROUP BY</c>. What
+    /// the POP3 folder tree and Inbox status are asking for: they need four folders' counts and
+    /// nothing else, and reading them off <see cref="LoadFolderReadStatesAsync"/> means building a
+    /// dictionary of every id in each folder to then count it.
+    /// </summary>
+    Task<Dictionary<string, (int Total, int Unread)>> CountMessagesByFolderAsync(Guid accountId);
+
+    // ── Local re-filing (#128) ───────────────────────────────────────────────────
+    // POP3's folders are QuickMail's own, so moving a message between them is a store operation with
+    // no server side at all.
+
+    /// <summary>
+    /// Re-files stored messages from one folder to another, moving the summary row, the detail row
+    /// and the raw MIME bytes intact — no column is read into managed memory and written back, so a
+    /// field the model gains later cannot be dropped in transit. When
+    /// <paramref name="copy"/> is true the rows are duplicated instead, leaving the originals.
+    /// Ids already present in <paramref name="toFolder"/> are replaced. Returns how many messages
+    /// were found in <paramref name="fromFolder"/> and re-filed.
+    /// </summary>
+    Task<int> RefileMessagesAsync(
+        Guid accountId, string fromFolder, string toFolder, IEnumerable<string> messageIds, bool copy);
 
     /// <summary>
     /// Returns the oldest message date stored for the given account, or null if no messages exist.

--- a/QuickMail/Services/IMailService.cs
+++ b/QuickMail/Services/IMailService.cs
@@ -68,6 +68,22 @@ public interface IMailService : IDisposable
     Task<int> CountTrashMessagesAsync(Guid accountId, CancellationToken ct = default);
 
     Task<int> EmptyTrashAsync(Guid accountId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Whether a cached id absent from this backend's listings means the message was deleted
+    /// elsewhere, and so may be dropped from the local cache. True for every backend that lists a
+    /// server-side mailbox.
+    ///
+    /// <para>False for POP3 (#128), where it is <b>not</b> a statement about efficiency but about
+    /// safety: a POP3 server legitimately stops listing a message the moment it has been collected,
+    /// and once collected the local store is the only copy in existence. Reconciling deletions
+    /// against such a listing would delete the user's mail permanently, on the sweep after it
+    /// arrived. <c>Pop3MailService</c> also unions its cached ids into the listing so the arithmetic
+    /// comes out as a no-op either way — but that is the backend defending itself against a caller
+    /// that cannot see the invariant. This is the invariant, where the sweep can see it.</para>
+    /// </summary>
+    bool ListingIsAuthoritativeForDeletions(Guid accountId) => true;
+
     Task<IList<string>> GetFolderMessageIdsAsync(Guid accountId, string folderName, CancellationToken ct = default);
 
     /// <summary>

--- a/QuickMail/Services/IMailService.cs
+++ b/QuickMail/Services/IMailService.cs
@@ -78,9 +78,16 @@ public interface IMailService : IDisposable
     /// safety: a POP3 server legitimately stops listing a message the moment it has been collected,
     /// and once collected the local store is the only copy in existence. Reconciling deletions
     /// against such a listing would delete the user's mail permanently, on the sweep after it
-    /// arrived. <c>Pop3MailService</c> also unions its cached ids into the listing so the arithmetic
-    /// comes out as a no-op either way — but that is the backend defending itself against a caller
-    /// that cannot see the invariant. This is the invariant, where the sweep can see it.</para>
+    /// arrived.</para>
+    ///
+    /// <para><b>This flag is a second lock, not a replacement for the first.</b>
+    /// <c>Pop3MailService.MergeListing</c> unions its cached ids into every listing it returns, which
+    /// is what makes the deletion arithmetic empty; that union stays load-bearing and must not be
+    /// removed on the strength of this flag. The router resolves an unregistered account to the
+    /// default (IMAP) backend, so a POP3 account that never registered would read as authoritative
+    /// here and the union would be the only thing left standing between the sweep and the user's
+    /// mail. What this flag adds is that the invariant is now visible to <c>SyncService</c>, instead
+    /// of being an arithmetic coincidence it could break without noticing.</para>
     /// </summary>
     bool ListingIsAuthoritativeForDeletions(Guid accountId) => true;
 

--- a/QuickMail/Services/ImapMailService.cs
+++ b/QuickMail/Services/ImapMailService.cs
@@ -813,7 +813,10 @@ public class ImapMailService : IMailService, IChangeNotifier, IConnectionProbe
                     else if (s.HtmlBody != null)
                     {
                         var part = await folder.GetBodyPartAsync(s.UniqueId, s.HtmlBody, ct);
-                        if (part is TextPart tp) text = StripHtml(tp.Text ?? string.Empty);
+                        // HtmlStripper, not a tag-stripping regex: it decodes entities, keeps list
+                        // and link structure, and is what the POP3 backend already builds previews
+                        // with — so the same message previews identically whichever fetched it.
+                        if (part is TextPart tp) text = Helpers.HtmlStripper.ToPlainText(tp.Text);
                     }
 
                     var preview = ExtractPreviewLines(text, maxLines);
@@ -1828,21 +1831,14 @@ public class ImapMailService : IMailService, IChangeNotifier, IConnectionProbe
         return null;
     }
 
-    private static string ExtractPreviewLines(string text, int maxLines) =>
+    /// <summary>Shared with <see cref="Pop3MailService"/>: the message list shows both backends'
+    /// messages side by side, so the preview text has to be built the same way in both.</summary>
+    internal static string ExtractPreviewLines(string text, int maxLines) =>
         string.Join(" ", text
             .Split('\n')
             .Select(l => l.Trim())
             .Where(l => l.Length > 0)
             .Take(maxLines));
-
-    private static string StripHtml(string html)
-    {
-        if (string.IsNullOrEmpty(html)) return string.Empty;
-        return System.Text.RegularExpressions.Regex.Replace(html, "<[^>]+>", " ")
-            .Replace("&nbsp;", " ").Replace("&amp;", "&")
-            .Replace("&lt;", "<").Replace("&gt;", ">")
-            .Trim();
-    }
 
     private static bool IsExcludedFromAllMail(FolderAttributes attrs, string fullName)
     {
@@ -1888,18 +1884,35 @@ public class ImapMailService : IMailService, IChangeNotifier, IConnectionProbe
         _          => ComposeMode.PlainText,
     };
 
-    private static string FormatAddressList(InternetAddressList? list) =>
+    // Shared with Pop3MailService for the same reason ParseComposeMode is: the message list renders
+    // both backends' rows side by side, so a second copy of these would be free to drift.
+
+    /// <summary>Full addresses ("Kelly Ford &lt;kelly@example.com&gt;"), for the detail view.</summary>
+    internal static string FormatAddressList(InternetAddressList? list) =>
         list == null || list.Count == 0
             ? string.Empty
             : string.Join(", ", list.Select(a => a.ToString()));
 
-    private static string FormatAddressListDisplay(InternetAddressList? list) =>
+    /// <summary>Display names where there is one, for the message list's From column.</summary>
+    internal static string FormatAddressListDisplay(InternetAddressList? list) =>
         list == null || list.Count == 0
             ? string.Empty
             : string.Join(", ", list.Select(a =>
                 a is MailboxAddress mb && !string.IsNullOrWhiteSpace(mb.Name)
                     ? mb.Name
                     : a.ToString()));
+
+    /// <summary>
+    /// Raw text of the first text/calendar body part of a downloaded message, or null when it carries
+    /// no invite. Feeds <see cref="PopulateCalendar"/>. Lives here, next to it, because both backends
+    /// that hold a whole <see cref="MimeMessage"/> need exactly this query: POP3 (every message it
+    /// downloads) and Graph (meeting messages, whose JSON never surfaces the MIME part, so it fetches
+    /// $value and re-parses).
+    /// </summary>
+    internal static string? FindCalendarText(MimeMessage message) =>
+        message.BodyParts
+            .OfType<TextPart>()
+            .FirstOrDefault(p => p.ContentType.IsMimeType("text", "calendar"))?.Text;
 
     public Task PermanentlyDeleteBatchAsync(Guid accountId, string folderName, IList<string> messageIds, CancellationToken ct = default) =>
         // Retry once on a fresh connection if the pooled one was silently dropped (issue #311).

--- a/QuickMail/Services/ImapMailService.cs
+++ b/QuickMail/Services/ImapMailService.cs
@@ -813,10 +813,13 @@ public class ImapMailService : IMailService, IChangeNotifier, IConnectionProbe
                     else if (s.HtmlBody != null)
                     {
                         var part = await folder.GetBodyPartAsync(s.UniqueId, s.HtmlBody, ct);
-                        // HtmlStripper, not a tag-stripping regex: it decodes entities, keeps list
-                        // and link structure, and is what the POP3 backend already builds previews
-                        // with — so the same message previews identically whichever fetched it.
-                        if (part is TextPart tp) text = Helpers.HtmlStripper.ToPlainText(tp.Text);
+                        // HtmlStripper, not a tag-stripping regex: it decodes entities and skips
+                        // script/style/head content, which the regex left in — HTML mail routinely
+                        // previewed as a run of CSS. It is what the POP3 backend already builds
+                        // previews with, so the same message reads the same way whichever fetched it.
+                        // includeLinkTargets: false because this is a preview — see HtmlStripper.
+                        if (part is TextPart tp)
+                            text = Helpers.HtmlStripper.ToPlainText(tp.Text, includeLinkTargets: false);
                     }
 
                     var preview = ExtractPreviewLines(text, maxLines);

--- a/QuickMail/Services/LocalStoreService.cs
+++ b/QuickMail/Services/LocalStoreService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.Data.Sqlite;
@@ -461,6 +462,22 @@ public class LocalStoreService : ILocalStoreService
         cmd.Parameters.AddWithValue("$fn",  folderName);
         if (limit.HasValue)
             cmd.Parameters.AddWithValue("$limit", Math.Max(0, limit.Value));
+        return await ReadSummariesAsync(cmd);
+    }
+
+    public async Task<List<MailMessageSummary>> LoadFolderSummariesSinceAsync(
+        Guid accountId, string folderName, DateTimeOffset since)
+    {
+        await using var conn = await OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText =
+            "SELECT unique_id, account_id, folder_name, from_disp, to_addr, subject, date_ticks, is_read, preview_text, is_replied, is_forwarded, has_attachments, is_mailing_list, flag_id, internet_message_id " +
+            "FROM MessageSummary WHERE account_id=$aid AND folder_name=$fn AND date_ticks>=$since ORDER BY date_ticks DESC;";
+        cmd.Parameters.AddWithValue("$aid", accountId.ToString());
+        cmd.Parameters.AddWithValue("$fn",  folderName);
+        // date_ticks is written as Date.UtcTicks, so the bound value has to be UtcTicks too — a
+        // local-offset DateTimeOffset compared as raw Ticks is off by the offset.
+        cmd.Parameters.AddWithValue("$since", since.UtcTicks);
         return await ReadSummariesAsync(cmd);
     }
 
@@ -1070,6 +1087,22 @@ public class LocalStoreService : ILocalStoreService
         return result;
     }
 
+    public async Task<IReadOnlyList<(string Id, DateTimeOffset Date, bool IsRead)>> LoadFolderMessageStatesAsync(
+        Guid accountId, string folderName)
+    {
+        await using var conn = await OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText =
+            "SELECT unique_id, date_ticks, is_read FROM MessageSummary WHERE account_id=$aid AND folder_name=$fn;";
+        cmd.Parameters.AddWithValue("$aid", accountId.ToString());
+        cmd.Parameters.AddWithValue("$fn",  folderName);
+        var result = new List<(string, DateTimeOffset, bool)>();
+        await using var r = await cmd.ExecuteReaderAsync();
+        while (await r.ReadAsync())
+            result.Add((r.GetString(0), new DateTimeOffset(r.GetInt64(1), TimeSpan.Zero), r.GetInt64(2) != 0));
+        return result;
+    }
+
     /// <summary>
     /// Which of <paramref name="messageIds"/> already exist in the folder — a bounded
     /// <c>WHERE unique_id IN (…)</c> so a live sync can dedupe its small fetched batch without
@@ -1165,6 +1198,120 @@ public class LocalStoreService : ILocalStoreService
         while (await reader.ReadAsync())
             byFolder[reader.GetString(0)] = reader.GetInt32(1);
         return byFolder;
+    }
+
+    public async Task<Dictionary<string, (int Total, int Unread)>> CountMessagesByFolderAsync(Guid accountId)
+    {
+        await using var conn = await OpenAsync();
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText =
+            "SELECT folder_name, COUNT(*), SUM(CASE WHEN is_read = 0 THEN 1 ELSE 0 END) " +
+            "FROM MessageSummary WHERE account_id = @id GROUP BY folder_name";
+        cmd.Parameters.AddWithValue("@id", accountId.ToString());
+        var byFolder = new Dictionary<string, (int, int)>();
+        await using var reader = await cmd.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+            byFolder[reader.GetString(0)] = (reader.GetInt32(1), reader.GetInt32(2));
+        return byFolder;
+    }
+
+    public async Task<int> RefileMessagesAsync(
+        Guid accountId, string fromFolder, string toFolder, IEnumerable<string> messageIds, bool copy)
+    {
+        var ids = messageIds as IReadOnlyList<string> ?? messageIds.ToList();
+        if (ids.Count == 0 || string.Equals(fromFolder, toFolder, StringComparison.Ordinal)) return 0;
+
+        await using var conn = await OpenAsync();
+        await using var tx = await conn.BeginTransactionAsync();
+
+        int refiled = 0;
+        // Chunked for the same reason DeleteSummariesAsync is: SQLite compiles a bounded number of
+        // parameters (~999), and the caller may be emptying a whole folder into Trash.
+        const int chunkSize = 500;
+        for (int offset = 0; offset < ids.Count; offset += chunkSize)
+        {
+            var count = Math.Min(chunkSize, ids.Count - offset);
+            var placeholders = string.Join(',', Enumerable.Range(0, count).Select(i => $"$u{i}"));
+
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = copy
+                // Column lists read from the live schema rather than written out here: the point of
+                // moving rows in SQL is that nothing is lost in transit, and a hand-written list
+                // would quietly stop carrying the next column someone adds.
+                ? await CopyRowsSqlAsync(conn, placeholders)
+                // UPDATE OR REPLACE, not UPDATE: an id already filed in the destination (the same
+                // message copied there earlier) would otherwise collide with the primary key and
+                // abort the whole transaction.
+                //
+                // The CalendarEvent leg retargets a harvested invite's back-link to the message's
+                // new home. Without it the event still points at the folder the message left, and
+                // "open the invitation" from the calendar dead-ends — the failure
+                // ClearOrphanedCalendarSourceLinksAsync exists to prevent, arriving by a route it
+                // cannot see (the detail row exists, just not where the event says).
+                : $"""
+                   UPDATE OR REPLACE MessageSummary SET folder_name=$to
+                     WHERE account_id=$aid AND folder_name=$from AND unique_id IN ({placeholders});
+                   UPDATE OR REPLACE MessageDetail  SET folder_name=$to
+                     WHERE account_id=$aid AND folder_name=$from AND unique_id IN ({placeholders});
+                   UPDATE CalendarEvent SET source_folder=$to
+                     WHERE account_id=$aid AND source_folder=$from AND source_message_id IN ({placeholders});
+                   """;
+            cmd.Parameters.AddWithValue("$aid",  accountId.ToString());
+            cmd.Parameters.AddWithValue("$from", fromFolder);
+            cmd.Parameters.AddWithValue("$to",   toFolder);
+            for (int i = 0; i < count; i++)
+                cmd.Parameters.AddWithValue($"$u{i}", ids[offset + i]);
+
+            // Two statements touch MessageSummary and MessageDetail; the summary is the row that
+            // exists for every message, so its count is how many were actually there to re-file.
+            await using (var counting = conn.CreateCommand())
+            {
+                counting.CommandText =
+                    $"SELECT COUNT(*) FROM MessageSummary WHERE account_id=$aid AND folder_name=$from AND unique_id IN ({placeholders});";
+                counting.Parameters.AddWithValue("$aid",  accountId.ToString());
+                counting.Parameters.AddWithValue("$from", fromFolder);
+                for (int i = 0; i < count; i++)
+                    counting.Parameters.AddWithValue($"$u{i}", ids[offset + i]);
+                refiled += Convert.ToInt32(await counting.ExecuteScalarAsync() ?? 0);
+            }
+
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        await tx.CommitAsync();
+        return refiled;
+    }
+
+    /// <summary>
+    /// <c>INSERT OR REPLACE … SELECT</c> for both message tables, with <c>folder_name</c> swapped for
+    /// the destination and every other column carried across verbatim. The column names come from
+    /// <c>PRAGMA table_info</c> so the copy stays complete as the schema grows — the same guarantee
+    /// the row-by-row version had by re-filing loaded objects, without loading them.
+    /// </summary>
+    private static async Task<string> CopyRowsSqlAsync(SqliteConnection conn, string placeholders)
+    {
+        var sql = new StringBuilder();
+        foreach (var table in new[] { "MessageSummary", "MessageDetail" })
+        {
+            var columns = await ColumnNamesAsync(conn, table);
+            var projected = string.Join(", ", columns.Select(c => c == "folder_name" ? "$to" : c));
+            sql.Append($"INSERT OR REPLACE INTO {table} ({string.Join(", ", columns)}) ")
+               .Append($"SELECT {projected} FROM {table} ")
+               .Append($"WHERE account_id=$aid AND folder_name=$from AND unique_id IN ({placeholders});");
+        }
+        return sql.ToString();
+    }
+
+    private static async Task<List<string>> ColumnNamesAsync(SqliteConnection conn, string table)
+    {
+        await using var cmd = conn.CreateCommand();
+        // Table names here are compile-time literals, never user input.
+        cmd.CommandText = $"PRAGMA table_info({table});";
+        var names = new List<string>();
+        await using var r = await cmd.ExecuteReaderAsync();
+        while (await r.ReadAsync())
+            names.Add(r.GetString(1));
+        return names;
     }
 
     public async Task<DateTimeOffset?> GetOldestMessageDateAsync(Guid accountId)

--- a/QuickMail/Services/MailServiceRouter.cs
+++ b/QuickMail/Services/MailServiceRouter.cs
@@ -187,6 +187,9 @@ public class MailServiceRouter : IMailService, IConnectionProbe
     public Task<int> EmptyTrashAsync(Guid accountId, CancellationToken ct = default)
         => For(accountId).EmptyTrashAsync(accountId, ct);
 
+    public bool ListingIsAuthoritativeForDeletions(Guid accountId)
+        => For(accountId).ListingIsAuthoritativeForDeletions(accountId);
+
     public Task<IList<string>> GetFolderMessageIdsAsync(Guid accountId, string folderName, CancellationToken ct = default)
         => For(accountId).GetFolderMessageIdsAsync(accountId, folderName, ct);
 

--- a/QuickMail/Services/Pop3MailService.cs
+++ b/QuickMail/Services/Pop3MailService.cs
@@ -107,12 +107,23 @@ public class Pop3MailService : IMailService
         _locks.GetOrAdd(account.Id, _ => new SemaphoreSlim(1, 1));
     }
 
+    /// <summary>
+    /// Forgets the account's registration and credential, so nothing can open a new session for it.
+    /// <para>The maildrop lock is deliberately left in <see cref="_locks"/>. Disposing it here would
+    /// be safe only if no session were in flight, and this is reachable while one is: a sweep holding
+    /// the semaphore would get <see cref="ObjectDisposedException"/> out of its <c>finally</c>, and a
+    /// reconnect would then build a second semaphore and allow the concurrent maildrop session
+    /// RFC 1939 forbids.</para>
+    /// <para>The cost is that Test Connection, which mints a throwaway account id per press, leaves
+    /// one semaphore behind each time — a few dozen bytes, bounded by button presses. That is the
+    /// cheaper side of the trade: the other side risks breaking a sweep mid-collection, and for POP3
+    /// the sweep is what holds the only copy of the user's mail. All of them are released in
+    /// <see cref="Dispose"/>.</para>
+    /// </summary>
     public Task DisconnectAsync(Guid accountId, CancellationToken ct = default)
     {
         _accounts.TryRemove(accountId, out _);
         _passwords.TryRemove(accountId, out _);
-        if (_locks.TryRemove(accountId, out var sem))
-            sem.Dispose();
         return Task.CompletedTask;
     }
 
@@ -122,6 +133,13 @@ public class Pop3MailService : IMailService
     /// analogue of IMAP's connection pool.
     /// </summary>
     public bool IsConnected(Guid accountId) => _accounts.ContainsKey(accountId);
+
+    /// <summary>
+    /// Never. A POP3 server stops listing a message as soon as it has been collected, and by then
+    /// this store holds the only copy — so "the server no longer lists it" must never mean "delete
+    /// it". See the sync contract on this class.
+    /// </summary>
+    public bool ListingIsAuthoritativeForDeletions(Guid accountId) => false;
 
     // ── Folders ───────────────────────────────────────────────────────────────
 
@@ -141,19 +159,22 @@ public class Pop3MailService : IMailService
 
         if (_onlineMode) return folders;
 
-        foreach (var f in folders)
+        try
         {
-            try
+            // One grouped aggregate for all four folders, rather than four scans that each build a
+            // dictionary of every id in a folder only to count it.
+            var counts = await _store.CountMessagesByFolderAsync(accountId);
+            foreach (var f in folders)
             {
-                var readStates = await _store.LoadFolderReadStatesAsync(accountId, f.FullName);
-                f.MessageCount = readStates.Count;
-                f.UnreadCount  = readStates.Count(kv => !kv.Value);
+                if (!counts.TryGetValue(f.FullName, out var c)) continue;
+                f.MessageCount = c.Total;
+                f.UnreadCount  = c.Unread;
             }
-            catch (Exception ex)
-            {
-                // Counts are cosmetic; a store hiccup must not cost the user their folder list.
-                LogService.Log($"POP3: failed to count {f.FullName} for account {accountId}", ex);
-            }
+        }
+        catch (Exception ex)
+        {
+            // Counts are cosmetic; a store hiccup must not cost the user their folder list.
+            LogService.Log($"POP3: failed to count folders for account {accountId}", ex);
         }
         return folders;
     }
@@ -185,20 +206,21 @@ public class Pop3MailService : IMailService
         if (IsInbox(folderName))
             (downloaded, firstCollection) = await DownloadNewMessagesAsync(accountId, ct);
 
-        var all = await LoadFromStoreAsync(accountId, folderName);
         var sinceUtc = since.Kind == DateTimeKind.Unspecified
             ? DateTime.SpecifyKind(since, DateTimeKind.Utc)
             : since.ToUniversalTime();
-        var window = all.Where(m => m.Date.UtcDateTime >= sinceUtc).ToList();
+
+        // Date-filtered in SQL. The store is the whole of a POP3 account's mail and nothing prunes
+        // it, so loading the folder to discard most of it costs more every year the account exists.
+        var window = await LoadFromStoreAsync(accountId, folderName, sinceUtc);
         if (firstCollection || downloaded.Count == 0) return window;
 
-        // Prefer the store-loaded instance for a message in both sets — LoadFromStoreAsync restated
-        // its flag state, and the sweep upserts whatever this returns.
+        // Anything downloaded on this call but dated outside the window still has to be returned —
+        // see the union note above. The instance StoreMessageAsync returned is what goes back: it is
+        // the row that was just written, and a message arriving off a POP3 server carries no flag,
+        // so there is no user flag state for a store re-read to protect.
         var inWindow = new HashSet<string>(window.Select(m => m.MessageId), StringComparer.Ordinal);
-        var byId = all.ToDictionary(m => m.MessageId, StringComparer.Ordinal);
-        foreach (var d in downloaded)
-            if (!inWindow.Contains(d.MessageId))
-                window.Add(byId.TryGetValue(d.MessageId, out var stored) ? stored : d);
+        window.AddRange(downloaded.Where(d => !inWindow.Contains(d.MessageId)));
         return window;
     }
 
@@ -289,29 +311,22 @@ public class Pop3MailService : IMailService
         if (serverIds.Count == 0) return;
 
         var wanted = new HashSet<string>(serverIds, StringComparer.Ordinal);
-        var sem = _locks.GetOrAdd(accountId, _ => new SemaphoreSlim(1, 1));
-        await sem.WaitAsync(ct);
-        try
+        var anyDeleted = await RunMaildropSessionAsync(accountId, async client =>
         {
-            using var client = await OpenConnectionAsync(accountId, ct);
             var uidls = await client.GetMessageUidsAsync(ct);
 
-            bool anyDeleted = false;
+            bool deleted = false;
             for (int i = 0; i < uidls.Count; i++)
             {
                 if (!wanted.Contains(uidls[i])) continue;
                 await client.DeleteMessageAsync(i, ct);
-                anyDeleted = true;
+                deleted = true;
             }
 
-            // QUIT is what commits the DELEs; a plain disconnect abandons them.
-            await client.DisconnectAsync(quit: anyDeleted, ct);
-            LogService.Log($"POP3 [{account.AccountLabel}]: permanently deleted {serverIds.Count} message(s) locally, {(anyDeleted ? "and on the server" : "none still on the server")}.");
-        }
-        finally
-        {
-            sem.Release();
-        }
+            return (Result: deleted, Quit: deleted);
+        }, ct);
+
+        LogService.Log($"POP3 [{account.AccountLabel}]: permanently deleted {serverIds.Count} message(s) locally, {(anyDeleted ? "and on the server" : "none still on the server")}.");
     }
 
     public async Task<int> EmptyTrashAsync(Guid accountId, CancellationToken ct = default)
@@ -412,8 +427,8 @@ public class Pop3MailService : IMailService
     {
         if (_onlineMode) return (0, 0);
 
-        var readStates = await _store.LoadFolderReadStatesAsync(accountId, InboxFolder);
-        return (readStates.Count, readStates.Count(kv => !kv.Value));
+        var counts = await _store.CountMessagesByFolderAsync(accountId);
+        return counts.TryGetValue(InboxFolder, out var inbox) ? inbox : (0, 0);
     }
 
     // ── Id listings (the sweep's input — see the sync contract on the class) ──
@@ -440,7 +455,12 @@ public class Pop3MailService : IMailService
     public async Task<IReadOnlyList<(string Id, DateTimeOffset ReceivedUtc, bool IsRead)>> GetFolderMessageIdDatesAsync(
         Guid accountId, string folderName, CancellationToken ct = default)
     {
-        var cached = await LoadFromStoreAsync(accountId, folderName);
+        // Id, date and read state only — this answer is an id listing, and materialising every
+        // summary in the folder to project three fields out of each is a cost that grows with a
+        // store nothing prunes.
+        var cached = _onlineMode
+            ? []
+            : await _store.LoadFolderMessageStatesAsync(accountId, folderName);
 
         if (!IsInbox(folderName) || _onlineMode || !_accounts.ContainsKey(accountId))
             return MergeListing(cached, [], new HashSet<string>(), DateTimeOffset.UtcNow);
@@ -486,11 +506,11 @@ public class Pop3MailService : IMailService
     /// a message the moment it is collected.</para>
     /// </summary>
     internal static IReadOnlyList<(string Id, DateTimeOffset ReceivedUtc, bool IsRead)> MergeListing(
-        IReadOnlyList<MailMessageSummary> cached, IEnumerable<string> serverUidls,
+        IReadOnlyList<(string Id, DateTimeOffset Date, bool IsRead)> cached, IEnumerable<string> serverUidls,
         IReadOnlySet<string> collectedUidls, DateTimeOffset now)
     {
         var result = cached
-            .Select(m => (Id: m.MessageId, ReceivedUtc: m.Date, m.IsRead))
+            .Select(m => (m.Id, ReceivedUtc: m.Date, m.IsRead))
             .ToList();
 
         var known = new HashSet<string>(result.Select(r => r.Id), StringComparer.Ordinal);
@@ -595,101 +615,112 @@ public class Pop3MailService : IMailService
         // backlog quiet while still announcing every later arrival.
         var firstCollection = ledger.Count == 0 && !anyServerDerivedRow;
 
-        var sem = _locks.GetOrAdd(accountId, _ => new SemaphoreSlim(1, 1));
-        await sem.WaitAsync(ct);
-        try
+        var uidls = await RunMaildropSessionAsync(accountId, async client =>
         {
-            IList<string> uidls;
-            using (var client = await OpenConnectionAsync(accountId, ct))
+            // Index into this list is the session-scoped message number the RETR/DELE commands take.
+            IList<string> listed = client.Count == 0
+                ? new List<string>()
+                : await client.GetMessageUidsAsync(ct);
+            bool anyDeleted = false;
+
+            for (int i = 0; i < listed.Count; i++)
             {
-                // Index into this list is the session-scoped message number the RETR/DELE commands take.
-                uidls = client.Count == 0
-                    ? new List<string>()
-                    : await client.GetMessageUidsAsync(ct);
-                bool anyDeleted = false;
-
-                for (int i = 0; i < uidls.Count; i++)
+                ct.ThrowIfCancellationRequested();
+                var uidl = listed[i];
+                if (seen.Contains(uidl))
                 {
-                    ct.ThrowIfCancellationRequested();
-                    var uidl = uidls[i];
-                    if (seen.Contains(uidl))
-                    {
-                        if (!account.Pop3LeaveMailOnServer)
-                        {
-                            // Already collected (or deliberately destroyed) — the server copy should
-                            // be gone under this setting. Covers DELEs rolled back by a lost
-                            // connection, and mail collected before the setting was turned off.
-                            await client.DeleteMessageAsync(i, ct);
-                            anyDeleted = true;
-                        }
-                        continue;
-                    }
-
-                    MimeMessage msg;
-                    try
-                    {
-                        msg = await client.GetMessageAsync(i, ct);
-                    }
-                    catch (OperationCanceledException) { throw; }
-                    catch (Exception ex)
-                    {
-                        // One unreadable message must not stop the rest of the mailbox from arriving.
-                        LogService.Log($"POP3 [{account.AccountLabel}]: failed to download UIDL {uidl}", ex);
-                        continue;
-                    }
-
-                    var summary = await StoreMessageAsync(accountId, uidl, msg, InboxFolder, isRead: false, ct);
-                    downloaded.Add(summary);
-
                     if (!account.Pop3LeaveMailOnServer)
                     {
-                        // Only after the message is committed to the store. DELEs take effect at QUIT.
+                        // Already collected (or deliberately destroyed) — the server copy should
+                        // be gone under this setting. Covers DELEs rolled back by a lost
+                        // connection, and mail collected before the setting was turned off.
                         await client.DeleteMessageAsync(i, ct);
                         anyDeleted = true;
                     }
+                    continue;
                 }
 
-                await client.DisconnectAsync(quit: anyDeleted, ct);
+                MimeMessage msg;
+                try
+                {
+                    msg = await client.GetMessageAsync(i, ct);
+                }
+                catch (OperationCanceledException) { throw; }
+                catch (Exception ex)
+                {
+                    // One unreadable message must not stop the rest of the mailbox from arriving.
+                    LogService.Log($"POP3 [{account.AccountLabel}]: failed to download UIDL {uidl}", ex);
+                    continue;
+                }
 
-                if (downloaded.Count > 0)
-                    LogService.Log($"POP3 [{account.AccountLabel}]: downloaded {downloaded.Count} new message(s)" +
-                                   (anyDeleted ? ", removed from the server" : ", left on the server") + ".");
+                var summary = await StoreMessageAsync(accountId, uidl, msg, InboxFolder, isRead: false, ct);
+                downloaded.Add(summary);
+
+                if (!account.Pop3LeaveMailOnServer)
+                {
+                    // Only after the message is committed to the store. DELEs take effect at QUIT.
+                    await client.DeleteMessageAsync(i, ct);
+                    anyDeleted = true;
+                }
             }
 
-            // Ledger upkeep, after the session so it never extends the maildrop lock's hold time.
-            // Both writes are recoverable if the app dies before them: the messages are already in
-            // the store, so the next sweep's seen set still covers them and re-records here.
-            //   Record: everything downloaded this call, plus store-known UIDLs the ledger lacked
-            //   (rows collected by a build before the ledger existed).
-            //   Prune: ledger entries the server no longer lists — those can never be offered again.
-            var serverSet = new HashSet<string>(uidls, StringComparer.Ordinal);
-            var record = downloaded.Select(m => m.MessageId)
-                .Concat(serverSet.Where(u => seen.Contains(u) && !ledger.Contains(u)))
-                .ToList();
-            await _store.AddPop3CollectedUidlsAsync(accountId, record);
-            await _store.RemovePop3CollectedUidlsAsync(accountId, ledger.Where(u => !serverSet.Contains(u)).ToList());
+            if (downloaded.Count > 0)
+                LogService.Log($"POP3 [{account.AccountLabel}]: downloaded {downloaded.Count} new message(s)" +
+                               (anyDeleted ? ", removed from the server" : ", left on the server") + ".");
 
-            return (downloaded, firstCollection);
-        }
-        finally
-        {
-            sem.Release();
-        }
+            return (Result: listed, Quit: anyDeleted);
+        }, ct);
+
+        // Ledger upkeep, after the session so it never extends the maildrop lock's hold time.
+        // Both writes are recoverable if the app dies before them: the messages are already in
+        // the store, so the next sweep's seen set still covers them and re-records here.
+        //   Record: everything downloaded this call, plus store-known UIDLs the ledger lacked
+        //   (rows collected by a build before the ledger existed).
+        //   Prune: ledger entries the server no longer lists — those can never be offered again.
+        var serverSet = new HashSet<string>(uidls, StringComparer.Ordinal);
+        var record = downloaded.Select(m => m.MessageId)
+            .Concat(serverSet.Where(u => seen.Contains(u) && !ledger.Contains(u)))
+            .ToList();
+        await _store.AddPop3CollectedUidlsAsync(accountId, record);
+        await _store.RemovePop3CollectedUidlsAsync(accountId, ledger.Where(u => !serverSet.Contains(u)).ToList());
+
+        return (downloaded, firstCollection);
     }
 
     /// <summary>Lists the server's UIDLs without retrieving anything. One short session.</summary>
-    private async Task<IList<string>> ListServerUidlsAsync(Guid accountId, CancellationToken ct)
+    private Task<IList<string>> ListServerUidlsAsync(Guid accountId, CancellationToken ct)
+        => RunMaildropSessionAsync<IList<string>>(accountId, async client =>
+            (Result: client.Count == 0 ? new List<string>() : await client.GetMessageUidsAsync(ct),
+             // Nothing was marked for deletion, so there is nothing for a QUIT to commit.
+             Quit: false), ct);
+
+    // ── Session ───────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Runs <paramref name="body"/> as one POP3 session: takes the account's maildrop lock, connects,
+    /// hands the body the open client, disconnects, releases. Every server-touching operation goes
+    /// through here so the RFC 1939 exclusive-access rule is structural rather than three separate
+    /// remembered-to-do-its — a second concurrent session against the same maildrop is refused by
+    /// most servers outright.
+    ///
+    /// <para>The body returns its result alongside whether the session must <c>QUIT</c>. QUIT is the
+    /// only command that commits pending DELEs; a plain disconnect abandons them (RFC 1939), which is
+    /// the behaviour a body that deleted nothing wants and the one a body that did must not get.</para>
+    ///
+    /// <para>A body that throws leaves the client to the <c>using</c> — dropped without a QUIT, so a
+    /// failed collection rolls its DELEs back rather than destroying mail it never stored.</para>
+    /// </summary>
+    private async Task<T> RunMaildropSessionAsync<T>(
+        Guid accountId, Func<Pop3Client, Task<(T Result, bool Quit)>> body, CancellationToken ct)
     {
         var sem = _locks.GetOrAdd(accountId, _ => new SemaphoreSlim(1, 1));
         await sem.WaitAsync(ct);
         try
         {
             using var client = await OpenConnectionAsync(accountId, ct);
-            IList<string> uidls = client.Count == 0
-                ? new List<string>()
-                : await client.GetMessageUidsAsync(ct);
-            await client.DisconnectAsync(quit: false, ct);
-            return uidls;
+            var (result, quit) = await body(client);
+            await client.DisconnectAsync(quit, ct);
+            return result;
         }
         finally
         {
@@ -730,14 +761,22 @@ public class Pop3MailService : IMailService
     /// state, so the local flag IS the state of record; without restating it, every sweep would
     /// re-upsert these rows as unflagged and silently clear the user's flags.</para>
     /// </summary>
-    private async Task<List<MailMessageSummary>> LoadFromStoreAsync(Guid accountId, string folderName, int? limit = null)
+    private Task<List<MailMessageSummary>> LoadFromStoreAsync(Guid accountId, string folderName, int? limit = null)
+        => RestatedAsync(() => _store.LoadFolderSummariesAsync(accountId, folderName, limit));
+
+    /// <summary>The same load, restricted to messages dated <paramref name="sinceUtc"/> or later.</summary>
+    private Task<List<MailMessageSummary>> LoadFromStoreAsync(Guid accountId, string folderName, DateTime sinceUtc)
+        => RestatedAsync(() => _store.LoadFolderSummariesSinceAsync(
+            accountId, folderName, new DateTimeOffset(sinceUtc, TimeSpan.Zero)));
+
+    private async Task<List<MailMessageSummary>> RestatedAsync(Func<Task<List<MailMessageSummary>>> load)
     {
         // --online skips LocalStoreService.Initialize(), so the tables do not exist. Reading anyway
         // raises "no such table: MessageSummary" from every aggregate load — an error in the log for
         // a supported configuration. A POP3 account in --online mode simply has no mail.
         if (_onlineMode) return [];
 
-        var summaries = await _store.LoadFolderSummariesAsync(accountId, folderName, limit);
+        var summaries = await load();
         foreach (var s in summaries)
             s.IsServerFlagged = s.IsFlagged;
         return summaries;
@@ -745,8 +784,10 @@ public class Pop3MailService : IMailService
 
     /// <summary>
     /// Copies or moves messages between the synthetic folders, carrying everything that makes the
-    /// message what it is: the stored row itself (so no field is lost when the model gains one), its
-    /// flag, its body and its raw bytes.
+    /// message what it is: the stored rows themselves (so no field is lost when the model gains one),
+    /// the flag, the body and the raw bytes. The re-file happens in the store, in SQL — nothing about
+    /// a message is read into managed memory to be written straight back out, which for a POP3
+    /// mailbox means not round-tripping every MIME blob through the heap to move a row.
     /// </summary>
     private async Task MoveLocalAsync(
         Guid accountId, string fromFolder, string toFolder, IList<string> messageIds, bool copy)
@@ -765,39 +806,10 @@ public class Pop3MailService : IMailService
 
         if (string.Equals(fromFolder, toFolder, StringComparison.OrdinalIgnoreCase)) return;
 
-        var byId = (await _store.LoadFolderSummariesAsync(accountId, fromFolder))
-            .ToDictionary(s => s.MessageId, StringComparer.Ordinal);
-
-        foreach (var id in messageIds)
-        {
-            if (!byId.TryGetValue(id, out var summary)) continue;
-
-            var detail    = await _store.LoadDetailAsync(accountId, fromFolder, id);
-            var mimeBytes = await _store.LoadMimeBytesAsync(accountId, fromFolder, id);
-            var flagId    = summary.FlagId;
-
-            // Re-file the loaded rows rather than projecting them field by field — these instances
-            // came from the store, not from the UI, so retargeting them is safe and cannot drop a
-            // column that the model gains later.
-            summary.FolderName      = toFolder;
-            summary.IsServerFlagged = flagId is not null;   // see LoadFromStoreAsync
-            await _store.UpsertSummariesAsync([summary]);
-
-            // The upsert writes the built-in flag id at most; a named flag has to be restated.
-            if (flagId is not null)
-                await _store.UpdateFlagIdAsync(accountId, toFolder, id, flagId);
-
-            if (detail is not null)
-            {
-                detail.FolderName = toFolder;
-                await _store.UpsertDetailAsync(detail);
-                if (mimeBytes is not null)
-                    await _store.StoreMimeBytesAsync(accountId, toFolder, id, mimeBytes);
-            }
-
-            if (!copy)
-                await _store.DeleteSummariesAsync(accountId, fromFolder, [id]);
-        }
+        // Rows move whole, so the named-flag restatement the old field-by-field version needed is
+        // gone with it: flag_id travels with the row rather than being re-derived from
+        // IsServerFlagged by an upsert built for a backend where the server owns flags.
+        await _store.RefileMessagesAsync(accountId, fromFolder, toFolder, messageIds, copy);
     }
 
     // ── Model building ────────────────────────────────────────────────────────
@@ -812,10 +824,10 @@ public class Pop3MailService : IMailService
             AccountId         = accountId,
             FolderName        = folderName,
             InternetMessageId = msg.MessageId ?? string.Empty,
-            // Display form in the summary, full addresses in the detail — matching ImapMailService,
-            // so the message list reads the same whichever backend fetched the message.
-            From              = FormatAddressesDisplay(msg.From),
-            To                = FormatAddresses(msg.To),
+            // Display form in the summary, full addresses in the detail — literally ImapMailService's
+            // formatters, so the message list reads the same whichever backend fetched the message.
+            From              = ImapMailService.FormatAddressListDisplay(msg.From),
+            To                = ImapMailService.FormatAddressList(msg.To),
             Subject           = string.IsNullOrEmpty(msg.Subject) ? "(no subject)" : msg.Subject,
             Date              = NormalizeDate(msg.Date),
             IsRead            = isRead,
@@ -851,10 +863,10 @@ public class Pop3MailService : IMailService
             AccountId         = accountId,
             FolderName        = folderName,
             InternetMessageId = msg.MessageId ?? string.Empty,
-            From              = FormatAddresses(msg.From),
-            To                = FormatAddresses(msg.To),
-            Cc                = FormatAddresses(msg.Cc),
-            ReplyTo           = FormatAddresses(msg.ReplyTo),
+            From              = ImapMailService.FormatAddressList(msg.From),
+            To                = ImapMailService.FormatAddressList(msg.To),
+            Cc                = ImapMailService.FormatAddressList(msg.Cc),
+            ReplyTo           = ImapMailService.FormatAddressList(msg.ReplyTo),
             Subject           = string.IsNullOrEmpty(msg.Subject) ? "(no subject)" : msg.Subject,
             Date              = NormalizeDate(msg.Date),
             IsRead            = isRead,
@@ -864,7 +876,7 @@ public class Pop3MailService : IMailService
             DraftComposeMode  = ImapMailService.ParseComposeMode(msg.Headers["X-QuickMail-Compose-Mode"]),
         };
 
-        ImapMailService.PopulateCalendar(detail, FindCalendarText(msg));
+        ImapMailService.PopulateCalendar(detail, ImapMailService.FindCalendarText(msg));
         return detail;
     }
 
@@ -898,21 +910,6 @@ public class Pop3MailService : IMailService
         }
     }
 
-    /// <summary>Raw text of the first text/calendar part, or null when the message carries no invite.</summary>
-    private static string? FindCalendarText(MimeMessage msg) =>
-        msg.BodyParts
-            .OfType<TextPart>()
-            .FirstOrDefault(p => p.ContentType.IsMimeType("text", "calendar"))?.Text;
-
-    private static string FormatAddresses(InternetAddressList list) =>
-        list.Count == 0 ? string.Empty : string.Join(", ", list.Select(a => a.ToString()));
-
-    private static string FormatAddressesDisplay(InternetAddressList list) =>
-        list.Count == 0
-            ? string.Empty
-            : string.Join(", ", list.Select(a =>
-                a is MailboxAddress mb && !string.IsNullOrWhiteSpace(mb.Name) ? mb.Name : a.ToString()));
-
     /// <summary>
     /// A message with no (or an unparseable) Date header sorts to the top of the list rather than to
     /// 1/1/0001 at the bottom, and — because the sweep's window test reads this date — is treated as
@@ -921,6 +918,12 @@ public class Pop3MailService : IMailService
     private static DateTimeOffset NormalizeDate(DateTimeOffset date) =>
         date == default ? DateTimeOffset.UtcNow : date;
 
+    /// <summary>
+    /// The message list's preview line. Built here at download time rather than fetched on demand —
+    /// POP3 cannot re-read part of a message — but from the same three-line rule
+    /// <see cref="ImapMailService.ExtractPreviewLines"/> applies, then capped, since this string is
+    /// stored rather than recomputed per repaint.
+    /// </summary>
     private static string BuildPreview(MimeMessage msg)
     {
         var text = msg.TextBody;
@@ -928,11 +931,7 @@ public class Pop3MailService : IMailService
             text = Helpers.HtmlStripper.ToPlainText(msg.HtmlBody);
         if (string.IsNullOrWhiteSpace(text)) return string.Empty;
 
-        var joined = string.Join(" ", text
-            .Split('\n')
-            .Select(l => l.Trim())
-            .Where(l => l.Length > 0)
-            .Take(3));
+        var joined = ImapMailService.ExtractPreviewLines(text, 3);
         return joined.Length > 200 ? joined[..200] : joined;
     }
 

--- a/QuickMail/Services/Pop3MailService.cs
+++ b/QuickMail/Services/Pop3MailService.cs
@@ -921,14 +921,15 @@ public class Pop3MailService : IMailService
     /// <summary>
     /// The message list's preview line. Built here at download time rather than fetched on demand —
     /// POP3 cannot re-read part of a message — but from the same three-line rule
-    /// <see cref="ImapMailService.ExtractPreviewLines"/> applies, then capped, since this string is
-    /// stored rather than recomputed per repaint.
+    /// <see cref="ImapMailService.ExtractPreviewLines"/> applies. The 200-character cap is this
+    /// backend's alone, because this string is stored rather than recomputed per repaint.
     /// </summary>
     private static string BuildPreview(MimeMessage msg)
     {
         var text = msg.TextBody;
         if (string.IsNullOrWhiteSpace(text))
-            text = Helpers.HtmlStripper.ToPlainText(msg.HtmlBody);
+            // includeLinkTargets: false because this is a preview — see HtmlStripper.
+            text = Helpers.HtmlStripper.ToPlainText(msg.HtmlBody, includeLinkTargets: false);
         if (string.IsNullOrWhiteSpace(text)) return string.Empty;
 
         var joined = ImapMailService.ExtractPreviewLines(text, 3);

--- a/QuickMail/Services/SyncService.cs
+++ b/QuickMail/Services/SyncService.cs
@@ -698,6 +698,12 @@ public class SyncService : ISyncService
     private async Task<int> ReconcileDeletionsAsync(
         AccountModel account, MailFolderModel folder, HashSet<string> localIds, IList<string> serverIds)
     {
+        // A backend whose listing is not authoritative for deletions (POP3: the server drops a
+        // message from its listing the moment it is collected, and the cache is then the only copy)
+        // makes this whole reconcile unsafe, not merely unnecessary. Asked here, once, rather than
+        // left to each backend to shape its listing so the arithmetic happens to come out empty.
+        if (!_imap.ListingIsAuthoritativeForDeletions(account.Id)) return 0;
+
         var serverSet  = new HashSet<string>(serverIds);
         var deletedIds = localIds.Where(id => !serverSet.Contains(id)).ToList();
 

--- a/QuickMail/ViewModels/AccountEditorViewModel.cs
+++ b/QuickMail/ViewModels/AccountEditorViewModel.cs
@@ -254,7 +254,7 @@ public abstract partial class AccountEditorViewModel : ObservableObject
                 // host empty rather than guessing one — the user types it, and IsReadyToSave says so.
                 Pop3Host = provider.Pop3Host ?? string.Empty;
                 Pop3Port = provider.Pop3Port;
-                Pop3UseSsl = provider.Pop3Port == 995;
+                Pop3UseSsl = provider.Pop3UseSsl;
                 Pop3AcceptInvalidCert = false;
             }
 
@@ -518,6 +518,53 @@ public abstract partial class AccountEditorViewModel : ObservableObject
         {
             _applyingSettings = wasApplying;
         }
+    }
+
+    // ── Server fields ↔ AccountModel ──────────────────────────────────────────
+    // The one place the connection fields are enumerated. There were four hand-maintained copies of
+    // this list — the probe account, Add Account's ToAccountModel, and the Account Manager's load and
+    // save — and the POP3 work had to touch every one of them to add five fields (#128). A field
+    // missed in any single copy is silent: the dialog shows it, the account saves without it.
+    // RequireStartTls is deliberately NOT here. It is not a server field but a decision about them,
+    // and each caller sequences it differently — assigning a host clears it as a hand edit, so the
+    // Account Manager has to restore it *after* the copy.
+
+    /// <summary>Copies the account's IMAP, POP3 and SMTP settings into the form.</summary>
+    protected void LoadServerFieldsFrom(AccountModel account)
+    {
+        ImapHost = account.ImapHost;
+        ImapPort = account.ImapPort;
+        ImapUseSsl = account.ImapUseSsl;
+        ImapAcceptInvalidCert = account.ImapAcceptInvalidCert;
+        Pop3Host = account.Pop3Host;
+        Pop3Port = account.Pop3Port;
+        Pop3UseSsl = account.Pop3UseSsl;
+        Pop3AcceptInvalidCert = account.Pop3AcceptInvalidCert;
+        Pop3LeaveMailOnServer = account.Pop3LeaveMailOnServer;
+        SmtpHost = account.SmtpHost;
+        SmtpPort = account.SmtpPort;
+        SmtpUseSsl = account.SmtpUseSsl;
+        SmtpAcceptInvalidCert = account.SmtpAcceptInvalidCert;
+    }
+
+    /// <summary>Copies the form's IMAP, POP3 and SMTP settings onto the account.</summary>
+    protected void WriteServerFieldsTo(AccountModel account)
+    {
+        account.ImapHost = ImapHost;
+        account.ImapPort = ImapPort;
+        account.ImapUseSsl = ImapUseSsl;
+        account.ImapAcceptInvalidCert = ImapAcceptInvalidCert;
+        account.Pop3Host = Pop3Host;
+        account.Pop3Port = Pop3Port;
+        account.Pop3UseSsl = Pop3UseSsl;
+        account.Pop3AcceptInvalidCert = Pop3AcceptInvalidCert;
+        // Editable after the fact, and consequential: turning "leave mail on the server" off means
+        // the next collection is the last chance any other client has to see that mail.
+        account.Pop3LeaveMailOnServer = Pop3LeaveMailOnServer;
+        account.SmtpHost = SmtpHost;
+        account.SmtpPort = SmtpPort;
+        account.SmtpUseSsl = SmtpUseSsl;
+        account.SmtpAcceptInvalidCert = SmtpAcceptInvalidCert;
     }
 
     /// <summary>
@@ -807,37 +854,29 @@ public abstract partial class AccountEditorViewModel : ObservableObject
     /// Builds a throwaway account carrying the form's current values, for a connectivity probe.
     /// Its Id is fresh so the probe never disturbs the real account's connection pool.
     /// </summary>
-    private AccountModel BuildProbeAccount() => new()
+    private AccountModel BuildProbeAccount()
     {
-        Id = Guid.NewGuid(),
-        AccountName = $"Test ({Username})",
-        DisplayName = Username,
-        Username = Username,
-        // The probe must log in under the same name the saved account will, or a passing test says
-        // nothing about whether the real credentials work.
-        LoginUsername = LoginUsername,
-        AuthType = AuthType,
-        BackendKind = BackendKind,
-        ProviderId = SelectedProvider?.Id,
-        IsPersonalMicrosoftAccount = IsPersonalMicrosoftAccount,
-        ImapHost = ImapHost,
-        ImapPort = ImapPort,
-        ImapUseSsl = ImapUseSsl,
-        ImapAcceptInvalidCert = ImapAcceptInvalidCert,
-        Pop3Host = Pop3Host,
-        Pop3Port = Pop3Port,
-        Pop3UseSsl = Pop3UseSsl,
-        Pop3AcceptInvalidCert = Pop3AcceptInvalidCert,
-        Pop3LeaveMailOnServer = Pop3LeaveMailOnServer,
-        SmtpHost = SmtpHost,
-        SmtpPort = SmtpPort,
-        SmtpUseSsl = SmtpUseSsl,
-        SmtpAcceptInvalidCert = SmtpAcceptInvalidCert,
-        // The probe must connect exactly as the saved account will, or "Test Connection: OK" is a
-        // claim about a different connection than the one the password will be sent over.
-        RequireStartTls = RequireStartTls,
-        Signature = Signature,
-    };
+        var probe = new AccountModel
+        {
+            Id = Guid.NewGuid(),
+            AccountName = $"Test ({Username})",
+            DisplayName = Username,
+            Username = Username,
+            // The probe must log in under the same name the saved account will, or a passing test says
+            // nothing about whether the real credentials work.
+            LoginUsername = LoginUsername,
+            AuthType = AuthType,
+            BackendKind = BackendKind,
+            ProviderId = SelectedProvider?.Id,
+            IsPersonalMicrosoftAccount = IsPersonalMicrosoftAccount,
+            // The probe must connect exactly as the saved account will, or "Test Connection: OK" is a
+            // claim about a different connection than the one the password will be sent over.
+            RequireStartTls = RequireStartTls,
+            Signature = Signature,
+        };
+        WriteServerFieldsTo(probe);
+        return probe;
+    }
 
     [RelayCommand]
     private async Task TestConnectionAsync()

--- a/QuickMail/ViewModels/AccountManagerViewModel.cs
+++ b/QuickMail/ViewModels/AccountManagerViewModel.cs
@@ -153,19 +153,7 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
         Password = value.AuthType == AuthType.Password
             ? (_credentials.GetPassword(value.Id) ?? string.Empty)
             : string.Empty;
-        ImapHost = value.ImapHost;
-        ImapPort = value.ImapPort;
-        ImapUseSsl = value.ImapUseSsl;
-        ImapAcceptInvalidCert = value.ImapAcceptInvalidCert;
-        Pop3Host = value.Pop3Host;
-        Pop3Port = value.Pop3Port;
-        Pop3UseSsl = value.Pop3UseSsl;
-        Pop3AcceptInvalidCert = value.Pop3AcceptInvalidCert;
-        Pop3LeaveMailOnServer = value.Pop3LeaveMailOnServer;
-        SmtpHost = value.SmtpHost;
-        SmtpPort = value.SmtpPort;
-        SmtpUseSsl = value.SmtpUseSsl;
-        SmtpAcceptInvalidCert = value.SmtpAcceptInvalidCert;
+        LoadServerFieldsFrom(value);
         Signature = value.Signature;
         SyncContacts = value.SyncContacts;
         SyncCalendar = value.SyncCalendar;
@@ -385,21 +373,7 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
         if (IsPersonalMicrosoftAccount.HasValue)
             account.IsPersonalMicrosoftAccount = IsPersonalMicrosoftAccount;
         account.AuthType = AuthType;
-        account.ImapHost = ImapHost;
-        account.ImapPort = ImapPort;
-        account.ImapUseSsl = ImapUseSsl;
-        account.ImapAcceptInvalidCert = ImapAcceptInvalidCert;
-        account.Pop3Host = Pop3Host;
-        account.Pop3Port = Pop3Port;
-        account.Pop3UseSsl = Pop3UseSsl;
-        account.Pop3AcceptInvalidCert = Pop3AcceptInvalidCert;
-        // Editable after the fact, and consequential: turning "leave mail on the server" off means
-        // the next collection is the last chance any other client has to see that mail.
-        account.Pop3LeaveMailOnServer = Pop3LeaveMailOnServer;
-        account.SmtpHost = SmtpHost;
-        account.SmtpPort = SmtpPort;
-        account.SmtpUseSsl = SmtpUseSsl;
-        account.SmtpAcceptInvalidCert = SmtpAcceptInvalidCert;
+        WriteServerFieldsTo(account);
         // Follows the fields: hand-editing a server in this dialog clears it, which is the user
         // taking the settings over and with them the choice about fallback.
         account.RequireStartTls = RequireStartTls;

--- a/QuickMail/ViewModels/AddAccountViewModel.cs
+++ b/QuickMail/ViewModels/AddAccountViewModel.cs
@@ -445,42 +445,34 @@ public partial class AddAccountViewModel : AccountEditorViewModel, IDisposable
         }
     }
 
-    public AccountModel ToAccountModel() => new()
+    public AccountModel ToAccountModel()
     {
-        AccountName = AccountName,
-        DisplayName = DisplayName,
-        // The NORMALIZED address where one can be parsed out, not the raw box: a pasted
-        // "Kelly Ford <kelly@example.com>" or a trailing space parses fine in the validator and then
-        // throws in MimeMessageBuilder on every send. Falls back to the raw value only on a path
-        // that never reaches here with an unusable address — IsReadyToSave has already refused it.
-        Username = EmailAddressValidator.TryNormalize(Username, out var address) ? address : Username,
-        // Null rather than "" when unset, so accounts.json carries the field only for the accounts
-        // that actually need it.
-        LoginUsername = string.IsNullOrWhiteSpace(LoginUsername) ? null : LoginUsername.Trim(),
-        AuthType = AuthType,
-        BackendKind = BackendKind,
-        ProviderId = SelectedProvider?.Id,
-        IsPersonalMicrosoftAccount = IsPersonalMicrosoftAccount,
-        ImapHost = ImapHost,
-        ImapPort = ImapPort,
-        ImapUseSsl = ImapUseSsl,
-        ImapAcceptInvalidCert = ImapAcceptInvalidCert,
-        Pop3Host = Pop3Host,
-        Pop3Port = Pop3Port,
-        Pop3UseSsl = Pop3UseSsl,
-        Pop3AcceptInvalidCert = Pop3AcceptInvalidCert,
-        Pop3LeaveMailOnServer = Pop3LeaveMailOnServer,
-        SmtpHost = SmtpHost,
-        SmtpPort = SmtpPort,
-        SmtpUseSsl = SmtpUseSsl,
-        SmtpAcceptInvalidCert = SmtpAcceptInvalidCert,
-        // Persisted with the account: settings QuickMail supplied must keep requiring encryption
-        // every time the account connects, not only on the day it was created.
-        RequireStartTls = RequireStartTls,
-        Signature = Signature,
-        SyncContacts = SyncContacts && ShowContactSyncOption,
-        SyncCalendar = SyncCalendar && ShowCalendarSyncOption,
-    };
+        var account = new AccountModel
+        {
+            AccountName = AccountName,
+            DisplayName = DisplayName,
+            // The NORMALIZED address where one can be parsed out, not the raw box: a pasted
+            // "Kelly Ford <kelly@example.com>" or a trailing space parses fine in the validator and then
+            // throws in MimeMessageBuilder on every send. Falls back to the raw value only on a path
+            // that never reaches here with an unusable address — IsReadyToSave has already refused it.
+            Username = EmailAddressValidator.TryNormalize(Username, out var address) ? address : Username,
+            // Null rather than "" when unset, so accounts.json carries the field only for the accounts
+            // that actually need it.
+            LoginUsername = string.IsNullOrWhiteSpace(LoginUsername) ? null : LoginUsername.Trim(),
+            AuthType = AuthType,
+            BackendKind = BackendKind,
+            ProviderId = SelectedProvider?.Id,
+            IsPersonalMicrosoftAccount = IsPersonalMicrosoftAccount,
+            // Persisted with the account: settings QuickMail supplied must keep requiring encryption
+            // every time the account connects, not only on the day it was created.
+            RequireStartTls = RequireStartTls,
+            Signature = Signature,
+            SyncContacts = SyncContacts && ShowContactSyncOption,
+            SyncCalendar = SyncCalendar && ShowCalendarSyncOption,
+        };
+        WriteServerFieldsTo(account);
+        return account;
+    }
 
     /// <summary>
     /// Called from AddAccountDialog.OnClosed. Cancels before disposing so an in-flight lookup gets a

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -7798,6 +7798,30 @@ public partial class MainViewModel : ObservableObject, IDisposable
         return false;
     }
 
+    /// <summary>
+    /// Why folder management is unavailable on this account, or null when it is available. The single
+    /// gate every folder-CRUD entry point asks before it opens a dialog or reaches a backend —
+    /// <paramref name="verb"/> is the action as the user would say it ("move", "create a folder in").
+    ///
+    /// <para>Here rather than in <c>MainWindow</c>: which accounts can manage folders is a state
+    /// decision, and code-behind is not where those live (see the MVVM rules). An account this
+    /// ViewModel has never heard of is allowed through — a guard is not the place to invent a
+    /// refusal, and the backend still answers for itself.</para>
+    /// </summary>
+    public string? FolderCrudRefusal(Guid accountId, string verb)
+    {
+        var account = Accounts.FirstOrDefault(a => a.Id == accountId);
+        if (account is null || account.SupportsFolderCrud) return null;
+
+        return $"POP3 accounts have no server folders, so there is nothing to {verb}. "
+             + $"{account.AccountLabel} has only Inbox, Sent, Drafts and Trash.";
+    }
+
+    /// <summary>True when every one of these accounts can manage folders — the test a picker that
+    /// offers to create one has to pass, since the button is not per-account.</summary>
+    public bool AllSupportFolderCrud(IEnumerable<Guid> accountIds) =>
+        accountIds.All(id => FolderCrudRefusal(id, "create a folder in") is null);
+
     /// <summary>Creates a new folder under the given parent and refreshes the tree.</summary>
     public async Task CreateFolderAndRefreshAsync(Guid accountId, string? parentFolderName, string name)
     {

--- a/QuickMail/Views/AccountManagerDialog.xaml.cs
+++ b/QuickMail/Views/AccountManagerDialog.xaml.cs
@@ -4,6 +4,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Navigation;
+using QuickMail.Helpers;
 using QuickMail.Models;
 using QuickMail.Services;
 using QuickMail.ViewModels;
@@ -139,29 +140,24 @@ public partial class AccountManagerDialog : Window
 
     private string? HintFor(IInputElement? focused)
     {
+        // Hints the Add Account dialog shows for the same field live in AccountFieldHints, so the two
+        // dialogs cannot describe one control two different ways. The rest are specific to this one.
         if (ReferenceEquals(focused, AccountNameBox))
-            return "Leave blank to use your email address.";
+            return AccountFieldHints.AccountName;
         if (ReferenceEquals(focused, PasswordBox))
-            return "Stored in Windows Credential Manager.";
+            return AccountFieldHints.Password;
         if (ReferenceEquals(focused, LoginUsernameBox))
-            return "Leave blank unless your mail server logs in under a different name than your email address.";
+            return AccountFieldHints.LoginUsername;
         if (ReferenceEquals(focused, SyncContactsCheckBox))
             return "Pulls this account's contacts into the address book. Enabling asks for a one-time read-only permission.";
         if (ReferenceEquals(focused, SyncCalendarCheckBox))
-            return "Shows this account's calendar in the Calendar view.";
-        // The ports are in the checkbox's visible Content, but an explicit
-        // AutomationProperties.Name OVERRIDES that text — so without this the port guidance existed
-        // for sighted users only. It belongs in a hint rather than back in the Name, which must
-        // stay a short label.
+            return AccountFieldHints.SyncCalendar;
         if (ReferenceEquals(focused, SmtpImplicitSslCheckBox))
-            return "Checked uses port 465. Cleared uses STARTTLS on port 587.";
-        // Same reasoning as the Add Account dialog: what clearing this costs is the point of the
-        // control, and it belongs in a hint rather than in a label that must stay short.
+            return AccountFieldHints.SmtpImplicitSsl;
         if (ReferenceEquals(focused, Pop3LeaveOnServerCheckBox))
-            return "Cleared, mail is removed from the server once QuickMail has downloaded it, "
-                 + "so this computer holds the only copy.";
+            return AccountFieldHints.Pop3LeaveOnServer;
         if (ReferenceEquals(focused, SignatureBox))
-            return "Added to the end of new messages, replies, and forwards.";
+            return AccountFieldHints.Signature;
         return null;
     }
 

--- a/QuickMail/Views/AddAccountDialog.xaml.cs
+++ b/QuickMail/Views/AddAccountDialog.xaml.cs
@@ -140,32 +140,26 @@ public partial class AddAccountDialog : Window
 
     private string? HintFor(IInputElement? focused)
     {
+        // Hints the Account Manager shows for the same field live in AccountFieldHints, so the two
+        // dialogs cannot describe one control two different ways. The rest are specific to this one.
         if (ReferenceEquals(focused, AccountNameBox))
-            return "Leave blank to use your email address.";
+            return AccountFieldHints.AccountName;
         if (ReferenceEquals(focused, DisplayNameBox))
             return "The name recipients see on messages you send.";
         if (ReferenceEquals(focused, PasswordBox))
-            return "Stored in Windows Credential Manager.";
+            return AccountFieldHints.Password;
         if (ReferenceEquals(focused, LoginUsernameBox))
-            return "Leave blank unless your mail server logs in under a different name than your email address.";
+            return AccountFieldHints.LoginUsername;
         if (ReferenceEquals(focused, SyncContactsCheckBox))
             return "Check this before signing in, so reading your contacts is part of the same permission.";
         if (ReferenceEquals(focused, SyncCalendarCheckBox))
-            return "Shows this account's calendar in the Calendar view.";
-        // The ports are in the checkbox's visible Content, but an explicit
-        // AutomationProperties.Name OVERRIDES that text — so without this the port guidance existed
-        // for sighted users only. It belongs in a hint rather than back in the Name, which must
-        // stay a short label.
+            return AccountFieldHints.SyncCalendar;
         if (ReferenceEquals(focused, SmtpImplicitSslCheckBox))
-            return "Checked uses port 465. Cleared uses STARTTLS on port 587.";
-        // POP3 hands the local store the only copy of a message once the server drops it, and that
-        // is what this checkbox decides. It belongs in a hint rather than in the label, which stays
-        // a short label — and in a hint the user's announcement preference still applies.
+            return AccountFieldHints.SmtpImplicitSsl;
         if (ReferenceEquals(focused, Pop3LeaveOnServerCheckBox))
-            return "Cleared, mail is removed from the server once QuickMail has downloaded it, "
-                 + "so this computer holds the only copy.";
+            return AccountFieldHints.Pop3LeaveOnServer;
         if (ReferenceEquals(focused, SignatureBox))
-            return "Added to the end of new messages, replies, and forwards.";
+            return AccountFieldHints.Signature;
         return null;
     }
 

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -5511,18 +5511,16 @@ public partial class MainWindow : Window
     }
 
     /// <summary>
-    /// Refuses folder management on an account whose protocol has no folders — POP3 (#128), whose
-    /// Inbox, Sent, Drafts and Trash are made up by QuickMail and are the only folders there can be.
-    /// Same contract as <see cref="IsMovableFolder"/>: say why, rather than let the command reach a
-    /// backend that throws and surface as "Failed to create folder".
+    /// Refuses folder management on an account whose protocol has no folders. Whether an account can
+    /// manage folders, and how the refusal reads, both come from the ViewModel
+    /// (<see cref="MainViewModel.FolderCrudRefusal"/>) — this is only the reporting. Same contract as
+    /// <see cref="IsMovableFolder"/>: say why, rather than let the command reach a backend that
+    /// throws and surface as "Failed to create folder".
     /// </summary>
     private bool SupportsServerFolders(Guid accountId, string verb)
     {
-        var account = _vm.Accounts.FirstOrDefault(a => a.Id == accountId);
-        if (account?.BackendKind != BackendKind.Pop3Smtp) return true;
-
-        Report($"POP3 accounts have no server folders, so there is nothing to {verb}. "
-             + $"{account.AccountLabel} has only Inbox, Sent, Drafts and Trash.");
+        if (_vm.FolderCrudRefusal(accountId, verb) is not { } refusal) return true;
+        Report(refusal);
         return false;
     }
 
@@ -6366,8 +6364,15 @@ public partial class MainWindow : Window
             // Filing is repetitive, so the place the user keeps choosing beats the place they
             // are leaving (#515).
             initialFolder: _vm.LastDestinationFor(list, copy) ?? CurrentFolderOf(list, folders),
-            folderCreator: (accountId, parentFullName, name) =>
-                _vm.CreateFolderReturningFoldersAsync(accountId, parentFullName, name))
+            // No creator, no New Folder button. Withheld when any account in the tree cannot manage
+            // folders (POP3, #128): the button is one button over a whole tree, not one per account,
+            // and offering an action that can only fail is worse than not offering it. Until now this
+            // was the one folder-CRUD entry point with no gate, surviving on the readability of the
+            // backend's NotSupportedException.
+            folderCreator: _vm.AllSupportFolderCrud(ids)
+                ? (accountId, parentFullName, name) =>
+                    _vm.CreateFolderReturningFoldersAsync(accountId, parentFullName, name)
+                : null)
             { Owner = this };
     }
 


### PR DESCRIPTION
Handles every item in #540. No behaviour change the user can see; the correctness findings were already fixed on #538's branch.

### Reuse
- `Pop3MailService`'s address formatters, preview builder and text/calendar part query were line-for-line copies of `ImapMailService`'s (and Graph's). The IMAP originals are `internal` now — the `ParseComposeMode` precedent from the same PR — and the copies are gone.
- `ImapMailService.StripHtml` (a private tag-stripping regex) retires with them: `HtmlStripper`, which POP3 already used, decodes entities and keeps list/link structure.

### Simplification
- One `RunMaildropSessionAsync` owns lock, connection and QUIT, so the RFC 1939 maildrop lock is structural rather than pasted into three methods.
- `MailProvider` states `Pop3UseSsl` instead of `ApplyProvider` inferring it from `Pop3Port == 995`.
- `AccountPropertiesBuilder` builds the Graph leg once.
- The four hand-maintained VM↔model field lists become `LoadServerFieldsFrom` / `WriteServerFieldsTo` on the editor base.
- The leave-on-server hint — and every other hint both account dialogs share — moves to `AccountFieldHints`.

### Efficiency
A POP3 store grows forever, so these scans grew with it.
- `GetFolderMessageIdDatesAsync` reads a lean `unique_id, date_ticks, is_read` projection instead of materialising every summary in the folder.
- `GetMessagesSinceDateAsync` filters by date in SQL.
- The folder tree and Inbox status share one `GROUP BY` aggregate.
- Move/copy between the synthetic folders is two `UPDATE` (or `INSERT … SELECT`) statements instead of N+1 round trips dragging every MIME blob through managed memory. The copy's column list comes from `PRAGMA table_info`, keeping the "no column left behind" property the row-by-row version had. The move also **retargets** a harvested invite's calendar back-link, which the old path cleared.

### Capability gates
- `AccountModel.SupportsFolderCrud`, asked through one VM-side guard (`MainViewModel.FolderCrudRefusal`), replaces a `BackendKind` comparison planted at four call sites in code-behind — and closes the one folder-CRUD entry point that had no gate at all: the message move/copy picker's New Folder button.
- `IMailService.ListingIsAuthoritativeForDeletions` lets `SyncService` see the sweep invariant it must not break, rather than relying on `Pop3MailService` shaping its listing so the arithmetic comes out empty.

### Hardening
`DisconnectAsync` no longer disposes the per-account semaphore. Unreachable today, but the moment account removal wires to it, a sweep holding the lock gets `ObjectDisposedException` out of its `finally` and a reconnect opens the second concurrent maildrop session RFC 1939 forbids.

### Tests
`StubLocalStoreService` is unsealed with virtual members and the six per-test `ILocalStoreService` fakes derive from it, ending the treadmill where every interface change had to be applied seven times (−530 lines of boilerplate).

Twelve new tests cover the SQL re-file (body, raw bytes, named flag, calendar link, id collision), the date-filtered and lean store reads, the counts aggregate, both halves of the deletion-authority gate, the folder-CRUD capability, and the server-field round-trip.

**2988 passed, 0 failed, 3 skipped** (`dotnet test -c Release`).

### Not done
The shared incoming-server XAML control. #540 offers "a shared control, or at minimum one shared hint constant"; the control is a visual restructure of four panels across two dialogs and needs a ui-probe pass, so this takes the stated minimum and leaves the control to its own change.

Closes #540.

🤖 Generated with [Claude Code](https://claude.com/claude-code)