### PR TITLE
Stop a disposed connection probe writing to the journal after it is gone

### DIFF
--- a/QuickMail.Tests/ConnectionDiagnosticsTests.cs
+++ b/QuickMail.Tests/ConnectionDiagnosticsTests.cs
@@ -313,6 +313,43 @@ public class ConnectionTruthProbeTests : IDisposable
     }
 
     [Fact]
+    public async Task ADisposedProbeStopsWritingToTheJournal()
+    {
+        // Dispose cancelled the verification loop without waiting for it. A loop already inside
+        // RunProbeAsync went on to Record its verdict — after Dispose had returned, after the owning
+        // test had reset the journal, and (the part that bit) after the NEXT test's constructor had
+        // reset it too. The stray verdict was therefore sitting in the journal when the next test
+        // started, and Verdict_ReportsTheLabelAsConnectedWhenItIs — which reads First(verdict) —
+        // read a "label=DISCONNECTED actual=UNREACHABLE ... trigger=auto round 1" line it never
+        // wrote, on roughly one full-suite run in three.
+        //
+        // Unreachable matters: it is what keeps the account marked disconnected, so the loop stays
+        // alive and has a probe in flight when Dispose lands. A Reachable probe stops the loop and
+        // reproduces nothing.
+        // Mirrors the real sequence exactly: the loop's round-1 probe queues behind the test's own
+        // explicit probe on the process-wide one-at-a-time semaphore, so it is still pending when
+        // Dispose lands and completes — and Records — afterwards. Repeated, because that is a race:
+        // one pass caught it about a third of the time, which is precisely the rate at which the
+        // suite was failing.
+        for (var attempt = 0; attempt < 25; attempt++)
+        {
+            var probe = new ConnectionTruthProbe(
+                new StubConnectionProbe(_ => new ProbeResult(ProbeOutcome.Unreachable, 5, "refused")),
+                _ => "Kelly");
+            probe.NoteDisconnected(_account, "reachability-event");
+            await probe.RunProbeAsync(_account, "test");
+
+            probe.Dispose();
+            ConnectionJournal.ResetForTests();
+            await Task.Delay(60, TestContext.Current.CancellationToken);
+
+            Assert.True(ConnectionJournal.Snapshot().Count == 0,
+                $"attempt {attempt}: a disposed probe wrote " +
+                string.Join(" | ", ConnectionJournal.Snapshot().Select(e => $"{e.Phase}:{e.Detail}")));
+        }
+    }
+
+    [Fact]
     public async Task RunProbeAsync_RecordsTheTriggerSoProbeTrafficIsIdentifiable()
     {
         using var probe = Create(reachable: true);

--- a/QuickMail/Services/ConnectionTruthProbe.cs
+++ b/QuickMail/Services/ConnectionTruthProbe.cs
@@ -406,7 +406,23 @@ public sealed class ConnectionTruthProbe : IDisposable
         // Cancel before disposing so in-flight probes see OperationCanceledException rather than
         // ObjectDisposedException (see the IDisposable rules in CLAUDE.md).
         try { _shutdown.Cancel(); } catch { }
+
+        // Capture the loop tasks BEFORE StopLoop forgets them, then WAIT. Cancelling only asks: a
+        // loop already inside RunProbeAsync goes on to record its verdict in the static
+        // ConnectionJournal, and does so after Dispose has returned. A class whose contract is to
+        // "never be part of the problem it measures" must not still be writing to the journal once
+        // it has been disposed. It also broke the test suite: the leaked verdict landed in whichever
+        // test ran next, and ConnectionTruthProbeTests.Verdict_ReportsTheLabelAsConnectedWhenItIs —
+        // which reads First(verdict) — intermittently read a DISCONNECTED verdict it never wrote.
+        //
+        // Bounded, so a probe wedged in a socket cannot hang shutdown. The loops run on the thread
+        // pool via Task.Run (no captured SynchronizationContext, so no deadlock when Dispose is
+        // called from the UI thread) and are already cancelled, so in practice this returns at once.
+        var running = _loops.Values.Select(l => l.Task).ToArray();
         foreach (var id in _loops.Keys.ToArray()) StopLoop(id);
+        try { Task.WaitAll(running, TimeSpan.FromSeconds(2)); }
+        catch { /* cancelled or faulted — either way there is nothing left to do at shutdown */ }
+
         _shutdown.Dispose();
         _oneAtATime.Dispose();
         GC.SuppressFinalize(this);


### PR DESCRIPTION
First of the flaky-test fixes. This one is proven; see the note at the end about the others.

## The symptom

`ConnectionTruthProbeTests.Verdict_ReportsTheLabelAsConnectedWhenItIs` failed on roughly **one full-suite run in three**, always at 3ms, and always passed when run alone. Six full runs early on gave two failures; eight later runs gave two more.

## What it actually was

Instrumenting the test to dump the journal at entry caught it. The journal already held a verdict *before the test ran a line*:

```
label=DISCONNECTED actual=UNREACHABLE trigger=auto round 1 detail=[SocketException: refused]
```

That is neither the account nor the outcome this test uses — `trigger=auto round 1` means it came from a **verification loop**, and `SocketException: refused` identifies the previous test.

`ConnectionTruthProbe.Dispose()` cancelled each loop but never waited for it. Cancelling only asks. The loop's round-1 probe queues behind the test's own explicit probe on the process-wide one-at-a-time semaphore, so it is still pending when `Dispose` lands and completes — and `Record`s — afterwards. Late enough to land after the *next* test's constructor had reset the journal, which is exactly what the instrumentation showed.

## The fix

`Dispose` captures the loop tasks before `StopLoop` forgets them and waits, bounded at two seconds so a probe wedged in a socket cannot hang shutdown. The loops run on the thread pool via `Task.Run` with no captured `SynchronizationContext`, so waiting from the UI thread cannot deadlock, and they are already cancelled, so it returns at once in practice.

**This is a production defect, not only a test one.** A class whose stated contract is to "never be part of the problem it measures" should not still be writing to the connection journal after it has been disposed.

## The regression test

It mirrors the failing sequence and repeats it 25 times, because it is a race — one pass caught it about a third of the time, the same rate the suite was failing at.

`Unreachable` is load-bearing: it keeps the account marked disconnected so the loop stays alive with a probe in flight. **My first version of this test used `Reachable` and passed against the unfixed code** — the loop stops immediately and nothing leaks. Worth knowing before anyone simplifies it.

Verified: **3 of 3 runs fail without the fix, 3 of 3 pass with it.**

## Not fixed here

Chasing this surfaced more flaky tests than the two we started with, all WPF/STA and plausibly one shared isolation problem:

- `TabStripNavigationTests` — **all six failed together** in one run, which looks systemic rather than racy
- `RadioGroupNavigationTests` — 2 tests
- `AccountManagerTabOrderTests.OAuthSignInIsTheLastStop_AfterAdvancedSettings`
- `ReportBugViewModelTests.CopyAndOpen_BlankSummary_DoesNotCopyOrOpen`

Being handled separately so this proven fix is not held up behind them.