### PR TITLE
Don't offer server rules to personal Microsoft Graph accounts (#541)

### DIFF
--- a/QuickMail.Tests/AddSharedMailboxViewModelTests.cs
+++ b/QuickMail.Tests/AddSharedMailboxViewModelTests.cs
@@ -42,6 +42,24 @@ public class AddSharedMailboxViewModelTests
     }
 
     [Fact]
+    public void ParentOptions_ExcludeUndetectedPersonalGraph_CaughtByDomainGuess() // #541
+    {
+        // Flag not detected yet (null), but a consumer-domain address → the domain-guess fallback
+        // resolves it as personal, so it is excluded just like a confirmed personal account.
+        var undetected = new AccountModel
+        {
+            Id = Guid.NewGuid(), AccountName = "Undetected", Username = "me@outlook.com",
+            BackendKind = BackendKind.MicrosoftGraph, // IsPersonalMicrosoftAccount left null
+        };
+        var work = Graph("Work");
+
+        var vm = new AddSharedMailboxViewModel([work, undetected]);
+
+        Assert.Contains(work, vm.ParentOptions);
+        Assert.DoesNotContain(undetected, vm.ParentOptions);
+    }
+
+    [Fact]
     public void ShowGraphPollNote_TrueForGraphParent_FalseForImap()
     {
         var vm = new AddSharedMailboxViewModel([Graph("Work"), Imap("Home")]);

--- a/QuickMail.Tests/OAuthServiceScopeSelectionTests.cs
+++ b/QuickMail.Tests/OAuthServiceScopeSelectionTests.cs
@@ -70,6 +70,19 @@ public class OAuthServiceScopeSelectionTests
         Assert.Same(OAuthService.GraphMailScopesWorkSchool, OAuthService.DefaultScopesFor(account));
     }
 
+    // ResolveIsPersonalMicrosoftAccount is the shared "flag, else domain guess" classifier used by scope
+    // selection AND the work/school-only capability gates (server rules #541, shared mailboxes).
+    [Theory]
+    [InlineData(true, "user@contoso.com", true)]    // explicit flag wins over a work-looking domain
+    [InlineData(false, "me@outlook.com", false)]    // explicit flag wins over a consumer domain
+    [InlineData(null, "me@outlook.com", true)]      // undetected → domain guess says personal
+    [InlineData(null, "user@contoso.com", false)]   // undetected → domain guess says work
+    public void ResolveIsPersonalMicrosoftAccount_PrefersFlag_FallsBackToDomain(bool? flag, string username, bool expected)
+    {
+        var account = new AccountModel { Username = username, IsPersonalMicrosoftAccount = flag };
+        Assert.Equal(expected, OAuthService.ResolveIsPersonalMicrosoftAccount(account));
+    }
+
     [Fact]
     public void ImapAccount_UsesImapScopes_EvenOnAPersonalDomain()
     {

--- a/QuickMail.Tests/UnifiedRulesViewModelTests.cs
+++ b/QuickMail.Tests/UnifiedRulesViewModelTests.cs
@@ -105,6 +105,23 @@ public class UnifiedRulesViewModelTests
     }
 
     [Fact]
+    public async Task Refresh_UndetectedPersonalGraphAccount_CaughtByDomainGuess_LoadsOnlyClientRules() // #541
+    {
+        // The tenant flag hasn't been detected yet (null), but the address is a consumer domain, so the
+        // domain-guess fallback (same as scope selection) resolves it as personal → still no server rules.
+        var a = Guid.NewGuid();
+        var acct = new AccountModel { Id = a, BackendKind = BackendKind.MicrosoftGraph, Username = "me@outlook.com", AccountName = "Undetected" };
+        var server = new FakeServerRules { Stored = [Server("S1")] };
+        var client = new StubRuleService { LoadedRules = [Client("C1", a)] };
+        var vm = new UnifiedRulesViewModel(client, server, [acct], preferredAccountId: a);
+
+        await vm.RefreshCommand.ExecuteAsync(null);
+
+        Assert.False(vm.AccountSupportsServerRules);
+        Assert.Single(vm.Rules);
+    }
+
+    [Fact]
     public async Task Refresh_NoServerService_LoadsOnlyClientRules_EvenForGraphAccount()
     {
         var a = Guid.NewGuid();

--- a/QuickMail.Tests/UnifiedRulesViewModelTests.cs
+++ b/QuickMail.Tests/UnifiedRulesViewModelTests.cs
@@ -48,6 +48,7 @@ public class UnifiedRulesViewModelTests
     }
 
     private static AccountModel Graph(Guid id) => new() { Id = id, BackendKind = BackendKind.MicrosoftGraph, Username = "g@x.com", AccountName = "Work" };
+    private static AccountModel PersonalGraph(Guid id) => new() { Id = id, BackendKind = BackendKind.MicrosoftGraph, IsPersonalMicrosoftAccount = true, Username = "me@outlook.com", AccountName = "Personal" };
     private static AccountModel Imap(Guid id) => new() { Id = id, BackendKind = BackendKind.ImapSmtp, Username = "i@x.com", AccountName = "Home" };
     private static ServerRuleModel Server(string name) => new() { Id = name, DisplayName = name, SubjectContains = "x", MarkAsRead = true };
     private static MailRule Client(string name, Guid accountId) => new() { Name = name, AccountId = accountId, SubjectContains = "y", Action = RuleAction.MarkAsRead };
@@ -82,6 +83,24 @@ public class UnifiedRulesViewModelTests
 
         Assert.False(vm.AccountSupportsServerRules);   // IMAP → no server rules
         Assert.Single(vm.Rules);
+        Assert.Equal(RuleRunsWhere.Client, vm.Rules[0].RunsWhere);
+    }
+
+    [Fact]
+    public async Task Refresh_PersonalGraphAccount_LoadsOnlyClientRules() // #541
+    {
+        // Personal Microsoft (Graph) accounts don't get MailboxSettings.ReadWrite, so server rules
+        // aren't possible — the rules window must not offer them (it would 403 into a meaningless
+        // "ask your administrator" for a mailbox with no admin). They use client rules only.
+        var a = Guid.NewGuid();
+        var server = new FakeServerRules { Stored = [Server("S1")] };
+        var client = new StubRuleService { LoadedRules = [Client("C1", a)] };
+        var vm = new UnifiedRulesViewModel(client, server, [PersonalGraph(a)], preferredAccountId: a);
+
+        await vm.RefreshCommand.ExecuteAsync(null);
+
+        Assert.False(vm.AccountSupportsServerRules);   // personal Graph → no server rules, despite Graph backend
+        Assert.Single(vm.Rules);                       // the server rule is NOT loaded
         Assert.Equal(RuleRunsWhere.Client, vm.Rules[0].RunsWhere);
     }
 

--- a/QuickMail/Services/OAuthService.cs
+++ b/QuickMail/Services/OAuthService.cs
@@ -130,16 +130,24 @@ public class OAuthService : IOAuthService
         return PersonalMicrosoftDomains.Contains(username[(at + 1)..].Trim().ToLowerInvariant());
     }
 
+    /// <summary>
+    /// The best available "is this a personal Microsoft account" answer: the persisted, tenant-derived
+    /// flag (#233), falling back to the email-domain guess only when the flag hasn't been set yet (first
+    /// sign-in, or an account added before detection shipped). This is the same resolution scope
+    /// selection uses — callers that gate a work/school-only Microsoft capability (server-side rules,
+    /// shared mailboxes) should use this rather than the raw <see cref="AccountModel.IsPersonalMicrosoftAccount"/>
+    /// flag, so an undetected account is still classified instead of slipping through as work/school.
+    /// </summary>
+    internal static bool ResolveIsPersonalMicrosoftAccount(AccountModel account)
+        => account.IsPersonalMicrosoftAccount ?? IsPersonalMicrosoftDomain(account.Username);
+
     internal static string[] DefaultScopesFor(AccountModel account)
     {
         if (account.BackendKind != BackendKind.MicrosoftGraph)
             return ImapSmtpScopes;
         // Both personal and work/school use explicit Graph scopes — personal for write access (#217),
         // work/school so a Graph sign-in never validates the Exchange entitlement (#511).
-        // Prefer the persisted, tenant-derived flag; fall back to the email-domain
-        // guess only when the account hasn't been detected yet (first sign-in, or added before detection).
-        var isPersonal = account.IsPersonalMicrosoftAccount ?? IsPersonalMicrosoftDomain(account.Username);
-        return isPersonal ? GraphMailScopesPersonal : GraphMailScopesWorkSchool;
+        return ResolveIsPersonalMicrosoftAccount(account) ? GraphMailScopesPersonal : GraphMailScopesWorkSchool;
     }
 
     // Prompt for an interactive sign-in. Forcing the CONSENT screen on add is a `.default`-only

--- a/QuickMail/ViewModels/AddSharedMailboxViewModel.cs
+++ b/QuickMail/ViewModels/AddSharedMailboxViewModel.cs
@@ -25,11 +25,13 @@ public partial class AddSharedMailboxViewModel : ObservableObject
         // Only shared-capable accounts can host a shared mailbox: a work/school Microsoft 365 (Graph)
         // account, or an IMAP account. A personal Microsoft account has no Exchange shared mailboxes,
         // a POP3 account has no concept of a second mailbox at all (one maildrop, no folders, no
-        // access delegation), and a shared account can't itself be a parent.
+        // access delegation), and a shared account can't itself be a parent. Personal is resolved via
+        // OAuthService.ResolveIsPersonalMicrosoftAccount (flag, else domain guess) so an undetected
+        // personal Graph account is excluded too — the same resolution scope selection uses.
         ParentOptions = _allAccounts
             .Where(a => !a.IsShared
                         && a.BackendKind != BackendKind.Pop3Smtp
-                        && !(a.BackendKind == BackendKind.MicrosoftGraph && a.IsPersonalMicrosoftAccount == true))
+                        && !(a.BackendKind == BackendKind.MicrosoftGraph && OAuthService.ResolveIsPersonalMicrosoftAccount(a)))
             .ToList();
 
         _selectedParent = ParentOptions.FirstOrDefault(a => a.Id == preferredParentId)

--- a/QuickMail/ViewModels/UnifiedRulesViewModel.cs
+++ b/QuickMail/ViewModels/UnifiedRulesViewModel.cs
@@ -457,11 +457,19 @@ public partial class UnifiedRulesViewModel : ObservableObject
     private void Announce(string text, AnnouncementCategory category) => AnnouncementRequested?.Invoke(text, category);
 
     /// <summary>
-    /// True when the selected account is a Microsoft 365 (Graph) account, so it can carry server-side
-    /// rules. Drives which rules load, and (later) how a New rule is classified/routed.
+    /// True when the selected account is a <em>work or school</em> Microsoft 365 (Graph) account, so it
+    /// can carry server-side rules. Drives which rules load, and how a New rule is classified/routed.
+    ///
+    /// Personal Microsoft (Graph) accounts are excluded (#541): server rules run on
+    /// <c>MailboxSettings.ReadWrite</c>, which <see cref="OAuthService.GraphMailScopesPersonal"/>
+    /// deliberately omits as an org-only capability — so offering them to a personal account only
+    /// yields a 403 that surfaces as a meaningless "ask your administrator" for a mailbox with no admin.
+    /// Personal accounts use client-side rules only, the same as any non-server-rules account. This
+    /// mirrors the exclusion <see cref="AddSharedMailboxViewModel"/> already applies.
     /// </summary>
     public bool AccountSupportsServerRules
-        => _serverRules != null && SelectedAccountModel?.BackendKind == BackendKind.MicrosoftGraph;
+        => _serverRules != null
+           && SelectedAccountModel is { BackendKind: BackendKind.MicrosoftGraph, IsPersonalMicrosoftAccount: not true };
 
     private AccountModel? SelectedAccountModel
         => _allAccounts.FirstOrDefault(a => a.Id == SelectedAccount?.Id);

--- a/QuickMail/ViewModels/UnifiedRulesViewModel.cs
+++ b/QuickMail/ViewModels/UnifiedRulesViewModel.cs
@@ -464,12 +464,15 @@ public partial class UnifiedRulesViewModel : ObservableObject
     /// <c>MailboxSettings.ReadWrite</c>, which <see cref="OAuthService.GraphMailScopesPersonal"/>
     /// deliberately omits as an org-only capability — so offering them to a personal account only
     /// yields a 403 that surfaces as a meaningless "ask your administrator" for a mailbox with no admin.
-    /// Personal accounts use client-side rules only, the same as any non-server-rules account. This
-    /// mirrors the exclusion <see cref="AddSharedMailboxViewModel"/> already applies.
+    /// Personal accounts use client-side rules only, the same as any non-server-rules account.
+    ///
+    /// Uses <see cref="OAuthService.ResolveIsPersonalMicrosoftAccount"/> (flag, else the domain guess),
+    /// the same resolution scope selection uses, so an undetected personal account is caught too.
     /// </summary>
     public bool AccountSupportsServerRules
         => _serverRules != null
-           && SelectedAccountModel is { BackendKind: BackendKind.MicrosoftGraph, IsPersonalMicrosoftAccount: not true };
+           && SelectedAccountModel is { BackendKind: BackendKind.MicrosoftGraph } acct
+           && !OAuthService.ResolveIsPersonalMicrosoftAccount(acct);
 
     private AccountModel? SelectedAccountModel
         => _allAccounts.FirstOrDefault(a => a.Id == SelectedAccount?.Id);


### PR DESCRIPTION
Fixes #541. Part of the #529 plan (a personal-Graph readiness gap that #527 exposed).

## The bug

`UnifiedRulesViewModel.AccountSupportsServerRules` gated on `BackendKind == MicrosoftGraph` alone. Once #527 made personal Microsoft accounts reachable on Graph, that gate offered **server-side rules to a personal Outlook.com account** — but personal Graph tokens deliberately omit `MailboxSettings.ReadWrite` (server rules is a work/school Exchange Online capability; see `GraphMailScopesPersonal`). The Graph call 403s, and QuickMail rendered it as *"Ask your administrator to grant it"* — meaningless for a personal mailbox with no admin.

## The fix

Exclude personal Microsoft accounts from server rules (**work/school Graph only**), mirroring the exclusion `AddSharedMailboxViewModel` already applies. Personal accounts use client-side rules only, exactly like any non-server-rules account — the New-rule classifier routes them to client, no server rows load, and no server action is reachable.

Personhood is resolved with the same **flag-or-domain-guess** logic scope selection uses, now extracted into a shared `OAuthService.ResolveIsPersonalMicrosoftAccount` (`account.IsPersonalMicrosoftAccount ?? IsPersonalMicrosoftDomain(username)`). Using the resolver rather than the raw flag also catches an **undetected** personal account on a consumer domain, not only a confirmed one. `DefaultScopesFor` now calls the same helper (behavior unchanged), and `AddSharedMailboxViewModel` is upgraded to the resolver too, so all three work/school-only gates classify personhood identically.

## Scope note

The UI gate is the root fix: with server rules withheld for personal accounts, `GraphServerRuleService` is unreachable for them (no server rows load, the classifier never routes to the server path), so no service-layer change is needed.

Everything else that gates on the Graph backend (calendar sync, contact sync, mail read/write/send, the delta poll, connect) works for personal Graph — a sweep confirmed server rules is the only work/school-only capability. `User.ReadBasic.All` is declared-but-unused (no call site), so there's no directory feature to break.

## Tests

- `Refresh_PersonalGraphAccount_LoadsOnlyClientRules` and `Refresh_UndetectedPersonalGraphAccount_CaughtByDomainGuess_LoadsOnlyClientRules` (rules window).
- `ParentOptions_ExcludeUndetectedPersonalGraph_CaughtByDomainGuess` (shared-mailbox parity).
- `ResolveIsPersonalMicrosoftAccount_PrefersFlag_FallsBackToDomain` — pins the resolver across flag {true,false,null} × domain {consumer,work}.
- Existing Graph tests still pass (their null-flag work-domain accounts resolve to not-personal → still supported). Full suite green; 0 CA analyzer warnings in a Release build.
