### PR TITLE
Release notes for 0.8.42, and the two guide gaps the release left behind

### DIFF
--- a/QuickMail/QuickMail.csproj
+++ b/QuickMail/QuickMail.csproj
@@ -15,9 +15,9 @@
          System.Windows(.Media) types this codebase uses unqualified (Point, Size, Color, Brush,
          Application, MessageBox, ...). -->
     <UseWindowsForms>true</UseWindowsForms>
-    <Version>0.8.41</Version>
-    <AssemblyVersion>0.8.41</AssemblyVersion>
-    <FileVersion>0.8.41</FileVersion>
+    <Version>0.8.42</Version>
+    <AssemblyVersion>0.8.42</AssemblyVersion>
+    <FileVersion>0.8.42</FileVersion>
     <!-- Velopack needs a hand-written Main that runs VelopackApp.Build().Run() before WPF
          initializes (install/update/uninstall hooks run and may exit the process). App.xaml
          therefore compiles as Page (no generated Main) and the entry point is declared here. -->

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -154,10 +154,12 @@ Press **New** in Manage Accounts. The Add Account dialog opens with focus on the
 2. Tab to **Email address** and type it. Leaving this field is also what starts the settings lookup for an address QuickMail does not already know; see [Automatic settings lookup](#automatic-settings-lookup).
 3. Tab to **Password** and enter it. Gmail, Yahoo Mail, and iCloud Mail all need an **app password** rather than your ordinary account password; QuickMail says so above the box and links to the page where you create one. Microsoft accounts have no password box at all — a **Sign in with Microsoft** button stands in its place.
 4. **Account name** and **Sender display name** are both optional. Leave the account name blank and the account is labelled with your email address, which is what most people want; give it a name when you have two accounts at the same provider. The sender display name is the name recipients see on messages you send.
-5. **Sync contacts from this account** and **Sync calendar from this account** appear for iCloud accounts and for accounts that sign in — Microsoft, and Gmail when you choose Google sign-in. Check them *before* signing in, so the permission is part of the same sign-in. (A Gmail account using an app password has no contact or calendar sync, so the boxes do not appear.)
+5. **Sync contacts from this account** and **Sync calendar from this account** appear for iCloud accounts and for accounts that sign in — Microsoft, and Gmail when you choose Google sign-in. Check them *before* signing in, so the permission can be part of the same sign-in. (A Gmail account using an app password has no contact or calendar sync, so the boxes do not appear.)
 6. Press **Add Account**.
 
-Server names, ports, and SSL settings are behind **Advanced settings**, an expander that stays closed unless you need it. Tab reaches its header before its contents, so one keystroke moves past the whole thing.
+Whether that permission really is part of the same sign-in depends on the account. Google sign-in folds it in, and so does a personal Outlook.com account set to connect over **Microsoft 365 (Graph)** — one screen lists mail, contacts, and calendar together. A work or school Microsoft account asks separately once the account is added, on purpose: organizations that restrict what their users may approve would turn one over-asking screen into a failed sign-in, and no account at all.
+
+Server names, ports, and SSL settings are behind **Advanced settings**, an expander that stays closed unless you need it. Tab reaches its header before its contents, so one keystroke moves past the whole thing. **Sign in with Microsoft** and **Sign in with Google** come last of all, after Advanced settings and everything inside it — signing in is the last thing you do, so it is the last thing you tab to. The same is true in Manage Accounts.
 
 If something required is missing, **Add Account** does not close the dialog. It says what is missing and moves focus to the field that needs attention — the email address, the password, or, when there are no server settings at all, the **IMAP host** with Advanced settings opened for you.
 
@@ -227,7 +229,7 @@ The result is announced and stays on screen as status text near the buttons. In 
 QuickMail signs in to Microsoft mailboxes rather than asking for a password — work or school **Microsoft 365 / Exchange Online** accounts and personal **Outlook.com / Hotmail / Live.com** accounts alike.
 
 1. In the Add Account dialog, set **Provider** to **Outlook.com / Microsoft 365** — or just type your address, which selects it for you. The password box disappears; Microsoft accounts sign in instead.
-2. Activate **Sign in with Microsoft**. A Microsoft sign-in window opens inside QuickMail. Sign in and approve the permissions QuickMail requests; the window closes itself and returns you to the dialog.
+2. Activate **Sign in with Microsoft** — the last tab stop in the dialog, after Advanced settings. A Microsoft sign-in window opens inside QuickMail. Sign in and approve the permissions QuickMail requests; the window closes itself and returns you to the dialog.
 3. Activate **Add Account**.
 
 Sign in as **the same address you typed** into the account. If the account you sign in with does not match, QuickMail warns you and keeps the address you entered rather than silently switching to a different mailbox — this matters most in organizations where an administrator signs in at the approval screen.

--- a/docs/release-notes-v0.8.42.md
+++ b/docs/release-notes-v0.8.42.md
@@ -1,0 +1,112 @@
+# QuickMail v0.8.42 Release Notes
+
+## New: expanding and collapsing folders
+
+Until now the only way to open or close a folder was Right and Left arrow on the folder itself, one
+level at a time. An account with folders nested several levels deep could only be folded away one
+item at a time, and there was no way at all to close the whole tree — which is what prompted this:
+*"I was in the folder tree and wanted to collapse all folders. There was no option to do so."*
+
+Four new actions:
+
+- **Expand Folder** opens the selected folder and everything inside it, all the way down.
+- **Collapse Folder** closes it and everything inside it, so a deeply nested branch folds back to a
+  single line.
+- **Expand All Folders** opens every folder in the tree.
+- **Collapse All Folders** closes everything, account headers included, leaving the tree as a short
+  list of accounts.
+
+The two single-folder actions deliberately act on the whole branch rather than one level, because
+one level is what Right and Left arrow already do — and those keep working exactly as before.
+
+Each is reachable three ways: from the new **Folder** menu items on the menu bar, from the folder
+tree's context menu (**Shift+F10**), and from the Command Palette (**Ctrl+Shift+P**). None of the
+four has a shortcut key to begin with; if you use one often, assign your own in **File → Settings →
+Keyboard Shortcuts**. On a calendar the first two read **Expand Calendar** and **Collapse Calendar**
+and do the same thing.
+
+Three details worth knowing:
+
+- **A collapse stays collapsed.** It survives QuickMail refreshing its folder list, and coming back
+  to the tree with **F6** or **Ctrl+2** no longer re-opens the branch holding the folder you are
+  reading. Go to a different folder and the tree opens up to show it again, as it always has.
+- **The selection never disappears into a closed branch.** If collapsing hides the folder you were
+  on, the selection moves up to the nearest folder still showing.
+- **The two "all folders" actions say what they did** — "All folders collapsed" — because you can
+  start them from the menu bar with focus anywhere. The single-folder ones stay quiet when you use
+  the context menu, where the folder keeps focus and your screen reader reports its own expanded or
+  collapsed state; started from the menu bar with focus elsewhere, where nothing would report it,
+  they say what they did instead.
+
+Expansion is not remembered between runs — QuickMail still starts with each account open.
+([#590](https://github.com/kellylford/QuickMail/issues/590))
+
+## Fixed: Microsoft 365 unread counts went stale until you refreshed
+
+On a Microsoft 365 account, the unread count beside a folder only changed when the whole folder list
+was fetched from the server again. Reading, deleting, or moving mail — including doing it inside
+QuickMail — left the number where it was for the rest of the session.
+
+That number is part of what a folder is called, so a stale count was not merely displayed: arrowing
+past the folder said "Newsletters, 3 unread" long after you had read all three. A manual **Refresh**
+was the only thing that put it right.
+
+The count now updates as the mail does, on Microsoft 365 accounts as it already did on IMAP ones.
+([#491](https://github.com/kellylford/QuickMail/issues/491))
+
+## Changed: Sign in is now the last thing you tab to
+
+In both **Add Account** and **Manage Accounts**, the **Sign in with Microsoft…** / **Sign in with
+Google…** button sat in the middle of the form — before **Advanced settings**. Signing in is the
+last thing you do when setting up or re-authenticating an account, so tabbing to it meant passing it
+on the way through the fields and coming back.
+
+The button is now the final tab stop in both dialogs, after Advanced settings and everything inside
+it. ([#584](https://github.com/kellylford/QuickMail/issues/584))
+
+## Changed: one permission screen instead of three, for a personal Microsoft account on Graph
+
+Adding a personal Outlook.com, Hotmail, or Live.com account with **Sync contacts** and **Sync
+calendar** checked asked for permission three separate times — mail, then contacts, then calendar.
+Cancelling any one of them left the account in a state that needed the checkbox switched off and
+back on to recover.
+
+The contact and calendar permissions are now folded into the mail sign-in, so one screen lists all
+three together. This applies when the account is set to connect over **Microsoft 365 (Graph)** —
+which you choose under **Advanced settings → Connection method**; a personal account left on the
+standard IMAP connection is unaffected. Work and school accounts are deliberately left as they were:
+on a tenant that restricts consent, asking for everything at once would end the whole sign-in rather
+than just the extra part, and the account would never be added at all.
+
+A related bug went with it: an account with only **Sync calendar** checked used to fall through to a
+plain mail sign-in and a separate calendar prompt. Either box now triggers the fold.
+([#544](https://github.com/kellylford/QuickMail/issues/544))
+
+---
+
+## Reporting Issues
+
+Found a problem or have a suggestion? There are three ways to reach us — pick the one that fits:
+
+1. **Report a Bug → Send** (Help menu, inside QuickMail). Files the report for you anonymously — it includes no email address or other identifying information, so there is no way to follow up with you. **Best when you don't want any follow-up.**
+2. **Report a Bug → Copy report and open GitHub** (Help menu). Opens a pre-filled issue that you submit under your own GitHub account, so your GitHub contact information is attached. **Best when you have a GitHub account and want automatic filing plus direct contact.**
+3. **Email** [quickmailissues@theideaplace.net](mailto:quickmailissues@theideaplace.net). **Best when you don't mind sending email and want a personal follow-up.**
+
+Full details, including exactly what a report contains (and what it never contains), are in the [Reporting Issues section of the User Guide](https://kellylford.github.io/QuickMail/reporting-issues.html).
+
+---
+
+## Download
+
+There are four downloads. Take a regular one unless you know your PC has an ARM processor — to check, open **Settings → System → About** and read **System type**.
+
+| Download | When to use |
+|----------|-------------|
+| [**QuickMail-0.8.42-win.msi**](https://github.com/kellylford/QuickMail/releases/download/v0.8.42/QuickMail-0.8.42-win.msi) — Windows installer | Recommended for most users. A standard setup wizard with license agreement; installs per-user with no elevation required, adds the WebView2 Runtime if missing, and enables automatic updates. |
+| [**QuickMail-0.8.42-win-arm64.msi**](https://github.com/kellylford/QuickMail/releases/download/v0.8.42/QuickMail-0.8.42-win-arm64.msi) — Windows installer, ARM | The same installer for PCs with an ARM processor, such as the Snapdragon X models of Surface Laptop and Surface Pro. |
+| [**QuickMail.exe**](https://github.com/kellylford/QuickMail/releases/download/v0.8.42/QuickMail.exe) — standalone portable executable | No installation required. Copy it anywhere and run. |
+| [**QuickMail-arm64.exe**](https://github.com/kellylford/QuickMail/releases/download/v0.8.42/QuickMail-arm64.exe) — standalone portable executable, ARM | The portable version for PCs with an ARM processor. |
+
+The regular downloads run on every supported PC, ARM ones included — just not as quickly there. The ARM downloads will not start at all on a non-ARM PC, so if you are unsure, the regular one is the safe guess.
+
+All downloads include the .NET 8 runtime — you do not need to install .NET separately.


### PR DESCRIPTION
Starts the 0.8.42 release notes, bumps the version, and closes two user-guide gaps that other 0.8.42 changes left open.

## Release notes — `docs/release-notes-v0.8.42.md`

Four user-facing changes on main since `v0.8.41`:

| Change | Issue |
|---|---|
| **New:** expanding and collapsing folders | [#590](https://github.com/kellylford/QuickMail/issues/590) |
| **Fixed:** Microsoft 365 unread counts went stale until you refreshed | [#491](https://github.com/kellylford/QuickMail/issues/491) |
| **Changed:** Sign in is now the last thing you tab to | [#584](https://github.com/kellylford/QuickMail/issues/584) |
| **Changed:** one permission screen instead of three, for a personal Microsoft account on Graph | [#544](https://github.com/kellylford/QuickMail/issues/544) |

**Deliberately left out:** the #529 Graph-default and IMAP→Graph convert work. `MicrosoftGraphDefault` and `MicrosoftGraphMigration` are both `false` in `ConfigFeatureGate`, so none of it reaches a user who has not opted in via `config.ini`. Say the word if you'd rather it were mentioned for testers.

Also left out: the test-infrastructure work (#583, #586–#589, #591) and the docs-only #552.

Section order follows the house rule — what's new, then Reporting Issues, then Download last, with every `X.Y.Z` in the Download footer replaced by `0.8.42`.

## User guide

Only #590 and #552 touched `docs/USER-GUIDE.md` since v0.8.41. Two of the other changes left the guide saying something that is now wrong:

- **Step 5 of Adding an account** told you to check Sync contacts / Sync calendar before signing in "so the permission is part of the same sign-in". After #544 that is true for Google and for a personal Outlook.com account connecting over **Microsoft 365 (Graph)** — and still not true for a work or school account, which is asked separately *on purpose*, because folding it in would end the whole sign-in on a tenant that restricts consent. The guide now says which is which and why.
- **Where Sign in sits in the dialog** is now stated, since #584 moved it to the last tab stop after Advanced settings.

#491 needs no guide change — the counts now behave the way the guide already implied.

## Version

`0.8.41` → `0.8.42` in `QuickMail.csproj` (`Version`, `AssemblyVersion`, `FileVersion`). Same pattern as the 0.8.41 bump, which landed in the first PR of its cycle rather than at tag time. The release workflow reads `docs/release-notes-${{ github.ref_name }}.md`, so the file name matches the `v0.8.42` tag exactly.

## Tests

Full suite with `--blame-hang` after the bump: **3134 passed, 3 skipped** (the opt-in synthesized-input tests).

## Before you tag

Publish the user guide — **Actions → Publish User Guide → Run workflow** — or let creating the release do it automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
