### PR TITLE
Speak the rule mode when the Rules manager lands on an account

### DIFF
--- a/QuickMail.Tests/UnifiedRulesViewModelTests.cs
+++ b/QuickMail.Tests/UnifiedRulesViewModelTests.cs
@@ -288,6 +288,80 @@ public class UnifiedRulesViewModelTests
         Assert.DoesNotContain("No rules for this account", vm.StatusText); // … not overwritten by BuildStatus
     }
 
+    // ── Spoken rule-mode hint on account selection ─────────────────────────────
+    // An empty rule list can't tell a screen-reader user whether this account runs rules on the server
+    // or only in QuickMail. A Hint on each account-context load states it; a write-reload does not.
+
+    [Fact]
+    public void RuleModeHint_DistinguishesServerCapableFromClientOnly()
+    {
+        Assert.Contains("server-side", UnifiedRulesViewModel.RuleModeHint(supportsServerRules: true));
+        Assert.Contains("run in QuickMail", UnifiedRulesViewModel.RuleModeHint(supportsServerRules: false));
+    }
+
+    [Fact]
+    public async Task Refresh_WorkSchoolGraph_AnnouncesServerCapableModeHint_AsAHint()
+    {
+        var a = Guid.NewGuid();
+        var vm = new UnifiedRulesViewModel(new StubRuleService(), new FakeServerRules(), [Graph(a)], preferredAccountId: a);
+        (string Text, AnnouncementCategory Cat)? hint = null;
+        vm.AnnouncementRequested += (t, c) => hint = (t, c);
+
+        await vm.RefreshCommand.ExecuteAsync(null);
+
+        Assert.NotNull(hint);
+        Assert.Equal(UnifiedRulesViewModel.RuleModeHint(true), hint!.Value.Text);
+        Assert.Equal(AnnouncementCategory.Hint, hint!.Value.Cat);       // silenceable, honors AnnounceHints
+    }
+
+    [Fact]
+    public async Task Refresh_PersonalGraph_AnnouncesClientOnlyModeHint()
+    {
+        var a = Guid.NewGuid();
+        var vm = new UnifiedRulesViewModel(new StubRuleService(), new FakeServerRules(), [PersonalGraph(a)], preferredAccountId: a);
+        string? hint = null;
+        vm.AnnouncementRequested += (t, _) => hint = t;
+
+        await vm.RefreshCommand.ExecuteAsync(null);
+
+        Assert.Equal(UnifiedRulesViewModel.RuleModeHint(false), hint);   // personal → client-only, no server
+    }
+
+    [Fact]
+    public async Task SwitchingAccount_ReSpeaksTheNewAccountsMode()
+    {
+        var work = Guid.NewGuid();
+        var personal = Guid.NewGuid();
+        var vm = new UnifiedRulesViewModel(new StubRuleService(), new FakeServerRules(),
+            [Graph(work), PersonalGraph(personal)], preferredAccountId: work);
+        await vm.RefreshCommand.ExecuteAsync(null);          // initial: work (server-capable)
+        string? hint = null;
+        vm.AnnouncementRequested += (t, _) => hint = t;
+
+        // Selecting a new account must itself re-speak the mode — no manual refresh. The client-only
+        // load path is synchronous, so the OnSelectedAccountChanged-triggered refresh + announce has
+        // completed by the time the setter returns; this pins the auto-refresh-on-switch wiring.
+        vm.SelectedAccount = vm.AccountOptions.First(o => o.Id == personal);
+
+        Assert.Equal(UnifiedRulesViewModel.RuleModeHint(false), hint);   // now the personal account's mode
+    }
+
+    [Fact]
+    public async Task WriteReload_DoesNotReSpeakTheModeHint()
+    {
+        var a = Guid.NewGuid();
+        var server = new FakeServerRules { Stored = [Server("S1")] };
+        var vm = new UnifiedRulesViewModel(new StubRuleService(), server, [Graph(a)], preferredAccountId: a);
+        await vm.RefreshCommand.ExecuteAsync(null);
+        vm.SelectedRule = vm.Rules.Single();
+        var announces = new List<string>();
+        vm.AnnouncementRequested += (t, _) => announces.Add(t);
+
+        await vm.ToggleEnabledCommand.ExecuteAsync(null);   // a write → reload, but the account is unchanged
+
+        Assert.DoesNotContain(UnifiedRulesViewModel.RuleModeHint(true), announces);
+    }
+
     // ── Prefill-from-message (Ctrl+Shift+T) and Run-on-Existing in the unified window ──────────
 
     [Fact]

--- a/QuickMail/ViewModels/UnifiedRulesViewModel.cs
+++ b/QuickMail/ViewModels/UnifiedRulesViewModel.cs
@@ -443,7 +443,9 @@ public partial class UnifiedRulesViewModel : ObservableObject
     private async Task ReloadAndReselectAsync(
         string? serverId = null, Guid? clientId = null, int? fallbackIndex = null, CancellationToken ct = default)
     {
-        await RefreshAsync(ct);
+        // A write-triggered reload, NOT an account switch — so it must not re-speak the rule-mode hint
+        // (the account hasn't changed; only its rules did).
+        await RefreshCoreAsync(announceMode: false, ct);
         SelectedRule = Rules.FirstOrDefault(r =>
             (serverId != null && r.Server?.Id == serverId) ||
             (clientId != null && r.Client?.Id == clientId));
@@ -487,8 +489,13 @@ public partial class UnifiedRulesViewModel : ObservableObject
     /// </summary>
     private CancellationTokenSource? _refreshCts;
 
+    // The account-context refresh (initial open + every account switch, via RefreshCommand). Speaks the
+    // rule-mode hint once the load settles, so a screen-reader user hears whether the account they landed
+    // on runs rules on the server or only in QuickMail — the one thing the empty list can't convey.
     [RelayCommand]
-    private async Task RefreshAsync(CancellationToken ct)
+    private Task RefreshAsync(CancellationToken ct) => RefreshCoreAsync(announceMode: true, ct);
+
+    private async Task RefreshCoreAsync(bool announceMode, CancellationToken ct)
     {
         if (SelectedAccount?.Id is not Guid accountId)
         {
@@ -561,12 +568,26 @@ public partial class UnifiedRulesViewModel : ObservableObject
             // A load failure must survive to the status line — otherwise "couldn't reach Graph" reads
             // as "this account has no server rules", which invites the wrong next action.
             StatusText = BuildStatus(rows, failures);
+
+            // Only the account-context load (open/switch) speaks the mode; a write-reload does not. This
+            // sits past every early return above, so a superseded refresh never announces a stale account.
+            if (announceMode)
+                Announce(RuleModeHint(AccountSupportsServerRules), AnnouncementCategory.Hint);
         }
         finally
         {
             IsBusy = false;
         }
     }
+
+    // The spoken rule-mode cue for the account just landed on — an AnnouncementCategory.Hint, so it
+    // honors the user's AnnounceHints preference. Both modes are announced (not just the client-only
+    // case) so that, in a multi-account manager, switching accounts always states the new account's mode
+    // rather than leaving silence to be interpreted. Pure so the wording is pinned by a test.
+    internal static string RuleModeHint(bool supportsServerRules)
+        => supportsServerRules
+            ? "This account also supports server-side rules that run in the cloud."
+            : "Rules for this account run in QuickMail while it's open.";
 
     /// <summary>Cancels any in-flight load. The View calls this on close so a slow Graph fetch can't
     /// complete and write into a window that's gone.</summary>

--- a/QuickMail/Views/UnifiedRulesWindow.xaml.cs
+++ b/QuickMail/Views/UnifiedRulesWindow.xaml.cs
@@ -145,7 +145,10 @@ public partial class UnifiedRulesWindow : Window
         => MessageBox.Show(this, message, "Saved as a QuickMail rule", MessageBoxButton.OK, MessageBoxImage.Information);
 
     private void OnAnnouncement(string text, AnnouncementCategory category)
-        => AccessibilityHelper.Announce(this, text, interrupt: true, category: category);
+        // Results and status are action outcomes the user should hear promptly, so they interrupt. A Hint
+        // is ambient — the rule-mode cue spoken as you land on an account — and must NOT cut off the
+        // platform's own announcement of the newly-selected account, so it queues instead of interrupting.
+        => AccessibilityHelper.Announce(this, text, interrupt: category != AnnouncementCategory.Hint, category: category);
 
     private void OnPermissionMessage(string message)
         => AccessibilityHelper.Announce(this, message, category: AnnouncementCategory.Hint);


### PR DESCRIPTION
## Problem

The unified Rules manager lists client and server rules in one per-account list, but an **empty** list gives a screen-reader user no cue about which kind of rules the selected account supports. The per-rule "in QuickMail" / "on server" label and the save-time confirmation only surface the distinction once rules exist — and only for the rule you're on.

## Change

Announce the selected account's **rule mode** as a `Hint` on each account-context load — initial open and every account switch:

- client-only account → *"Rules for this account run in QuickMail while it's open."*
- work/school Graph account → *"This account also supports server-side rules that run in the cloud."*

Both modes are spoken, so in a multi-account manager, switching accounts always states the new account's mode rather than leaving silence to be interpreted.

### Design

- **Tied to account selection, not rule edits.** `RefreshAsync` (open + switch, via `RefreshCommand`) announces; the write-reload path (`ReloadAndReselectAsync` → `RefreshCoreAsync(announceMode: false)`) does not — toggling, adding, or deleting a rule never re-speaks the mode.
- **Never stale.** The announce sits past every early return in the load, so a superseded/cancelled refresh doesn't announce.
- **`AnnouncementCategory.Hint`** — honors the user's `AnnounceHints` setting.
- **Non-interrupting.** Unlike the window's action-outcome announces, the mode Hint does **not** interrupt — it must not cut off the platform's own announcement of the newly-selected account, so it queues. (Only `Hint`s are made non-interrupting; `Result`/`Status` still interrupt.)
- `RuleModeHint(bool)` is a pure static, so the wording is pinned by a test.

### Tests

- `RuleModeHint` wording (server-capable vs client-only).
- Work/school Graph refresh announces the server-capable hint **as a `Hint`**; personal Graph announces the client-only hint.
- Switching account re-speaks the new account's mode (pins the auto-refresh-on-switch trigger).
- A write-reload (toggle) does **not** re-speak the mode.

Build clean (0 warnings), 29 `UnifiedRulesViewModelTests` green. Independent adversarial review run pre-PR (verdict SHIP); its one flag — the hint interrupting the per-arrow combo announcement — is fixed here by making `Hint`s non-interrupting.

## Stacking

**Stacked on #543** (`fix/541-server-rules-not-personal-graph`). The mode decision reads `AccountSupportsServerRules`, which #543 narrows to work/school Graph — so a personal Graph account correctly hears the client-only cue. Base retargets to `main` once #543 merges. Please merge #543 first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
