### PR TITLE
Move OAuth sign-in to the end of tab order, after Advanced settings (#584)

### DIFF
--- a/QuickMail.Tests/AccountManagerTabOrderTests.cs
+++ b/QuickMail.Tests/AccountManagerTabOrderTests.cs
@@ -27,7 +27,7 @@ namespace QuickMail.Tests;
 [Collection("WpfTests")]
 public class AccountManagerTabOrderTests
 {
-    private static AccountManagerViewModel NewVm()
+    private static AccountManagerViewModel NewVm(AuthType authType = AuthType.Password)
     {
         var vm = new AccountManagerViewModel(
             new StubAccountService(), new StubCredentialService(), new StubImapMailService(),
@@ -36,12 +36,15 @@ public class AccountManagerTabOrderTests
 
         // An account must be selected: with none, the whole edit form is disabled (IsEditing) and a
         // disabled control is not a tab stop at all, so there would be nothing to measure.
+        // OAuth2Microsoft shows the "Sign in with Microsoft" button (IsOAuth2); Password shows the
+        // password box instead. Either way the account stays on the IMAP/SMTP backend, so Advanced
+        // shows the auth combo and host fields.
         var account = new AccountModel
         {
             Id = Guid.NewGuid(),
             AccountName = "Test account",
             Username = "kelly@example.com",
-            AuthType = AuthType.Password,
+            AuthType = authType,
             ImapHost = "imap.example.com",
             SmtpHost = "smtp.example.com",
         };
@@ -144,6 +147,65 @@ public class AccountManagerTabOrderTests
             Assert.True(At("AuthTypeCombo") < At("ImapHostBox"), $"Order: {order}");
             Assert.True(At("ImapHostBox") < At("SmtpHostBox"), $"Order: {order}");
             Assert.True(At("SmtpHostBox") < At("SignatureBox"), $"Order: {order}");
+        }
+        finally { window.Close(); }
+    }
+
+    /// <summary>
+    /// #584: the OAuth "Sign in with Microsoft" button is the LAST stop in the edit form — after the
+    /// Advanced expander and everything it reveals — so re-authenticating is the final thing a
+    /// keyboard user Tabs to, not a control stranded above Advanced that forces a Shift+Tab back up.
+    /// The forward walk pins the position; the backward walk pins that Shift+Tab is its exact reverse.
+    /// </summary>
+    [StaFact]
+    public void OAuthSignInIsTheLastStop_AfterAdvancedSettings()
+    {
+        var vm = NewVm(AuthType.OAuth2Microsoft);
+        var window = new AccountManagerDialog(vm)
+        {
+            WindowStyle = WindowStyle.None, ShowInTaskbar = false, ShowActivated = false,
+        };
+        window.Show();
+        try
+        {
+            vm.IsAdvancedExpanded = true;
+            window.UpdateLayout();
+            Drain();
+
+            var close = window.FindName("CloseButton") as Button;
+            Assert.NotNull(close);
+
+            // The button has no x:Name, so the walker reports it by its AutomationProperties.Name.
+            const string SignIn = "Sign in with Microsoft";
+
+            // Forward (Tab): sign-in comes after the expander header and after the last Advanced
+            // control (Signature), and did not jump above the main-surface fields.
+            TabOrderWalker.StartAt(window, close!, "Close");
+            var stops = TabOrderWalker.Walk(window);
+            var order = string.Join(" -> ", stops);
+            int At(string name) => stops.IndexOf(name);
+
+            Assert.True(At(SignIn) >= 0, $"sign-in button not reachable. Order: {order}");
+            Assert.True(At("HeaderSite") >= 0, $"expander header never reached. Order: {order}");
+            Assert.True(At("SignatureBox") >= 0, $"Signature never reached. Order: {order}");
+            // >= 0 guarded: -1 < a real index passes vacuously and would hide the regression.
+            Assert.True(At("UsernameBox") >= 0 && At("UsernameBox") < At(SignIn),
+                $"email field unreachable, or sign-in jumped above the form. Order: {order}");
+            Assert.True(At("HeaderSite") < At(SignIn), $"sign-in precedes the Advanced expander. Order: {order}");
+            Assert.True(At("SignatureBox") < At(SignIn), $"sign-in precedes the Advanced contents. Order: {order}");
+
+            // Backward (Shift+Tab): from Close, the stop after sign-in, going back reaches sign-in
+            // first, then the Advanced contents, then the expander header — the exact reverse.
+            TabOrderWalker.StartAt(window, close!, "Close");
+            var back = TabOrderWalker.WalkBackward(window);
+            var backOrder = string.Join(" -> ", back);
+            int BackAt(string name) => back.IndexOf(name);
+
+            Assert.True(BackAt(SignIn) >= 0, $"Shift+Tab never reached sign-in. Backward: {backOrder}");
+            Assert.True(BackAt(SignIn) < BackAt("SignatureBox"),
+                $"Shift+Tab reached Advanced before sign-in. Backward: {backOrder}");
+            Assert.True(BackAt("SignatureBox") < BackAt("HeaderSite"),
+                $"Shift+Tab order is not the reverse of Tab. Backward: {backOrder}");
         }
         finally { window.Close(); }
     }

--- a/QuickMail.Tests/AddAccountTabOrderTests.cs
+++ b/QuickMail.Tests/AddAccountTabOrderTests.cs
@@ -113,4 +113,69 @@ public class AddAccountTabOrderTests
         }
         finally { window.Close(); }
     }
+
+    /// <summary>
+    /// #584: the OAuth "Sign in with Microsoft" button is the LAST stop in the form — after the
+    /// Advanced expander and everything it reveals — so signing in is the final thing a keyboard user
+    /// Tabs to, not a control stranded above Advanced that forces a Shift+Tab back up. The sync
+    /// opt-ins stay before sign-in so their permission is part of the same consent (#256, #282).
+    /// </summary>
+    [StaFact]
+    public void OAuthSignInIsTheLastStop_AfterAdvancedSettings()
+    {
+        var vm = NewVm();
+        // A Microsoft provider makes the account OAuth (ApplyProvider sets AuthType.OAuth2Microsoft),
+        // so the "Sign in with Microsoft" button and the sync opt-ins appear.
+        vm.SelectedProvider = new ProviderCatalog().All.First(p => p.Id == ProviderCatalog.MicrosoftId);
+        var window = new AddAccountDialog(vm)
+        {
+            WindowStyle = WindowStyle.None, ShowInTaskbar = false, ShowActivated = false,
+        };
+        window.Show();
+        try
+        {
+            vm.IsAdvancedExpanded = true;
+            window.UpdateLayout();
+            Drain();
+
+            var provider = (Control)window.FindName("ProviderComboBox");
+
+            // The button has no x:Name, so the walker reports it by its AutomationProperties.Name.
+            const string SignIn = "Sign in with Microsoft";
+
+            // Forward (Tab): sign-in comes after the expander header and after the last Advanced
+            // control (Signature); the sync opt-ins still precede it.
+            TabOrderWalker.StartAt(window, provider, "ProviderComboBox");
+            var stops = WalkTabOrder(window);
+            var order = string.Join(" -> ", stops);
+            int At(string name) => stops.IndexOf(name);
+
+            Assert.True(At(SignIn) >= 0, $"sign-in button not reachable. Order: {order}");
+            Assert.True(At("HeaderSite") >= 0, $"expander header never reached. Order: {order}");
+            Assert.True(At("SignatureBox") >= 0, $"Signature never reached. Order: {order}");
+            Assert.True(At("HeaderSite") < At(SignIn), $"sign-in precedes the Advanced expander. Order: {order}");
+            Assert.True(At("SignatureBox") < At(SignIn), $"sign-in precedes the Advanced contents. Order: {order}");
+            // Guard the >= 0 explicitly: IndexOf returns -1 for an unreachable control, and -1 < a
+            // real index passes vacuously — that would hide the very regression this pins.
+            Assert.True(At("SyncContactsCheckBox") >= 0 && At("SyncContactsCheckBox") < At(SignIn),
+                $"sync contacts opt-in is unreachable or falls after sign-in. Order: {order}");
+            Assert.True(At("SyncCalendarCheckBox") >= 0 && At("SyncCalendarCheckBox") < At(SignIn),
+                $"sync calendar opt-in is unreachable or falls after sign-in. Order: {order}");
+
+            // Backward (Shift+Tab): from the Add button, past the bottom row, going back reaches
+            // sign-in first, then the Advanced contents — the exact reverse of Tab.
+            var add = (Control)window.FindName("AddButton");
+            TabOrderWalker.StartAt(window, add, "AddButton");
+            var back = TabOrderWalker.WalkBackward(window);
+            var backOrder = string.Join(" -> ", back);
+            int BackAt(string name) => back.IndexOf(name);
+
+            Assert.True(BackAt(SignIn) >= 0, $"Shift+Tab never reached sign-in. Backward: {backOrder}");
+            Assert.True(BackAt(SignIn) < BackAt("SignatureBox"),
+                $"Shift+Tab reached Advanced before sign-in. Backward: {backOrder}");
+            Assert.True(BackAt("SignatureBox") < BackAt("HeaderSite"),
+                $"Shift+Tab order is not the reverse of Tab. Backward: {backOrder}");
+        }
+        finally { window.Close(); }
+    }
 }

--- a/QuickMail.Tests/TabOrderWalker.cs
+++ b/QuickMail.Tests/TabOrderWalker.cs
@@ -58,10 +58,22 @@ internal static class TabOrderWalker
     }
 
     /// <summary>
-    /// Tabs forward from the current focus, recording each stop, until the order wraps or
+    /// Tabs forward (Tab) from the current focus, recording each stop, until the order wraps or
     /// <paramref name="maxStops"/> is reached.
     /// </summary>
-    public static List<string> Walk(Window window, int maxStops = 50)
+    public static List<string> Walk(Window window, int maxStops = 50) =>
+        Walk(window, FocusNavigationDirection.Next, maxStops);
+
+    /// <summary>
+    /// Tabs backward (Shift+Tab) from the current focus, recording each stop. Shift+Tab must be the
+    /// exact reverse of Tab; a test that pins the forward order should pin this too, because a
+    /// control can be correct going forward yet unreachable or out of place going backward.
+    /// </summary>
+    public static List<string> WalkBackward(Window window, int maxStops = 50) =>
+        Walk(window, FocusNavigationDirection.Previous, maxStops);
+
+    /// <summary>Walks Tab traversal in <paramref name="direction"/>, recording each stop.</summary>
+    public static List<string> Walk(Window window, FocusNavigationDirection direction, int maxStops = 50)
     {
         var stops = new List<string>();
         var seen = new HashSet<FrameworkElement>();
@@ -69,7 +81,7 @@ internal static class TabOrderWalker
         for (var i = 0; i < maxStops; i++)
         {
             if (FocusManager.GetFocusedElement(window) is not UIElement current) break;
-            if (!current.MoveFocus(new TraversalRequest(FocusNavigationDirection.Next))) break;
+            if (!current.MoveFocus(new TraversalRequest(direction))) break;
             Drain();
 
             if (FocusManager.GetFocusedElement(window) is not FrameworkElement next) break;

--- a/QuickMail/Views/AccountManagerDialog.xaml
+++ b/QuickMail/Views/AccountManagerDialog.xaml
@@ -190,21 +190,8 @@
                     </Border>
                 </StackPanel>
 
-                <!-- OAuth sign-in -->
-                <Button Content="Sign in _with Microsoft…"
-                        Visibility="{Binding IsOAuth2, Converter={StaticResource BoolToVisibility}}"
-                        Command="{Binding SignInMicrosoftCommand}"
-                        AutomationProperties.Name="Sign in with Microsoft"
-                        HorizontalAlignment="Left" MinWidth="200" Margin="0,8,0,0" TabIndex="12"/>
-
-                <Button Content="Sign in _with Google…"
-                        Visibility="{Binding IsGoogleOAuth, Converter={StaticResource BoolToVisibility}}"
-                        Command="{Binding SignInGoogleCommand}"
-                        AutomationProperties.Name="Sign in with Google"
-                        HorizontalAlignment="Left" MinWidth="200" Margin="0,8,0,0" TabIndex="13"/>
-
                 </StackPanel>
-                <!-- end #31 ShowNormalAccountFields wrapper (password + OAuth sign-in) -->
+                <!-- end #31 ShowNormalAccountFields wrapper (password panel) -->
 
                 <!-- Contact sync (issue #256) — shown only for accounts with a contact API. Stays on
                      the main surface: it is a per-account choice, not a server setting. -->
@@ -379,6 +366,29 @@
                                 />
                     </StackPanel>
                 </Expander>
+
+                <!-- OAuth sign-in is the LAST tab stop in the form, after Advanced settings and
+                     everything it reveals (#584). Signing in / re-authenticating is the final action,
+                     so tabbing top to bottom now ends on it, instead of stranding it above Advanced
+                     where a keyboard user had to Shift+Tab back up to reach settings they had just
+                     opened. The buttons carry no explicit TabIndex, so they fall into the default
+                     (int.MaxValue) bucket ordered by tree position — declared here, after the
+                     expander, they sort after the expander's contents. Wrapped in the same
+                     ShowNormalAccountFields gate as the password panel above (#31): a shared mailbox
+                     authenticates through its parent and shows no sign-in of its own. -->
+                <StackPanel Visibility="{Binding ShowNormalAccountFields, Converter={StaticResource BoolToVisibility}}">
+                    <Button Content="Sign in _with Microsoft…"
+                            Visibility="{Binding IsOAuth2, Converter={StaticResource BoolToVisibility}}"
+                            Command="{Binding SignInMicrosoftCommand}"
+                            AutomationProperties.Name="Sign in with Microsoft"
+                            HorizontalAlignment="Left" MinWidth="200" Margin="0,14,0,0"/>
+
+                    <Button Content="Sign in _with Google…"
+                            Visibility="{Binding IsGoogleOAuth, Converter={StaticResource BoolToVisibility}}"
+                            Command="{Binding SignInGoogleCommand}"
+                            AutomationProperties.Name="Sign in with Google"
+                            HorizontalAlignment="Left" MinWidth="200" Margin="0,8,0,0"/>
+                </StackPanel>
 
             </StackPanel>
         </ScrollViewer>

--- a/QuickMail/Views/AddAccountDialog.xaml
+++ b/QuickMail/Views/AddAccountDialog.xaml
@@ -106,20 +106,6 @@
                           AutomationProperties.Name="Sync calendar from this account"
                           Margin="0,6,0,0" TabIndex="6"/>
 
-                <!-- OAuth sign-in stays on the main surface too: for an OAuth provider this is the
-                     primary action, not an advanced one. -->
-                <Button Content="Sign in _with Microsoft…"
-                        Visibility="{Binding IsOAuth2, Converter={StaticResource BoolToVisibility}}"
-                        Command="{Binding SignInMicrosoftCommand}"
-                        AutomationProperties.Name="Sign in with Microsoft"
-                        HorizontalAlignment="Left" MinWidth="200" Margin="0,10,0,0" TabIndex="7"/>
-
-                <Button Content="Sign in _with Google…"
-                        Visibility="{Binding IsGoogleOAuth, Converter={StaticResource BoolToVisibility}}"
-                        Command="{Binding SignInGoogleCommand}"
-                        AutomationProperties.Name="Sign in with Google"
-                        HorizontalAlignment="Left" MinWidth="200" Margin="0,10,0,0" TabIndex="8"/>
-
                 <!-- Everything a recognized provider already answers for the user. Collapsed unless
                      the provider is "Other" or discovery came back empty (VM.IsAdvancedExpanded). -->
                 <Expander x:Name="AdvancedExpander"
@@ -288,6 +274,27 @@
                                 />
                     </StackPanel>
                 </Expander>
+
+                <!-- OAuth sign-in is the LAST tab stop in the form, after Advanced settings and
+                     everything it reveals (#584). Signing in is the final action, so tabbing top to
+                     bottom now ends on it, instead of stranding it above Advanced where a keyboard
+                     user had to Shift+Tab back up to reach settings they had just opened. It carries
+                     no explicit TabIndex, so it falls into the default (int.MaxValue) bucket ordered
+                     by tree position — declared here, after the expander, it sorts after the
+                     expander's contents. Still a main-surface primary action (it sits below the
+                     expander, not inside it), and still after the sync opt-ins above, so the
+                     same-consent ordering (#256, #282) is unchanged. -->
+                <Button Content="Sign in _with Microsoft…"
+                        Visibility="{Binding IsOAuth2, Converter={StaticResource BoolToVisibility}}"
+                        Command="{Binding SignInMicrosoftCommand}"
+                        AutomationProperties.Name="Sign in with Microsoft"
+                        HorizontalAlignment="Left" MinWidth="200" Margin="0,14,0,0"/>
+
+                <Button Content="Sign in _with Google…"
+                        Visibility="{Binding IsGoogleOAuth, Converter={StaticResource BoolToVisibility}}"
+                        Command="{Binding SignInGoogleCommand}"
+                        AutomationProperties.Name="Sign in with Google"
+                        HorizontalAlignment="Left" MinWidth="200" Margin="0,8,0,0"/>
 
             </StackPanel>
         </ScrollViewer>


### PR DESCRIPTION
Fixes #584.

In the **Add Account** and **Manage Accounts** dialogs the OAuth **"Sign in with Microsoft…"** / **"Sign in with Google…"** button sat in the *middle* of the form's tab order — before the **Advanced settings** expander. Because signing in is the final action, a keyboard user who tabbed into Advanced to change something then had to Shift+Tab back up to reach sign-in.

## The fix

Move the sign-in button(s) to be the **last tab stop** in each form:

- Relocate them in the visual tree to **after** the Advanced expander, and **drop their explicit `TabIndex`**. They then fall into the default (`int.MaxValue`) bucket, which WPF orders by tree position — so, declared after the expander, they sort after the expander's contents. (This flattening through non-focusable wrapper panels is the same mechanism the existing tab-order tests already rely on.)
- They stay a **main-surface** primary action (below the expander, not inside it), and still come **after** the sync opt-ins, so the same-consent ordering (#256, #282) is unchanged.
- In Manage Accounts the buttons move into a **new `ShowNormalAccountFields` StackPanel**, so a shared mailbox still hides sign-in (#31).

## Tab order now

- **Add Account:** … sync contacts → sync calendar → Advanced settings (+ its contents) → **Sign in**.
- **Manage Accounts:** … email → Advanced settings (+ its contents) → **Sign in**.

## Tests

Both tab-order suites walk WPF's *real* focus traversal (not the written `TabIndex` values). Added `OAuthSignInIsTheLastStop_AfterAdvancedSettings` to each, asserting sign-in lands after the Advanced expander header **and** its last control (Signature) — in **both** Tab and Shift+Tab directions. `TabOrderWalker` gains a `WalkBackward` for the reverse walk. All 6 tab-order tests pass; the main project builds clean in Release (0 analyzer warnings).

Verified by an independent review (no blocking findings) and by the automated forward/backward walks. A manual screen-reader Tab / Shift+Tab pass through both dialogs is the final check.

## Out of scope

Pre-existing and untouched here: in Manage Accounts the `Alt+W` access key is shared by "Ne_w" and "Sign in _with Microsoft/Google" (only one sign-in button is ever visible; WPF cycles access-key targets). Not introduced by this change.
