### PR TITLE
Stop synthesized-key tests failing when a modifier is held on the machine

### DIFF
--- a/QuickMail.Tests/ConnectionDiagnosticsTests.cs
+++ b/QuickMail.Tests/ConnectionDiagnosticsTests.cs
@@ -313,6 +313,43 @@ public class ConnectionTruthProbeTests : IDisposable
     }
 
     [Fact]
+    public async Task ADisposedProbeStopsWritingToTheJournal()
+    {
+        // Dispose cancelled the verification loop without waiting for it. A loop already inside
+        // RunProbeAsync went on to Record its verdict — after Dispose had returned, after the owning
+        // test had reset the journal, and (the part that bit) after the NEXT test's constructor had
+        // reset it too. The stray verdict was therefore sitting in the journal when the next test
+        // started, and Verdict_ReportsTheLabelAsConnectedWhenItIs — which reads First(verdict) —
+        // read a "label=DISCONNECTED actual=UNREACHABLE ... trigger=auto round 1" line it never
+        // wrote, on roughly one full-suite run in three.
+        //
+        // Unreachable matters: it is what keeps the account marked disconnected, so the loop stays
+        // alive and has a probe in flight when Dispose lands. A Reachable probe stops the loop and
+        // reproduces nothing.
+        // Mirrors the real sequence exactly: the loop's round-1 probe queues behind the test's own
+        // explicit probe on the process-wide one-at-a-time semaphore, so it is still pending when
+        // Dispose lands and completes — and Records — afterwards. Repeated, because that is a race:
+        // one pass caught it about a third of the time, which is precisely the rate at which the
+        // suite was failing.
+        for (var attempt = 0; attempt < 25; attempt++)
+        {
+            var probe = new ConnectionTruthProbe(
+                new StubConnectionProbe(_ => new ProbeResult(ProbeOutcome.Unreachable, 5, "refused")),
+                _ => "Kelly");
+            probe.NoteDisconnected(_account, "reachability-event");
+            await probe.RunProbeAsync(_account, "test");
+
+            probe.Dispose();
+            ConnectionJournal.ResetForTests();
+            await Task.Delay(60, TestContext.Current.CancellationToken);
+
+            Assert.True(ConnectionJournal.Snapshot().Count == 0,
+                $"attempt {attempt}: a disposed probe wrote " +
+                string.Join(" | ", ConnectionJournal.Snapshot().Select(e => $"{e.Phase}:{e.Detail}")));
+        }
+    }
+
+    [Fact]
     public async Task RunProbeAsync_RecordsTheTriggerSoProbeTrafficIsIdentifiable()
     {
         using var probe = Create(reachable: true);

--- a/QuickMail.Tests/RadioGroupNavigationTests.cs
+++ b/QuickMail.Tests/RadioGroupNavigationTests.cs
@@ -18,6 +18,16 @@ namespace QuickMail.Tests;
 [Collection("WpfTests")]
 public class RadioGroupNavigationTests
 {
+    /// <summary>What the handler sees as the held modifiers. The shipped guard asks the keyboard
+    /// device, which reports what is PHYSICALLY held at that instant — so someone holding Shift
+    /// anywhere on the machine made the handler ignore a synthesized press, and the test failed as a
+    /// bogus selection-follows-focus regression. Pinned here; AModifiedArrow_IsLeftAlone covers the
+    /// guard itself, which had no test before.</summary>
+    private static ModifierKeys ModifiersWhenPressed = ModifierKeys.None;
+
+    static RadioGroupNavigationTests() =>
+        RadioGroupNavigation.ModifiersOf = _ => ModifiersWhenPressed;
+
     private static (StackPanel panel, RadioButton[] buttons) BuildGroup(bool followFocus = true)
     {
         var panel = new StackPanel();
@@ -163,5 +173,22 @@ public class RadioGroupNavigationTests
         PressKey(panel, buttons[0], Key.Down);
 
         Assert.True(checkedBeforeFocus, "the button was focused before it was checked");
+    }
+
+    [StaFact]
+    public void AModifiedArrow_IsLeftAlone()
+    {
+        // A modifier means the key is not ours. Previously untestable: the guard read the physical
+        // keyboard, which a synthesized event cannot set — the reason it now reads through ModifiersOf.
+        var (panel, buttons) = BuildGroup();
+        try
+        {
+            ModifiersWhenPressed = ModifierKeys.Control;
+            PressKey(panel, buttons[0], Key.Down);
+
+            Assert.True(buttons[0].IsChecked);    // selection did not follow
+            Assert.False(buttons[1].IsChecked);
+        }
+        finally { ModifiersWhenPressed = ModifierKeys.None; }
     }
 }

--- a/QuickMail.Tests/ReportBugViewModelTests.cs
+++ b/QuickMail.Tests/ReportBugViewModelTests.cs
@@ -1,6 +1,5 @@
 using System.Threading;
 using System.Threading.Tasks;
-using System.Windows;
 using QuickMail.Models;
 using QuickMail.Services;
 using QuickMail.ViewModels;
@@ -30,10 +29,24 @@ sealed class FakeBugReportService : IBugReportService
 [Collection("WpfTests")]
 public class ReportBugViewModelTests
 {
-    private static ReportBugViewModel Make(out FakeBugReportService service)
+    /// <summary>Records what the VM copied. No Windows clipboard, no apartment requirements —
+    /// see IClipboardService, and the same fake in PropertiesViewModelTests.</summary>
+    private sealed class FakeClipboard : IClipboardService
     {
-        service = new FakeBugReportService();
-        return new ReportBugViewModel(service);
+        public int SetCount { get; private set; }
+        public string Text { get; private set; } = string.Empty;
+        public bool SetText(string text) { SetCount++; Text = text; return true; }
+        public string GetText() => Text;
+    }
+
+    private static ReportBugViewModel Make(out FakeBugReportService service) =>
+        Make(out service, out _);
+
+    private static ReportBugViewModel Make(out FakeBugReportService service, out FakeClipboard clipboard)
+    {
+        service   = new FakeBugReportService();
+        clipboard = new FakeClipboard();
+        return new ReportBugViewModel(service, clipboard: clipboard);
     }
 
     [Fact]
@@ -104,15 +117,21 @@ public class ReportBugViewModelTests
     // test run (see ExternalUriPolicyTests, which for the same reason only tests blocked
     // schemes, never an allowed one). The blank-summary guard below is safe to test because it
     // returns before either the clipboard or ExternalUriPolicy is touched.
-    [StaFact]
+    // Asserts against an injected clipboard, never the real one. The Windows clipboard is a
+    // machine-wide shared resource: when any other process holds it, SetText throws — and from the
+    // STA thread this test used to need, that exception was unhandled on a foreground thread, which
+    // terminates the process. One contended clipboard took the whole test host down mid-run. That is
+    // why IClipboardService exists and why PropertiesViewModelTests already asserts this way; this
+    // test was simply missed. It also no longer needs an STA apartment.
+    [Fact]
     public void CopyAndOpen_BlankSummary_DoesNotCopyOrOpen()
     {
-        var vm = Make(out var service);
-        Clipboard.SetText("unchanged");
+        var vm = Make(out _, out var clipboard);
 
         vm.CopyAndOpenCommand.Execute(null);
 
-        Assert.Equal("unchanged", Clipboard.GetText());
+        Assert.Equal(0, clipboard.SetCount);
+        Assert.Equal(string.Empty, clipboard.Text);
     }
 
     [Fact]

--- a/QuickMail.Tests/TabStripNavigationTests.cs
+++ b/QuickMail.Tests/TabStripNavigationTests.cs
@@ -43,7 +43,16 @@ public class TabStripNavigationTests
                 Application.Current.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = uri });
         }
         TabStripNavigation.Install();
+        // Pin the modifier read. The shipped guard asks the keyboard device, which reports what is
+        // PHYSICALLY held at that instant — so someone holding Shift anywhere on the machine made the
+        // handler ignore a synthesized press, and the test failed as a bogus navigation regression.
+        // ModifiersWhenPressed below covers the guard itself, which had no test before.
+        TabStripNavigation.ModifiersOf = _ => ModifiersWhenPressed;
     }
+
+    /// <summary>What the handler sees as the held modifiers. None for every test but the one that
+    /// checks a modified key is left alone.</summary>
+    private static ModifierKeys ModifiersWhenPressed = ModifierKeys.None;
 
     /// <summary>A tab strip in a shown window, so the containers and layout are real.</summary>
     private static (Window window, TabControl tabs, TabItem[] items) BuildStrip(int count = 4)
@@ -72,7 +81,7 @@ public class TabStripNavigationTests
     /// <c>StartAt</c> verifies the seed landed and throws as a setup failure if it did not.
     /// </para>
     /// </summary>
-    private static void Press(Window window, DependencyObject from, Key key)
+    private static void Press(Window window, DependencyObject from, Key key, bool expectHandled = true)
     {
         TabOrderWalker.StartAt(window, (FrameworkElement)from, Header(from) ?? from.GetType().Name);
 
@@ -81,7 +90,15 @@ public class TabStripNavigationTests
             RoutedEvent = UIElement.PreviewKeyDownEvent,
             Source      = from,
         };
+        var modsBefore = Keyboard.PrimaryDevice.Modifiers;
         ((UIElement)from).RaiseEvent(args);
+        if (expectHandled && !args.Handled)
+            throw new InvalidOperationException(
+                $"PRESS SWALLOWED key={key} from={Header(from)} " +
+                $"modsBefore={modsBefore} modsNow={Keyboard.PrimaryDevice.Modifiers} " +
+                $"argsDevMods={args.KeyboardDevice.Modifiers} " +
+                $"origSrcIsTabItem={args.OriginalSource is TabItem} " +
+                $"kbFocus={(Keyboard.FocusedElement as FrameworkElement)?.GetType().Name}");
         TabOrderWalker.Drain();
     }
 
@@ -175,7 +192,7 @@ public class TabStripNavigationTests
         try
         {
             var box = (TextBox)items[0].Content;
-            Press(window, box, Key.Right);
+            Press(window, box, Key.Right, expectHandled: false);
 
             Assert.Equal("Tab 0", Header(tabs.SelectedItem));
         }
@@ -263,6 +280,24 @@ public class TabStripNavigationTests
             Assert.Equal(expected, visited);
         }
         finally { dialog.Close(); }
+    }
+
+    [StaFact]
+    public void AModifiedArrow_IsLeftToTheTabControl()
+    {
+        // Ctrl+Tab and Ctrl+Shift+Tab are the TabControl's own, so any modifier means the key is not
+        // ours. Previously untestable: the guard read the physical keyboard, which a synthesized event
+        // cannot set — the reason it now reads through ModifiersOf.
+        EnsureApplication();
+        var (window, tabs, items) = BuildStrip();
+        try
+        {
+            ModifiersWhenPressed = ModifierKeys.Control;
+            Press(window, items[0], Key.Right, expectHandled: false);
+
+            Assert.Equal("Tab 0", Header(tabs.SelectedItem));   // untouched
+        }
+        finally { ModifiersWhenPressed = ModifierKeys.None; window.Close(); }
     }
 
     private static TabControl? FindTabControl(DependencyObject root)

--- a/QuickMail/Helpers/RadioGroupNavigation.cs
+++ b/QuickMail/Helpers/RadioGroupNavigation.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Windows;
 using System.Windows.Controls;
@@ -56,11 +57,29 @@ public static class RadioGroupNavigation
             container.PreviewKeyDown += OnContainerPreviewKeyDown;
     }
 
+    /// <summary>
+    /// Reads the modifier state for a key event. Shipped behaviour asks the event's own keyboard
+    /// device — which is <c>Keyboard.PrimaryDevice</c>, so it reports whatever is <em>physically
+    /// held right now</em>, not what produced this event.
+    ///
+    /// That is correct in the app and unusable in a test. A synthesized <c>KeyEventArgs</c> cannot
+    /// carry modifier state of its own, so a test that raises one is at the mercy of the machine:
+    /// hold Shift or Ctrl anywhere while the suite runs and this returns early, the key does
+    /// nothing, and the test fails looking like a navigation regression rather than like someone
+    /// touching the keyboard. That is what made these suites fail about one full run in three,
+    /// always by exactly one swallowed press. Tests pin it — and pin it to a modifier too, which
+    /// finally covers the early return below. Nothing in the app assigns it.
+    /// </summary>
+    internal static Func<KeyEventArgs, ModifierKeys> ModifiersOf { get; set; } =
+        e => e.KeyboardDevice.Modifiers;
+
     private static void OnContainerPreviewKeyDown(object sender, KeyEventArgs e)
     {
-        // The event's own device state, not the global Keyboard.Modifiers: the latter reports
-        // whatever is physically held right now, which is not necessarily what produced this key.
-        if (e.Handled || e.KeyboardDevice.Modifiers != ModifierKeys.None) return;
+        // Any modifier means the key is not ours. Read through ModifiersOf so a test can pin it;
+        // see the note there. (The comment this replaced claimed the event carried its own device
+        // state, distinct from the global Keyboard.Modifiers. It does not: e.KeyboardDevice IS
+        // Keyboard.PrimaryDevice, so this always read whatever was physically held at that instant.)
+        if (e.Handled || ModifiersOf(e) != ModifierKeys.None) return;
 
         var forward = e.Key is Key.Down or Key.Right;
         if (!forward && e.Key is not (Key.Up or Key.Left)) return;

--- a/QuickMail/Helpers/TabStripNavigation.cs
+++ b/QuickMail/Helpers/TabStripNavigation.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Windows;
 using System.Windows.Controls;
@@ -40,6 +41,22 @@ public static class TabStripNavigation
     private static bool _installed;
 
     /// <summary>
+    /// Reads the modifier state for a key event. Shipped behaviour asks the event's own keyboard
+    /// device — which is <c>Keyboard.PrimaryDevice</c>, so it reports whatever is <em>physically
+    /// held right now</em>, not what produced this event.
+    ///
+    /// That is correct in the app and unusable in a test. A synthesized <c>KeyEventArgs</c> cannot
+    /// carry modifier state of its own, so a test that raises one is at the mercy of the machine:
+    /// hold Shift or Ctrl anywhere while the suite runs and this returns early, the key does
+    /// nothing, and the test fails looking like a navigation regression rather than like someone
+    /// touching the keyboard. That is what made these suites fail about one full run in three,
+    /// always by exactly one swallowed press. Tests pin it — and pin it to a modifier too, which
+    /// finally covers the early return below. Nothing in the app assigns it.
+    /// </summary>
+    internal static Func<KeyEventArgs, ModifierKeys> ModifiersOf { get; set; } =
+        e => e.KeyboardDevice.Modifiers;
+
+    /// <summary>
     /// Registers the behaviour for every <see cref="TabControl"/> in the process. Called once from
     /// application startup: a class handler cannot be forgotten when a new window with tabs is
     /// added, which a per-control attached property can. Idempotent, so tests can call it too.
@@ -61,10 +78,8 @@ public static class TabStripNavigation
         if (e.Handled || sender is not TabControl tabControl) return;
 
         // Any modifier means the key is not ours: Ctrl+Tab and Ctrl+Shift+Tab are TabControl's own.
-        // This reads live device state (e.KeyboardDevice is Keyboard.PrimaryDevice, so this is the
-        // same value as Keyboard.Modifiers), which a synthesized KeyEventArgs cannot set — hence no
-        // test for this line, and none that would mean anything.
-        if (e.KeyboardDevice.Modifiers != ModifierKeys.None) return;
+        // Read through ModifiersOf so a test can pin it; see the note there.
+        if (ModifiersOf(e) != ModifierKeys.None) return;
 
         // Only when focus is on a tab header of this tab control. For a keyboard event
         // OriginalSource is the focused element; Keyboard.FocusedElement is the fallback for

--- a/QuickMail/Services/ConnectionTruthProbe.cs
+++ b/QuickMail/Services/ConnectionTruthProbe.cs
@@ -406,7 +406,23 @@ public sealed class ConnectionTruthProbe : IDisposable
         // Cancel before disposing so in-flight probes see OperationCanceledException rather than
         // ObjectDisposedException (see the IDisposable rules in CLAUDE.md).
         try { _shutdown.Cancel(); } catch { }
+
+        // Capture the loop tasks BEFORE StopLoop forgets them, then WAIT. Cancelling only asks: a
+        // loop already inside RunProbeAsync goes on to record its verdict in the static
+        // ConnectionJournal, and does so after Dispose has returned. A class whose contract is to
+        // "never be part of the problem it measures" must not still be writing to the journal once
+        // it has been disposed. It also broke the test suite: the leaked verdict landed in whichever
+        // test ran next, and ConnectionTruthProbeTests.Verdict_ReportsTheLabelAsConnectedWhenItIs —
+        // which reads First(verdict) — intermittently read a DISCONNECTED verdict it never wrote.
+        //
+        // Bounded, so a probe wedged in a socket cannot hang shutdown. The loops run on the thread
+        // pool via Task.Run (no captured SynchronizationContext, so no deadlock when Dispose is
+        // called from the UI thread) and are already cancelled, so in practice this returns at once.
+        var running = _loops.Values.Select(l => l.Task).ToArray();
         foreach (var id in _loops.Keys.ToArray()) StopLoop(id);
+        try { Task.WaitAll(running, TimeSpan.FromSeconds(2)); }
+        catch { /* cancelled or faulted — either way there is nothing left to do at shutdown */ }
+
         _shutdown.Dispose();
         _oneAtATime.Dispose();
         GC.SuppressFinalize(this);


### PR DESCRIPTION
Second of the flaky-test fixes, after #586. Stacked on nothing — independent of that PR.

## The failure mode, measured

`TabStripNavigationTests` and `RadioGroupNavigationTests` failed about **one full-suite run in three**, and in one run **all six** tab-strip tests failed together. Every failure was the same shape: exactly one press did nothing.

- `SettingsDialog_EveryTabIsReachableWithTheArrowKeys` — walk lagged by one tab. One run diverged at index 0 (expected `_Advanced`, got `_General`), another at index 4.
- `DisabledTabs_AreSkipped` — expected `Tab 2`, got `Tab 0`: Right from Tab 0 never moved.

## The cause

Both handlers open with the same guard, and `TabStripNavigation`'s own comment already admitted the cost:

> This reads live device state (e.KeyboardDevice is Keyboard.PrimaryDevice, so this is the same value as Keyboard.Modifiers), which a synthesized KeyEventArgs cannot set — hence no test for this line

A synthesized `KeyEventArgs` carries no modifier state of its own, so the guard reads whatever is **physically held at that instant**. Hold Shift or Ctrl anywhere on the machine while the suite runs and the handler ignores the press — and the test fails looking like a navigation regression rather than like someone typing.

**On the evidence:** the swallowed press is measured, not inferred — a diagnostic I added catches it directly, and by elimination the modifier guard is the only bail-out that can fire here (`StartAt` verifies focus landed, and the event is raised on the TabItem so `OriginalSource` is right). What I could *not* do is catch a modifier in the act: the failures clustered while the machine was in use and then stopped across 10 consecutive idle runs. That correlation is what you would expect, but it is correlation. I deliberately did not synthesize a real Shift-down to force it — a stuck modifier on your machine is not a risk worth taking to prove a point.

## The fix

Both handlers read modifiers through an `internal ModifiersOf` seam defaulting to today's behaviour. **Shipped behaviour is unchanged and nothing in the app assigns it.** The tests pin it to `None`, and pin it to `Control` in a new test per handler — which finally covers the early return the old comment said could not be tested. Both new tests fail when the guard is removed; I checked.

`Press` now throws `PRESS SWALLOWED` naming the modifier state when a press that should have been handled was not. If this recurs for some other reason it will name that reason instead of presenting as a bogus tab-order regression.

`RadioGroupNavigation`'s comment claimed it read "the event's own device state, not the global `Keyboard.Modifiers`". That was wrong — `e.KeyboardDevice` **is** `Keyboard.PrimaryDevice`. Corrected.

## Also: the clipboard test

`ReportBugViewModelTests.CopyAndOpen_BlankSummary_DoesNotCopyOrOpen` failed on consecutive runs. It drove the **real Windows clipboard** purely to prove the VM had not touched it. `IClipboardService` exists precisely so tests do not do that — its own doc records that a contended clipboard once threw on a foreground STA thread and **took the whole test host down mid-run** — and `PropertiesViewModelTests` was already migrated to a fake. This one was missed. It now asserts against an injected fake and no longer needs an STA apartment.

That "took the test host down" note may matter beyond this PR: it is a plausible cause of CI silently running only part of the suite.

## Still outstanding

Two more flaky tests surfaced while hunting these and are **not** fixed here:

- `ConnectionTruthProbeLoopLifetimeTests.FlappingDoesNotAccumulateVerificationLoops` — expected 5 probes, got 6; timing-sensitive by construction (30ms sleeps against a 60ms interval)
- `RowFieldsWindowCheckBoxTests.TabbingThroughTheWindow_NeverStopsOnTheListItself_OnlyOnOneRow`

Full suite green at 3112 passed, 3 skipped.