### PR TITLE
Fix #529 step 4 review follow-ups: tab order, idempotent remap, one finisher

### DIFF
--- a/QuickMail.Tests/AccountManagerConvertTests.cs
+++ b/QuickMail.Tests/AccountManagerConvertTests.cs
@@ -27,7 +27,8 @@ public class AccountManagerConvertTests
 
     private static AccountManagerViewModel Vm(
         AccountModel selected, bool migration = true, bool graph = true,
-        StubOAuthService? oauth = null, StubLocalStoreService? store = null)
+        StubOAuthService? oauth = null, StubLocalStoreService? store = null,
+        IAccountService? accounts = null)
     {
         var gate = new StubFeatureGate
         {
@@ -35,7 +36,7 @@ public class AccountManagerConvertTests
             [FeatureFlag.MicrosoftGraphMigration] = migration,
         };
         var vm = new AccountManagerViewModel(
-            new StubAccountService(), new StubCredentialService(), new StubImapMailService(),
+            accounts ?? new StubAccountService(), new StubCredentialService(), new StubImapMailService(),
             oauth ?? new StubOAuthService(), store ?? new StubLocalStoreService(), new StubConfigService(),
             gate, Catalog);
         vm.Accounts.Add(selected);
@@ -186,5 +187,80 @@ public class AccountManagerConvertTests
         await vm.ConvertToGraphCommand.ExecuteAsync(null);
 
         Assert.Same(OAuthService.GraphMailScopesWorkSchool, oauth.LastAccessTokenScopes);
+    }
+
+    // ── The conversion marker is not this dialog's to write ───────────────────────
+
+    /// <summary>An account service that actually round-trips, so a test can see what a save wrote and
+    /// can stand in for another writer (MainViewModel) changing the file underneath the dialog.</summary>
+    private sealed class RecordingAccountService : IAccountService
+    {
+        // Copies, not the caller's instances: the real service round-trips through JSON, so a loaded
+        // account is a distinct object. Sharing references here would let a test mutate "the file" and
+        // the VM's copy at once, which is precisely the confusion these tests exist to rule out.
+        private static AccountModel Copy(AccountModel a) => new()
+        {
+            Id = a.Id, AccountName = a.AccountName, Username = a.Username,
+            BackendKind = a.BackendKind, AuthType = a.AuthType,
+            GraphConversionPending = a.GraphConversionPending,
+        };
+
+        public List<AccountModel> Stored { get; private set; } = [];
+        public int SaveCount { get; private set; }
+        public List<AccountModel> LoadAccounts() => [.. Stored.Select(Copy)];
+        public void SaveAccounts(List<AccountModel> accounts) { SaveCount++; Stored = [.. accounts.Select(Copy)]; }
+        public void SetDefaultAccount(Guid accountId) { }
+    }
+
+    [Fact]
+    public async Task Convert_PersistsTheMarkerAsSet() // the one place allowed to RAISE it
+    {
+        var acct = MsImap();
+        var svc = new RecordingAccountService();
+        var vm = Vm(acct, accounts: svc);
+
+        await vm.ConvertToGraphCommand.ExecuteAsync(null);
+
+        var written = Assert.Single(svc.Stored.Where(a => a.Id == acct.Id));
+        Assert.True(written.GraphConversionPending);
+        Assert.Equal(BackendKind.MicrosoftGraph, written.BackendKind);
+    }
+
+    [Fact]
+    public async Task ALaterSave_DoesNotResurrectAMarkerClearedElsewhere()
+    {
+        var acct = MsImap();
+        var svc = new RecordingAccountService();
+        var vm = Vm(acct, accounts: svc);
+        await vm.ConvertToGraphCommand.ExecuteAsync(null);
+        Assert.True(acct.GraphConversionPending);   // the dialog's copy still says "converting"
+
+        // MainViewModel finishes the conversion and clears the marker on disk while this dialog is
+        // still open — it owns the re-sync, not the dialog.
+        foreach (var stored in svc.Stored) stored.GraphConversionPending = false;
+
+        // Any later save from the dialog (here: the account Save button) must not write our stale copy
+        // back over that. Doing so would cost a full redundant re-download on the next launch.
+        var savesBefore = svc.SaveCount;
+        vm.SaveAccountCommand.Execute(null);
+        Assert.True(svc.SaveCount > savesBefore, "the Save command did not reach a save");
+
+        Assert.All(svc.Stored, a => Assert.False(a.GraphConversionPending));
+        Assert.False(acct.GraphConversionPending);   // and our copy is reconciled, not just the file
+    }
+
+    [Fact]
+    public void SaveOfAnAccountTheFileDoesNotKnow_KeepsItsOwnMarker()
+    {
+        // A brand-new account has no persisted row to read the marker from; the save must keep what the
+        // in-memory model says rather than defaulting it away.
+        var acct = MsImap();
+        acct.GraphConversionPending = true;
+        var svc = new RecordingAccountService();   // empty store
+        var vm = Vm(acct, accounts: svc);
+
+        vm.SaveAccountCommand.Execute(null);
+
+        Assert.True(Assert.Single(svc.Stored.Where(a => a.Id == acct.Id)).GraphConversionPending);
     }
 }

--- a/QuickMail.Tests/FolderReferenceRemapperTests.cs
+++ b/QuickMail.Tests/FolderReferenceRemapperTests.cs
@@ -188,6 +188,47 @@ public class FolderReferenceRemapperTests
         Assert.Equal("id-archive", rules[0].TargetFolder);
         Assert.True(rules[0].IsEnabled);
         Assert.Empty(r2.DisabledRules);
+        // …and must not report a rewrite it did not perform. AnythingChanged drives a re-save of
+        // rules + views + config and a spoken summary, so a re-run that reports work makes both
+        // permanent once an account has been converted.
+        Assert.Empty(r2.RemappedRules);
+        Assert.False(r2.AnythingChanged);
+    }
+
+    [Fact]
+    public void Remap_SecondRun_ReportsNothingChanged_AcrossRulesViewsAndStartupFolder()
+    {
+        var rules = new List<MailRule> { MoveRule("File to Archive", "Archive") };
+        var view = new SavedView
+        {
+            Name = "My view",
+            Folders = [new ViewFolder { AccountId = Acct, FolderFullName = "Priority" }],
+        };
+        var views = new List<SavedView> { view };
+        var config = new ConfigModel
+        {
+            StartupFolder = "Archive",
+            StartupFolderAccount = Acct.ToString(),
+            StartupFolderLabel = "Archive",
+        };
+
+        var first = FolderReferenceRemapper.Remap(Acct, Folders(), rules, views, config);
+        Assert.True(first.AnythingChanged);
+
+        var second = FolderReferenceRemapper.Remap(Acct, Folders(), rules, views, config);
+
+        // Every reference already holds the value the match returns — that is not a change.
+        Assert.False(second.AnythingChanged);
+        Assert.Empty(second.RemappedRules);
+        Assert.Empty(second.DisabledRules);
+        Assert.Empty(second.AffectedViews);
+        Assert.False(second.StartupFolderChanged);
+        Assert.Equal(string.Empty, second.Summary());
+
+        // And nothing was actually rewritten the second time.
+        Assert.Equal("id-archive", rules[0].TargetFolder);
+        Assert.Equal("id-priority", view.Folders[0].FolderFullName);
+        Assert.Equal("id-archive", config.StartupFolder);
     }
 
     [Fact]

--- a/QuickMail/Services/FolderReferenceRemapper.cs
+++ b/QuickMail/Services/FolderReferenceRemapper.cs
@@ -76,7 +76,11 @@ public static class FolderReferenceRemapper
                 .Where(f => string.Equals(f.DisplayName, reference, StringComparison.OrdinalIgnoreCase))
                 .ToList();
             if (exact.Count == 1) return exact[0].FullName;
-            // Otherwise the leaf (last path segment), only if it resolves to exactly one folder.
+            // Otherwise the leaf (last path segment), only if it resolves to exactly one folder. '/' is
+            // the only delimiter handled, which is enough: the sole reference that reaches here came
+            // from a Microsoft IMAP account, and Exchange/Outlook IMAP delimits with '/'. A '.'-delimited
+            // hierarchy would fall through to unmatched — safe (the rule is disabled and named, not
+            // silently retargeted), just not remapped.
             var slash = reference.LastIndexOf('/');
             var leaf = slash >= 0 ? reference[(slash + 1)..] : reference;
             var byLeaf = graphFolders
@@ -90,15 +94,16 @@ public static class FolderReferenceRemapper
                      r.AccountId == accountId && r.Action == RuleAction.MoveToFolder && !string.IsNullOrEmpty(r.TargetFolder)))
         {
             var match = Match(rule.TargetFolder);
-            if (match != null)
-            {
-                rule.TargetFolder = match;
-                report.RemappedRules.Add(rule.Name);
-            }
-            else
+            if (match == null)
             {
                 rule.IsEnabled = false;   // disabled, not deleted — the user can set a folder to re-enable
                 report.DisabledRules.Add(rule.Name);
+            }
+            // Already equal to the match is an idempotent re-run, not a rewrite — do not report one.
+            else if (!string.Equals(rule.TargetFolder, match, StringComparison.Ordinal))
+            {
+                rule.TargetFolder = match;
+                report.RemappedRules.Add(rule.Name);
             }
         }
 
@@ -110,8 +115,13 @@ public static class FolderReferenceRemapper
             foreach (var vf in view.Folders.Where(f => f.AccountId == accountId))
             {
                 var match = Match(vf.FolderFullName);
-                if (match != null) { vf.FolderFullName = match; touched = true; }
-                else drop.Add(vf);
+                if (match == null) { drop.Add(vf); continue; }
+                // Compare before assigning: on an idempotent re-run every reference matches the value
+                // it already holds, and reporting that as "updated" makes AnythingChanged permanently
+                // true — an unnecessary re-save of all three files and a spoken summary of no change.
+                if (string.Equals(vf.FolderFullName, match, StringComparison.Ordinal)) continue;
+                vf.FolderFullName = match;
+                touched = true;
             }
             foreach (var vf in drop) view.Folders.Remove(vf);
             if (touched || drop.Count > 0) report.AffectedViews.Add(view.Name);
@@ -122,18 +132,21 @@ public static class FolderReferenceRemapper
             && !string.IsNullOrEmpty(config.StartupFolder))
         {
             var match = Match(config.StartupFolder);
-            if (match != null)
-            {
-                config.StartupFolder = match;   // StartupFolderLabel stays; it is display text
-            }
-            else
+            if (match == null)
             {
                 // Fall back to the "sync wide" / All Mail default rather than pointing at nothing.
                 config.StartupFolder = string.Empty;
                 config.StartupFolderAccount = string.Empty;
                 config.StartupFolderLabel = string.Empty;
+                report.StartupFolderChanged = true;
             }
-            report.StartupFolderChanged = true;
+            // Already equal to the match is an idempotent re-run, not a change: reporting one there
+            // makes AnythingChanged permanently true. Same guard as the saved-view references above.
+            else if (!string.Equals(config.StartupFolder, match, StringComparison.Ordinal))
+            {
+                config.StartupFolder = match;   // StartupFolderLabel stays; it is display text
+                report.StartupFolderChanged = true;
+            }
         }
 
         return report;

--- a/QuickMail/ViewModels/AccountManagerViewModel.cs
+++ b/QuickMail/ViewModels/AccountManagerViewModel.cs
@@ -216,7 +216,7 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
                     StatusText = "Requesting permission to read your contacts…";
                     await _oauth.RequestContactsConsentAsync(account);
                 }
-                _accountService.SaveAccounts([.. Accounts]);
+                SaveAccountsPreservingConversionMarkers();
                 // Pull an initial snapshot so contacts appear without waiting for the next launch.
                 _contactSync?.SyncAccountAsync(account).LogFaults("contact sync after enable");
                 StatusText = "Contact sync enabled — new contact data will be available in QuickMail.";
@@ -224,7 +224,7 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
             else
             {
                 account.SyncContacts = false;
-                _accountService.SaveAccounts([.. Accounts]);
+                SaveAccountsPreservingConversionMarkers();
                 if (_contactSync != null)
                     await _contactSync.RemoveAccountContactsAsync(account.Id);
                 StatusText = "Contact sync disabled.";
@@ -236,7 +236,7 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
             // against a missing grant.
             account.SyncContacts = false;
             SyncContacts = false;
-            _accountService.SaveAccounts([.. Accounts]);
+            SaveAccountsPreservingConversionMarkers();
             StatusText = $"Contact sync not enabled: {ex.Message}";
             LogService.Log($"AccountManager: contact-sync enable failed for {account.AccountLabel} — {ex.Message}");
         }
@@ -267,7 +267,7 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
                     StatusText = "Requesting permission to read your calendar…";
                     await _oauth.RequestCalendarConsentAsync(account);
                 }
-                _accountService.SaveAccounts([.. Accounts]);
+                SaveAccountsPreservingConversionMarkers();
                 // Pull an initial snapshot so events appear without waiting for the next sync pass.
                 _graphCalendarSync?.SyncAccountCalendarAsync(account).LogFaults("calendar sync after enable");
                 StatusText = "Calendar sync enabled — this account's events will appear in the Calendar.";
@@ -275,7 +275,7 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
             else
             {
                 account.SyncCalendar = false;
-                _accountService.SaveAccounts([.. Accounts]);
+                SaveAccountsPreservingConversionMarkers();
                 if (_graphCalendarSync != null)
                     await _graphCalendarSync.RemoveAccountCalendarAsync(account.Id);
                 StatusText = "Calendar sync disabled.";
@@ -287,7 +287,7 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
             // against a missing grant.
             account.SyncCalendar = false;
             SyncCalendar = false;
-            _accountService.SaveAccounts([.. Accounts]);
+            SaveAccountsPreservingConversionMarkers();
             StatusText = $"Calendar sync not enabled: {ex.Message}";
             LogService.Log($"AccountManager: calendar-sync enable failed for {account.AccountLabel} — {ex.Message}");
         }
@@ -301,7 +301,7 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
         if (!string.IsNullOrEmpty(password))
             _credentials.SavePassword(account.Id, password);
         Accounts.Add(account);
-        _accountService.SaveAccounts([.. Accounts]);
+        SaveAccountsPreservingConversionMarkers();
         SelectedAccount = account;
         StatusText = "Account added.";
 
@@ -329,7 +329,7 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
         catch (Exception ex)
         {
             account.SyncContacts = false;
-            _accountService.SaveAccounts([.. Accounts]);
+            SaveAccountsPreservingConversionMarkers();
             StatusText = $"Account added, but contact sync couldn't be enabled: {ex.Message}";
             LogService.Log($"AccountManager: new-account contact sync failed for {account.AccountLabel} — {ex.Message}");
         }
@@ -347,7 +347,7 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
         catch (Exception ex)
         {
             account.SyncCalendar = false;
-            _accountService.SaveAccounts([.. Accounts]);
+            SaveAccountsPreservingConversionMarkers();
             StatusText = $"Account added, but calendar sync couldn't be enabled: {ex.Message}";
             LogService.Log($"AccountManager: new-account calendar sync failed for {account.AccountLabel} — {ex.Message}");
         }
@@ -405,7 +405,7 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
         if (AuthType == AuthType.Password && !string.IsNullOrEmpty(Password))
             _credentials.SavePassword(account.Id, Password);
 
-        _accountService.SaveAccounts([.. Accounts]);
+        SaveAccountsPreservingConversionMarkers();
         StatusText = "Account saved.";
 
         // Force list item refresh
@@ -416,6 +416,32 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
             Accounts.Insert(idx, account);
             SelectedAccount = Accounts[idx];
         }
+    }
+
+    /// <summary>
+    /// Persists the account list, taking <see cref="AccountModel.GraphConversionPending"/> from disk
+    /// rather than from our copy (#529 step 4).
+    ///
+    /// That marker is not this dialog's to write once a convert is under way: MainViewModel owns the
+    /// re-sync and clears it when the Inbox has been baselined, which can land while this dialog is
+    /// still open. Our copy then still reads "converting", and any later save here — a contact-sync
+    /// toggle, a rename — would write that stale true back over the cleared value and cost a redundant
+    /// full re-download on the next launch. ConvertToGraphAsync is the one place that legitimately
+    /// RAISES the marker, so it saves directly instead of calling this.
+    /// </summary>
+    private void SaveAccountsPreservingConversionMarkers()
+    {
+        // Not ToDictionary: a duplicated id in accounts.json must not turn a tolerable data oddity into
+        // a crash on every save (same reasoning as MainViewModel.LoadAccountList). Last one wins.
+        var persisted = new Dictionary<Guid, bool>();
+        foreach (var stored in _accountService.LoadAccounts())
+            persisted[stored.Id] = stored.GraphConversionPending;
+
+        foreach (var account in Accounts)
+            if (persisted.TryGetValue(account.Id, out var pending))
+                account.GraphConversionPending = pending;
+
+        _accountService.SaveAccounts([.. Accounts]);
     }
 
     /// <summary>Set by the View to confirm an IMAP→Graph conversion (#529 step 4): message → user's
@@ -550,7 +576,7 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
         Accounts.Remove(account);
         foreach (var child in sharedChildren) Accounts.Remove(child);
         SelectedAccount = null;
-        _accountService.SaveAccounts([.. Accounts]);
+        SaveAccountsPreservingConversionMarkers();
 
         var config = _configService.Load();
         var configChanged = config.Accounts.Remove(account.Id);
@@ -595,7 +621,7 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
     public void CommitNewSharedMailbox(AccountModel sharedMailbox)
     {
         Accounts.Add(sharedMailbox);
-        _accountService.SaveAccounts([.. Accounts]);
+        SaveAccountsPreservingConversionMarkers();
         SelectedAccount = sharedMailbox;
         // Result, not Status: the add succeeded and the add window has already closed, so this is the
         // only feedback — it must be spoken even for a user who has AnnounceStatus off (#396 pattern).

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -1682,6 +1682,19 @@ public partial class MainViewModel : ObservableObject, IDisposable
         _syncService.SeedRebuildBaseline([accountId]);
         RegisterAccountBackend?.Invoke(account);
 
+        // Drop this account's cached folder models. They are the pre-convert IMAP list — the purge
+        // cleared only the SQLite rows — and their FullNames are IMAP paths, which are not valid Graph
+        // folder ids. Left in place they draw a tree of folders that no longer resolve, so selecting
+        // one lands on nothing. Assigning the cache directly rather than calling SetCachedFolders,
+        // which would also mark the account connected (it is not — the IMAP session just went down and
+        // Graph has not connected yet) and skip an empty write anyway.
+        //
+        // The tree is deliberately NOT rebuilt here: this runs inside the Account Manager's modal
+        // message loop, and rebuilding parent-window UI from there is exactly the re-entrancy the
+        // modal-dialog rule forbids. RefreshAccountList rebuilds from this cache the moment the dialog
+        // closes, and FinishGraphConversionAsync refills it with the real Graph folders when they land.
+        _cachedFolders[accountId] = [];
+
         // Drive the re-download + folder-reference remap + marker clear in the background so the convert
         // returns promptly. If the app closes before it finishes, the persisted marker makes startup
         // resume it (see StartBackgroundSyncAsync).
@@ -1700,10 +1713,39 @@ public partial class MainViewModel : ObservableObject, IDisposable
         var account = Accounts.FirstOrDefault(a => a.Id == accountId);
         if (account is null || !account.GraphConversionPending) return;
 
-        // Connect the Graph account and take the folders it returns DIRECTLY — not a read-back through
-        // _cachedFolders, which on the in-session path still holds the pre-convert IMAP folder models (the
-        // purge cleared only the SQLite rows). A transient no-folders result must retry next launch, not
-        // remap references against stale IMAP folders.
+        // One finisher per account. Converting while the startup sweep is still running reaches this
+        // twice for the same account: the in-session handoff fires immediately, and StartBackgroundSyncAsync's
+        // resume loop then sees the same live AccountModel still carrying the marker when SyncAllAccountsAsync
+        // returns. Both would connect and force-sync the same Inbox concurrently. Dropping the second is
+        // right rather than merely cheaper — the first is already driving the account to the same end state,
+        // and if it fails the marker survives for the next launch either way.
+        lock (_graphConversionsInFlight)
+        {
+            if (!_graphConversionsInFlight.Add(accountId)) return;
+        }
+
+        try
+        {
+            await FinishGraphConversionCoreAsync(account, accountId, ct);
+        }
+        finally
+        {
+            lock (_graphConversionsInFlight) _graphConversionsInFlight.Remove(accountId);
+        }
+    }
+
+    /// <summary>Accounts with a <see cref="FinishGraphConversionAsync"/> already running, so the
+    /// in-session handoff and the startup resume loop cannot both drive the same one (#529 step 4).</summary>
+    private readonly HashSet<Guid> _graphConversionsInFlight = [];
+
+    /// <summary>The body of <see cref="FinishGraphConversionAsync"/>, which owns the one-at-a-time guard.</summary>
+    private async Task FinishGraphConversionCoreAsync(AccountModel account, Guid accountId, CancellationToken ct)
+    {
+        // Connect the Graph account and take the folders it returns DIRECTLY, never a read-back through
+        // _cachedFolders. The remap has to run against folders this account genuinely exposes now: a
+        // transient no-folders connect must retry next launch rather than remap against whatever the
+        // cache happens to hold. (The handoff clears that cache of its pre-convert IMAP models, but the
+        // startup-resume path does not go through the handoff, so this cannot rely on it being empty.)
         var (_, folders) = await ConnectOneAccountAsync(account);
         if (folders is not { Count: > 0 }) return;
         SetCachedFolders(accountId, folders);

--- a/QuickMail/Views/AccountManagerDialog.xaml
+++ b/QuickMail/Views/AccountManagerDialog.xaml
@@ -32,7 +32,14 @@
         <!-- Account list. TabIndex is explicit on everything in this column: without it these
              controls default to int.MaxValue like the Advanced-settings contents do, and — because
              the form's fields carry low explicit indices — the account list and its buttons landed
-             in the MIDDLE of the form, between the password box and Advanced settings. -->
+             in the MIDDLE of the form, between the password box and Advanced settings.
+
+             The two columns share one flat run of indices and must not overlap: this column owns
+             0–5 (the list, then its buttons left to right), the edit form owns 6–15. A duplicate
+             index across the columns does not fail loudly — WPF breaks the tie on tree order, which
+             happens to give the right result here — so a collision reads as working and only bites
+             when something later moves. Adding a button here means renumbering the form, not
+             reusing an index the form already holds. -->
         <DockPanel Grid.Column="0" Grid.Row="0">
             <TextBlock DockPanel.Dock="Top" Text="Accounts" FontWeight="SemiBold" Margin="0,0,0,4"/>
             <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" Margin="0,4,0,0">
@@ -105,7 +112,7 @@
                          Text="{Binding SelectedProvider.DisplayName, Mode=OneWay}"
                          IsReadOnly="True"
                          AutomationProperties.LabeledBy="{Binding ElementName=LblProvider}"
-                         TabIndex="5"
+                         TabIndex="6"
                          Margin="0,0,0,4"/>
 
                 <!-- Account Name -->
@@ -113,7 +120,7 @@
                 <TextBox x:Name="AccountNameBox"
                          Text="{Binding AccountName, UpdateSourceTrigger=PropertyChanged}"
                          AutomationProperties.LabeledBy="{Binding ElementName=LblAccountName}"
-                         TabIndex="6"/>
+                         TabIndex="7"/>
 
                 <!-- Sender Display Name — hidden for a shared mailbox (#31): its outgoing identity is the
                      mailbox's own directory display name on send, not a name set per-account here. -->
@@ -122,7 +129,7 @@
                     <TextBox x:Name="DisplayNameBox"
                              Text="{Binding DisplayName, UpdateSourceTrigger=PropertyChanged}"
                              AutomationProperties.LabeledBy="{Binding ElementName=LblDisplayName}"
-                             TabIndex="7"/>
+                             TabIndex="8"/>
                 </StackPanel>
 
                 <!-- The account's own email address. Since #396 it is only that: a server whose
@@ -132,7 +139,7 @@
                          Text="{Binding Username, UpdateSourceTrigger=PropertyChanged}"
                          IsReadOnly="{Binding IsSharedSelected}"
                          AutomationProperties.LabeledBy="{Binding ElementName=LblUsername}"
-                         TabIndex="8"/>
+                         TabIndex="9"/>
 
                 <!-- #31: a shared mailbox has no credentials or connection of its own — it reads through
                      its parent account and shows mail only. In place of the connection/auth/sync
@@ -159,7 +166,7 @@
                     <Label x:Name="LblPassword" Content="Pass_word:" Target="{Binding ElementName=PasswordBox}" Padding="0" Margin="0,8,0,2"/>
                     <PasswordBox x:Name="PasswordBox"
                                  AutomationProperties.LabeledBy="{Binding ElementName=LblPassword}"
-                                 TabIndex="9"
+                                 TabIndex="10"
                                  PasswordChanged="PasswordBox_PasswordChanged"/>
 
                     <!-- App-specific password warning, driven by the account's provider (Gmail, Yahoo,
@@ -173,7 +180,7 @@
                         <StackPanel>
                             <TextBlock Text="{Binding AppPasswordHint}" TextWrapping="Wrap" FontWeight="SemiBold"/>
                             <TextBlock Margin="0,4,0,0" TextWrapping="Wrap">
-                                <Hyperlink NavigateUri="{Binding AppPasswordUrl}" KeyboardNavigation.TabIndex="10"
+                                <Hyperlink NavigateUri="{Binding AppPasswordUrl}" KeyboardNavigation.TabIndex="11"
                                            RequestNavigate="AppPasswordLink_RequestNavigate"
                                            AutomationProperties.Name="Create an app password">
                                     <Run Text="{Binding AppPasswordUrl, Mode=OneWay}"/>
@@ -188,13 +195,13 @@
                         Visibility="{Binding IsOAuth2, Converter={StaticResource BoolToVisibility}}"
                         Command="{Binding SignInMicrosoftCommand}"
                         AutomationProperties.Name="Sign in with Microsoft"
-                        HorizontalAlignment="Left" MinWidth="200" Margin="0,8,0,0" TabIndex="11"/>
+                        HorizontalAlignment="Left" MinWidth="200" Margin="0,8,0,0" TabIndex="12"/>
 
                 <Button Content="Sign in _with Google…"
                         Visibility="{Binding IsGoogleOAuth, Converter={StaticResource BoolToVisibility}}"
                         Command="{Binding SignInGoogleCommand}"
                         AutomationProperties.Name="Sign in with Google"
-                        HorizontalAlignment="Left" MinWidth="200" Margin="0,8,0,0" TabIndex="12"/>
+                        HorizontalAlignment="Left" MinWidth="200" Margin="0,8,0,0" TabIndex="13"/>
 
                 </StackPanel>
                 <!-- end #31 ShowNormalAccountFields wrapper (password + OAuth sign-in) -->
@@ -209,7 +216,7 @@
                               IsChecked="{Binding SyncContacts}"
                               Click="SyncContactsCheckBox_Click"
                               AutomationProperties.Name="Sync contacts from this account"
-                              Margin="0,0,0,4" TabIndex="13"/>
+                              Margin="0,0,0,4" TabIndex="14"/>
                 </StackPanel>
 
                 <!-- Calendar sync (#282) — shown for Microsoft, Google, and iCloud accounts. -->
@@ -221,7 +228,7 @@
                               IsChecked="{Binding SyncCalendar}"
                               Click="SyncCalendarCheckBox_Click"
                               AutomationProperties.Name="Sync calendar from this account"
-                              Margin="0,0,0,4" TabIndex="14"/>
+                              Margin="0,0,0,4" TabIndex="15"/>
                 </StackPanel>
 
                 <!-- Server settings live behind the same expander as the Add Account dialog, so an


### PR DESCRIPTION
Follow-ups from reviewing the #578 / #579 / #580 stack (#529 step 4, the opt-in IMAP→Graph convert). Six findings, none of them a ship blocker behind the default-off `MicrosoftGraphMigration` flag — but all cheap now and awkward once the flag turns on.

## Tab order

The Convert button took `TabIndex="5"`, which `ProviderText` already held. The observed order stayed correct only because WPF breaks the tie on tree order — a collision that reads as working. The form moves to 6–15 so the two columns own disjoint runs, and the comment now records the scheme. This is the one dialog that already documents having been bitten by tab order, so relying on a tie-break here seemed worth not doing.

## The remap reported work it did not do

`FolderReferenceRemapper` matched every reference to the value it already held on a re-run and counted that as a rewrite, so `AnythingChanged` was permanently true once an account had been converted — a re-save of rules, views and config plus a spoken "N rules updated, startup folder updated" summary of no change, every subsequent run. Rules, view folders and the startup folder now compare before assigning. Also added a note on why leaf extraction only splits on `/`.

## Two finishers for one conversion

Converting while the startup sweep is still running reached `FinishGraphConversionAsync` twice for the same account: the in-session handoff fires immediately, and `StartBackgroundSyncAsync`'s resume loop then sees the same live `AccountModel` still carrying the marker when `SyncAllAccountsAsync` returns (`accountList` holds the same references as `Accounts`). Both would connect and force-sync the same Inbox concurrently. A per-account in-flight set drops the second — the first is already driving the account to the same end state, and if it fails the marker survives for the next launch either way.

## The folder tree kept drawing IMAP folders

The handoff purged the SQLite rows but left the account's pre-convert IMAP folder models in `_cachedFolders`, so the tree kept showing folders whose IMAP paths are not valid Graph ids — selecting one lands on nothing. Cleared at handoff.

The tree is deliberately **not** rebuilt there: that code runs inside the Account Manager's modal message loop, and rebuilding parent-window UI from inside a modal loop is exactly the re-entrancy CLAUDE.md's modal-dialog rule forbids. `RefreshAccountList` already runs when the dialog closes and rebuilds from this cache, so clearing the data is enough.

## A stale dialog copy could resurrect the marker

`MainViewModel` clears `GraphConversionPending` when the re-sync finishes, which can land while the Account Manager is still open holding a copy that still reads "converting" (`AccountService.LoadAccounts` does not cache, so the two hold independent object graphs). Any later save from the dialog — a contact-sync toggle, a rename — wrote that stale `true` back, costing a redundant full re-download on the next launch. Saves now take that one field from disk. `ConvertToGraphAsync`, the one place that legitimately *raises* the marker, still saves directly.

## Tests

Idempotent re-runs report nothing changed across rules, views and the startup folder; a later dialog save does not resurrect a cleared marker; a brand-new account with no persisted row keeps its own. **Each new test was confirmed to fail against the pre-fix code** — the first version of the marker test passed against both, because the fake account service shared object references with the VM and so wasn't simulating an external writer at all; it now copies on save and load, like the real JSON round-trip.

Release build clean. Full suite: 3105–3106 passed, 3 skipped. `TabStripNavigationTests.DisabledTabs_AreSkipped` fails intermittently and passes in isolation — it failed the same way on the merged stack before any change here, and nothing in this PR goes near it. Probably worth its own issue.
