### PR TITLE
Fix #590: expand and collapse folders from a menu

### DIFF
--- a/QuickMail.Tests/CalendarContextMenuTests.cs
+++ b/QuickMail.Tests/CalendarContextMenuTests.cs
@@ -19,6 +19,9 @@ namespace QuickMail.Tests;
 /// nothing — and an over-broad trigger would strip real folders of the menu that is their only
 /// mouse path to Move, Copy, and Set as Archive.
 /// </summary>
+// Loads a real MainWindow, so it belongs in the collection that serializes window-loading
+// tests: two of them constructing a MainWindow at once race inside XAML loading (#590).
+[Collection("WpfTests")]
 public class CalendarContextMenuTests
 {
     /// <summary>The shared host owns the Application (issue #211); this suite additionally needs

--- a/QuickMail.Tests/FolderExpansionTests.cs
+++ b/QuickMail.Tests/FolderExpansionTests.cs
@@ -1,0 +1,351 @@
+// Expanding and collapsing folders from a menu — issue #590.
+//
+// Reported as: "I was in the folder tree and wanted to collapse all folders. There was no option to
+// do so." Right and Left arrow on a tree item were the only expansion controls in the app, so a
+// deeply nested account could only be folded away one item at a time, and there was no entry point
+// on the context menu, on a menu, or in the Command Palette.
+//
+// Four things are pinned here, because each fails silently on its own:
+//   * the branch semantics — these commands are not a duplicate of the arrow keys,
+//   * that Collapse All reaches account headers, which is the whole point of collapsing all,
+//   * that a rebuild of the tree does not quietly undo it (it did: expansion state was restored
+//     additively, so a collapsed account header sprang back open on the next folder refresh),
+//   * and that all three entry points the issue asks for actually exist.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using System.Windows.Automation;
+using System.Windows.Controls;
+using QuickMail.Models;
+using QuickMail.Services;
+using QuickMail.ViewModels;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+public class FolderExpansionTests
+{
+    private static readonly Guid AccountA = Guid.Parse("11111111-1111-1111-1111-111111111111");
+
+    // Inbox / Projects / 2026 — three levels, so "one level" and "the whole branch" are
+    // distinguishable outcomes.
+    private static FolderTreeNode Branch()
+    {
+        var leaf   = new FolderTreeNode { Label = "2026" };
+        var middle = new FolderTreeNode { Label = "Projects" };
+        var root   = new FolderTreeNode { Label = "Inbox" };
+        middle.Children.Add(leaf);
+        root.Children.Add(middle);
+        return root;
+    }
+
+    private static IEnumerable<FolderTreeNode> Flatten(IEnumerable<FolderTreeNode> nodes)
+    {
+        foreach (var n in nodes)
+        {
+            yield return n;
+            foreach (var c in Flatten(n.Children)) yield return c;
+        }
+    }
+
+    // ── Branch semantics ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void ExpandingAFolder_OpensTheWholeBranch_NotJustOneLevel()
+    {
+        var root = Branch();
+
+        MainViewModel.SetFolderBranchExpanded(root, true);
+
+        Assert.All(Flatten([root]), n => Assert.True(n.IsExpanded, n.Label + " is still collapsed."));
+    }
+
+    [Fact]
+    public void CollapsingAFolder_ClosesTheWholeBranch()
+    {
+        var root = Branch();
+        MainViewModel.SetFolderBranchExpanded(root, true);
+
+        MainViewModel.SetFolderBranchExpanded(root, false);
+
+        Assert.All(Flatten([root]), n => Assert.False(n.IsExpanded, n.Label + " is still expanded."));
+    }
+
+    [Fact]
+    public void ANullNodeIsIgnored()
+    {
+        // The context menu is attached to every tree item, so the handler can be reached with no
+        // resolvable node. Throwing there would take the app down from a menu activation.
+        MainViewModel.SetFolderBranchExpanded(null, true);
+    }
+
+    // ── Whole tree ───────────────────────────────────────────────────────────
+
+    private static async Task<MainViewModel> MakeVmAsync()
+    {
+        var folders = new Dictionary<Guid, List<MailFolderModel>>
+        {
+            [AccountA] =
+            [
+                new MailFolderModel { AccountId = AccountA, FullName = "INBOX", DisplayName = "Inbox", Kind = SpecialFolderKind.Inbox },
+                new MailFolderModel { AccountId = AccountA, FullName = "INBOX/Projects", DisplayName = "Projects" },
+                new MailFolderModel { AccountId = AccountA, FullName = "INBOX/Projects/2026", DisplayName = "2026" },
+            ],
+        };
+
+        var vm = new MainViewModel(
+            new FolderedMailService(folders, []), new StubAccountService(), new StubCredentialService(),
+            new StubLocalStoreService(), new StubOAuthService(), new StubSyncService(),
+            new StubConfigService(), new StubCommandRegistry(), new StubViewService(),
+            new StubRuleService(), new StubSmtpService());
+
+        vm.Accounts.Add(new AccountModel
+        {
+            Id = AccountA, AccountName = "Work", Username = "work@example.com",
+            AuthType = AuthType.OAuth2Microsoft,
+        });
+        await vm.ConnectAllAccountsAsync();
+        return vm;
+    }
+
+    [Fact]
+    public async Task CollapseAll_ReachesAccountHeaders()
+    {
+        // The header is what has to close: with it left open, "collapse all folders" still leaves
+        // the account's whole first level on screen, which is not what was asked for.
+        var vm = await MakeVmAsync();
+        Assert.Contains(Flatten(vm.FolderTree), n => n.IsHeader && n.IsExpanded);
+
+        vm.SetAllFoldersExpanded(false);
+
+        Assert.All(Flatten(vm.FolderTree), n => Assert.False(n.IsExpanded, n.Label + " is still expanded."));
+    }
+
+    [Fact]
+    public async Task ExpandAll_OpensEveryNode()
+    {
+        var vm = await MakeVmAsync();
+
+        vm.SetAllFoldersExpanded(true);
+
+        Assert.All(Flatten(vm.FolderTree), n => Assert.True(n.IsExpanded, n.Label + " is still collapsed."));
+    }
+
+    [Fact]
+    public async Task HasExpandableFolders_IsTrueOnceTheTreeNests_AndFalseBeforeIt()
+    {
+        var empty = new MainViewModel(
+            new StubImapMailService(), new StubAccountService(), new StubCredentialService(),
+            new StubLocalStoreService(), new StubOAuthService(), new StubSyncService(),
+            new StubConfigService(), new StubCommandRegistry(), new StubViewService(),
+            new StubRuleService(), new StubSmtpService());
+        Assert.False(empty.HasExpandableFolders);
+
+        Assert.True((await MakeVmAsync()).HasExpandableFolders);
+    }
+
+    // ── The tree rebuild must not undo it ────────────────────────────────────
+
+    [Fact]
+    public async Task ARebuiltTree_KeepsACollapsedAccountHeaderCollapsed()
+    {
+        // Regression. BuildFolderTree used to capture only the expanded nodes and re-apply them
+        // additively, so a header — built expanded by default — re-opened on the next folder
+        // refresh. Collapse All then looked like it had silently failed a few seconds later.
+        var vm = await MakeVmAsync();
+        vm.SetAllFoldersExpanded(false);
+
+        await vm.ConnectAllAccountsAsync();   // reloads folders, rebuilding the tree
+
+        Assert.All(Flatten(vm.FolderTree).Where(n => n.IsHeader),
+                   n => Assert.False(n.IsExpanded, "header '" + n.Label + "' re-expanded on rebuild."));
+    }
+
+    [Fact]
+    public async Task ARebuiltTree_KeepsAnExpandedFolderExpanded()
+    {
+        // The other direction, which the additive restore did get right — kept so a fix to the
+        // above cannot regress it.
+        var vm = await MakeVmAsync();
+        vm.SetAllFoldersExpanded(true);
+
+        await vm.ConnectAllAccountsAsync();
+
+        Assert.All(Flatten(vm.FolderTree), n => Assert.True(n.IsExpanded, n.Label + " collapsed on rebuild."));
+    }
+
+    // ── Entry points: the Folder menu and the Command Palette ────────────────
+    //
+    // Both are read from the source. The menu bar's items and the command registrations live behind
+    // a shown window (registrations run in OnLoaded), which is the opt-in input-test territory these
+    // tests deliberately stay out of. Renaming or deleting either entry point fails here.
+
+    [Theory]
+    [InlineData("MenuExpandFolder_Click")]
+    [InlineData("MenuCollapseFolder_Click")]
+    [InlineData("MenuExpandAllFolders_Click")]
+    [InlineData("MenuCollapseAllFolders_Click")]
+    public void TheFolderMenuCarriesEachAction(string handler)
+    {
+        Assert.Contains(handler, FolderMenuBody(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TheFolderMenusAccessKeysStayUnique()
+    {
+        // Same collision rule as the context menus, read from source because the menu bar is not a
+        // resource that can be resolved without showing the window.
+        var keys = Regex.Matches(FolderMenuBody(), "Header=\"(?<h>[^\"]*)\"")
+            .Select(m => AccessKeyOf(m.Groups["h"].Value))
+            .Where(k => k != null)
+            .ToList();
+
+        Assert.NotEmpty(keys);
+        Assert.Equal(keys.Count, keys.Distinct(StringComparer.OrdinalIgnoreCase).Count());
+    }
+
+    // The access key a menu header declares, e.g. "Colla_pse Folder" -> "p". Null when it has none.
+    internal static string? AccessKeyOf(string? header)
+    {
+        if (header == null) return null;
+        var m = Regex.Match(header, "_(?<k>[A-Za-z0-9])");
+        return m.Success ? m.Groups["k"].Value : null;
+    }
+
+    // The body of the menu bar's Folder menu, from its own header to the View menu that follows it.
+    private static string FolderMenuBody()
+    {
+        var match = Regex.Match(
+            Source("Views/MainWindow.xaml"),
+            "<MenuItem Header=\"Fol_der\">(?<body>.*?)</MenuItem>\\s*\\r?\\n\\s*<!-- View -->",
+            RegexOptions.Singleline);
+        Assert.True(match.Success, "the Folder menu is gone from MainWindow.xaml.");
+        return match.Groups["body"].Value;
+    }
+
+    [Theory]
+    [InlineData("folder.expand")]
+    [InlineData("folder.collapse")]
+    [InlineData("folder.expandAll")]
+    [InlineData("folder.collapseAll")]
+    public void EachActionIsRegisteredAsACommand(string commandId)
+    {
+        // Registration is what puts an action in the Command Palette and in keyboard
+        // customizations — the third entry point #590 asks for.
+        Assert.Contains("id: \"" + commandId + "\"", Source("Views/MainWindow.xaml.cs"), StringComparison.Ordinal);
+    }
+
+    private static string Source(string relativePath)
+    {
+        var path = Path.Combine(RepoRoot(), "QuickMail", relativePath.Replace('/', Path.DirectorySeparatorChar));
+        Assert.True(File.Exists(path), path + " not found.");
+        return File.ReadAllText(path);
+    }
+
+    private static string RepoRoot()
+    {
+        for (var dir = new DirectoryInfo(AppContext.BaseDirectory); dir != null; dir = dir.Parent)
+            if (Directory.Exists(Path.Combine(dir.FullName, "QuickMail", "Views")))
+                return dir.FullName;
+        throw new InvalidOperationException("Repo source tree not found from " + AppContext.BaseDirectory + ".");
+    }
+}
+
+/// <summary>
+/// The window-loading half of the #590 tests. Split from <see cref="FolderExpansionTests"/> and put
+/// in the WpfTests collection: constructing a MainWindow in parallel with another test doing the
+/// same races inside XAML loading, which is what that collection exists to serialize. The plain
+/// tests stay out of it — a non-STA test scheduled inside the collection disturbs it in turn.
+/// </summary>
+[Collection("WpfTests")]
+public class FolderExpansionMenuTests
+{
+    private static readonly string[] WholeTreeActions = ["Expand All Folders", "Collapse All Folders"];
+
+    // ── Entry points: the two context menus ──────────────────────────────────
+
+    private static List<MenuItem> MenuItemsOf(System.Windows.FrameworkElement owner, string resourceKey)
+    {
+        var menu = owner.FindResource(resourceKey) as ContextMenu;
+        Assert.NotNull(menu);
+        return [.. menu!.Items.OfType<MenuItem>()];
+    }
+
+    [StaFact]
+    public void TheFolderContextMenu_OffersAllFourActions()
+    {
+        WpfTestHost.EnsureStyles("AccessibleStyles", "ThemedControls");
+        var window = MakeWindow();
+        try
+        {
+            var names = MenuItemsOf(window, "FolderContextMenu").Select(AutomationProperties.GetName).ToList();
+            Assert.Contains("Expand Folder", names);
+            Assert.Contains("Collapse Folder", names);
+            Assert.All(WholeTreeActions, a => Assert.Contains(a, names));
+        }
+        finally { window.Close(); }
+    }
+
+    [StaFact]
+    public void TheCalendarContextMenu_OffersThemToo_WordedForACalendar()
+    {
+        // Calendar nodes nest in the same tree but get a different menu (#497), so they would
+        // otherwise be the one branch of the folder tree with no way to fold itself away.
+        WpfTestHost.EnsureStyles("AccessibleStyles", "ThemedControls");
+        var window = MakeWindow();
+        try
+        {
+            var names = MenuItemsOf(window, "CalendarContextMenu").Select(AutomationProperties.GetName).ToList();
+            Assert.Contains("Expand Calendar", names);
+            Assert.Contains("Collapse Calendar", names);
+            Assert.All(WholeTreeActions, a => Assert.Contains(a, names));
+        }
+        finally { window.Close(); }
+    }
+
+    [StaFact]
+    public void EachMenusAccessKeysStayUnique()
+    {
+        // WPF cycles between duplicate access keys instead of invoking, so a collision turns a
+        // menu item into a highlight that does nothing — the failure #516 called out.
+        WpfTestHost.EnsureStyles("AccessibleStyles", "ThemedControls");
+        var window = MakeWindow();
+        try
+        {
+            foreach (var key in new[] { "FolderContextMenu", "CalendarContextMenu" })
+            {
+                var keys = MenuItemsOf(window, key)
+                    .Select(i => FolderExpansionTests.AccessKeyOf(i.Header as string))
+                    .Where(k => k != null)
+                    .ToList();
+                Assert.Equal(keys.Count, keys.Distinct(StringComparer.OrdinalIgnoreCase).Count());
+            }
+        }
+        finally { window.Close(); }
+    }
+
+    private static QuickMail.Views.MainWindow MakeWindow()
+    {
+        var imap     = new StubImapMailService();
+        var accounts = new StubAccountService();
+        var creds    = new StubCredentialService();
+        var store    = new StubLocalStoreService();
+        var config   = new StubConfigService();
+        var registry = new StubCommandRegistry();
+
+        var vm = new MainViewModel(imap, accounts, creds, store, new StubOAuthService(),
+            new StubSyncService(), config, registry, new StubViewService(), new StubRuleService(),
+            new StubSmtpService());
+
+        return new QuickMail.Views.MainWindow(vm, new StubSmtpService(), accounts, creds, imap,
+            new StubOAuthService(), registry, new StubContactService(), config, store,
+            new StubViewService(), new StubRuleService(), new StubTemplateService(),
+            new StubFeatureGate());
+    }
+
+
+}

--- a/QuickMail.Tests/FolderExpansionTests.cs
+++ b/QuickMail.Tests/FolderExpansionTests.cs
@@ -239,6 +239,36 @@ public class FolderExpansionTests
         Assert.Contains("id: \"" + commandId + "\"", Source("Views/MainWindow.xaml.cs"), StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void TheCollapseGuard_ComparesFoldersByIdentityNotByReference()
+    {
+        // SyncFolderTreeSelection holds back the path expansion while the folder the user collapsed
+        // around is still the open one. RebuildFolderListFromCache re-resolves SelectedFolder
+        // against a freshly fetched folder list, so the same mailbox comes back as a NEW
+        // MailFolderModel after any folder refresh — a reference comparison stopped matching
+        // seconds later and let the branch re-open, which is the bug the guard exists to stop.
+        // Virtual folders are singletons, so the fault hides from anyone testing on All Inboxes.
+        var source = Source("Views/MainWindow.xaml.cs");
+
+        Assert.DoesNotContain("ReferenceEquals(_collapsedWhileViewing", source, StringComparison.Ordinal);
+        Assert.Contains("TreeViewFocusHelper.FoldersMatch(collapsed, folder)", source, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TheMenuBarPath_SaysWhatHappenedWhenTheTreeNeverGetsFocus()
+    {
+        // From the folder tree's context menu the collapsed node keeps focus and the platform
+        // reports its own expanded state, so QuickMail says nothing extra. From the Folder menu or
+        // the Command Palette focus never enters the tree, nothing has a state to report, and the
+        // action would land in silence — the dead end #250 and #590 are both about.
+        var source = Source("Views/MainWindow.xaml.cs");
+
+        Assert.Contains("if (!FolderList.IsKeyboardFocusWithin)", source, StringComparison.Ordinal);
+        Assert.Contains(
+            "AccessibilityHelper.Announce(this, outcome, category: AnnouncementCategory.Result)",
+            source, StringComparison.Ordinal);
+    }
+
     private static string Source(string relativePath)
     {
         var path = Path.Combine(RepoRoot(), "QuickMail", relativePath.Replace('/', Path.DirectorySeparatorChar));

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -481,6 +481,39 @@ public partial class MainViewModel : ObservableObject, IDisposable
         return $"Startup folder '{previous}' cleared. QuickMail will open in All Mail.";
     }
 
+    // ── Folder tree expansion (#590) ─────────────────────────────────────────
+    // Expanding and collapsing was arrow-keys-only: there was no way to fold a whole account away,
+    // and no way to reach either action from a menu, the context menu, or the Command Palette.
+    //
+    // Both operate on the branch, not one level. Right and Left arrow already do one level, so a
+    // command that did the same would be a duplicate; what neither arrow can do is fold a folder
+    // with nested subfolders back to a single line, or open one all the way down.
+
+    /// <summary>
+    /// Expands or collapses <paramref name="node"/> and every node beneath it.
+    /// </summary>
+    public static void SetFolderBranchExpanded(FolderTreeNode? node, bool expanded)
+    {
+        if (node == null) return;
+        foreach (var n in FlattenAllNodes([node]))
+            n.IsExpanded = expanded;
+    }
+
+    /// <summary>
+    /// Expands or collapses every node in the folder tree, account headers included — collapsing
+    /// all is how a many-account tree gets back to a list of accounts.
+    /// </summary>
+    public void SetAllFoldersExpanded(bool expanded)
+    {
+        if (FolderTree == null) return;
+        foreach (var n in FlattenAllNodes(FolderTree))
+            n.IsExpanded = expanded;
+    }
+
+    /// <summary>Whether the folder tree holds a node whose expansion state could be changed.</summary>
+    public bool HasExpandableFolders =>
+        FolderTree != null && FlattenAllNodes(FolderTree).Any(n => n.Children.Count > 0);
+
     private void PersistDefaultCalendar()
     {
         var cfg = _configService.Load();
@@ -4512,12 +4545,15 @@ public partial class MainViewModel : ObservableObject, IDisposable
 
     private void BuildFolderTree()
     {
-        // Capture which folders the user has expanded so the rebuild (which creates fresh, collapsed
-        // node objects) doesn't collapse the whole tree on a refresh.
-        var expandedKeys = new HashSet<string>(StringComparer.Ordinal);
+        // Capture the expansion state of every current node so the rebuild (which creates fresh
+        // node objects) doesn't undo what the user did. Both directions are remembered, not just
+        // the expanded ones: an account header is built expanded, so remembering only expansions
+        // silently re-opened every account the user had collapsed on the next folder refresh —
+        // which made Collapse All Folders (#590) look like it had not worked.
+        var expansion = new Dictionary<string, bool>(StringComparer.Ordinal);
         if (FolderTree != null)
             foreach (var n in FlattenAllNodes(FolderTree))
-                if (n.IsExpanded) expandedKeys.Add(NodeKey(n));
+                expansion[NodeKey(n)] = n.IsExpanded;
 
         var roots = new List<FolderTreeNode>();
 
@@ -4677,11 +4713,11 @@ public partial class MainViewModel : ObservableObject, IDisposable
             }
         }
 
-        // Restore expansion captured above (additive: header groups keep their built-in expanded
-        // default; previously-expanded folders are re-expanded).
+        // Restore the state captured above. A node the tree has not seen before keeps the default
+        // it was built with (header groups expanded, folders collapsed).
         foreach (var n in FlattenAllNodes(roots))
-            if (expandedKeys.Contains(NodeKey(n)))
-                n.IsExpanded = true;
+            if (expansion.TryGetValue(NodeKey(n), out var wasExpanded))
+                n.IsExpanded = wasExpanded;
 
         FolderTree = new ObservableCollection<FolderTreeNode>(roots);
         // Fresh node objects start unmarked; restore the default calendar's marker on the rebuild.

--- a/QuickMail/Views/MainWindow.xaml
+++ b/QuickMail/Views/MainWindow.xaml
@@ -1,4 +1,4 @@
-<Window x:Class="QuickMail.Views.MainWindow"
+﻿<Window x:Class="QuickMail.Views.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -262,6 +262,22 @@
             <MenuItem Header="_Delete Folder"
                       AutomationProperties.Name="Delete Folder"
                       Click="FolderContextMenu_DeleteFolder_Click"/>
+            <Separator/>
+            <!-- #590. Access keys still free after the items above (N, M, C, A, U, S, F, D): X, P,
+                 E and L. Both single-folder items act on the whole branch, not one level — Right
+                 and Left arrow already do one level. -->
+            <MenuItem Header="E_xpand Folder"
+                      AutomationProperties.Name="Expand Folder"
+                      Click="FolderContextMenu_ExpandFolder_Click"/>
+            <MenuItem Header="Colla_pse Folder"
+                      AutomationProperties.Name="Collapse Folder"
+                      Click="FolderContextMenu_CollapseFolder_Click"/>
+            <MenuItem Header="_Expand All Folders"
+                      AutomationProperties.Name="Expand All Folders"
+                      Click="FolderContextMenu_ExpandAllFolders_Click"/>
+            <MenuItem Header="Collapse A_ll Folders"
+                      AutomationProperties.Name="Collapse All Folders"
+                      Click="FolderContextMenu_CollapseAllFolders_Click"/>
         </ContextMenu>
 
         <!-- Calendar context menu — replaces FolderContextMenu on the Calendar node and its
@@ -276,6 +292,22 @@
             <MenuItem Header="_Clear Default Calendar"
                       AutomationProperties.Name="Clear Default Calendar"
                       Click="CalendarContextMenu_ClearDefault_Click"/>
+            <Separator/>
+            <!-- #590. Calendar nodes sit in the same tree and nest the same way, so they get the
+                 same expansion actions — worded for a calendar, since "Expand Folder" on the
+                 Calendar node would name something the user is not looking at. -->
+            <MenuItem Header="E_xpand Calendar"
+                      AutomationProperties.Name="Expand Calendar"
+                      Click="FolderContextMenu_ExpandFolder_Click"/>
+            <MenuItem Header="Colla_pse Calendar"
+                      AutomationProperties.Name="Collapse Calendar"
+                      Click="FolderContextMenu_CollapseFolder_Click"/>
+            <MenuItem Header="_Expand All Folders"
+                      AutomationProperties.Name="Expand All Folders"
+                      Click="FolderContextMenu_ExpandAllFolders_Click"/>
+            <MenuItem Header="Collapse A_ll Folders"
+                      AutomationProperties.Name="Collapse All Folders"
+                      Click="FolderContextMenu_CollapseAllFolders_Click"/>
         </ContextMenu>
     </Window.Resources>
 
@@ -408,6 +440,21 @@
                 <MenuItem Header="_New Folder…"
                           Click="MenuNewFolder_Click"
                           AutomationProperties.Name="New Folder"/>
+                <Separator/>
+                <!-- #590. These act on the folder tree's selection, so they work the same whether
+                     the user got here from the menu bar or from the tree's own context menu. -->
+                <MenuItem Header="E_xpand Folder"
+                          Click="MenuExpandFolder_Click"
+                          AutomationProperties.Name="Expand Folder"/>
+                <MenuItem Header="Colla_pse Folder"
+                          Click="MenuCollapseFolder_Click"
+                          AutomationProperties.Name="Collapse Folder"/>
+                <MenuItem Header="_Expand All Folders"
+                          Click="MenuExpandAllFolders_Click"
+                          AutomationProperties.Name="Expand All Folders"/>
+                <MenuItem Header="Collapse A_ll Folders"
+                          Click="MenuCollapseAllFolders_Click"
+                          AutomationProperties.Name="Collapse All Folders"/>
             </MenuItem>
 
             <!-- View -->

--- a/QuickMail/Views/MainWindow.xaml
+++ b/QuickMail/Views/MainWindow.xaml
@@ -1,4 +1,4 @@
-﻿<Window x:Class="QuickMail.Views.MainWindow"
+<Window x:Class="QuickMail.Views.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -1128,6 +1128,30 @@ public partial class MainWindow : Window
             isAvailable: () => FolderList.IsKeyboardFocusWithin
                 && FolderList.SelectedItem is FolderTreeNode n && IsDeletableFolderNode(n)));
 
+        // Folder tree expansion (#590). No default keys — Right and Left arrow already expand and
+        // collapse one level, and these do the whole branch; users can bind their own in keyboard
+        // customizations. Registered so all four also appear in the Command Palette, which is the
+        // third entry point the issue asks for alongside the context menu and the Folder menu.
+        _registry.Register(new CommandDefinition(
+            id: "folder.expand", category: "Mail", title: "Expand Folder",
+            execute: () => ExpandSelectedFolder(true),
+            isAvailable: () => CurrentFolderNode() is { Children.Count: > 0 }));
+
+        _registry.Register(new CommandDefinition(
+            id: "folder.collapse", category: "Mail", title: "Collapse Folder",
+            execute: () => ExpandSelectedFolder(false),
+            isAvailable: () => CurrentFolderNode() is { Children.Count: > 0 }));
+
+        _registry.Register(new CommandDefinition(
+            id: "folder.expandAll", category: "Mail", title: "Expand All Folders",
+            execute: () => SetAllFoldersExpanded(true, null),
+            isAvailable: () => _vm.HasExpandableFolders));
+
+        _registry.Register(new CommandDefinition(
+            id: "folder.collapseAll", category: "Mail", title: "Collapse All Folders",
+            execute: () => SetAllFoldersExpanded(false, null),
+            isAvailable: () => _vm.HasExpandableFolders));
+
         // ── Pane navigation (Ctrl+Alt+1/2/3 — always work regardless of tab mode) ──
         _registry.Register(new CommandDefinition(
             id: "view.focusAccounts", category: "View", title: "Focus Account List",
@@ -2040,6 +2064,16 @@ public partial class MainWindow : Window
         var roots = FolderList.Items.OfType<FolderTreeNode>().ToList();
         if (roots.Count == 0)
             return false;
+
+        // A deliberate collapse holds: while the folder the user collapsed around is still the open
+        // one, returning to the tree keeps its visible selection rather than re-opening the branch
+        // that holds the current folder. Without this, F6 or Ctrl+2 quietly undid Collapse All
+        // Folders (#590) the moment the user came back to look at the result. Going to a different
+        // folder clears it, so the tree still reveals wherever the user navigates next.
+        if (ReferenceEquals(_collapsedWhileViewing, _vm.SelectedFolder) &&
+            FolderList.SelectedItem is FolderTreeNode shown &&
+            FlattenVisibleFolderNodes(roots).Contains(shown))
+            return SelectTreeViewNode(FolderList, shown, focusNode);
 
         if (!FindAndExpandFolderPath(roots, _vm.SelectedFolder))
             return false;
@@ -5764,6 +5798,160 @@ public partial class MainWindow : Window
                 foreach (var c in FlattenVisibleFolderNodes(n.Children))
                     yield return c;
         }
+    }
+
+    // ── Folder tree expansion (#590) ─────────────────────────────────────────
+    // Before this, Right and Left arrow on a tree item were the only way to expand or collapse
+    // anything, and there was no way at all to fold the whole tree away. All four actions are
+    // reachable three ways, per the issue: the folder tree's context menu, the Folder menu, and
+    // the Command Palette (folder.expand / folder.collapse / folder.expandAll / folder.collapseAll,
+    // rebindable in keyboard customizations).
+    //
+    // "Expand Folder" and "Collapse Folder" act on the whole branch, not one level: one level is
+    // what the arrow keys already do, so a command repeating it would add nothing, while folding a
+    // deeply nested folder back to one line has no keyboard equivalent at all.
+
+    // The folder that was open when the user last collapsed something. Read by
+    // SyncFolderTreeSelection to decide whether re-entering the tree may expand a path.
+    private MailFolderModel? _collapsedWhileViewing;
+
+    private void FolderContextMenu_ExpandFolder_Click(object sender, RoutedEventArgs e)
+        => SetFolderBranchExpanded(GetContextMenuFolderNode(sender), true, focusNode: true);
+
+    private void FolderContextMenu_CollapseFolder_Click(object sender, RoutedEventArgs e)
+        => SetFolderBranchExpanded(GetContextMenuFolderNode(sender), false, focusNode: true);
+
+    private void FolderContextMenu_ExpandAllFolders_Click(object sender, RoutedEventArgs e)
+        => SetAllFoldersExpanded(true, GetContextMenuFolderNode(sender));
+
+    private void FolderContextMenu_CollapseAllFolders_Click(object sender, RoutedEventArgs e)
+        => SetAllFoldersExpanded(false, GetContextMenuFolderNode(sender));
+
+    // Menu-bar and Command Palette twins. They act on the folder tree's selection, so the same
+    // action is reachable without the context menu — the dead end #250 was filed about. They do not
+    // pull focus into the tree: the user may be in the message list and only wanted the tree tidied.
+    private void MenuExpandFolder_Click(object sender, RoutedEventArgs e) => ExpandSelectedFolder(true);
+
+    private void MenuCollapseFolder_Click(object sender, RoutedEventArgs e) => ExpandSelectedFolder(false);
+
+    private void MenuExpandAllFolders_Click(object sender, RoutedEventArgs e) => SetAllFoldersExpanded(true, null);
+
+    private void MenuCollapseAllFolders_Click(object sender, RoutedEventArgs e) => SetAllFoldersExpanded(false, null);
+
+    private void ExpandSelectedFolder(bool expanded)
+    {
+        if (CurrentFolderNode() is { } node)
+            SetFolderBranchExpanded(node, expanded, focusNode: false);
+        else
+            Report("Select a folder first.");
+    }
+
+    // The folder the menu-bar and palette entries act on. The tree's own selection when there is
+    // one, and otherwise the folder currently open — the tree does not get a selection until it is
+    // first focused, and "select a folder first" is a poor answer to someone sitting in the very
+    // folder they meant.
+    private FolderTreeNode? CurrentFolderNode() =>
+        FolderList.SelectedItem as FolderTreeNode
+        ?? (_vm.SelectedFolder is { } folder
+            ? TreeViewFocusHelper.FindFolderTreeNode(_vm.FolderTree, folder)
+            : null);
+
+    private void SetFolderBranchExpanded(FolderTreeNode? node, bool expanded, bool focusNode)
+    {
+        if (node == null) return;
+
+        // Say why rather than do nothing. A leaf has no expansion state to change, and silence
+        // there reads as a broken menu item.
+        if (node.Children.Count == 0)
+        {
+            Report($"'{node.Label}' has nothing inside it to {(expanded ? "expand" : "collapse")}.");
+            return;
+        }
+
+        MainViewModel.SetFolderBranchExpanded(node, expanded);
+        _collapsedWhileViewing = expanded ? null : _vm.SelectedFolder;
+
+        // No Announce here: the node keeps focus and the platform reports its own expanded state.
+        // The status bar still carries it for sighted users.
+        _vm.StatusText = $"'{node.Label}' {(expanded ? "expanded" : "collapsed")}.";
+
+        if (focusNode)
+            FocusTreeItem(FolderList, node);
+        else
+            KeepFolderSelectionVisible();
+    }
+
+    // <paramref name="cameFrom"/> is the context-menu node when the action came from the tree, and
+    // null from the menu bar or the palette. It is the difference between landing focus in the tree
+    // (the user was there) and leaving focus alone (they were not).
+    private void SetAllFoldersExpanded(bool expanded, FolderTreeNode? cameFrom)
+    {
+        if (!_vm.HasExpandableFolders)
+        {
+            Report("There are no folders to expand or collapse.");
+            return;
+        }
+
+        _vm.SetAllFoldersExpanded(expanded);
+        _collapsedWhileViewing = expanded ? null : _vm.SelectedFolder;
+
+        // This one is announced: it can be invoked from the menu bar with focus anywhere, and a
+        // whole tree folding away with nothing said is exactly the silence #590 reports.
+        Report(expanded ? "All folders expanded." : "All folders collapsed.");
+
+        var landing = cameFrom ?? CurrentFolderNode();
+        if (landing == null) return;
+
+        if (DeepestVisibleAncestor(landing) is not { } visible) return;
+        if (cameFrom != null || FolderList.IsKeyboardFocusWithin)
+            FocusTreeItem(FolderList, visible);
+        else
+            SelectTreeViewNode(FolderList, visible, focusNode: false);
+    }
+
+    // Collapsing can hide the selected folder. A TreeView left selecting a node inside a collapsed
+    // branch has no visible selection at all, so the next arrow key starts from nowhere.
+    private void KeepFolderSelectionVisible()
+    {
+        if (FolderList.SelectedItem is not FolderTreeNode selected) return;
+        if (DeepestVisibleAncestor(selected) is not { } visible || ReferenceEquals(visible, selected))
+            return;
+
+        if (FolderList.IsKeyboardFocusWithin)
+            FocusTreeItem(FolderList, visible);
+        else
+            SelectTreeViewNode(FolderList, visible, focusNode: false);
+    }
+
+    // The deepest node on the path to <paramref name="node"/> that is still on screen — the node
+    // itself when every ancestor is expanded. Null when the node is not in the tree at all.
+    private FolderTreeNode? DeepestVisibleAncestor(FolderTreeNode node)
+    {
+        var path = new List<FolderTreeNode>();
+        if (!TryFindFolderPath(_vm.FolderTree, node, path) || path.Count == 0) return null;
+
+        var visible = path[0];   // root nodes are always on screen
+        for (var i = 1; i < path.Count; i++)
+        {
+            if (!path[i - 1].IsExpanded) break;
+            visible = path[i];
+        }
+        return visible;
+    }
+
+    // Fills <paramref name="path"/> with the nodes from a root down to (and including) the target.
+    private static bool TryFindFolderPath(
+        IEnumerable<FolderTreeNode>? nodes, FolderTreeNode target, List<FolderTreeNode> path)
+    {
+        if (nodes == null) return false;
+        foreach (var n in nodes)
+        {
+            path.Add(n);
+            if (ReferenceEquals(n, target) || TryFindFolderPath(n.Children, target, path))
+                return true;
+            path.RemoveAt(path.Count - 1);
+        }
+        return false;
     }
 
     // ── Message context menu handlers ────────────────────────────────────────

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -2070,7 +2070,7 @@ public partial class MainWindow : Window
         // that holds the current folder. Without this, F6 or Ctrl+2 quietly undid Collapse All
         // Folders (#590) the moment the user came back to look at the result. Going to a different
         // folder clears it, so the tree still reveals wherever the user navigates next.
-        if (ReferenceEquals(_collapsedWhileViewing, _vm.SelectedFolder) &&
+        if (IsStillCollapsedAround(_vm.SelectedFolder) &&
             FolderList.SelectedItem is FolderTreeNode shown &&
             FlattenVisibleFolderNodes(roots).Contains(shown))
             return SelectTreeViewNode(FolderList, shown, focusNode);
@@ -5813,7 +5813,16 @@ public partial class MainWindow : Window
 
     // The folder that was open when the user last collapsed something. Read by
     // SyncFolderTreeSelection to decide whether re-entering the tree may expand a path.
+    //
+    // Compared by identity rather than by object reference: RebuildFolderListFromCache re-resolves
+    // SelectedFolder against a freshly fetched folder list, so the very same mailbox arrives as a
+    // new MailFolderModel after any folder refresh. A reference comparison therefore stopped
+    // matching a few seconds after the collapse, and the branch re-opened after all.
     private MailFolderModel? _collapsedWhileViewing;
+
+    private bool IsStillCollapsedAround(MailFolderModel? folder) =>
+        _collapsedWhileViewing is { } collapsed && folder != null &&
+        TreeViewFocusHelper.FoldersMatch(collapsed, folder);
 
     private void FolderContextMenu_ExpandFolder_Click(object sender, RoutedEventArgs e)
         => SetFolderBranchExpanded(GetContextMenuFolderNode(sender), true, focusNode: true);
@@ -5871,14 +5880,25 @@ public partial class MainWindow : Window
         MainViewModel.SetFolderBranchExpanded(node, expanded);
         _collapsedWhileViewing = expanded ? null : _vm.SelectedFolder;
 
-        // No Announce here: the node keeps focus and the platform reports its own expanded state.
-        // The status bar still carries it for sighted users.
-        _vm.StatusText = $"'{node.Label}' {(expanded ? "expanded" : "collapsed")}.";
+        var outcome = $"'{node.Label}' {(expanded ? "expanded" : "collapsed")}.";
+        _vm.StatusText = outcome;
 
         if (focusNode)
+        {
+            // The node keeps focus and the platform reports its own expanded state, so announcing
+            // on top of that would say it twice.
             FocusTreeItem(FolderList, node);
-        else
-            KeepFolderSelectionVisible();
+            return;
+        }
+
+        KeepFolderSelectionVisible();
+
+        // Reached from the Folder menu or the Command Palette. If focus is not in the tree it never
+        // moves there, nothing has an expanded state to report, and the action would land in
+        // silence — the dead end this change exists to remove. Announce it ourselves in that case
+        // only; when focus is already in the tree the platform has it covered.
+        if (!FolderList.IsKeyboardFocusWithin)
+            AccessibilityHelper.Announce(this, outcome, category: AnnouncementCategory.Result);
     }
 
     // <paramref name="cameFrom"/> is the context-menu node when the action came from the tree, and

--- a/docs/KEYBOARD-SHORTCUTS.md
+++ b/docs/KEYBOARD-SHORTCUTS.md
@@ -66,6 +66,15 @@
 | *(unassigned)* | `view.density.comfortable` | Density: Comfortable |
 | *(unassigned)* | `view.density.compact` | Density: Compact |
 | *(unassigned)* | `view.rowFields` | Message List Fields… |
+| *(unassigned)* | `folder.expand` | Expand Folder — the selected folder and every subfolder in it |
+| *(unassigned)* | `folder.collapse` | Collapse Folder — the selected folder and every subfolder in it |
+| *(unassigned)* | `folder.expandAll` | Expand All Folders |
+| *(unassigned)* | `folder.collapseAll` | Collapse All Folders — account headers included |
+
+The folder tree's own Right and Left arrow keys expand and collapse one level. They are
+in-control navigation — the same kind as the arrow keys inside a list box — and are not registered
+commands. The four `folder.expand*` / `folder.collapse*` commands above are the bulk equivalents
+(#590): they act on the whole branch, or on the whole tree.
 
 ## Message List Fields Window
 

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -502,6 +502,27 @@ What each list matches is the text you would expect to hear first: the folder na
 
 The same typing works in the **Go to Folder** picker, in the address book's contact, group, and member lists, and in the [Message List Fields](#message-list-fields) window.
 
+### Expanding and Collapsing Folders
+
+Right and Left arrow still open and close one folder at a time, and that has not changed. What is new is four actions for doing it in bulk — useful when an account has folders nested several levels deep, or when several accounts have filled the tree.
+
+- **Expand Folder** opens the selected folder and everything inside it, all the way down, rather than one level.
+- **Collapse Folder** closes it and everything inside it, so the whole branch folds back to a single line.
+- **Expand All Folders** opens every folder in the tree.
+- **Collapse All Folders** closes everything, account headers included, leaving the tree as a short list of accounts.
+
+Each is reachable three ways:
+
+- Choose **Folder → Expand Folder**, **Collapse Folder**, **Expand All Folders**, or **Collapse All Folders** from the menu bar.
+- Press **Shift+F10** on the folder tree and choose it from the context menu. On a calendar the first two read **Expand Calendar** and **Collapse Calendar**; they do the same thing.
+- Open the Command Palette (**Ctrl+Shift+P**) and choose it there. None of the four has a shortcut key to begin with, so if you use one often, assign it your own in [Keyboard Customization](#keyboard-customization).
+
+The two "all folders" actions say what they did — "All folders collapsed" — because you can start them from the menu bar with focus anywhere. The two single-folder actions say nothing extra: the folder keeps focus and your screen reader reports its own expanded or collapsed state.
+
+If collapsing hides the folder you were on, the selection moves up to the nearest folder still showing rather than disappearing into a closed branch. Choosing Expand or Collapse Folder on a folder with nothing inside it says so instead of doing nothing.
+
+How you leave the tree is how you find it: a folder you collapse stays collapsed while QuickMail refreshes its folder list, and coming back to the tree with **F6** or **Ctrl+2** leaves it collapsed rather than re-opening the branch holding the folder you are reading. Go to a different folder and the tree opens up to show it again, as it always has. Expansion is not remembered between runs — QuickMail starts each account open, and opens whatever it needs to reach the folder it lands in.
+
 ### Creating Folders
 
 Create a new folder in any of these ways:
@@ -1847,7 +1868,7 @@ Every announcement is optional and controlled by the settings above. No custom s
 | `Shift+.` | Last message in group |
 | `Escape` | Close contact mail results (message list focus) |
 
-**Move to Folder…** and **Copy to Folder…** are available from the context menu (Shift+F10) or the command palette; they have no default keyboard shortcut. **Manage Themes**, **Next Theme**, **Previous Theme**, **Message List Fields…**, **Density: Comfortable**, **Density: Compact**, **Manage Flags…**, and **Report a Bug** likewise have no default key — reach them from the menus or the command palette, or assign a shortcut yourself in File → Settings → Keyboard Shortcuts.
+**Move to Folder…** and **Copy to Folder…** are available from the context menu (Shift+F10) or the command palette; they have no default keyboard shortcut. **Manage Themes**, **Next Theme**, **Previous Theme**, **Message List Fields…**, **Density: Comfortable**, **Density: Compact**, **Manage Flags…**, **Expand Folder**, **Collapse Folder**, **Expand All Folders**, **Collapse All Folders**, and **Report a Bug** likewise have no default key — reach them from the menus or the command palette, or assign a shortcut yourself in File → Settings → Keyboard Shortcuts.
 
 `Ctrl+1`, `Ctrl+2`, and `Ctrl+3` jump to a pane when no message tabs are open; with tabs open they select tab 1, 2, and 3 instead. **`Ctrl+Alt+1`, `Ctrl+Alt+2`, and `Ctrl+Alt+3` always** go to the account list, folder tree, and message list, whatever else is open. `Ctrl+0` moves to the toolbar.
 

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -517,7 +517,7 @@ Each is reachable three ways:
 - Press **Shift+F10** on the folder tree and choose it from the context menu. On a calendar the first two read **Expand Calendar** and **Collapse Calendar**; they do the same thing.
 - Open the Command Palette (**Ctrl+Shift+P**) and choose it there. None of the four has a shortcut key to begin with, so if you use one often, assign it your own in [Keyboard Customization](#keyboard-customization).
 
-The two "all folders" actions say what they did — "All folders collapsed" — because you can start them from the menu bar with focus anywhere. The two single-folder actions say nothing extra: the folder keeps focus and your screen reader reports its own expanded or collapsed state.
+The two "all folders" actions say what they did — "All folders collapsed" — because you can start them from the menu bar with focus anywhere. The two single-folder actions say nothing extra when you use the context menu: the folder keeps focus and your screen reader reports its own expanded or collapsed state. Started from the Folder menu or the Command Palette with focus outside the tree, where nothing is there to report it, they say what they did instead.
 
 If collapsing hides the folder you were on, the selection moves up to the nearest folder still showing rather than disappearing into a closed branch. Choosing Expand or Collapse Folder on a folder with nothing inside it says so instead of doing nothing.
 


### PR DESCRIPTION
Closes #590.

## What was reported

> I was in the folder tree and wanted to collapse all folders. There was no option to do so. … This should include being available on the context menu, the cmd list and a menu.

Right and Left arrow on a tree item were the app's only expansion controls, so a deeply nested account could only be folded away one item at a time.

## What this adds

Four actions, each reachable the three ways the issue asks for:

| Action | What it does |
|---|---|
| **Expand Folder** | Opens the selected folder and everything inside it, all the way down |
| **Collapse Folder** | Closes it and everything inside it — the branch folds to one line |
| **Expand All Folders** | Opens every folder in the tree |
| **Collapse All Folders** | Closes everything, account headers included |

Entry points: the folder tree's context menu (Shift+F10), the **Folder** menu on the menu bar, and the Command Palette — `folder.expand`, `folder.collapse`, `folder.expandAll`, `folder.collapseAll`, rebindable in keyboard customizations. No default keys: the arrow keys already own one-level expansion.

The single-folder actions act on the **whole branch**, not one level. One level is what the arrow keys already do; folding a folder with nested subfolders back to a single line has no keyboard equivalent at all.

Calendar nodes sit in the same tree but get their own context menu (#497), so they get the same four, worded for a calendar (**Expand Calendar** / **Collapse Calendar**).

## Three things had to change for the collapse to actually hold

1. **`BuildFolderTree` captured only the expanded nodes** and re-applied them additively. An account header is built expanded, so every account the user had collapsed sprang back open on the next folder refresh — Collapse All looked like it had silently failed a few seconds later. It now captures both directions and restores what it saw. (`ARebuiltTree_KeepsACollapsedAccountHeaderCollapsed` was verified to fail against the old code.)
2. **Re-entering the tree with F6 or Ctrl+2 re-expanded the path to the open folder**, undoing Collapse All the moment the user came back to look. That is now held back while the folder collapsed around is still the open one. Navigating to a different folder clears it, so the tree still reveals wherever the user goes next.
3. **Collapsing can hide the selected folder**, leaving a TreeView with no visible selection and the next arrow key starting from nowhere. The selection moves up to the deepest ancestor still on screen — and only takes focus with it when focus was already in the tree.

## Announcements

- The two whole-tree actions report their outcome ("All folders collapsed", `AnnouncementCategory.Result`) — they can be started from the menu bar with focus anywhere, and a tree folding away in silence is the same problem the issue reports.
- The two single-folder actions say nothing extra: the node keeps focus and the platform reports its own expanded state. They still write to the status bar.
- A leaf says why ("'Inbox' has nothing inside it to collapse") rather than doing nothing.

## Accessibility checklist

- `AutomationProperties.Name` on every new item is a short label, no role words, no sentences.
- Access keys checked for collisions in all three menus, and pinned by tests — WPF cycles between duplicates instead of invoking (#516).
- No new pane, so no F6 ring change.

## Tests

New `FolderExpansionTests` (plain) and `FolderExpansionMenuTests` (window-loading, in the `WpfTests` collection) — 21 tests covering branch semantics, headers, the rebuild regression, both context menus, the Folder menu, access-key uniqueness, and command registration.

`CalendarContextMenuTests` joins the `WpfTests` collection in the same change: it loads a real `MainWindow`, and two tests doing that at once race inside XAML loading — which showed up as a one-off failure while this branch was being built.

Full suite run locally with `--blame-hang`: **3132 passed, 3 skipped** (the opt-in synthesized-input tests). Two unrelated pre-existing flakes were seen once each across five runs — `CalendarContextMenuTests` (addressed above) and `LogServiceTests.Log_AfterDelete_RecreatesFile` (a temp-file lock, untouched by this change).

Not run: `scripts\ui-probe.ps1`. This change adds items to existing themed menus and introduces no style, layout, or theme resource — and the probe needs the author's own unlocked desktop session.

## Docs

- `docs/USER-GUIDE.md` — new **Expanding and Collapsing Folders** section under Main Window, plus the no-default-key list.
- `docs/KEYBOARD-SHORTCUTS.md` — the four command IDs, and a note that the tree's own arrow keys stay in-control navigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
