### PR TITLE
Address step-4 convert review follow-ups (#529)

### DIFF
--- a/QuickMail.Tests/FolderReferenceRemapperTests.cs
+++ b/QuickMail.Tests/FolderReferenceRemapperTests.cs
@@ -145,6 +145,22 @@ public class FolderReferenceRemapperTests
     }
 
     [Fact]
+    public void StartupFolder_AlreadyGraphId_NotReportedChanged() // idempotent re-run (crash between save and marker-clear)
+    {
+        var config = new ConfigModel
+        {
+            StartupFolder = "id-archive",                 // already the Graph id from a prior pass
+            StartupFolderAccount = Acct.ToString(),
+            StartupFolderLabel = "Archive",
+        };
+
+        var r = FolderReferenceRemapper.Remap(Acct, Folders(), [], [], config);
+
+        Assert.Equal("id-archive", config.StartupFolder);  // unchanged
+        Assert.False(r.StartupFolderChanged);              // and not re-announced
+    }
+
+    [Fact]
     public void StartupFolder_FallsBackToAllMail_WhenUnmatched()
     {
         var config = new ConfigModel

--- a/QuickMail/Services/FolderReferenceRemapper.cs
+++ b/QuickMail/Services/FolderReferenceRemapper.cs
@@ -76,7 +76,9 @@ public static class FolderReferenceRemapper
                 .Where(f => string.Equals(f.DisplayName, reference, StringComparison.OrdinalIgnoreCase))
                 .ToList();
             if (exact.Count == 1) return exact[0].FullName;
-            // Otherwise the leaf (last path segment), only if it resolves to exactly one folder.
+            // Otherwise the leaf (last path segment), only if it resolves to exactly one folder. Splitting
+            // on '/' is correct here: only a Microsoft IMAP account can be converted to Graph, and its
+            // stored folder paths use '/'. A '.'-delimited hierarchy would fall through to unmatched.
             var slash = reference.LastIndexOf('/');
             var leaf = slash >= 0 ? reference[(slash + 1)..] : reference;
             var byLeaf = graphFolders
@@ -121,6 +123,7 @@ public static class FolderReferenceRemapper
         if (Guid.TryParse(config.StartupFolderAccount, out var sfa) && sfa == accountId
             && !string.IsNullOrEmpty(config.StartupFolder))
         {
+            var original = config.StartupFolder;
             var match = Match(config.StartupFolder);
             if (match != null)
             {
@@ -133,7 +136,9 @@ public static class FolderReferenceRemapper
                 config.StartupFolderAccount = string.Empty;
                 config.StartupFolderLabel = string.Empty;
             }
-            report.StartupFolderChanged = true;
+            // Only report a change when there actually was one — an idempotent re-run (Match returns the
+            // startup folder's Graph id unchanged) must not re-announce "startup folder updated".
+            if (config.StartupFolder != original) report.StartupFolderChanged = true;
         }
 
         return report;

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -1695,10 +1695,18 @@ public partial class MainViewModel : ObservableObject, IDisposable
     /// Runs both from the in-session handoff and from the startup crash-resume; idempotent — a re-run
     /// re-connects and re-syncs harmlessly, and it no-ops once the marker is clear.
     /// </summary>
+    // Conversions currently being finished, so the in-session handoff and the startup crash-resume don't
+    // both drive a connect + full Inbox sync for the same account at once (they can overlap when a convert
+    // happens while the startup sweep is still running). UI-thread only, so a plain HashSet is enough.
+    private readonly HashSet<Guid> _convertingInFlight = [];
+
     private async Task FinishGraphConversionAsync(Guid accountId, CancellationToken ct)
     {
         var account = Accounts.FirstOrDefault(a => a.Id == accountId);
         if (account is null || !account.GraphConversionPending) return;
+        if (!_convertingInFlight.Add(accountId)) return;   // already finishing this one — don't double-run
+        try
+        {
 
         // Connect the Graph account and take the folders it returns DIRECTLY — not a read-back through
         // _cachedFolders, which on the in-session path still holds the pre-convert IMAP folder models (the
@@ -1741,6 +1749,8 @@ public partial class MainViewModel : ObservableObject, IDisposable
         Announce(
             $"{account.AccountLabel} finished converting to Microsoft 365." + (summary.Length > 0 ? " " + summary : ""),
             AnnouncementCategory.Result);
+        }
+        finally { _convertingInFlight.Remove(accountId); }
     }
 
     public void LoadAccountList(List<AccountModel>? preloaded = null)

--- a/QuickMail/Views/AccountManagerDialog.xaml
+++ b/QuickMail/Views/AccountManagerDialog.xaml
@@ -105,7 +105,7 @@
                          Text="{Binding SelectedProvider.DisplayName, Mode=OneWay}"
                          IsReadOnly="True"
                          AutomationProperties.LabeledBy="{Binding ElementName=LblProvider}"
-                         TabIndex="5"
+                         TabIndex="6"
                          Margin="0,0,0,4"/>
 
                 <!-- Account Name -->
@@ -113,7 +113,7 @@
                 <TextBox x:Name="AccountNameBox"
                          Text="{Binding AccountName, UpdateSourceTrigger=PropertyChanged}"
                          AutomationProperties.LabeledBy="{Binding ElementName=LblAccountName}"
-                         TabIndex="6"/>
+                         TabIndex="7"/>
 
                 <!-- Sender Display Name — hidden for a shared mailbox (#31): its outgoing identity is the
                      mailbox's own directory display name on send, not a name set per-account here. -->
@@ -122,7 +122,7 @@
                     <TextBox x:Name="DisplayNameBox"
                              Text="{Binding DisplayName, UpdateSourceTrigger=PropertyChanged}"
                              AutomationProperties.LabeledBy="{Binding ElementName=LblDisplayName}"
-                             TabIndex="7"/>
+                             TabIndex="8"/>
                 </StackPanel>
 
                 <!-- The account's own email address. Since #396 it is only that: a server whose
@@ -132,7 +132,7 @@
                          Text="{Binding Username, UpdateSourceTrigger=PropertyChanged}"
                          IsReadOnly="{Binding IsSharedSelected}"
                          AutomationProperties.LabeledBy="{Binding ElementName=LblUsername}"
-                         TabIndex="8"/>
+                         TabIndex="9"/>
 
                 <!-- #31: a shared mailbox has no credentials or connection of its own — it reads through
                      its parent account and shows mail only. In place of the connection/auth/sync
@@ -159,7 +159,7 @@
                     <Label x:Name="LblPassword" Content="Pass_word:" Target="{Binding ElementName=PasswordBox}" Padding="0" Margin="0,8,0,2"/>
                     <PasswordBox x:Name="PasswordBox"
                                  AutomationProperties.LabeledBy="{Binding ElementName=LblPassword}"
-                                 TabIndex="9"
+                                 TabIndex="10"
                                  PasswordChanged="PasswordBox_PasswordChanged"/>
 
                     <!-- App-specific password warning, driven by the account's provider (Gmail, Yahoo,
@@ -173,7 +173,7 @@
                         <StackPanel>
                             <TextBlock Text="{Binding AppPasswordHint}" TextWrapping="Wrap" FontWeight="SemiBold"/>
                             <TextBlock Margin="0,4,0,0" TextWrapping="Wrap">
-                                <Hyperlink NavigateUri="{Binding AppPasswordUrl}" KeyboardNavigation.TabIndex="10"
+                                <Hyperlink NavigateUri="{Binding AppPasswordUrl}" KeyboardNavigation.TabIndex="11"
                                            RequestNavigate="AppPasswordLink_RequestNavigate"
                                            AutomationProperties.Name="Create an app password">
                                     <Run Text="{Binding AppPasswordUrl, Mode=OneWay}"/>
@@ -188,13 +188,13 @@
                         Visibility="{Binding IsOAuth2, Converter={StaticResource BoolToVisibility}}"
                         Command="{Binding SignInMicrosoftCommand}"
                         AutomationProperties.Name="Sign in with Microsoft"
-                        HorizontalAlignment="Left" MinWidth="200" Margin="0,8,0,0" TabIndex="11"/>
+                        HorizontalAlignment="Left" MinWidth="200" Margin="0,8,0,0" TabIndex="12"/>
 
                 <Button Content="Sign in _with Google…"
                         Visibility="{Binding IsGoogleOAuth, Converter={StaticResource BoolToVisibility}}"
                         Command="{Binding SignInGoogleCommand}"
                         AutomationProperties.Name="Sign in with Google"
-                        HorizontalAlignment="Left" MinWidth="200" Margin="0,8,0,0" TabIndex="12"/>
+                        HorizontalAlignment="Left" MinWidth="200" Margin="0,8,0,0" TabIndex="13"/>
 
                 </StackPanel>
                 <!-- end #31 ShowNormalAccountFields wrapper (password + OAuth sign-in) -->
@@ -209,7 +209,7 @@
                               IsChecked="{Binding SyncContacts}"
                               Click="SyncContactsCheckBox_Click"
                               AutomationProperties.Name="Sync contacts from this account"
-                              Margin="0,0,0,4" TabIndex="13"/>
+                              Margin="0,0,0,4" TabIndex="14"/>
                 </StackPanel>
 
                 <!-- Calendar sync (#282) — shown for Microsoft, Google, and iCloud accounts. -->
@@ -221,7 +221,7 @@
                               IsChecked="{Binding SyncCalendar}"
                               Click="SyncCalendarCheckBox_Click"
                               AutomationProperties.Name="Sync calendar from this account"
-                              Margin="0,0,0,4" TabIndex="14"/>
+                              Margin="0,0,0,4" TabIndex="15"/>
                 </StackPanel>
 
                 <!-- Server settings live behind the same expander as the Add Account dialog, so an


### PR DESCRIPTION
Non-blocking follow-ups from Kelly's review of the merged step-4 convert stack (#578 / #579 / #580 — the opt-in convert of an existing Microsoft IMAP account to Graph). One logical cleanup change; no behavior change users can see beyond the tab-order fix.

## What this addresses

- **#579 concurrent guard** — `FinishGraphConversionAsync` is now guarded by an in-flight `HashSet<Guid>` so the in-session handoff and the startup crash-resume never both drive a connect + full Inbox sync for the same account. They can overlap when a convert happens while the startup sweep is still running. UI-thread only, so a plain `HashSet` suffices; a `try/finally` removes the id (a transient failure leaves `GraphConversionPending` set for a clean retry next launch).
- **#579 StartupFolderChanged only when changed** — `FolderReferenceRemapper` now sets `StartupFolderChanged` only when the startup folder actually changed, so an idempotent re-run (crash between save and marker-clear) does not re-announce "startup folder updated". New test pins the already-Graph-id no-change case.
- **#579 leaf-split comment** — comment-only: explains why the leaf split is on `/` (only a Microsoft IMAP account can be converted, and its stored paths use `/`).
- **#580 TabIndex collision** — the new Convert button had `TabIndex=5` colliding with `ProviderText`. The form fields are renumbered so Convert stays a unique `5` and the form runs `6..15` with no duplicates or gaps.

## Reviewed

Independent adversarial review before opening: no HIGH/MEDIUM findings. try/finally coverage complete (no HashSet leak path, marker cleared exactly once), idempotency comparison correct for both the remap and fall-back cases, full-file TabIndex audit shows `0..15` each exactly once. The two LOW points it raised are folded in (comment narrowed, idempotency test added).

## Deferred (not in this PR)

Bounded, no-data-loss observations left for a separate change: #578-5 (a stale dialog copy could resurrect the marker), #578-6 (`_cachedFolders` briefly shows pre-convert IMAP folder names until the tree rebuilds), #578-7 (`FinishGraphConversionAsync` end-to-end is hard to unit-test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)