### PR TITLE
Fix #566: every mail command follows the group selection, not a stale message

### DIFF
--- a/QuickMail.Tests/GroupSelectionActionTests.cs
+++ b/QuickMail.Tests/GroupSelectionActionTests.cs
@@ -1,0 +1,174 @@
+// Issue #566: what a mail command acts on when the selection is a group header, not a message.
+//
+// Selecting a conversation / sender / recipient header does not update SelectedMessage — the tree
+// controller only assigns it for message nodes — so every command that read SelectedMessage acted
+// on whatever had been selected before the user arrowed onto the header, or, with nothing selected
+// yet, reported itself unavailable and did nothing at all. The View now hands the VM a
+// SelectedGroupResolver, and these tests pin the two rules that resolver exists to enforce:
+// reply-shaped actions answer the group's NEWEST message (one reply, not twenty), and
+// delete-shaped actions act on the whole group.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using QuickMail.Models;
+using QuickMail.Services;
+using QuickMail.ViewModels;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+public class GroupSelectionActionTests
+{
+    private static readonly Guid AccountId = Guid.Parse("33333333-3333-3333-3333-333333333333");
+
+    private sealed class AccountsStub : IAccountService
+    {
+        public List<AccountModel> LoadAccounts() =>
+            [new AccountModel { Id = AccountId, AccountName = "Work" }];
+        public void SaveAccounts(List<AccountModel> a) { }
+        public void SetDefaultAccount(Guid accountId) { }
+    }
+
+    private static MailMessageSummary Message(string id, string subject = "Thread") => new()
+    {
+        MessageId  = id,
+        AccountId  = AccountId,
+        FolderName = "INBOX",
+        Subject    = subject,
+    };
+
+    private static MainViewModel MakeVm() => new(
+        new StubImapMailService(), new AccountsStub(), new StubCredentialService(),
+        new StubLocalStoreService(), new StubOAuthService(), new StubSyncService(),
+        new StubConfigService(), new StubCommandRegistry(), new StubViewService(),
+        new StubRuleService(), new StubSmtpService());
+
+    /// <summary>A three-message conversation, newest first, as the builders produce them.</summary>
+    private static MailMessageSummary[] Conversation() =>
+        [Message("newest"), Message("middle"), Message("oldest")];
+
+    /// <summary>
+    /// The reported symptom: no message had been selected, so the command was never even offered.
+    /// </summary>
+    [Fact]
+    public void AGroupHeaderIsATarget_EvenWithNoSelectedMessage()
+    {
+        var vm = MakeVm();
+        Assert.False(vm.CanActOnSelection());
+
+        vm.SelectedGroupResolver = Conversation;
+
+        Assert.True(vm.CanActOnSelection());
+    }
+
+    /// <summary>An empty group is not a target — there is nothing in it to act on.</summary>
+    [Fact]
+    public void AnEmptyGroupIsNotATarget()
+    {
+        var vm = MakeVm();
+        vm.SelectedGroupResolver = () => [];
+
+        Assert.False(vm.CanActOnSelection());
+    }
+
+    /// <summary>
+    /// Reply, Reply All and Forward answer the newest message in the thread — the latest word in
+    /// it — not the message that happened to be selected before the header was.
+    /// </summary>
+    [Theory]
+    [InlineData("reply")]
+    [InlineData("replyAll")]
+    [InlineData("forward")]
+    public async Task ReplyingToAGroup_AnswersItsNewestMessage(string which)
+    {
+        var vm    = MakeVm();
+        var group = Conversation();
+        vm.SelectedMessage      = Message("stale", "Some other thread");
+        vm.SelectedGroupResolver = () => group;
+
+        await (which switch
+        {
+            "reply"    => vm.ReplyCommand.ExecuteAsync(null),
+            "replyAll" => vm.ReplyAllCommand.ExecuteAsync(null),
+            _          => vm.ForwardCommand.ExecuteAsync(null),
+        });
+
+        Assert.Same(group[0], vm.SelectedMessage);
+    }
+
+    /// <summary>
+    /// Delete acts on every message in the group. The count in the status text is the observable
+    /// difference between filing the thread and filing one stale message.
+    /// </summary>
+    [Fact]
+    public async Task DeletingAGroup_DeletesEveryMessageInIt()
+    {
+        var vm    = MakeVm();
+        var group = Conversation();
+        vm.SelectedMessage       = Message("stale", "Some other thread");
+        vm.SelectedGroupResolver = () => group;
+
+        await vm.DeleteMessageCommand.ExecuteAsync(null);
+
+        Assert.Contains("3 messages deleted", vm.StatusText, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The fallback has to keep working: with a message selected and no group header, every command
+    /// acts on that message exactly as it did before.
+    /// </summary>
+    [Fact]
+    public async Task WithNoGroupSelected_TheSelectedMessageIsStillTheTarget()
+    {
+        var vm  = MakeVm();
+        var msg = Message("only");
+        vm.SelectedMessage       = msg;
+        vm.SelectedGroupResolver = () => null;
+
+        Assert.True(vm.CanActOnSelection());
+
+        await vm.ReplyCommand.ExecuteAsync(null);
+        Assert.Same(msg, vm.SelectedMessage);
+
+        await vm.DeleteMessageCommand.ExecuteAsync(null);
+        Assert.Contains("1 message deleted", vm.StatusText, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// No resolver at all — the state of any host without group trees, and of the VM before the
+    /// window wires itself up. Nothing may throw, and the selected message stays the target.
+    /// </summary>
+    [Fact]
+    public async Task WithNoResolverWired_NothingChanges()
+    {
+        var vm  = MakeVm();
+        var msg = Message("only");
+        vm.SelectedMessage = msg;
+
+        Assert.True(vm.CanActOnSelection());
+
+        await vm.ReplyCommand.ExecuteAsync(null);
+        Assert.Same(msg, vm.SelectedMessage);
+    }
+
+    /// <summary>
+    /// HasMessageTarget is what the Message menu dims on. It is a snapshot, refreshed as the menu
+    /// opens, because a header selection changes the answer without changing SelectedMessage.
+    /// </summary>
+    [Fact]
+    public void RefreshMessageTarget_TracksTheGroupSelection()
+    {
+        var vm = MakeVm();
+        vm.RefreshMessageTarget();
+        Assert.False(vm.HasMessageTarget);
+
+        vm.SelectedGroupResolver = Conversation;
+        vm.RefreshMessageTarget();
+        Assert.True(vm.HasMessageTarget);
+
+        vm.SelectedGroupResolver = () => null;
+        vm.RefreshMessageTarget();
+        Assert.False(vm.HasMessageTarget);
+    }
+}

--- a/QuickMail.Tests/LastMessageDestinationTests.cs
+++ b/QuickMail.Tests/LastMessageDestinationTests.cs
@@ -336,7 +336,11 @@ public class LastMessageDestinationCallSiteTests
         var source = File.ReadAllText(SourcePath("Views/MainWindow.xaml.cs"));
         var calls  = Regex.Matches(source, @"BuildMessageFolderPicker\(\s*[^;]*?""(?<title>[^""]*)""[^;]*?\)\s*;");
 
-        Assert.Equal(10, calls.Count);   // update deliberately when an entry point is added or removed
+        // Update deliberately when an entry point is added or removed. It was 10 until the two
+        // menu-bar handlers stopped building their own picker and delegated to the command's
+        // method instead (#566), which is one entry point fewer to keep in step for each of
+        // move and copy, not one fewer place the user can file from.
+        Assert.Equal(8, calls.Count);
 
         foreach (Match call in calls)
         {

--- a/QuickMail.Tests/MoveToFolderGroupTargetTests.cs
+++ b/QuickMail.Tests/MoveToFolderGroupTargetTests.cs
@@ -1,0 +1,136 @@
+using System;
+using System.IO;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// Issue #566: Move to Folder did nothing when the selection was a conversation, not a message.
+/// Selecting a group header does not update <c>MainViewModel.SelectedMessage</c>
+/// (<c>GroupedMessageTreeController.OnSelectedItemChanged</c>), so a command that reads only the
+/// selected message either files the message the user had selected before arrowing onto the header —
+/// silently the wrong one — or, with none selected, is never even available. Both failure modes are
+/// invisible: the wrong-message one leaves a picker looking perfectly normal.
+///
+/// <para>Neither the handlers nor the registrations can be exercised without a shown
+/// <c>MainWindow</c> and a realized <c>TreeView</c> container (WPF's <c>TreeView.SelectedItem</c> is
+/// read-only; only a live container can set it), and the handlers then block on a modal picker. So
+/// this reads the source, as <see cref="FolderMoveCopyCallSiteTests"/> does for the same reason:
+/// dropping the group branch, or putting the availability gate back on the selected message alone,
+/// fails here.</para>
+///
+/// <para>Plain <c>[Fact]</c>/<c>[Theory]</c> — text and regex, no WPF — so it stays out of the
+/// <c>WpfTests</c> collection.</para>
+/// </summary>
+public class MoveToFolderGroupTargetTests
+{
+    private const string MainWindowSource = "Views/MainWindow.xaml.cs";
+
+    /// <summary>Both file actions must resolve a selected group header before falling back.</summary>
+    [Theory]
+    [InlineData("MoveMessageToFolderAsync")]
+    [InlineData("CopyMessageToFolderAsync")]
+    public void FilingAMessage_ResolvesASelectedGroupHeaderFirst(string method)
+    {
+        var body = MethodBody(MainWindowSource, method);
+
+        Assert.Contains("SelectedGroupTarget()", body, StringComparison.Ordinal);
+        Assert.Contains("GetSelectedMessages()", body, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The whole point of the fix: the hotkey and the palette must offer the command when a group
+    /// header is selected. Gating on the selected message alone is what made the hotkey do nothing.
+    /// </summary>
+    [Theory]
+    [InlineData("mail.moveToFolder")]
+    [InlineData("mail.copyToFolder")]
+    public void TheFileCommandsAreAvailableOnAGroupHeader(string commandId)
+    {
+        var registration = RegistrationOf(MainWindowSource, commandId);
+
+        Assert.Contains("isAvailable: CanFileSelection", registration, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Availability and target resolution have to agree, and both have to cover every grouped view —
+    /// a fix that only reached Conversations would leave From and To exactly as #566 found them.
+    /// </summary>
+    [Fact]
+    public void GroupTargetingCoversAllThreeGroupedViews()
+    {
+        foreach (var method in new[] { "SelectedGroupTarget", "IsGroupRowSelected" })
+        {
+            var body = MethodBody(MainWindowSource, method);
+            foreach (var tree in new[] { "ConversationTree", "SenderGroupTree", "ToGroupTree" })
+                Assert.Contains(tree, body, StringComparison.Ordinal);
+        }
+
+        Assert.Contains("IsGroupRowSelected()", MethodBody(MainWindowSource, "CanFileSelection"),
+                        StringComparison.Ordinal);
+    }
+
+    /// <summary>The text of one <c>_registry.Register</c> call, found by the command id it declares.</summary>
+    private static string RegistrationOf(string relativePath, string commandId)
+    {
+        var source = ReadSource(relativePath);
+        var idAt   = source.IndexOf($"id: \"{commandId}\"", StringComparison.Ordinal);
+        Assert.True(idAt >= 0, $"{commandId} is not registered in {relativePath} — renamed or removed?");
+
+        var end = source.IndexOf("));", idAt, StringComparison.Ordinal);
+        Assert.True(end > idAt, $"could not find the end of the {commandId} registration.");
+
+        return source.Substring(idAt, end - idAt);
+    }
+
+    /// <summary>
+    /// Text of one method, from its declaration to the first closing brace at the same indentation
+    /// (or, for an expression body, to the first semicolon). Crude, but this file's braces are
+    /// consistently indented, and a miss fails loudly rather than silently matching the wrong text.
+    /// <para>The declaration is matched on its access modifier, not on the name alone: these methods
+    /// are also named inside the command registrations above them, and matching a call site would
+    /// silently read the wrong block of source.</para>
+    /// </summary>
+    private static string MethodBody(string relativePath, string methodName)
+    {
+        var source = ReadSource(relativePath);
+        var start  = Regex.Match(
+            source,
+            $@"^(?<indent>[ \t]*)(private|public|internal|protected)[^\r\n]*\b{Regex.Escape(methodName)}\s*\(",
+            RegexOptions.Multiline);
+        Assert.True(start.Success, $"{methodName} not found in {relativePath} — renamed or removed?");
+
+        var rest = source[start.Index..];
+        var end  = rest.Contains("=>", StringComparison.Ordinal)
+                   && rest.IndexOf("=>", StringComparison.Ordinal) < FirstBraceOrEnd(rest)
+            ? Regex.Match(rest, @";")                                   // expression body
+            : Regex.Match(rest, $@"^{start.Groups["indent"].Value}}}", RegexOptions.Multiline);
+        Assert.True(end.Success, $"could not find the end of {methodName} in {relativePath}.");
+
+        return rest[..(end.Index + end.Length)];
+    }
+
+    private static int FirstBraceOrEnd(string text)
+    {
+        var i = text.IndexOf('{');
+        return i < 0 ? text.Length : i;
+    }
+
+    private static string ReadSource(string relativePath)
+    {
+        var path = Path.Combine(RepoRoot(), "QuickMail", relativePath.Replace('/', Path.DirectorySeparatorChar));
+        Assert.True(File.Exists(path), $"{path} not found.");
+        return File.ReadAllText(path);
+    }
+
+    private static string RepoRoot()
+    {
+        for (var dir = new DirectoryInfo(AppContext.BaseDirectory); dir != null; dir = dir.Parent)
+        {
+            if (Directory.Exists(Path.Combine(dir.FullName, "QuickMail", "Views")))
+                return dir.FullName;
+        }
+        throw new InvalidOperationException($"Repo source tree not found from {AppContext.BaseDirectory}.");
+    }
+}

--- a/QuickMail.Tests/MoveToFolderGroupTargetTests.cs
+++ b/QuickMail.Tests/MoveToFolderGroupTargetTests.cs
@@ -7,25 +7,33 @@ namespace QuickMail.Tests;
 
 /// <summary>
 /// Issue #566: Move to Folder did nothing when the selection was a conversation, not a message.
-/// Selecting a group header does not update <c>MainViewModel.SelectedMessage</c>
-/// (<c>GroupedMessageTreeController.OnSelectedItemChanged</c>), so a command that reads only the
-/// selected message either files the message the user had selected before arrowing onto the header —
-/// silently the wrong one — or, with none selected, is never even available. Both failure modes are
-/// invisible: the wrong-message one leaves a picker looking perfectly normal.
+/// <see cref="GroupSelectionActionTests"/> covers the rules themselves, which now live in the VM
+/// and can be tested directly. What cannot be tested that way is the wiring on either side of them:
+/// the window resolving the tree's selection, and each command asking for it.
 ///
-/// <para>Neither the handlers nor the registrations can be exercised without a shown
-/// <c>MainWindow</c> and a realized <c>TreeView</c> container (WPF's <c>TreeView.SelectedItem</c> is
-/// read-only; only a live container can set it), and the handlers then block on a modal picker. So
-/// this reads the source, as <see cref="FolderMoveCopyCallSiteTests"/> does for the same reason:
-/// dropping the group branch, or putting the availability gate back on the selected message alone,
-/// fails here.</para>
+/// <para>Neither can be exercised without a shown <c>MainWindow</c> and a realized <c>TreeView</c>
+/// container (WPF's <c>TreeView.SelectedItem</c> is read-only; only a live container can set it),
+/// and the file handlers then block on a modal picker. So this reads the source, as
+/// <see cref="FolderMoveCopyCallSiteTests"/> does for the same reason: unhooking the resolver, or
+/// putting an availability gate back on the selected message alone, fails here.</para>
 ///
 /// <para>Plain <c>[Fact]</c>/<c>[Theory]</c> — text and regex, no WPF — so it stays out of the
 /// <c>WpfTests</c> collection.</para>
 /// </summary>
 public class MoveToFolderGroupTargetTests
 {
-    private const string MainWindowSource = "Views/MainWindow.xaml.cs";
+    private const string MainWindow = "Views/MainWindow.xaml.cs";
+    private const string MainVm     = "ViewModels/MainViewModel.cs";
+
+    /// <summary>
+    /// The one wire between the two halves: without it the VM has no way to see a group header and
+    /// every rule below it goes back to reading the stale selected message.
+    /// </summary>
+    [Fact]
+    public void TheWindowHandsTheViewModelItsGroupSelection()
+    {
+        Assert.Matches(@"_vm\.SelectedGroupResolver\s*=", ReadSource(MainWindow));
+    }
 
     /// <summary>Both file actions must resolve a selected group header before falling back.</summary>
     [Theory]
@@ -33,45 +41,58 @@ public class MoveToFolderGroupTargetTests
     [InlineData("CopyMessageToFolderAsync")]
     public void FilingAMessage_ResolvesASelectedGroupHeaderFirst(string method)
     {
-        var body = MethodBody(MainWindowSource, method);
+        var body = MethodBody(MainWindow, method);
 
         Assert.Contains("SelectedGroupTarget()", body, StringComparison.Ordinal);
         Assert.Contains("GetSelectedMessages()", body, StringComparison.Ordinal);
+        // The silent return is what made #566 read as "nothing happened"; an unsynced folder list
+        // must not reproduce it.
+        Assert.Contains("FoldersAreReady()", body, StringComparison.Ordinal);
     }
 
     /// <summary>
-    /// The whole point of the fix: the hotkey and the palette must offer the command when a group
-    /// header is selected. Gating on the selected message alone is what made the hotkey do nothing.
+    /// The whole point of the fix: every command that acts on the mail selection must be offered
+    /// when a group header is selected. Gating on the selected message alone is what made the
+    /// hotkey do nothing.
     /// </summary>
     [Theory]
-    [InlineData("mail.moveToFolder")]
-    [InlineData("mail.copyToFolder")]
-    public void TheFileCommandsAreAvailableOnAGroupHeader(string commandId)
+    [InlineData(MainWindow, "mail.moveToFolder")]
+    [InlineData(MainWindow, "mail.copyToFolder")]
+    [InlineData(MainWindow, "mail.openInNewTab")]
+    [InlineData(MainWindow, "mail.openInWindow")]
+    [InlineData(MainWindow, "mail.pickFlag")]
+    [InlineData(MainWindow, "mail.delete")]
+    [InlineData(MainWindow, "mail.archive")]
+    [InlineData(MainVm,     "mail.reply")]
+    [InlineData(MainVm,     "mail.replyAll")]
+    [InlineData(MainVm,     "mail.forward")]
+    [InlineData(MainVm,     "mail.delete")]
+    [InlineData(MainVm,     "mail.archive")]
+    [InlineData(MainVm,     "mail.createRuleFromMessage")]
+    public void SelectionCommandsAreAvailableOnAGroupHeader(string source, string commandId)
     {
-        var registration = RegistrationOf(MainWindowSource, commandId);
+        var registration = RegistrationOf(source, commandId);
 
-        Assert.Contains("isAvailable: CanFileSelection", registration, StringComparison.Ordinal);
+        Assert.Contains("CanActOnSelection", registration, StringComparison.Ordinal);
+        Assert.DoesNotContain("HasSelectedMessage", registration, StringComparison.Ordinal);
     }
 
     /// <summary>
-    /// Availability and target resolution have to agree, and both have to cover every grouped view —
-    /// a fix that only reached Conversations would leave From and To exactly as #566 found them.
+    /// Target resolution has to cover every grouped view — a fix that only reached Conversations
+    /// would leave From and To exactly as #566 found them.
     /// </summary>
     [Fact]
     public void GroupTargetingCoversAllThreeGroupedViews()
     {
-        foreach (var method in new[] { "SelectedGroupTarget", "IsGroupRowSelected" })
+        foreach (var method in new[] { "SelectedGroupTarget", "IsGroupRowSelected", "SelectedGroupIndex" })
         {
-            var body = MethodBody(MainWindowSource, method);
-            foreach (var tree in new[] { "ConversationTree", "SenderGroupTree", "ToGroupTree" })
-                Assert.Contains(tree, body, StringComparison.Ordinal);
+            var body = MethodBody(MainWindow, method);
+            foreach (var view in new[] { "Conversation", "SenderGroup", "ToGroup" })
+                Assert.Contains(view, body, StringComparison.Ordinal);
         }
-
-        Assert.Contains("IsGroupRowSelected()", MethodBody(MainWindowSource, "CanFileSelection"),
-                        StringComparison.Ordinal);
     }
 
-    /// <summary>The text of one <c>_registry.Register</c> call, found by the command id it declares.</summary>
+    /// <summary>The text of one <c>Register</c> call, found by the command id it declares.</summary>
     private static string RegistrationOf(string relativePath, string commandId)
     {
         var source = ReadSource(relativePath);
@@ -86,11 +107,11 @@ public class MoveToFolderGroupTargetTests
 
     /// <summary>
     /// Text of one method, from its declaration to the first closing brace at the same indentation
-    /// (or, for an expression body, to the first semicolon). Crude, but this file's braces are
+    /// (or, for an expression body, to the first semicolon). Crude, but these files' braces are
     /// consistently indented, and a miss fails loudly rather than silently matching the wrong text.
-    /// <para>The declaration is matched on its access modifier, not on the name alone: these methods
-    /// are also named inside the command registrations above them, and matching a call site would
-    /// silently read the wrong block of source.</para>
+    /// <para>The declaration is matched on its access modifier, not on the name alone: these
+    /// methods are also named inside the command registrations above them, and matching a call site
+    /// would silently read the wrong block of source.</para>
     /// </summary>
     private static string MethodBody(string relativePath, string methodName)
     {
@@ -102,8 +123,8 @@ public class MoveToFolderGroupTargetTests
         Assert.True(start.Success, $"{methodName} not found in {relativePath} — renamed or removed?");
 
         var rest = source[start.Index..];
-        var end  = rest.Contains("=>", StringComparison.Ordinal)
-                   && rest.IndexOf("=>", StringComparison.Ordinal) < FirstBraceOrEnd(rest)
+        var end  = rest.IndexOf("=>", StringComparison.Ordinal) is var arrow
+                   && arrow >= 0 && arrow < FirstBraceOrEnd(rest)
             ? Regex.Match(rest, @";")                                   // expression body
             : Regex.Match(rest, $@"^{start.Groups["indent"].Value}}}", RegexOptions.Multiline);
         Assert.True(end.Success, $"could not find the end of {methodName} in {relativePath}.");

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -2265,29 +2265,32 @@ public partial class MainViewModel : ObservableObject, IDisposable
             execute: () => NewMessageCommand.Execute(null),
             defaultKey: Key.N, defaultModifiers: ModifierKeys.Control));
 
+        // These gate on CanActOnSelection, not HasSelectedMessage: a selected group header is a
+        // target too, and gating on the selected message alone left them unavailable — the hotkey
+        // doing nothing at all — whenever no message had been selected yet (issue #566).
         registry.Register(new CommandDefinition(
             id: "mail.reply", category: "Mail", title: "Reply",
             execute: () => ReplyCommand.Execute(null),
             defaultKey: Key.R, defaultModifiers: ModifierKeys.Control,
-            isAvailable: () => HasSelectedMessage));
+            isAvailable: CanActOnSelection));
 
         registry.Register(new CommandDefinition(
             id: "mail.replyAll", category: "Mail", title: "Reply All",
             execute: () => ReplyAllCommand.Execute(null),
             defaultKey: Key.R, defaultModifiers: ModifierKeys.Control | ModifierKeys.Shift,
-            isAvailable: () => HasSelectedMessage));
+            isAvailable: CanActOnSelection));
 
         registry.Register(new CommandDefinition(
             id: "mail.forward", category: "Mail", title: "Forward",
             execute: () => ForwardCommand.Execute(null),
             defaultKey: Key.F, defaultModifiers: ModifierKeys.Control,
-            isAvailable: () => HasSelectedMessage));
+            isAvailable: CanActOnSelection));
 
         registry.Register(new CommandDefinition(
             id: "mail.delete", category: "Mail", title: "Delete",
             execute: () => DeleteMessageCommand.Execute(null),
             defaultKey: Key.Delete, defaultModifiers: ModifierKeys.None,
-            isAvailable: () => HasSelectedMessage));
+            isAvailable: CanActOnSelection));
 
         // Archive (issue #318) — moves the selection to the account's Archive folder instead of
         // deleting. Default gesture Ctrl+Shift+M. (Not Alt+Delete: that collides with the common
@@ -2298,7 +2301,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
             id: "mail.archive", category: "Mail", title: "Move to Archive",
             execute: () => ArchiveMessageCommand.Execute(null),
             defaultKey: Key.M, defaultModifiers: ModifierKeys.Control | ModifierKeys.Shift,
-            isAvailable: () => HasSelectedMessage));
+            isAvailable: CanActOnSelection));
 
         registry.Register(new CommandDefinition(
             id: "mail.refresh", category: "Mail", title: "Refresh",
@@ -2456,7 +2459,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
             id: "mail.createRuleFromMessage", category: "Mail", title: "Create Rule from Message",
             execute: () => CreateRuleFromMessageCommand.Execute(null),
             defaultKey: Key.T, defaultModifiers: ModifierKeys.Control | ModifierKeys.Shift,
-            isAvailable: () => HasSelectedMessage));
+            isAvailable: CanActOnSelection));
 
         registry.Register(new CommandDefinition(
             id: "mail.acceptInvite", category: "Mail", title: "Accept Invitation",
@@ -5923,24 +5926,49 @@ public partial class MainViewModel : ObservableObject, IDisposable
     public bool HasWatchTarget => _watchService != null && HasWatchableSubject(WatchTargetSubject);
 
     /// <summary>
-    /// Supplied by the View: resolves whether Move/Copy to Folder have anything to act on.
-    /// <para>Same shape and same reason as <see cref="WatchTargetResolver"/> — a selected group
-    /// header does not update <see cref="SelectedMessage"/>, so only the View can tell that a whole
-    /// conversation is selected. Null falls back to the selected message, which is correct for any
-    /// host without group trees.</para>
+    /// Supplied by the View: the messages of the group header selected in the active grouped view,
+    /// newest first, or null when the selection is a single message.
+    /// <para>Same shape and same reason as <see cref="WatchTargetResolver"/> — selecting a group
+    /// header does not update <see cref="SelectedMessage"/> (see
+    /// <c>GroupedMessageTreeController.OnSelectedItemChanged</c>), so only the View can tell that a
+    /// whole conversation, sender, or recipient is selected. Without it every action below reads
+    /// the message that was selected before the user arrowed onto the header, and acts on that —
+    /// silently the wrong one. That was issue #566.</para>
     /// </summary>
-    public Func<bool>? FileTargetResolver { get; set; }
+    public Func<IReadOnlyList<MailMessageSummary>?>? SelectedGroupResolver { get; set; }
+
+    /// <summary>The selected group's messages, or null when a group header is not the selection.</summary>
+    private IReadOnlyList<MailMessageSummary>? SelectedGroupMessages() =>
+        SelectedGroupResolver?.Invoke() is { Count: > 0 } messages ? messages : null;
 
     /// <summary>
-    /// True when Move/Copy to Folder have a target: a selected message, or a selected group header
-    /// (issue #566). Recomputed as the Message menu opens, because a header selection changes it
+    /// True when a message action has something to act on: a selected message, or a selected group
+    /// header. The availability gate for every command that acts on the mail selection, so the
+    /// hotkey, the menu bar and the Command Palette agree on what is possible (issue #566).
+    /// </summary>
+    public bool CanActOnSelection() => HasSelectedMessage || SelectedGroupMessages() != null;
+
+    /// <summary>
+    /// Backs the Message menu's dimming — a property, because the menu binds to it. Recomputed as
+    /// the menu opens (<see cref="RefreshMessageTarget"/>), because a header selection changes it
     /// without changing <see cref="SelectedMessage"/>.
     /// </summary>
     [ObservableProperty]
-    private bool _hasFileTarget;
+    private bool _hasMessageTarget;
 
-    /// <summary>Recomputes <see cref="HasFileTarget"/> from the View's resolver.</summary>
-    public void RefreshFileTarget() => HasFileTarget = FileTargetResolver?.Invoke() ?? HasSelectedMessage;
+    /// <summary>Recomputes <see cref="HasMessageTarget"/> from the View's resolver.</summary>
+    public void RefreshMessageTarget() => HasMessageTarget = CanActOnSelection();
+
+    /// <summary>
+    /// Points Reply, Reply All and Forward at the newest message of a selected group: one reply to
+    /// the latest word in the thread, not one per message. The group context menus already work
+    /// this way — they set <see cref="SelectedMessage"/> to <c>Messages[0]</c> before composing —
+    /// and this is the same rule for the menu bar, the hotkeys and the Command Palette.
+    /// </summary>
+    private void RetargetToGroupNewest()
+    {
+        if (SelectedGroupMessages() is { } messages) SelectedMessage = messages[0];
+    }
 
     /// <summary>
     /// Opens the Watched Conversations folder and selects the newest message of one conversation.
@@ -6601,6 +6629,9 @@ public partial class MainViewModel : ObservableObject, IDisposable
     [RelayCommand]
     private async Task DeleteMessageAsync()
     {
+        // A selected group header deletes the whole group, as the group trees' own Delete key and
+        // the group context menus already do (issue #566).
+        if (SelectedGroupMessages() is { } group) { await DeleteMessagesAsync(group); return; }
         if (SelectedMessage == null) return;
         await DeleteMessagesAsync([SelectedMessage]);
     }
@@ -6757,6 +6788,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
     [RelayCommand]
     private async Task ArchiveMessageAsync()
     {
+        if (SelectedGroupMessages() is { } group) { await ArchiveMessagesAsync(group); return; }
         if (SelectedMessage == null) return;
         await ArchiveMessagesAsync([SelectedMessage]);
     }
@@ -7155,6 +7187,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
     [RelayCommand]
     private async Task Reply()
     {
+        RetargetToGroupNewest();
         var detail = await EnsureDetailAsync();
         if (detail == null) return;
         ComposeRequested?.Invoke(ComposeViewModel.CreateReply(detail, detail.AccountId));
@@ -7163,6 +7196,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
     [RelayCommand]
     private async Task ReplyAll()
     {
+        RetargetToGroupNewest();
         var detail = await EnsureDetailAsync();
         if (detail == null) return;
         var ownAddress = Accounts.FirstOrDefault(a => a.Id == detail.AccountId)?.Username ?? string.Empty;
@@ -7172,6 +7206,8 @@ public partial class MainViewModel : ObservableObject, IDisposable
     [RelayCommand]
     private async Task Forward()
     {
+        // No-op when a group command already set the target to this same newest message.
+        RetargetToGroupNewest();
         var detail = await EnsureDetailAsync();
         if (detail == null) return;
 
@@ -7325,6 +7361,8 @@ public partial class MainViewModel : ObservableObject, IDisposable
     [RelayCommand]
     private void CreateRuleFromMessage()
     {
+        // On a group header the rule comes from its newest message, the same one Reply answers.
+        RetargetToGroupNewest();
         var source = SelectedMessage;
         if (source == null) return;
 

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -5923,6 +5923,26 @@ public partial class MainViewModel : ObservableObject, IDisposable
     public bool HasWatchTarget => _watchService != null && HasWatchableSubject(WatchTargetSubject);
 
     /// <summary>
+    /// Supplied by the View: resolves whether Move/Copy to Folder have anything to act on.
+    /// <para>Same shape and same reason as <see cref="WatchTargetResolver"/> — a selected group
+    /// header does not update <see cref="SelectedMessage"/>, so only the View can tell that a whole
+    /// conversation is selected. Null falls back to the selected message, which is correct for any
+    /// host without group trees.</para>
+    /// </summary>
+    public Func<bool>? FileTargetResolver { get; set; }
+
+    /// <summary>
+    /// True when Move/Copy to Folder have a target: a selected message, or a selected group header
+    /// (issue #566). Recomputed as the Message menu opens, because a header selection changes it
+    /// without changing <see cref="SelectedMessage"/>.
+    /// </summary>
+    [ObservableProperty]
+    private bool _hasFileTarget;
+
+    /// <summary>Recomputes <see cref="HasFileTarget"/> from the View's resolver.</summary>
+    public void RefreshFileTarget() => HasFileTarget = FileTargetResolver?.Invoke() ?? HasSelectedMessage;
+
+    /// <summary>
     /// Opens the Watched Conversations folder and selects the newest message of one conversation.
     /// Called by the manager's "go to conversation". Selecting the folder rather than filtering
     /// keeps every other view control (mode, sort, fields) behaving exactly as it does when the

--- a/QuickMail/Views/MainWindow.xaml
+++ b/QuickMail/Views/MainWindow.xaml
@@ -360,12 +360,15 @@
                 <!-- Keep IsEnabled off these three items so they remain keyboard-navigable
                      per Windows convention (dimmed items are still focusable). Visual dimming
                      is applied via DataTrigger; the Click handlers guard against invalid state. -->
+                <!-- HasFileTarget, not HasSelectedMessage: these also file a selected conversation,
+                     whose header selection leaves SelectedMessage untouched (issue #566). It is
+                     recomputed in MessageMenu_SubmenuOpened, as HasWatchTarget above is. -->
                 <MenuItem Header="_Move to Folder…"
                           Click="MenuMoveToFolder_Click">
                     <MenuItem.Style>
                         <Style TargetType="MenuItem" BasedOn="{StaticResource {x:Type MenuItem}}">
                             <Style.Triggers>
-                                <DataTrigger Binding="{Binding HasSelectedMessage}" Value="False">
+                                <DataTrigger Binding="{Binding HasFileTarget}" Value="False">
                                     <Setter Property="Foreground" Value="{DynamicResource Theme.TextDisabled}"/>
                                 </DataTrigger>
                             </Style.Triggers>
@@ -377,7 +380,7 @@
                     <MenuItem.Style>
                         <Style TargetType="MenuItem" BasedOn="{StaticResource {x:Type MenuItem}}">
                             <Style.Triggers>
-                                <DataTrigger Binding="{Binding HasSelectedMessage}" Value="False">
+                                <DataTrigger Binding="{Binding HasFileTarget}" Value="False">
                                     <Setter Property="Foreground" Value="{DynamicResource Theme.TextDisabled}"/>
                                 </DataTrigger>
                             </Style.Triggers>

--- a/QuickMail/Views/MainWindow.xaml
+++ b/QuickMail/Views/MainWindow.xaml
@@ -360,7 +360,7 @@
                 <!-- Keep IsEnabled off these three items so they remain keyboard-navigable
                      per Windows convention (dimmed items are still focusable). Visual dimming
                      is applied via DataTrigger; the Click handlers guard against invalid state. -->
-                <!-- HasFileTarget, not HasSelectedMessage: these also file a selected conversation,
+                <!-- HasMessageTarget, not HasSelectedMessage: these also file a selected conversation,
                      whose header selection leaves SelectedMessage untouched (issue #566). It is
                      recomputed in MessageMenu_SubmenuOpened, as HasWatchTarget above is. -->
                 <MenuItem Header="_Move to Folder…"
@@ -368,7 +368,7 @@
                     <MenuItem.Style>
                         <Style TargetType="MenuItem" BasedOn="{StaticResource {x:Type MenuItem}}">
                             <Style.Triggers>
-                                <DataTrigger Binding="{Binding HasFileTarget}" Value="False">
+                                <DataTrigger Binding="{Binding HasMessageTarget}" Value="False">
                                     <Setter Property="Foreground" Value="{DynamicResource Theme.TextDisabled}"/>
                                 </DataTrigger>
                             </Style.Triggers>
@@ -380,7 +380,7 @@
                     <MenuItem.Style>
                         <Style TargetType="MenuItem" BasedOn="{StaticResource {x:Type MenuItem}}">
                             <Style.Triggers>
-                                <DataTrigger Binding="{Binding HasFileTarget}" Value="False">
+                                <DataTrigger Binding="{Binding HasMessageTarget}" Value="False">
                                     <Setter Property="Foreground" Value="{DynamicResource Theme.TextDisabled}"/>
                                 </DataTrigger>
                             </Style.Triggers>

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -1043,9 +1043,11 @@ public partial class MainWindow : Window
         // VM; this hands it the resolver. (Same shape as MainViewModel.RegisterAccountBackend.)
         _vm.WatchTargetResolver = WatchTargetSubject;
 
-        // Same shape, same reason: whether Move/Copy to Folder have a target depends on the group
-        // tree's selection, which the VM cannot see (issue #566).
-        _vm.FileTargetResolver = CanFileSelection;
+        // Same shape, same reason: which messages a mail action acts on depends on the group tree's
+        // selection, which the VM cannot see. Every command that reads the mail selection goes
+        // through this — reply and forward answer the group's newest message, delete, archive and
+        // file act on all of it (issue #566).
+        _vm.SelectedGroupResolver = () => SelectedGroupTarget()?.Messages;
 
         // No default gesture: like the Flag, Theme and Row Fields managers, this is reached from its
         // menu item or the palette. A free Ctrl+Shift chord is worth more to a per-message action.
@@ -1065,7 +1067,7 @@ public partial class MainWindow : Window
             id: "mail.pickFlag", category: "Mail", title: "Pick Flag…",
             execute: async () => await PickFlagCommandAsync(),
             defaultKey: Key.K, defaultModifiers: ModifierKeys.Control | ModifierKeys.Shift,
-            isAvailable: () => _vm.HasSelectedMessage));
+            isAvailable: _vm.CanActOnSelection));
 
         _registry.Register(new CommandDefinition(
             id: "mail.openFlagManager", category: "Mail", title: "Manage Flags…",
@@ -1089,7 +1091,7 @@ public partial class MainWindow : Window
             id: "mail.delete", category: "Mail", title: "Delete",
             execute: () => _vm.DeleteMessageCommand.Execute(null),
             defaultKey: Key.Delete, defaultModifiers: ModifierKeys.None,
-            isAvailable: () => _vm.HasSelectedMessage
+            isAvailable: () => _vm.CanActOnSelection()
                 && !(IsMessageListFocused() && MessageList.SelectedItems.Count > 1)
                 && !IsGroupTreeFocused()
                 && !FolderList.IsKeyboardFocusWithin)); // folder.delete owns Delete in the folder tree
@@ -1102,7 +1104,7 @@ public partial class MainWindow : Window
             id: "mail.archive", category: "Mail", title: "Move to Archive",
             execute: () => _vm.ArchiveMessageCommand.Execute(null),
             defaultKey: Key.M, defaultModifiers: ModifierKeys.Control | ModifierKeys.Shift,
-            isAvailable: () => _vm.HasSelectedMessage
+            isAvailable: () => _vm.CanActOnSelection()
                 && !(IsMessageListFocused() && MessageList.SelectedItems.Count > 1)
                 && !IsGroupTreeFocused()
                 && !FolderList.IsKeyboardFocusWithin));
@@ -1224,15 +1226,18 @@ public partial class MainWindow : Window
             execute: () => _vm.PromoteActiveTabToWindow(),
             isAvailable: () => _vm.ActiveTab != null));
 
+        // On a group header these open its newest message, the one Reply answers — opening the
+        // message the user happened to select before arrowing onto the header is never what they
+        // asked for (issue #566).
         _registry.Register(new CommandDefinition(
             id: "mail.openInNewTab", category: "Mail", title: "Open in New Tab",
-            execute: () => { if (_vm.SelectedMessage != null) _vm.OpenMessageTab(_vm.SelectedMessage); },
-            isAvailable: () => _vm.SelectedMessage != null));
+            execute: () => { if (TargetMessage() is { } msg) _vm.OpenMessageTab(msg); },
+            isAvailable: _vm.CanActOnSelection));
 
         _registry.Register(new CommandDefinition(
             id: "mail.openInWindow", category: "Mail", title: "Open in New Window",
-            execute: () => { if (_vm.SelectedMessage != null) OpenMessageInNewWindow(_vm.SelectedMessage); },
-            isAvailable: () => _vm.SelectedMessage != null));
+            execute: () => { if (TargetMessage() is { } msg) OpenMessageInNewWindow(msg); },
+            isAvailable: _vm.CanActOnSelection));
 
         // Available on a selected group header too, not just a selected message: gating on
         // HasSelectedMessage alone meant a user's hotkey did nothing at all on a conversation
@@ -1240,12 +1245,12 @@ public partial class MainWindow : Window
         _registry.Register(new CommandDefinition(
             id: "mail.moveToFolder", category: "Mail", title: "Move to Folder…",
             execute: async () => await MoveMessageToFolderAsync(),
-            isAvailable: CanFileSelection));
+            isAvailable: _vm.CanActOnSelection));
 
         _registry.Register(new CommandDefinition(
             id: "mail.copyToFolder", category: "Mail", title: "Copy to Folder…",
             execute: async () => await CopyMessageToFolderAsync(),
-            isAvailable: CanFileSelection));
+            isAvailable: _vm.CanActOnSelection));
 
         // ── Calendar list commands (T/Enter while the calendar list has focus) ──
         // F5 is not registered separately here: MainViewModel.RefreshAsync (mail.refresh)
@@ -2843,33 +2848,48 @@ public partial class MainWindow : Window
     }
 
     /// <summary>
-    /// The group header selected in the active grouped view: every message it holds, and its index
-    /// in the view's collection so focus can land on the row that replaces it after a move. Null
-    /// when no header is selected — a message node, the flat list, or an ungrouped view.
-    /// <para>Commands that file messages must consult this before <see cref="GetSelectedMessages"/>,
-    /// for the reason <see cref="WatchTargetSubject"/> and <see cref="ToggleFlagCommandAsync"/> read
-    /// the tree's selection first: selecting a header does not update <c>_vm.SelectedMessage</c>
-    /// (<c>GroupedMessageTreeController.OnSelectedItemChanged</c>). Move to Folder did not, so on a
-    /// conversation it filed whatever message had been selected before the user arrowed onto the
-    /// header — or, when none had been, did nothing at all. That was issue #566.</para>
+    /// The group header selected in the active grouped view — the header itself and every message
+    /// it holds, newest first. Null when no header is selected: a message node, the flat list, an
+    /// ungrouped view, or an empty group.
+    /// <para>This is what the window hands the VM as <c>SelectedGroupResolver</c>, and what
+    /// commands must consult before <see cref="GetSelectedMessages"/>, for the reason
+    /// <see cref="WatchTargetSubject"/> and <see cref="ToggleFlagCommandAsync"/> read the tree's
+    /// selection first: selecting a header does not update <c>_vm.SelectedMessage</c>
+    /// (<c>GroupedMessageTreeController.OnSelectedItemChanged</c>). The mail commands did not, so
+    /// on a conversation they acted on whatever message had been selected before the user arrowed
+    /// onto the header — or, when none had been, did nothing at all. That was issue #566.</para>
     /// </summary>
-    private (IReadOnlyList<MailMessageSummary> Messages, int Index)? SelectedGroupTarget()
+    private (object Group, IReadOnlyList<MailMessageSummary> Messages)? SelectedGroupTarget()
     {
-        if (_vm.IsConversationsView && ConversationTree.SelectedItem is ConversationGroup cg)
-            return (cg.Messages, _vm.Conversations.IndexOf(cg));
-        if (_vm.IsFromView && SenderGroupTree.SelectedItem is SenderGroup sg)
-            return (sg.Messages, _vm.SenderGroups.IndexOf(sg));
-        if (_vm.IsToView && ToGroupTree.SelectedItem is SenderGroup tg)
-            return (tg.Messages, _vm.ToGroups.IndexOf(tg));
+        if (_vm.IsConversationsView && ConversationTree.SelectedItem is ConversationGroup cg && cg.Messages.Count > 0)
+            return (cg, cg.Messages);
+        if (_vm.IsFromView && SenderGroupTree.SelectedItem is SenderGroup sg && sg.Messages.Count > 0)
+            return (sg, sg.Messages);
+        if (_vm.IsToView && ToGroupTree.SelectedItem is SenderGroup tg && tg.Messages.Count > 0)
+            return (tg, tg.Messages);
         return null;
     }
 
     /// <summary>
-    /// True when Move/Copy to Folder have something to act on: a selected message, or a selected
-    /// group header. The availability gate for both commands and the source of the VM's
-    /// <c>HasFileTarget</c>, so the hotkey, the palette and the Message menu all agree.
+    /// Where a group sits in its view's collection, so focus can land on the row that replaces it
+    /// once it is filed away. Kept apart from <see cref="SelectedGroupTarget"/> because only the
+    /// move path needs it and the scan is wasted work everywhere else. Falls back to 0 when the
+    /// collection was rebuilt out from under the selection.
     /// </summary>
-    private bool CanFileSelection() => _vm.HasSelectedMessage || IsGroupRowSelected();
+    private int SelectedGroupIndex(object group) => group switch
+    {
+        ConversationGroup cg          => Math.Max(0, _vm.Conversations.IndexOf(cg)),
+        SenderGroup sg when _vm.IsFromView => Math.Max(0, _vm.SenderGroups.IndexOf(sg)),
+        SenderGroup sg                => Math.Max(0, _vm.ToGroups.IndexOf(sg)),
+        _                             => 0,
+    };
+
+    /// <summary>
+    /// The one message a single-message action answers: the newest in a selected group — one reply
+    /// to the latest word in a thread, not one per message — or the selected message.
+    /// </summary>
+    private MailMessageSummary? TargetMessage() =>
+        SelectedGroupTarget()?.Messages[0] ?? _vm.SelectedMessage;
 
     /// <summary>
     /// The subject whose conversation Ctrl+Shift+W acts on, or null when there is no valid target.
@@ -2896,7 +2916,7 @@ public partial class MainWindow : Window
     private void MessageMenu_SubmenuOpened(object sender, RoutedEventArgs e)
     {
         _vm.RefreshWatchTarget();
-        _vm.RefreshFileTarget();
+        _vm.RefreshMessageTarget();
     }
 
     private void MenuWatchConversation_Click(object sender, RoutedEventArgs e) =>
@@ -2959,7 +2979,10 @@ public partial class MainWindow : Window
     private async Task PickFlagCommandAsync()
     {
         if (_flagService == null) return;
-        var msg = _vm.SelectedMessage;
+        // On a group header the chosen flag applies to the whole group, as K (toggle) already does;
+        // the picker opens on the newest message's flag, which is what the row speaks (issue #566).
+        var group = SelectedGroupTarget();
+        var msg = group?.Messages[0] ?? _vm.SelectedMessage;
         if (msg == null) return;
 
         var prev = Keyboard.FocusedElement as IInputElement;
@@ -2967,7 +2990,11 @@ public partial class MainWindow : Window
         picker.ShowDialog();
         (prev ?? MessageList).Focus();
 
-        if (picker.DialogResult == true)
+        if (picker.DialogResult != true) return;
+
+        if (group != null)
+            await _vm.SetGroupFlagAsync(group.Value.Messages, picker.ResultFlagId);
+        else
             await _vm.SetMessageFlagAsync(msg, picker.ResultFlagId);
     }
 
@@ -6047,7 +6074,12 @@ public partial class MainWindow : Window
         // A selected group header wins over the selected message — see SelectedGroupTarget (#566).
         var group = SelectedGroupTarget();
         IReadOnlyList<MailMessageSummary> messages = group?.Messages ?? GetSelectedMessages();
-        if (messages.Count == 0 || _vm.CachedFolders.Count == 0) return;
+        if (messages.Count == 0) return;
+        if (!FoldersAreReady()) return;
+
+        // Read now, not after the move: by then the view has been rebuilt and the group this came
+        // from is no longer in the collection to be found. The group context menus do the same.
+        var targetIdx = group != null ? SelectedGroupIndex(group.Value.Group) : 0;
 
         // Naming the conversation is the only signal the picker gives that this files the whole
         // thread rather than one message, and its title is what a screen reader reads on open.
@@ -6065,7 +6097,6 @@ public partial class MainWindow : Window
         // Messages view: MessageListFocusRequested in MoveSelectedMessagesToFolderAsync handles it.
         // Filing a whole group empties its row, so land where it was — the row that takes its place,
         // as the group context menus do — rather than jumping the user back to the top of the list.
-        var targetIdx = group?.Index ?? 0;
         if (_vm.IsConversationsView)
             LandOnConversationAfterRebuild(targetIdx);
         else if (_vm.IsFromView)
@@ -6074,11 +6105,26 @@ public partial class MainWindow : Window
             LandOnToGroupAfterRebuild(targetIdx);
     }
 
+    /// <summary>
+    /// True when there are cached folders to file into. Otherwise says so — in the status bar and,
+    /// for anyone not watching it, as an announcement. Returning in silence is what made #566 read
+    /// as "nothing happened", and an unsynced folder list would have produced exactly that again.
+    /// </summary>
+    private bool FoldersAreReady()
+    {
+        if (_vm.CachedFolders.Count > 0) return true;
+
+        _vm.StatusText = "Folders are still loading.";
+        AccessibilityHelper.Announce(this, _vm.StatusText, category: AnnouncementCategory.Result);
+        return false;
+    }
+
     private async Task CopyMessageToFolderAsync()
     {
         var group = SelectedGroupTarget();
         IReadOnlyList<MailMessageSummary> messages = group?.Messages ?? GetSelectedMessages();
-        if (messages.Count == 0 || _vm.CachedFolders.Count == 0) return;
+        if (messages.Count == 0) return;
+        if (!FoldersAreReady()) return;
 
         var picker = BuildMessageFolderPicker(
             messages,

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -1043,6 +1043,10 @@ public partial class MainWindow : Window
         // VM; this hands it the resolver. (Same shape as MainViewModel.RegisterAccountBackend.)
         _vm.WatchTargetResolver = WatchTargetSubject;
 
+        // Same shape, same reason: whether Move/Copy to Folder have a target depends on the group
+        // tree's selection, which the VM cannot see (issue #566).
+        _vm.FileTargetResolver = CanFileSelection;
+
         // No default gesture: like the Flag, Theme and Row Fields managers, this is reached from its
         // menu item or the palette. A free Ctrl+Shift chord is worth more to a per-message action.
         _registry.Register(new CommandDefinition(
@@ -1230,15 +1234,18 @@ public partial class MainWindow : Window
             execute: () => { if (_vm.SelectedMessage != null) OpenMessageInNewWindow(_vm.SelectedMessage); },
             isAvailable: () => _vm.SelectedMessage != null));
 
+        // Available on a selected group header too, not just a selected message: gating on
+        // HasSelectedMessage alone meant a user's hotkey did nothing at all on a conversation
+        // whose messages had never been selected (issue #566).
         _registry.Register(new CommandDefinition(
             id: "mail.moveToFolder", category: "Mail", title: "Move to Folder…",
             execute: async () => await MoveMessageToFolderAsync(),
-            isAvailable: () => _vm.HasSelectedMessage));
+            isAvailable: CanFileSelection));
 
         _registry.Register(new CommandDefinition(
             id: "mail.copyToFolder", category: "Mail", title: "Copy to Folder…",
             execute: async () => await CopyMessageToFolderAsync(),
-            isAvailable: () => _vm.HasSelectedMessage));
+            isAvailable: CanFileSelection));
 
         // ── Calendar list commands (T/Enter while the calendar list has focus) ──
         // F5 is not registered separately here: MainViewModel.RefreshAsync (mail.refresh)
@@ -2824,6 +2831,9 @@ public partial class MainWindow : Window
     // while focus is elsewhere (folder tree, account list) and steal that control's type-ahead.
     private bool IsMessageAreaFocused() => IsMessageListFocused() || IsGroupTreeFocused();
 
+    // Deliberately a type check rather than SelectedGroupTarget() != null: this runs from
+    // isAvailable on every keystroke, and resolving the full target scans the view's collection
+    // for the group's index.
     private bool IsGroupRowSelected()
     {
         if (_vm.IsConversationsView) return ConversationTree.SelectedItem is ConversationGroup;
@@ -2831,6 +2841,35 @@ public partial class MainWindow : Window
         if (_vm.IsToView)            return ToGroupTree.SelectedItem is SenderGroup;
         return false;
     }
+
+    /// <summary>
+    /// The group header selected in the active grouped view: every message it holds, and its index
+    /// in the view's collection so focus can land on the row that replaces it after a move. Null
+    /// when no header is selected — a message node, the flat list, or an ungrouped view.
+    /// <para>Commands that file messages must consult this before <see cref="GetSelectedMessages"/>,
+    /// for the reason <see cref="WatchTargetSubject"/> and <see cref="ToggleFlagCommandAsync"/> read
+    /// the tree's selection first: selecting a header does not update <c>_vm.SelectedMessage</c>
+    /// (<c>GroupedMessageTreeController.OnSelectedItemChanged</c>). Move to Folder did not, so on a
+    /// conversation it filed whatever message had been selected before the user arrowed onto the
+    /// header — or, when none had been, did nothing at all. That was issue #566.</para>
+    /// </summary>
+    private (IReadOnlyList<MailMessageSummary> Messages, int Index)? SelectedGroupTarget()
+    {
+        if (_vm.IsConversationsView && ConversationTree.SelectedItem is ConversationGroup cg)
+            return (cg.Messages, _vm.Conversations.IndexOf(cg));
+        if (_vm.IsFromView && SenderGroupTree.SelectedItem is SenderGroup sg)
+            return (sg.Messages, _vm.SenderGroups.IndexOf(sg));
+        if (_vm.IsToView && ToGroupTree.SelectedItem is SenderGroup tg)
+            return (tg.Messages, _vm.ToGroups.IndexOf(tg));
+        return null;
+    }
+
+    /// <summary>
+    /// True when Move/Copy to Folder have something to act on: a selected message, or a selected
+    /// group header. The availability gate for both commands and the source of the VM's
+    /// <c>HasFileTarget</c>, so the hotkey, the palette and the Message menu all agree.
+    /// </summary>
+    private bool CanFileSelection() => _vm.HasSelectedMessage || IsGroupRowSelected();
 
     /// <summary>
     /// The subject whose conversation Ctrl+Shift+W acts on, or null when there is no valid target.
@@ -2851,9 +2890,14 @@ public partial class MainWindow : Window
         return _vm.SelectedMessage?.Subject;
     }
 
-    // Keeps the Message menu's Watch Conversation check state honest: the target can change without
-    // SelectedMessage changing (a group header selection), so it is recomputed as the menu opens.
-    private void MessageMenu_SubmenuOpened(object sender, RoutedEventArgs e) => _vm.RefreshWatchTarget();
+    // Keeps the Message menu's Watch Conversation check state, and the Move/Copy to Folder dimming,
+    // honest: both targets can change without SelectedMessage changing (a group header selection),
+    // so they are recomputed as the menu opens.
+    private void MessageMenu_SubmenuOpened(object sender, RoutedEventArgs e)
+    {
+        _vm.RefreshWatchTarget();
+        _vm.RefreshFileTarget();
+    }
 
     private void MenuWatchConversation_Click(object sender, RoutedEventArgs e) =>
         _vm.ToggleWatchConversation();
@@ -5990,45 +6034,27 @@ public partial class MainWindow : Window
     private void MenuSearchFolders_Click(object sender, RoutedEventArgs e)
         => OpenFolderPicker();
 
+    // The menu-bar items are the same action as the command; they delegate so the two entry points
+    // cannot drift (they were duplicate copies of the body below).
     private async void MenuMoveToFolder_Click(object sender, RoutedEventArgs e)
-    {
-        var messages = GetSelectedMessages();
-        if (messages.Count == 0 || _vm.CachedFolders.Count == 0) return;
-
-        var picker = BuildMessageFolderPicker(messages, "Move to Folder", copy: false);
-        var pickerOpened = picker.ShowDialog();
-        _vm.CommitPendingFolderTreeRebuild(); // apply a folder created inside the picker, even on cancel (no-op otherwise)
-        if (pickerOpened != true || picker.SelectedFolder == null) return;
-
-        await _vm.MoveSelectedMessagesToFolderAsync(messages, picker.SelectedFolder);
-
-        if (_vm.IsConversationsView)
-            LandOnConversationAfterRebuild(0);
-        else if (_vm.IsFromView)
-            LandOnSenderGroupAfterRebuild(0);
-        else if (_vm.IsToView)
-            LandOnToGroupAfterRebuild(0);
-    }
+        => await MoveMessageToFolderAsync();
 
     private async void MenuCopyToFolder_Click(object sender, RoutedEventArgs e)
-    {
-        var messages = GetSelectedMessages();
-        if (messages.Count == 0 || _vm.CachedFolders.Count == 0) return;
-
-        var picker = BuildMessageFolderPicker(messages, "Copy to Folder", copy: true);
-        var pickerOpened = picker.ShowDialog();
-        _vm.CommitPendingFolderTreeRebuild(); // apply a folder created inside the picker, even on cancel (no-op otherwise)
-        if (pickerOpened != true || picker.SelectedFolder == null) return;
-
-        await _vm.CopySelectedMessagesToFolderAsync(messages, picker.SelectedFolder);
-    }
+        => await CopyMessageToFolderAsync();
 
     private async Task MoveMessageToFolderAsync()
     {
-        var messages = GetSelectedMessages();
+        // A selected group header wins over the selected message — see SelectedGroupTarget (#566).
+        var group = SelectedGroupTarget();
+        IReadOnlyList<MailMessageSummary> messages = group?.Messages ?? GetSelectedMessages();
         if (messages.Count == 0 || _vm.CachedFolders.Count == 0) return;
 
-        var picker = BuildMessageFolderPicker(messages, "Move to Folder", copy: false);
+        // Naming the conversation is the only signal the picker gives that this files the whole
+        // thread rather than one message, and its title is what a screen reader reads on open.
+        var picker = BuildMessageFolderPicker(
+            messages,
+            group != null && _vm.IsConversationsView ? "Move Conversation to Folder" : "Move to Folder",
+            copy: false);
         var pickerOpened = picker.ShowDialog();
         _vm.CommitPendingFolderTreeRebuild(); // apply a folder created inside the picker, even on cancel (no-op otherwise)
         if (pickerOpened != true || picker.SelectedFolder == null) return;
@@ -6037,20 +6063,27 @@ public partial class MainWindow : Window
 
         // Conversations/From: LandOnX waits for the async rebuild before focusing.
         // Messages view: MessageListFocusRequested in MoveSelectedMessagesToFolderAsync handles it.
+        // Filing a whole group empties its row, so land where it was — the row that takes its place,
+        // as the group context menus do — rather than jumping the user back to the top of the list.
+        var targetIdx = group?.Index ?? 0;
         if (_vm.IsConversationsView)
-            LandOnConversationAfterRebuild(0);
+            LandOnConversationAfterRebuild(targetIdx);
         else if (_vm.IsFromView)
-            LandOnSenderGroupAfterRebuild(0);
+            LandOnSenderGroupAfterRebuild(targetIdx);
         else if (_vm.IsToView)
-            LandOnToGroupAfterRebuild(0);
+            LandOnToGroupAfterRebuild(targetIdx);
     }
 
     private async Task CopyMessageToFolderAsync()
     {
-        var messages = GetSelectedMessages();
+        var group = SelectedGroupTarget();
+        IReadOnlyList<MailMessageSummary> messages = group?.Messages ?? GetSelectedMessages();
         if (messages.Count == 0 || _vm.CachedFolders.Count == 0) return;
 
-        var picker = BuildMessageFolderPicker(messages, "Copy to Folder", copy: true);
+        var picker = BuildMessageFolderPicker(
+            messages,
+            group != null && _vm.IsConversationsView ? "Copy Conversation to Folder" : "Copy to Folder",
+            copy: true);
         var pickerOpened = picker.ShowDialog();
         _vm.CommitPendingFolderTreeRebuild(); // apply a folder created inside the picker, even on cancel (no-op otherwise)
         if (pickerOpened != true || picker.SelectedFolder == null) return;


### PR DESCRIPTION
Fixes #566.

## The bug

Selecting a group header in the Conversations / From / To trees does not update `MainViewModel.SelectedMessage` — `GroupedMessageTreeController.OnSelectedItemChanged` only assigns it for `MailMessageSummary` nodes. Every command that read it therefore misbehaved on a conversation, in one of two silent ways:

- **Nothing happens** (what was reported): the availability gate was `HasSelectedMessage`, false when no message in the view had been selected yet, so the user's hotkey never dispatched.
- **The wrong message is acted on**: with a message selected earlier, Move filed *that* message, Reply answered *that* thread, Delete deleted it. Everything looks completely normal on screen.

Move to Folder is where it was noticed; it was never the only one. `ToggleFlagCommandAsync`, `MarkReadCommand`, `WatchTargetSubject`, Properties and every group context menu already read the tree's selection first — the menu bar, the hotkeys and the Command Palette did not.

## The fix

The window hands the VM a `SelectedGroupResolver` — the same shape as the existing `WatchTargetResolver`, for the same reason: only the View can see what the tree has selected. Two rules follow from it:

| Acts on the group's **newest message** | Acts on the **whole group** |
| --- | --- |
| Reply, Reply All, Forward | Delete, Move to Archive |
| Create Rule from Message | Move to Folder, Copy to Folder |
| Open in New Tab, Open in New Window | Pick Flag |

Replying to a thread answers its latest word — one reply, not one per message. That is exactly what the group context menus have always done (`ReplyConversationAsync` sets `SelectedMessage = group.Messages[0]` before composing); it is now also what the menu bar, the hotkeys and the palette do. Delete and Archive act on all of it, as the trees' own Delete key already did.

Availability follows the same rule via `MainViewModel.CanActOnSelection()`, so each command is offered exactly when it has something to act on, and the Message menu's Move/Copy dimming binds to `HasMessageTarget`, recomputed in `MessageMenu_SubmenuOpened` beside `HasWatchTarget`.

Two more things, both from review:

- **The other silent path.** Move/Copy returned without a word when no folders were cached yet — to the user, the same "nothing happened". `FoldersAreReady()` now sets the status text and announces it (`Result` category).
- **Focus landing.** Filing a whole group lands on the row that takes its place, as the group context menus do, instead of jumping to the top of the list. The index is read before the move, not after the view has been rebuilt out from under it.

## Keyboard walkthrough (Conversations view, reading pane mode)

1. User arrows to a conversation header. The row is announced as usual; `SelectedMessage` is untouched.
2. User presses their Move to Folder hotkey. The picker opens, titled "Move Conversation to Folder", on the folder this account last filed into (or the folder the messages are in).
3. User chooses a folder and presses Enter. Every message in the conversation moves.
4. The list rebuilds and focus lands on the conversation now occupying the moved one's position — not at the top.
5. Escape at step 3 closes the picker and nothing moves.

On the same header: Ctrl+R opens a reply to the thread's newest message; Delete deletes the whole thread; Ctrl+Shift+K applies the chosen flag to all of it. With no folders cached, step 2 says "Folders are still loading." instead of nothing.

Same behaviour in the From and To views, and unchanged throughout on a single message node.

## Infrastructure changes

- F6 ring: unchanged.
- `CommandRegistry`: no new commands, no new keys, no changed defaults. Thirteen registrations change availability from `HasSelectedMessage` to `CanActOnSelection`.
- `AutomationProperties.Name`: unchanged.
- `AccessibilityHelper.Announce`: one added — "Folders are still loading.", `AnnouncementCategory.Result`.
- VM state: adds `SelectedGroupResolver`, `CanActOnSelection()`, `HasMessageTarget` + `RefreshMessageTarget()`, mirroring the existing watch-target trio.

## Out of scope

- The group context-menu handlers keep their own bodies; they already behaved correctly.
- Grab Addresses still gates on `IsMessageOpen` — it acts on the message open in the pane, not on the list selection.
- `MainWindow.BuildMessageFolderPicker` still scopes to the owning account**s** for a multi-account selection (the collision CLAUDE.md documents) — untouched here.

## Testing

- New `GroupSelectionActionTests` — real behavioural tests, no WPF needed now that the rules live in the VM: a group header is a target with no selected message, an empty group is not, reply/reply-all/forward retarget to `Messages[0]`, delete removes all three messages ("3 messages deleted") and not the stale one, and both the message fallback and the no-resolver case still work.
- New `MoveToFolderGroupTargetTests` — source-inspection guards for the wiring that cannot be reached without a shown window and a realized `TreeView` container: the resolver is hooked up, the file handlers resolve the group and check `FoldersAreReady`, all thirteen registrations gate on `CanActOnSelection`, and targeting covers all three grouped views. Verified they bite — reverting the fix fails them.
- `LastMessageDestinationCallSiteTests` call-site count 10 → 8 (the two menu-bar handlers now delegate to the command's method instead of building their own picker).
- Full suite: 3041 passed, 1 pre-existing failure (`AddressBookFilterMenuTests.ActivatingTheButton_OpensTheMenu_OnTheActiveFilter`, confirmed failing on the branch point without these changes and passing in isolation — the #380 focus-dependent family).
- No UI probe run: the only XAML edit is a `DataTrigger`'s binding path inside an existing menu-item style. No layout, colour, or token changes, and the probe does not capture opened menus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
