### PR TITLE
Measure the winget install paths on CI (#536)

### DIFF
--- a/.github/workflows/winget-install-matrix.yml
+++ b/.github/workflows/winget-install-matrix.yml
@@ -1,0 +1,176 @@
+name: Winget install-path matrix
+
+# Measures QuickMail's installer behaviour across every install and upgrade path winget can
+# put a machine through, on GitHub-hosted runners, for issue #536.
+#
+# Why this exists: the winget plan's Phase 1 was done by hand on one ARM64 machine. That left
+# three gaps that the plan's own conclusions depend on — x64 was never tested, Setup.exe over
+# an MSI-installed copy (the path every existing user takes when they move to winget) was
+# never tested at all, and the winget correlation claims were inferred from registry state
+# rather than measured. Hand-testing does not scale to a matrix and cannot be re-run against
+# a future vpk, so it lives here instead.
+#
+# It packs two synthetic versions with the *same* vpk arguments the release workflow uses,
+# then walks the scenarios in scripts/winget-install-matrix.ps1. Nothing is signed: signing
+# does not affect install location, Add/Remove Programs registration, or upgrade semantics,
+# which is all this measures, and the Azure OIDC credentials are deliberately reachable only
+# from tag builds.
+#
+# Run it by pushing a branch named test/winget-** , or from the Actions tab once this file is
+# on the default branch.
+
+on:
+  push:
+    branches:
+      - 'test/winget-**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  matrix:
+    name: ${{ matrix.arch }}
+    runs-on: ${{ matrix.runner }}
+    # A leg whose runner label is unavailable, or whose scenarios misbehave badly enough to
+    # abort, must not hide the other leg's results.
+    continue-on-error: true
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x64
+            runner: windows-latest
+            rid: win-x64
+          - arch: arm64
+            runner: windows-11-arm
+            rid: win-arm64
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: '8.0.x'
+
+      # QuickMail.csproj will not compile without these gitignored partial classes. The
+      # values are irrelevant here — nothing in this workflow signs in to anything — so they
+      # are written empty rather than pulled from secrets.
+      - name: Write placeholder credential partials
+        shell: pwsh
+        run: |
+          @'
+          namespace QuickMail.Services;
+          public partial class GoogleOAuthService
+          {
+              private const string ClientId     = "";
+              private const string ClientSecret = "";
+          }
+          '@ | Set-Content -Path "QuickMail/Services/GoogleOAuthService.Credentials.cs" -Encoding UTF8
+          @'
+          namespace QuickMail.Services;
+          public partial class BugReportService
+          {
+              private const string RelayUrl = "";
+              private const string RelayKey = "";
+          }
+          '@ | Set-Content -Path "QuickMail/Services/BugReportService.Credentials.cs" -Encoding UTF8
+
+      # Native publish per leg. The release workflow cross-compiles ARM64 from an x64 runner;
+      # here each leg builds for the machine it will actually install on, because the point is
+      # to run the installer, not just produce it.
+      - name: Publish
+        run: dotnet publish QuickMail/QuickMail.csproj -c Release -r ${{ matrix.rid }} -o publish/
+
+      # Record the version rather than pin it: the release workflow installs vpk unpinned, so
+      # whatever this run measured is only true for the version named here.
+      - name: Install vpk
+        shell: pwsh
+        run: |
+          dotnet tool install -g vpk
+          $v = (vpk --version 2>&1 | Out-String).Trim()
+          Write-Host "vpk version: $v"
+          "VPK_VERSION=$v" | Out-File $env:GITHUB_ENV -Append -Encoding utf8
+
+      # Two packs, same arguments as the release workflow's (minus signing), differing only in
+      # --packVersion. 1.0.0 and 1.0.1 are deliberately not real QuickMail versions so nothing
+      # in the report can be mistaken for a measurement of a shipped artifact.
+      - name: Pack both versions
+        shell: pwsh
+        run: |
+          Copy-Item LICENSE installer/velopack/license.txt
+          $archArgs = @()
+          if ('${{ matrix.arch }}' -eq 'arm64') { $archArgs = @('--runtime', 'win-arm64', '--channel', 'win-arm64') }
+          $suffix = if ('${{ matrix.arch }}' -eq 'arm64') { 'win-arm64' } else { 'win' }
+          foreach ($v in '1.0.0', '1.0.1') {
+            $out = "packs/$v"
+            New-Item -ItemType Directory -Force -Path $out | Out-Null
+            vpk pack --packId QuickMail --packVersion $v --packDir publish `
+              --mainExe QuickMail.exe --packTitle QuickMail --packAuthors "Kelly Ford" `
+              --shortcuts StartMenuRoot --outputDir $out `
+              --framework webview2 `
+              --msi --instLocation PerUser `
+              --instWelcome installer/velopack/welcome.txt `
+              --instLicense installer/velopack/license.txt `
+              --instConclusion installer/velopack/conclusion.txt @archArgs
+            if ($LASTEXITCODE -ne 0) { throw "vpk pack $v failed with exit code $LASTEXITCODE." }
+            # Match the release workflow's rename so the probe exercises the shipped filenames.
+            Rename-Item "$out/QuickMail-$suffix.msi"       "QuickMail-$v-$suffix.msi"
+            Rename-Item "$out/QuickMail-$suffix-Setup.exe" "QuickMail-$v-$suffix-Setup.exe"
+            Write-Host "--- $v ---"
+            Get-ChildItem $out | Select-Object -ExpandProperty Name
+          }
+
+      # Best-effort. winget is not on the Windows Server images; it is on windows-11-arm. The
+      # probe degrades to registry-only evidence when it is missing, and says so in the report,
+      # rather than failing the run.
+      - name: Make winget available (best effort)
+        shell: pwsh
+        continue-on-error: true
+        run: |
+          $ErrorActionPreference = 'Continue'
+          $wa = "$env:LOCALAPPDATA\Microsoft\WindowsApps"
+          if (Test-Path $wa) { $env:PATH = "$wa;$env:PATH"; "$wa" | Out-File $env:GITHUB_PATH -Append -Encoding utf8 }
+          if (Get-Command winget -ErrorAction SilentlyContinue) { winget --version; exit 0 }
+          # Re-register an App Installer that is provisioned but not registered for this user.
+          Get-AppxPackage -AllUsers Microsoft.DesktopAppInstaller -ErrorAction SilentlyContinue | ForEach-Object {
+            Add-AppxPackage -DisableDevelopmentMode -Register "$($_.InstallLocation)\AppXManifest.xml" -ErrorAction SilentlyContinue
+          }
+          if (Get-Command winget -ErrorAction SilentlyContinue) { winget --version; exit 0 }
+          # Otherwise install it from the winget-cli release, dependencies first.
+          try {
+            $rel = Invoke-RestMethod https://api.github.com/repos/microsoft/winget-cli/releases/latest -Headers @{ 'User-Agent' = 'quickmail-ci' }
+            $bundle = ($rel.assets | Where-Object name -like '*.msixbundle')[0]
+            $deps   = ($rel.assets | Where-Object name -like 'DesktopAppInstaller_Dependencies.zip')[0]
+            if ($deps) {
+              Invoke-WebRequest $deps.browser_download_url -OutFile deps.zip
+              Expand-Archive deps.zip -DestinationPath deps -Force
+              $archDir = if ('${{ matrix.arch }}' -eq 'arm64') { 'arm64' } else { 'x64' }
+              Get-ChildItem "deps/$archDir" -Filter *.appx -ErrorAction SilentlyContinue |
+                ForEach-Object { Add-AppxPackage $_.FullName -ErrorAction SilentlyContinue }
+            }
+            Invoke-WebRequest $bundle.browser_download_url -OutFile winget.msixbundle
+            Add-AppxPackage winget.msixbundle -ErrorAction SilentlyContinue
+          } catch { Write-Host "winget install attempt failed: $_" }
+          if (Get-Command winget -ErrorAction SilentlyContinue) { winget --version } else { Write-Host 'winget still unavailable; the probe will report it as such.' }
+
+      - name: Run the install-path matrix
+        shell: pwsh
+        run: |
+          ./scripts/winget-install-matrix.ps1 `
+            -OldDir packs/1.0.0 -NewDir packs/1.0.1 `
+            -OldVersion 1.0.0 -NewVersion 1.0.1 `
+            -Arch '${{ matrix.arch }}' `
+            -Report "winget-matrix-${{ matrix.arch }}.md"
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: winget-matrix-${{ matrix.arch }}
+          path: |
+            winget-matrix-${{ matrix.arch }}.md
+            msi-fresh.log
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/winget-install-matrix.yml
+++ b/.github/workflows/winget-install-matrix.yml
@@ -50,6 +50,21 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # Before the six-minute publish, not after it. The probe script is the last step in
+      # this job, so a syntax error in it costs a full build to discover otherwise — which
+      # it did, once.
+      - name: Syntax-check the probe script
+        shell: pwsh
+        run: |
+          $errors = $null
+          $null = [System.Management.Automation.Language.Parser]::ParseFile(
+            (Resolve-Path ./scripts/winget-install-matrix.ps1), [ref]$null, [ref]$errors)
+          if ($errors) {
+            $errors | ForEach-Object { Write-Host "::error file=scripts/winget-install-matrix.ps1,line=$($_.Extent.StartLineNumber)::$($_.Message)" }
+            throw "$($errors.Count) parse error(s) in scripts/winget-install-matrix.ps1."
+          }
+          Write-Host 'scripts/winget-install-matrix.ps1 parses.'
+
       - uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '8.0.x'

--- a/.github/workflows/winget-install-matrix.yml
+++ b/.github/workflows/winget-install-matrix.yml
@@ -32,11 +32,13 @@ jobs:
   matrix:
     name: ${{ matrix.arch }}
     runs-on: ${{ matrix.runner }}
-    # A leg whose runner label is unavailable, or whose scenarios misbehave badly enough to
-    # abort, must not hide the other leg's results.
-    continue-on-error: true
     timeout-minutes: 60
     strategy:
+      # This alone is what keeps one leg's failure from cancelling the other. Job-level
+      # continue-on-error was here too and did something quite different: it made the run
+      # report success no matter what either leg did. For a harness whose output is cited as
+      # evidence in other PRs, "the run was green" has to mean the measurements happened.
+      # Artifacts still upload on failure (`if: always()` below), so a red leg loses nothing.
       fail-fast: false
       matrix:
         include:
@@ -132,10 +134,22 @@ jobs:
               --instLicense installer/velopack/license.txt `
               --instConclusion installer/velopack/conclusion.txt @archArgs
             if ($LASTEXITCODE -ne 0) { throw "vpk pack $v failed with exit code $LASTEXITCODE." }
-            # Match the release workflow's rename so the probe exercises the shipped filenames.
+            # Record what vpk emitted BEFORE renaming anything. Scenario 0 reports these as
+            # vpk's own filenames, and PR #555 hardcodes those names -- so the listing behind
+            # that claim must not be one this workflow wrote. Kept outside $out so it cannot
+            # be mistaken for a pack artifact.
+            Write-Host "--- $v : as vpk emitted ---"
+            $emitted = Get-ChildItem $out | Select-Object -ExpandProperty Name | Sort-Object
+            $emitted
+            $emitted | Set-Content "packs/vpk-emitted-$v.txt" -Encoding utf8
+            # Rename to the shipped filenames, so the probe installs what users will. This
+            # matches the release workflow for the MSI today, and for Setup.exe once #555
+            # lands -- vpk emits it unversioned as QuickMail-<channel>-Setup.exe. Rename-Item
+            # throws if either name ever changes, which is itself the check that #555's
+            # hardcoded names still hold.
             Rename-Item "$out/QuickMail-$suffix.msi"       "QuickMail-$v-$suffix.msi"
             Rename-Item "$out/QuickMail-$suffix-Setup.exe" "QuickMail-$v-$suffix-Setup.exe"
-            Write-Host "--- $v ---"
+            Write-Host "--- $v : after rename ---"
             Get-ChildItem $out | Select-Object -ExpandProperty Name
           }
 
@@ -179,6 +193,7 @@ jobs:
             -OldDir packs/1.0.0 -NewDir packs/1.0.1 `
             -OldVersion 1.0.0 -NewVersion 1.0.1 `
             -Arch '${{ matrix.arch }}' `
+            -EmittedListing packs/vpk-emitted-1.0.1.txt `
             -Report "winget-matrix-${{ matrix.arch }}.md"
 
       - name: Upload report
@@ -189,5 +204,6 @@ jobs:
           path: |
             winget-matrix-${{ matrix.arch }}.md
             msi-fresh.log
+            packs/vpk-emitted-*.txt
           if-no-files-found: warn
           retention-days: 14

--- a/.github/workflows/winget-install-matrix.yml
+++ b/.github/workflows/winget-install-matrix.yml
@@ -89,7 +89,9 @@ jobs:
         shell: pwsh
         run: |
           dotnet tool install -g vpk
-          $v = (vpk --version 2>&1 | Out-String).Trim()
+          # vpk has no --version; the installed version comes from the tool manifest. Kept to
+          # one line because GITHUB_ENV rejects a multi-line value written this way.
+          $v = ((dotnet tool list -g | Select-String '^vpk\s') -split '\s+')[1]
           Write-Host "vpk version: $v"
           "VPK_VERSION=$v" | Out-File $env:GITHUB_ENV -Append -Encoding utf8
 

--- a/scripts/winget-install-matrix.ps1
+++ b/scripts/winget-install-matrix.ps1
@@ -116,11 +116,16 @@ function Get-MsiProductRows {
 }
 
 function Get-InstallDirs {
+    # Every fixed drive's root, not just C:. A silent MSI install takes the Directory
+    # table's TARGETDIR default, which Windows Installer resolves to the drive with the
+    # most free space -- on a GitHub runner that is D:, and hardcoding C: reported "no
+    # install directories" for an install that had plainly happened.
     $candidates = @(
-        'C:\QuickMail'
+        (Get-PSDrive -PSProvider FileSystem -ErrorAction SilentlyContinue |
+            Where-Object { $null -ne $_.Free } | ForEach-Object { "$($_.Name):\QuickMail" })
         (Join-Path $env:LOCALAPPDATA 'QuickMail')
         (Join-Path $env:ProgramFiles 'QuickMail')
-    )
+    ) | Select-Object -Unique
     $out = @()
     foreach ($c in $candidates) {
         if (-not (Test-Path $c)) { continue }
@@ -151,14 +156,26 @@ function Get-Shortcuts {
 }
 
 function Get-WingetView {
-    <#  winget's own opinion, when it is usable. Reported verbatim rather than parsed:
-        the question is what a user sees, and the raw table is the answer. #>
+    <#  winget's own opinion, when it is usable. Reported verbatim rather than filtered:
+        the question is what a user sees, and an empty filtered result is indistinguishable
+        from a command that refused to run. --accept-source-agreements matters on a fresh
+        machine -- without it, and with interactivity disabled, winget declines rather than
+        prompting, which is exactly how the first run of this probe recorded nothing at
+        all for every scenario. #>
     if (-not $script:WingetAvailable) { return '(winget not available on this runner)' }
     $out = @()
-    foreach ($cmd in @('list --query QuickMail', 'upgrade')) {
-        $text = & { cmd /c "winget $cmd --disable-interactivity 2>&1" } | Out-String
-        $quickmailLines = ($text -split "`r?`n" | Where-Object { $_ -match 'QuickMail|No installed package|No applicable' }) -join "`n"
-        $out += "`$ winget $cmd`n" + ($(if ($quickmailLines) { $quickmailLines } else { '(no QuickMail lines)' }))
+    foreach ($cmd in @('list --accept-source-agreements', 'upgrade --accept-source-agreements')) {
+        $text = (& cmd /c "winget $cmd --disable-interactivity 2>&1" | Out-String)
+        $lines = @($text -split "`r?`n" | Where-Object { $_.Trim() })
+        $hits  = @($lines | Where-Object { $_ -match 'QuickMail' })
+        $body = if ($hits.Count) {
+            ($hits -join "`n")
+        } else {
+            # No QuickMail row: show the head of the raw output so a refusal, an error, or a
+            # genuinely empty list can be told apart.
+            "(no QuickMail row; raw output follows)`n" + (($lines | Select-Object -First 8) -join "`n")
+        }
+        $out += "`$ winget $cmd`n$body"
     }
     return ($out -join "`n`n")
 }
@@ -262,7 +279,7 @@ function Reset-Machine {
             ForEach-Object { Remove-Item $_.PSPath -Recurse -Force -ErrorAction SilentlyContinue }
     }
 
-    foreach ($d in @('C:\QuickMail', (Join-Path $env:LOCALAPPDATA 'QuickMail'), (Join-Path $env:APPDATA 'QuickMail'))) {
+    foreach ($d in (@(Get-InstallDirs | ForEach-Object { $_.Path }) + (Join-Path $env:APPDATA 'QuickMail'))) {
         Remove-Item $d -Recurse -Force -ErrorAction SilentlyContinue
     }
     Get-ChildItem (Join-Path $env:APPDATA 'Microsoft\Windows\Start Menu\Programs') -Recurse -Filter '*QuickMail*.lnk' -ErrorAction SilentlyContinue |
@@ -275,18 +292,12 @@ function Reset-Machine {
 # --- install primitives --------------------------------------------------------------
 
 function Invoke-Installer {
-    param([string]$Path, [string[]]$Arguments, [hashtable]$EnvVars = @{})
-
-    foreach ($k in $EnvVars.Keys) { Set-Item "env:$k" $EnvVars[$k] }
-    try {
-        $sw = [Diagnostics.Stopwatch]::StartNew()
-        $p = Start-Process -FilePath $Path -ArgumentList $Arguments -Wait -PassThru
-        $sw.Stop()
-        Get-Process QuickMail -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
-        return [pscustomobject]@{ ExitCode = $p.ExitCode; Seconds = [math]::Round($sw.Elapsed.TotalSeconds, 1) }
-    } finally {
-        foreach ($k in $EnvVars.Keys) { Remove-Item "env:$k" -ErrorAction SilentlyContinue }
-    }
+    param([string]$Path, [string[]]$Arguments)
+    $sw = [Diagnostics.Stopwatch]::StartNew()
+    $p = Start-Process -FilePath $Path -ArgumentList $Arguments -Wait -PassThru
+    $sw.Stop()
+    Get-Process QuickMail -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+    return [pscustomobject]@{ ExitCode = $p.ExitCode; Seconds = [math]::Round($sw.Elapsed.TotalSeconds, 1) }
 }
 
 function Get-PackedFile {
@@ -396,13 +407,24 @@ Invoke-Scenario 'Scenario 1 -- silent MSI, fresh machine' `
 Invoke-Scenario 'Scenario 2 -- Setup.exe over an MSI install (the migration path)' `
     'Every existing user installed from the MSI wizard into %LocalAppData%. What does `winget install`/`upgrade` -- that is, `Setup.exe --silent` -- do to that machine?' {
     # Reproduce the wizard's install location without driving the wizard: VELOPACK_INSTALLDIR
-    # is exactly what the Next button sets, per the #554 investigation.
+    # is exactly what the Next button sets, per the #554 investigation. It must be passed as
+    # an msiexec PROPERTY, not an environment variable -- the install runs in the Windows
+    # Installer service, which does not inherit this process's environment. Setting it as an
+    # env var silently did nothing, and the first run of this probe measured an MSI install
+    # sitting on D:\ while claiming to be the wizard-equivalent %LocalAppData% one.
     $target = Join-Path $env:LOCALAPPDATA 'QuickMail'
-    $r1 = Invoke-Installer 'msiexec.exe' @('/i', "`"$oldMsi`"", '/qn') -EnvVars @{ VELOPACK_INSTALLDIR = $target }
+    $r1 = Invoke-Installer 'msiexec.exe' @('/i', "`"$oldMsi`"", '/qn', "VELOPACK_INSTALLDIR=`"$target`"")
     Write-Section "Step 1 -- MSI $OldVersion into ``%LocalAppData%\QuickMail`` (wizard-equivalent): exit $($r1.ExitCode) in $($r1.Seconds)s"
     Write-Section ''
     $before = Get-Snapshot "after MSI $OldVersion (wizard-equivalent)"
     Write-Section (Format-Snapshot $before)
+
+    # Assert the premise before measuring anything on top of it. If the MSI did not land
+    # where the wizard would have put it, this scenario is not the migration path and its
+    # result must not be read as one.
+    if (-not (@($before.Dirs | Where-Object { $_.Path -eq $target }).Count)) {
+        throw "Premise failed: the MSI did not install to $target, so this is not the wizard-equivalent starting state. Installed instead at: $(($before.Arp | ForEach-Object { $_.InstallLocation }) -join ', ')"
+    }
 
     $r2 = Invoke-Installer $newSetup @('--silent')
     Write-Section "Step 2 -- ``Setup.exe --silent`` $NewVersion over it: exit $($r2.ExitCode) in $($r2.Seconds)s"
@@ -481,7 +503,7 @@ Invoke-Scenario 'Scenario 5 -- MSI over a Setup.exe install (the reverse migrati
     Write-Section "Step 1 -- ``Setup.exe --silent`` ${OldVersion}: exit $($r1.ExitCode) in $($r1.Seconds)s"
     Write-Section ''
     $target = Join-Path $env:LOCALAPPDATA 'QuickMail'
-    $r2 = Invoke-Installer 'msiexec.exe' @('/i', "`"$newMsi`"", '/qn') -EnvVars @{ VELOPACK_INSTALLDIR = $target }
+    $r2 = Invoke-Installer 'msiexec.exe' @('/i', "`"$newMsi`"", '/qn', "VELOPACK_INSTALLDIR=`"$target`"")
     Write-Section "Step 2 -- MSI $NewVersion over it (wizard-equivalent location): exit $($r2.ExitCode) in $($r2.Seconds)s"
     Write-Section ''
     $after = Get-Snapshot "after MSI $NewVersion over Setup.exe $OldVersion"

--- a/scripts/winget-install-matrix.ps1
+++ b/scripts/winget-install-matrix.ps1
@@ -6,7 +6,7 @@
 .DESCRIPTION
   Written for issue #536 (winget distribution). The winget plan's Phase 1 was done by hand
   on one ARM64 machine and left three gaps: x64 was never tested, Setup.exe over an
-  MSI-installed copy — the path every existing user takes — was never tested at all, and
+  MSI-installed copy -- the path every existing user takes -- was never tested at all, and
   the winget correlation claims were inferred from registry state rather than measured.
 
   This script closes those gaps on a CI runner, so the answers are reproducible and nobody
@@ -30,7 +30,7 @@
 .NOTES
   Non-destructive on a developer machine only in the sense that it removes QuickMail.
   It uninstalls QuickMail repeatedly and deletes its install directories. Do not run it
-  on a machine with a QuickMail install you care about — it is meant for CI runners.
+  on a machine with a QuickMail install you care about -- it is meant for CI runners.
 #>
 [CmdletBinding()]
 param(
@@ -64,7 +64,7 @@ $UninstallRoots = @(
 function Get-ArpRows {
     <#  Every Add/Remove Programs row that mentions QuickMail, from all three hives.
         SystemComponent is carried through because an MSI row with SystemComponent=1 is
-        hidden from Settings > Apps but is still a real product registration — the
+        hidden from Settings > Apps but is still a real product registration -- the
         distinction the migration question turns on. #>
     $rows = @()
     foreach ($root in $UninstallRoots) {
@@ -190,14 +190,14 @@ function Format-Snapshot {
         foreach ($r in $Snap.Arp) {
             $hidden = if ($r.SystemComponent -eq 1) { 'yes' } else { 'no' }
             $loc = if ($r.InstallLocation) { $r.InstallLocation.Replace($env:LOCALAPPDATA, '%LocalAppData%') } else { '' }
-            $q = if ($r.QuietUninstallString) { '`' + $r.QuietUninstallString.Replace($env:LOCALAPPDATA, '%LocalAppData%') + '`' } else { '—' }
+            $q = if ($r.QuietUninstallString) { '`' + $r.QuietUninstallString.Replace($env:LOCALAPPDATA, '%LocalAppData%') + '`' } else { '--' }
             [void]$sb.AppendLine("| $($r.Scope) | ``$($r.KeyName)`` | $($r.DisplayName) | $($r.DisplayVersion) | $hidden | $loc | $q |")
         }
         [void]$sb.AppendLine()
     }
 
     [void]$sb.AppendLine("Windows Installer product registrations: **$($Snap.MsiProducts.Count)**" +
-        $(if ($Snap.MsiProducts.Count) { ' — ' + (($Snap.MsiProducts | ForEach-Object { "$($_.Scope) $($_.ProductName)" }) -join '; ') } else { '' }))
+        $(if ($Snap.MsiProducts.Count) { ' -- ' + (($Snap.MsiProducts | ForEach-Object { "$($_.Scope) $($_.ProductName)" }) -join '; ') } else { '' }))
     [void]$sb.AppendLine()
 
     [void]$sb.AppendLine('Install directories:')
@@ -205,7 +205,7 @@ function Format-Snapshot {
     if ($Snap.Dirs.Count) {
         foreach ($d in $Snap.Dirs) {
             $p = $d.Path.Replace($env:LOCALAPPDATA, '%LocalAppData%')
-            [void]$sb.AppendLine("- ``$p`` — exe version $($d.ExeVersion); contains: $($d.Entries)")
+            [void]$sb.AppendLine("- ``$p`` -- exe version $($d.ExeVersion); contains: $($d.Entries)")
         }
     } else { [void]$sb.AppendLine('- (none)') }
     [void]$sb.AppendLine()
@@ -225,7 +225,7 @@ function Format-Snapshot {
 function Reset-Machine {
     <#  Return to a verified-clean state so the next scenario measures only its own
         actions. Uninstalls through the product's own strings first (the supported path),
-        then removes anything left behind by force — a scenario that leaves residue is
+        then removes anything left behind by force -- a scenario that leaves residue is
         itself a finding, recorded by the caller's post-uninstall snapshot, not here. #>
     Get-Process QuickMail -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
 
@@ -234,7 +234,7 @@ function Reset-Machine {
             if ($row.KeyName -match '^\{[0-9A-Fa-f-]+\}$') {
                 Start-Process msiexec -ArgumentList "/x $($row.KeyName) /qn" -Wait -ErrorAction SilentlyContinue
             } elseif ($row.QuietUninstallString) {
-                # "path\Update.exe" --uninstall --silent  →  split exe from arguments
+                # "path\Update.exe" --uninstall --silent  ->  split exe from arguments
                 if ($row.QuietUninstallString -match '^"([^"]+)"\s*(.*)$') {
                     $exe = $Matches[1]; $argline = $Matches[2]
                     if (Test-Path $exe) {
@@ -310,9 +310,9 @@ $oldSetup = Get-PackedFile $OldDir "QuickMail-$OldVersion-$suffix-Setup.exe"
 $newMsi   = Get-PackedFile $NewDir "QuickMail-$NewVersion-$suffix.msi"
 $newSetup = Get-PackedFile $NewDir "QuickMail-$NewVersion-$suffix-Setup.exe"
 
-Write-Section "# Installer path matrix — $Arch"
+Write-Section "# Installer path matrix -- $Arch"
 Write-Section ''
-Write-Section "Old version **$OldVersion**, new version **$NewVersion**, both packed locally by this run — neither is a shipped QuickMail artifact."
+Write-Section "Old version **$OldVersion**, new version **$NewVersion**, both packed locally by this run -- neither is a shipped QuickMail artifact."
 Write-Section ''
 Write-Section "Runner: $((Get-CimInstance Win32_OperatingSystem).Caption) build $([Environment]::OSVersion.Version). vpk: $(if ($env:VPK_VERSION) { $env:VPK_VERSION } else { 'unrecorded' }). winget: $(if ($script:WingetAvailable) { (& winget --version) } else { 'not available' })."
 Write-Section ''
@@ -331,7 +331,7 @@ function Get-PEMachine {
 }
 $machineNames = @{ 0x8664 = 'x64'; 0xAA64 = 'ARM64'; 0x14C = 'x86' }
 
-Write-Section '## Scenario 0 — what `vpk pack` emits'
+Write-Section '## Scenario 0 -- what `vpk pack` emits'
 Write-Section ''
 Write-Section 'Filenames, verbatim, from the same `vpk pack` arguments the release workflow uses (`--msi --instLocation PerUser`):'
 Write-Section ''
@@ -374,32 +374,32 @@ function Invoke-Scenario {
     Write-Section ''
 }
 
-Invoke-Scenario 'Scenario 1 — silent MSI, fresh machine' `
+Invoke-Scenario 'Scenario 1 -- silent MSI, fresh machine' `
     'Does `msiexec /qn` land in C:\QuickMail on this architecture too (issue #554 was only ever measured on ARM64)?' {
     $r = Invoke-Installer 'msiexec.exe' @('/i', "`"$newMsi`"", '/qn', '/l*v', "$PWD\msi-fresh.log")
-    Write-Section "``msiexec /i … /qn`` → exit $($r.ExitCode) in $($r.Seconds)s"
+    Write-Section "``msiexec /i ... /qn`` -> exit $($r.ExitCode) in $($r.Seconds)s"
     Write-Section ''
     Write-Section (Format-Snapshot (Get-Snapshot 'after silent MSI install'))
     if (Test-Path 'C:\QuickMail') {
-        Add-Finding "Confirmed on $Arch: a silent MSI install lands in C:\QuickMail, not %LocalAppData%. Issue #554 is not architecture-specific."
+        Add-Finding "Confirmed on ${Arch}: a silent MSI install lands in C:\QuickMail, not %LocalAppData%. Issue #554 is not architecture-specific."
     } elseif (Test-Path (Join-Path $env:LOCALAPPDATA 'QuickMail')) {
-        Add-Finding "On $Arch a silent MSI install landed in %LocalAppData% — the opposite of the ARM64 Phase 1 result. Issue #554 may be fixed in this vpk, or architecture-specific."
+        Add-Finding "On $Arch a silent MSI install landed in %LocalAppData% -- the opposite of the ARM64 Phase 1 result. Issue #554 may be fixed in this vpk, or architecture-specific."
     }
 }
 
-Invoke-Scenario 'Scenario 2 — Setup.exe over an MSI install (the migration path)' `
-    'Every existing user installed from the MSI wizard into %LocalAppData%. What does `winget install`/`upgrade` — that is, `Setup.exe --silent` — do to that machine?' {
+Invoke-Scenario 'Scenario 2 -- Setup.exe over an MSI install (the migration path)' `
+    'Every existing user installed from the MSI wizard into %LocalAppData%. What does `winget install`/`upgrade` -- that is, `Setup.exe --silent` -- do to that machine?' {
     # Reproduce the wizard's install location without driving the wizard: VELOPACK_INSTALLDIR
     # is exactly what the Next button sets, per the #554 investigation.
     $target = Join-Path $env:LOCALAPPDATA 'QuickMail'
     $r1 = Invoke-Installer 'msiexec.exe' @('/i', "`"$oldMsi`"", '/qn') -Env @{ VELOPACK_INSTALLDIR = $target }
-    Write-Section "Step 1 — MSI $OldVersion into ``%LocalAppData%\QuickMail`` (wizard-equivalent): exit $($r1.ExitCode) in $($r1.Seconds)s"
+    Write-Section "Step 1 -- MSI $OldVersion into ``%LocalAppData%\QuickMail`` (wizard-equivalent): exit $($r1.ExitCode) in $($r1.Seconds)s"
     Write-Section ''
     $before = Get-Snapshot "after MSI $OldVersion (wizard-equivalent)"
     Write-Section (Format-Snapshot $before)
 
     $r2 = Invoke-Installer $newSetup @('--silent')
-    Write-Section "Step 2 — ``Setup.exe --silent`` $NewVersion over it: exit $($r2.ExitCode) in $($r2.Seconds)s"
+    Write-Section "Step 2 -- ``Setup.exe --silent`` $NewVersion over it: exit $($r2.ExitCode) in $($r2.Seconds)s"
     Write-Section ''
     $after = Get-Snapshot "after Setup.exe $NewVersion over the MSI install"
     Write-Section (Format-Snapshot $after)
@@ -416,15 +416,15 @@ Invoke-Scenario 'Scenario 2 — Setup.exe over an MSI install (the migration pat
     }
 }
 
-Invoke-Scenario 'Scenario 3 — Setup.exe over Setup.exe (the steady-state upgrade)' `
+Invoke-Scenario 'Scenario 3 -- Setup.exe over Setup.exe (the steady-state upgrade)' `
     'Phase 1 measured this by hand on ARM64. Does it hold on this runner, and does winget see the version advance?' {
     $r1 = Invoke-Installer $oldSetup @('--silent')
-    Write-Section "Step 1 — ``Setup.exe --silent`` $OldVersion, fresh: exit $($r1.ExitCode) in $($r1.Seconds)s"
+    Write-Section "Step 1 -- ``Setup.exe --silent`` $OldVersion, fresh: exit $($r1.ExitCode) in $($r1.Seconds)s"
     Write-Section ''
     Write-Section (Format-Snapshot (Get-Snapshot "after Setup.exe $OldVersion"))
 
     $r2 = Invoke-Installer $newSetup @('--silent')
-    Write-Section "Step 2 — ``Setup.exe --silent`` $NewVersion over it: exit $($r2.ExitCode) in $($r2.Seconds)s"
+    Write-Section "Step 2 -- ``Setup.exe --silent`` $NewVersion over it: exit $($r2.ExitCode) in $($r2.Seconds)s"
     Write-Section ''
     $after = Get-Snapshot "after Setup.exe $NewVersion over Setup.exe $OldVersion"
     Write-Section (Format-Snapshot $after)
@@ -437,10 +437,10 @@ Invoke-Scenario 'Scenario 3 — Setup.exe over Setup.exe (the steady-state upgra
     }
 }
 
-Invoke-Scenario 'Scenario 4 — uninstall through the quiet string winget uses' `
+Invoke-Scenario 'Scenario 4 -- uninstall through the quiet string winget uses' `
     'winget uninstall runs QuietUninstallString. Does it complete unattended, and what does it leave behind?' {
     $r1 = Invoke-Installer $newSetup @('--silent')
-    Write-Section "Step 1 — install $NewVersion: exit $($r1.ExitCode) in $($r1.Seconds)s"
+    Write-Section "Step 1 -- install ${NewVersion}: exit $($r1.ExitCode) in $($r1.Seconds)s"
     $installed = Get-Snapshot "installed $NewVersion"
     $row = @($installed.Arp | Where-Object { $_.QuietUninstallString })
     if (-not $row.Count) { throw 'No QuietUninstallString on any ARP row; winget uninstall would have nothing to run.' }
@@ -450,7 +450,7 @@ Invoke-Scenario 'Scenario 4 — uninstall through the quiet string winget uses' 
 
     if ($row[0].QuietUninstallString -match '^"([^"]+)"\s*(.*)$') {
         $r2 = Invoke-Installer $Matches[1] ($Matches[2] -split '\s+')
-        Write-Section "Step 2 — running it: exit $($r2.ExitCode) in $($r2.Seconds)s"
+        Write-Section "Step 2 -- running it: exit $($r2.ExitCode) in $($r2.Seconds)s"
     }
     Write-Section ''
     $after = Get-Snapshot 'after quiet uninstall'
@@ -463,20 +463,20 @@ Invoke-Scenario 'Scenario 4 — uninstall through the quiet string winget uses' 
     }
 }
 
-Invoke-Scenario 'Scenario 5 — MSI over a Setup.exe install (the reverse migration)' `
+Invoke-Scenario 'Scenario 5 -- MSI over a Setup.exe install (the reverse migration)' `
     'A user who installs from winget and later downloads the MSI from the release page ends up here. Is it survivable?' {
     $r1 = Invoke-Installer $oldSetup @('--silent')
-    Write-Section "Step 1 — ``Setup.exe --silent`` $OldVersion: exit $($r1.ExitCode) in $($r1.Seconds)s"
+    Write-Section "Step 1 -- ``Setup.exe --silent`` ${OldVersion}: exit $($r1.ExitCode) in $($r1.Seconds)s"
     Write-Section ''
     $target = Join-Path $env:LOCALAPPDATA 'QuickMail'
     $r2 = Invoke-Installer 'msiexec.exe' @('/i', "`"$newMsi`"", '/qn') -Env @{ VELOPACK_INSTALLDIR = $target }
-    Write-Section "Step 2 — MSI $NewVersion over it (wizard-equivalent location): exit $($r2.ExitCode) in $($r2.Seconds)s"
+    Write-Section "Step 2 -- MSI $NewVersion over it (wizard-equivalent location): exit $($r2.ExitCode) in $($r2.Seconds)s"
     Write-Section ''
     $after = Get-Snapshot "after MSI $NewVersion over Setup.exe $OldVersion"
     Write-Section (Format-Snapshot $after)
     $visible = @($after.Arp | Where-Object { $_.SystemComponent -ne 1 })
     if ($visible.Count -gt 1) {
-        Add-Finding "MSI over a Setup.exe install leaves $($visible.Count) visible ARP rows — the reverse migration is as messy as the forward one."
+        Add-Finding "MSI over a Setup.exe install leaves $($visible.Count) visible ARP rows -- the reverse migration is as messy as the forward one."
     }
 }
 
@@ -485,7 +485,7 @@ Invoke-Scenario 'Scenario 5 — MSI over a Setup.exe install (the reverse migrat
 Reset-Machine
 
 $header = @()
-$header += "# QuickMail installer path matrix — $Arch"
+$header += "# QuickMail installer path matrix -- $Arch"
 $header += ''
 $header += "Generated by ``scripts/winget-install-matrix.ps1`` on a GitHub-hosted runner. Every scenario starts from a verified-clean machine."
 $header += ''

--- a/scripts/winget-install-matrix.ps1
+++ b/scripts/winget-install-matrix.ps1
@@ -166,12 +166,16 @@ function Get-WingetView {
 function Get-Snapshot {
     param([string]$Label)
     Get-Process QuickMail -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+    # @() on every collection is load-bearing, not decoration: a function that returns one
+    # object returns it unwrapped, and under Set-StrictMode -Version Latest the resulting
+    # `.Count` on a bare PSCustomObject is a terminating error. One ARP row is the normal
+    # case here, so without these the whole probe reports nothing.
     return [pscustomobject]@{
         Label       = $Label
-        Arp         = Get-ArpRows
-        MsiProducts = Get-MsiProductRows
-        Dirs        = Get-InstallDirs
-        Shortcuts   = Get-Shortcuts
+        Arp         = @(Get-ArpRows)
+        MsiProducts = @(Get-MsiProductRows)
+        Dirs        = @(Get-InstallDirs)
+        Shortcuts   = @(Get-Shortcuts)
         Winget      = Get-WingetView
     }
 }
@@ -271,9 +275,9 @@ function Reset-Machine {
 # --- install primitives --------------------------------------------------------------
 
 function Invoke-Installer {
-    param([string]$Path, [string[]]$Arguments, [hashtable]$Env = @{})
+    param([string]$Path, [string[]]$Arguments, [hashtable]$EnvVars = @{})
 
-    foreach ($k in $Env.Keys) { Set-Item "env:$k" $Env[$k] }
+    foreach ($k in $EnvVars.Keys) { Set-Item "env:$k" $EnvVars[$k] }
     try {
         $sw = [Diagnostics.Stopwatch]::StartNew()
         $p = Start-Process -FilePath $Path -ArgumentList $Arguments -Wait -PassThru
@@ -281,7 +285,7 @@ function Invoke-Installer {
         Get-Process QuickMail -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
         return [pscustomobject]@{ ExitCode = $p.ExitCode; Seconds = [math]::Round($sw.Elapsed.TotalSeconds, 1) }
     } finally {
-        foreach ($k in $Env.Keys) { Remove-Item "env:$k" -ErrorAction SilentlyContinue }
+        foreach ($k in $EnvVars.Keys) { Remove-Item "env:$k" -ErrorAction SilentlyContinue }
     }
 }
 
@@ -360,12 +364,14 @@ Write-Section ''
 function Invoke-Scenario {
     param([string]$Title, [string]$Question, [scriptblock]$Body)
     Write-Host "`n=== $Title ==="
-    Reset-Machine
     Write-Section "## $Title"
     Write-Section ''
     Write-Section "*Question: $Question*"
     Write-Section ''
     try {
+        # Inside the try: a reset that cannot clean the machine is this scenario's failure
+        # to report, not a reason to abandon every scenario after it.
+        Reset-Machine
         & $Body
     } catch {
         Write-Section "**Scenario aborted:** ``$_``"
@@ -392,7 +398,7 @@ Invoke-Scenario 'Scenario 2 -- Setup.exe over an MSI install (the migration path
     # Reproduce the wizard's install location without driving the wizard: VELOPACK_INSTALLDIR
     # is exactly what the Next button sets, per the #554 investigation.
     $target = Join-Path $env:LOCALAPPDATA 'QuickMail'
-    $r1 = Invoke-Installer 'msiexec.exe' @('/i', "`"$oldMsi`"", '/qn') -Env @{ VELOPACK_INSTALLDIR = $target }
+    $r1 = Invoke-Installer 'msiexec.exe' @('/i', "`"$oldMsi`"", '/qn') -EnvVars @{ VELOPACK_INSTALLDIR = $target }
     Write-Section "Step 1 -- MSI $OldVersion into ``%LocalAppData%\QuickMail`` (wizard-equivalent): exit $($r1.ExitCode) in $($r1.Seconds)s"
     Write-Section ''
     $before = Get-Snapshot "after MSI $OldVersion (wizard-equivalent)"
@@ -449,8 +455,14 @@ Invoke-Scenario 'Scenario 4 -- uninstall through the quiet string winget uses' `
     Write-Section ''
 
     if ($row[0].QuietUninstallString -match '^"([^"]+)"\s*(.*)$') {
-        $r2 = Invoke-Installer $Matches[1] ($Matches[2] -split '\s+')
+        # Copy out of $Matches at once: any later -match in this scope replaces it. The
+        # Where-Object drops the empty element -split yields for an argument-less string.
+        $exe  = $Matches[1]
+        $argv = @($Matches[2] -split '\s+' | Where-Object { $_ })
+        $r2 = Invoke-Installer $exe $argv
         Write-Section "Step 2 -- running it: exit $($r2.ExitCode) in $($r2.Seconds)s"
+    } else {
+        Add-Finding "QuietUninstallString did not parse as a quoted path plus arguments: $($row[0].QuietUninstallString)"
     }
     Write-Section ''
     $after = Get-Snapshot 'after quiet uninstall'
@@ -469,7 +481,7 @@ Invoke-Scenario 'Scenario 5 -- MSI over a Setup.exe install (the reverse migrati
     Write-Section "Step 1 -- ``Setup.exe --silent`` ${OldVersion}: exit $($r1.ExitCode) in $($r1.Seconds)s"
     Write-Section ''
     $target = Join-Path $env:LOCALAPPDATA 'QuickMail'
-    $r2 = Invoke-Installer 'msiexec.exe' @('/i', "`"$newMsi`"", '/qn') -Env @{ VELOPACK_INSTALLDIR = $target }
+    $r2 = Invoke-Installer 'msiexec.exe' @('/i', "`"$newMsi`"", '/qn') -EnvVars @{ VELOPACK_INSTALLDIR = $target }
     Write-Section "Step 2 -- MSI $NewVersion over it (wizard-equivalent location): exit $($r2.ExitCode) in $($r2.Seconds)s"
     Write-Section ''
     $after = Get-Snapshot "after MSI $NewVersion over Setup.exe $OldVersion"

--- a/scripts/winget-install-matrix.ps1
+++ b/scripts/winget-install-matrix.ps1
@@ -27,10 +27,20 @@
 .PARAMETER Report
   Path to write the Markdown report to.
 
+.PARAMETER EmittedListing
+  Optional file listing the pack folder's contents as `vpk pack` emitted them, captured by
+  the caller BEFORE it renames anything. Scenario 0 reports vpk's own filenames; without
+  this it can only report the post-rename ones, which is not the same claim.
+
+.PARAMETER Force
+  Run outside CI. Required there because Reset-Machine deletes %APPDATA%\QuickMail.
+
 .NOTES
-  Non-destructive on a developer machine only in the sense that it removes QuickMail.
-  It uninstalls QuickMail repeatedly and deletes its install directories. Do not run it
-  on a machine with a QuickMail install you care about -- it is meant for CI runners.
+  This is destructive well beyond "it removes QuickMail". It uninstalls QuickMail
+  repeatedly, deletes its install directories, force-deletes its registry keys, and
+  deletes %APPDATA%\QuickMail -- the profile directory holding accounts, settings, rules,
+  templates and cached mail. It is meant for a throwaway CI runner and refuses to start
+  anywhere else unless -Force says the machine is disposable.
 #>
 [CmdletBinding()]
 param(
@@ -39,16 +49,27 @@ param(
     [Parameter(Mandatory)][string]$OldVersion,
     [Parameter(Mandatory)][string]$NewVersion,
     [Parameter(Mandatory)][ValidateSet('x64', 'arm64')][string]$Arch,
-    [string]$Report = 'winget-matrix-report.md'
+    [string]$Report = 'winget-matrix-report.md',
+    [string]$EmittedListing,
+    [switch]$Force
 )
 
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 
+if (-not $Force -and -not $env:GITHUB_ACTIONS -and -not $env:CI) {
+    throw ('Refusing to run outside CI. This script deletes %APPDATA%\QuickMail, which on a ' +
+           'developer machine is the real profile directory -- accounts, settings, rules, ' +
+           'templates, cached mail. Pass -Force only if this machine is genuinely disposable.')
+}
+
 # Scenario failures must not abort the run: a scenario that misbehaves is a finding, and
 # the scenarios after it are still worth measuring. Only harness errors should be fatal.
 $script:Findings = [System.Collections.Generic.List[string]]::new()
 $script:Sections = [System.Collections.Generic.List[string]]::new()
+# A scenario that aborted measured nothing. Counted so the exit code can say the matrix has
+# a hole in it, rather than reporting success for a run that half happened.
+$script:Aborted = 0
 
 function Write-Section { param([string]$Text) $script:Sections.Add($Text) | Out-Null }
 function Add-Finding { param([string]$Text) $script:Findings.Add($Text) | Out-Null; Write-Host "FINDING: $Text" }
@@ -244,10 +265,15 @@ function Format-Snapshot {
 # --- machine reset -------------------------------------------------------------------
 
 function Reset-Machine {
-    <#  Return to a verified-clean state so the next scenario measures only its own
-        actions. Uninstalls through the product's own strings first (the supported path),
-        then removes anything left behind by force -- a scenario that leaves residue is
-        itself a finding, recorded by the caller's post-uninstall snapshot, not here. #>
+    <#  Return to a clean state so the next scenario measures only its own actions.
+        Uninstalls through the product's own strings first (the supported path), then
+        removes anything left behind by force -- a scenario that leaves residue is itself a
+        finding, recorded by the caller's post-uninstall snapshot, not here.
+
+        Returns what survived. "Every scenario starts from a verified-clean machine" is a
+        claim the report makes; the caller turns this object into the evidence for it, or
+        into a finding when it is not true. A reset that silently fails is the one way this
+        probe can report a previous scenario's residue as the current scenario's result. #>
     Get-Process QuickMail -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
 
     foreach ($row in Get-ArpRows) {
@@ -279,14 +305,49 @@ function Reset-Machine {
             ForEach-Object { Remove-Item $_.PSPath -Recurse -Force -ErrorAction SilentlyContinue }
     }
 
+    # Windows Installer's own product registration outlives the ARP row and is NOT removed by
+    # deleting it. When msiexec /x succeeds it goes with the product, but scenario 2 leaves an
+    # MSI registration pointing at files Setup.exe has overwritten, and an /x against that can
+    # fail -- after which the stale key would be counted as the NEXT scenario's MSI
+    # registration. Scenario 2's second finding is exactly a count of these, so a leak here
+    # fabricates that finding for a scenario that never installed an MSI.
+    foreach ($prod in Get-MsiProductRows) {
+        $installerRoot = if ($prod.Scope -eq 'HKCU-Installer') {
+            'HKCU:\Software\Microsoft\Installer'
+        } else {
+            'HKLM:\SOFTWARE\Classes\Installer'
+        }
+        foreach ($sub in 'Products', 'Features') {
+            Remove-Item (Join-Path $installerRoot "$sub\$($prod.PackedCode)") -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
     foreach ($d in (@(Get-InstallDirs | ForEach-Object { $_.Path }) + (Join-Path $env:APPDATA 'QuickMail'))) {
         Remove-Item $d -Recurse -Force -ErrorAction SilentlyContinue
     }
-    Get-ChildItem (Join-Path $env:APPDATA 'Microsoft\Windows\Start Menu\Programs') -Recurse -Filter '*QuickMail*.lnk' -ErrorAction SilentlyContinue |
-        Remove-Item -Force -ErrorAction SilentlyContinue
+    # Both Start Menu roots, not just the per-user one: Get-Shortcuts reports the machine-wide
+    # root too, so cleaning only one leaves residue this function would then report as
+    # unclearable forever.
+    foreach ($menu in @((Join-Path $env:APPDATA 'Microsoft\Windows\Start Menu\Programs'),
+                        (Join-Path $env:ProgramData 'Microsoft\Windows\Start Menu\Programs'))) {
+        if (-not (Test-Path $menu)) { continue }
+        Get-ChildItem $menu -Recurse -Filter '*QuickMail*.lnk' -ErrorAction SilentlyContinue |
+            Remove-Item -Force -ErrorAction SilentlyContinue
+    }
 
-    $left = @(Get-ArpRows).Count + @(Get-InstallDirs).Count
-    if ($left -ne 0) { Write-Host "reset: warning, $left QuickMail traces survived the reset" }
+    $residue = [pscustomobject]@{
+        Arp         = @(Get-ArpRows).Count
+        MsiProducts = @(Get-MsiProductRows).Count
+        Dirs        = @(Get-InstallDirs).Count
+        Shortcuts   = @(Get-Shortcuts).Count
+    }
+    $residue | Add-Member -NotePropertyName Total `
+        -NotePropertyValue ($residue.Arp + $residue.MsiProducts + $residue.Dirs + $residue.Shortcuts)
+    if ($residue.Total -ne 0) {
+        Write-Host ("reset: warning, QuickMail traces survived: {0} ARP, {1} MSI registration, {2} dir, {3} shortcut" -f
+            $residue.Arp, $residue.MsiProducts, $residue.Dirs, $residue.Shortcuts)
+    }
+    return $residue
 }
 
 # --- install primitives --------------------------------------------------------------
@@ -329,8 +390,21 @@ Write-Section "# Installer path matrix -- $Arch"
 Write-Section ''
 Write-Section "Old version **$OldVersion**, new version **$NewVersion**, both packed locally by this run -- neither is a shipped QuickMail artifact."
 Write-Section ''
-Write-Section "Runner: $((Get-CimInstance Win32_OperatingSystem).Caption) build $([Environment]::OSVersion.Version). vpk: $(if ($env:VPK_VERSION) { $env:VPK_VERSION } else { 'unrecorded' }). winget: $(if ($script:WingetAvailable) { (& winget --version) } else { 'not available' })."
+# Record the architecture the probe actually ran on. The whole value of the ARM64 leg is
+# that it is native; "runs-on: windows-11-arm" is an assertion about a runner label, and the
+# report is where it has to become a measurement. ProcessArchitecture matters separately:
+# a non-native PowerShell would read HKLM:\SOFTWARE through the WOW64 view.
+$osArch   = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
+$procArch = [System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture
+Write-Section "Runner: $((Get-CimInstance Win32_OperatingSystem).Caption) build $([Environment]::OSVersion.Version), OS architecture **$osArch**, probe process **$procArch**. vpk: $(if ($env:VPK_VERSION) { $env:VPK_VERSION } else { 'unrecorded' }). winget: $(if ($script:WingetAvailable) { (& winget --version) } else { 'not available' })."
 Write-Section ''
+
+$expectedOsArch = if ($Arch -eq 'arm64') { 'Arm64' } else { 'X64' }
+if ("$osArch" -ne $expectedOsArch) {
+    Add-Finding "The $Arch leg ran on a $osArch runner, so it is not measuring $Arch behaviour at all. Every result below is mislabelled."
+} elseif ("$procArch" -ne $expectedOsArch) {
+    Add-Finding "The $Arch leg's PowerShell is a $procArch process on a $osArch OS. Registry reads under HKLM:\SOFTWARE go through the WOW64 view, so the ARP snapshots may be incomplete."
+}
 
 # --- scenario 0: what vpk emitted, and what architecture it is -----------------------
 
@@ -348,7 +422,22 @@ $machineNames = @{ 0x8664 = 'x64'; 0xAA64 = 'ARM64'; 0x14C = 'x86' }
 
 Write-Section '## Scenario 0 -- what `vpk pack` emits'
 Write-Section ''
-Write-Section 'Filenames, verbatim, from the same `vpk pack` arguments the release workflow uses (`--msi --instLocation PerUser`):'
+Write-Section 'Filenames from the same `vpk pack` arguments the release workflow uses (`--msi --instLocation PerUser`).'
+Write-Section ''
+if ($EmittedListing -and (Test-Path $EmittedListing)) {
+    # Read the pre-rename listing the caller captured. Listing the pack folder here instead
+    # would print names this workflow assigned, while calling them vpk's -- and #555 hardcodes
+    # vpk's names, so that is precisely the claim that must not be second-hand.
+    Write-Section 'As `vpk pack` wrote them, before this workflow renames the MSI and Setup.exe to carry a version:'
+    Write-Section ''
+    Write-Section '```'
+    Write-Section (((Get-Content $EmittedListing) | Where-Object { $_.Trim() }) -join "`n")
+    Write-Section '```'
+    Write-Section ''
+    Write-Section 'After the rename (what the scenarios below install):'
+} else {
+    Write-Section '**The caller did not record the pre-rename listing**, so these are the names *after* this workflow renamed the MSI and Setup.exe. They are not evidence of what `vpk pack` emits.'
+}
 Write-Section ''
 Write-Section '```'
 Write-Section (Get-ChildItem $NewDir | Select-Object -ExpandProperty Name | Sort-Object | Out-String).Trim()
@@ -364,8 +453,17 @@ foreach ($f in @($newSetup, $newMsi)) {
     $m = Get-PEMachine $f
     $shown = if ($machineNames.ContainsKey([int]$m)) { $machineNames[[int]$m] } else { "unknown (0x$('{0:X4}' -f $m))" }
     Write-Section "| ``$name`` | $shown |"
-    if ($Arch -eq 'arm64' -and $shown -ne 'ARM64') {
-        Add-Finding "ARM64 channel's Setup.exe is a $shown binary. komac infers architecture from the binary when the filename carries no architecture token; the ARM64 asset's name does carry one, so this is survivable, but the x64 asset's does not."
+    # Emit this on BOTH legs. Gating it on arm64 meant the x64 report -- the leg where the
+    # filename carries no architecture token and the PE header is therefore the ONLY thing
+    # komac can read -- printed "x86" in the table and listed no finding at all.
+    $expectedMachine = if ($Arch -eq 'arm64') { 'ARM64' } else { 'x64' }
+    if ($shown -ne $expectedMachine) {
+        $consequence = if ($Arch -eq 'arm64') {
+            "The ARM64 asset's filename does carry an architecture token, so komac has something other than this header to go on."
+        } else {
+            "The x64 asset ships as ``QuickMail-<v>-win-Setup.exe``, whose filename carries NO architecture token, so this header is all komac has: it would infer ``Architecture: x86``. Check the first automated winget-pkgs PR before letting it merge."
+        }
+        Add-Finding "The $Arch channel's Setup.exe is a $shown PE image, not $expectedMachine. $consequence"
     }
 }
 Write-Section ''
@@ -382,11 +480,19 @@ function Invoke-Scenario {
     try {
         # Inside the try: a reset that cannot clean the machine is this scenario's failure
         # to report, not a reason to abandon every scenario after it.
-        Reset-Machine
+        $residue = Reset-Machine
+        if ($residue.Total -ne 0) {
+            Write-Section "**Start state NOT clean:** $($residue.Arp) ARP row(s), $($residue.MsiProducts) Windows Installer registration(s), $($residue.Dirs) install director(ies) and $($residue.Shortcuts) shortcut(s) survived the reset. Everything below may be the previous scenario's residue."
+            Add-Finding "$Title started from a machine the reset could not clean ($($residue.Total) trace(s) left behind). Its measurements may be contaminated by the scenario before it."
+        } else {
+            Write-Section '*Start state: verified clean -- no QuickMail ARP rows, Windows Installer registrations, install directories or shortcuts.*'
+        }
+        Write-Section ''
         & $Body
     } catch {
         Write-Section "**Scenario aborted:** ``$_``"
         Add-Finding "$Title aborted: $_"
+        $script:Aborted++
     }
     Write-Section ''
 }
@@ -396,11 +502,26 @@ Invoke-Scenario 'Scenario 1 -- silent MSI, fresh machine' `
     $r = Invoke-Installer 'msiexec.exe' @('/i', "`"$newMsi`"", '/qn', '/l*v', "$PWD\msi-fresh.log")
     Write-Section "``msiexec /i ... /qn`` -> exit $($r.ExitCode) in $($r.Seconds)s"
     Write-Section ''
-    Write-Section (Format-Snapshot (Get-Snapshot 'after silent MSI install'))
-    if (Test-Path 'C:\QuickMail') {
-        Add-Finding "Confirmed on ${Arch}: a silent MSI install lands in C:\QuickMail, not %LocalAppData%. Issue #554 is not architecture-specific."
-    } elseif (Test-Path (Join-Path $env:LOCALAPPDATA 'QuickMail')) {
+    $snap = Get-Snapshot 'after silent MSI install'
+    Write-Section (Format-Snapshot $snap)
+    if ($r.ExitCode -ne 0) {
+        Add-Finding "On $Arch the silent MSI install exited $($r.ExitCode); everything measured for this scenario is the state after a failed install. See msi-fresh.log."
+    }
+    # Read the answer off the directories actually measured, rather than testing C:\ by name.
+    # Windows Installer resolves TARGETDIR to a drive root -- whichever fixed drive it picks --
+    # and the x64 runner picked D:. A C:-only test therefore matched neither branch and left
+    # the x64 report with NO finding for this scenario, while its own table showed
+    # D:\QuickMail. The defect was measured and then not reported.
+    $perUser = Join-Path $env:LOCALAPPDATA 'QuickMail'
+    $stray = @($snap.Dirs | Where-Object { $_.Path -ne $perUser })
+    if ($stray.Count) {
+        Add-Finding ("Confirmed on ${Arch}: a silent MSI install lands in " +
+            (($stray | ForEach-Object { $_.Path }) -join ', ') +
+            ", not %LocalAppData%. Issue #554 is neither architecture-specific nor specific to C: -- Windows Installer resolves TARGETDIR to a drive root, and which drive is the runner's choice.")
+    } elseif ($snap.Dirs.Count) {
         Add-Finding "On $Arch a silent MSI install landed in %LocalAppData% -- the opposite of the ARM64 Phase 1 result. Issue #554 may be fixed in this vpk, or architecture-specific."
+    } else {
+        Add-Finding "On $Arch a silent MSI install produced no QuickMail install directory anywhere this probe looks. The scenario measured nothing; do not read its silence as a pass."
     }
 }
 
@@ -421,9 +542,14 @@ Invoke-Scenario 'Scenario 2 -- Setup.exe over an MSI install (the migration path
 
     # Assert the premise before measuring anything on top of it. If the MSI did not land
     # where the wizard would have put it, this scenario is not the migration path and its
-    # result must not be read as one.
-    if (-not (@($before.Dirs | Where-Object { $_.Path -eq $target }).Count)) {
-        throw "Premise failed: the MSI did not install to $target, so this is not the wizard-equivalent starting state. Installed instead at: $(($before.Arp | ForEach-Object { $_.InstallLocation }) -join ', ')"
+    # result must not be read as one. "Exactly one directory" rather than "the right one is
+    # among them": a second install elsewhere means the starting state is not a wizard
+    # install either, and the ARP rows counted below would include its row.
+    if ($r1.ExitCode -ne 0) {
+        throw "Premise failed: the MSI install exited $($r1.ExitCode), so there is no wizard-equivalent starting state to migrate from."
+    }
+    if (@($before.Dirs).Count -ne 1 -or $before.Dirs[0].Path -ne $target) {
+        throw "Premise failed: the MSI did not install to $target and nowhere else, so this is not the wizard-equivalent starting state. Directories found: $(($before.Dirs | ForEach-Object { $_.Path }) -join ', ')"
     }
 
     $r2 = Invoke-Installer $newSetup @('--silent')
@@ -476,24 +602,41 @@ Invoke-Scenario 'Scenario 4 -- uninstall through the quiet string winget uses' `
     Write-Section "QuietUninstallString: ``$($row[0].QuietUninstallString)``"
     Write-Section ''
 
+    $ran = $false
     if ($row[0].QuietUninstallString -match '^"([^"]+)"\s*(.*)$') {
         # Copy out of $Matches at once: any later -match in this scope replaces it. The
         # Where-Object drops the empty element -split yields for an argument-less string.
         $exe  = $Matches[1]
         $argv = @($Matches[2] -split '\s+' | Where-Object { $_ })
         $r2 = Invoke-Installer $exe $argv
+        $ran = $true
         Write-Section "Step 2 -- running it: exit $($r2.ExitCode) in $($r2.Seconds)s"
+        if ($r2.ExitCode -ne 0) {
+            Add-Finding "The quiet uninstall string exited $($r2.ExitCode). ``winget uninstall`` runs exactly this and would report a failure."
+        }
     } else {
         Add-Finding "QuietUninstallString did not parse as a quoted path plus arguments: $($row[0].QuietUninstallString)"
     }
     Write-Section ''
     $after = Get-Snapshot 'after quiet uninstall'
     Write-Section (Format-Snapshot $after)
-    if ($after.Arp.Count -gt 0) {
-        Add-Finding "The quiet uninstall left $($after.Arp.Count) Add/Remove Programs row(s) behind."
-    }
-    if ($after.Dirs.Count -gt 0) {
-        Add-Finding "The quiet uninstall left directories behind: $(($after.Dirs | ForEach-Object { $_.Path }) -join ', ')."
+    # Only judge the leftovers when the uninstall actually ran. Otherwise the app is simply
+    # still installed, and the three checks below would report a healthy install as three
+    # separate uninstall defects.
+    if (-not $ran) {
+        Write-Section '*The uninstall was never run, so the state above is the install, not what an uninstall leaves behind.*'
+    } else {
+        if ($after.Arp.Count -gt 0) {
+            Add-Finding "The quiet uninstall left $($after.Arp.Count) Add/Remove Programs row(s) behind."
+        }
+        if ($after.Dirs.Count -gt 0) {
+            Add-Finding "The quiet uninstall left directories behind: $(($after.Dirs | ForEach-Object { $_.Path }) -join ', ')."
+        }
+        # Snapshotted since the first run and never judged. A leftover Start Menu entry
+        # pointing at a deleted exe is exactly the kind of thing this scenario exists to catch.
+        if ($after.Shortcuts.Count -gt 0) {
+            Add-Finding "The quiet uninstall left Start Menu shortcuts behind: $(($after.Shortcuts) -join ', ')."
+        }
     }
 }
 
@@ -503,26 +646,48 @@ Invoke-Scenario 'Scenario 5 -- MSI over a Setup.exe install (the reverse migrati
     Write-Section "Step 1 -- ``Setup.exe --silent`` ${OldVersion}: exit $($r1.ExitCode) in $($r1.Seconds)s"
     Write-Section ''
     $target = Join-Path $env:LOCALAPPDATA 'QuickMail'
+    # Show the starting state and assert it, exactly as scenario 2 does. Without this the
+    # scenario asserts "over it" in prose only: if VELOPACK_INSTALLDIR stopped taking effect
+    # the MSI would land on a drive root beside the Setup install, and the two ARP rows that
+    # produces would still be reported as "the reverse migration is as messy as the forward
+    # one" -- a correct-looking finding about a completely different machine state.
+    $before = Get-Snapshot "after Setup.exe $OldVersion"
+    Write-Section (Format-Snapshot $before)
+    if (@($before.Dirs).Count -ne 1 -or $before.Dirs[0].Path -ne $target) {
+        throw "Premise failed: Setup.exe $OldVersion did not install to $target and nowhere else. Directories found: $(($before.Dirs | ForEach-Object { $_.Path }) -join ', ')"
+    }
+
     $r2 = Invoke-Installer 'msiexec.exe' @('/i', "`"$newMsi`"", '/qn', "VELOPACK_INSTALLDIR=`"$target`"")
     Write-Section "Step 2 -- MSI $NewVersion over it (wizard-equivalent location): exit $($r2.ExitCode) in $($r2.Seconds)s"
     Write-Section ''
     $after = Get-Snapshot "after MSI $NewVersion over Setup.exe $OldVersion"
     Write-Section (Format-Snapshot $after)
+    if ($r2.ExitCode -ne 0) {
+        Add-Finding "MSI over a Setup.exe install exited $($r2.ExitCode) on $Arch."
+    }
+    $onTop = @($after.Dirs | Where-Object { $_.Path -eq $target }).Count -eq 1 -and @($after.Dirs).Count -eq 1
+    if (-not $onTop) {
+        Add-Finding "MSI over a Setup.exe install did not land on top of it: directories after the MSI are $(($after.Dirs | ForEach-Object { $_.Path }) -join ', '). This measured two side-by-side installs, not an overwrite, so read the ARP rows below accordingly."
+    }
     $visible = @($after.Arp | Where-Object { $_.SystemComponent -ne 1 })
-    if ($visible.Count -gt 1) {
-        Add-Finding "MSI over a Setup.exe install leaves $($visible.Count) visible ARP rows -- the reverse migration is as messy as the forward one."
+    if ($visible.Count -gt 1 -and $onTop) {
+        Add-Finding "MSI over a Setup.exe install leaves $($visible.Count) visible ARP rows ($(($visible | ForEach-Object { $_.KeyName }) -join ', ')) over a single install directory -- the reverse migration is as messy as the forward one."
     }
 }
 
 # --- report --------------------------------------------------------------------------
 
-Reset-Machine
+$null = Reset-Machine
 
 $header = @()
 $header += "# QuickMail installer path matrix -- $Arch"
 $header += ''
-$header += "Generated by ``scripts/winget-install-matrix.ps1`` on a GitHub-hosted runner. Every scenario starts from a verified-clean machine."
+$header += "Generated by ``scripts/winget-install-matrix.ps1`` on a GitHub-hosted runner. Each scenario resets the machine first and states, in its own section, whether that reset actually left it clean."
 $header += ''
+if ($script:Aborted -gt 0) {
+    $header += "**$($script:Aborted) scenario(s) aborted.** The matrix below is incomplete; do not cite it as covering every path."
+    $header += ''
+}
 if ($script:Findings.Count) {
     $header += '## Findings'
     $header += ''
@@ -540,3 +705,18 @@ $body = ($header + $script:Sections) -join "`n"
 $body | Out-File -FilePath $Report -Encoding utf8
 Write-Host "`nReport written to $Report"
 if ($env:GITHUB_STEP_SUMMARY) { $body | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append }
+
+# Decide the exit code explicitly, and never let it be decided for us. GitHub's pwsh handler
+# appends `exit $LASTEXITCODE`, and the last thing to set $LASTEXITCODE here is
+# `cmd /c winget ...` -- winget exits non-zero when a list comes back empty. Leaving it
+# implicit means the step's pass/fail is settled by whether some unrelated package on the
+# runner happened to have an update available, which has already failed one run.
+#
+# Findings are data, not failures: recording misbehaviour is the entire job. An aborted
+# scenario is different -- it measured nothing, and a green step would advertise a matrix
+# with a hole in it.
+if ($script:Aborted -gt 0) {
+    Write-Host "$($script:Aborted) scenario(s) aborted; failing the step so the gap is not mistaken for coverage."
+    exit 1
+}
+exit 0

--- a/scripts/winget-install-matrix.ps1
+++ b/scripts/winget-install-matrix.ps1
@@ -1,0 +1,506 @@
+<#
+.SYNOPSIS
+  Measures QuickMail's installer behaviour across every install/upgrade path winget can
+  put a machine through, and writes the results as Markdown.
+
+.DESCRIPTION
+  Written for issue #536 (winget distribution). The winget plan's Phase 1 was done by hand
+  on one ARM64 machine and left three gaps: x64 was never tested, Setup.exe over an
+  MSI-installed copy — the path every existing user takes — was never tested at all, and
+  the winget correlation claims were inferred from registry state rather than measured.
+
+  This script closes those gaps on a CI runner, so the answers are reproducible and nobody
+  has to lend a machine to find out. It takes two already-packed Velopack output folders
+  (an "old" version and a "new" one) and walks a fixed list of scenarios, snapshotting
+  Add/Remove Programs rows, Windows Installer product registrations, install directories,
+  Start Menu shortcuts, and winget's own view of the machine after each step.
+
+  Every scenario starts from a verified-clean machine (Reset-Machine below) so the
+  scenarios cannot contaminate each other.
+
+.PARAMETER OldDir
+  Velopack output folder for the older version (must contain its MSI and Setup.exe).
+
+.PARAMETER NewDir
+  Velopack output folder for the newer version.
+
+.PARAMETER Report
+  Path to write the Markdown report to.
+
+.NOTES
+  Non-destructive on a developer machine only in the sense that it removes QuickMail.
+  It uninstalls QuickMail repeatedly and deletes its install directories. Do not run it
+  on a machine with a QuickMail install you care about — it is meant for CI runners.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][string]$OldDir,
+    [Parameter(Mandatory)][string]$NewDir,
+    [Parameter(Mandatory)][string]$OldVersion,
+    [Parameter(Mandatory)][string]$NewVersion,
+    [Parameter(Mandatory)][ValidateSet('x64', 'arm64')][string]$Arch,
+    [string]$Report = 'winget-matrix-report.md'
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+# Scenario failures must not abort the run: a scenario that misbehaves is a finding, and
+# the scenarios after it are still worth measuring. Only harness errors should be fatal.
+$script:Findings = [System.Collections.Generic.List[string]]::new()
+$script:Sections = [System.Collections.Generic.List[string]]::new()
+
+function Write-Section { param([string]$Text) $script:Sections.Add($Text) | Out-Null }
+function Add-Finding { param([string]$Text) $script:Findings.Add($Text) | Out-Null; Write-Host "FINDING: $Text" }
+
+# --- state capture -------------------------------------------------------------------
+
+$UninstallRoots = @(
+    @{ Scope = 'HKCU'; Path = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall' }
+    @{ Scope = 'HKLM'; Path = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall' }
+    @{ Scope = 'HKLM-Wow'; Path = 'HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall' }
+)
+
+function Get-ArpRows {
+    <#  Every Add/Remove Programs row that mentions QuickMail, from all three hives.
+        SystemComponent is carried through because an MSI row with SystemComponent=1 is
+        hidden from Settings > Apps but is still a real product registration — the
+        distinction the migration question turns on. #>
+    $rows = @()
+    foreach ($root in $UninstallRoots) {
+        if (-not (Test-Path $root.Path)) { continue }
+        foreach ($key in Get-ChildItem $root.Path -ErrorAction SilentlyContinue) {
+            $p = Get-ItemProperty $key.PSPath -ErrorAction SilentlyContinue
+            if (-not $p) { continue }
+            $display = if ($p.PSObject.Properties['DisplayName']) { $p.DisplayName } else { $null }
+            if (($key.PSChildName -notlike '*QuickMail*') -and ($display -notlike '*QuickMail*')) { continue }
+            $rows += [pscustomobject]@{
+                Scope               = $root.Scope
+                KeyName             = $key.PSChildName
+                DisplayName         = $display
+                DisplayVersion      = if ($p.PSObject.Properties['DisplayVersion']) { $p.DisplayVersion } else { $null }
+                Publisher           = if ($p.PSObject.Properties['Publisher']) { $p.Publisher } else { $null }
+                SystemComponent     = if ($p.PSObject.Properties['SystemComponent']) { $p.SystemComponent } else { 0 }
+                InstallLocation     = if ($p.PSObject.Properties['InstallLocation']) { $p.InstallLocation } else { $null }
+                UninstallString     = if ($p.PSObject.Properties['UninstallString']) { $p.UninstallString } else { $null }
+                QuietUninstallString = if ($p.PSObject.Properties['QuietUninstallString']) { $p.QuietUninstallString } else { $null }
+            }
+        }
+    }
+    return @($rows)
+}
+
+function Get-MsiProductRows {
+    <#  Windows Installer's own product registration, which survives independently of the
+        ARP row. This is what would be orphaned if Setup.exe overwrites an MSI install
+        without going through msiexec. #>
+    $rows = @()
+    $roots = @(
+        @{ Scope = 'HKCU-Installer'; Path = 'HKCU:\Software\Microsoft\Installer\Products' }
+        @{ Scope = 'HKLM-Installer'; Path = 'HKLM:\SOFTWARE\Classes\Installer\Products' }
+    )
+    foreach ($root in $roots) {
+        if (-not (Test-Path $root.Path)) { continue }
+        foreach ($key in Get-ChildItem $root.Path -ErrorAction SilentlyContinue) {
+            $p = Get-ItemProperty $key.PSPath -ErrorAction SilentlyContinue
+            if (-not $p -or -not $p.PSObject.Properties['ProductName']) { continue }
+            if ($p.ProductName -notlike '*QuickMail*') { continue }
+            $rows += [pscustomobject]@{
+                Scope         = $root.Scope
+                PackedCode    = $key.PSChildName
+                ProductName   = $p.ProductName
+            }
+        }
+    }
+    return @($rows)
+}
+
+function Get-InstallDirs {
+    $candidates = @(
+        'C:\QuickMail'
+        (Join-Path $env:LOCALAPPDATA 'QuickMail')
+        (Join-Path $env:ProgramFiles 'QuickMail')
+    )
+    $out = @()
+    foreach ($c in $candidates) {
+        if (-not (Test-Path $c)) { continue }
+        $current = Join-Path $c 'current'
+        $exe = Join-Path $current 'QuickMail.exe'
+        $out += [pscustomobject]@{
+            Path       = $c
+            HasCurrent = Test-Path $current
+            ExeVersion = if (Test-Path $exe) { (Get-Item $exe).VersionInfo.FileVersion } else { $null }
+            Entries    = ((Get-ChildItem $c -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Name) -join ', ')
+        }
+    }
+    return @($out)
+}
+
+function Get-Shortcuts {
+    $roots = @(
+        (Join-Path $env:APPDATA 'Microsoft\Windows\Start Menu\Programs')
+        (Join-Path $env:ProgramData 'Microsoft\Windows\Start Menu\Programs')
+    )
+    $out = @()
+    foreach ($r in $roots) {
+        if (-not (Test-Path $r)) { continue }
+        $out += Get-ChildItem $r -Recurse -Filter '*QuickMail*.lnk' -ErrorAction SilentlyContinue |
+            ForEach-Object { $_.FullName.Replace($env:USERPROFILE, '~') }
+    }
+    return @($out)
+}
+
+function Get-WingetView {
+    <#  winget's own opinion, when it is usable. Reported verbatim rather than parsed:
+        the question is what a user sees, and the raw table is the answer. #>
+    if (-not $script:WingetAvailable) { return '(winget not available on this runner)' }
+    $out = @()
+    foreach ($cmd in @('list --query QuickMail', 'upgrade')) {
+        $text = & { cmd /c "winget $cmd --disable-interactivity 2>&1" } | Out-String
+        $quickmailLines = ($text -split "`r?`n" | Where-Object { $_ -match 'QuickMail|No installed package|No applicable' }) -join "`n"
+        $out += "`$ winget $cmd`n" + ($(if ($quickmailLines) { $quickmailLines } else { '(no QuickMail lines)' }))
+    }
+    return ($out -join "`n`n")
+}
+
+function Get-Snapshot {
+    param([string]$Label)
+    Get-Process QuickMail -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+    return [pscustomobject]@{
+        Label       = $Label
+        Arp         = Get-ArpRows
+        MsiProducts = Get-MsiProductRows
+        Dirs        = Get-InstallDirs
+        Shortcuts   = Get-Shortcuts
+        Winget      = Get-WingetView
+    }
+}
+
+function Format-Snapshot {
+    param([pscustomobject]$Snap)
+    $sb = [System.Text.StringBuilder]::new()
+    [void]$sb.AppendLine("**State: $($Snap.Label)**")
+    [void]$sb.AppendLine()
+
+    [void]$sb.AppendLine("Add/Remove Programs rows: **$($Snap.Arp.Count)**")
+    [void]$sb.AppendLine()
+    if ($Snap.Arp.Count) {
+        [void]$sb.AppendLine('| Hive | Key | DisplayName | DisplayVersion | Hidden | InstallLocation | QuietUninstallString |')
+        [void]$sb.AppendLine('| --- | --- | --- | --- | --- | --- | --- |')
+        foreach ($r in $Snap.Arp) {
+            $hidden = if ($r.SystemComponent -eq 1) { 'yes' } else { 'no' }
+            $loc = if ($r.InstallLocation) { $r.InstallLocation.Replace($env:LOCALAPPDATA, '%LocalAppData%') } else { '' }
+            $q = if ($r.QuietUninstallString) { '`' + $r.QuietUninstallString.Replace($env:LOCALAPPDATA, '%LocalAppData%') + '`' } else { '—' }
+            [void]$sb.AppendLine("| $($r.Scope) | ``$($r.KeyName)`` | $($r.DisplayName) | $($r.DisplayVersion) | $hidden | $loc | $q |")
+        }
+        [void]$sb.AppendLine()
+    }
+
+    [void]$sb.AppendLine("Windows Installer product registrations: **$($Snap.MsiProducts.Count)**" +
+        $(if ($Snap.MsiProducts.Count) { ' — ' + (($Snap.MsiProducts | ForEach-Object { "$($_.Scope) $($_.ProductName)" }) -join '; ') } else { '' }))
+    [void]$sb.AppendLine()
+
+    [void]$sb.AppendLine('Install directories:')
+    [void]$sb.AppendLine()
+    if ($Snap.Dirs.Count) {
+        foreach ($d in $Snap.Dirs) {
+            $p = $d.Path.Replace($env:LOCALAPPDATA, '%LocalAppData%')
+            [void]$sb.AppendLine("- ``$p`` — exe version $($d.ExeVersion); contains: $($d.Entries)")
+        }
+    } else { [void]$sb.AppendLine('- (none)') }
+    [void]$sb.AppendLine()
+
+    [void]$sb.AppendLine("Start Menu shortcuts: " + $(if ($Snap.Shortcuts.Count) { ($Snap.Shortcuts -join ', ') } else { '(none)' }))
+    [void]$sb.AppendLine()
+    [void]$sb.AppendLine('winget:')
+    [void]$sb.AppendLine()
+    [void]$sb.AppendLine('```')
+    [void]$sb.AppendLine($Snap.Winget)
+    [void]$sb.AppendLine('```')
+    return $sb.ToString()
+}
+
+# --- machine reset -------------------------------------------------------------------
+
+function Reset-Machine {
+    <#  Return to a verified-clean state so the next scenario measures only its own
+        actions. Uninstalls through the product's own strings first (the supported path),
+        then removes anything left behind by force — a scenario that leaves residue is
+        itself a finding, recorded by the caller's post-uninstall snapshot, not here. #>
+    Get-Process QuickMail -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+
+    foreach ($row in Get-ArpRows) {
+        try {
+            if ($row.KeyName -match '^\{[0-9A-Fa-f-]+\}$') {
+                Start-Process msiexec -ArgumentList "/x $($row.KeyName) /qn" -Wait -ErrorAction SilentlyContinue
+            } elseif ($row.QuietUninstallString) {
+                # "path\Update.exe" --uninstall --silent  →  split exe from arguments
+                if ($row.QuietUninstallString -match '^"([^"]+)"\s*(.*)$') {
+                    $exe = $Matches[1]; $argline = $Matches[2]
+                    if (Test-Path $exe) {
+                        Start-Process $exe -ArgumentList $argline -Wait -ErrorAction SilentlyContinue
+                    }
+                }
+            }
+        } catch { Write-Host "reset: uninstall of $($row.KeyName) threw: $_" }
+    }
+
+    Start-Sleep -Seconds 2
+    Get-Process QuickMail -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+
+    foreach ($root in $UninstallRoots) {
+        if (-not (Test-Path $root.Path)) { continue }
+        Get-ChildItem $root.Path -ErrorAction SilentlyContinue |
+            Where-Object {
+                $p = Get-ItemProperty $_.PSPath -ErrorAction SilentlyContinue
+                $_.PSChildName -like '*QuickMail*' -or ($p -and $p.PSObject.Properties['DisplayName'] -and $p.DisplayName -like '*QuickMail*')
+            } |
+            ForEach-Object { Remove-Item $_.PSPath -Recurse -Force -ErrorAction SilentlyContinue }
+    }
+
+    foreach ($d in @('C:\QuickMail', (Join-Path $env:LOCALAPPDATA 'QuickMail'), (Join-Path $env:APPDATA 'QuickMail'))) {
+        Remove-Item $d -Recurse -Force -ErrorAction SilentlyContinue
+    }
+    Get-ChildItem (Join-Path $env:APPDATA 'Microsoft\Windows\Start Menu\Programs') -Recurse -Filter '*QuickMail*.lnk' -ErrorAction SilentlyContinue |
+        Remove-Item -Force -ErrorAction SilentlyContinue
+
+    $left = @(Get-ArpRows).Count + @(Get-InstallDirs).Count
+    if ($left -ne 0) { Write-Host "reset: warning, $left QuickMail traces survived the reset" }
+}
+
+# --- install primitives --------------------------------------------------------------
+
+function Invoke-Installer {
+    param([string]$Path, [string[]]$Arguments, [hashtable]$Env = @{})
+
+    foreach ($k in $Env.Keys) { Set-Item "env:$k" $Env[$k] }
+    try {
+        $sw = [Diagnostics.Stopwatch]::StartNew()
+        $p = Start-Process -FilePath $Path -ArgumentList $Arguments -Wait -PassThru
+        $sw.Stop()
+        Get-Process QuickMail -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+        return [pscustomobject]@{ ExitCode = $p.ExitCode; Seconds = [math]::Round($sw.Elapsed.TotalSeconds, 1) }
+    } finally {
+        foreach ($k in $Env.Keys) { Remove-Item "env:$k" -ErrorAction SilentlyContinue }
+    }
+}
+
+function Get-PackedFile {
+    param([string]$Dir, [string]$Pattern)
+    $f = @(Get-ChildItem $Dir -Filter $Pattern -ErrorAction SilentlyContinue)
+    if ($f.Count -ne 1) { throw "Expected exactly one '$Pattern' in $Dir, found $($f.Count): $(($f | Select-Object -ExpandProperty Name) -join ', ')" }
+    return $f[0].FullName
+}
+
+# --- winget availability -------------------------------------------------------------
+
+$script:WingetAvailable = $null -ne (Get-Command winget -ErrorAction SilentlyContinue)
+if ($script:WingetAvailable) {
+    $wingetVersion = (& winget --version) 2>&1 | Out-String
+    Write-Host "winget available: $wingetVersion"
+} else {
+    Write-Host 'winget not available on this runner; winget-specific checks will report as unavailable.'
+}
+
+# --- resolve inputs ------------------------------------------------------------------
+
+$suffix = if ($Arch -eq 'arm64') { 'win-arm64' } else { 'win' }
+$oldMsi   = Get-PackedFile $OldDir "QuickMail-$OldVersion-$suffix.msi"
+$oldSetup = Get-PackedFile $OldDir "QuickMail-$OldVersion-$suffix-Setup.exe"
+$newMsi   = Get-PackedFile $NewDir "QuickMail-$NewVersion-$suffix.msi"
+$newSetup = Get-PackedFile $NewDir "QuickMail-$NewVersion-$suffix-Setup.exe"
+
+Write-Section "# Installer path matrix — $Arch"
+Write-Section ''
+Write-Section "Old version **$OldVersion**, new version **$NewVersion**. Runner: $((Get-CimInstance Win32_OperatingSystem).Caption) build $([Environment]::OSVersion.Version). winget: $(if ($script:WingetAvailable) { (& winget --version) } else { 'not available' })."
+Write-Section ''
+
+# --- scenario 0: what vpk emitted, and what architecture it is -----------------------
+
+function Get-PEMachine {
+    param([string]$Path)
+    $fs = [System.IO.File]::OpenRead($Path)
+    try {
+        $br = New-Object System.IO.BinaryReader($fs)
+        $fs.Position = 0x3c
+        $fs.Position = $br.ReadInt32() + 4
+        return $br.ReadUInt16()
+    } finally { $fs.Dispose() }
+}
+$machineNames = @{ 0x8664 = 'x64'; 0xAA64 = 'ARM64'; 0x14C = 'x86' }
+
+Write-Section '## Scenario 0 — what `vpk pack` emits'
+Write-Section ''
+Write-Section 'Filenames, verbatim, from the same `vpk pack` arguments the release workflow uses (`--msi --instLocation PerUser`):'
+Write-Section ''
+Write-Section '```'
+Write-Section (Get-ChildItem $NewDir | Select-Object -ExpandProperty Name | Sort-Object | Out-String).Trim()
+Write-Section '```'
+Write-Section ''
+Write-Section 'PE machine type of each installer (this is what komac infers `Architecture:` from when the filename carries no architecture token):'
+Write-Section ''
+Write-Section '| File | PE machine |'
+Write-Section '| --- | --- |'
+foreach ($f in @($newSetup, $newMsi)) {
+    $name = Split-Path $f -Leaf
+    if ($f -like '*.msi') { Write-Section "| ``$name`` | (MSI, not a PE image) |"; continue }
+    $m = Get-PEMachine $f
+    $shown = if ($machineNames.ContainsKey([int]$m)) { $machineNames[[int]$m] } else { "unknown (0x$('{0:X4}' -f $m))" }
+    Write-Section "| ``$name`` | $shown |"
+    if ($Arch -eq 'arm64' -and $shown -ne 'ARM64') {
+        Add-Finding "ARM64 channel's Setup.exe is a $shown binary. komac infers architecture from the binary when the filename carries no architecture token; the ARM64 asset's name does carry one, so this is survivable, but the x64 asset's does not."
+    }
+}
+Write-Section ''
+
+# --- scenario runner -----------------------------------------------------------------
+
+function Invoke-Scenario {
+    param([string]$Title, [string]$Question, [scriptblock]$Body)
+    Write-Host "`n=== $Title ==="
+    Reset-Machine
+    Write-Section "## $Title"
+    Write-Section ''
+    Write-Section "*Question: $Question*"
+    Write-Section ''
+    try {
+        & $Body
+    } catch {
+        Write-Section "**Scenario aborted:** ``$_``"
+        Add-Finding "$Title aborted: $_"
+    }
+    Write-Section ''
+}
+
+Invoke-Scenario 'Scenario 1 — silent MSI, fresh machine' `
+    'Does `msiexec /qn` land in C:\QuickMail on this architecture too (issue #554 was only ever measured on ARM64)?' {
+    $r = Invoke-Installer 'msiexec.exe' @('/i', "`"$newMsi`"", '/qn', '/l*v', "$PWD\msi-fresh.log")
+    Write-Section "``msiexec /i … /qn`` → exit $($r.ExitCode) in $($r.Seconds)s"
+    Write-Section ''
+    Write-Section (Format-Snapshot (Get-Snapshot 'after silent MSI install'))
+    if (Test-Path 'C:\QuickMail') {
+        Add-Finding "Confirmed on $Arch: a silent MSI install lands in C:\QuickMail, not %LocalAppData%. Issue #554 is not architecture-specific."
+    } elseif (Test-Path (Join-Path $env:LOCALAPPDATA 'QuickMail')) {
+        Add-Finding "On $Arch a silent MSI install landed in %LocalAppData% — the opposite of the ARM64 Phase 1 result. Issue #554 may be fixed in this vpk, or architecture-specific."
+    }
+}
+
+Invoke-Scenario 'Scenario 2 — Setup.exe over an MSI install (the migration path)' `
+    'Every existing user installed from the MSI wizard into %LocalAppData%. What does `winget install`/`upgrade` — that is, `Setup.exe --silent` — do to that machine?' {
+    # Reproduce the wizard's install location without driving the wizard: VELOPACK_INSTALLDIR
+    # is exactly what the Next button sets, per the #554 investigation.
+    $target = Join-Path $env:LOCALAPPDATA 'QuickMail'
+    $r1 = Invoke-Installer 'msiexec.exe' @('/i', "`"$oldMsi`"", '/qn') -Env @{ VELOPACK_INSTALLDIR = $target }
+    Write-Section "Step 1 — MSI $OldVersion into ``%LocalAppData%\QuickMail`` (wizard-equivalent): exit $($r1.ExitCode) in $($r1.Seconds)s"
+    Write-Section ''
+    $before = Get-Snapshot "after MSI $OldVersion (wizard-equivalent)"
+    Write-Section (Format-Snapshot $before)
+
+    $r2 = Invoke-Installer $newSetup @('--silent')
+    Write-Section "Step 2 — ``Setup.exe --silent`` $NewVersion over it: exit $($r2.ExitCode) in $($r2.Seconds)s"
+    Write-Section ''
+    $after = Get-Snapshot "after Setup.exe $NewVersion over the MSI install"
+    Write-Section (Format-Snapshot $after)
+
+    $visibleAfter = @($after.Arp | Where-Object { $_.SystemComponent -ne 1 })
+    if ($visibleAfter.Count -gt 1) {
+        Add-Finding "Setup.exe over an MSI install leaves $($visibleAfter.Count) visible Add/Remove Programs rows ($(($visibleAfter | ForEach-Object { $_.KeyName }) -join ', ')). Users see QuickMail more than once in Settings > Apps, and winget has more than one row to correlate against."
+    }
+    if ($after.MsiProducts.Count -gt 0) {
+        Add-Finding "Setup.exe over an MSI install leaves the Windows Installer product registration in place ($(($after.MsiProducts | ForEach-Object { $_.Scope }) -join ', ')). The machine still believes an MSI product is installed at a location Setup.exe has overwritten."
+    }
+    if ($r2.ExitCode -ne 0) {
+        Add-Finding "Setup.exe over an MSI install exited $($r2.ExitCode). winget would report the upgrade as failed."
+    }
+}
+
+Invoke-Scenario 'Scenario 3 — Setup.exe over Setup.exe (the steady-state upgrade)' `
+    'Phase 1 measured this by hand on ARM64. Does it hold on this runner, and does winget see the version advance?' {
+    $r1 = Invoke-Installer $oldSetup @('--silent')
+    Write-Section "Step 1 — ``Setup.exe --silent`` $OldVersion, fresh: exit $($r1.ExitCode) in $($r1.Seconds)s"
+    Write-Section ''
+    Write-Section (Format-Snapshot (Get-Snapshot "after Setup.exe $OldVersion"))
+
+    $r2 = Invoke-Installer $newSetup @('--silent')
+    Write-Section "Step 2 — ``Setup.exe --silent`` $NewVersion over it: exit $($r2.ExitCode) in $($r2.Seconds)s"
+    Write-Section ''
+    $after = Get-Snapshot "after Setup.exe $NewVersion over Setup.exe $OldVersion"
+    Write-Section (Format-Snapshot $after)
+
+    $visible = @($after.Arp | Where-Object { $_.SystemComponent -ne 1 })
+    if ($visible.Count -ne 1) {
+        Add-Finding "Setup-over-Setup left $($visible.Count) visible ARP rows; exactly one was expected."
+    } elseif ($visible[0].DisplayVersion -ne $NewVersion) {
+        Add-Finding "After upgrading to $NewVersion the ARP DisplayVersion still reads '$($visible[0].DisplayVersion)'. winget correlates on this value, so it would keep offering an upgrade that has already been applied."
+    }
+}
+
+Invoke-Scenario 'Scenario 4 — uninstall through the quiet string winget uses' `
+    'winget uninstall runs QuietUninstallString. Does it complete unattended, and what does it leave behind?' {
+    $r1 = Invoke-Installer $newSetup @('--silent')
+    Write-Section "Step 1 — install $NewVersion: exit $($r1.ExitCode) in $($r1.Seconds)s"
+    $installed = Get-Snapshot "installed $NewVersion"
+    $row = @($installed.Arp | Where-Object { $_.QuietUninstallString })
+    if (-not $row.Count) { throw 'No QuietUninstallString on any ARP row; winget uninstall would have nothing to run.' }
+    Write-Section ''
+    Write-Section "QuietUninstallString: ``$($row[0].QuietUninstallString)``"
+    Write-Section ''
+
+    if ($row[0].QuietUninstallString -match '^"([^"]+)"\s*(.*)$') {
+        $r2 = Invoke-Installer $Matches[1] ($Matches[2] -split '\s+')
+        Write-Section "Step 2 — running it: exit $($r2.ExitCode) in $($r2.Seconds)s"
+    }
+    Write-Section ''
+    $after = Get-Snapshot 'after quiet uninstall'
+    Write-Section (Format-Snapshot $after)
+    if ($after.Arp.Count -gt 0) {
+        Add-Finding "The quiet uninstall left $($after.Arp.Count) Add/Remove Programs row(s) behind."
+    }
+    if ($after.Dirs.Count -gt 0) {
+        Add-Finding "The quiet uninstall left directories behind: $(($after.Dirs | ForEach-Object { $_.Path }) -join ', ')."
+    }
+}
+
+Invoke-Scenario 'Scenario 5 — MSI over a Setup.exe install (the reverse migration)' `
+    'A user who installs from winget and later downloads the MSI from the release page ends up here. Is it survivable?' {
+    $r1 = Invoke-Installer $oldSetup @('--silent')
+    Write-Section "Step 1 — ``Setup.exe --silent`` $OldVersion: exit $($r1.ExitCode) in $($r1.Seconds)s"
+    Write-Section ''
+    $target = Join-Path $env:LOCALAPPDATA 'QuickMail'
+    $r2 = Invoke-Installer 'msiexec.exe' @('/i', "`"$newMsi`"", '/qn') -Env @{ VELOPACK_INSTALLDIR = $target }
+    Write-Section "Step 2 — MSI $NewVersion over it (wizard-equivalent location): exit $($r2.ExitCode) in $($r2.Seconds)s"
+    Write-Section ''
+    $after = Get-Snapshot "after MSI $NewVersion over Setup.exe $OldVersion"
+    Write-Section (Format-Snapshot $after)
+    $visible = @($after.Arp | Where-Object { $_.SystemComponent -ne 1 })
+    if ($visible.Count -gt 1) {
+        Add-Finding "MSI over a Setup.exe install leaves $($visible.Count) visible ARP rows — the reverse migration is as messy as the forward one."
+    }
+}
+
+# --- report --------------------------------------------------------------------------
+
+Reset-Machine
+
+$header = @()
+$header += "# QuickMail installer path matrix — $Arch"
+$header += ''
+$header += "Generated by ``scripts/winget-install-matrix.ps1`` on a GitHub-hosted runner. Every scenario starts from a verified-clean machine."
+$header += ''
+if ($script:Findings.Count) {
+    $header += '## Findings'
+    $header += ''
+    foreach ($f in $script:Findings) { $header += "- $f" }
+} else {
+    $header += '## Findings'
+    $header += ''
+    $header += '- None. Every scenario behaved as the winget plan assumes.'
+}
+$header += ''
+$header += '---'
+$header += ''
+
+$body = ($header + $script:Sections) -join "`n"
+$body | Out-File -FilePath $Report -Encoding utf8
+Write-Host "`nReport written to $Report"
+if ($env:GITHUB_STEP_SUMMARY) { $body | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append }

--- a/scripts/winget-install-matrix.ps1
+++ b/scripts/winget-install-matrix.ps1
@@ -227,13 +227,20 @@ function Format-Snapshot {
     [void]$sb.AppendLine("Add/Remove Programs rows: **$($Snap.Arp.Count)**")
     [void]$sb.AppendLine()
     if ($Snap.Arp.Count) {
-        [void]$sb.AppendLine('| Hive | Key | DisplayName | DisplayVersion | Hidden | InstallLocation | QuietUninstallString |')
-        [void]$sb.AppendLine('| --- | --- | --- | --- | --- | --- | --- |')
+        # Publisher is printed, not just captured. A winget manifest's AppsAndFeaturesEntries
+        # must match the ARP row on EVERY field it names, and the manifest in #557 names
+        # DisplayName, Publisher and ProductCode. Two of those were verifiable from this table
+        # and Publisher was not, so a manifest asserting a publisher string Velopack does not
+        # write would fail correlation outright -- winget would treat the package as not
+        # installed after installing it. Do not remove this column to save width.
+        [void]$sb.AppendLine('| Hive | Key | DisplayName | Publisher | DisplayVersion | Hidden | InstallLocation | QuietUninstallString |')
+        [void]$sb.AppendLine('| --- | --- | --- | --- | --- | --- | --- | --- |')
         foreach ($r in $Snap.Arp) {
             $hidden = if ($r.SystemComponent -eq 1) { 'yes' } else { 'no' }
             $loc = if ($r.InstallLocation) { $r.InstallLocation.Replace($env:LOCALAPPDATA, '%LocalAppData%') } else { '' }
             $q = if ($r.QuietUninstallString) { '`' + $r.QuietUninstallString.Replace($env:LOCALAPPDATA, '%LocalAppData%') + '`' } else { '--' }
-            [void]$sb.AppendLine("| $($r.Scope) | ``$($r.KeyName)`` | $($r.DisplayName) | $($r.DisplayVersion) | $hidden | $loc | $q |")
+            $pub = if ($r.Publisher) { $r.Publisher } else { '*(not set)*' }
+            [void]$sb.AppendLine("| $($r.Scope) | ``$($r.KeyName)`` | $($r.DisplayName) | $pub | $($r.DisplayVersion) | $hidden | $loc | $q |")
         }
         [void]$sb.AppendLine()
     }
@@ -586,8 +593,25 @@ Invoke-Scenario 'Scenario 3 -- Setup.exe over Setup.exe (the steady-state upgrad
     $visible = @($after.Arp | Where-Object { $_.SystemComponent -ne 1 })
     if ($visible.Count -ne 1) {
         Add-Finding "Setup-over-Setup left $($visible.Count) visible ARP rows; exactly one was expected."
-    } elseif ($visible[0].DisplayVersion -ne $NewVersion) {
-        Add-Finding "After upgrading to $NewVersion the ARP DisplayVersion still reads '$($visible[0].DisplayVersion)'. winget correlates on this value, so it would keep offering an upgrade that has already been applied."
+    } else {
+        if ($visible[0].DisplayVersion -ne $NewVersion) {
+            Add-Finding "After upgrading to $NewVersion the ARP DisplayVersion still reads '$($visible[0].DisplayVersion)'. winget correlates on this value, so it would keep offering an upgrade that has already been applied."
+        }
+        # This is the row the winget manifest (#557) is written against, in its steady state.
+        # That manifest's AppsAndFeaturesEntries names DisplayName, Publisher and ProductCode,
+        # and winget requires EVERY field a manifest names to match: one wrong value is not a
+        # weaker match, it is no match, after which winget treats QuickMail as not installed
+        # immediately after installing it. Only ProductCode had been checked -- indirectly, by
+        # the key name appearing in `winget list`. Mirror the manifest's values here so a
+        # change on either side shows up as a finding rather than as a support ticket.
+        $manifestEntries = @{ DisplayName = 'QuickMail'; Publisher = 'Kelly Ford'; KeyName = 'QuickMail' }
+        foreach ($field in @($manifestEntries.Keys)) {
+            $actual = $visible[0].$field
+            if ($actual -ne $manifestEntries[$field]) {
+                $named = if ($field -eq 'KeyName') { 'ProductCode' } else { $field }
+                Add-Finding "Velopack's Add/Remove Programs row has $field '$actual', but the winget manifest's AppsAndFeaturesEntries names $named '$($manifestEntries[$field])'. winget requires every field the manifest names to match, so correlation would fail outright."
+            }
+        }
     }
 }
 

--- a/scripts/winget-install-matrix.ps1
+++ b/scripts/winget-install-matrix.ps1
@@ -312,7 +312,9 @@ $newSetup = Get-PackedFile $NewDir "QuickMail-$NewVersion-$suffix-Setup.exe"
 
 Write-Section "# Installer path matrix — $Arch"
 Write-Section ''
-Write-Section "Old version **$OldVersion**, new version **$NewVersion**. Runner: $((Get-CimInstance Win32_OperatingSystem).Caption) build $([Environment]::OSVersion.Version). winget: $(if ($script:WingetAvailable) { (& winget --version) } else { 'not available' })."
+Write-Section "Old version **$OldVersion**, new version **$NewVersion**, both packed locally by this run — neither is a shipped QuickMail artifact."
+Write-Section ''
+Write-Section "Runner: $((Get-CimInstance Win32_OperatingSystem).Caption) build $([Environment]::OSVersion.Version). vpk: $(if ($env:VPK_VERSION) { $env:VPK_VERSION } else { 'unrecorded' }). winget: $(if ($script:WingetAvailable) { (& winget --version) } else { 'not available' })."
 Write-Section ''
 
 # --- scenario 0: what vpk emitted, and what architecture it is -----------------------


### PR DESCRIPTION
Adds a workflow that measures QuickMail's installer behaviour across every install and upgrade path winget can put a machine through, on GitHub-hosted runners — x64 on `windows-latest`, ARM64 on `windows-11-arm`. Pushed as its own PR because it is test infrastructure for #536, not part of the three PRs under review (#553, #555, #557).

**Why.** The winget plan's Phase 1 was hand-tested on one ARM64 machine. That left three gaps the plan's conclusions rest on: x64 was never tested, `Setup.exe` over an MSI-installed copy — the path every existing user takes when they move to winget — was never tested at all, and the winget correlation claims were inferred from registry state rather than measured. Hand-testing does not scale to a matrix and cannot be re-run against a future vpk.

**How.** It packs two synthetic versions (1.0.0, 1.0.1) with the release workflow's own `vpk pack` arguments, then walks five scenarios, snapshotting Add/Remove Programs rows across all three hives, Windows Installer product registrations, install directories, Start Menu shortcuts, and `winget list` / `winget upgrade` output after each step. Every scenario starts from a verified-clean machine. Nothing is signed — signing does not affect install location, ARP registration, or upgrade semantics, and the Azure OIDC credentials are deliberately reachable only from tag builds.

**What it found on its first complete run** ([31958458925](https://github.com/kellylford/QuickMail/actions/runs/31958458925), vpk 1.2.0):

- **`Setup.exe` over an MSI install leaves two Add/Remove Programs rows, both called QuickMail, and `winget list` shows the app twice.** The old `MSI:QuickMail` row keeps the pre-upgrade version and its `msiexec /x` quiet-uninstall string, pointed at files the new install now owns. The MSI's Windows Installer product registration survives too. Identical on both architectures.
- Both `Setup.exe` binaries are **x86** PE images, on both channels — architecture cannot be inferred from the binary, only from the filename, and the x64 asset's filename carries no architecture token.
- The silent-MSI defect (#554) reproduces on **x64**, which Phase 1 never covered — and it is not literally `C:\`: the x64 runner installed to `D:\QuickMail`, i.e. whatever drive Windows Installer picks for TARGETDIR.
- Setup-over-Setup and the quiet uninstall are clean: exactly one ARP row, `DisplayVersion` advances, and the uninstall leaves no rows, directories, or shortcuts.
- `vpk pack`'s output filenames are exactly what #555 hardcodes, on both channels.

Findings are written into the plan document by #553; the manifest change they imply is in #557.

**Trigger:** push a branch named `test/winget-**`, or from the Actions tab once this is on `main`. Roughly 12 minutes per leg, dominated by `dotnet publish`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
