### PR TITLE
Fix #211 at the root, and fail CI when a test class never ran

### DIFF
--- a/.github/workflows/quickmail.yml
+++ b/.github/workflows/quickmail.yml
@@ -175,14 +175,15 @@ jobs:
         # and the filter that skipped them is gone. It had been silently costing two whole classes of
         # coverage on every CI run.
         #
-        # Pass/fail is decided from the trx result counters, not the `dotnet test` exit code.
-        # WPF StaFact tests intermittently crash the xUnit host *after* every test has passed:
-        # a leftover window's HWND receives a message once its owning STA thread is gone, so
-        # MS.Win32.HwndSubclass.SubclassWndProc calls Thread.get_CurrentThread() and throws a
-        # NullReferenceException. xUnit reports this as a "catastrophic failure" and exits
-        # non-zero even though the trx records failed=0/error=0. That benign teardown crash must
-        # not fail the release, but a genuine test failure (failed>0, error>0, or no tests run)
-        # still must. Root-cause tracked in issue #211.
+        # This step fails on THREE things, and the third is the one that used to be missing:
+        # a genuine test failure, no tests at all, or a run that did not execute every discovered
+        # test class. A truncated run reports failed=0 and reads as a pass, which is exactly how
+        # issue #211 hid for months while costing up to 46% of the suite per run. It is fixed
+        # (StaDispatcherShutdown / WpfTestHost), so short runs are now errors rather than warnings.
+        #
+        # The trx counters, not the `dotnet test` exit code, still decide what "a test failed"
+        # means — the exit code alone cannot distinguish a failing assertion from a host-level
+        # crash — but a non-zero exit is no longer tolerated on its own either.
         run: |
           dotnet test QuickMail.Tests/QuickMail.Tests.csproj -c Release `
             --logger "trx;LogFileName=results.trx"
@@ -254,18 +255,34 @@ jobs:
             Select-String -Pattern '^\s+(QuickMail\.Tests\.[A-Za-z0-9_]+)\.' |
             ForEach-Object { $_.Matches[0].Groups[1].Value } |
             Sort-Object -Unique)
-          if ($allClasses.Count -gt 0) {
-            $missing = @($allClasses | Where-Object { $ranClasses -notcontains $_ })
-            Write-Host "Test classes: $($ranClasses.Count) ran of $($allClasses.Count) discovered."
-            if ($missing.Count -gt 0) {
-              Write-Warning ("$($missing.Count) test class(es) never executed, so 'failed=0' does NOT mean the " +
-                             "suite passed. Investigate the host crash before trusting this run (issue #380):`n  " +
-                             (($missing) -join "`n  "))
-            }
+          # A class that never ran is a FAILURE, not a warning. This was a warning while issue #211
+          # made truncation routine, and the cost of that was invisible: four main runs measured
+          # 3042, 1597, 2729 and 3024 cases against 3115 discovered — one of them silently skipped
+          # 46% of the suite and reported success. The nine ConnectionDiagnostics classes were
+          # missing from every single run, so they had never executed in CI at all. #211 is fixed
+          # now, so a short run means something new is wrong and must stop the job.
+          if ($allClasses.Count -le 0) {
+            Write-Error "Could not discover the test classes, so completeness cannot be checked; failing rather than guessing."
+            exit 1
+          }
+          $missing = @($allClasses | Where-Object { $ranClasses -notcontains $_ })
+          Write-Host "Test classes: $($ranClasses.Count) ran of $($allClasses.Count) discovered."
+          if ($missing.Count -gt 0) {
+            Write-Error ("$($missing.Count) test class(es) never executed, so 'failed=0' does NOT mean the suite " +
+                         "passed. The usual cause is the xUnit host dying mid-run and taking the remaining tests " +
+                         "with it — see issue #211, and check the run for a 'Catastrophic failure'.`n  " +
+                         (($missing) -join "`n  "))
+            exit 1
           }
 
+          # Likewise: the benign-teardown-crash allowance existed only for #211. With that fixed, a
+          # non-zero exit alongside failed=0 is an unexplained host-level failure, and swallowing it
+          # is how #211 survived for months.
           if ($testExit -ne 0) {
-            Write-Warning "dotnet test exited $testExit but all $passed tests passed (failed=0, error=0). Treating as the benign WPF STA test-host teardown crash (HwndSubclass.SubclassWndProc / Thread.get_CurrentThread NRE, issue #211)."
+            Write-Error ("dotnet test exited $testExit even though every test passed (failed=0, error=0) and all " +
+                         "$($allClasses.Count) classes ran. That is a host-level failure with no known benign " +
+                         "cause since #211 was fixed; do not re-add a blanket allowance for it without one.")
+            exit 1
           }
           exit 0
 

--- a/QuickMail.Tests/AccessKeyRegressionTests.cs
+++ b/QuickMail.Tests/AccessKeyRegressionTests.cs
@@ -343,20 +343,9 @@ public class AccessKeyRegressionTests
         try { if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true); } catch { }
     }
 
-    private static void EnsureApplication()
-    {
-        // The XamlParseTests class uses the same lock; both classes
-        // share a single Application instance per process.
-        lock (typeof(Application))
-        {
-            if (Application.Current == null)
-                new Application { ShutdownMode = ShutdownMode.OnExplicitShutdown };
-            const string stylesUri = "pack://application:,,,/QuickMail;component/Styles/AccessibleStyles.xaml";
-            var uri = new Uri(stylesUri, UriKind.Absolute);
-            if (Application.Current!.Resources.MergedDictionaries.All(d => d.Source != uri))
-                Application.Current.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = uri });
-        }
-    }
+    /// <summary>Delegates to the shared host: the Application must live on a thread that outlives
+    /// the run, not on whichever [StaFact] thread happened to be first (issue #211).</summary>
+    private static void EnsureApplication() => WpfTestHost.EnsureApplication();
 
     private static Button FindButtonByContent(Window window, string contentText, int occurrence = 1)
     {

--- a/QuickMail.Tests/AddressBookFilterMenuTests.cs
+++ b/QuickMail.Tests/AddressBookFilterMenuTests.cs
@@ -269,16 +269,7 @@ public class AddressBookFilterMenuTests
         System.Windows.Threading.Dispatcher.PushFrame(frame);
     }
 
-    private static void EnsureApplication()
-    {
-        lock (typeof(Application))
-        {
-            if (Application.Current == null)
-                new Application { ShutdownMode = ShutdownMode.OnExplicitShutdown };
-            const string stylesUri = "pack://application:,,,/QuickMail;component/Styles/AccessibleStyles.xaml";
-            var uri = new Uri(stylesUri, UriKind.Absolute);
-            if (Application.Current!.Resources.MergedDictionaries.All(d => d.Source != uri))
-                Application.Current.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = uri });
-        }
-    }
+    /// <summary>Delegates to the shared host: the Application must live on a thread that outlives
+    /// the run, not on whichever [StaFact] thread happened to be first (issue #211).</summary>
+    private static void EnsureApplication() => WpfTestHost.EnsureApplication();
 }

--- a/QuickMail.Tests/AddressBookTypeAheadTests.cs
+++ b/QuickMail.Tests/AddressBookTypeAheadTests.cs
@@ -231,16 +231,7 @@ public class AddressBookTypeAheadTests
         System.Windows.Threading.Dispatcher.PushFrame(frame);
     }
 
-    private static void EnsureApplication()
-    {
-        lock (typeof(Application))
-        {
-            if (Application.Current == null)
-                new Application { ShutdownMode = ShutdownMode.OnExplicitShutdown };
-            const string stylesUri = "pack://application:,,,/QuickMail;component/Styles/AccessibleStyles.xaml";
-            var uri = new Uri(stylesUri, UriKind.Absolute);
-            if (Application.Current!.Resources.MergedDictionaries.All(d => d.Source != uri))
-                Application.Current.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = uri });
-        }
-    }
+    /// <summary>Delegates to the shared host: the Application must live on a thread that outlives
+    /// the run, not on whichever [StaFact] thread happened to be first (issue #211).</summary>
+    private static void EnsureApplication() => WpfTestHost.EnsureApplication();
 }

--- a/QuickMail.Tests/CalendarContextMenuTests.cs
+++ b/QuickMail.Tests/CalendarContextMenuTests.cs
@@ -21,23 +21,11 @@ namespace QuickMail.Tests;
 /// </summary>
 public class CalendarContextMenuTests
 {
-    private static void EnsureThemedApplication()
-    {
-        lock (typeof(Application))
-        {
-            if (Application.Current == null)
-                new Application { ShutdownMode = ShutdownMode.OnExplicitShutdown };
-        }
-
-        var app = Application.Current!;
-        foreach (var style in new[] { "AccessibleStyles", "ThemedControls" })
-        {
-            var uri = new Uri($"pack://application:,,,/QuickMail;component/Styles/{style}.xaml",
-                UriKind.Absolute);
-            if (app.Resources.MergedDictionaries.All(d => d.Source != uri))
-                app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = uri });
-        }
-    }
+    /// <summary>The shared host owns the Application (issue #211); this suite additionally needs
+    /// ThemedControls, or the XAML fails to parse with "Cannot find resource named
+    /// 'System.Windows.Controls.ListViewItem'".</summary>
+    private static void EnsureThemedApplication() =>
+        WpfTestHost.EnsureStyles("AccessibleStyles", "ThemedControls");
 
     private static MainWindow MakeWindow()
     {

--- a/QuickMail.Tests/GrabAddressesDialogTests.cs
+++ b/QuickMail.Tests/GrabAddressesDialogTests.cs
@@ -364,18 +364,9 @@ public class GrabAddressesDialogTests
         }
     }
 
-    private static void EnsureApplication()
-    {
-        lock (typeof(Application))
-        {
-            if (Application.Current == null)
-                new Application { ShutdownMode = ShutdownMode.OnExplicitShutdown };
-            const string stylesUri = "pack://application:,,,/QuickMail;component/Styles/AccessibleStyles.xaml";
-            var uri = new Uri(stylesUri, UriKind.Absolute);
-            if (Application.Current!.Resources.MergedDictionaries.All(d => d.Source != uri))
-                Application.Current.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = uri });
-        }
-    }
+    /// <summary>Delegates to the shared host: the Application must live on a thread that outlives
+    /// the run, not on whichever [StaFact] thread happened to be first (issue #211).</summary>
+    private static void EnsureApplication() => WpfTestHost.EnsureApplication();
 
     private static void DoEvents()
     {

--- a/QuickMail.Tests/GroupsTabFocusTests.cs
+++ b/QuickMail.Tests/GroupsTabFocusTests.cs
@@ -313,16 +313,7 @@ public class GroupsTabFocusTests
         return null;
     }
 
-    private static void EnsureApplication()
-    {
-        lock (typeof(Application))
-        {
-            if (Application.Current == null)
-                new Application { ShutdownMode = ShutdownMode.OnExplicitShutdown };
-            const string stylesUri = "pack://application:,,,/QuickMail;component/Styles/AccessibleStyles.xaml";
-            var uri = new Uri(stylesUri, UriKind.Absolute);
-            if (Application.Current!.Resources.MergedDictionaries.All(d => d.Source != uri))
-                Application.Current.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = uri });
-        }
-    }
+    /// <summary>Delegates to the shared host: the Application must live on a thread that outlives
+    /// the run, not on whichever [StaFact] thread happened to be first (issue #211).</summary>
+    private static void EnsureApplication() => WpfTestHost.EnsureApplication();
 }

--- a/QuickMail.Tests/SelectorItemAccessibilityTests.cs
+++ b/QuickMail.Tests/SelectorItemAccessibilityTests.cs
@@ -37,23 +37,11 @@ public class SelectorItemAccessibilityTests
     /// ThemeService before the first window is created. Without them the XAML fails to parse with
     /// "Cannot find resource named 'System.Windows.Controls.ListViewItem'".
     /// </summary>
-    private static void EnsureThemedApplication()
-    {
-        lock (typeof(Application))
-        {
-            if (Application.Current == null)
-                new Application { ShutdownMode = ShutdownMode.OnExplicitShutdown };
-        }
-
-        var app = Application.Current!;
-        foreach (var style in new[] { "AccessibleStyles", "ThemedControls" })
-        {
-            var uri = new Uri($"pack://application:,,,/QuickMail;component/Styles/{style}.xaml",
-                UriKind.Absolute);
-            if (app.Resources.MergedDictionaries.All(d => d.Source != uri))
-                app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = uri });
-        }
-    }
+    /// <summary>The shared host owns the Application (issue #211); this suite additionally needs
+    /// ThemedControls, or the XAML fails to parse with "Cannot find resource named
+    /// 'System.Windows.Controls.ListViewItem'".</summary>
+    private static void EnsureThemedApplication() =>
+        WpfTestHost.EnsureStyles("AccessibleStyles", "ThemedControls");
 
     // End-to-end: the actual reported control. Reads the real UIA item peer names a
     // screen reader would speak — this is what the reviews never checked.

--- a/QuickMail.Tests/StaDispatcherShutdown.cs
+++ b/QuickMail.Tests/StaDispatcherShutdown.cs
@@ -1,0 +1,56 @@
+using System.Reflection;
+using System.Threading;
+using System.Windows.Threading;
+using Xunit;
+using Xunit.v3;
+
+// Applied to the whole assembly: After() runs on the test's own thread once the test body has
+// finished, which is the only place a per-test STA thread's Dispatcher can still be shut down
+// while its owner is alive.
+[assembly: QuickMail.Tests.ShutDownStaDispatcher]
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// Fixes the test-host crash tracked as issue #211 — the one that silently cost between 4% and 46%
+/// of the suite on every CI run.
+///
+/// <para>
+/// Xunit.StaFact runs each <c>[StaFact]</c> on a FRESH STA thread and does not shut that thread's
+/// <see cref="Dispatcher"/> down when the test ends. Measured directly: a later test reported
+/// <c>priorTestThread=9 priorAlive=False priorDispatcherShutdownStarted=False</c>. A Dispatcher owns
+/// a message-only HWND, so every StaFact test left one behind on a dead thread — a hundred-odd of
+/// them per run. When a stray window message reaches any of them,
+/// <c>MS.Win32.HwndSubclass.SubclassWndProc</c> calls <c>Thread.get_CurrentThread()</c>, which is
+/// null because the owning managed thread is gone, and the NullReferenceException takes down the
+/// whole xUnit host. Tests that had not run yet simply never appear in the trx: `failed` stays 0 and
+/// the job goes green having skipped hundreds of cases. That is why the loss varied so wildly between
+/// runs — it depends on which orphan happens to get a message, and when.
+/// </para>
+///
+/// <para>
+/// Shutting the Dispatcher down destroys that HWND while the thread is still alive, so there is
+/// nothing left to receive a message. The Application's own Dispatcher must NOT be caught by this,
+/// which is why <see cref="WpfTestHost"/> puts it on a dedicated thread that outlives every test.
+/// </para>
+/// </summary>
+public sealed class ShutDownStaDispatcherAttribute : BeforeAfterTestAttribute
+{
+    public override void After(MethodInfo methodUnderTest, IXunitTest test)
+    {
+        // Only STA test threads have one, and only ones that actually used WPF.
+        if (Thread.CurrentThread.GetApartmentState() != ApartmentState.STA) return;
+
+        var dispatcher = Dispatcher.FromThread(Thread.CurrentThread);
+        if (dispatcher is null || dispatcher.HasShutdownStarted) return;
+
+        // Never the Application's — it lives on WpfTestHost's dedicated thread and must survive the
+        // whole run. Guarded anyway: if some future test creates an Application inline, shutting its
+        // dispatcher down here would break every later test in a way that looks nothing like the cause.
+        if (System.Windows.Application.Current?.Dispatcher == dispatcher) return;
+
+        // InvokeShutdown, not BeginInvokeShutdown: this must complete before the thread ends, and we
+        // are already on that thread, so it runs synchronously.
+        dispatcher.InvokeShutdown();
+    }
+}

--- a/QuickMail.Tests/TabStripNavigationTests.cs
+++ b/QuickMail.Tests/TabStripNavigationTests.cs
@@ -31,24 +31,20 @@ namespace QuickMail.Tests;
 [Collection("WpfTests")]
 public class TabStripNavigationTests
 {
+    /// <summary>The shared host owns the Application — it must live on a thread that outlives the
+    /// run, not on whichever [StaFact] thread happened to be first (issue #211). The rest is this
+    /// suite's own setup.</summary>
     private static void EnsureApplication()
     {
-        lock (typeof(Application))
-        {
-            if (Application.Current == null)
-                new Application { ShutdownMode = ShutdownMode.OnExplicitShutdown };
-            const string stylesUri = "pack://application:,,,/QuickMail;component/Styles/AccessibleStyles.xaml";
-            var uri = new Uri(stylesUri, UriKind.Absolute);
-            if (Application.Current!.Resources.MergedDictionaries.All(d => d.Source != uri))
-                Application.Current.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = uri });
-        }
+        WpfTestHost.EnsureApplication();
         TabStripNavigation.Install();
         // Pin the modifier read. The shipped guard asks the keyboard device, which reports what is
         // PHYSICALLY held at that instant — so someone holding Shift anywhere on the machine made the
         // handler ignore a synthesized press, and the test failed as a bogus navigation regression.
-        // ModifiersWhenPressed below covers the guard itself, which had no test before.
+        // AModifiedArrow_IsLeftToTheTabControl covers the guard itself, which had no test before.
         TabStripNavigation.ModifiersOf = _ => ModifiersWhenPressed;
     }
+
 
     /// <summary>What the handler sees as the held modifiers. None for every test but the one that
     /// checks a modified key is left alone.</summary>

--- a/QuickMail.Tests/TokenizedAddressBoxPasteTests.cs
+++ b/QuickMail.Tests/TokenizedAddressBoxPasteTests.cs
@@ -74,14 +74,9 @@ public class TokenizedAddressBoxPasteTests
         Assert.Equal(string.Empty, box.InputBox.Text);
     }
 
-    private static void EnsureApplication()
-    {
-        lock (typeof(Application))
-        {
-            if (Application.Current == null)
-                new Application { ShutdownMode = ShutdownMode.OnExplicitShutdown };
-        }
-    }
+    /// <summary>Delegates to the shared host: the Application must live on a thread that outlives
+    /// the run, not on whichever [StaFact] thread happened to be first (issue #211).</summary>
+    private static void EnsureApplication() => WpfTestHost.EnsureApplication();
 
     private static void DoEvents()
     {

--- a/QuickMail.Tests/UnitTest1.cs
+++ b/QuickMail.Tests/UnitTest1.cs
@@ -195,30 +195,9 @@ public class XamlParseTests
     /// required for StaticResource / DynamicResource resolution during XAML parsing.
     /// Uses a process-wide lock so that parallel [StaFact] threads from different test
     /// classes don't race to create a second Application (WPF forbids more than one).
-    private static void EnsureApplication()
-    {
-        // Lock on the Application type object — shared across all test classes.
-        lock (typeof(Application))
-        {
-            if (Application.Current == null)
-                new Application { ShutdownMode = ShutdownMode.OnExplicitShutdown };
-        }
-
-        // Merge the same resource dictionaries the running app has present when its
-        // windows are parsed, so StaticResource references resolve: AccessibleStyles
-        // (merged by App.xaml) and ThemedControls (merged by ThemeService.Initialize
-        // before the first window is created). ThemedControls defines the implicit
-        // container styles ({x:Type ListView/TreeView/ListBox}) that window XAML now
-        // references via BasedOn; its DynamicResource Theme.* tokens resolve to nothing
-        // in the test (no ThemeService), which is harmless for parsing.
-        var app = Application.Current!;
-        foreach (var style in new[] { "AccessibleStyles", "ThemedControls" })
-        {
-            var uri = new Uri($"pack://application:,,,/QuickMail;component/Styles/{style}.xaml", UriKind.Absolute);
-            if (app.Resources.MergedDictionaries.All(d => d.Source != uri))
-                app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = uri });
-        }
-    }
+    /// <summary>Delegates to the shared host: the Application must live on a thread that outlives
+    /// the run, not on whichever [StaFact] thread happened to be first (issue #211).</summary>
+    private static void EnsureApplication() => WpfTestHost.EnsureApplication();
 
     private static void ParseXamlFile(string relativePathFromAssembly)
     {

--- a/QuickMail.Tests/ViewManagerViewModelTests.cs
+++ b/QuickMail.Tests/ViewManagerViewModelTests.cs
@@ -240,24 +240,9 @@ public class ViewManagerViewModelTests
 [Collection("WpfTests")]
 public class ViewManagerWindowTests
 {
-    private static void EnsureApplication()
-    {
-        // Lock on the Application type object — the same lock used by XamlParseTests —
-        // so that parallel [StaFact] threads from different classes don't race to create
-        // a second Application (WPF only allows one per AppDomain).
-        lock (typeof(Application))
-        {
-            if (Application.Current == null)
-                new Application { ShutdownMode = ShutdownMode.OnExplicitShutdown };
-        }
-
-        const string stylesUri = "pack://application:,,,/QuickMail;component/Styles/AccessibleStyles.xaml";
-        var uri = new Uri(stylesUri, UriKind.Absolute);
-        // Capture to local so nullable analysis knows it's non-null (it was just created above).
-        var app = Application.Current!;
-        if (app.Resources.MergedDictionaries.All(d => d.Source != uri))
-            app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = uri });
-    }
+    /// <summary>Delegates to the shared host: the Application must live on a thread that outlives
+    /// the run, not on whichever [StaFact] thread happened to be first (issue #211).</summary>
+    private static void EnsureApplication() => WpfTestHost.EnsureApplication();
 
     /// <summary>
     /// WPF schedules binding updates at <see cref="System.Windows.Threading.DispatcherPriority.DataBind"/>

--- a/QuickMail.Tests/WpfTestHost.cs
+++ b/QuickMail.Tests/WpfTestHost.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Windows;
+using System.Windows.Threading;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// Owns the single WPF <see cref="Application"/> the test run needs, on a thread that outlives the
+/// run (issue #211).
+///
+/// <para>
+/// Every WPF test class used to create it inline — nine copies of the same
+/// <c>if (Application.Current == null) new Application(...)</c>. Whichever <c>[StaFact]</c> ran first
+/// therefore owned it, and Xunit.StaFact gives each test a fresh STA thread that ends with the test.
+/// Measured: <c>creatorThread=9 creatorAlive=False appDispatcherThread=9 appDispatcherAlive=False
+/// shutdownStarted=False</c> — the Application spent the rest of the run with its Dispatcher pinned to
+/// a dead thread, and that Dispatcher's message-only HWND is one of the orphans that crashes the host
+/// (see <see cref="ShutDownStaDispatcherAttribute"/> for the full mechanism).
+/// </para>
+///
+/// <para>
+/// Here it gets a dedicated STA thread that runs a dispatcher loop for the life of the process, so it
+/// is never on a thread that dies and <see cref="ShutDownStaDispatcherAttribute"/> never touches it.
+/// The thread is a background thread, so it cannot keep the process alive at the end of the run.
+/// Windows are still created on each test's own STA thread, exactly as before — that was already the
+/// arrangement and is not what was crashing.
+/// </para>
+/// </summary>
+internal static class WpfTestHost
+{
+    private static readonly object Gate = new();
+    private static Thread? _host;
+    private static Application? _app;
+
+    private static Uri StyleUri(string name) =>
+        new($"pack://application:,,,/QuickMail;component/Styles/{name}.xaml", UriKind.Absolute);
+
+    /// <summary>
+    /// Ensures an <see cref="Application"/> exists with the accessible styles merged in, and returns
+    /// once it is usable. Idempotent and safe to call from every test.
+    /// </summary>
+    public static void EnsureApplication()
+    {
+        lock (Gate)
+        {
+            if (_host is not null) return;
+
+            // An Application created by something else (a stray inline copy) would make the dedicated
+            // thread pointless and reintroduce the orphan, so fail loudly rather than limp on.
+            if (Application.Current is not null)
+                throw new InvalidOperationException(
+                    "An Application already exists, so it was created outside WpfTestHost — probably an " +
+                    "inline `new Application(...)` in a test class. That puts its Dispatcher on a " +
+                    "per-test STA thread that dies with the test, which is issue #211. Call " +
+                    "WpfTestHost.EnsureApplication() instead.");
+
+            using var ready = new ManualResetEventSlim();
+            Exception? failure = null;
+
+            _host = new Thread(() =>
+            {
+                try
+                {
+                    _app = new Application { ShutdownMode = ShutdownMode.OnExplicitShutdown };
+                    _app.Resources.MergedDictionaries.Add(
+                        new ResourceDictionary { Source = StyleUri("AccessibleStyles") });
+                }
+                catch (Exception ex) { failure = ex; }
+                finally { ready.Set(); }
+
+                // Keeps this thread — and so the Application's Dispatcher and its HWND — alive for the
+                // whole run. Never shut down: the thread is a background thread, so the process still
+                // exits normally.
+                if (failure is null) Dispatcher.Run();
+            })
+            {
+                IsBackground = true,
+                Name = "WPF test Application host",
+            };
+            _host.SetApartmentState(ApartmentState.STA);
+            _host.Start();
+            ready.Wait();
+
+            if (failure is not null)
+            {
+                _host = null;
+                throw new InvalidOperationException("Could not start the WPF test Application host.", failure);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Merges additional style dictionaries — some suites need ThemedControls as well, or the XAML
+    /// fails to parse with "Cannot find resource named 'System.Windows.Controls.ListViewItem'".
+    ///
+    /// The merge is marshalled onto the host thread. Reading resources across threads is what the
+    /// suite has always done and works; MUTATING another thread's ResourceDictionary is not, and is
+    /// the kind of thing that fails once in a hundred runs rather than reliably.
+    /// </summary>
+    public static void EnsureStyles(params string[] names)
+    {
+        EnsureApplication();
+        var app = _app!;
+        app.Dispatcher.Invoke(() =>
+        {
+            foreach (var name in names)
+            {
+                var uri = StyleUri(name);
+                if (app.Resources.MergedDictionaries.All(d => d.Source != uri))
+                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = uri });
+            }
+        });
+    }
+}


### PR DESCRIPTION
Fixes the crash behind [#211](https://github.com/kellylford/QuickMail/issues/211), and then makes CI refuse to go green on a truncated run.

## What was happening, measured

A diagnostic test reported this from a later test running on a fresh thread:

```
thisThread=10  creatorThread=9  creatorAlive=False
appDispatcherThread=9  appDispatcherAlive=False  shutdownStarted=False
priorTestThread=9  priorAlive=False  priorDispatcherShutdownStarted=False
```

`Xunit.StaFact` runs each `[StaFact]` on a **new STA thread** and never shuts that thread's `Dispatcher` down. A Dispatcher owns a message-only HWND, so every StaFact test left one behind on a dead thread — a hundred-odd per run. When a stray window message reaches any of them, `MS.Win32.HwndSubclass.SubclassWndProc` calls `Thread.get_CurrentThread()`, gets null because the owning thread is gone, and the `NullReferenceException` kills the xUnit host. Tests that had not run yet are simply absent from the trx, so `failed` stays 0 and the job goes green.

Separately, nine test classes each created the `Application` inline, so whichever test ran first owned it — pinning `Application.Current.Dispatcher` to a thread that died moments later, for the rest of the run.

## What it was costing

Four `main` runs, all reporting success:

| Cases | Classes |
|---|---|
| 3042 | 234 / 243 |
| **1597** | **132 / 243** |
| 2729 | 208 / 243 |
| 3024 | 232 / 243 |

`dotnet test` exited 1 on every one. Ten hunt iterations on a runner gave `1987, 3115, 3115, 1984, 3045, 1334, 3115, 2384, 1388, 3115` — one run executed **43%** of the suite and reported no failures.

The nine `ConnectionDiagnostics` classes were missing from *every* run: that collection is `DisableParallelization`, so it is scheduled last and the crash always beat it. **Those classes have never executed in CI.** It is why the probe bug fixed in #586 could not have been caught there.

## The fix

- **`ShutDownStaDispatcherAttribute`** — applied assembly-wide, shuts each STA test thread's Dispatcher down in `After()`, on that thread while it is still alive, so the HWND is destroyed rather than orphaned. One attribute; no per-class churn.
- **`WpfTestHost`** — owns the single `Application` on a dedicated background STA thread that outlives the run, replacing all eleven inline creations. It **throws if it finds an `Application` it did not create**, so a future inline copy fails loudly instead of quietly restoring the bug. Two suites also need `ThemedControls`; `EnsureStyles` merges extra dictionaries marshalled onto the host thread, since mutating another thread's `ResourceDictionary` is its own once-in-a-hundred-runs bug.

Three consecutive local runs after the fix: `total=3115` every time, no "Catastrophic failure", exit 0 on two. The third exited 1 on a genuine unrelated flaky test (`ComposeWindowEnterSendGuardTests`), not a host crash.

## CI now fails on a truncated run

The completeness check existed already, but as a `Write-Warning` — so it never stopped anything, which is how this hid for months. It now fails and names the classes that did not run. Two related tightenings:

- Failing to *discover* the class list is now an error rather than a silent skip. A completeness check that quietly does nothing is worse than not having one.
- The blanket "exited non-zero but everything passed" allowance is gone. It existed only for #211's benign teardown crash; with that fixed, an unexplained host-level failure should stop the job.

## Verification in flight

A 10-iteration hunt is running against this branch. If any iteration still comes up short I will say so before this merges rather than after.

## Note

Issue #211 is currently closed, with only the mitigation in place. It is worth reopening and closing against this, or noting the real fix on it.