### PR TITLE
Fix the flapping test's in-flight baseline, and stop CI skipping two test classes

### DIFF
--- a/.github/workflows/quickmail.yml
+++ b/.github/workflows/quickmail.yml
@@ -170,12 +170,10 @@ jobs:
           # here. If this variable is ever dropped, the guard below fails the job rather than
           # letting them silently run nowhere.
           QUICKMAIL_RUN_INPUT_TESTS: "1"
-        # PropertiesViewModelTests and ReportBugViewModelTests exercise real clipboard access
-        # (Clipboard.SetText), which is unreliable on GitHub-hosted Windows runners — no
-        # interactive desktop session backs the clipboard, so these intermittently throw
-        # COMException("OpenClipboard Failed") or crash the whole test host on shutdown even
-        # when every assertion passed. Excluded here; run them locally where clipboard access
-        # is real.
+        # Both classes that were excluded here for driving the real clipboard now assert against an
+        # injected IClipboardService instead, so nothing in the unit suite touches the OS clipboard
+        # and the filter that skipped them is gone. It had been silently costing two whole classes of
+        # coverage on every CI run.
         #
         # Pass/fail is decided from the trx result counters, not the `dotnet test` exit code.
         # WPF StaFact tests intermittently crash the xUnit host *after* every test has passed:
@@ -187,8 +185,7 @@ jobs:
         # still must. Root-cause tracked in issue #211.
         run: |
           dotnet test QuickMail.Tests/QuickMail.Tests.csproj -c Release `
-            --logger "trx;LogFileName=results.trx" `
-            --filter "FullyQualifiedName!~PropertiesViewModelTests&FullyQualifiedName!~ReportBugViewModelTests"
+            --logger "trx;LogFileName=results.trx"
           $testExit = $LASTEXITCODE
           $trx = "QuickMail.Tests/TestResults/results.trx"
           if (-not (Test-Path $trx)) {

--- a/QuickMail.Tests/ConnectionDiagnosticsReviewFixTests.cs
+++ b/QuickMail.Tests/ConnectionDiagnosticsReviewFixTests.cs
@@ -396,6 +396,22 @@ public class ConnectionTruthProbeLoopLifetimeTests : IDisposable
             probe.NoteConnected(_account, $"recovered {i}");
         }
 
+        // Let the last flap's probe finish before taking the baseline. NoteConnected cancels the
+        // loop but does not wait for it — deliberately, since it is called from the UI thread on
+        // every status change — so a probe can still be in flight here. Snapshotting mid-probe made
+        // the counter tick once more as that probe completed, and the test read a FINISHING probe as
+        // an orphaned loop: it failed intermittently with "expected 5, actual 6".
+        //
+        // Caveat found while fixing that, and NOT addressed here: this assertion is weaker than it
+        // reads. Disabling BOTH orphan protections — the StopLoop in NoteConnected and the
+        // StopAndDispose in StartLoop's AddOrUpdate — leaves it green. An orphan only survives while
+        // the account is in _disconnected, so once flapping stops every orphan wakes within
+        // MinInterval (60ms here), finds the account absent and exits, well before the 400ms window
+        // below opens. The original defect was visible because the shipped interval is 60 SECONDS,
+        // so orphans were still asleep long after. Measuring probe count DURING the flapping, against
+        // the number of flaps, is what would actually pin this.
+        await Task.Delay(200);
+
         var afterFlapping = backend.Calls;
         await Task.Delay(400);
 
@@ -418,9 +434,15 @@ public class ConnectionTruthProbeLoopLifetimeTests : IDisposable
         Assert.True(whileDown >= 1, "the first check should run immediately");
 
         probe.NoteConnected(_account, "recovered");
+
+        // Same reason as FlappingDoesNotAccumulateVerificationLoops: re-baseline after the cancelled
+        // loop's in-flight probe has had time to finish, so a probe that was already running when we
+        // reconnected is not counted as one the loop started afterwards.
+        await Task.Delay(200);
+        var afterReconnect = backend.Calls;
         await Task.Delay(300);
 
-        Assert.Equal(whileDown, backend.Calls);
+        Assert.Equal(afterReconnect, backend.Calls);
     }
 
     [Fact]


### PR DESCRIPTION
Two small things the flaky hunt turned up. Third in the series after #586 and #587.

## The flapping test

`ConnectionTruthProbeLoopLifetimeTests.FlappingDoesNotAccumulateVerificationLoops` failed intermittently with **"expected 5, actual 6"**.

It took its baseline probe count immediately after the last flap, while a probe could still be in flight. `NoteConnected` cancels the verification loop but deliberately does *not* wait for it — it runs on the UI thread on every status change, so blocking there would be wrong. The counter therefore ticked once more as that probe completed, and the test read a **finishing** probe as an orphaned loop.

Both it and `ReconnectingStopsTheLoopPromptlyRatherThanAtTheNextWakeUp` now let the trailing probe land before baselining.

### A caveat I found while checking the fix, recorded but not fixed

I wanted to be sure the settle delay had not blinded the test. It turns out it was **already blind**: disabling *both* orphan protections — the `StopLoop` in `NoteConnected` and the `StopAndDispose` in `StartLoop`'s `AddOrUpdate` — leaves it green.

An orphan only survives while the account is in `_disconnected`. Once flapping stops, every orphan wakes within `MinInterval` (60ms in the test), finds the account gone, and exits — well before the 400ms measurement window opens. The original defect was visible because the shipped interval is 60 **seconds**, so orphans were still asleep long after.

Pinning it properly means counting probes *during* the flapping against the number of flaps, which is a bigger change than this flake fix. I have written the caveat into the test rather than leaving it silently overstated.

## CI was skipping two whole test classes

The unit-test job filtered out `PropertiesViewModelTests` and `ReportBugViewModelTests` because they drove the real Windows clipboard, which is unreliable on a runner with no interactive desktop session.

Both now assert against an injected `IClipboardService` — `PropertiesViewModelTests` already did, and `ReportBugViewModelTests` was migrated in #587 — so nothing in the unit suite touches the OS clipboard. Filter removed. It had been costing two whole classes of coverage on every CI run, silently.

## Related

The `Flaky test hunt` workflow that found these is in a separate branch and will come as its own PR.