### PR TITLE
Convert resync + folder-reference remap + marker clear (#529 step 4, PR 2)

### DIFF
--- a/QuickMail.Tests/FolderReferenceRemapperTests.cs
+++ b/QuickMail.Tests/FolderReferenceRemapperTests.cs
@@ -1,0 +1,204 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using QuickMail.Models;
+using QuickMail.Services;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// #529 step 4 (§5.2): after an IMAP→Graph convert, folder references stored by IMAP name are rewritten
+/// to the matching Graph folder id, or safely invalidated. Matching is exact-full → unique-leaf → else
+/// unmatched (never guess between two same-named folders).
+/// </summary>
+public class FolderReferenceRemapperTests
+{
+    private static readonly Guid Acct = Guid.NewGuid();
+
+    private static MailFolderModel GFolder(string id, string display, Guid? acct = null) =>
+        new() { AccountId = acct ?? Acct, FullName = id, DisplayName = display };
+
+    private static MailRule MoveRule(string name, string target, Guid? acct = null) =>
+        new() { Name = name, AccountId = acct ?? Acct, Action = RuleAction.MoveToFolder, TargetFolder = target };
+
+    // Well-known Graph folders for the account, by opaque id.
+    private static List<MailFolderModel> Folders() =>
+    [
+        GFolder("id-inbox", "Inbox"),
+        GFolder("id-archive", "Archive"),
+        GFolder("id-priority", "Priority"),
+    ];
+
+    [Fact]
+    public void MoveRule_ExactName_RewrittenToGraphId()
+    {
+        var rules = new List<MailRule> { MoveRule("File to Archive", "Archive") };
+        var r = FolderReferenceRemapper.Remap(Acct, Folders(), rules, [], new ConfigModel());
+
+        Assert.Equal("id-archive", rules[0].TargetFolder);
+        Assert.True(rules[0].IsEnabled);
+        Assert.Contains("File to Archive", r.RemappedRules);
+    }
+
+    [Fact]
+    public void MoveRule_NestedPath_MatchedByUniqueLeaf()
+    {
+        var rules = new List<MailRule> { MoveRule("File", "INBOX/Priority") };
+        FolderReferenceRemapper.Remap(Acct, Folders(), rules, [], new ConfigModel());
+
+        Assert.Equal("id-priority", rules[0].TargetFolder);   // leaf "Priority" resolved uniquely
+    }
+
+    [Fact]
+    public void MoveRule_AmbiguousLeaf_LeftUnmatched_AndDisabled()
+    {
+        // Two Graph folders named "Reports" — a leaf match must NOT guess between them.
+        var folders = new List<MailFolderModel>
+        {
+            GFolder("id-work-reports", "Reports"),
+            GFolder("id-home-reports", "Reports"),
+        };
+        var rules = new List<MailRule> { MoveRule("File to Reports", "Work/Reports") };
+
+        var r = FolderReferenceRemapper.Remap(Acct, folders, rules, [], new ConfigModel());
+
+        Assert.Equal("Work/Reports", rules[0].TargetFolder);   // unchanged
+        Assert.False(rules[0].IsEnabled);                      // disabled, not deleted
+        Assert.Contains("File to Reports", r.DisabledRules);
+    }
+
+    [Fact]
+    public void MoveRule_NoMatch_Disabled()
+    {
+        var rules = new List<MailRule> { MoveRule("File to Ghost", "NoSuchFolder") };
+        var r = FolderReferenceRemapper.Remap(Acct, Folders(), rules, [], new ConfigModel());
+
+        Assert.False(rules[0].IsEnabled);
+        Assert.Contains("File to Ghost", r.DisabledRules);
+    }
+
+    [Fact]
+    public void OtherAccountsRules_AndNonMoveRules_Untouched()
+    {
+        var otherAcct = Guid.NewGuid();
+        var rules = new List<MailRule>
+        {
+            MoveRule("Other account", "Archive", otherAcct),
+            new() { Name = "Mark read", AccountId = Acct, Action = RuleAction.MarkAsRead },
+        };
+
+        FolderReferenceRemapper.Remap(Acct, Folders(), rules, [], new ConfigModel());
+
+        Assert.Equal("Archive", rules[0].TargetFolder);   // other account untouched (still an IMAP name)
+        Assert.True(rules[0].IsEnabled);
+        Assert.True(rules[1].IsEnabled);                  // non-move rule untouched
+    }
+
+    [Fact]
+    public void SavedView_RealFolder_Remapped_UnmatchedDropped()
+    {
+        var view = new SavedView
+        {
+            Name = "My view",
+            Folders =
+            [
+                new ViewFolder { AccountId = Acct, FolderFullName = "Archive" },
+                new ViewFolder { AccountId = Acct, FolderFullName = "Gone" },
+            ],
+        };
+        var views = new List<SavedView> { view };
+
+        var r = FolderReferenceRemapper.Remap(Acct, Folders(), [], views, new ConfigModel());
+
+        Assert.Single(view.Folders);                            // the unmatched one dropped
+        Assert.Equal("id-archive", view.Folders[0].FolderFullName);
+        Assert.Contains("My view", r.AffectedViews);
+    }
+
+    [Fact]
+    public void VirtualFolderView_Untouched()
+    {
+        var view = new SavedView { Name = "All Inboxes", VirtualFolderKey = "AllInboxes" };
+        var views = new List<SavedView> { view };
+
+        var r = FolderReferenceRemapper.Remap(Acct, Folders(), [], views, new ConfigModel());
+
+        Assert.Empty(r.AffectedViews);
+        Assert.Equal("AllInboxes", view.VirtualFolderKey);
+    }
+
+    [Fact]
+    public void StartupFolder_Remapped_WhenMatched()
+    {
+        var config = new ConfigModel
+        {
+            StartupFolder = "Archive",
+            StartupFolderAccount = Acct.ToString(),
+            StartupFolderLabel = "Archive",
+        };
+
+        var r = FolderReferenceRemapper.Remap(Acct, Folders(), [], [], config);
+
+        Assert.Equal("id-archive", config.StartupFolder);
+        Assert.True(r.StartupFolderChanged);
+    }
+
+    [Fact]
+    public void StartupFolder_FallsBackToAllMail_WhenUnmatched()
+    {
+        var config = new ConfigModel
+        {
+            StartupFolder = "Gone",
+            StartupFolderAccount = Acct.ToString(),
+            StartupFolderLabel = "Gone",
+        };
+
+        FolderReferenceRemapper.Remap(Acct, Folders(), [], [], config);
+
+        Assert.Equal(string.Empty, config.StartupFolder);          // fell back
+        Assert.Equal(string.Empty, config.StartupFolderAccount);
+    }
+
+    [Fact]
+    public void StartupFolder_OtherAccount_Untouched()
+    {
+        var config = new ConfigModel
+        {
+            StartupFolder = "Archive",
+            StartupFolderAccount = Guid.NewGuid().ToString(),   // a different account
+        };
+
+        var r = FolderReferenceRemapper.Remap(Acct, Folders(), [], [], config);
+
+        Assert.Equal("Archive", config.StartupFolder);
+        Assert.False(r.StartupFolderChanged);
+    }
+
+    [Fact]
+    public void Remap_IsIdempotent_ReRunKeepsRemappedRules() // a crash between save and marker-clear re-runs this
+    {
+        var rules = new List<MailRule> { MoveRule("File to Archive", "Archive") };
+        FolderReferenceRemapper.Remap(Acct, Folders(), rules, [], new ConfigModel());
+        Assert.Equal("id-archive", rules[0].TargetFolder);   // remapped to the Graph id
+
+        // Second run over the already-Graph-id reference must NOT disable the rule.
+        var r2 = FolderReferenceRemapper.Remap(Acct, Folders(), rules, [], new ConfigModel());
+
+        Assert.Equal("id-archive", rules[0].TargetFolder);
+        Assert.True(rules[0].IsEnabled);
+        Assert.Empty(r2.DisabledRules);
+    }
+
+    [Fact]
+    public void Summary_NamesTheDisabledRules_AndIsEmptyWhenNothingChanged()
+    {
+        Assert.Equal(string.Empty, new FolderReferenceRemapper.Report().Summary());
+
+        var rules = new List<MailRule> { MoveRule("Broken", "Gone"), MoveRule("Fine", "Archive") };
+        var r = FolderReferenceRemapper.Remap(Acct, Folders(), rules, [], new ConfigModel());
+
+        Assert.Contains("Broken", r.Summary());       // the disabled rule is named (actionable)
+        Assert.Contains("updated", r.Summary());      // the remapped one is counted
+    }
+}

--- a/QuickMail/Services/FolderReferenceRemapper.cs
+++ b/QuickMail/Services/FolderReferenceRemapper.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using QuickMail.Models;
+
+namespace QuickMail.Services;
+
+/// <summary>
+/// #529 step 4 (§5.2): after an account is converted from IMAP to Graph, its settings that name a folder
+/// by IMAP path — move-to-folder rules, real-folder saved views, and the startup folder — no longer
+/// resolve, because Graph folders are keyed by opaque id, not path. This rewrites those references to the
+/// matching Graph folder, or invalidates them safely (never silently pointing at a folder that no longer
+/// exists).
+///
+/// Matching (spec §9.3, no guessing): an exact display-name match on the full reference first, then a leaf
+/// name match only when it is unique; if two Graph folders share the name, the reference is left unmatched
+/// rather than retargeted to a guess. Pure — the caller loads the models, calls this, and persists them.
+/// </summary>
+public static class FolderReferenceRemapper
+{
+    public sealed class Report
+    {
+        /// <summary>Move-to-folder rules whose target was rewritten to the matching Graph folder.</summary>
+        public List<string> RemappedRules { get; } = [];
+        /// <summary>Move-to-folder rules disabled because their target could not be matched.</summary>
+        public List<string> DisabledRules { get; } = [];
+        /// <summary>Saved views a real-folder entry was remapped or dropped from.</summary>
+        public List<string> AffectedViews { get; } = [];
+        /// <summary>True when the startup folder was remapped or fell back to All Mail.</summary>
+        public bool StartupFolderChanged { get; set; }
+
+        public bool AnythingChanged =>
+            RemappedRules.Count > 0 || DisabledRules.Count > 0 || AffectedViews.Count > 0 || StartupFolderChanged;
+
+        /// <summary>A one-line human/screen-reader summary, or empty when nothing changed. The
+        /// disabled-rules part is actionable — it names the rules the user must reset a folder on.</summary>
+        public string Summary()
+        {
+            if (!AnythingChanged) return string.Empty;
+            var parts = new List<string>();
+            if (RemappedRules.Count > 0) parts.Add($"{RemappedRules.Count} rule{(RemappedRules.Count == 1 ? "" : "s")} updated");
+            if (AffectedViews.Count > 0) parts.Add($"{AffectedViews.Count} view{(AffectedViews.Count == 1 ? "" : "s")} updated");
+            if (StartupFolderChanged) parts.Add("startup folder updated");
+            var s = string.Join(", ", parts);
+            if (DisabledRules.Count > 0)
+                s += (s.Length > 0 ? ". " : "") +
+                     $"Turned off {(DisabledRules.Count == 1 ? "rule" : "rules")} whose folder could not be matched — set a folder to re-enable: {string.Join(", ", DisabledRules)}";
+            return s;
+        }
+    }
+
+    /// <summary>
+    /// Rewrites this account's folder references against the account's freshly-synced Graph folders,
+    /// mutating <paramref name="allRules"/>, <paramref name="allViews"/>, and <paramref name="config"/> in
+    /// place. Returns what changed. Virtual-folder views (an account-agnostic key) are untouched.
+    /// </summary>
+    public static Report Remap(
+        Guid accountId,
+        IReadOnlyList<MailFolderModel> graphFolders,
+        List<MailRule> allRules,
+        List<SavedView> allViews,
+        ConfigModel config)
+    {
+        var report = new Report();
+
+        string? Match(string? reference)
+        {
+            if (string.IsNullOrWhiteSpace(reference)) return null;
+            // Already a Graph folder id — an idempotent re-run (e.g. a crash between saving the rewrite and
+            // clearing the marker re-runs this). Keep it as-is rather than failing to match an opaque id
+            // (which would wrongly disable an already-remapped rule).
+            if (graphFolders.Any(f => string.Equals(f.FullName, reference, StringComparison.Ordinal)))
+                return reference;
+            // Exact match on the whole reference (top-level folders whose path is just their name).
+            var exact = graphFolders
+                .Where(f => string.Equals(f.DisplayName, reference, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+            if (exact.Count == 1) return exact[0].FullName;
+            // Otherwise the leaf (last path segment), only if it resolves to exactly one folder.
+            var slash = reference.LastIndexOf('/');
+            var leaf = slash >= 0 ? reference[(slash + 1)..] : reference;
+            var byLeaf = graphFolders
+                .Where(f => string.Equals(f.DisplayName, leaf, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+            return byLeaf.Count == 1 ? byLeaf[0].FullName : null;
+        }
+
+        // Move-to-folder rules for this account.
+        foreach (var rule in allRules.Where(r =>
+                     r.AccountId == accountId && r.Action == RuleAction.MoveToFolder && !string.IsNullOrEmpty(r.TargetFolder)))
+        {
+            var match = Match(rule.TargetFolder);
+            if (match != null)
+            {
+                rule.TargetFolder = match;
+                report.RemappedRules.Add(rule.Name);
+            }
+            else
+            {
+                rule.IsEnabled = false;   // disabled, not deleted — the user can set a folder to re-enable
+                report.DisabledRules.Add(rule.Name);
+            }
+        }
+
+        // Real-folder saved views (skip virtual-folder views — their key is account-agnostic).
+        foreach (var view in allViews.Where(v => string.IsNullOrEmpty(v.VirtualFolderKey)))
+        {
+            var drop = new List<ViewFolder>();
+            var touched = false;
+            foreach (var vf in view.Folders.Where(f => f.AccountId == accountId))
+            {
+                var match = Match(vf.FolderFullName);
+                if (match != null) { vf.FolderFullName = match; touched = true; }
+                else drop.Add(vf);
+            }
+            foreach (var vf in drop) view.Folders.Remove(vf);
+            if (touched || drop.Count > 0) report.AffectedViews.Add(view.Name);
+        }
+
+        // Startup folder, when it names a real folder on this account.
+        if (Guid.TryParse(config.StartupFolderAccount, out var sfa) && sfa == accountId
+            && !string.IsNullOrEmpty(config.StartupFolder))
+        {
+            var match = Match(config.StartupFolder);
+            if (match != null)
+            {
+                config.StartupFolder = match;   // StartupFolderLabel stays; it is display text
+            }
+            else
+            {
+                // Fall back to the "sync wide" / All Mail default rather than pointing at nothing.
+                config.StartupFolder = string.Empty;
+                config.StartupFolderAccount = string.Empty;
+                config.StartupFolderLabel = string.Empty;
+            }
+            report.StartupFolderChanged = true;
+        }
+
+        return report;
+    }
+}

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -1681,6 +1681,66 @@ public partial class MainViewModel : ObservableObject, IDisposable
         account.BackendKind = BackendKind.MicrosoftGraph;
         _syncService.SeedRebuildBaseline([accountId]);
         RegisterAccountBackend?.Invoke(account);
+
+        // Drive the re-download + folder-reference remap + marker clear in the background so the convert
+        // returns promptly. If the app closes before it finishes, the persisted marker makes startup
+        // resume it (see StartBackgroundSyncAsync).
+        FinishGraphConversionAsync(accountId, CancellationToken.None).LogFaults("FinishGraphConversion");
+    }
+
+    /// <summary>
+    /// #529 step 4: completes a conversion — connect the now-Graph account, force its Inbox to sync so the
+    /// rule-refire baseline is consumed, remap the account's folder-referencing settings to the new Graph
+    /// folder ids (§5.2), and finally clear the <see cref="AccountModel.GraphConversionPending"/> marker.
+    /// Runs both from the in-session handoff and from the startup crash-resume; idempotent — a re-run
+    /// re-connects and re-syncs harmlessly, and it no-ops once the marker is clear.
+    /// </summary>
+    private async Task FinishGraphConversionAsync(Guid accountId, CancellationToken ct)
+    {
+        var account = Accounts.FirstOrDefault(a => a.Id == accountId);
+        if (account is null || !account.GraphConversionPending) return;
+
+        // Connect the Graph account and take the folders it returns DIRECTLY — not a read-back through
+        // _cachedFolders, which on the in-session path still holds the pre-convert IMAP folder models (the
+        // purge cleared only the SQLite rows). A transient no-folders result must retry next launch, not
+        // remap references against stale IMAP folders.
+        var (_, folders) = await ConnectOneAccountAsync(account);
+        if (folders is not { Count: > 0 }) return;
+        SetCachedFolders(accountId, folders);
+        var graphFolders = folders;
+
+        // Force an Inbox sync so its rule-refire baseline is consumed BEFORE the marker clears (client
+        // rules only ever run on the Inbox, so it is the one that matters). No Inbox exposed yet → do NOT
+        // clear the marker; retry next launch, because clearing without a baselined Inbox and then crashing
+        // would leave the next launch re-firing rules over the pre-existing mail (#454, §5.3).
+        var inbox = graphFolders.FirstOrDefault(f => f.Kind == SpecialFolderKind.Inbox);
+        if (inbox is null) return;
+        await _syncService.SyncFolderFullAsync(account, inbox, ct);
+
+        // Remap folder-referencing settings now that the Graph folders exist.
+        var rules = _ruleService.LoadRules();
+        var views = _viewService.Load();
+        var cfg = _configService.Load();
+        var report = FolderReferenceRemapper.Remap(accountId, graphFolders, rules, views, cfg);
+        if (report.AnythingChanged)
+        {
+            _ruleService.SaveRules(rules);
+            _viewService.Save(views);
+            _configService.Save(cfg);
+        }
+
+        // Clear the marker — resolve the CURRENT instance (a reload may have replaced it) and persist.
+        var current = Accounts.FirstOrDefault(a => a.Id == accountId);
+        if (current != null)
+        {
+            current.GraphConversionPending = false;
+            _accountService.SaveAccounts([.. Accounts]);
+        }
+
+        var summary = report.Summary();
+        Announce(
+            $"{account.AccountLabel} finished converting to Microsoft 365." + (summary.Length > 0 ? " " + summary : ""),
+            AnnouncementCategory.Result);
     }
 
     public void LoadAccountList(List<AccountModel>? preloaded = null)
@@ -2964,6 +3024,13 @@ public partial class MainViewModel : ObservableObject, IDisposable
         try
         {
             await _syncService.SyncAllAccountsAsync(accountList, _cachedFolders, ct);
+
+            // #529 step 4 crash-resume: an account whose convert didn't finish (marker still set, e.g. the
+            // app closed mid-convert) had its rule-refire baseline seeded before this sweep. Complete it
+            // now — remap its folder references and clear the marker. Fire-and-forget so a slow account
+            // doesn't hold up the rest of startup; the marker keeps it recoverable if this is interrupted.
+            foreach (var acct in accountList.Where(a => a.GraphConversionPending))
+                FinishGraphConversionAsync(acct.Id, ct).LogFaults("resume Graph conversion");
 
             // Sync done — refresh the current view/folder once so the UI reflects every
             // folder that was synced without N intermediate screen-reader announcements.


### PR DESCRIPTION
**PR 2 of 3** for #529 step 4 — **stacked on #578** (base is the PR 1 branch; retarget to `main` once PR 1 merges). Finishes the convert mechanics: the re-sync, the folder-reference remap, and the marker clear. Still behind the default-off `MicrosoftGraphMigration` flag with no UI entry point (PR 3 adds the button).

## What's here (spec §5.1 steps 6–7 + §5.2)
- **`FolderReferenceRemapper`** — a pure, fully-tested service (12 tests). Rewrites move-to-folder rules, real-folder saved views, and the startup folder to the new Graph folder ids. Matching is **exact display name → unique leaf → else unmatched** (never guesses between two same-named folders): an unmatched move-to-folder rule is **disabled and named** in the result, a view folder is dropped, the startup folder falls back to All Mail. **Idempotent** — a reference already equal to a Graph id is kept.
- **`MainViewModel.FinishGraphConversionAsync`** — connects the now-Graph account, **force-syncs its Inbox so the rule-refire baseline is consumed first**, remaps the references, then clears the marker. Runs from the in-session handoff and from the startup crash-resume. The marker is **never cleared without a baselined Inbox** (no Inbox / no folders → retain and retry next launch), so a crash can't leave the next launch re-firing rules over old mail (#454).

## Review
Independent adversarial review: **SHIP** — after it caught three real vectors that all could reintroduce #454 in edge cases, now fixed:
1. A Graph mailbox exposing no Inbox folder yet would clear the marker without a baselined sync → now returns without clearing.
2. A transient no-folders connect read the *stale in-memory IMAP* folder cache (the purge only cleared the SQLite rows) and remapped against IMAP folders → now uses the freshly-fetched folders directly.
3. A crash between the remap-save and the marker-clear re-ran the remap over already-Graph-id references and disabled them → now recognized as already-mapped (with an idempotency test).

## Next
**PR 3** — the Account Manager button + the modeless confirmation window (the only remaining piece; makes the feature reachable). Merge order PR1 → PR2 → PR3.

Part of #529.
