### PR TITLE
winget: publish workflow and manifest template (#536)

### DIFF
--- a/.github/workflows/winget-publish.yml
+++ b/.github/workflows/winget-publish.yml
@@ -41,7 +41,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # `secrets.*` cannot be referenced in a job-level `if`, so surface presence via env and
-      # gate the step. Empty string when the secret is unset.
+      # gate the steps instead. The expression yields a boolean, which lands in env as the
+      # string "true" or "false" — never an empty string, so compare against 'true'.
       HAS_TOKEN: ${{ secrets.WINGET_TOKEN != '' }}
     steps:
       - name: Skip until WINGET_TOKEN is configured

--- a/.github/workflows/winget-publish.yml
+++ b/.github/workflows/winget-publish.yml
@@ -1,0 +1,62 @@
+name: Publish to winget
+
+# Opens a PR against microsoft/winget-pkgs with a new KellyLford.QuickMail version whenever a
+# release is *promoted* (issue #536, docs/planning/winget-distribution-plan.md, Phase 4).
+#
+# Trigger: `released` fires when a full release is published AND when a pre-release is
+# promoted to a release. It does not fire for pre-releases themselves, so this repo's
+# publish-as-pre-release-then-promote cadence (see the Release step in quickmail.yml) means
+# winget only ever sees builds Kelly has already promoted. `published` would fire on the
+# pre-release too — do not switch to it.
+#
+# Installers: only the two Velopack Setup.exe assets. The MSIs must never reach the manifest
+# — a silent MSI install lands in C:\QuickMail and upgrades relocate the app (issue #554) —
+# and the portable exes are not installers. The regex below matches
+# QuickMail-<v>-win-Setup.exe and QuickMail-<v>-win-arm64-Setup.exe and nothing else.
+#
+# Prerequisites, both one-time and both Kelly's:
+#   1. The first KellyLford.QuickMail version must already be in winget-pkgs (winget-releaser
+#      only *updates* existing packages; the first submission is manual — plan Phase 3).
+#   2. A CLASSIC personal access token with the `public_repo` scope, stored as the repo
+#      secret WINGET_TOKEN. Fine-grained tokens cannot fork/PR into microsoft/winget-pkgs
+#      (winget-releaser issue #172). The token forks winget-pkgs under Kelly's account and
+#      opens the PR from there.
+# Until the secret exists the job is skipped, not failed, so a release never goes red for a
+# feature that is not switched on yet.
+
+on:
+  release:
+    types: [released]
+  workflow_dispatch:
+    inputs:
+      release-tag:
+        description: 'Release tag to publish (e.g. v0.8.41); must be a promoted, non-pre-release'
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    env:
+      # `secrets.*` cannot be referenced in a job-level `if`, so surface presence via env and
+      # gate the step. Empty string when the secret is unset.
+      HAS_TOKEN: ${{ secrets.WINGET_TOKEN != '' }}
+    steps:
+      - name: Skip until WINGET_TOKEN is configured
+        if: env.HAS_TOKEN != 'true'
+        run: echo "WINGET_TOKEN is not set; skipping winget publish (see the comment at the top of this workflow)."
+
+      - name: Open winget-pkgs PR
+        if: env.HAS_TOKEN == 'true'
+        uses: vedantmgoyal9/winget-releaser@v2
+        with:
+          identifier: KellyLford.QuickMail
+          # workflow_dispatch supplies the tag; on `released` the action's default
+          # (github.event.release.tag_name) is what we want.
+          release-tag: ${{ github.event.inputs.release-tag || github.event.release.tag_name }}
+          installers-regex: '-win(-arm64)?-Setup\.exe$'
+          # Keep the catalog tidy; older versions are still on GitHub Releases.
+          max-versions-to-keep: 5
+          token: ${{ secrets.WINGET_TOKEN }}

--- a/.github/workflows/winget-publish.yml
+++ b/.github/workflows/winget-publish.yml
@@ -10,7 +10,8 @@ name: Publish to winget
 # pre-release too — do not switch to it.
 #
 # Installers: only the two Velopack Setup.exe assets. The MSIs must never reach the manifest
-# — a silent MSI install lands in C:\QuickMail and upgrades relocate the app (issue #554) —
+# — a silent MSI install lands in a drive root, not %LocalAppData% (C:\QuickMail on one
+# machine, D:\QuickMail on a CI runner), and upgrades relocate the app (issue #554) —
 # and the portable exes are not installers. The regex below matches
 # QuickMail-<v>-win-Setup.exe and QuickMail-<v>-win-arm64-Setup.exe and nothing else.
 #

--- a/installer/winget/KellyLford.QuickMail.installer.yaml
+++ b/installer/winget/KellyLford.QuickMail.installer.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+# Installer manifest. See README.md in this folder for why each choice is what it is.
+PackageIdentifier: KellyLford.QuickMail
+PackageVersion: <VERSION>
+InstallerType: exe
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  # Velopack Setup.exe: --silent hides all UI, answers yes to the overwrite prompt when an
+  # older copy is present, and does not launch the app afterwards.
+  Silent: --silent
+  SilentWithProgress: --silent
+# Never uninstallPrevious: that would run Update.exe --uninstall (and the data-removal
+# prompt) before every upgrade. Setup.exe over an existing install is the upgrade.
+UpgradeBehavior: install
+ReleaseDate: <RELEASE-DATE>
+# Velopack's own Add/Remove Programs entry (HKCU\...\Uninstall\QuickMail).
+AppsAndFeaturesEntries:
+- DisplayName: QuickMail
+  Publisher: Kelly Ford
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/kellylford/QuickMail/releases/download/v<VERSION>/QuickMail-<VERSION>-win-Setup.exe
+  InstallerSha256: <X64-SHA256>
+- Architecture: arm64
+  InstallerUrl: https://github.com/kellylford/QuickMail/releases/download/v<VERSION>/QuickMail-<VERSION>-win-arm64-Setup.exe
+  InstallerSha256: <ARM64-SHA256>
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/installer/winget/KellyLford.QuickMail.installer.yaml
+++ b/installer/winget/KellyLford.QuickMail.installer.yaml
@@ -18,9 +18,21 @@ InstallerSwitches:
 UpgradeBehavior: install
 ReleaseDate: <RELEASE-DATE>
 # Velopack's own Add/Remove Programs entry (HKCU\...\Uninstall\QuickMail).
+#
+# ProductCode is load-bearing, not belt-and-braces. On a machine upgraded from an MSI
+# install -- which is every existing user -- there are TWO Add/Remove Programs rows both
+# named QuickMail: Velopack's `QuickMail` and the MSI's leftover `MSI:QuickMail`, which
+# Setup.exe does not remove. Measured on both architectures, see the Phase 1b table in
+# docs/planning/winget-distribution-plan.md; `winget list` shows the app twice there.
+# For a non-MSI entry winget's ProductCode IS the Add/Remove Programs key name (its
+# identifier reads `ARP\User\X64\QuickMail`), so naming it here selects Velopack's row and
+# excludes the MSI one. Without it this manifest matches both, and `winget upgrade` may act
+# on the stale row -- whose uninstall string is `msiexec /x` against the directory the
+# Velopack install now owns.
 AppsAndFeaturesEntries:
 - DisplayName: QuickMail
   Publisher: Kelly Ford
+  ProductCode: QuickMail
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/kellylford/QuickMail/releases/download/v<VERSION>/QuickMail-<VERSION>-win-Setup.exe

--- a/installer/winget/KellyLford.QuickMail.locale.en-US.yaml
+++ b/installer/winget/KellyLford.QuickMail.locale.en-US.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+# Default-locale manifest. See README.md in this folder.
+PackageIdentifier: KellyLford.QuickMail
+PackageVersion: <VERSION>
+PackageLocale: en-US
+Publisher: Kelly Ford
+PublisherUrl: https://github.com/kellylford
+PublisherSupportUrl: https://github.com/kellylford/QuickMail/issues
+# PrivacyUrl deliberately omitted: docs/privacy.html is not deployed to GitHub Pages yet
+# (the URL 404s). Add it once it is published.
+PackageName: QuickMail
+PackageUrl: https://github.com/kellylford/QuickMail
+License: MIT
+LicenseUrl: https://github.com/kellylford/QuickMail/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Kelly Ford
+ShortDescription: Keyboard-first, screen-reader-friendly desktop email client for Windows.
+Description: |-
+  QuickMail is a keyboard-first desktop email client for Windows, built screen-reader-first.
+  Multiple IMAP/SMTP and Microsoft 365 accounts in one unified inbox, conversation view,
+  mail rules, saved views, message templates, and a sandboxed HTML reading pane. Installs
+  per user without administrator rights and keeps itself up to date automatically.
+Moniker: quickmail
+Tags:
+- accessibility
+- accessible
+- email
+- email-client
+- imap
+- keyboard
+- mail
+- screen-reader
+- smtp
+ReleaseNotesUrl: https://github.com/kellylford/QuickMail/releases/tag/v<VERSION>
+Documentations:
+- DocumentLabel: User Guide
+  DocumentUrl: https://kellylford.github.io/QuickMail/
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/installer/winget/KellyLford.QuickMail.yaml
+++ b/installer/winget/KellyLford.QuickMail.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+# Version manifest. See README.md in this folder.
+PackageIdentifier: KellyLford.QuickMail
+PackageVersion: <VERSION>
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0

--- a/installer/winget/README.md
+++ b/installer/winget/README.md
@@ -1,0 +1,52 @@
+# winget manifest for `KellyLford.QuickMail`
+
+Reference copy of the three manifests that describe QuickMail to the
+[Windows Package Manager community repository](https://github.com/microsoft/winget-pkgs)
+(issue #536, `docs/planning/winget-distribution-plan.md`). The **published** manifests live
+in winget-pkgs under `manifests/k/KellyLford/QuickMail/<version>/`; the files here are the
+template for the first, manual submission and the record of every deliberate choice in it.
+After that first version merges, `.github/workflows/winget-publish.yml` opens the PR for
+each promoted release automatically and these files are reference only.
+
+## What the choices mean
+
+- **`InstallerType: exe`, `--silent`** — the installer is Velopack's one-click
+  `QuickMail-<version>-win-Setup.exe` / `-win-arm64-Setup.exe`, never the MSI. A silent MSI
+  install lands in `C:\QuickMail` and a silent MSI upgrade uninstalls the old copy (data
+  prompt and all) before relocating the app — issue #554. `Setup.exe --silent` installs to
+  `%LocalAppData%\QuickMail`, and run over an existing install it overwrites in place
+  without invoking the uninstall hook.
+- **`Scope: user`** — per-user, no elevation. Matches the wizard.
+- **`UpgradeBehavior: install`** — winget just runs the newer Setup.exe; that *is* the
+  upgrade. `uninstallPrevious` would run `Update.exe --uninstall` first and fire the
+  data-removal prompt on every upgrade.
+- **`AppsAndFeaturesEntries`** — Velopack writes `HKCU\…\Uninstall\QuickMail` with
+  `DisplayName: QuickMail`, `Publisher: Kelly Ford` and a 3-part `DisplayVersion`; this is
+  how `winget list`/`upgrade` correlate an installed copy to the package.
+- **`Moniker: quickmail`** — makes `winget install quickmail` resolve without the full id.
+- **Two `Installers` entries** — x64 and arm64. Winget picks the native one.
+
+## First submission (manual, once)
+
+Prerequisite: a promoted release that carries both Setup.exe assets (0.8.41 onward — 0.8.40
+predates PR #555).
+
+1. Fill `<VERSION>`, `<X64-SHA256>`, `<ARM64-SHA256>` and `<RELEASE-DATE>` (YYYY-MM-DD)
+   into copies of these three files in a folder named after the version. Hashes:
+   `Get-FileHash <file> -Algorithm SHA256`, or `certutil -hashfile <file> SHA256`.
+   `wingetcreate new <x64-url> <arm64-url>` produces the same files interactively if you
+   would rather start from its prompts — but check its output against these choices.
+2. `winget validate --manifest <folder>`
+3. `winget install --manifest <folder>` on a machine without QuickMail (needs the
+   `LocalManifestFiles` setting enabled once, from an elevated prompt:
+   `winget settings --enable LocalManifestFiles`). Then `winget uninstall quickmail`.
+4. Fork microsoft/winget-pkgs, add the folder as
+   `manifests/k/KellyLford/QuickMail/<version>/`, open the PR. Or from the folder:
+   `wingetcreate submit --token <classic PAT with public_repo> <folder>`.
+5. Expect the automated validation to run and a moderator to look at a first-time package;
+   days, not hours.
+
+## Every later release
+
+Nothing to do by hand once `WINGET_TOKEN` is set: promoting a release fires the
+`released` event and `winget-publish.yml` opens the winget-pkgs PR. Confirm it appeared.

--- a/installer/winget/README.md
+++ b/installer/winget/README.md
@@ -20,6 +20,11 @@ each promoted release automatically and these files are reference only.
 - **`UpgradeBehavior: install`** — winget just runs the newer Setup.exe; that *is* the
   upgrade. `uninstallPrevious` would run `Update.exe --uninstall` first and fire the
   data-removal prompt on every upgrade.
+  Accept one consequence knowingly: Setup.exe force-stops a running instance before it
+  overwrites. So `winget upgrade --all` — a routine, unattended thing to run — closes
+  QuickMail if it is open, without asking. There is no better option (`uninstallPrevious`
+  does the same *and* prompts about the user's data), but it belongs in the user guide's
+  winget section rather than being discovered.
 - **`AppsAndFeaturesEntries`** — Velopack writes `HKCU\…\Uninstall\QuickMail` with
   `DisplayName: QuickMail`, `Publisher: Kelly Ford` and a 3-part `DisplayVersion`; this is
   how `winget list`/`upgrade` correlate an installed copy to the package.
@@ -37,9 +42,12 @@ predates PR #555).
    `wingetcreate new <x64-url> <arm64-url>` produces the same files interactively if you
    would rather start from its prompts — but check its output against these choices.
 2. `winget validate --manifest <folder>`
-3. `winget install --manifest <folder>` on a machine without QuickMail (needs the
-   `LocalManifestFiles` setting enabled once, from an elevated prompt:
-   `winget settings --enable LocalManifestFiles`). Then `winget uninstall quickmail`.
+3. Install from the local manifest **in Windows Sandbox**, not on your own machine.
+   winget-pkgs ships `Tools/SandboxTest.ps1` for exactly this. The reason to keep it out of
+   a working machine is the package's own upgrade semantics: `Setup.exe --silent` overwrites
+   an existing install in place, so testing it against the copy you use replaces that copy.
+   Inside the Sandbox: `winget settings --enable LocalManifestFiles` (elevated, once),
+   `winget install --manifest <folder>`, launch, then `winget uninstall quickmail`.
 4. Fork microsoft/winget-pkgs, add the folder as
    `manifests/k/KellyLford/QuickMail/<version>/`, open the PR. Or from the folder:
    `wingetcreate submit --token <classic PAT with public_repo> <folder>`.

--- a/installer/winget/README.md
+++ b/installer/winget/README.md
@@ -27,7 +27,12 @@ each promoted release automatically and these files are reference only.
   winget section rather than being discovered.
 - **`AppsAndFeaturesEntries`** — Velopack writes `HKCU\…\Uninstall\QuickMail` with
   `DisplayName: QuickMail`, `Publisher: Kelly Ford` and a 3-part `DisplayVersion`; this is
-  how `winget list`/`upgrade` correlate an installed copy to the package.
+  how `winget list`/`upgrade` correlate an installed copy to the package. The
+  `ProductCode: QuickMail` line matters on any machine that came from the MSI: Setup.exe
+  does not remove the MSI's `MSI:QuickMail` row, so two rows named QuickMail coexist and
+  `winget list` shows the app twice (measured on both architectures — Phase 1b in
+  `docs/planning/winget-distribution-plan.md`). winget's ProductCode for a non-MSI entry is
+  the registry key name, so naming it picks Velopack's row and leaves the stale one alone.
 - **`Moniker: quickmail`** — makes `winget install quickmail` resolve without the full id.
 - **Two `Installers` entries** — x64 and arm64. Winget picks the native one.
 
@@ -48,10 +53,18 @@ predates PR #555).
    an existing install in place, so testing it against the copy you use replaces that copy.
    Inside the Sandbox: `winget settings --enable LocalManifestFiles` (elevated, once),
    `winget install --manifest <folder>`, launch, then `winget uninstall quickmail`.
-4. Fork microsoft/winget-pkgs, add the folder as
+4. Test the **upgrade-from-MSI** path too, in a second Sandbox: install the release's MSI
+   first (`msiexec /i <msi> /qn VELOPACK_INSTALLDIR="%LocalAppData%\QuickMail"` — the
+   property must be on the command line, an environment variable does not reach the Windows
+   Installer service), then `winget install --manifest <folder>` over it. Expect two rows in
+   Settings → Apps and two `winget list` rows; confirm `winget upgrade` and
+   `winget uninstall` act on the `ARP\...\QuickMail` row and not `ARP\...\MSI:QuickMail`.
+   This is the state every existing user will be in, and it is the one thing the manifest's
+   `ProductCode` exists to handle.
+5. Fork microsoft/winget-pkgs, add the folder as
    `manifests/k/KellyLford/QuickMail/<version>/`, open the PR. Or from the folder:
    `wingetcreate submit --token <classic PAT with public_repo> <folder>`.
-5. Expect the automated validation to run and a moderator to look at a first-time package;
+6. Expect the automated validation to run and a moderator to look at a first-time package;
    days, not hours.
 
 ## Every later release

--- a/installer/winget/README.md
+++ b/installer/winget/README.md
@@ -12,8 +12,10 @@ each promoted release automatically and these files are reference only.
 
 - **`InstallerType: exe`, `--silent`** — the installer is Velopack's one-click
   `QuickMail-<version>-win-Setup.exe` / `-win-arm64-Setup.exe`, never the MSI. A silent MSI
-  install lands in `C:\QuickMail` and a silent MSI upgrade uninstalls the old copy (data
-  prompt and all) before relocating the app — issue #554. `Setup.exe --silent` installs to
+  install lands in a drive root rather than `%LocalAppData%` — `C:\QuickMail` on one machine,
+  `D:\QuickMail` on a CI runner, since Windows Installer picks the drive — and a silent MSI
+  upgrade uninstalls the old copy (data prompt and all) before relocating the app — issue
+  #554. `Setup.exe --silent` installs to
   `%LocalAppData%\QuickMail`, and run over an existing install it overwrites in place
   without invoking the uninstall hook.
 - **`Scope: user`** — per-user, no elevation. Matches the wizard.


### PR DESCRIPTION
Phases 3–4 groundwork for winget (#536). Pairs with #555 (which ships the Setup.exe assets the manifest points at).

**`.github/workflows/winget-publish.yml`** — runs [winget-releaser@v2](https://github.com/vedantmgoyal9/winget-releaser) on `release: released`, which fires when a pre-release is **promoted** (and never for the pre-release itself), so it fits the promote-by-hand cadence with no change. `installers-regex: -win(-arm64)?-Setup\.exe$` matches only the two Setup.exe assets — never the MSIs (#554) or the portable exes. Skips (does not fail) until the `WINGET_TOKEN` secret exists. Also has a `workflow_dispatch` input for republishing a specific tag.

**`installer/winget/`** — the three-manifest template for the one-time manual first submission plus a README explaining every choice: `InstallerType: exe` + `--silent`, `Scope: user`, `UpgradeBehavior: install` (never `uninstallPrevious`, which would fire the data prompt on every upgrade), `AppsAndFeaturesEntries` matching Velopack's ARP row, `Moniker: quickmail`, both architectures. A filled-in copy passes `winget validate`. `PrivacyUrl` is left out because the Pages privacy URL 404s — filed as #556.

**What still needs Kelly (in order):**
1. Merge #555, then cut and promote 0.8.41 — the first release with Setup.exe assets.
2. Fill the template for 0.8.41 (hashes + date), `winget validate`, submit to microsoft/winget-pkgs (steps in the README).
3. After that PR merges: create a **classic PAT with `public_repo`** and add it as repo secret `WINGET_TOKEN`. From then on every promoted release publishes itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
