### PR TITLE
Default new Microsoft accounts to Graph behind the MicrosoftGraphDefault flag (#529 step 3)

### DIFF
--- a/QuickMail.Tests/GraphBackendGateTests.cs
+++ b/QuickMail.Tests/GraphBackendGateTests.cs
@@ -442,6 +442,16 @@ public class ConfigFeatureGateTests
             .IsEnabled(FeatureFlag.GraphBackend));
 
     [Fact]
+    public void Default_MicrosoftGraphDefaultOff() // #529 step 3: ships off; testers opt in
+        => Assert.False(new ConfigFeatureGate(new ConfigModel(), Array.Empty<string>())
+            .IsEnabled(FeatureFlag.MicrosoftGraphDefault));
+
+    [Fact]
+    public void Config_EnablesMicrosoftGraphDefault()
+        => Assert.True(new ConfigFeatureGate(ConfigWith("MicrosoftGraphDefault", "true"), Array.Empty<string>())
+            .IsEnabled(FeatureFlag.MicrosoftGraphDefault));
+
+    [Fact]
     public void Config_DisablesFlag() // now the meaningful override: turn the default off
         => Assert.False(new ConfigFeatureGate(ConfigWith("GraphBackend", "false"), Array.Empty<string>())
             .IsEnabled(FeatureFlag.GraphBackend));

--- a/QuickMail.Tests/PersonalGraphBackendChoiceTests.cs
+++ b/QuickMail.Tests/PersonalGraphBackendChoiceTests.cs
@@ -17,9 +17,17 @@ namespace QuickMail.Tests;
 /// </summary>
 public class PersonalGraphBackendChoiceTests
 {
-    private static AddAccountViewModel Make(StubOAuthService oauth) =>
-        new(new StubFeatureGate { [FeatureFlag.GraphBackend] = true },
+    private static AddAccountViewModel Make(StubOAuthService oauth, bool graphDefault = false) =>
+        new(new StubFeatureGate { [FeatureFlag.GraphBackend] = true, [FeatureFlag.MicrosoftGraphDefault] = graphDefault },
             new StubImapMailService(), oauth, new ProviderCatalog());
+
+    private static AddAccountViewModel Microsoft(string address, bool graphDefault, StubOAuthService? oauth = null)
+    {
+        var vm = Make(oauth ?? new StubOAuthService(), graphDefault);
+        vm.SelectedProvider = new ProviderCatalog().ById(ProviderCatalog.MicrosoftId);
+        vm.Username = address;
+        return vm;
+    }
 
     [Fact]
     public async Task PersonalAccount_UserPicksGraphByHand_SignInKeepsGraph()
@@ -58,5 +66,76 @@ public class PersonalGraphBackendChoiceTests
         // Sign-in reveals a personal account → the auto-inferred Graph is corrected back to IMAP.
         // This behavior is unchanged by #527; only a hand-picked choice is now spared.
         Assert.Equal(BackendKind.ImapSmtp, vm.BackendKind);
+    }
+
+    // ── #529 step 3: MicrosoftGraphDefault makes Graph the default for new Microsoft accounts ──
+    // Flag off = today's behavior (consumer → IMAP). Flag on = Graph for every Microsoft account,
+    // personal included, with IMAP still hand-selectable and the personal→IMAP revert suppressed.
+
+    [Fact]
+    public void FlagOff_ConsumerAccount_DefaultsToImap() // regression pin of today's default
+    {
+        var vm = Microsoft("me@outlook.com", graphDefault: false);
+        vm.CommitUsername();
+        Assert.Equal(BackendKind.ImapSmtp, vm.BackendKind);
+    }
+
+    [Fact]
+    public void FlagOn_ConsumerAccount_DefaultsToGraph()
+    {
+        var vm = Microsoft("me@outlook.com", graphDefault: true);
+        vm.CommitUsername();
+        Assert.Equal(BackendKind.MicrosoftGraph, vm.BackendKind);
+    }
+
+    [Fact]
+    public void FlagOn_WorkAccount_StillDefaultsToGraph()
+    {
+        var vm = Microsoft("user@contoso.com", graphDefault: true);
+        vm.CommitUsername();
+        Assert.Equal(BackendKind.MicrosoftGraph, vm.BackendKind);
+    }
+
+    [Fact]
+    public void GraphDefaultOn_ButGraphBackendOff_StaysImap() // the AND: Graph must be offered to be the default
+    {
+        var vm = new AddAccountViewModel(
+            new StubFeatureGate { [FeatureFlag.GraphBackend] = false, [FeatureFlag.MicrosoftGraphDefault] = true },
+            new StubImapMailService(), new StubOAuthService(), new ProviderCatalog());
+        vm.SelectedProvider = new ProviderCatalog().ById(ProviderCatalog.MicrosoftId);
+        vm.Username = "me@outlook.com";
+        vm.CommitUsername();
+        Assert.Equal(BackendKind.ImapSmtp, vm.BackendKind);
+    }
+
+    [Fact]
+    public void FlagOn_HandPickedImapInAdvanced_Survives()
+    {
+        var vm = Microsoft("me@outlook.com", graphDefault: true);
+        vm.CommitUsername();
+        Assert.Equal(BackendKind.MicrosoftGraph, vm.BackendKind);   // flag defaulted it to Graph
+
+        // The user switches the connection method to Standard IMAP/SMTP in Advanced — a real change
+        // (Graph → IMAP), so _backendUserChosen is set and the default no longer applies.
+        vm.SelectedBackend = vm.AvailableBackends.First(b => b.Kind == BackendKind.ImapSmtp);
+        vm.CommitUsername();                                        // must not override the hand-pick
+        Assert.Equal(BackendKind.ImapSmtp, vm.BackendKind);
+    }
+
+    [Fact]
+    public async Task FlagOn_PersonalAccount_StaysOnGraphAfterSignIn()
+    {
+        var oauth = new StubOAuthService { SignInUsername = "me@outlook.com", SignInIsPersonalAccount = true };
+        var vm = Microsoft("me@outlook.com", graphDefault: true, oauth);
+        vm.CommitUsername();
+        Assert.Equal(BackendKind.MicrosoftGraph, vm.BackendKind);
+
+        await vm.SignInMicrosoftCommand.ExecuteAsync(null);
+
+        // OnMicrosoftSignInCompleted is suppressed when the flag is on → the personal account is NOT
+        // reverted to IMAP (contrast PersonalAccount_GraphAutoInferredFromDomain_SignInStillRevertsToImap,
+        // which is the flag-off path).
+        Assert.True(vm.IsPersonalMicrosoftAccount);
+        Assert.Equal(BackendKind.MicrosoftGraph, vm.BackendKind);
     }
 }

--- a/QuickMail/Models/FeatureFlag.cs
+++ b/QuickMail/Models/FeatureFlag.cs
@@ -14,6 +14,21 @@ public enum FeatureFlag
     GraphBackend,
 
     /// <summary>
+    /// Makes Microsoft 365 (Graph) the default connection method for a NEW Microsoft account —
+    /// personal Outlook.com included, not only work/school — instead of IMAP. IMAP/SMTP stays
+    /// selectable under Advanced → Connection method, and a hand-pick there is always honored.
+    /// Effective only when <see cref="GraphBackend"/> is also on (Graph must be an offered backend);
+    /// "Graph is offered" vs "Graph is the default" are the two distinct knobs.
+    ///
+    /// Default: false. Ships off so the broad release keeps today's behavior (personal → IMAP);
+    /// testers turn it on, and the default is flipped in a later release once personal-Graph has
+    /// mileage (#529 step 3). Only the DEFAULT for new accounts changes — existing accounts are not
+    /// touched. Turn it on with MicrosoftGraphDefault=true under [features] in config.ini, or
+    /// --feature MicrosoftGraphDefault at launch.
+    /// </summary>
+    MicrosoftGraphDefault,
+
+    /// <summary>
     /// Offers Google sign-in for Gmail accounts: the "Gmail (sign in with Google)" provider entry
     /// and the Google OAuth item in the Authentication combo.
     ///

--- a/QuickMail/Services/ConfigFeatureGate.cs
+++ b/QuickMail/Services/ConfigFeatureGate.cs
@@ -16,6 +16,11 @@ public class ConfigFeatureGate : IFeatureGate
     private static readonly Dictionary<FeatureFlag, bool> Defaults = new Dictionary<FeatureFlag, bool>
     {
         [FeatureFlag.GraphBackend] = true,
+        // Off until personal-Graph has mileage (#529 step 3): with it on, a NEW Microsoft account —
+        // personal included — defaults to the Graph backend instead of IMAP. IMAP stays hand-selectable
+        // under Advanced. Testers opt in with MicrosoftGraphDefault=true under [features]; the default
+        // flips in a later release.
+        [FeatureFlag.MicrosoftGraphDefault] = false,
         // Off since v0.8.37: Google no longer grants QuickMail new authorizations, so offering the
         // option to everyone only produced sign-ins that could not succeed. Opt-in for the users
         // whose authorization predates the block (#369).

--- a/QuickMail/ViewModels/AddAccountViewModel.cs
+++ b/QuickMail/ViewModels/AddAccountViewModel.cs
@@ -267,8 +267,12 @@ public partial class AddAccountViewModel : AccountEditorViewModel, IDisposable
         if (HostsUserEdited) return;   // the user has taken over the servers
         if (_backendUserChosen) return; // ...or the connection method itself
 
-        // A consumer domain, or a sign-in that reported a personal account, means IMAP.
-        var wantGraph = !provider.MatchesEmail(Username) && IsPersonalMicrosoftAccount != true;
+        // A consumer domain, or a sign-in that reported a personal account, means IMAP — UNLESS the
+        // MicrosoftGraphDefault flag makes Graph the default for every Microsoft account (#529 step 3).
+        var graphIsDefault = _gate.IsEnabled(FeatureFlag.GraphBackend)
+                             && _gate.IsEnabled(FeatureFlag.MicrosoftGraphDefault);
+        var wantGraph = graphIsDefault
+                        || (!provider.MatchesEmail(Username) && IsPersonalMicrosoftAccount != true);
         MoveToBackend(wantGraph ? BackendKind.MicrosoftGraph : BackendKind.ImapSmtp);
     }
 
@@ -283,9 +287,18 @@ public partial class AddAccountViewModel : AccountEditorViewModel, IDisposable
     /// uses. Its absence here was the #527 bug: an explicit "Microsoft 365 (Graph)" pick for a
     /// personal account survived the address-commit step and was then silently reverted after sign-in,
     /// leaving no way to reach Graph for a personal account through the UI at all.
+    ///
+    /// And when the MicrosoftGraphDefault flag is on (#529 step 3), the revert is off entirely: a
+    /// personal account is deliberately defaulted to Graph, so there is nothing to put back on IMAP.
     /// </summary>
     protected override void OnMicrosoftSignInCompleted(bool isPersonalAccount)
     {
+        // Graph is the default for every Microsoft account (#529 step 3) — a personal account is meant
+        // to stay on Graph, so do not revert it. Checked first, before the guards below, because the
+        // whole revert is suppressed when the flag is on.
+        if (_gate.IsEnabled(FeatureFlag.GraphBackend)
+            && _gate.IsEnabled(FeatureFlag.MicrosoftGraphDefault)) return;
+
         if (!isPersonalAccount) return;
         if (SelectedProvider is not { } provider || provider.Id != ProviderCatalog.MicrosoftId) return;
         if (BackendKind != BackendKind.MicrosoftGraph) return;

--- a/docs/planning/graph-default-microsoft-pm-dev-spec.md
+++ b/docs/planning/graph-default-microsoft-pm-dev-spec.md
@@ -86,7 +86,11 @@ put real accounts on it by default — reversibly, behind a flag, testers first.
   token-before-purge, cache purge + re-sync, idempotency marker). New accounts only here.
 - **Removing the IMAP/SMTP option or the Exchange scopes from the app registration** — #529 keeps
   them; nothing is removed.
-- **Flipping the flag's default to true** — a later release, gated on accumulated mileage.
+- **Flipping the flag's default to true** — a later release, gated on accumulated personal-Graph
+  mileage **and** on #544's declined-consent fallback being in place. With the flag on, a new personal
+  account lands on the Graph backend, which is the exact path #544's consent fold takes — so its
+  fold and its retry-on-decline become the default consumer onboarding, and must be settled before the
+  default flips, not after.
 - **Any work/school behavior change** — already Graph; this flag does not alter that path.
 - **A one-time migration or announcement UX** — new accounts only; no existing account is touched.
 


### PR DESCRIPTION
Implements **#529 step 3** per the merged spec (#551): a new `MicrosoftGraphDefault` feature flag (default **off**) that, when on, makes **Microsoft 365 (Graph)** the default connection method for a new Microsoft account — personal Outlook.com included — instead of IMAP.

## What it does
- **New flag `MicrosoftGraphDefault`**, default off, effective only when `GraphBackend` is also on ("Graph is offered" vs "Graph is the default" — the two distinct knobs). Testers opt in; the default flips in a later release.
- **`ChooseBackendForMicrosoftAccount`**: `wantGraph = graphIsDefault || (today's consumer/personal logic)`. Flag on → every Microsoft account defaults to Graph. The `_backendUserChosen` / `HostsUserEdited` early-returns are untouched, so a hand-picked IMAP in Advanced still wins.
- **`OnMicrosoftSignInCompleted`**: an early return when the flag is on, placed **first** (before the `isPersonalAccount` check, per your review note), suppressing the personal→IMAP revert so a personal account stays on Graph.
- **Flag off = today's behavior, byte-for-byte** (`graphIsDefault` false → `wantGraph` collapses to the original expression; the revert early-return is skipped). IMAP is not hidden or removed; only the default changes, and only for new accounts.

## Your two implementation notes
1. `OnMicrosoftSignInCompleted` early-return is at the top, before the `isPersonalAccount` check. ✓
2. Spec §4.2 amended (this branch edits the merged doc): flipping the default→true is gated on #544's declined-consent fallback being in place, not just mileage. ✓

## Tests
Consumer/work default to Graph with the flag on; consumer defaults to IMAP with it off (regression pin); hand-picked IMAP survives; personal account stays on Graph after sign-in; flag-on-but-`GraphBackend`-off stays IMAP; gate default is false. Build clean (0 warnings), targeted tests green. Independent adversarial review: **SHIP**.

## Ordering
Per your note on #551, this is meant to land **after #544** (the flag makes #544's consent fold the default consumer path). It's independent of #544 in code — different files, no conflict — so it's ready whenever #544 is in.

Part of #529.
