### PR TITLE
Keep the focused startup-folder idempotency test from #581

### DIFF
--- a/QuickMail.Tests/FolderReferenceRemapperTests.cs
+++ b/QuickMail.Tests/FolderReferenceRemapperTests.cs
@@ -145,6 +145,22 @@ public class FolderReferenceRemapperTests
     }
 
     [Fact]
+    public void StartupFolder_AlreadyGraphId_NotReportedChanged() // idempotent re-run (crash between save and marker-clear)
+    {
+        var config = new ConfigModel
+        {
+            StartupFolder = "id-archive",                 // already the Graph id from a prior pass
+            StartupFolderAccount = Acct.ToString(),
+            StartupFolderLabel = "Archive",
+        };
+
+        var r = FolderReferenceRemapper.Remap(Acct, Folders(), [], [], config);
+
+        Assert.Equal("id-archive", config.StartupFolder);  // unchanged
+        Assert.False(r.StartupFolderChanged);              // and not re-announced
+    }
+
+    [Fact]
     public void StartupFolder_FallsBackToAllMail_WhenUnmatched()
     {
         var config = new ConfigModel


### PR DESCRIPTION
Test-only. Carries over the one piece of [#581](https://github.com/kellylford/QuickMail/pull/581) that [#582](https://github.com/kellylford/QuickMail/pull/582) did not already supersede: `StartupFolder_AlreadyGraphId_NotReportedChanged`.

#582 asserts the same behaviour, but inside a broader rules + views + startup-folder test. A single named test for "the reference is already a Graph id" is what someone greps for when this breaks, so it earns its place separately.

Authored by @CityDweller in #581; credited in the commit.