### PR TITLE
Ship Velopack Setup.exe with every release, for winget (#536)

### DIFF
--- a/.github/workflows/quickmail.yml
+++ b/.github/workflows/quickmail.yml
@@ -457,6 +457,13 @@ jobs:
           # Same for Setup.exe (issue #536): vpk names it QuickMail-win-Setup.exe. Rename-Item
           # throws if vpk ever stops emitting it, which fails the release rather than
           # publishing without the winget installer.
+          #
+          # build-installer.yml renames "whichever single *Setup.exe landed" behind a
+          # count guard rather than naming the file. That guard cannot be copied here:
+          # both channels pack into this one output folder, so by the time the ARM64 pack
+          # runs the folder already holds the renamed x64 Setup.exe and a *Setup.exe glob
+          # would match two files and throw on every release. Naming the file is what the
+          # MSI rename directly above already does, for the same reason.
           Rename-Item installer/Output/Releases/QuickMail-win-Setup.exe "QuickMail-$version-win-Setup.exe"
           # The previous version's full .nupkg (fetched above as the delta input) stays in
           # the folder and is uploaded with the rest: vpk pack bakes an entry for every
@@ -465,15 +472,22 @@ jobs:
 
       # Native ARM64 pack, into the SAME output folder as x64. That is safe because
       # Velopack suffixes every file it writes with the channel name — verified against
-      # real vpk 1.2.0 output in run 30710511730, where the two channels produced:
+      # real vpk 1.2.0 output in run 30710511730. These are COMPLETE listings — every file
+      # each channel wrote, including the ones this workflow does not ship — because the
+      # only use for this comment is checking the two sets for a collision, and a partial
+      # listing cannot answer that:
       #   x64   : RELEASES, releases.win.json, assets.win.json,
-      #           QuickMail-<v>-full.nupkg, QuickMail-win.msi, QuickMail-win-Setup.exe
+      #           QuickMail-<v>-full.nupkg, QuickMail-win.msi, QuickMail-win-Setup.exe,
+      #           QuickMail-win-Portable.zip
       #   arm64 : RELEASES-win-arm64, releases.win-arm64.json, assets.win-arm64.json,
       #           QuickMail-<v>-win-arm64-full.nupkg, QuickMail-win-arm64.msi,
-      #           QuickMail-win-arm64-Setup.exe
+      #           QuickMail-win-arm64-Setup.exe, QuickMail-win-arm64-Portable.zip
       # No filename appears in both sets, so the two update feeds cannot overwrite each
       # other. Re-check this listing if vpk is ever upgraded: a collision here would
-      # corrupt the x64 feed and strand every existing install.
+      # corrupt the x64 feed and strand every existing install. Note that vpk is installed
+      # unpinned (`dotnet tool install -g vpk` above), so "if vpk is ever upgraded" means
+      # "on some future release run, without warning" — .github/workflows/
+      # winget-install-matrix.yml re-measures the packed output on demand for that reason.
       #
       # x64 deliberately stays on Velopack's default `win` channel. Every installed copy
       # of QuickMail already polls releases.win.json; renaming that channel would strand
@@ -547,7 +561,15 @@ jobs:
       #  - people: QuickMail-<version>-win.msi (wizard installer with license acceptance)
       #    and QuickMail.exe (portable) for x64; the -win-arm64 / -arm64 pair for ARM64
       #  - winget: QuickMail-<version>-win-Setup.exe and -win-arm64-Setup.exe, Velopack's
-      #    one-click installer, which the KellyLford.QuickMail manifest points at (#536)
+      #    one-click installer, which the KellyLford.QuickMail manifest points at (#536).
+      #    Shipping it publicly reverses the earlier "not shipped" decision, whose stated
+      #    reason was that Setup.exe skips the welcome/license/conclusion pages the --inst*
+      #    arguments above exist to provide. That reason was reconsidered, not overlooked:
+      #    winget itself never shows a license page for any package, so the moment
+      #    QuickMail is installable with `winget install` the licence-unseen install exists
+      #    regardless of whether the asset is also on the release page. Given that, hiding
+      #    it from people who want a one-click download buys nothing. The MSI remains the
+      #    installer the download links and the user guide point at.
       #  - the in-app updater: RELEASES, releases.win.json, assets.win.json and the
       #    matching -win-arm64 trio, plus the .nupkg packages (full + delta), which
       #    Velopack's GithubSource reads from the latest release.

--- a/.github/workflows/quickmail.yml
+++ b/.github/workflows/quickmail.yml
@@ -422,10 +422,14 @@ jobs:
       # --shortcuts StartMenuRoot: Start Menu entry only, no desktop shortcut
       # (matches the previous installer's default).
       # --msi builds the wizard installer (welcome, license acceptance, conclusion pages)
-      # that is the user-facing download; the one-click Setup.exe is also produced but
-      # intentionally not shipped. --instLocation PerUser keeps the install in
-      # %LocalAppData% so background updates never need elevation. vpk requires the
-      # license file to carry a .txt/.md/.rtf extension, hence the copy.
+      # that is the user-facing download. The one-click Setup.exe vpk also emits is
+      # shipped too, since issue #536: it is what the winget package installs, because
+      # a silent MSI install (`msiexec /qn`, which is all winget ever runs) lands in
+      # C:\QuickMail and upgrades relocate the app — issue #554 — while
+      # `Setup.exe --silent` installs and upgrades in place under %LocalAppData%.
+      # --instLocation PerUser keeps the wizard install in %LocalAppData% so background
+      # updates never need elevation. vpk requires the license file to carry a
+      # .txt/.md/.rtf extension, hence the copy.
       - name: Pack Velopack release
         if: startsWith(github.ref, 'refs/tags/v')
         shell: pwsh
@@ -450,6 +454,10 @@ jobs:
           # versions apart in their Downloads folder. The version is only in the filename;
           # the MSI's internal ProductVersion is unchanged (vpk set it from --packVersion).
           Rename-Item installer/Output/Releases/QuickMail-win.msi "QuickMail-$version-win.msi"
+          # Same for Setup.exe (issue #536): vpk names it QuickMail-win-Setup.exe. Rename-Item
+          # throws if vpk ever stops emitting it, which fails the release rather than
+          # publishing without the winget installer.
+          Rename-Item installer/Output/Releases/QuickMail-win-Setup.exe "QuickMail-$version-win-Setup.exe"
           # The previous version's full .nupkg (fetched above as the delta input) stays in
           # the folder and is uploaded with the rest: vpk pack bakes an entry for every
           # package it saw into RELEASES/releases.win.json, so deleting the file would
@@ -459,9 +467,10 @@ jobs:
       # Velopack suffixes every file it writes with the channel name — verified against
       # real vpk 1.2.0 output in run 30710511730, where the two channels produced:
       #   x64   : RELEASES, releases.win.json, assets.win.json,
-      #           QuickMail-<v>-full.nupkg, QuickMail-win.msi
+      #           QuickMail-<v>-full.nupkg, QuickMail-win.msi, QuickMail-win-Setup.exe
       #   arm64 : RELEASES-win-arm64, releases.win-arm64.json, assets.win-arm64.json,
-      #           QuickMail-<v>-win-arm64-full.nupkg, QuickMail-win-arm64.msi
+      #           QuickMail-<v>-win-arm64-full.nupkg, QuickMail-win-arm64.msi,
+      #           QuickMail-win-arm64-Setup.exe
       # No filename appears in both sets, so the two update feeds cannot overwrite each
       # other. Re-check this listing if vpk is ever upgraded: a collision here would
       # corrupt the x64 feed and strand every existing install.
@@ -486,6 +495,7 @@ jobs:
             --instConclusion installer/velopack/conclusion.txt
           if ($LASTEXITCODE -ne 0) { throw "vpk pack (arm64) failed with exit code $LASTEXITCODE." }
           Rename-Item installer/Output/Releases/QuickMail-win-arm64.msi "QuickMail-$version-win-arm64.msi"
+          Rename-Item installer/Output/Releases/QuickMail-win-arm64-Setup.exe "QuickMail-$version-win-arm64-Setup.exe"
           Write-Host "--- Velopack output (both channels) ---"
           Get-ChildItem installer/Output/Releases | Select-Object -ExpandProperty Name
 
@@ -533,20 +543,22 @@ jobs:
       # Release notes are read from docs/release-notes-<tag>.md if present,
       # otherwise GitHub auto-generates notes from commits.
       #
-      # Uploaded assets serve two consumers:
+      # Uploaded assets serve three consumers:
       #  - people: QuickMail-<version>-win.msi (wizard installer with license acceptance)
       #    and QuickMail.exe (portable) for x64; the -win-arm64 / -arm64 pair for ARM64
+      #  - winget: QuickMail-<version>-win-Setup.exe and -win-arm64-Setup.exe, Velopack's
+      #    one-click installer, which the KellyLford.QuickMail manifest points at (#536)
       #  - the in-app updater: RELEASES, releases.win.json, assets.win.json and the
       #    matching -win-arm64 trio, plus the .nupkg packages (full + delta), which
       #    Velopack's GithubSource reads from the latest release.
-      # Intentionally not shipped: QuickMail-win-Setup.exe (one-click, no wizard/license)
-      # and QuickMail-win-Portable.zip (the raw single-file QuickMail.exe remains the
-      # portable download), and their ARM64 equivalents.
+      # Intentionally not shipped: QuickMail-win-Portable.zip (the raw single-file
+      # QuickMail.exe remains the portable download) and its ARM64 equivalent.
       #
       # The *.nupkg glob covers both channels' packages; every other Velopack path is
       # listed per channel so a missing file fails the release rather than silently
       # publishing a feed that clients cannot read. Note QuickMail-*-win.msi does NOT
-      # match QuickMail-<v>-win-arm64.msi — the ARM64 installer needs its own entry.
+      # match QuickMail-<v>-win-arm64.msi (and likewise for -Setup.exe) — the ARM64
+      # installers need their own entries.
       - name: Release
         if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v3
@@ -557,6 +569,8 @@ jobs:
             publish-arm64/QuickMail-arm64.exe
             installer/Output/Releases/QuickMail-*-win.msi
             installer/Output/Releases/QuickMail-*-win-arm64.msi
+            installer/Output/Releases/QuickMail-*-win-Setup.exe
+            installer/Output/Releases/QuickMail-*-win-arm64-Setup.exe
             installer/Output/Releases/*.nupkg
             installer/Output/Releases/RELEASES
             installer/Output/Releases/releases.win.json

--- a/.github/workflows/quickmail.yml
+++ b/.github/workflows/quickmail.yml
@@ -424,8 +424,10 @@ jobs:
       # --msi builds the wizard installer (welcome, license acceptance, conclusion pages)
       # that is the user-facing download. The one-click Setup.exe vpk also emits is
       # shipped too, since issue #536: it is what the winget package installs, because
-      # a silent MSI install (`msiexec /qn`, which is all winget ever runs) lands in
-      # C:\QuickMail and upgrades relocate the app — issue #554 — while
+      # a silent MSI install (`msiexec /qn`, which is all winget ever runs) lands in a
+      # drive root rather than %LocalAppData% — C:\QuickMail on one machine, D:\QuickMail
+      # on a CI runner, since Windows Installer picks the drive — and upgrades relocate
+      # the app — issue #554 — while
       # `Setup.exe --silent` installs and upgrades in place under %LocalAppData%.
       # --instLocation PerUser keeps the wizard install in %LocalAppData% so background
       # updates never need elevation. vpk requires the license file to carry a

--- a/docs/INSTALLER.md
+++ b/docs/INSTALLER.md
@@ -7,8 +7,11 @@ containing:
 - `QuickMail-win.msi` — **the user-facing installer**: a standard Windows Installer wizard
   (WiX 5) with welcome, license acceptance, and conclusion pages fed from
   `installer/velopack/*.txt` and the repo `LICENSE`
-- `QuickMail-win-Setup.exe` — Velopack's one-click installer (no wizard, no license page);
-  produced by `vpk pack` but **not shipped** — the MSI is the installer users download
+- `QuickMail-win-Setup.exe` — Velopack's one-click installer (no wizard, no license page).
+  **Shipped since issue #536 as `QuickMail-<version>-win-Setup.exe`**: it is what the winget
+  package (`KellyLford.QuickMail`) installs, because `Setup.exe --silent` installs and
+  upgrades in place under `%LocalAppData%\QuickMail` while a silent MSI install does not (see
+  *Silent installs* below). The MSI remains the installer the download page offers people.
 - `QuickMail-<version>-full.nupkg` — the full update package consumed by the in-app updater
 - `QuickMail-<version>-delta.nupkg` — binary delta from the previous release (generated only
   when the previous release's packages are present; CI fetches them with `vpk download github`
@@ -30,6 +33,7 @@ two architectures would offer each build's update to the wrong machine.
 | Channel | `win` (Velopack's default) | `win-arm64` |
 | Pack arguments | none extra | `--runtime win-arm64 --channel win-arm64` |
 | Installer | `QuickMail-<version>-win.msi` | `QuickMail-<version>-win-arm64.msi` |
+| One-click / winget | `QuickMail-<version>-win-Setup.exe` | `QuickMail-<version>-win-arm64-Setup.exe` |
 | Portable | `QuickMail.exe` | `QuickMail-arm64.exe` |
 | Feed metadata | `RELEASES`, `releases.win.json`, `assets.win.json` | `RELEASES-win-arm64`, `releases.win-arm64.json`, `assets.win-arm64.json` |
 | Package | `QuickMail-<version>-full.nupkg` | `QuickMail-<version>-win-arm64-full.nupkg` |
@@ -99,8 +103,22 @@ leaves ARM64 output in `bin/Release` until the next ordinary build.
   `VelopackApp.Build().Run()`. That is why `App.xaml` compiles as `Page` and `App.xaml.cs`
   declares an explicit `Main` (see the csproj `StartupObject`). Removing or reordering that
   call breaks packaging.
-- **Code signing** is not wired up yet. `vpk pack` supports Azure Trusted Signing via
-  `--azureTrustedSignFile` when that work completes.
+- **Code signing** runs in CI on every tagged release through Azure Trusted Signing:
+  `vpk pack --azureTrustedSignFile` signs the packaged binaries, `Update.exe`, `Setup.exe`
+  and the MSI as they are produced, and a separate step signs the two portable exes. There
+  is no signing certificate or long-lived secret in the repo — the workflow's OIDC token is
+  exchanged for Azure credentials via `azure/login`. Consequence: **nothing may edit a
+  packed MSI or exe after `vpk pack`** (a post-pack transform would void the signature).
+- **Silent installs must use `Setup.exe --silent`, not `msiexec /qn`** (issue #554). In
+  vpk 1.2.0 the MSI's `%LocalAppData%` default is set by the wizard's Next button, so an
+  unattended `msiexec /i … /qn` falls back to the Directory-table default and installs to
+  `C:\QuickMail`; a silent MSI over an existing install then uninstalls the old copy
+  (data-removal prompt included, per the #245 investigation) and relocates the app. If an
+  MSI must be deployed silently, pass `VELOPACK_INSTALLDIR="<absolute per-user path>"`.
+  `Setup.exe --silent` has none of these problems: it installs to `%LocalAppData%\QuickMail`,
+  overwrites an existing install in place without invoking its uninstall hook, and writes
+  the `HKCU\…\Uninstall\QuickMail` entry (3-part `DisplayVersion`, `QuietUninstallString`)
+  that `winget list` / `upgrade` / `uninstall` key off.
 
 ## Release flow (CI)
 
@@ -113,8 +131,8 @@ On a `v*` tag, `.github/workflows/quickmail.yml`:
 4. `vpk pack` — builds setup exe, full/delta packages, and feed metadata; then deletes the
    downloaded previous-version `.nupkg` so only current-version assets upload.
 5. `softprops/action-gh-release` uploads the portable `QuickMail.exe`, the MSI installer, the
-   `.nupkg` packages, and the feed metadata files. The in-app updater reads these from the
-   latest GitHub release.
+   one-click `Setup.exe` (for winget), the `.nupkg` packages, and the feed metadata files —
+   for both architectures. The in-app updater reads these from the latest GitHub release.
 
 ## Testing updates locally (no GitHub release needed)
 

--- a/docs/INSTALLER.md
+++ b/docs/INSTALLER.md
@@ -116,7 +116,9 @@ leaves ARM64 output in `bin/Release` until the next ordinary build.
 - **Silent installs must use `Setup.exe --silent`, not `msiexec /qn`** (issue #554). In
   vpk 1.2.0 the MSI's `%LocalAppData%` default is set by the wizard's Next button, so an
   unattended `msiexec /i … /qn` falls back to the Directory-table default and installs to
-  `C:\QuickMail`; a silent MSI over an existing install then uninstalls the old copy
+  a drive root — `C:\QuickMail` on one machine, `D:\QuickMail` on a CI runner, because
+  Windows Installer resolves `TARGETDIR` to the drive it prefers; a silent MSI over an
+  existing install then uninstalls the old copy
   (data-removal prompt included, per the #245 investigation) and relocates the app. If an
   MSI must be deployed silently, pass `VELOPACK_INSTALLDIR="<absolute per-user path>"`.
   `Setup.exe --silent` has none of these problems: it installs to `%LocalAppData%\QuickMail`,

--- a/docs/INSTALLER.md
+++ b/docs/INSTALLER.md
@@ -12,6 +12,10 @@ containing:
   package (`KellyLford.QuickMail`) installs, because `Setup.exe --silent` installs and
   upgrades in place under `%LocalAppData%\QuickMail` while a silent MSI install does not (see
   *Silent installs* below). The MSI remains the installer the download page offers people.
+  Accept the consequence knowingly: this asset is public, so anyone browsing the release
+  page can install QuickMail without ever seeing the license acceptance page the MSI wizard
+  shows. That is already true of every winget install — winget shows no license page for any
+  package — so restricting the asset would not buy the license page back.
 - `QuickMail-<version>-full.nupkg` — the full update package consumed by the in-app updater
 - `QuickMail-<version>-delta.nupkg` — binary delta from the previous release (generated only
   when the previous release's packages are present; CI fetches them with `vpk download github`


### PR DESCRIPTION
Phase 2 of the winget plan (#536): ship Velopack's one-click `Setup.exe` for both architectures with every release, so the winget manifest has an installer that behaves correctly under silent install/upgrade (see #554 for why the MSI cannot be that installer).

**Workflow (`.github/workflows/quickmail.yml`)**
- After each `vpk pack`, rename `QuickMail-win-Setup.exe` → `QuickMail-<version>-win-Setup.exe` and `QuickMail-win-arm64-Setup.exe` → `QuickMail-<version>-win-arm64-Setup.exe` (same treatment the MSIs get; `Rename-Item` throws if vpk stops emitting the file, so a missing installer fails the release loudly).
- Add both to the release upload list. `QuickMail-*-win-Setup.exe` does not match the arm64 name, so each has its own entry, mirroring the MSI globs.
- Comments updated: Setup.exe is no longer "intentionally not shipped".

No new signing step is needed — `vpk pack --azureTrustedSignFile` already signs Setup.exe (verified on today's on-demand builds, which are signed by the same profile).

**Docs (`docs/INSTALLER.md`)**
- Asset list and architecture table gain the Setup.exe row.
- "Code signing is not wired up yet" was stale — it is, via OIDC + Azure Trusted Signing on every tag; documented, plus the consequence that nothing may edit a packed artifact after `vpk pack`.
- New note: silent installs must use `Setup.exe --silent`, not `msiexec /qn`, with the reason and the `VELOPACK_INSTALLDIR` escape hatch.

**Verification:** this only takes effect on a `v*` tag, so it is proven by the next release. The YAML parses; the file list is exactly the previous one plus the two Setup.exe globs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
