### PR TITLE
Pin the Advanced-collapsed tab order for the sign-in button (#585 follow-up)

### DIFF
--- a/QuickMail.Tests/AccountManagerTabOrderTests.cs
+++ b/QuickMail.Tests/AccountManagerTabOrderTests.cs
@@ -209,4 +209,57 @@ public class AccountManagerTabOrderTests
         }
         finally { window.Close(); }
     }
+
+    /// <summary>
+    /// #584 follow-up (PR #585 review note 3): pins the common case — Advanced COLLAPSED. Its contents
+    /// are then not focusable, so the expander header is the only Advanced stop, and sign-in must still
+    /// sort after it (and after the main-surface fields), in both Tab and Shift+Tab directions.
+    /// </summary>
+    [StaFact]
+    public void OAuthSignInIsTheLastStop_WithAdvancedCollapsed()
+    {
+        var vm = NewVm(AuthType.OAuth2Microsoft);
+        var window = new AccountManagerDialog(vm)
+        {
+            WindowStyle = WindowStyle.None, ShowInTaskbar = false, ShowActivated = false,
+        };
+        window.Show();
+        try
+        {
+            vm.IsAdvancedExpanded = false;   // the common case: Advanced stays closed
+            window.UpdateLayout();
+            Drain();
+
+            var close = window.FindName("CloseButton") as Button;
+            Assert.NotNull(close);
+            const string SignIn = "Sign in with Microsoft";
+
+            TabOrderWalker.StartAt(window, close!, "Close");
+            var stops = TabOrderWalker.Walk(window);
+            var order = string.Join(" -> ", stops);
+            int At(string name) => stops.IndexOf(name);
+
+            Assert.True(At(SignIn) >= 0, $"sign-in button not reachable. Order: {order}");
+            Assert.True(At("HeaderSite") >= 0, $"expander header never reached. Order: {order}");
+            // Collapsed: no Advanced contents are tab stops...
+            Assert.True(At("SignatureBox") < 0, $"Advanced contents are reachable while collapsed. Order: {order}");
+            Assert.True(At("ImapHostBox") < 0, $"Advanced contents are reachable while collapsed. Order: {order}");
+            // ...and sign-in still sorts after the collapsed Advanced header and after the form fields.
+            Assert.True(At("UsernameBox") >= 0 && At("UsernameBox") < At(SignIn),
+                $"email field unreachable, or sign-in jumped above the form. Order: {order}");
+            Assert.True(At("HeaderSite") < At(SignIn), $"sign-in precedes the Advanced header. Order: {order}");
+
+            // Backward (Shift+Tab): from Close, going back reaches sign-in before the Advanced header.
+            TabOrderWalker.StartAt(window, close!, "Close");
+            var back = TabOrderWalker.WalkBackward(window);
+            var backOrder = string.Join(" -> ", back);
+            int BackAt(string name) => back.IndexOf(name);
+
+            Assert.True(BackAt(SignIn) >= 0, $"Shift+Tab never reached sign-in. Backward: {backOrder}");
+            Assert.True(BackAt("HeaderSite") >= 0, $"Shift+Tab never reached the Advanced header. Backward: {backOrder}");
+            Assert.True(BackAt(SignIn) < BackAt("HeaderSite"),
+                $"Shift+Tab reached the Advanced header before sign-in. Backward: {backOrder}");
+        }
+        finally { window.Close(); }
+    }
 }

--- a/QuickMail.Tests/AddAccountTabOrderTests.cs
+++ b/QuickMail.Tests/AddAccountTabOrderTests.cs
@@ -178,4 +178,61 @@ public class AddAccountTabOrderTests
         }
         finally { window.Close(); }
     }
+
+    /// <summary>
+    /// #584 follow-up (PR #585 review note 3): the common case is Advanced COLLAPSED. Its contents
+    /// are then not focusable, so the expander header is the only Advanced stop — sign-in must still
+    /// sort after it (and after the sync opt-ins), in both directions. The expanded case is pinned
+    /// above; this pins the case a user actually meets most of the time.
+    /// </summary>
+    [StaFact]
+    public void OAuthSignInIsTheLastStop_WithAdvancedCollapsed()
+    {
+        var vm = NewVm();
+        vm.SelectedProvider = new ProviderCatalog().All.First(p => p.Id == ProviderCatalog.MicrosoftId);
+        var window = new AddAccountDialog(vm)
+        {
+            WindowStyle = WindowStyle.None, ShowInTaskbar = false, ShowActivated = false,
+        };
+        window.Show();
+        try
+        {
+            vm.IsAdvancedExpanded = false;   // the common case: Advanced stays closed
+            window.UpdateLayout();
+            Drain();
+
+            var provider = (Control)window.FindName("ProviderComboBox");
+            const string SignIn = "Sign in with Microsoft";
+
+            TabOrderWalker.StartAt(window, provider, "ProviderComboBox");
+            var stops = WalkTabOrder(window);
+            var order = string.Join(" -> ", stops);
+            int At(string name) => stops.IndexOf(name);
+
+            Assert.True(At(SignIn) >= 0, $"sign-in button not reachable. Order: {order}");
+            Assert.True(At("HeaderSite") >= 0, $"expander header never reached. Order: {order}");
+            // Collapsed: the Advanced contents are not tab stops at all...
+            Assert.True(At("SignatureBox") < 0, $"Advanced contents are reachable while collapsed. Order: {order}");
+            Assert.True(At("ImapHostBox") < 0, $"Advanced contents are reachable while collapsed. Order: {order}");
+            // ...and sign-in still sorts after the collapsed Advanced header and after the sync opt-ins.
+            Assert.True(At("HeaderSite") < At(SignIn), $"sign-in precedes the Advanced header. Order: {order}");
+            Assert.True(At("SyncContactsCheckBox") >= 0 && At("SyncContactsCheckBox") < At(SignIn),
+                $"sync contacts opt-in is unreachable or falls after sign-in. Order: {order}");
+            Assert.True(At("SyncCalendarCheckBox") >= 0 && At("SyncCalendarCheckBox") < At(SignIn),
+                $"sync calendar opt-in is unreachable or falls after sign-in. Order: {order}");
+
+            // Backward (Shift+Tab): from Add, going back reaches sign-in before the Advanced header.
+            var add = (Control)window.FindName("AddButton");
+            TabOrderWalker.StartAt(window, add, "AddButton");
+            var back = TabOrderWalker.WalkBackward(window);
+            var backOrder = string.Join(" -> ", back);
+            int BackAt(string name) => back.IndexOf(name);
+
+            Assert.True(BackAt(SignIn) >= 0, $"Shift+Tab never reached sign-in. Backward: {backOrder}");
+            Assert.True(BackAt("HeaderSite") >= 0, $"Shift+Tab never reached the Advanced header. Backward: {backOrder}");
+            Assert.True(BackAt(SignIn) < BackAt("HeaderSite"),
+                $"Shift+Tab reached the Advanced header before sign-in. Backward: {backOrder}");
+        }
+        finally { window.Close(); }
+    }
 }


### PR DESCRIPTION
Follows up on #585's review. The tab-order tests added in #585 only walked the Add Account and Manage Accounts dialogs with **Advanced settings expanded**. Collapsed is the common case, and the #585 review flagged it as unpinned.

## What this adds

`OAuthSignInIsTheLastStop_WithAdvancedCollapsed` in both `AddAccountTabOrderTests` and `AccountManagerTabOrderTests`. With Advanced collapsed:

- The expander's contents are not tab stops — asserted directly (`SignatureBox` / `ImapHostBox` unreachable), which also confirms the collapse actually took effect.
- The expander **header** is then the only Advanced stop, and **sign-in still sorts after it** and after the main-surface fields (sync opt-ins in Add Account; the email field in Manage Accounts).
- Verified in **both** Tab and Shift+Tab directions (`WalkBackward`).

The collapsed and expanded tests mutually pin the two states: the expanded tests assert `SignatureBox >= 0`, the collapsed ones assert `SignatureBox < 0`, so neither can pass vacuously.

Test-only; no production code changes. All 8 tab-order tests pass; the failing case (sign-in before the expander) still fails these as intended. Independently reviewed before opening.
