### PR TITLE
Fix #558: say "unread" without saying "read", and fix the field chooser's read-only text

### DIFF
--- a/QuickMail.Tests/RowFieldsPreviewConsistencyTests.cs
+++ b/QuickMail.Tests/RowFieldsPreviewConsistencyTests.cs
@@ -54,10 +54,11 @@ public class RowFieldsPreviewConsistencyTests
         vm.Fields.First(f => f.Id == "preview").Enabled = false;
         AssertConsistent(vm, "disable a field");
 
-        var unread = vm.Fields.First(f => f.Id == "unread");
-        unread.Enabled = true;
+        var status = vm.Fields.First(f => f.Id == "status");
+        status.Enabled = true;
         AssertConsistent(vm, "enable a field");
 
+        var unread = vm.Fields.First(f => f.Id == "unread");
         unread.SpeakMode = SpeakMode.Always;
         AssertConsistent(vm, "change speak mode");
 
@@ -103,15 +104,16 @@ public class RowFieldsPreviewConsistencyTests
     }
 
     /// <summary>
-    /// Both "Status (combined)" and "Unread" say the word "unread". With both enabled the row says
-    /// it twice — which is what a user gets by turning Unread on without noticing Status is already
-    /// on. The preview has to show that honestly, so it is visible before the window closes.
+    /// Both "Read status (combined)" and "Unread" say the word "unread". With both enabled the row
+    /// says it twice — which is what a user gets by turning the combined field back on without
+    /// noticing Unread is already on. The preview has to show that honestly, so it is visible
+    /// before the window closes.
     /// </summary>
     [Fact]
     public void OverlappingStatusFields_AreShownDoubledRatherThanHidden()
     {
         var vm = Make();
-        vm.Fields.First(f => f.Id == "unread").Enabled = true;
+        vm.Fields.First(f => f.Id == "status").Enabled = true;
 
         Assert.Equal(2, vm.Preview.Split("unread", StringSplitOptions.None).Length - 1);
     }
@@ -130,7 +132,8 @@ public class RowFieldsPreviewConsistencyTests
         };
         var vm = new RowFieldsViewModel(new StubRowLayoutService(), new StubConfigService(), real);
 
-        Assert.Equal($"read. Angela. Updates. Sneak peek. {real.DateDisplay}.", vm.Preview);
+        // Read, so the default layout says nothing about read state at all (#558).
+        Assert.Equal($"Angela. Updates. Sneak peek. {real.DateDisplay}.", vm.Preview);
         Assert.DoesNotContain("Follow up", vm.Preview, StringComparison.Ordinal);
         Assert.DoesNotContain("attachments", vm.Preview, StringComparison.Ordinal);
     }
@@ -150,8 +153,12 @@ public class RowFieldsPreviewConsistencyTests
         vm.MoveDownCommand.Execute(null);
         Assert.Equal(Expected(vm, real), vm.Preview);
 
+        vm.Fields.First(f => f.Id == "status").Enabled = true;
+        Assert.Equal(Expected(vm, real), vm.Preview);
+        // Combined status is on again, so the read message says "read".
+        Assert.Contains("read", vm.Preview, StringComparison.Ordinal);
+
         vm.Fields.First(f => f.Id == "status").Enabled = false;
-        vm.Fields.First(f => f.Id == "unread").Enabled = true;
         Assert.Equal(Expected(vm, real), vm.Preview);
         // The message is read and Unread is "only when true", so nothing is said about status.
         Assert.DoesNotContain("read", vm.Preview, StringComparison.Ordinal);
@@ -178,8 +185,8 @@ public class RowFieldsPreviewConsistencyTests
         string? announced = null;
         vm.AnnouncementRequested += (text, _) => announced = text;
 
-        // "unread" ships disabled — exactly the field that was moved in the bug report.
-        vm.SelectedField = vm.Fields.First(f => f.Id == "unread");
+        // "to" ships disabled — the same shape as the field that was moved in the bug report.
+        vm.SelectedField = vm.Fields.First(f => f.Id == "to");
         vm.MoveUpCommand.Execute(null);
 
         Assert.EndsWith("Not spoken.", announced!, StringComparison.Ordinal);
@@ -202,16 +209,18 @@ public class RowFieldsPreviewConsistencyTests
     public void SelectingUnreadWhileStatusIsOn_ExplainsTheOverlap()
     {
         var vm = Make();
+        vm.Fields.First(f => f.Id == "status").Enabled = true;   // off by default since #558
 
         vm.SelectedField = vm.Fields.First(f => f.Id == "unread");
 
-        Assert.Contains("Status (combined) is also on", vm.SelectedFieldNote, StringComparison.Ordinal);
+        Assert.Contains("Read status (combined) is also on", vm.SelectedFieldNote, StringComparison.Ordinal);
     }
 
     [Fact]
     public void TurningStatusOff_ClearsTheOverlapNote()
     {
         var vm = Make();
+        vm.Fields.First(f => f.Id == "status").Enabled = true;
         vm.SelectedField = vm.Fields.First(f => f.Id == "unread");
         Assert.NotEqual(string.Empty, vm.SelectedFieldNote);
 
@@ -228,6 +237,24 @@ public class RowFieldsPreviewConsistencyTests
         vm.SelectedField = vm.Fields.First(f => f.Id == "status");
 
         Assert.Contains("replied, forwarded, unread, or read", vm.SelectedFieldNote, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The overlap note is about doubled speech, so it belongs to the field that is doubling. A
+    /// field that is off says nothing and cannot double anything — it gets the note explaining why
+    /// its speak-mode choice is unavailable instead (#558).
+    /// </summary>
+    [Fact]
+    public void AnOffStateFieldGetsTheTurnItOnNote_NotTheOverlapNote()
+    {
+        var vm = Make();
+        vm.Fields.First(f => f.Id == "status").Enabled = true;
+        vm.Fields.First(f => f.Id == "unread").Enabled = false;
+
+        vm.SelectedField = vm.Fields.First(f => f.Id == "unread");
+
+        Assert.Contains("Turn this field on", vm.SelectedFieldNote, StringComparison.Ordinal);
+        Assert.DoesNotContain("said twice", vm.SelectedFieldNote, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/QuickMail.Tests/RowFieldsViewModelTests.cs
+++ b/QuickMail.Tests/RowFieldsViewModelTests.cs
@@ -229,6 +229,23 @@ public class RowFieldsViewModelTests
     }
 
     [Fact]
+    public void TwoFieldsSharingTheSameNote_BothAnnounceIt()
+    {
+        // "Turn this field on…" is the same sentence for every off state field, so announcing only
+        // on a change of text left the second of two such fields silent — arrowing from Mailing
+        // list to Watched explained the first and made the second look like it behaved differently.
+        var (vm, _, _) = Make();
+        vm.SelectedField = Field(vm, "mailinglist");
+
+        var heard = new List<string>();
+        vm.AnnouncementRequested += (text, _) => heard.Add(text);
+
+        vm.SelectedField = Field(vm, "watched");
+
+        Assert.Equal(vm.SelectedFieldNote, Assert.Single(heard));
+    }
+
+    [Fact]
     public void AFieldWithNoNoteAnnouncesNothingAtAll()
     {
         // An empty note must not be spoken as an empty utterance on every arrow key.

--- a/QuickMail.Tests/RowFieldsViewModelTests.cs
+++ b/QuickMail.Tests/RowFieldsViewModelTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using QuickMail.Helpers;
 using QuickMail.Models;
@@ -61,6 +62,20 @@ public class RowFieldsViewModelTests
         Assert.Contains("Chris Lee", vm.Preview, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void SampleValuesSupplyOneEntryPerCatalogField()
+    {
+        // RowSpeechBuilder tolerates a short array by treating the tail as absent, so a sample
+        // that falls behind the catalog is silent rather than loud: "watched" was appended to the
+        // catalog without a sample entry and simply never previewed.
+        foreach (var kind in new[] { RowKind.Message, RowKind.Conversation, RowKind.SenderGroup })
+        {
+            Assert.Equal(
+                RowFieldCatalog.For(kind).Count,
+                RowFieldsViewModel.SampleValues(kind).Length);
+        }
+    }
+
     // ── moving ────────────────────────────────────────────────────────────────
 
     [Fact]
@@ -105,10 +120,10 @@ public class RowFieldsViewModelTests
     {
         var (vm, _, _) = Make();
 
-        // "from" ahead of the status token.
+        // "from" ahead of the unread token. Default order is flag, unread, replied, forwarded,
+        // attachments, from — so four moves put it directly behind flag and ahead of unread.
         vm.SelectedField = Field(vm, "from");
-        vm.MoveUpCommand.Execute(null);
-        vm.MoveUpCommand.Execute(null);
+        for (int i = 0; i < 4; i++) vm.MoveUpCommand.Execute(null);
 
         Assert.Contains("Chris Lee. unread", vm.Preview, StringComparison.Ordinal);
     }
@@ -127,23 +142,29 @@ public class RowFieldsViewModelTests
     }
 
     [Fact]
-    public void UnreadOnlyWhenTrue_IsTheSupplementRequestEndToEnd()
+    public void UnreadOnlyWhenTrue_IsTheShippedDefault()
     {
-        // "I want to know about unread but not read."
-        var (vm, layouts, _) = Make();
+        // "I want to know about unread but not read" — #558. It needed no configuration at all
+        // once the combined status field stopped owning the wording.
+        var (vm, _, _) = Make();
 
-        Field(vm, "status").Enabled = false;
-        var unread = Field(vm, "unread");
-        unread.Enabled   = true;
-        unread.SpeakMode = SpeakMode.WhenTrue;
-
-        var saved = layouts.Load().Message;
-        Assert.False(saved.First(f => f.Id == "status").Enabled);
-        Assert.True(saved.First(f => f.Id == "unread").Enabled);
-        Assert.Equal(SpeakMode.WhenTrue, saved.First(f => f.Id == "unread").SpeakMode);
+        Assert.False(Field(vm, "status").Enabled);
+        Assert.True(Field(vm, "unread").Enabled);
+        Assert.Equal(SpeakMode.WhenTrue, Field(vm, "unread").SpeakMode);
 
         // The sample row is unread, so the preview says so — and never says "read".
         Assert.Contains("unread", vm.Preview, StringComparison.Ordinal);
+        Assert.DoesNotContain(". read", vm.Preview, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ChangingASpeakModePersists()
+    {
+        var (vm, layouts, _) = Make();
+
+        Field(vm, "unread").SpeakMode = SpeakMode.Always;
+
+        Assert.Equal(SpeakMode.Always, layouts.Load().Message.First(f => f.Id == "unread").SpeakMode);
     }
 
     [Fact]
@@ -160,6 +181,66 @@ public class RowFieldsViewModelTests
         Assert.True(vm.SpeakAlways);
         Assert.False(vm.SpeakWhenTrue);
         Assert.Equal(SpeakMode.Always, Field(vm, "attachments").SpeakMode);
+    }
+
+    [Fact]
+    public void SpeakModeIsUnavailableWhileTheFieldIsOff_AndComesBackWhenItIsTurnedOn()
+    {
+        // #558: "uncheck the field, then set speak only when true" was a sequence the window
+        // accepted and the builder ignored — it skips disabled fields before reading SpeakMode.
+        var (vm, _, _) = Make();
+
+        vm.SelectedField = Field(vm, "watched");     // a state field that ships off
+        Assert.True(vm.SelectedIsState);
+        Assert.False(vm.SelectedIsOn);
+
+        Field(vm, "watched").Enabled = true;
+        Assert.True(vm.SelectedIsOn);
+
+        Field(vm, "watched").Enabled = false;
+        Assert.False(vm.SelectedIsOn);
+    }
+
+    [Fact]
+    public void TurningTheSelectedFieldOff_ExplainsWhyTheSpeakModeChoiceWent()
+    {
+        var (vm, _, _) = Make();
+
+        vm.SelectedField = Field(vm, "attachments");
+        Assert.Equal(string.Empty, vm.SelectedFieldNote);
+
+        Field(vm, "attachments").Enabled = false;
+
+        Assert.Contains("Turn this field on", vm.SelectedFieldNote, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FieldNotesAreSpokenAsHintsSoTheyDoNotOverrideTheFieldName()
+    {
+        var (vm, _, _) = Make();
+        var heard = new List<(string Text, AnnouncementCategory Category)>();
+        vm.AnnouncementRequested += (text, cat) => heard.Add((text, cat));
+
+        vm.SelectedField = Field(vm, "status");
+
+        var note = Assert.Single(heard);
+        Assert.Equal(AnnouncementCategory.Hint, note.Category);
+        Assert.Equal(vm.SelectedFieldNote, note.Text);
+    }
+
+    [Fact]
+    public void AFieldWithNoNoteAnnouncesNothingAtAll()
+    {
+        // An empty note must not be spoken as an empty utterance on every arrow key.
+        var (vm, _, _) = Make();
+        vm.SelectedField = Field(vm, "status");        // has a note
+
+        var heard = new List<string>();
+        vm.AnnouncementRequested += (text, _) => heard.Add(text);
+
+        vm.SelectedField = Field(vm, "subject");       // has none
+
+        Assert.Empty(heard);
     }
 
     [Fact]

--- a/QuickMail.Tests/RowSpeechBuilderTests.cs
+++ b/QuickMail.Tests/RowSpeechBuilderTests.cs
@@ -17,15 +17,18 @@ public class RowSpeechBuilderTests
 {
     // ── helpers ───────────────────────────────────────────────────────────────
 
-    /// <summary>Bound values in catalog order for a message row.</summary>
+    /// <summary>
+    /// Bound values in catalog order for a message row. One entry per catalog field — see
+    /// <see cref="SampleValuesCoverEveryCatalogField"/>, which pins that.
+    /// </summary>
     private static object?[] MessageValues(
         string flag = "", string status = "unread", bool attachments = false,
         string from = "Chris Lee", string subject = "Budget review",
         string preview = "Lunch tomorrow?", string date = "2:14P",
         bool isUnread = true, bool replied = false, bool forwarded = false,
-        string to = "", string folder = "", bool mailingList = false)
+        string to = "", string folder = "", bool mailingList = false, bool watched = false)
         => [flag, status, attachments, from, subject, preview, date,
-            isUnread, replied, forwarded, to, folder, mailingList];
+            isUnread, replied, forwarded, to, folder, mailingList, watched];
 
     private static object?[] ConversationValues(
         string subject = "Budget review", int count = 3, string sender = "Chris Lee",
@@ -58,9 +61,11 @@ public class RowSpeechBuilderTests
     {
         // What MessageAccessibleNameConverter emitted for a flagged, unread message with an
         // attachment: "{flag}. {status}. attachments. {from}. {subject}. {preview}. {date}."
+        // The word now comes from the separate "unread" field rather than "status", in the same
+        // position — an unread row is unchanged by the #558 default change.
         var text = RowSpeechBuilder.Build(
             RowKind.Message,
-            MessageValues(flag: "Follow up", status: "unread", attachments: true),
+            MessageValues(flag: "Follow up", isUnread: true, attachments: true),
             Layout(RowKind.Message));
 
         Assert.Equal(
@@ -69,12 +74,53 @@ public class RowSpeechBuilderTests
     }
 
     [Fact]
+    public void DefaultLayout_SaysNothingAboutReadStateOnAReadMessage()
+    {
+        // #558: the app used to say "read" on every read row, and the field that said it had no
+        // speak mode to turn that off. Silence on read is now the default.
+        var text = RowSpeechBuilder.Build(
+            RowKind.Message, MessageValues(isUnread: false), Layout(RowKind.Message));
+
+        Assert.Equal("Chris Lee. Budget review. Lunch tomorrow?. 2:14P.", text);
+        Assert.DoesNotContain("read", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DefaultLayout_SaysUnreadAndRepliedTogether_WhichTheCombinedFieldCouldNot()
+    {
+        // status's priority chain returns "replied" first and never reaches the unread test, so a
+        // replied-but-unread message used to lose its unread state entirely.
+        var text = RowSpeechBuilder.Build(
+            RowKind.Message, MessageValues(isUnread: true, replied: true), Layout(RowKind.Message));
+
+        Assert.StartsWith("unread. replied.", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void DefaultLayout_OmitsFlagAndAttachmentsWhenAbsent()
     {
         var text = RowSpeechBuilder.Build(
-            RowKind.Message, MessageValues(status: "read"), Layout(RowKind.Message));
+            RowKind.Message, MessageValues(), Layout(RowKind.Message));
 
-        Assert.Equal("read. Chris Lee. Budget review. Lunch tomorrow?. 2:14P.", text);
+        Assert.Equal("unread. Chris Lee. Budget review. Lunch tomorrow?. 2:14P.", text);
+    }
+
+    [Fact]
+    public void TheOldSingleWordIsStillAvailableByTurningStatusBackOn()
+    {
+        // The default changed; the capability did not. Anyone who preferred one word restores it.
+        var layout = Layout(RowKind.Message);
+        Field(layout, "status").Enabled  = true;
+        Field(layout, "unread").Enabled  = false;
+        Field(layout, "replied").Enabled = false;
+        // Off-by-default fields are appended, so status starts at the tail; put it back in the
+        // slot it used to hold, behind flag.
+        Move(layout, "status", 1 - layout.FindIndex(f => f.Id == "status"));
+
+        Assert.Equal(
+            "read. Chris Lee. Budget review. Lunch tomorrow?. 2:14P.",
+            RowSpeechBuilder.Build(
+                RowKind.Message, MessageValues(status: "read", isUnread: false), layout));
     }
 
     [Fact]
@@ -195,7 +241,8 @@ public class RowSpeechBuilderTests
     [Fact]
     public void UnreadWhenTrue_SpeaksOnUnreadAndIsSilentOnRead()
     {
-        // "I want to know about unread but not read."
+        // "I want to know about unread but not read." Since #558 this is the shipped default; the
+        // explicit setup stays so the behaviour is pinned independently of what the default is.
         var layout = Layout(RowKind.Message);
         Field(layout, "status").Enabled = false;
         var unread = Field(layout, "unread");
@@ -220,12 +267,11 @@ public class RowSpeechBuilderTests
         unread.Enabled   = true;
         unread.SpeakMode = SpeakMode.Always;
 
-        // Off-by-default fields sit at the end of the shipped layout until the user moves them,
-        // so this reads at the end of the row rather than the front.
-        Assert.EndsWith("2:14P. unread.",
+        // Unread leads the shipped order, so Always is heard at the front of the row.
+        Assert.StartsWith("unread. Chris Lee.",
             RowSpeechBuilder.Build(RowKind.Message, MessageValues(isUnread: true), layout),
             StringComparison.Ordinal);
-        Assert.EndsWith("2:14P. read.",
+        Assert.StartsWith("read. Chris Lee.",
             RowSpeechBuilder.Build(RowKind.Message, MessageValues(isUnread: false), layout),
             StringComparison.Ordinal);
     }
@@ -302,11 +348,13 @@ public class RowSpeechBuilderTests
     [Fact]
     public void ShortValueArrayIsToleratedRatherThanThrowing()
     {
-        // Bindings are still being wired up: the row should say what it can, not crash.
+        // Bindings are still being wired up: the row should say what it can, not crash. Only
+        // flag/status/attachments have arrived, and the unread slot has not — so a state field
+        // reading as absent must stay silent rather than being treated as false-and-spoken.
         var text = RowSpeechBuilder.Build(
-            RowKind.Message, ["", "unread", false], Layout(RowKind.Message));
+            RowKind.Message, ["", "unread", true], Layout(RowKind.Message));
 
-        Assert.Equal("unread.", text);
+        Assert.Equal("attachments.", text);
     }
 
     [Fact]
@@ -318,6 +366,16 @@ public class RowSpeechBuilderTests
         var text = RowSpeechBuilder.Build(RowKind.Message, MessageValues(), layout);
 
         Assert.StartsWith("unread.", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SampleValuesCoverEveryCatalogField()
+    {
+        // Build tolerates a short array by treating the tail as absent, so a helper that falls
+        // behind the catalog does not fail loudly — it just makes the newest fields untestable.
+        Assert.Equal(RowFieldCatalog.For(RowKind.Message).Count, MessageValues().Length);
+        Assert.Equal(RowFieldCatalog.For(RowKind.Conversation).Count, ConversationValues().Length);
+        Assert.Equal(RowFieldCatalog.For(RowKind.SenderGroup).Count, SenderGroupValues().Length);
     }
 
     [Fact]

--- a/QuickMail.Tests/RowSpeechConverterTests.cs
+++ b/QuickMail.Tests/RowSpeechConverterTests.cs
@@ -36,6 +36,7 @@ public class RowSpeechConverterTests
                 "",                    // to
                 folder,                // folder (#423)
                 false,                 // mailingList
+                false,                 // watched
                 settings ?? RowSpeechSettings.Default,
             ],
             typeof(string), parameter: null!, CultureInfo.InvariantCulture);

--- a/QuickMail/Models/RowFieldCatalog.cs
+++ b/QuickMail/Models/RowFieldCatalog.cs
@@ -89,7 +89,11 @@ public static class RowFieldCatalog
     private static readonly RowFieldDef[] MessageFields =
     [
         new("flag",        "Flag",            "Flag",        "FlagLabel",       RowFieldFormat.Text),
-        new("status",      "Status (combined)", "Status",    "ReadStatusLabel", RowFieldFormat.Text),
+        // One word for four states, by priority: replied > forwarded > unread > read. Off by
+        // default since #558 — it cannot say "unread but not read" (it is Text, so it has no
+        // SpeakMode), and its priority chain hides unread on a replied or forwarded message.
+        // The three fields below say the same things separately and each carry a SpeakMode.
+        new("status",      "Read status (combined)", "Status", "ReadStatusLabel", RowFieldFormat.Text),
         new("attachments", "Attachments",     "Attachments", "HasAttachments",  RowFieldFormat.State, "attachments"),
         new("from",        "From",            "From",        "From",            RowFieldFormat.Text),
         new("subject",     "Subject",         "Subject",     "Subject",         RowFieldFormat.Text),
@@ -136,12 +140,22 @@ public static class RowFieldCatalog
 
     // ── Default spoken order, by id ──────────────────────────────────────────
     //
-    // These reproduce the strings the app has always spoken, so an existing user who never
-    // opens the chooser hears exactly what they heard before. The one intentional difference
-    // is that empty fields are now skipped instead of emitting a bare ". ".
+    // The group orders reproduce the strings the app has always spoken. The message order does
+    // too for an unread message, but deliberately no longer does for a read one: #558 reported
+    // that the app said "read" on every read row with no way to switch that off, because the
+    // combined "status" field owned the wording and, being a Text field, has no SpeakMode.
+    //
+    // Decomposing it into unread/replied/forwarded — each a State field, each defaulting to
+    // "speak only when true" — means an unread row still says "unread" in the same position, a
+    // read row says nothing about read state, and a replied-but-unread row says both instead of
+    // only "replied". Anyone who wants the old single word turns "status" back on and these off.
+    //
+    // Only users with no rowlayout.json see this change; Reconcile never re-enables a field a
+    // saved layout already covers.
 
     private static readonly string[] MessageDefaultOrder =
-        ["flag", "status", "attachments", "from", "subject", "preview", "date", "folder"];
+        ["flag", "unread", "replied", "forwarded", "attachments",
+         "from", "subject", "preview", "date", "folder"];
 
     private static readonly string[] ConversationDefaultOrder =
         ["subject", "count", "sender", "flag", "hasunread", "preview", "date"];

--- a/QuickMail/QuickMail.csproj
+++ b/QuickMail/QuickMail.csproj
@@ -15,9 +15,9 @@
          System.Windows(.Media) types this codebase uses unqualified (Point, Size, Color, Brush,
          Application, MessageBox, ...). -->
     <UseWindowsForms>true</UseWindowsForms>
-    <Version>0.8.40</Version>
-    <AssemblyVersion>0.8.40</AssemblyVersion>
-    <FileVersion>0.8.40</FileVersion>
+    <Version>0.8.41</Version>
+    <AssemblyVersion>0.8.41</AssemblyVersion>
+    <FileVersion>0.8.41</FileVersion>
     <!-- Velopack needs a hand-written Main that runs VelopackApp.Build().Run() before WPF
          initializes (install/update/uninstall hooks run and may exit the process). App.xaml
          therefore compiles as Page (no generated Main) and the entry point is declared here. -->

--- a/QuickMail/ViewModels/RowFieldsViewModel.cs
+++ b/QuickMail/ViewModels/RowFieldsViewModel.cs
@@ -141,7 +141,16 @@ public sealed partial class RowFieldsViewModel : ObservableObject
     [NotifyCanExecuteChangedFor(nameof(MoveDownCommand))]
     private RowFieldRow? _selectedField;
 
-    partial void OnSelectedFieldChanged(RowFieldRow? value) => UpdateSelectedFieldNote();
+    partial void OnSelectedFieldChanged(RowFieldRow? value)
+    {
+        // Recompute under the flag so the note's own change handler stays quiet, then announce
+        // once here — whether or not the text differs from the field the user just left.
+        _selectionChanging = true;
+        try { UpdateSelectedFieldNote(); }
+        finally { _selectionChanging = false; }
+
+        AnnounceSelectedFieldNote();
+    }
 
     public bool HasSelection    => SelectedField is not null;
     public bool SelectedIsState => SelectedField?.IsState == true;
@@ -215,15 +224,34 @@ public sealed partial class RowFieldsViewModel : ObservableObject
     [ObservableProperty]
     private string _selectedFieldNote = string.Empty;
 
+    /// <summary>True while a selection change is recomputing the note, so it announces once.</summary>
+    private bool _selectionChanging;
+
     /// <summary>
-    /// Speaks the note when the selection lands on a field that has one. It is a
-    /// <see cref="AnnouncementCategory.Hint"/>, and the View does not interrupt hints, so it
-    /// follows the field name rather than talking over it. Silence is never announced — a field
-    /// with no note must not produce "" as an utterance.
+    /// Speaks the note when the user toggles the selected field and that changes what the note
+    /// says. The selection path announces separately, in <see cref="OnSelectedFieldChanged"/>.
     /// </summary>
     partial void OnSelectedFieldNoteChanged(string value)
     {
-        if (!string.IsNullOrEmpty(value)) Announce(value, AnnouncementCategory.Hint);
+        if (!_selectionChanging) AnnounceSelectedFieldNote();
+    }
+
+    /// <summary>
+    /// Speaks the selected field's note, if it has one. A
+    /// <see cref="AnnouncementCategory.Hint"/>, which the View does not interrupt, so it follows
+    /// the field name rather than talking over it. Silence is never announced — a field with no
+    /// note must not produce "" as an utterance.
+    ///
+    /// <para>Landing on a field announces unconditionally rather than only when the text changed:
+    /// two fields can carry the <em>same</em> note, since "Turn this field on…" applies to every
+    /// state field that is off. Keying the announcement off value inequality meant the second of
+    /// two such fields said nothing at all — arrowing from Mailing list to Watched explained the
+    /// first and left the second looking like it behaved differently.</para>
+    /// </summary>
+    private void AnnounceSelectedFieldNote()
+    {
+        if (!string.IsNullOrEmpty(SelectedFieldNote))
+            Announce(SelectedFieldNote, AnnouncementCategory.Hint);
     }
 
     // Fields that say the same thing as "status", and therefore double up with it.

--- a/QuickMail/ViewModels/RowFieldsViewModel.cs
+++ b/QuickMail/ViewModels/RowFieldsViewModel.cs
@@ -132,6 +132,7 @@ public sealed partial class RowFieldsViewModel : ObservableObject
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(HasSelection))]
     [NotifyPropertyChangedFor(nameof(SelectedIsState))]
+    [NotifyPropertyChangedFor(nameof(SelectedIsOn))]
     [NotifyPropertyChangedFor(nameof(SpeakWhenTrue))]
     [NotifyPropertyChangedFor(nameof(SpeakAlways))]
     [NotifyPropertyChangedFor(nameof(CanMoveUp))]
@@ -144,6 +145,15 @@ public sealed partial class RowFieldsViewModel : ObservableObject
 
     public bool HasSelection    => SelectedField is not null;
     public bool SelectedIsState => SelectedField?.IsState == true;
+
+    /// <summary>
+    /// Whether the selected field is turned on. Gates the speak-mode radios: <c>RowSpeechBuilder</c>
+    /// skips a disabled field before it ever looks at <see cref="SpeakMode"/>, so offering the
+    /// choice for a field that is off offers a setting that cannot do anything — which is half of
+    /// what #558 reported ("uncheck the field, then set speak only when true", and nothing happens).
+    /// Move Up/Down already say "Not spoken" for the same reason.
+    /// </summary>
+    public bool SelectedIsOn => SelectedField?.Enabled == true;
 
     public bool CanMoveUp   => SelectedField is not null && Fields.IndexOf(SelectedField) > 0;
     public bool CanMoveDown => SelectedField is not null && Fields.IndexOf(SelectedField) < Fields.Count - 1;
@@ -196,37 +206,59 @@ public sealed partial class RowFieldsViewModel : ObservableObject
     private string _preview = string.Empty;
 
     /// <summary>
-    /// Guidance about the selected field, shown in the options pane. Its main job is the overlap
-    /// between "Status (combined)" and the separate Unread/Replied/Forwarded fields: both produce
-    /// the word "unread", so turning one on while the other is already on says it twice, and
-    /// turning one on without turning the other off looks like the setting did nothing.
+    /// Guidance about the selected field, shown in the options pane and spoken as a hint when the
+    /// selection lands on a field that has one. Two jobs: the overlap between "Read status
+    /// (combined)" and the separate Unread/Replied/Forwarded fields, which all produce the word
+    /// "unread" and so say it twice when both halves are on; and telling the user why the
+    /// speak-mode radios are unavailable on a field that is turned off (#558).
     /// </summary>
     [ObservableProperty]
     private string _selectedFieldNote = string.Empty;
 
+    /// <summary>
+    /// Speaks the note when the selection lands on a field that has one. It is a
+    /// <see cref="AnnouncementCategory.Hint"/>, and the View does not interrupt hints, so it
+    /// follows the field name rather than talking over it. Silence is never announced — a field
+    /// with no note must not produce "" as an utterance.
+    /// </summary>
+    partial void OnSelectedFieldNoteChanged(string value)
+    {
+        if (!string.IsNullOrEmpty(value)) Announce(value, AnnouncementCategory.Hint);
+    }
+
     // Fields that say the same thing as "status", and therefore double up with it.
     private static readonly string[] StatusParts = ["unread", "replied", "forwarded"];
+
+    private const string StatusName = "Read status (combined)";
 
     private void UpdateSelectedFieldNote()
     {
         if (SelectedField is not { } field) { SelectedFieldNote = string.Empty; return; }
 
-        bool StatusOn() => Fields.Any(f => f.Id == "status" && f.Enabled);
+        bool StatusOn()  => Fields.Any(f => f.Id == "status" && f.Enabled);
         bool AnyPartOn() => Fields.Any(f => StatusParts.Contains(f.Id) && f.Enabled);
 
         SelectedFieldNote = field.Id switch
         {
-            "status" when AnyPartOn() =>
+            // Both halves on. Only worth saying when this field is itself spoken — an off field
+            // cannot double anything, and its own note (below) is the more useful one.
+            "status" when field.Enabled && AnyPartOn() =>
                 "Says one word: replied, forwarded, unread, or read. Unread, Replied or Forwarded "
                 + "is also on, so that word is said twice — turn this off to use those instead.",
 
-            "status" =>
-                "Says one word: replied, forwarded, unread, or read. Turn it off if you would "
-                + "rather place Unread, Replied and Forwarded separately.",
+            _ when StatusParts.Contains(field.Id) && field.Enabled && StatusOn() =>
+                $"{StatusName} is also on and already says this, so it is said twice. "
+                + $"Turn {StatusName} off to use this field on its own.",
 
-            _ when StatusParts.Contains(field.Id) && StatusOn() =>
-                "Status (combined) is also on and already says this, so it is said twice. "
-                + "Turn Status (combined) off to use this field on its own.",
+            // Why the speak-mode radios are greyed out.
+            _ when field.IsState && !field.Enabled =>
+                "Turn this field on to choose when it is spoken.",
+
+            "status" =>
+                "Says one word: replied, forwarded, unread, or read — whichever applies first, so "
+                + "a replied message never says unread. Off by default: Unread, Replied and "
+                + "Forwarded say the same things separately and can each be set to speak only "
+                + "when true.",
 
             _ => string.Empty,
         };
@@ -299,6 +331,9 @@ public sealed partial class RowFieldsViewModel : ObservableObject
     {
         if (_suppressSave) return;
         RefreshSpeakMode();
+        // Ticking the selected field's check box is what makes the speak-mode radios available,
+        // so the gate has to re-evaluate here and not only when the selection moves.
+        OnPropertyChanged(nameof(SelectedIsOn));
         SaveLayouts();
         UpdatePreview();
     }
@@ -352,8 +387,11 @@ public sealed partial class RowFieldsViewModel : ObservableObject
     };
 
     /// <summary>
-    /// A synthetic row that exercises every field, so turning any of them on shows something.
-    /// Positional, in <see cref="RowFieldCatalog.For"/> order.
+    /// A synthetic row for the preview when the real selection is not of this kind. Positional, in
+    /// <see cref="RowFieldCatalog.For"/> order — one entry per catalog field, so appending a field
+    /// to the catalog means appending one here too. <c>RowSpeechBuilder.Build</c> tolerates a short
+    /// array by treating the tail as absent, which is why a missing entry showed up as a field that
+    /// silently never previews rather than as a crash (<c>watched</c> did exactly that).
     /// </summary>
     internal static object?[] SampleValues(RowKind kind) => kind switch
     {
@@ -372,6 +410,7 @@ public sealed partial class RowFieldsViewModel : ObservableObject
             "Sales Team",       // to
             "Work — Archive",   // folder
             false,              // mailing list
+            false,              // watched
         ],
         RowKind.Conversation =>
         [

--- a/QuickMail/Views/AccountManagerDialog.xaml
+++ b/QuickMail/Views/AccountManagerDialog.xaml
@@ -139,6 +139,7 @@
                     <TextBox x:Name="SharedSummaryText"
                              Text="{Binding SharedParentName, Mode=OneWay, StringFormat=Reads through {0}. Mail only — no separate sign-in.}"
                              IsReadOnly="True"
+                             IsReadOnlyCaretVisible="True"
                              TextWrapping="Wrap"
                              AutomationProperties.LabeledBy="{Binding ElementName=LblSharedParent}"/>
                 </StackPanel>

--- a/QuickMail/Views/EventEditorWindow.xaml
+++ b/QuickMail/Views/EventEditorWindow.xaml
@@ -227,6 +227,7 @@
                  Text="{Binding ErrorText, Mode=OneWay}"
                  Visibility="{Binding HasError, Converter={StaticResource BoolToVis}}"
                  IsReadOnly="True"
+                 IsReadOnlyCaretVisible="True"
                  TextWrapping="Wrap"
                  Foreground="{DynamicResource Theme.Error}"
                  Margin="0,0,0,8"/>

--- a/QuickMail/Views/PropertiesWindow.xaml
+++ b/QuickMail/Views/PropertiesWindow.xaml
@@ -74,8 +74,11 @@
                           Visibility="{Binding RawHeaders, Converter={StaticResource NullToCollapsed}}"
                           Margin="0,4,0,0"
                           AutomationProperties.Name="Raw headers">
+                    <!-- IsReadOnlyCaretVisible: without a caret there is no insertion point to
+                         move, so only the first line of this multi-line value can be read (#558). -->
                     <TextBox Text="{Binding RawHeaders, Mode=OneWay}"
                              IsReadOnly="True"
+                             IsReadOnlyCaretVisible="True"
                              AcceptsReturn="True"
                              TextWrapping="Wrap"
                              VerticalScrollBarVisibility="Auto"

--- a/QuickMail/Views/RowFieldsWindow.xaml
+++ b/QuickMail/Views/RowFieldsWindow.xaml
@@ -47,9 +47,15 @@
         <Border DockPanel.Dock="Bottom" Padding="8,4,8,0">
             <StackPanel>
                 <TextBlock Text="Spoken preview" FontWeight="SemiBold" Margin="0,0,0,2"/>
+                <!-- IsReadOnlyCaretVisible + AcceptsReturn: without the caret a read-only TextBox
+                     has no insertion point to move, so the content is only ever reachable as a
+                     single value and lines past the first cannot be read (#558). This is the same
+                     pairing the reading-pane header fields use. -->
                 <TextBox x:Name="PreviewBox"
                          Text="{Binding Preview, Mode=OneWay}"
                          IsReadOnly="True"
+                         IsReadOnlyCaretVisible="True"
+                         AcceptsReturn="True"
                          TextWrapping="Wrap"
                          MinHeight="44"
                          VerticalScrollBarVisibility="Auto"
@@ -135,8 +141,12 @@
                 <StackPanel>
                     <TextBlock Text="Field options" FontWeight="SemiBold" Margin="0,0,0,4"/>
 
-                    <!-- Shown only for state fields (unread, attachments, replied…) -->
+                    <!-- Shown only for state fields (unread, attachments, replied…), and available
+                         only while that field is turned on: RowSpeechBuilder skips a disabled field
+                         before it looks at SpeakMode, so the choice would have no effect (#558).
+                         SelectedFieldNote says why when it is unavailable. -->
                     <StackPanel x:Name="SpeakModeGroup"
+                                IsEnabled="{Binding SelectedIsOn}"
                                 KeyboardNavigation.TabNavigation="Once"
                                 KeyboardNavigation.DirectionalNavigation="Cycle"
                                 helpers:RadioGroupNavigation.SelectionFollowsFocus="True"
@@ -184,7 +194,11 @@
                     <TextBox x:Name="FieldNoteBox"
                              Text="{Binding SelectedFieldNote, Mode=OneWay}"
                              IsReadOnly="True"
+                             IsReadOnlyCaretVisible="True"
+                             AcceptsReturn="True"
                              TextWrapping="Wrap"
+                             MaxHeight="120"
+                             VerticalScrollBarVisibility="Auto"
                              BorderThickness="0"
                              Background="Transparent"
                              Margin="0,8,0,0"

--- a/QuickMail/Views/RowFieldsWindow.xaml.cs
+++ b/QuickMail/Views/RowFieldsWindow.xaml.cs
@@ -49,8 +49,14 @@ public partial class RowFieldsWindow : Window
         };
     }
 
+    /// <summary>
+    /// Results interrupt; hints do not. A hint here rides on a selection change — the field note
+    /// fires as the user arrows the list — so interrupting would replace the field name the
+    /// platform is speaking with the note about it, which is the wrong half to lose.
+    /// </summary>
     private void OnAnnouncement(string text, AnnouncementCategory category) =>
-        AccessibilityHelper.Announce(this, text, interrupt: true, category: category);
+        AccessibilityHelper.Announce(this, text,
+            interrupt: category != AnnouncementCategory.Hint, category: category);
 
     private void RegisterLocalCommands()
     {

--- a/QuickMail/Views/SpellCheckDialog.xaml
+++ b/QuickMail/Views/SpellCheckDialog.xaml
@@ -40,6 +40,8 @@
                      Text="{Binding ContextLine, Mode=OneWay}"
                      AutomationProperties.Name="Not in dictionary"
                      IsReadOnly="True"
+                     IsReadOnlyCaretVisible="True"
+                     AcceptsReturn="True"
                      TextWrapping="Wrap"
                      VerticalScrollBarVisibility="Auto"
                      Height="56"

--- a/docs/release-notes-v0.8.41.md
+++ b/docs/release-notes-v0.8.41.md
@@ -1,0 +1,101 @@
+# QuickMail v0.8.41 Release Notes
+
+## Download
+
+There are four downloads. Take a regular one unless you know your PC has an ARM processor — to check, open **Settings → System → About** and read **System type**.
+
+| Download | When to use |
+|----------|-------------|
+| **`QuickMail-0.8.41-win.msi`** — Windows installer | Recommended for most users. A standard setup wizard with license agreement; installs per-user with no elevation required, adds the WebView2 Runtime if missing, and enables automatic updates. |
+| **`QuickMail-0.8.41-win-arm64.msi`** — Windows installer, ARM | The same installer for PCs with an ARM processor, such as the Snapdragon X models of Surface Laptop and Surface Pro. |
+| **`QuickMail.exe`** — standalone portable executable | No installation required. Copy it anywhere and run. |
+| **`QuickMail-arm64.exe`** — standalone portable executable, ARM | The portable version for PCs with an ARM processor. |
+
+The regular downloads run on every supported PC, ARM ones included — just not as quickly there. The ARM downloads will not start at all on a non-ARM PC, so if you are unsure, the regular one is the safe guess.
+
+All downloads include the .NET 8 runtime — you do not need to install .NET separately.
+
+---
+
+## Changed: hearing "unread" without also hearing "read"
+
+Arrowing through the message list used to say **read** on every message you had already read. Plenty
+of people want to know which messages are unread and have no use at all for being told, once per row,
+about the ones they have finished with — and there was no way to switch the one off and keep the
+other.
+
+The reason was buried in **View → Message List Fields**. The field doing the talking was called
+**Status (combined)**, and it says exactly one word per message — *replied*, *forwarded*, *unread* or
+*read*, whichever fits first. Being a single word, it has no "only when true" choice, so *read* came
+with *unread* whether you wanted it or not. There was a separate **Unread** field that does have that
+choice, but it arrived switched off — so anyone hunting for the unread setting found a switched-off
+box named Unread while the list was plainly saying "unread", switched it off and on again, and heard
+nothing change.
+
+QuickMail now uses **Unread**, **Replied** and **Forwarded** as three separate fields, each set to
+speak only when it applies. In practice:
+
+- An unread message says **unread**, in the same place in the row as before.
+- A message you have read says **nothing at all** about read state.
+- A message that is unread *and* replied to now says **both**. The old single word could only ever
+  say *replied*, so the fact that it was still unread went unsaid.
+
+The combined field is still there, renamed **Read status (combined)** so its name mentions the thing
+it speaks. If you preferred the one-word version, switch it back on and switch the three separate
+fields off.
+
+### If you have opened Message List Fields before, please read this
+
+**Your existing setup is kept exactly as it is**, which means this change does not reach you
+automatically — QuickMail will not overwrite choices you have made. If you have ever opened
+**View → Message List Fields**, even just to look, your arrangement was saved at that moment.
+
+To pick up the new behaviour: open **View → Message List Fields**, leave **Row type** on **Messages**,
+and press **Reset to Defaults**. That is the whole job. If you had arranged other fields the way you
+like them, note that Reset restores everything on that row type, so you may want to set those back
+afterwards — or simply switch **Read status (combined)** off and **Unread** on by hand, which gets you
+the same result without disturbing anything else.
+
+([#558](https://github.com/kellylford/QuickMail/issues/558))
+
+## Fixed: "speak only when true" did nothing on a field that was switched off
+
+In **View → Message List Fields**, the **Speak only when true** and **Always speak** choices stayed
+available for a field you had just switched off — and setting them did nothing whatever, because a
+field that is off is not spoken at any time. Following the obvious path of switching a field off and
+then choosing when it should speak left you with a setting that looked applied and had no effect.
+
+Those two choices are now unavailable while the field is switched off, and the field's description
+says why: *Turn this field on to choose when it is spoken.* ([#558](https://github.com/kellylford/QuickMail/issues/558))
+
+## Fixed: the explanations in Message List Fields were announced first line only
+
+The **Spoken preview** and the description of the selected field are boxes you can move through and
+copy from, but they had no cursor to move — so screen readers reached the first line and no further.
+Both now behave like any other read-only box in QuickMail: arrow through them a line at a time, select
+and copy as usual.
+
+The same gap was fixed in four other places with the same kind of box: the raw message headers under
+**Message → Properties**, the context line in the spell check window, the shared-mailbox note in
+Manage Accounts, and the error line in the appointment editor.
+([#558](https://github.com/kellylford/QuickMail/issues/558))
+
+## Fixed: a field description was sometimes skipped
+
+Still in **View → Message List Fields**: when two fields in a row carried the same description —
+"Turn this field on to choose when it is spoken" applies to every switched-off field of that kind —
+the description was announced for the first and silently skipped for the second. Arrowing from
+**Mailing list** to **Watched** explained one and said nothing about the other. Every field now
+announces its own description.
+
+---
+
+## Reporting Issues
+
+Found a problem or have a suggestion? There are three ways to reach us — pick the one that fits:
+
+1. **Report a Bug → Send** (Help menu, inside QuickMail). Files the report for you anonymously — it includes no email address or other identifying information, so there is no way to follow up with you. **Best when you don't want any follow-up.**
+2. **Report a Bug → Copy report and open GitHub** (Help menu). Opens a pre-filled issue that you submit under your own GitHub account, so your GitHub contact information is attached. **Best when you have a GitHub account and want automatic filing plus direct contact.**
+3. **Email** [quickmailissues@theideaplace.net](mailto:quickmailissues@theideaplace.net). **Best when you don't mind sending email and want a personal follow-up.**
+
+Full details, including exactly what a report contains (and what it never contains), are in the [Reporting Issues section of the User Guide](https://kellylford.github.io/QuickMail/reporting-issues.html).


### PR DESCRIPTION
Closes #558.

## What was wrong

The field speaking read state by default was **Status (combined)** — a Text field, so it carries no `SpeakMode`. It says one word by priority (`replied > forwarded > unread > read`), which means it could neither be silenced on read messages nor report unread on a replied one. The separate **Unread** field, which does carry a `SpeakMode`, shipped disabled. So the reporter found a checkbox named Unread that was off while the app plainly said "unread", and toggling it changed nothing.

## What changed

- **Default decomposed** into `unread` / `replied` / `forwarded`, each a State field defaulting to *speak only when true*. An unread row says "unread" in the same position as before; a read row says nothing about read state; a replied-but-unread row now says both instead of only "replied". The combined field remains, renamed **Read status (combined)**, for anyone who prefers one word.
- **Speak-mode radios gated on the field being on.** `RowSpeechBuilder` skips a disabled field before it ever reads `SpeakMode`, so the choice was inert — half of what #558 reported. The field note now says why.
- **The field note is spoken**, as a `Hint`, which this window no longer interrupts, so it follows the field name instead of replacing it. It already carried exactly the guidance the reporter needed and was only ever visible to someone who tabbed to it.
- **`SampleValues` supplied 13 values for 14 catalog fields**, so `watched` never appeared in the preview. Fixed, with a guard test on both it and the test helpers.
- **Read-only multi-line text boxes** with no `IsReadOnlyCaretVisible` have no insertion point to move, so only their first line can be read. Added to the two boxes in this window and the four elsewhere with the same gap: raw headers, spell check context, shared-mailbox summary, event editor error.

## Upgrade behaviour — deliberate

The new default only reaches users with **no `rowlayout.json`**: `Reconcile` never re-enables a field a saved layout already covers. That includes the reporter, whose file exists precisely because they went looking for this setting. By decision this is carried in the release notes rather than by migrating saved layouts — the notes tell existing users to press **Reset to Defaults** on the Messages row type, or make the two-field change by hand.

## Review

Independent review raised two findings; both addressed — the upgrade gap above (release notes, as decided) and a bug where two fields sharing the same note text announced only on the first (`Mailing list` → `Watched`). A third suspected issue, that `AcceptsReturn` on the read-only Spell Check context box would swallow Enter from the `IsDefault` Change button, was tested and disproved: `AcceptsReturn` only swallows Enter on an *editable* box.

## Testing

`dotnet test -c Release`, 0 failures. The full run hits the known nondeterministic host crash that silently truncates the suite (2731 and 3015 executed on two runs, crashing at different points), so the affected classes were re-run under filter to confirm they actually executed: **104** row-speech/row-fields/row-layout tests and **189** XAML/accessibility tests, all passing.

Also bumps the version to 0.8.41 and adds `docs/release-notes-v0.8.41.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)