### PR TITLE
Docs: rules-manager server-rules scope + mode announcement, and v0.8.41 notes

### DIFF
--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -1047,11 +1047,13 @@ Select a message and choose **Create Rule from Message** from the context menu o
 
 ### Microsoft 365: server-side rules
 
-If you have a Microsoft 365 (Exchange) account, the Rules Manager does a little more. Alongside the rules that run inside QuickMail, it shows the **server-side rules** on your Exchange mailbox — the same rules Outlook calls "Inbox rules." A server rule runs on Microsoft's servers, so it acts on your mail **even when QuickMail is closed**, and it applies wherever you read that mailbox.
+If you have a **work or school** Microsoft 365 (Exchange) account, the Rules Manager does a little more. Alongside the rules that run inside QuickMail, it shows the **server-side rules** on your Exchange mailbox — the same rules Outlook calls "Inbox rules." A server rule runs on Microsoft's servers, so it acts on your mail **even when QuickMail is closed**, and it applies wherever you read that mailbox.
+
+Server-side rules are an organization feature, so **personal Outlook.com, Hotmail, and Live.com accounts do not have them** — even when connected through Microsoft 365 directly. For a personal account the Rules Manager shows only the rules that run inside QuickMail, the same as any other non-Exchange account.
 
 **One account at a time.** With a Microsoft 365 account present, the Rules Manager opens on a single account chosen in an **Account** list at the top, rather than listing every account's rules together. Choose the account whose rules you want, and the list below shows just that mailbox's rules. If you have only one account there is no picker. This is the first thing to notice if you are used to seeing every account's rules in one list: your rules are not gone, they are behind the account picker.
 
-**One list, marked where each rule runs.** Server rules and QuickMail rules appear together in a single list. Each row says where the rule runs — **on server** or **in QuickMail** — along with its name and whether it is enabled. Creating, editing, enabling or disabling, reordering, and deleting all work the same way whichever kind a rule is.
+**One list, marked where each rule runs.** Server rules and QuickMail rules appear together in a single list. Each row says where the rule runs — **on server** or **in QuickMail** — along with its name and whether it is enabled. Creating, editing, enabling or disabling, reordering, and deleting all work the same way whichever kind a rule is. When you open the Rules Manager, or switch to another account with the account picker, QuickMail announces that account's rule mode — that its rules run in QuickMail while it is open, or that the account also supports server-side rules — so an empty list is never a mystery about which kind the account can have.
 
 **QuickMail chooses where a new rule lives.** When you create a rule, QuickMail saves it as a server rule whenever it can, so it keeps working while QuickMail is closed. A rule that needs something only QuickMail can do — today that is **Mark as unread** — is saved as a QuickMail rule instead, and QuickMail tells you why.
 


### PR DESCRIPTION
Documentation for the two rules changes that have merged since v0.8.40 (#541 fix in #543, and #545), plus a draft next-version release-notes file.

## User Guide (`docs/USER-GUIDE.md`)
- **Server-side rules are a work/school feature (#541).** The "Microsoft 365: server-side rules" section now says so explicitly, and adds that a personal Outlook.com/Hotmail/Live account — even connected through Microsoft 365 directly — has no server-side rules, so the Rules Manager shows only its QuickMail rules. This matches the #543 gating: a personal Graph account is no longer offered server rules it can't have.
- **Rule-mode announcement (#545).** Notes that the Rules Manager announces an account's rule mode when you open it or switch accounts, so an empty list isn't a mystery about which kind of rules the account can hold.

## Release notes (`docs/release-notes-v0.8.41.md`)
New file covering the two shipped-but-unreleased changes, in the house tone, ending with the standard Reporting Issues footer.

**Two things to confirm before this ships:**
1. **Version is provisional.** I used `0.8.41` and bumped the download-table filenames to match, but the version and cut are yours — rename if the next release is numbered differently.
2. **#544 is not included** — the personal-Graph single-consent fold is still in review. Its release note belongs in this same file once it merges; I'll add it then (or say the word and I'll draft it now as a pending entry).

No code changes; docs only.
