### PR TITLE
Convert-to-Graph command + crash-safe marker (#529 step 4, PR 1)

### DIFF
--- a/QuickMail.Tests/AccountManagerConvertTests.cs
+++ b/QuickMail.Tests/AccountManagerConvertTests.cs
@@ -1,0 +1,190 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using QuickMail.Models;
+using QuickMail.Services;
+using QuickMail.ViewModels;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// #529 step 4 (PR 1): the opt-in "Convert to Microsoft 365 (Graph)" command's gating and its safe half
+/// of the sequence — token BEFORE any destructive step, then the crash-safe marker + backend flip + cache
+/// purge. The in-session re-sync and the folder-reference remap are the follow-up; this pins that the
+/// command never purges without a Graph token and always resolves Graph (not IMAP) scopes.
+/// </summary>
+public class AccountManagerConvertTests
+{
+    private static readonly ProviderCatalog Catalog = new();
+
+    private static AccountModel MsImap(string user = "me@outlook.com", bool? personal = null) => new()
+    {
+        Id = Guid.NewGuid(), AccountName = user, Username = user,
+        BackendKind = BackendKind.ImapSmtp, AuthType = AuthType.OAuth2Microsoft,
+        IsPersonalMicrosoftAccount = personal,
+    };
+
+    private static AccountManagerViewModel Vm(
+        AccountModel selected, bool migration = true, bool graph = true,
+        StubOAuthService? oauth = null, StubLocalStoreService? store = null)
+    {
+        var gate = new StubFeatureGate
+        {
+            [FeatureFlag.GraphBackend] = graph,
+            [FeatureFlag.MicrosoftGraphMigration] = migration,
+        };
+        var vm = new AccountManagerViewModel(
+            new StubAccountService(), new StubCredentialService(), new StubImapMailService(),
+            oauth ?? new StubOAuthService(), store ?? new StubLocalStoreService(), new StubConfigService(),
+            gate, Catalog);
+        vm.Accounts.Add(selected);
+        vm.SelectedAccount = selected;
+        vm.ConfirmConvertToGraph = _ => true;   // default: user says yes; overridden per test
+        return vm;
+    }
+
+    // ── Gating ────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void CanConvert_MicrosoftImapOAuth_BothFlagsOn()
+        => Assert.True(Vm(MsImap()).CanConvertToGraph);
+
+    [Fact]
+    public void CanConvert_False_WhenMigrationFlagOff()
+        => Assert.False(Vm(MsImap(), migration: false).CanConvertToGraph);
+
+    [Fact]
+    public void CanConvert_False_WhenGraphBackendOff()
+        => Assert.False(Vm(MsImap(), graph: false).CanConvertToGraph);
+
+    [Fact]
+    public void CanConvert_False_ForAGraphAccount() // already converted
+        => Assert.False(Vm(new AccountModel { Id = Guid.NewGuid(), BackendKind = BackendKind.MicrosoftGraph, AuthType = AuthType.OAuth2Microsoft }).CanConvertToGraph);
+
+    [Fact]
+    public void CanConvert_False_ForAPasswordAccount()
+        => Assert.False(Vm(new AccountModel { Id = Guid.NewGuid(), BackendKind = BackendKind.ImapSmtp, AuthType = AuthType.Password }).CanConvertToGraph);
+
+    [Fact]
+    public void CanConvert_False_ForAGoogleAccount()
+        => Assert.False(Vm(new AccountModel { Id = Guid.NewGuid(), BackendKind = BackendKind.ImapSmtp, AuthType = AuthType.OAuth2Google }).CanConvertToGraph);
+
+    [Fact]
+    public void CanConvert_False_ForASharedMailbox()
+        => Assert.False(Vm(new AccountModel { Id = Guid.NewGuid(), BackendKind = BackendKind.ImapSmtp, AuthType = AuthType.OAuth2Microsoft, IsShared = true }).CanConvertToGraph);
+
+    // ── The sequence ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Convert_Success_FlipsMarksAndPurges()
+    {
+        var acct = MsImap();
+        var store = new StubLocalStoreService();
+        var vm = Vm(acct, store: store);
+
+        await vm.ConvertToGraphCommand.ExecuteAsync(null);
+
+        Assert.Equal(BackendKind.MicrosoftGraph, acct.BackendKind);
+        Assert.True(acct.GraphConversionPending);                       // crash-safe marker set
+        Assert.Contains(acct.Id, store.ClearedMailAccountIds);          // cache purged
+        Assert.True(store.SeededFolders.TryGetValue(acct.Id, out var f) && f.Count == 0); // folder rows cleared
+    }
+
+    [Fact]
+    public async Task Convert_Success_HandsOffToTheSyncLoop()
+    {
+        var acct = MsImap();
+        var vm = Vm(acct);
+        Guid? handedOff = null;
+        vm.AccountConvertedToGraph = id => { handedOff = id; return Task.CompletedTask; };
+
+        await vm.ConvertToGraphCommand.ExecuteAsync(null);
+
+        Assert.Equal(acct.Id, handedOff);   // the main sync loop is told, in-session (the #454 safeguard)
+    }
+
+    [Fact]
+    public async Task Convert_TokenFails_NoHandoff()
+    {
+        var acct = MsImap();
+        var vm = Vm(acct, oauth: new StubOAuthService { ThrowOnGetAccessToken = new Exception("declined") });
+        var handedOff = false;
+        vm.AccountConvertedToGraph = _ => { handedOff = true; return Task.CompletedTask; };
+
+        await vm.ConvertToGraphCommand.ExecuteAsync(null);
+
+        Assert.False(handedOff);
+    }
+
+    [Fact]
+    public async Task Convert_TokenFails_LeavesAccountEntirelyOnImap()
+    {
+        var acct = MsImap();
+        var store = new StubLocalStoreService();
+        var oauth = new StubOAuthService { ThrowOnGetAccessToken = new Exception("user declined consent") };
+        var vm = Vm(acct, oauth: oauth, store: store);
+
+        await vm.ConvertToGraphCommand.ExecuteAsync(null);
+
+        Assert.Equal(BackendKind.ImapSmtp, acct.BackendKind);           // untouched
+        Assert.False(acct.GraphConversionPending);                     // no marker
+        Assert.Empty(store.ClearedMailAccountIds);                     // never purged
+        Assert.DoesNotContain(acct.Id, store.SeededFolders.Keys);      // folders not cleared
+    }
+
+    [Fact]
+    public async Task Convert_Declined_DoesNothing()
+    {
+        var acct = MsImap();
+        var store = new StubLocalStoreService();
+        var vm = Vm(acct, store: store);
+        vm.ConfirmConvertToGraph = _ => false;   // user says no
+
+        await vm.ConvertToGraphCommand.ExecuteAsync(null);
+
+        Assert.Equal(BackendKind.ImapSmtp, acct.BackendKind);
+        Assert.Empty(store.ClearedMailAccountIds);
+    }
+
+    [Fact]
+    public async Task Convert_NoConfirmCallback_FailsClosed()
+    {
+        var acct = MsImap();
+        var store = new StubLocalStoreService();
+        var vm = Vm(acct, store: store);
+        vm.ConfirmConvertToGraph = null;   // View didn't wire it
+
+        await vm.ConvertToGraphCommand.ExecuteAsync(null);
+
+        Assert.Equal(BackendKind.ImapSmtp, acct.BackendKind);
+        Assert.Empty(store.ClearedMailAccountIds);
+    }
+
+    // ── Explicit Graph scopes (the trap Kelly caught) ─────────────────────────────
+    // DefaultScopesFor would return IMAP scopes here (BackendKind is still ImapSmtp), so the token must
+    // be requested with the explicit Graph scope set, chosen personal-vs-work.
+
+    [Fact]
+    public async Task Convert_PersonalAccount_RequestsPersonalGraphScopes()
+    {
+        var oauth = new StubOAuthService();
+        var vm = Vm(MsImap("me@outlook.com", personal: true), oauth: oauth);
+
+        await vm.ConvertToGraphCommand.ExecuteAsync(null);
+
+        Assert.Same(OAuthService.GraphMailScopesPersonal, oauth.LastAccessTokenScopes);
+        Assert.NotSame(OAuthService.ImapSmtpScopes, oauth.LastAccessTokenScopes);
+    }
+
+    [Fact]
+    public async Task Convert_WorkAccount_RequestsWorkSchoolGraphScopes()
+    {
+        var oauth = new StubOAuthService();
+        var vm = Vm(MsImap("user@contoso.com", personal: false), oauth: oauth);
+
+        await vm.ConvertToGraphCommand.ExecuteAsync(null);
+
+        Assert.Same(OAuthService.GraphMailScopesWorkSchool, oauth.LastAccessTokenScopes);
+    }
+}

--- a/QuickMail.Tests/GraphBackendGateTests.cs
+++ b/QuickMail.Tests/GraphBackendGateTests.cs
@@ -467,6 +467,11 @@ public class ConfigFeatureGateTests
             .IsEnabled(FeatureFlag.MicrosoftGraphDefault));
 
     [Fact]
+    public void Default_MicrosoftGraphMigrationOff() // #529 step 4: opt-in convert, ships off
+        => Assert.False(new ConfigFeatureGate(new ConfigModel(), Array.Empty<string>())
+            .IsEnabled(FeatureFlag.MicrosoftGraphMigration));
+
+    [Fact]
     public void Config_DisablesFlag() // now the meaningful override: turn the default off
         => Assert.False(new ConfigFeatureGate(ConfigWith("GraphBackend", "false"), Array.Empty<string>())
             .IsEnabled(FeatureFlag.GraphBackend));

--- a/QuickMail.Tests/StubServices.cs
+++ b/QuickMail.Tests/StubServices.cs
@@ -169,8 +169,21 @@ sealed class StubGoogleOAuthService : IGoogleOAuthService
 
 sealed class StubOAuthService : IOAuthService
 {
+    /// <summary>The scope array handed to the last explicit-scope GetAccessTokenAsync — lets a test
+    /// assert a caller asked for Graph scopes rather than IMAP scopes (#529 step 4 token-before-purge).</summary>
+    public string[]? LastAccessTokenScopes { get; private set; }
+
+    /// <summary>When set, the explicit-scope GetAccessTokenAsync throws it — to simulate a failed or
+    /// declined Graph sign-in so a test can assert the caller left state untouched.</summary>
+    public Exception? ThrowOnGetAccessToken { get; set; }
+
     public Task<string> GetAccessTokenAsync(AccountModel account, CancellationToken ct = default) => Task.FromResult(string.Empty);
-    public Task<string> GetAccessTokenAsync(AccountModel account, string[] scopes, CancellationToken ct = default) => Task.FromResult(string.Empty);
+    public Task<string> GetAccessTokenAsync(AccountModel account, string[] scopes, CancellationToken ct = default)
+    {
+        LastAccessTokenScopes = scopes;
+        if (ThrowOnGetAccessToken is { } ex) throw ex;
+        return Task.FromResult(string.Empty);
+    }
     public Task<string> GetAccessTokenSilentAsync(AccountModel account, string[] scopes, CancellationToken ct = default) => Task.FromResult(string.Empty);
     public Task EnsureSilentTokenAsync(AccountModel account, CancellationToken ct = default) => Task.CompletedTask;
     /// <summary>
@@ -216,7 +229,14 @@ class StubLocalStoreService : ILocalStoreService
             ? Newest(rows.Where(m => m.Date >= since)) : []);
     public virtual Task DeleteSummariesAsync(Guid accountId, string folderName, IEnumerable<string> messageIds) => Task.CompletedTask;
     public virtual Task DeleteAccountDataAsync(Guid accountId) => Task.CompletedTask;
-    public virtual Task ClearCachedMailAsync(System.Collections.Generic.IEnumerable<System.Guid> accountIds) => Task.CompletedTask;
+    /// <summary>Account ids passed to <see cref="ClearCachedMailAsync"/>, so a test can assert the
+    /// convert purged the right account (#529 step 4).</summary>
+    public List<Guid> ClearedMailAccountIds { get; } = [];
+    public virtual Task ClearCachedMailAsync(System.Collections.Generic.IEnumerable<System.Guid> accountIds)
+    {
+        ClearedMailAccountIds.AddRange(accountIds);
+        return Task.CompletedTask;
+    }
     public virtual Task PurgeCalendarEventsForUnknownAccountsAsync(IReadOnlyCollection<Guid> knownAccountIds) => Task.CompletedTask;
 
     /// <summary>Folders the stub hands back from <see cref="LoadFoldersAsync"/> — seed this to stand in

--- a/QuickMail/App.xaml.cs
+++ b/QuickMail/App.xaml.cs
@@ -389,6 +389,15 @@ public partial class App : Application
             // read old mail as new and re-run rules over it on upgrade day. Baseline it (#366/N5).
             if (immutableIdRebuilt) syncService.SeedRebuildBaseline(rebuiltGraphAccountIds);
 
+            // #529 step 4: an IMAP→Graph convert purges the account's store before it re-syncs. If the
+            // app closed (or crashed) between the purge and the first baselined sync, the store is empty
+            // and the in-memory baseline is gone, so the first re-sync would read all pre-existing mail as
+            // new and re-fire client rules over it (the #454 failure). The persisted GraphConversionPending
+            // marker survives that, so seed the baseline for every account still mid-convert — before any
+            // sync runs (the sync service is built above; StartBackgroundSyncAsync runs later).
+            var convertingAccountIds = accounts.Where(a => a.GraphConversionPending).Select(a => a.Id).ToList();
+            if (convertingAccountIds.Count > 0) syncService.SeedRebuildBaseline(convertingAccountIds);
+
             // Contact sync (issue #256): Graph source reuses the Graph backend's client; Google source
             // gets its own People API client (owns an HttpClient → disposed in OnExit).
             var graphContactSource  = new GraphContactSource(graphBackend.Client);

--- a/QuickMail/Models/AccountModel.cs
+++ b/QuickMail/Models/AccountModel.cs
@@ -69,6 +69,16 @@ public partial class AccountModel : ObservableObject
     /// <summary>Optional Azure AD tenant ID for Graph accounts. Null = "common" authority.</summary>
     public string? TenantId { get; set; }
 
+    /// <summary>
+    /// Crash-safe marker for an in-progress IMAP→Graph conversion (#529 step 4). Set — and persisted —
+    /// before the local cache is purged, and cleared only after the first post-convert Graph sync has
+    /// baselined the account's folders. While it is true, startup seeds the SyncService rule-refire
+    /// baseline for this account, so a crash between the purge and the first sync cannot re-fire client
+    /// rules over pre-existing mail (the #454 failure this safeguard exists to prevent). See
+    /// docs/planning/graph-migrate-existing-accounts-pm-dev-spec.md §5.3.
+    /// </summary>
+    public bool GraphConversionPending { get; set; }
+
     // IMAP
     public string ImapHost { get; set; } = string.Empty;
     public int ImapPort { get; set; } = 993;

--- a/QuickMail/Models/FeatureFlag.cs
+++ b/QuickMail/Models/FeatureFlag.cs
@@ -29,6 +29,19 @@ public enum FeatureFlag
     MicrosoftGraphDefault,
 
     /// <summary>
+    /// Offers the opt-in "Convert to Microsoft 365 (Graph)" command in the Account Manager, which moves
+    /// an existing Microsoft IMAP account onto the Graph backend in place (#529 step 4). Effective only
+    /// when <see cref="GraphBackend"/> is also on. Nothing converts automatically; the command is per
+    /// account and asks first.
+    ///
+    /// Default: false. Ships off while the convert is exercised by testers — it purges and re-downloads
+    /// the account's local cache, so it stays opt-in until it has real mileage. Turn it on with
+    /// MicrosoftGraphMigration=true under [features] in config.ini, or --feature MicrosoftGraphMigration
+    /// at launch.
+    /// </summary>
+    MicrosoftGraphMigration,
+
+    /// <summary>
     /// Offers Google sign-in for Gmail accounts: the "Gmail (sign in with Google)" provider entry
     /// and the Google OAuth item in the Authentication combo.
     ///

--- a/QuickMail/Services/ConfigFeatureGate.cs
+++ b/QuickMail/Services/ConfigFeatureGate.cs
@@ -21,6 +21,10 @@ public class ConfigFeatureGate : IFeatureGate
         // under Advanced. Testers opt in with MicrosoftGraphDefault=true under [features]; the default
         // flips in a later release.
         [FeatureFlag.MicrosoftGraphDefault] = false,
+        // Off while the opt-in IMAP→Graph convert (#529 step 4) is exercised by testers — it purges and
+        // re-downloads the account's local cache, so it stays opt-in. Set MicrosoftGraphMigration=true
+        // under [features] to test.
+        [FeatureFlag.MicrosoftGraphMigration] = false,
         // Off since v0.8.37: Google no longer grants QuickMail new authorizations, so offering the
         // option to everyone only produced sign-ins that could not succeed. Opt-in for the users
         // whose authorization predates the block (#369).

--- a/QuickMail/ViewModels/AccountManagerViewModel.cs
+++ b/QuickMail/ViewModels/AccountManagerViewModel.cs
@@ -34,7 +34,9 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
     [NotifyPropertyChangedFor(nameof(IsSharedSelected))]
     [NotifyPropertyChangedFor(nameof(ShowNormalAccountFields))]
     [NotifyPropertyChangedFor(nameof(SharedParentName))]
+    [NotifyPropertyChangedFor(nameof(CanConvertToGraph))]
     [NotifyCanExecuteChangedFor(nameof(SetDefaultCommand))]
+    [NotifyCanExecuteChangedFor(nameof(ConvertToGraphCommand))]
     private AccountModel? _selectedAccount;
 
     public bool IsEditing => SelectedAccount != null;
@@ -97,6 +99,18 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
          || ProviderCatalog.IsICloud(acct));
 
     protected override bool IsGoogleAuthEnabled => _featureGate.IsEnabled(FeatureFlag.GoogleAuth);
+
+    /// <summary>
+    /// #529 step 4: offers the opt-in "Convert to Microsoft 365 (Graph)" command for the selected
+    /// account. Shown only for a real (non-shared) Microsoft OAuth IMAP account, and only when Graph is
+    /// an available backend (<see cref="FeatureFlag.GraphBackend"/>) and the convert feature is on
+    /// (<see cref="FeatureFlag.MicrosoftGraphMigration"/>). A Graph account is already converted; a
+    /// password/non-Microsoft account has no Graph identity; a shared mailbox reads through its parent.
+    /// </summary>
+    public bool CanConvertToGraph =>
+        SelectedAccount is { BackendKind: BackendKind.ImapSmtp, AuthType: AuthType.OAuth2Microsoft, IsShared: false }
+        && _featureGate.IsEnabled(FeatureFlag.GraphBackend)
+        && _featureGate.IsEnabled(FeatureFlag.MicrosoftGraphMigration);
 
     /// <summary>#31: gates the "Add shared…" button — the sole path that can create a shared mailbox.
     /// Off by default while the multi-PR feature is built (see <see cref="FeatureFlag.SharedMailboxes"/>).</summary>
@@ -401,6 +415,107 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
             Accounts.RemoveAt(idx);
             Accounts.Insert(idx, account);
             SelectedAccount = Accounts[idx];
+        }
+    }
+
+    /// <summary>Set by the View to confirm an IMAP→Graph conversion (#529 step 4): message → user's
+    /// yes/no. The convert purges and re-downloads the account's local cache, so it must be confirmed;
+    /// an unset callback fails closed (treated as declined), never converting unconfirmed. The shipped
+    /// View wires it.</summary>
+    public Func<string, bool>? ConfirmConvertToGraph { get; set; }
+
+    /// <summary>
+    /// Set by the View to hand a just-converted account (by id) to the main window's sync loop, which
+    /// owns the live account list, the backend router, and the SyncService. Without this, the main loop
+    /// keeps its own IMAP-backed copy of the account and would re-download the pre-existing mail we just
+    /// purged and re-fire client rules over it (the #454 symptom) — the startup seed only protects the
+    /// NEXT launch. The handler flips the main copy to Graph, disconnects the IMAP session, seeds the
+    /// in-session rule-refire baseline, and rebinds the router. Unset (e.g. in tests) is safe: the
+    /// persisted marker still makes the next launch recover.
+    /// </summary>
+    public Func<Guid, Task>? AccountConvertedToGraph { get; set; }
+
+    /// <summary>
+    /// #529 step 4 — moves an existing Microsoft IMAP account onto the Graph backend in place. This PR
+    /// performs the safe half of the sequence (spec §5.1 steps 1–5): confirm, acquire a Graph token
+    /// BEFORE any destructive step, then persist a crash-safe marker + flip the backend and purge the
+    /// local cache. It deliberately does not yet drive the in-session re-sync or remap the account's
+    /// folder-referencing settings — those are the follow-up; the marker keeps it crash-safe and the
+    /// next sync re-downloads from Graph. See the spec's §5.3 for why the marker is set before the purge.
+    /// </summary>
+    [RelayCommand(CanExecute = nameof(CanConvertToGraph))]
+    private async Task ConvertToGraphAsync()
+    {
+        if (SelectedAccount is not
+            { BackendKind: BackendKind.ImapSmtp, AuthType: AuthType.OAuth2Microsoft, IsShared: false } account)
+            return;
+        if (!CanConvertToGraph) return;
+
+        // Step 2 — confirm. No side effect until yes; fail closed if the View didn't wire the callback.
+        var confirmed = ConfirmConvertToGraph?.Invoke(
+            $"Convert {account.AccountLabel} to Microsoft 365? This re-downloads the mailbox once. Mail older " +
+            "than your sync window stays on the server and is not kept on this PC. Continue?") ?? false;
+        if (!confirmed) return;
+
+        var flipped = false;
+        try
+        {
+            // Step 3 — token BEFORE purge. Acquire a GRAPH token with an EXPLICIT scope array. Do NOT let
+            // DefaultScopesFor pick: BackendKind is still ImapSmtp here, so it would return the IMAP scopes
+            // and the convert would proceed on a token with no Graph access, defeating this safeguard.
+            // Resolve personal-vs-work with ResolveIsPersonalMicrosoftAccount (the flag is nullable on
+            // older accounts and falls back to a domain guess). A failure or decline stops here with the
+            // account entirely unchanged — still IMAP; MSAL's cache is scope-additive, so its existing
+            // IMAP grant is not evicted.
+            // Fully qualified: the base class exposes an instance property also named OAuthService, which
+            // would otherwise shadow the static scope helpers on the service class.
+            var graphScopes = Services.OAuthService.ResolveIsPersonalMicrosoftAccount(account)
+                ? Services.OAuthService.GraphMailScopesPersonal
+                : Services.OAuthService.GraphMailScopesWorkSchool;
+            StatusText = "Signing in to Microsoft 365…";
+            await _oauth.GetAccessTokenAsync(account, graphScopes);
+
+            // Steps 4 + 5 — mark, flip, persist, purge, in that order. The marker is persisted WITH the
+            // backend flip and BEFORE the purge, so a crash after this point leaves a converting Graph
+            // account whose startup baseline seeding suppresses client rules over the pre-existing mail
+            // (the #454 safeguard). ClearCachedMailAsync drops the IMAP-keyed messages; SaveFoldersAsync
+            // with an empty list clears the IMAP folder rows too, so the tree does not render IMAP names
+            // (invalid Graph ids) under a Graph account before the first Graph folder fetch.
+            account.GraphConversionPending = true;
+            account.BackendKind = BackendKind.MicrosoftGraph;
+            _accountService.SaveAccounts([.. Accounts]);
+            flipped = true;
+
+            await _localStore.ClearCachedMailAsync([account.Id]);
+            await _localStore.SaveFoldersAsync(account.Id, []);
+
+            // Hand the account to the main sync loop so it flips its own copy to Graph, disconnects the
+            // IMAP session, seeds the in-session rule-refire baseline, and rebinds the router — otherwise
+            // the main loop would re-sync the purged account over IMAP and re-fire rules on old mail this
+            // session (the startup marker only guards the next launch). Unset in tests; the marker covers it.
+            if (AccountConvertedToGraph is { } handoff)
+                await handoff(account.Id);
+
+            StatusText = $"{account.AccountLabel} now connects through Microsoft 365 and is re-downloading.";
+
+            // Refresh the list item so the editor reflects the new backend (mirrors SaveAccount).
+            var idx = Accounts.IndexOf(account);
+            if (idx >= 0)
+            {
+                Accounts.RemoveAt(idx);
+                Accounts.Insert(idx, account);
+                SelectedAccount = Accounts[idx];
+            }
+        }
+        catch (Exception ex)
+        {
+            // Distinguish "never started" (token/confirm failed — account untouched on IMAP) from a
+            // failure AFTER the backend flip was persisted, where the conversion did start and the
+            // persisted marker will resume it on the next launch — reporting "didn't start" there would
+            // be wrong.
+            StatusText = flipped
+                ? $"{account.AccountLabel} is converting to Microsoft 365; a step didn't finish ({ex.Message}). It will resume on the next restart."
+                : $"Conversion didn't start: {ex.Message}";
         }
     }
 

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -1659,6 +1659,30 @@ public partial class MainViewModel : ObservableObject, IDisposable
     /// </summary>
     public Action<AccountModel>? RegisterAccountBackend { get; set; }
 
+    /// <summary>
+    /// #529 step 4: the Account Manager just converted an account to the Graph backend (it flipped its
+    /// own copy, persisted the <see cref="AccountModel.GraphConversionPending"/> marker, and purged the
+    /// local cache). Bring THIS window's live copy in line so nothing re-syncs the account over IMAP this
+    /// session: disconnect the IMAP session, flip our copy to Graph, seed the in-session rule-refire
+    /// baseline (so the Graph re-download does not run client rules over the pre-existing mail — the #454
+    /// safeguard, matching the startup seed), and rebind the router to the Graph backend. The normal sync
+    /// then re-downloads the account over Graph. The marker clear and folder-reference remap are the
+    /// follow-up; the marker keeps it crash-safe until then.
+    /// </summary>
+    public async Task OnAccountConvertedToGraphAsync(Guid accountId)
+    {
+        var account = Accounts.FirstOrDefault(a => a.Id == accountId);
+        if (account is null) return;
+
+        // Best effort — the IMAP session may already be down; either way stop it before rebinding.
+        try { await _imap.DisconnectAsync(accountId); } catch { }
+
+        account.GraphConversionPending = true;
+        account.BackendKind = BackendKind.MicrosoftGraph;
+        _syncService.SeedRebuildBaseline([accountId]);
+        RegisterAccountBackend?.Invoke(account);
+    }
+
     public void LoadAccountList(List<AccountModel>? preloaded = null)
     {
         var accounts = preloaded ?? _accountService.LoadAccounts();

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -5074,6 +5074,9 @@ public partial class MainWindow : Window
     private void OpenAccountManager()
     {
         var accountVm = new AccountManagerViewModel(_accountService, _credentials, _imap, _oauth, _localStore, _configService, _featureGate, _providerCatalog, _autoDiscover, _smtp, _contactSyncService, _graphCalendarSyncService);
+        // #529 step 4: keep the main sync loop safe in-session after an IMAP→Graph convert (disconnect,
+        // flip our copy, seed the rule-refire baseline, rebind the router).
+        accountVm.AccountConvertedToGraph = id => _vm.OnAccountConvertedToGraphAsync(id);
         var dialog = new AccountManagerDialog(accountVm) { Owner = this };
         dialog.ShowDialog();
         // Refresh regardless of the dialog result: the contact- and calendar-sync toggles apply
@@ -5085,6 +5088,7 @@ public partial class MainWindow : Window
     private void OpenAccountManagerForAccount(AccountModel account)
     {
         var accountVm = new AccountManagerViewModel(_accountService, _credentials, _imap, _oauth, _localStore, _configService, _featureGate, _providerCatalog, _autoDiscover, _smtp, _contactSyncService, _graphCalendarSyncService);
+        accountVm.AccountConvertedToGraph = id => _vm.OnAccountConvertedToGraphAsync(id);  // #529 step 4 (see OpenAccountManager)
         var dialog    = new AccountManagerDialog(accountVm) { Owner = this };
         // Pre-select the account in the manager
         accountVm.SelectedAccount = accountVm.Accounts.FirstOrDefault(a => a.Id == account.Id);


### PR DESCRIPTION
**PR 1 of 3** for #529 step 4 — the opt-in convert of an existing Microsoft IMAP account to the Graph backend, per the merged spec (`docs/planning/graph-migrate-existing-accounts-pm-dev-spec.md`). Everything is behind a new **default-off `MicrosoftGraphMigration`** flag, and this PR has **no UI entry point yet**, so the feature is unreachable until the series completes.

## What's here (spec §5.1 steps 1–5 + the #454 safeguard)
- **`MicrosoftGraphMigration` flag** (default off) + a persisted **`GraphConversionPending`** marker on `AccountModel`.
- **`ConvertToGraphAsync`** on `AccountManagerViewModel`: confirm (fail-closed callback) → **Graph token BEFORE any destructive step** → persist the marker + flip `BackendKind` → purge the cache + clear folder rows.
  - The **explicit-scope** point you caught on the spec is enforced in code: it resolves `GraphMailScopesPersonal`/`GraphMailScopesWorkSchool` via `ResolveIsPersonalMicrosoftAccount`, never `DefaultScopesFor` (which returns IMAP scopes here). A test asserts the scope array, so a regression fails.
  - A token failure/decline leaves the account **entirely on IMAP** (test-pinned).
- **Crash-safe on both axes:** App startup seeds the SyncService rule-refire baseline for any `GraphConversionPending` account (next-launch safety); and an **in-session handoff** (`AccountConvertedToGraph` → `MainViewModel.OnAccountConvertedToGraphAsync`) disconnects IMAP, flips the main window's copy, seeds the in-session baseline, and rebinds the router (this-session safety).

## Deliberately out of scope (follow-ups)
- **PR 2:** drive the in-session re-sync to completion and **clear the marker**; remap folder-referencing settings (move-to-folder rules, saved views, startup folder).
- **PR 3:** the Account Manager button + the modeless confirmation window.

So merge order is PR1 → PR2 → PR3, and the flag stays off throughout. Until PR 2 lands, a converted account re-seeds the baseline each launch (rules suppressed on the first Inbox sync) and its move-to-folder rules still hold IMAP folder names — both fine behind the off flag, both closed by PR 2.

## Review
Independent adversarial review: **SHIP**. It caught two real things, both fixed before this PR opened: (1) the in-session window where the main sync loop's own IMAP copy could re-download the purged mail and re-fire rules — closed by the handoff above; (2) a post-flip failure wrongly reporting "conversion didn't start" — the catch now distinguishes pre-flip vs post-flip. Build clean, 28 targeted tests green (gating matrix, token-before-purge, explicit scopes, flip+purge, handoff, fail-closed confirm).

Part of #529.
