### PR TITLE
Convert-to-Graph button + confirmation (#529 step 4, PR 3)

### DIFF
--- a/QuickMail/Views/AccountManagerDialog.xaml
+++ b/QuickMail/Views/AccountManagerDialog.xaml
@@ -55,7 +55,12 @@
                         Click="AddSharedMailboxButton_Click"
                         AutomationProperties.Name="Add shared mailbox"
                         Visibility="{Binding IsSharedMailboxesEnabled, Converter={StaticResource BoolToVisibility}}"
-                        MinWidth="90" TabIndex="4"/>
+                        MinWidth="90" Margin="0,0,4,0" TabIndex="4"/>
+                <Button Content="Con_vert to Microsoft 365"
+                        Command="{Binding ConvertToGraphCommand}"
+                        AutomationProperties.Name="Convert to Microsoft 365"
+                        Visibility="{Binding CanConvertToGraph, Converter={StaticResource BoolToVisibility}}"
+                        MinWidth="90" TabIndex="5"/>
             </StackPanel>
             <ListBox x:Name="AccountListBox"
                      TabIndex="0"

--- a/QuickMail/Views/AccountManagerDialog.xaml.cs
+++ b/QuickMail/Views/AccountManagerDialog.xaml.cs
@@ -40,6 +40,12 @@ public partial class AccountManagerDialog : Window
         vm.ConfirmCascadeRemoval = message =>
             MessageBox.Show(this, message, "Remove shared mailboxes",
                 MessageBoxButton.YesNo, MessageBoxImage.Warning) == MessageBoxResult.Yes;
+        // #529 step 4: the convert re-downloads the mailbox and can leave older mail off this PC — confirm
+        // first. A plain Yes/No MessageBox (no editable field) is safe here, the same as the cascade
+        // confirmation above; an unset callback fails closed in the VM, so nothing converts unconfirmed.
+        vm.ConfirmConvertToGraph = message =>
+            MessageBox.Show(this, message, "Convert to Microsoft 365",
+                MessageBoxButton.YesNo, MessageBoxImage.Warning) == MessageBoxResult.Yes;
     }
 
     private void AddSharedMailboxButton_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
**PR 3 of 3** for #529 step 4 — **stacked on #579** (base is the PR 2 branch; retarget down the stack as PR 1/PR 2 merge). The UI entry point, and the last piece: with this, the opt-in convert is reachable — but still only when the default-off `MicrosoftGraphMigration` flag is turned on.

## What's here
- A **"Convert to Microsoft 365"** button in the Account Manager's action row, bound to `ConvertToGraphCommand` and shown only when `CanConvertToGraph` (a Microsoft OAuth IMAP account with `GraphBackend` + `MicrosoftGraphMigration` on) — the same flag-gated-visibility pattern as the adjacent "Add shared…" button.
- The `ConfirmConvertToGraph` callback wired to a **Yes/No `MessageBox`**, matching the existing `ConfirmCascadeRemoval` confirmation. A plain message box has no editable field, so it's safe over this dialog (the modal-dialog deadlock rule is specifically about an *editable field* over a live WebView2); an unset callback fails closed in the VM.

## Accessibility
`AutomationProperties.Name` is the short label "Convert to Microsoft 365" (no instructions, no role). Access key on the button. No new pane/F6/Selector changes.

## Verification
`XamlParseTests` green; the button reuses the established flag-gated-button convention verbatim, and is hidden by default (flag off), so it doesn't alter the default UI. The command logic + the resync/remap/marker safety are covered by PR 1 and PR 2's tests and reviews.

## The whole feature
Once PR1 → PR2 → PR3 land (in that order), a tester who turns the flag on can convert an existing Microsoft IMAP account to Graph: token-before-purge, crash-safe marker, in-session + startup re-sync with rules suppressed over the re-downloaded mail, folder-reference remap, and a spoken outcome. Default-off until it has mileage.

Part of #529.
