### PR TITLE
Test that every FeatureFlag resolves to a default (#571 follow-up)

### DIFF
--- a/QuickMail.Tests/GraphBackendGateTests.cs
+++ b/QuickMail.Tests/GraphBackendGateTests.cs
@@ -447,6 +447,21 @@ public class ConfigFeatureGateTests
             .IsEnabled(FeatureFlag.MicrosoftGraphDefault));
 
     [Fact]
+    public void EveryFeatureFlag_ResolvesToADefault() // #571 follow-up
+    {
+        // ConfigFeatureGate resolves an un-overridden flag through Defaults[flag], which throws
+        // KeyNotFoundException for a FeatureFlag member with no entry. Iterating every member turns
+        // that omission into a red test here, instead of a runtime crash at the first call site.
+        var gate = new ConfigFeatureGate(new ConfigModel(), Array.Empty<string>());
+        var ex = Record.Exception(() =>
+        {
+            foreach (var flag in Enum.GetValues<FeatureFlag>())
+                _ = gate.IsEnabled(flag);
+        });
+        Assert.Null(ex);
+    }
+
+    [Fact]
     public void Config_EnablesMicrosoftGraphDefault()
         => Assert.True(new ConfigFeatureGate(ConfigWith("MicrosoftGraphDefault", "true"), Array.Empty<string>())
             .IsEnabled(FeatureFlag.MicrosoftGraphDefault));


### PR DESCRIPTION
Follow-up from your #571 code review (note 2): a test so a future `FeatureFlag` added without a `ConfigFeatureGate.Defaults` entry fails here rather than throwing `KeyNotFoundException` at its first runtime call site.

`EveryFeatureFlag_ResolvesToADefault` iterates `Enum.GetValues<FeatureFlag>()` and calls `IsEnabled` on each — which falls through to `Defaults[flag]` for an un-overridden flag. Passes now (all six flags have entries); goes red the moment one is added without one.

One file, test-only. Build clean, `ConfigFeatureGateTests` 12/12 green.
