### PR TITLE
Give the app-password link its own tab index in Add Account

### DIFF
--- a/QuickMail.Tests/UnitTest1.cs
+++ b/QuickMail.Tests/UnitTest1.cs
@@ -191,13 +191,19 @@ public class ViewModelConstructionTests
 [Collection("WpfTests")]
 public class XamlParseTests
 {
-    /// Ensure Application.Current exists and has the app's resource dictionaries loaded —
-    /// required for StaticResource / DynamicResource resolution during XAML parsing.
-    /// Uses a process-wide lock so that parallel [StaFact] threads from different test
-    /// classes don't race to create a second Application (WPF forbids more than one).
-    /// <summary>Delegates to the shared host: the Application must live on a thread that outlives
-    /// the run, not on whichever [StaFact] thread happened to be first (issue #211).</summary>
-    private static void EnsureApplication() => WpfTestHost.EnsureApplication();
+    /// <summary>
+    /// The Application and the resource dictionaries StaticResource/DynamicResource need while the
+    /// XAML is parsed. The shared host owns it, on a thread that outlives the run rather than
+    /// whichever [StaFact] thread happened to be first (issue #211).
+    ///
+    /// ThemedControls is named explicitly, not left to whichever other suite happens to merge it
+    /// first: MainWindow's XAML resolves ListView's themed style, so parsing it fails with "Cannot
+    /// find resource named 'System.Windows.Controls.ListView'" whenever this class runs without
+    /// CalendarContextMenuTests or SelectorItemAccessibilityTests alongside it — which is what any
+    /// `dotnet test --filter` narrow enough to exclude them does.
+    /// </summary>
+    private static void EnsureApplication() =>
+        WpfTestHost.EnsureStyles("AccessibleStyles", "ThemedControls");
 
     private static void ParseXamlFile(string relativePathFromAssembly)
     {

--- a/QuickMail/Views/AddAccountDialog.xaml
+++ b/QuickMail/Views/AddAccountDialog.xaml
@@ -56,7 +56,13 @@
 
                     <!-- App-specific password warning, driven by the selected provider (Gmail, Yahoo,
                          iCloud). The same text is announced as a Hint when the provider changes, so it
-                         is deliberately not duplicated into any AutomationProperties.Name. -->
+                         is deliberately not duplicated into any AutomationProperties.Name.
+
+                         The link below carries TabIndex 3, its own: this form's indices run 0-7 with no
+                         duplicates. It used to share 2 with the password box above it, and the order
+                         still came out right only because WPF breaks a tie on declaration order — so
+                         the collision read as working and would have bitten the first time anything
+                         moved. Adding a control here means renumbering, not reusing an index. -->
                     <Border Visibility="{Binding ShowAppPasswordHint, Converter={StaticResource BoolToVisibility}}"
                             Background="{DynamicResource Theme.WarningBackground}"
                             BorderBrush="{DynamicResource Theme.Warning}"
@@ -68,7 +74,7 @@
                                        TextWrapping="Wrap"
                                        FontWeight="SemiBold"/>
                             <TextBlock Margin="0,4,0,0" TextWrapping="Wrap">
-                                <Hyperlink NavigateUri="{Binding AppPasswordUrl}" KeyboardNavigation.TabIndex="2"
+                                <Hyperlink NavigateUri="{Binding AppPasswordUrl}" KeyboardNavigation.TabIndex="3"
                                            RequestNavigate="AppPasswordLink_RequestNavigate"
                                            AutomationProperties.Name="Create an app password">
                                     <Run Text="{Binding AppPasswordUrl, Mode=OneWay}"/>
@@ -82,13 +88,13 @@
                 <TextBox x:Name="AccountNameBox"
                          Text="{Binding AccountName, UpdateSourceTrigger=PropertyChanged}"
                          AutomationProperties.LabeledBy="{Binding ElementName=LblAccountName}"
-                         TabIndex="3"/>
+                         TabIndex="4"/>
 
                 <Label x:Name="LblDisplayName" Content="Sender _display name:" Target="{Binding ElementName=DisplayNameBox}" Padding="0" Margin="0,8,0,2"/>
                 <TextBox x:Name="DisplayNameBox"
                          Text="{Binding DisplayName, UpdateSourceTrigger=PropertyChanged}"
                          AutomationProperties.LabeledBy="{Binding ElementName=LblDisplayName}"
-                         TabIndex="4"/>
+                         TabIndex="5"/>
 
                 <!-- Sync opt-ins stay on the main surface: they must be checked BEFORE sign-in so the
                      permission is part of the same consent (#256, #282). -->
@@ -97,14 +103,14 @@
                           Visibility="{Binding ShowContactSyncOption, Converter={StaticResource BoolToVisibility}}"
                           IsChecked="{Binding SyncContacts, Mode=TwoWay}"
                           AutomationProperties.Name="Sync contacts from this account"
-                          Margin="0,12,0,0" TabIndex="5"/>
+                          Margin="0,12,0,0" TabIndex="6"/>
 
                 <CheckBox x:Name="SyncCalendarCheckBox"
                           Content="Sync ca_lendar from this account"
                           Visibility="{Binding ShowCalendarSyncOption, Converter={StaticResource BoolToVisibility}}"
                           IsChecked="{Binding SyncCalendar, Mode=TwoWay}"
                           AutomationProperties.Name="Sync calendar from this account"
-                          Margin="0,6,0,0" TabIndex="6"/>
+                          Margin="0,6,0,0" TabIndex="7"/>
 
                 <!-- Everything a recognized provider already answers for the user. Collapsed unless
                      the provider is "Other" or discovery came back empty (VM.IsAdvancedExpanded). -->


### PR DESCRIPTION
The one product issue left over from today's test-infrastructure work.

## The collision

In `AddAccountDialog.xaml`, `PasswordBox` carried `TabIndex="2"` and the app-specific-password link carried `KeyboardNavigation.TabIndex="2"` as well.

The observed order was still correct — but only because WPF breaks a tie on declaration order and the link happens to be declared second. A collision that produces the right answer by accident reads as working, and bites the first time anything in that form moves. The sibling dialog had exactly this shape and was fixed in #582; this is the one that was left behind.

The form now runs **0–7 with no duplicates**: the link takes 3, and the four controls after it shift up one. Order on screen and under Tab is unchanged. `AddAccountTabOrderTests` walks the real focus traversal rather than the written values, so it pins the result.

## Also here: a filtered-run failure

`XamlParseTests.MainWindow_XamlParsesWithoutException` now asks for `ThemedControls` by name instead of relying on another suite having merged it first.

MainWindow's XAML resolves ListView's themed style, so parsing it failed with `Cannot find resource named 'System.Windows.Controls.ListView'` whenever the class ran without `CalendarContextMenuTests` or `SelectorItemAccessibilityTests` alongside it — which is any `dotnet test --filter` narrow enough to exclude them. That is the everyday case when working on one area, and it fails in a way that looks like a XAML regression rather than a missing dictionary.

I checked it against **unmodified main** before touching it: it reproduces there, so it is pre-existing rather than fallout from #589. #589 is simply what made it a one-line fix, since style merging is now centralised in `WpfTestHost`.

Full suite green: 3134 passed, 3 skipped.