### PR TITLE
Shared mailboxes PR 2: Graph read access (#31)

### DIFF
--- a/QuickMail.IntegrationTests/GraphApiTests.cs
+++ b/QuickMail.IntegrationTests/GraphApiTests.cs
@@ -144,6 +144,8 @@ internal sealed class FakeMicrosoftOAuthService : IOAuthService
         throw new NotSupportedException("Consent flows are not available in tests.");
     public Task RequestCalendarConsentAsync(AccountModel account, CancellationToken ct = default) =>
         throw new NotSupportedException("Consent flows are not available in tests.");
+    public Task RequestSharedMailboxConsentAsync(AccountModel parent, CancellationToken ct = default) =>
+        throw new NotSupportedException("Consent flows are not available in tests.");
     public Task SignOutAsync(AccountModel account) =>
         throw new NotSupportedException("Sign-out is not available in tests.");
 }

--- a/QuickMail.IntegrationTests/NoOpOAuthService.cs
+++ b/QuickMail.IntegrationTests/NoOpOAuthService.cs
@@ -21,5 +21,6 @@ internal sealed class NoOpOAuthService : IOAuthService
     public Task<OAuthResult> SignInInteractiveWithContactsAsync(AccountModel account, CancellationToken ct = default) => throw Fail();
     public Task RequestContactsConsentAsync(AccountModel account, CancellationToken ct = default) => throw Fail();
     public Task RequestCalendarConsentAsync(AccountModel account, CancellationToken ct = default) => throw Fail();
+    public Task RequestSharedMailboxConsentAsync(AccountModel parent, CancellationToken ct = default) => throw Fail();
     public Task SignOutAsync(AccountModel account) => throw Fail();
 }

--- a/QuickMail.Tests/AccountEditorSignInTests.cs
+++ b/QuickMail.Tests/AccountEditorSignInTests.cs
@@ -44,6 +44,7 @@ public class AccountEditorSignInTests
         public Task EnsureSilentTokenAsync(AccountModel account, CancellationToken ct = default) => Task.CompletedTask;
         public Task RequestContactsConsentAsync(AccountModel account, CancellationToken ct = default) => Task.CompletedTask;
         public Task RequestCalendarConsentAsync(AccountModel account, CancellationToken ct = default) => Task.CompletedTask;
+        public Task RequestSharedMailboxConsentAsync(AccountModel parent, CancellationToken ct = default) => Task.CompletedTask;
         public Task SignOutAsync(AccountModel account) => Task.CompletedTask;
     }
 

--- a/QuickMail.Tests/ContactSourceMappingTests.cs
+++ b/QuickMail.Tests/ContactSourceMappingTests.cs
@@ -81,6 +81,7 @@ public class ContactSourceMappingTests
         public Task<OAuthResult> SignInInteractiveWithContactsAsync(AccountModel account, CancellationToken ct = default) => Task.FromResult(new OAuthResult(string.Empty, string.Empty));
         public Task RequestContactsConsentAsync(AccountModel account, CancellationToken ct = default) => Task.CompletedTask;
         public Task RequestCalendarConsentAsync(AccountModel account, CancellationToken ct = default) => Task.CompletedTask;
+        public Task RequestSharedMailboxConsentAsync(AccountModel parent, CancellationToken ct = default) => Task.CompletedTask;
         public Task SignOutAsync(AccountModel account) => Task.CompletedTask;
     }
 

--- a/QuickMail.Tests/GraphCalendarSyncServiceTests.cs
+++ b/QuickMail.Tests/GraphCalendarSyncServiceTests.cs
@@ -89,6 +89,7 @@ public class GraphCalendarSyncServiceTests : IDisposable
         public Task<OAuthResult> SignInInteractiveWithContactsAsync(AccountModel account, CancellationToken ct = default) => Task.FromResult(new OAuthResult(string.Empty, string.Empty));
         public Task RequestContactsConsentAsync(AccountModel account, CancellationToken ct = default) => Task.CompletedTask;
         public Task RequestCalendarConsentAsync(AccountModel account, CancellationToken ct = default) => Task.CompletedTask;
+        public Task RequestSharedMailboxConsentAsync(AccountModel parent, CancellationToken ct = default) => Task.CompletedTask;
         public Task SignOutAsync(AccountModel account) => Task.CompletedTask;
     }
 

--- a/QuickMail.Tests/GraphChangeNotifierTests.cs
+++ b/QuickMail.Tests/GraphChangeNotifierTests.cs
@@ -83,6 +83,28 @@ public class GraphChangeNotifierTests : IDisposable
     }
 
     [Fact]
+    public async Task StartWatchers_SkipsSharedMailbox_SoNoPollLoopRuns() // #31 PR 2, spec §5.1
+    {
+        // A shared Graph mailbox is sweep-only: its .Shared scopes can't hold a change-notification
+        // subscription, so the notifier must never spin a delta-poll loop against it. If it did, the
+        // stub would record the first (immediate) delta request.
+        var handler = new StubHttpHandler(_ => (HttpStatusCode.OK, """{"value":[]}"""));
+        using var notifier = MakeNotifier(handler);
+
+        var shared = GraphAccount();
+        shared.IsShared = true;
+        shared.SharedAddress = "support@contoso.com";
+        shared.ParentAccountId = Guid.NewGuid();
+
+        notifier.StartWatchers(new[] { shared }, TestContext.Current.CancellationToken);
+
+        // Give any erroneously-started loop time to fire its immediate first request, then assert none did.
+        await Task.Delay(300, TestContext.Current.CancellationToken);
+        Assert.Empty(handler.Requests);
+        notifier.StopWatchers();
+    }
+
+    [Fact]
     public async Task FirstPoll_WithMessages_RaisesInboxNewMail_AndPersistsDeltaLink()
     {
         const string deltaLink = "https://graph.microsoft.com/v1.0/me/mailFolders/Inbox/messages/delta?$deltatoken=NEW";

--- a/QuickMail.Tests/GraphMailServiceTests.cs
+++ b/QuickMail.Tests/GraphMailServiceTests.cs
@@ -64,6 +64,38 @@ public class GraphMailServiceTests
         Assert.Equal("user@contoso.com", account.Username);
     }
 
+    private static AccountModel SharedGraphAccount() => new()
+    {
+        Id = Guid.NewGuid(),
+        Username = "support@contoso.com",
+        SharedAddress = "support@contoso.com",
+        IsShared = true,
+        ParentAccountId = Guid.NewGuid(),
+        BackendKind = BackendKind.MicrosoftGraph,   // stamped from the parent at add time
+    };
+
+    [Fact]
+    public async Task SharedMailbox_RoutesReadsToUsersEndpoint_NeverMe() // #31 PR 2
+    {
+        // Every folder/message read for a shared account must hit /users/{SharedAddress}, never /me —
+        // and ConnectAsync must NOT overwrite the shared address with a /me identity (the token belongs
+        // to the parent, so /me would be the parent UPN).
+        var (svc, handler) = Make(url =>
+            url.Contains("/messages")       ? (HttpStatusCode.OK, """{"value":[]}""")
+            : url.Contains("/mailFolders/") ? (HttpStatusCode.OK, """{"id":"wk"}""")   // Inbox probe + well-known
+            : (HttpStatusCode.OK, """{"value":[]}"""));                                 // folder list (empty)
+
+        var shared = SharedGraphAccount();
+        await svc.ConnectAsync(shared, ct: TestContext.Current.CancellationToken);
+        await svc.GetFoldersAsync(shared.Id, TestContext.Current.CancellationToken);
+        await svc.GetMessageSummariesAsync(shared.Id, "inbox-id", 50, TestContext.Current.CancellationToken);
+
+        Assert.NotEmpty(handler.Requests);
+        Assert.All(handler.Requests, url => Assert.DoesNotContain("/v1.0/me", url));   // no /me/ and no /me?
+        Assert.Contains(handler.Requests, url => url.Contains("/users/support@contoso.com/mailFolders"));
+        Assert.Equal("support@contoso.com", shared.Username);   // not clobbered by a /me identity read
+    }
+
     [Fact]
     public async Task GetFoldersAsync_MapsFolders_FollowsNextLink_AndFlagsSpecial()
     {

--- a/QuickMail.Tests/ImapConnectionInstrumentationTests.cs
+++ b/QuickMail.Tests/ImapConnectionInstrumentationTests.cs
@@ -201,6 +201,7 @@ public class ImapConnectionInstrumentationTests : IDisposable
         public Task<OAuthResult> SignInInteractiveWithContactsAsync(AccountModel a, CancellationToken ct = default) => throw Fail();
         public Task RequestContactsConsentAsync(AccountModel a, CancellationToken ct = default) => throw Fail();
         public Task RequestCalendarConsentAsync(AccountModel a, CancellationToken ct = default) => throw Fail();
+        public Task RequestSharedMailboxConsentAsync(AccountModel a, CancellationToken ct = default) => throw Fail();
         public Task SignOutAsync(AccountModel a) => throw Fail();
     }
 }

--- a/QuickMail.Tests/OAuthServiceScopeSelectionTests.cs
+++ b/QuickMail.Tests/OAuthServiceScopeSelectionTests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.IO;
 using Microsoft.Identity.Client;
 using QuickMail.Models;
 using QuickMail.Services;
@@ -89,6 +91,80 @@ public class OAuthServiceScopeSelectionTests
         // The personal-domain check applies only to the Graph backend; IMAP always gets IMAP scopes.
         var account = new AccountModel { BackendKind = BackendKind.ImapSmtp, Username = "me@outlook.com" };
         Assert.Same(OAuthService.ImapSmtpScopes, OAuthService.DefaultScopesFor(account));
+    }
+
+    [Fact]
+    public void GraphParentSharedMailbox_UsesSharedScope() // #31 PR 2
+    {
+        // A shared mailbox borrows its parent's token but requests the delegated .Shared scope against
+        // /users/{SharedAddress}. It is always work/school Graph (the Add-shared dialog excludes personal
+        // parents), and its BackendKind is stamped from the parent at creation.
+        var account = new AccountModel
+        {
+            BackendKind = BackendKind.MicrosoftGraph,
+            Username = "support@contoso.com",
+            SharedAddress = "support@contoso.com",
+            IsShared = true,
+        };
+        Assert.Same(OAuthService.GraphMailScopesShared, OAuthService.DefaultScopesFor(account));
+        Assert.Contains("https://graph.microsoft.com/Mail.ReadWrite.Shared", OAuthService.GraphMailScopesShared);
+        // Not the work/school set — a shared read never touches /me, so no User.Read etc.
+        Assert.DoesNotContain("https://graph.microsoft.com/User.Read", OAuthService.GraphMailScopesShared);
+    }
+
+    [Fact]
+    public void ImapParentSharedMailbox_StillUsesImapScopes() // #31 PR 2 — IMAP-parent shared is PR 3
+    {
+        // An IMAP-parent shared account (BackendKind ImapSmtp) is not a Graph read; it falls through to
+        // the IMAP scopes (PR 3 will use XOAUTH2 user=). The shared branch is Graph-only.
+        var account = new AccountModel
+        {
+            BackendKind = BackendKind.ImapSmtp,
+            Username = "support@example.com",
+            SharedAddress = "support@example.com",
+            IsShared = true,
+        };
+        Assert.Same(OAuthService.ImapSmtpScopes, OAuthService.DefaultScopesFor(account));
+    }
+
+    // ── Shared-mailbox token identity (#31 PR 2) ────────────────────────────────
+    // A credential-less shared mailbox has no MSAL entry of its own; every token lookup resolves to the
+    // PARENT account's cached sign-in. ResolveTokenIdentity is that single resolution point.
+
+    private static OAuthService NewOAuth() =>
+        new(new ProfileContext(Path.Combine(Path.GetTempPath(), "qm-oauth-" + Guid.NewGuid().ToString("N"))));
+
+    [Fact]
+    public void ResolveTokenIdentity_SharedAccount_ResolvesToParent()
+    {
+        var parent = new AccountModel { Id = Guid.NewGuid(), Username = "user@contoso.com" };
+        var oauth = NewOAuth();
+        oauth.ResolveAccount = id => id == parent.Id ? parent : null;
+
+        var shared = new AccountModel
+        {
+            IsShared = true, ParentAccountId = parent.Id, SharedAddress = "support@contoso.com",
+            BackendKind = BackendKind.MicrosoftGraph,
+        };
+
+        Assert.Same(parent, oauth.ResolveTokenIdentity(shared));   // borrows the parent's identity
+        Assert.Same(parent, oauth.ResolveTokenIdentity(parent));   // a normal account resolves to itself
+    }
+
+    [Fact]
+    public void ResolveTokenIdentity_SharedWithNoResolvableParent_Throws()
+    {
+        // Parent signed out / removed → surfaced as InteractiveSignInRequiredException, which
+        // ConnectOneAccountAsync turns into a disconnected shared account, never a silent empty state.
+        var oauth = NewOAuth();
+        oauth.ResolveAccount = _ => null;   // parent not found
+        var shared = new AccountModel
+        {
+            IsShared = true, ParentAccountId = Guid.NewGuid(), SharedAddress = "support@contoso.com",
+            BackendKind = BackendKind.MicrosoftGraph,
+        };
+
+        Assert.Throws<InteractiveSignInRequiredException>(() => oauth.ResolveTokenIdentity(shared));
     }
 
     [Fact]

--- a/QuickMail.Tests/ReconnectConditionTests.cs
+++ b/QuickMail.Tests/ReconnectConditionTests.cs
@@ -42,4 +42,24 @@ public class ReconnectConditionTests
         var result = MainViewModel.AccountsNeedingConnect([Acct(id)], _ => true, _ => false);
         Assert.Contains(result, a => a.Id == id);
     }
+
+    [Fact]
+    public void GraphParentSharedMailbox_IsConnected() // #31 PR 2
+    {
+        // A Graph-parent shared mailbox borrows the parent's token and reads /users/{SharedAddress}, so
+        // it now connects like any account (it was skipped in PR 1).
+        var id = Guid.NewGuid();
+        var shared = new AccountModel { Id = id, IsShared = true, BackendKind = BackendKind.MicrosoftGraph };
+        var result = MainViewModel.AccountsNeedingConnect([shared], _ => false, _ => false);
+        Assert.Contains(result, a => a.Id == id);
+    }
+
+    [Fact]
+    public void ImapParentSharedMailbox_IsNotConnected() // #31 — deferred to PR 3 (XOAUTH2 user=)
+    {
+        var id = Guid.NewGuid();
+        var shared = new AccountModel { Id = id, IsShared = true, BackendKind = BackendKind.ImapSmtp };
+        var result = MainViewModel.AccountsNeedingConnect([shared], _ => false, _ => false);
+        Assert.DoesNotContain(result, a => a.Id == id);
+    }
 }

--- a/QuickMail.Tests/SharedMailboxAggregateTests.cs
+++ b/QuickMail.Tests/SharedMailboxAggregateTests.cs
@@ -60,10 +60,10 @@ public class SharedMailboxAggregateTests
             [Normal(NormalId, "Work"), Shared(SharedId, ParentId, "Support")],
             new() { [NormalId] = [Inbox(NormalId)], [SharedId] = [sharedInbox] });
 
-        // Seed the shared account's folder cache (ConnectAllAccounts skips shared, so it would otherwise
-        // be absent and the TryGetValue guard — not the new IsShared guard — would do the excluding).
-        // With the cache populated, the exclusion can only come from `if (account.IsShared) continue;`,
-        // which is the line this test exists to pin (and the state PR 2 will actually be in).
+        // Ensure the shared account's folder cache is populated. From PR 2 a Graph-parent shared account
+        // is connected by ConnectAllAccountsAsync (above), which already caches its folders; this refresh
+        // is belt-and-suspenders. With the cache populated, the exclusion can only come from
+        // `if (account.IsShared) continue;` — the line this test exists to pin — not the TryGetValue guard.
         await vm.RefreshFolderListAsync(SharedId);
         Assert.NotEmpty(vm.FolderScopedAggregateSources(MainViewModel.AllInboxesFolder.FullName)); // sanity: cache is live
 
@@ -113,8 +113,9 @@ public class SharedMailboxAggregateTests
     [Fact]
     public async Task SharedAccount_HasOwnTopLevelTreeNode_WithSharedAccessibleName()
     {
-        // PR 1 reality: a shared account has no backend access yet, so it renders as a placeholder
-        // top-level node (no folders) — which must still carry the account id and the shared qualifier.
+        // No folders are seeded for the shared account here, so even though PR 2 now connects it,
+        // GetFoldersAsync returns nothing and it renders as a placeholder top-level node — which must
+        // still carry the account id and the shared qualifier.
         var vm = await MakeVmAsync([Shared(SharedId, ParentId, "Support")], new());
 
         var node = vm.FolderTree.FirstOrDefault(n => n.IsHeader && n.AccountId == SharedId);

--- a/QuickMail.Tests/SharedMailboxAggregateTests.cs
+++ b/QuickMail.Tests/SharedMailboxAggregateTests.cs
@@ -80,6 +80,25 @@ public class SharedMailboxAggregateTests
     }
 
     [Fact]
+    public async Task ResolveAccountById_TracksTheLiveAccountList() // #31 PR 2 — thread-safe token-resolver snapshot
+    {
+        // The shared-mailbox token resolver (App wires OAuthService.ResolveAccount to this) reads a
+        // snapshot rebuilt on every add/remove, so it never enumerates the UI-thread-owned collection off
+        // a background sweep thread. Pin that the snapshot actually tracks the list.
+        var vm = await MakeVmAsync(
+            [Normal(NormalId, "Work"), Shared(SharedId, ParentId, "Support")],
+            new() { [NormalId] = [Inbox(NormalId)], [SharedId] = [Inbox(SharedId)] });
+
+        Assert.Equal(NormalId, vm.ResolveAccountById(NormalId)?.Id);
+        Assert.Equal(SharedId, vm.ResolveAccountById(SharedId)?.Id);
+        Assert.Null(vm.ResolveAccountById(Guid.NewGuid()));   // unknown id → null, not a throw
+
+        // In-place removal updates the snapshot — the resolver must not resolve a removed account.
+        vm.Accounts.Remove(vm.Accounts.First(a => a.Id == NormalId));
+        Assert.Null(vm.ResolveAccountById(NormalId));
+    }
+
+    [Fact]
     public async Task MainWindowDelete_OfParent_CascadesSharedChildren()
     {
         // The main-window account context menu delete (MainViewModel) must cascade a parent's shared

--- a/QuickMail.Tests/SharedMailboxConsentTests.cs
+++ b/QuickMail.Tests/SharedMailboxConsentTests.cs
@@ -66,4 +66,34 @@ public class SharedMailboxConsentTests
         Assert.Contains(parent.Id, oauth.SharedConsentRequestedFor);
         Assert.Contains(vm.Accounts, a => a.Id == shared.Id);   // kept, not rolled back
     }
+
+    [Fact]
+    public async Task ImapParentSharedMailbox_DoesNotDriveGraphConsent() // #31 — IMAP-parent shared is PR 3
+    {
+        // The Add-shared dialog allows IMAP parents. A shared mailbox under one must NOT trigger the
+        // Microsoft Graph consent — that would pop a spurious Microsoft sign-in at a non-Microsoft
+        // account. It is added (disconnected until PR 3 wires XOAUTH2 access), with no consent request.
+        var oauth = new StubOAuthService();
+        var vm = new AccountManagerViewModel(
+            new StubAccountService(), new StubCredentialService(), new StubImapMailService(),
+            oauth, new StubLocalStoreService(), new StubConfigService(),
+            new StubFeatureGate(), new ProviderCatalog());
+        var imapParent = new AccountModel
+        {
+            Id = Guid.NewGuid(), AccountName = "Fastmail", Username = "me@fastmail.com",
+            BackendKind = BackendKind.ImapSmtp, AuthType = AuthType.Password,
+        };
+        vm.Accounts.Add(imapParent);
+        var shared = new AccountModel
+        {
+            Id = Guid.NewGuid(), AccountName = "team@fastmail.com", Username = "team@fastmail.com",
+            SharedAddress = "team@fastmail.com", IsShared = true, ParentAccountId = imapParent.Id,
+            BackendKind = imapParent.BackendKind,
+        };
+
+        await vm.CommitNewSharedMailboxAsync(shared);
+
+        Assert.Empty(oauth.SharedConsentRequestedFor);          // no Graph consent for an IMAP parent
+        Assert.Contains(vm.Accounts, a => a.Id == shared.Id);   // still added (disconnected until PR 3)
+    }
 }

--- a/QuickMail.Tests/SharedMailboxConsentTests.cs
+++ b/QuickMail.Tests/SharedMailboxConsentTests.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using QuickMail.Models;
+using QuickMail.Services;
+using QuickMail.ViewModels;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// #31 PR 2.5: adding a shared mailbox drives the one-time shared-mailbox consent on the PARENT account
+/// (Mail.ReadWrite.Shared + Mail.Send.Shared) — silent if already granted, otherwise the interactive
+/// Microsoft consent window. A declined / admin-approval-pending consent must NOT roll back the add nor
+/// throw: the mailbox is kept (added, and disconnected until consent lands), never a silent failure.
+/// </summary>
+public class SharedMailboxConsentTests
+{
+    private static (AccountManagerViewModel Vm, StubOAuthService Oauth, AccountModel Parent) Setup()
+    {
+        var oauth = new StubOAuthService();
+        var vm = new AccountManagerViewModel(
+            new StubAccountService(), new StubCredentialService(), new StubImapMailService(),
+            oauth, new StubLocalStoreService(), new StubConfigService(),
+            new StubFeatureGate(), new ProviderCatalog());
+        var parent = new AccountModel
+        {
+            Id = Guid.NewGuid(), AccountName = "Work", Username = "user@work.com",
+            BackendKind = BackendKind.MicrosoftGraph, AuthType = AuthType.OAuth2Microsoft,
+        };
+        vm.Accounts.Add(parent);
+        return (vm, oauth, parent);
+    }
+
+    private static AccountModel SharedUnder(AccountModel parent, string addr) => new()
+    {
+        Id = Guid.NewGuid(), AccountName = addr, Username = addr, SharedAddress = addr,
+        IsShared = true, ParentAccountId = parent.Id, BackendKind = parent.BackendKind,
+        AuthType = parent.AuthType,
+    };
+
+    [Fact]
+    public async Task AddingSharedMailbox_DrivesConsentOnTheParent()
+    {
+        var (vm, oauth, parent) = Setup();
+        var shared = SharedUnder(parent, "support@work.com");
+
+        await vm.CommitNewSharedMailboxAsync(shared);
+
+        Assert.Contains(parent.Id, oauth.SharedConsentRequestedFor);   // consent driven on the parent
+        Assert.Contains(vm.Accounts, a => a.Id == shared.Id);          // and the mailbox is added
+    }
+
+    [Fact]
+    public async Task ConsentDeclinedOrPending_KeepsTheMailbox_NoRollback_NoThrow()
+    {
+        var (vm, oauth, parent) = Setup();
+        // Simulate a decline / admin-approval-pending consent.
+        oauth.ThrowOnSharedMailboxConsent = new InvalidOperationException("admin approval required");
+        var shared = SharedUnder(parent, "support@work.com");
+
+        // Must not throw — a failed consent leaves the mailbox added (disconnected until consent lands),
+        // never rolls it back and never bubbles an exception out of the add.
+        await vm.CommitNewSharedMailboxAsync(shared);
+
+        Assert.Contains(parent.Id, oauth.SharedConsentRequestedFor);
+        Assert.Contains(vm.Accounts, a => a.Id == shared.Id);   // kept, not rolled back
+    }
+}

--- a/QuickMail.Tests/StubServices.cs
+++ b/QuickMail.Tests/StubServices.cs
@@ -201,6 +201,20 @@ sealed class StubOAuthService : IOAuthService
     private OAuthResult SignInResult() => new(string.Empty, SignInUsername ?? string.Empty, SignInIsPersonalAccount);
     public Task RequestContactsConsentAsync(AccountModel account, CancellationToken ct = default) => Task.CompletedTask;
     public Task RequestCalendarConsentAsync(AccountModel account, CancellationToken ct = default) => Task.CompletedTask;
+
+    /// <summary>Parent account ids RequestSharedMailboxConsentAsync was called for (#31) — lets a test
+    /// assert the add-shared flow drove consent on the parent.</summary>
+    public List<Guid> SharedConsentRequestedFor { get; } = [];
+    /// <summary>When set, RequestSharedMailboxConsentAsync throws it — to simulate a declined or
+    /// admin-approval-pending consent so a test can assert the shared mailbox is left disconnected.</summary>
+    public Exception? ThrowOnSharedMailboxConsent { get; set; }
+    public Task RequestSharedMailboxConsentAsync(AccountModel parent, CancellationToken ct = default)
+    {
+        SharedConsentRequestedFor.Add(parent.Id);
+        if (ThrowOnSharedMailboxConsent is { } ex) throw ex;
+        return Task.CompletedTask;
+    }
+
     public Task SignOutAsync(AccountModel account) => Task.CompletedTask;
 }
 

--- a/QuickMail.Tests/WatchedConversationsPhase2Tests.cs
+++ b/QuickMail.Tests/WatchedConversationsPhase2Tests.cs
@@ -514,6 +514,28 @@ public class WatchedConversationsPhase2Tests
     }
 
     [Fact]
+    public void SharedMailbox_ProducesNoToast_EvenWithNotificationsOn() // #31 PR 2, spec §4.1
+    {
+        // Now that shared accounts connect (PR 2), the #456 sweep delivers their inbox arrivals to the
+        // notify path. A shared mailbox is someone else's inbox you also watch, so it must not toast —
+        // the same incoming that produces two toasts for a normal account (test above) produces none.
+        var (vm, watch, toasts, _) = MakeNotifyVm();
+        watch.Watch("Budget Review");
+        var shared = new AccountModel
+        {
+            Id = Guid.NewGuid(), AccountName = "Support", Username = "support@example.com",
+            AuthType = AuthType.OAuth2Microsoft, IsShared = true, ParentAccountId = AccountA,
+            SharedAddress = "support@example.com", BackendKind = BackendKind.MicrosoftGraph,
+        };
+        var incoming = new[] { Msg("1", "Re: Budget Review"), Msg("2", "Something unrelated") };
+
+        vm.MaybeNotifyWatchedMail(shared, incoming);
+        vm.MaybeNotifyNewMail(shared, incoming);
+
+        Assert.Empty(toasts.Toasts);
+    }
+
+    [Fact]
     public void OrdinaryInboxMail_StillToastsNormally_AfterTheWatchedPathHasRun()
     {
         // The consumption trap: if the watched path were handed the whole incoming list it would

--- a/QuickMail/App.xaml.cs
+++ b/QuickMail/App.xaml.cs
@@ -494,6 +494,10 @@ public partial class App : Application
                 watchService: watchService,
                 folderViewState: folderViewState);
             mainVm.RegisterAccountBackend = a => { if (!probeMode) mailRouter.RegisterAccount(a.Id, BackendFor(a)); };
+            // #31: a credential-less shared mailbox borrows its parent account's token. Point the token
+            // resolver at the live account list (rebuilt from disk on every LoadAccountList) so a shared
+            // mailbox added at runtime resolves its parent without a restart.
+            msOAuthService.ResolveAccount = id => mainVm.Accounts.FirstOrDefault(a => a.Id == id);
             mainVm.ImmutableIdRebuildAnnouncePending = immutableIdRebuilt;   // #366 one-time re-sync notice
             // Registers/unregisters the Help command and shows or hides the menu item, and sets
             // ConnectionJournal.Enabled — so nothing records until the user opts in.

--- a/QuickMail/App.xaml.cs
+++ b/QuickMail/App.xaml.cs
@@ -494,10 +494,10 @@ public partial class App : Application
                 watchService: watchService,
                 folderViewState: folderViewState);
             mainVm.RegisterAccountBackend = a => { if (!probeMode) mailRouter.RegisterAccount(a.Id, BackendFor(a)); };
-            // #31: a credential-less shared mailbox borrows its parent account's token. Point the token
-            // resolver at the live account list (rebuilt from disk on every LoadAccountList) so a shared
-            // mailbox added at runtime resolves its parent without a restart.
-            msOAuthService.ResolveAccount = id => mainVm.Accounts.FirstOrDefault(a => a.Id == id);
+            // #31: a credential-less shared mailbox borrows its parent account's token. The resolver runs
+            // on background sweep threads, so it goes through ResolveAccountById — a thread-safe snapshot
+            // of the account list — never the UI-thread-owned Accounts collection directly.
+            msOAuthService.ResolveAccount = mainVm.ResolveAccountById;
             mainVm.ImmutableIdRebuildAnnouncePending = immutableIdRebuilt;   // #366 one-time re-sync notice
             // Registers/unregisters the Help command and shows or hides the menu item, and sets
             // ConnectionJournal.Enabled — so nothing records until the user opts in.

--- a/QuickMail/Services/Graph/GraphClient.cs
+++ b/QuickMail/Services/Graph/GraphClient.cs
@@ -259,11 +259,35 @@ public sealed class GraphClient : IDisposable
         AccountModel account, HttpMethod method, string pathOrUrl, Func<HttpContent>? contentFactory, CancellationToken ct)
         => SendAsync(account, method, pathOrUrl, contentFactory, null, silentOnly: false, headers: null, ct);
 
+    /// <summary>
+    /// #31: a shared mailbox is read through its parent's token but against the shared address's own
+    /// messages, so every <c>/me</c>-relative Graph path becomes <c>/users/{SharedAddress}</c>. Keeping
+    /// this rewrite in the one request funnel lets <see cref="GraphMailService"/> keep writing <c>/me</c>
+    /// everywhere. Only mail paths (<c>/users/{addr}/mailFolders…</c>, <c>/messages…</c>) are used for a
+    /// shared account — the parent's delegated <c>Mail.ReadWrite.Shared</c> covers those; the bare
+    /// <c>/users/{addr}</c> directory object is never requested (it would need a directory permission we
+    /// don't hold). Absolute follow-on URLs already point at the shared mailbox and never reach here.
+    /// </summary>
+    private static string ApplySharedRoot(AccountModel account, string path)
+    {
+        if (!account.IsShared) return path;
+        // Always rewrite for a shared account — never fall through to /me, which is the PARENT's mailbox.
+        // A missing SharedAddress is an upstream bug (the add dialog requires one); it yields /users// and
+        // a clean 404 → disconnected, which is far safer than silently reading the parent's mail here.
+        if (path.Equals("/me", StringComparison.Ordinal)
+            || path.StartsWith("/me/", StringComparison.Ordinal)
+            || path.StartsWith("/me?", StringComparison.Ordinal))
+            return $"/users/{account.SharedAddress}" + path["/me".Length..];
+        return path;
+    }
+
     private async Task<HttpResponseMessage> SendAsync(
         AccountModel account, HttpMethod method, string pathOrUrl, Func<HttpContent>? contentFactory, string[]? scopes, bool silentOnly,
         IReadOnlyDictionary<string, string>? headers, CancellationToken ct)
     {
-        var url = pathOrUrl.StartsWith("http", StringComparison.OrdinalIgnoreCase) ? pathOrUrl : _baseUrl + pathOrUrl;
+        var url = pathOrUrl.StartsWith("http", StringComparison.OrdinalIgnoreCase)
+            ? pathOrUrl                              // absolute @odata.nextLink — already the right mailbox
+            : _baseUrl + ApplySharedRoot(account, pathOrUrl);
 
         // Up to 3 attempts to ride out HTTP 429 throttling.
         for (int attempt = 0; ; attempt++)

--- a/QuickMail/Services/GraphChangeNotifier.cs
+++ b/QuickMail/Services/GraphChangeNotifier.cs
@@ -42,7 +42,11 @@ public sealed class GraphChangeNotifier : IChangeNotifier, IDisposable
         StopWatchers();
         _cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
 
-        foreach (var account in accounts.Where(a => a.BackendKind == BackendKind.MicrosoftGraph))
+        // #31: never poll a shared mailbox. Its delegated .Shared scopes can't hold a change-notification
+        // subscription and delta over them is out of scope, so a shared Graph mailbox is sweep-only
+        // (spec §5.1). WireUpWatchers already excludes shared accounts from the set it passes; this
+        // boundary guard keeps the notifier from ever spinning a poll loop against one regardless.
+        foreach (var account in accounts.Where(a => a.BackendKind == BackendKind.MicrosoftGraph && !a.IsShared))
         {
             var captured = account;
             _watchers[captured.Id] = Task.Run(() => PollLoopAsync(captured, _cts.Token), _cts.Token);

--- a/QuickMail/Services/GraphMailService.cs
+++ b/QuickMail/Services/GraphMailService.cs
@@ -56,13 +56,29 @@ public class GraphMailService : IMailService, IConnectionProbe
     // ── Connect ────────────────────────────────────────────────────────────────────
     public async Task ConnectAsync(AccountModel account, string? password = null, CancellationToken ct = default)
     {
-        var me = await _client.GetAsync<GraphMe>(account, "/me?$select=id,userPrincipalName", ct);
-        if (string.IsNullOrEmpty(me?.UserPrincipalName))
-            throw new InvalidOperationException("Graph /me returned no userPrincipalName.");
-        if (!string.Equals(account.Username, me.UserPrincipalName, StringComparison.OrdinalIgnoreCase))
+        if (account.IsShared)
         {
-            LogService.Log($"GraphMailService: token UPN {me.UserPrincipalName} differs from account.Username {account.Username}; updating.");
-            account.Username = me.UserPrincipalName;
+            // #31: a shared mailbox has no /me identity of its own — its token is the parent's, and the
+            // bare /users/{address} directory object needs a permission we don't hold. So skip the
+            // identity reconciliation (Username is already the shared address, fixed at add time) and
+            // probe a MAIL endpoint instead. This proves the .Shared grant and the address are good, and
+            // FAILS the connect (→ disconnected, surfaced) rather than returning an empty mailbox — the
+            // well-known folder resolve below swallows per-folder errors, so it can't be the check.
+            _ = await _client.GetAsync<GraphMailFolder>(account, "/me/mailFolders/Inbox?$select=id", ct)
+                ?? throw new InvalidOperationException(
+                    $"Shared mailbox '{account.SharedAddress}' returned no Inbox — check that access is " +
+                    "granted and the address is correct.");
+        }
+        else
+        {
+            var me = await _client.GetAsync<GraphMe>(account, "/me?$select=id,userPrincipalName", ct);
+            if (string.IsNullOrEmpty(me?.UserPrincipalName))
+                throw new InvalidOperationException("Graph /me returned no userPrincipalName.");
+            if (!string.Equals(account.Username, me.UserPrincipalName, StringComparison.OrdinalIgnoreCase))
+            {
+                LogService.Log($"GraphMailService: token UPN {me.UserPrincipalName} differs from account.Username {account.Username}; updating.");
+                account.Username = me.UserPrincipalName;
+            }
         }
         var wellKnown = await ResolveWellKnownFolderIdsAsync(account, ct);
 

--- a/QuickMail/Services/IOAuthService.cs
+++ b/QuickMail/Services/IOAuthService.cs
@@ -76,5 +76,15 @@ public interface IOAuthService
     /// </summary>
     Task RequestCalendarConsentAsync(AccountModel account, CancellationToken ct = default);
 
+    /// <summary>
+    /// #31: ensures the PARENT account has consented to the shared-mailbox scopes
+    /// (<c>Mail.ReadWrite.Shared</c> + <c>Mail.Send.Shared</c>) so a shared mailbox can be read (and,
+    /// from PR 4, sent as) through its token. Silent when already granted (e.g. admin-consented);
+    /// otherwise opens the interactive Microsoft consent window. Throws if consent is declined or
+    /// pending admin approval — the caller then leaves the shared mailbox added but disconnected. Call
+    /// from a foreground user action only (adding a shared mailbox, or an explicit reconnect).
+    /// </summary>
+    Task RequestSharedMailboxConsentAsync(AccountModel parent, CancellationToken ct = default);
+
     Task SignOutAsync(AccountModel account);
 }

--- a/QuickMail/Services/OAuthRouter.cs
+++ b/QuickMail/Services/OAuthRouter.cs
@@ -93,8 +93,10 @@ public class OAuthRouter : IOAuthService
             : _microsoft.RequestCalendarConsentAsync(account, ct);
     }
 
-    // #31: shared mailboxes are a Microsoft-only, work/school-only feature — the parent is always a
-    // Microsoft Graph account, so this always routes to the Microsoft implementation.
+    // #31: shared-mailbox consent is a Microsoft Graph flow (Mail.ReadWrite.Shared / Mail.Send.Shared).
+    // Callers drive it only for a Graph parent (CommitNewSharedMailboxAsync gates on BackendKind — an
+    // IMAP-parent shared mailbox is PR 3 and must not trigger a Graph sign-in), so it routes to the
+    // Microsoft implementation. There is no Google/IMAP equivalent.
     public Task RequestSharedMailboxConsentAsync(AccountModel parent, CancellationToken ct = default)
         => _microsoft.RequestSharedMailboxConsentAsync(parent, ct);
 

--- a/QuickMail/Services/OAuthRouter.cs
+++ b/QuickMail/Services/OAuthRouter.cs
@@ -93,6 +93,11 @@ public class OAuthRouter : IOAuthService
             : _microsoft.RequestCalendarConsentAsync(account, ct);
     }
 
+    // #31: shared mailboxes are a Microsoft-only, work/school-only feature — the parent is always a
+    // Microsoft Graph account, so this always routes to the Microsoft implementation.
+    public Task RequestSharedMailboxConsentAsync(AccountModel parent, CancellationToken ct = default)
+        => _microsoft.RequestSharedMailboxConsentAsync(parent, ct);
+
     public Task SignOutAsync(AccountModel account)
     {
         return account.AuthType == AuthType.OAuth2Google

--- a/QuickMail/Services/OAuthService.cs
+++ b/QuickMail/Services/OAuthService.cs
@@ -69,6 +69,19 @@ public class OAuthService : IOAuthService
         "https://graph.microsoft.com/User.Read",                  // /me profile read (GraphMailService)
     ];
 
+    // Shared mailboxes (#31, PR 2): a shared mailbox reads through its PARENT work/school account's
+    // token, but against the shared address's messages (/users/{SharedAddress}/…), which needs the
+    // delegated *.Shared* permission — Mail.ReadWrite.Shared covers read, mark-read, and (PR 3+) move.
+    // WORK/SCHOOL ONLY: personal Microsoft accounts have no Exchange shared mailboxes, and the Add-shared
+    // dialog already excludes personal parents. Like the work/school scopes above, this is hand-maintained
+    // AND must be declared on the app registration (delegated Mail.ReadWrite.Shared) or the call 403s at
+    // runtime — see docs/ENTRA-APP-REGISTRATION.md and #31. Mail.Send.Shared (send-as) is PR 4, not here.
+    // No /me is ever called on the shared path, so User.Read is deliberately absent.
+    public static readonly string[] GraphMailScopesShared =
+    [
+        "https://graph.microsoft.com/Mail.ReadWrite.Shared",
+    ];
+
     // Personal Microsoft accounts (Outlook.com/Hotmail/Live): `.default` under-delivers for MSA,
     // because personal accounts have no admin-consent model — `.default` returns only the permissions
     // the user already consented to, which came back read-only (delete/move → 403 ErrorAccessDenied,
@@ -144,6 +157,12 @@ public class OAuthService : IOAuthService
 
     internal static string[] DefaultScopesFor(AccountModel account)
     {
+        // A Graph-parent shared mailbox (#31) borrows its parent's token but requests the .Shared scope
+        // against /users/{SharedAddress}. It is always work/school (the Add-shared dialog excludes
+        // personal parents). An IMAP-parent shared account falls through to ImapSmtpScopes (PR 3, XOAUTH2
+        // user=), the same as any IMAP account.
+        if (account.IsShared && account.BackendKind == BackendKind.MicrosoftGraph)
+            return GraphMailScopesShared;
         if (account.BackendKind != BackendKind.MicrosoftGraph)
             return ImapSmtpScopes;
         // Both personal and work/school use explicit Graph scopes — personal for write access (#217),
@@ -229,22 +248,48 @@ public class OAuthService : IOAuthService
         LogService.Log("OAuthService: token cache registered.");
     }
 
+    /// <summary>
+    /// Looks up a live <see cref="AccountModel"/> by id. Set once at startup to
+    /// <c>mainVm.Accounts</c> (the authoritative, disk-rebuilt list) so a shared mailbox added at
+    /// runtime resolves its parent without a restart. Used only by <see cref="ResolveTokenIdentity"/>;
+    /// left null in tests that don't exercise the shared path.
+    /// </summary>
+    public Func<Guid, AccountModel?>? ResolveAccount { get; set; }
+
+    /// <summary>
+    /// The Microsoft identity whose cached sign-in backs this account's token. For a normal account
+    /// that is the account itself; for a credential-less shared mailbox (#31) it is the PARENT account,
+    /// whose token is borrowed to read <c>/users/{SharedAddress}</c> with the <c>.Shared</c> scope. A
+    /// shared account has no MSAL entry of its own, so every MSAL identity lookup must go through here.
+    /// Throws <see cref="InteractiveSignInRequiredException"/> — surfaced as "disconnected" by
+    /// <c>ConnectOneAccountAsync</c>, never a silent empty state — when the parent can't be resolved.
+    /// </summary>
+    internal AccountModel ResolveTokenIdentity(AccountModel account)
+    {
+        if (!account.IsShared) return account;
+        if (account.ParentAccountId is { } pid && ResolveAccount?.Invoke(pid) is { } parent)
+            return parent;
+        throw new InteractiveSignInRequiredException(
+            $"Shared mailbox '{account.SharedAddress}' has no signed-in parent account.");
+    }
+
     public Task<string> GetAccessTokenAsync(AccountModel account, CancellationToken ct = default)
         => GetAccessTokenAsync(account, DefaultScopesFor(account), ct);
 
     public async Task<string> GetAccessTokenAsync(AccountModel account, string[] scopes, CancellationToken ct = default)
     {
         await EnsureTokenCacheAsync();
+        var identity = ResolveTokenIdentity(account);   // #31: a shared mailbox borrows its parent's token
         var msalAccounts = await _msal.GetAccountsAsync();
         var msalAccount  = msalAccounts.FirstOrDefault(a =>
-            string.Equals(a.Username, account.Username, StringComparison.OrdinalIgnoreCase));
+            string.Equals(a.Username, identity.Username, StringComparison.OrdinalIgnoreCase));
 
         if (msalAccount is not null)
         {
             try
             {
                 var silent = await _msal.AcquireTokenSilent(scopes, msalAccount).ExecuteAsync(ct);
-                LogService.Log($"OAuthService: silent token acquired for {account.Username}");
+                LogService.Log($"OAuthService: silent token acquired for {identity.Username}");
                 return silent.AccessToken;
             }
             catch (MsalUiRequiredException)
@@ -253,6 +298,13 @@ public class OAuthService : IOAuthService
             }
         }
 
+        // A shared mailbox (#31) never drives its own interactive sign-in: it has no MSAL entry, and a
+        // background read (the #456 sweep) must not spawn a sign-in window. When the parent's token isn't
+        // silently available the shared mailbox is simply disconnected, surfaced by the caller.
+        if (account.IsShared)
+            throw new InteractiveSignInRequiredException(
+                $"Shared mailbox '{account.SharedAddress}' is disconnected — sign in to its parent account.");
+
         var result = await SignInInteractiveAsync(account, scopes, ct);
         return result.AccessToken;
     }
@@ -260,12 +312,13 @@ public class OAuthService : IOAuthService
     public async Task<string> GetAccessTokenSilentAsync(AccountModel account, string[] scopes, CancellationToken ct = default)
     {
         await EnsureTokenCacheAsync();
+        var identity = ResolveTokenIdentity(account);   // #31: shared mailbox → parent's cached sign-in
         var msalAccounts = await _msal.GetAccountsAsync();
         var msalAccount  = msalAccounts.FirstOrDefault(a =>
-            string.Equals(a.Username, account.Username, StringComparison.OrdinalIgnoreCase));
+            string.Equals(a.Username, identity.Username, StringComparison.OrdinalIgnoreCase));
 
         if (msalAccount is null)
-            throw new InteractiveSignInRequiredException($"No cached sign-in for {account.Username}.");
+            throw new InteractiveSignInRequiredException($"No cached sign-in for {identity.Username}.");
 
         try
         {
@@ -283,13 +336,14 @@ public class OAuthService : IOAuthService
     public async Task EnsureSilentTokenAsync(AccountModel account, CancellationToken ct = default)
     {
         await EnsureTokenCacheAsync();
+        var identity = ResolveTokenIdentity(account);   // #31: shared mailbox → parent's cached sign-in
         var msalAccounts = await _msal.GetAccountsAsync();
         var msalAccount  = msalAccounts.FirstOrDefault(a =>
-            string.Equals(a.Username, account.Username, StringComparison.OrdinalIgnoreCase));
+            string.Equals(a.Username, identity.Username, StringComparison.OrdinalIgnoreCase));
 
         // No cached account at all → the only way to a token is interactive.
         if (msalAccount is null)
-            throw new InteractiveSignInRequiredException($"No cached sign-in for {account.Username}.");
+            throw new InteractiveSignInRequiredException($"No cached sign-in for {identity.Username}.");
 
         try
         {

--- a/QuickMail/Services/OAuthService.cs
+++ b/QuickMail/Services/OAuthService.cs
@@ -82,6 +82,17 @@ public class OAuthService : IOAuthService
         "https://graph.microsoft.com/Mail.ReadWrite.Shared",
     ];
 
+    // The scopes CONSENTED when a shared mailbox is added (RequestSharedMailboxConsentAsync). Read AND
+    // send together, so the one consent covers PR 2 (read) and PR 4 (send-as) — the user is never
+    // re-prompted when sending ships. Both are declared on the app registration (Kelly). The ongoing
+    // read path still requests only GraphMailScopesShared; this wider set exists purely to drive the
+    // one-time consent up front.
+    public static readonly string[] GraphSharedMailboxConsentScopes =
+    [
+        "https://graph.microsoft.com/Mail.ReadWrite.Shared",
+        "https://graph.microsoft.com/Mail.Send.Shared",
+    ];
+
     // Personal Microsoft accounts (Outlook.com/Hotmail/Live): `.default` under-delivers for MSA,
     // because personal accounts have no admin-consent model — `.default` returns only the permissions
     // the user already consented to, which came back read-only (delete/move → 403 ErrorAccessDenied,
@@ -485,6 +496,19 @@ public class OAuthService : IOAuthService
         // grant now lives in the MSAL cache, so later silent acquisition (including background sync)
         // succeeds without another prompt.
         await GetAccessTokenAsync(account, GraphContactScopes, ct);
+    }
+
+    public async Task RequestSharedMailboxConsentAsync(AccountModel parent, CancellationToken ct = default)
+    {
+        // #31: the one-time consent that lets a shared mailbox be read (and, from PR 4, sent as) through
+        // this PARENT account's token. Acquiring a token for the .Shared scopes drives it — silent if the
+        // grant already exists (e.g. the tenant admin-consented), otherwise the real Microsoft consent
+        // window, where the user consents, an admin grants for the org, or it is declined/pending. The
+        // token is discarded; the grant now lives in the MSAL cache, so the shared account's later silent
+        // acquisition succeeds. Runs on the PARENT (not IsShared), so the interactive fallback is allowed —
+        // a shared account is silent-only and would throw instead of prompting. A decline/pending consent
+        // throws MsalException up to the caller, which leaves the shared mailbox added-but-disconnected.
+        await GetAccessTokenAsync(parent, GraphSharedMailboxConsentScopes, ct);
     }
 
     public async Task RequestCalendarConsentAsync(AccountModel account, CancellationToken ct = default)

--- a/QuickMail/Services/ProbeOfflineServices.cs
+++ b/QuickMail/Services/ProbeOfflineServices.cs
@@ -74,5 +74,6 @@ public sealed class ProbeOfflineOAuthService : IOAuthService
     public Task<OAuthResult> SignInInteractiveWithContactsAsync(AccountModel account, CancellationToken ct = default) => Task.FromException<OAuthResult>(Refused());
     public Task RequestContactsConsentAsync(AccountModel account, CancellationToken ct = default) => Task.FromException(Refused());
     public Task RequestCalendarConsentAsync(AccountModel account, CancellationToken ct = default) => Task.FromException(Refused());
+    public Task RequestSharedMailboxConsentAsync(AccountModel parent, CancellationToken ct = default) => Task.FromException(Refused());
     public Task SignOutAsync(AccountModel account) => Task.FromException(Refused());
 }

--- a/QuickMail/ViewModels/AccountManagerViewModel.cs
+++ b/QuickMail/ViewModels/AccountManagerViewModel.cs
@@ -635,8 +635,11 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
         // window reconnects. On failure it stays added but DISCONNECTED (surfaced by its accessible
         // name, per PR 1), self-healing on a later connect once consent lands. Consent is never allowed
         // to roll back the add, and never a silent data loss.
+        // Shared-mailbox consent is a Microsoft Graph flow. An IMAP-parent shared mailbox (PR 3, XOAUTH2)
+        // must NOT trigger a Graph consent — that would pop a spurious Microsoft sign-in window at a
+        // non-Microsoft account. It is added here and stays disconnected until PR 3 wires its access.
         var parent = Accounts.FirstOrDefault(a => a.Id == sharedMailbox.ParentAccountId);
-        if (parent is null) return;
+        if (parent is null || parent.BackendKind != BackendKind.MicrosoftGraph) return;
         try
         {
             await _oauth.RequestSharedMailboxConsentAsync(parent);
@@ -644,10 +647,11 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
         catch (Exception ex)
         {
             // Declined / admin-approval pending / offline: the interactive window already showed the
-            // user what was needed; the disconnected state carries it from here.
+            // user what was needed; the disconnected state carries it from here. Log the message too —
+            // for a pending-approval case it is the actionable detail.
             LogService.Log($"Shared mailbox '{sharedMailbox.SharedAddress}': consent not granted on parent " +
-                           $"'{parent.AccountLabel}' ({ex.GetType().Name}); it will stay disconnected until " +
-                           "access is granted.");
+                           $"'{parent.AccountLabel}' ({ex.GetType().Name}: {ex.Message}); it will stay " +
+                           "disconnected until access is granted.");
         }
     }
 

--- a/QuickMail/ViewModels/AccountManagerViewModel.cs
+++ b/QuickMail/ViewModels/AccountManagerViewModel.cs
@@ -616,9 +616,10 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
         new(Accounts, SelectedAccount?.Id);
 
     /// <summary>Adds a created shared mailbox to the list and persists it — no credentials to save (it
-    /// reads through its parent). The dialog closes on success; the manager's close refreshes the main
-    /// window, which registers the backend and shows the new top-level node.</summary>
-    public void CommitNewSharedMailbox(AccountModel sharedMailbox)
+    /// reads through its parent) — then drives the one-time shared-mailbox consent on the parent. The
+    /// manager's close refreshes the main window, which registers the backend and connects the mailbox
+    /// (silently, using the consent obtained here). Consent failure never rolls back the add.</summary>
+    public async Task CommitNewSharedMailboxAsync(AccountModel sharedMailbox)
     {
         Accounts.Add(sharedMailbox);
         SaveAccountsPreservingConversionMarkers();
@@ -626,6 +627,28 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
         // Result, not Status: the add succeeded and the add window has already closed, so this is the
         // only feedback — it must be spoken even for a user who has AnnounceStatus off (#396 pattern).
         SetStatusOutcome("Shared mailbox added.");
+
+        // #31: drive the one-time shared-mailbox consent on the PARENT now — silent if already granted
+        // (e.g. admin-consented), otherwise the real Microsoft consent window, where the user consents,
+        // an admin grants for the org, or it is declined / pending admin approval. On success the grant
+        // lands in the shared MSAL cache, so the mailbox connects when the manager closes and the main
+        // window reconnects. On failure it stays added but DISCONNECTED (surfaced by its accessible
+        // name, per PR 1), self-healing on a later connect once consent lands. Consent is never allowed
+        // to roll back the add, and never a silent data loss.
+        var parent = Accounts.FirstOrDefault(a => a.Id == sharedMailbox.ParentAccountId);
+        if (parent is null) return;
+        try
+        {
+            await _oauth.RequestSharedMailboxConsentAsync(parent);
+        }
+        catch (Exception ex)
+        {
+            // Declined / admin-approval pending / offline: the interactive window already showed the
+            // user what was needed; the disconnected state carries it from here.
+            LogService.Log($"Shared mailbox '{sharedMailbox.SharedAddress}': consent not granted on parent " +
+                           $"'{parent.AccountLabel}' ({ex.GetType().Name}); it will stay disconnected until " +
+                           "access is granted.");
+        }
     }
 
     /// <summary>A shared mailbox cannot be the default account (#31, spec §4: default-account semantics

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -2,6 +2,7 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Collections.Specialized;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -984,6 +985,41 @@ public partial class MainViewModel : ObservableObject, IDisposable
     [ObservableProperty]
     private ObservableCollection<AccountModel> _accounts = [];
 
+    // #31: a thread-safe id→account snapshot for the OAuthService shared-mailbox token resolver, which
+    // runs on background sweep threads (GraphClient acquires the token deep in a ConfigureAwait(false)
+    // flow). Accounts is a UI-thread-owned ObservableCollection — enumerating it off the UI thread while
+    // the user adds/removes an account throws "Collection was modified". Instead the resolver reads this
+    // volatile reference to an immutable map, rebuilt on the UI thread whenever the collection changes
+    // (reassignment via the generated OnAccountsChanged, and in-place add/remove via CollectionChanged).
+    private volatile Dictionary<Guid, AccountModel> _accountsById = new();
+    private ObservableCollection<AccountModel>? _accountsSubscription;
+
+    /// <summary>Thread-safe by-id account lookup for the shared-mailbox token resolver (App wires this to
+    /// <see cref="Services.OAuthService.ResolveAccount"/>). Safe to call from any thread.</summary>
+    public AccountModel? ResolveAccountById(Guid id) => _accountsById.TryGetValue(id, out var a) ? a : null;
+
+    partial void OnAccountsChanged(ObservableCollection<AccountModel> value)
+    {
+        // Re-subscribe when the whole collection is replaced (LoadAccountList), so in-place add/remove on
+        // the new instance keeps the snapshot current.
+        if (_accountsSubscription is not null) _accountsSubscription.CollectionChanged -= OnAccountsCollectionChanged;
+        _accountsSubscription = value;
+        if (value is not null) value.CollectionChanged += OnAccountsCollectionChanged;
+        RebuildAccountsById();
+    }
+
+    private void OnAccountsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e) => RebuildAccountsById();
+
+    // Runs on the UI thread (collection mutations are UI-thread-owned). Publishes a fresh immutable map;
+    // readers on other threads see the new reference atomically via the volatile field. Last-wins on the
+    // (unexpected) duplicate-id case so a rebuild never throws.
+    private void RebuildAccountsById()
+    {
+        var map = new Dictionary<Guid, AccountModel>(Accounts.Count);
+        foreach (var a in Accounts) map[a.Id] = a;
+        _accountsById = map;
+    }
+
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(HasSelectedAccount))]
     private AccountModel? _selectedAccount;
@@ -1677,6 +1713,10 @@ public partial class MainViewModel : ObservableObject, IDisposable
             _rowLayoutService.LayoutsChanged += _onRowLayoutsChanged;
             ReloadRowSpeech();
         }
+
+        // #31: subscribe the initial account collection so ResolveAccountById reflects add/remove even
+        // before the first LoadAccountList reassigns it (which re-subscribes the new instance).
+        OnAccountsChanged(Accounts);
 
         // Load saved views and register their commands before the UI is shown.
         LoadSavedViews();

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -3175,7 +3175,13 @@ public partial class MainViewModel : ObservableObject, IDisposable
         // Connected means "this session reached the server", not "we have folders for it" — the
         // folder cache is restored from SQLite at launch (#516), so keying off it here would start
         // watchers against accounts that never connected.
-        var connected    = Accounts.Where(a => _connectedAccountIds.Contains(a.Id)).ToList();
+        //
+        // #31: a shared mailbox never gets a live watcher. A Graph shared mailbox's .Shared scopes can't
+        // hold change-notification subscriptions (and delta over them is out of scope), so its only
+        // freshness is the #456 sweep (which still includes it — it filters on the folder flag, not
+        // IsShared). An IMAP-parent shared mailbox (PR 3) reads through its parent's connection and gets
+        // no watcher of its own either. Excluding here covers every notifier type in one place.
+        var connected    = Accounts.Where(a => _connectedAccountIds.Contains(a.Id) && !a.IsShared).ToList();
         var connectedIds = connected.Select(a => a.Id).ToHashSet();
 
         // Only (re)start watchers when the connected set changed — StartWatchers stops and restarts
@@ -3785,6 +3791,10 @@ public partial class MainViewModel : ObservableObject, IDisposable
     // Settings change takes effect without a restart.
     internal void MaybeNotifyNewMail(AccountModel account, IReadOnlyList<MailMessageSummary> incoming)
     {
+        // #31: no new-mail toast for a shared mailbox. Now that shared accounts connect (PR 2) the #456
+        // sweep delivers their inbox arrivals here, but a shared mailbox is someone else's inbox you also
+        // watch — it stays off, defaulting off, until the per-account opt-in ships (spec §4.1, PR 5).
+        if (account.IsShared) return;
         if (_notifications is not { IsSupported: true }) return;
         if (!_configService.Load().NotifyOnNewMail) return;
 
@@ -3844,6 +3854,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
     // argument for this pair of methods and is not observable from any public surface.
     internal void MaybeNotifyWatchedMail(AccountModel account, IReadOnlyList<MailMessageSummary> incoming)
     {
+        if (account.IsShared) return;   // #31: no toast for a shared mailbox (spec §4.1) — see MaybeNotifyNewMail
         if (_notifications is not { IsSupported: true }) return;
         if (_watchService == null) return;
         if (!_configService.Load().NotifyOnWatchedConversation) return;
@@ -4299,7 +4310,10 @@ public partial class MainViewModel : ObservableObject, IDisposable
         // POP3 account against an IMAP account on the same host. Serializing matters more for POP3
         // than for IMAP: RFC 1939 gives a session an exclusive lock on the maildrop.
         var resultsByHost = await Task.WhenAll(
-            Accounts.Where(a => !a.IsShared)   // #31: shared mailboxes are not connected in PR 1 (no own creds)
+            // #31: a Graph-parent shared mailbox connects in PR 2 — it borrows the parent's token
+            // (OAuthService resolver) and reads /users/{SharedAddress}. An IMAP-parent shared mailbox
+            // stays deferred to PR 3 (XOAUTH2 user=), so it is still skipped here.
+            Accounts.Where(a => !a.IsShared || a.BackendKind == BackendKind.MicrosoftGraph)
                     .GroupBy(a => a.IncomingHost, StringComparer.OrdinalIgnoreCase)
                     .Select(async hostGroup =>
                     {
@@ -8911,9 +8925,12 @@ public partial class MainViewModel : ObservableObject, IDisposable
         IEnumerable<AccountModel> accounts,
         Func<Guid, bool> isBackendConnected,
         Func<Guid, bool> hasCachedFolders)
-        // #31: a shared mailbox has no credentials of its own — it reads through its parent's token
-        // (from PR 2). PR 1 never connects it: it's a navigable, empty top-level node until then.
-        => accounts.Where(a => !a.IsShared && (!isBackendConnected(a.Id) || !hasCachedFolders(a.Id))).ToList();
+        // #31: a shared mailbox has no credentials of its own — it reads through its parent's token. A
+        // Graph-parent shared mailbox connects from PR 2 (the resolver borrows the parent's token); an
+        // IMAP-parent shared mailbox stays deferred to PR 3, so it is excluded here and remains a
+        // navigable, empty top-level node until then.
+        => accounts.Where(a => (!a.IsShared || a.BackendKind == BackendKind.MicrosoftGraph)
+                               && (!isBackendConnected(a.Id) || !hasCachedFolders(a.Id))).ToList();
 
     public void RefreshAccountList()
     {

--- a/QuickMail/Views/AccountManagerDialog.xaml.cs
+++ b/QuickMail/Views/AccountManagerDialog.xaml.cs
@@ -59,7 +59,16 @@ public partial class AccountManagerDialog : Window
             return;
         }
 
-        addVm.SharedMailboxAdded += _vm.CommitNewSharedMailbox;   // commit + persist; the window closes itself
+        // Commit + persist, then drive the shared-mailbox consent (#31). async void is the sanctioned
+        // View pattern for a fire-and-forget UI reaction; CommitNewSharedMailboxAsync handles its own
+        // consent failures (leaving the mailbox added but disconnected), so this only guards the add.
+        async void OnSharedMailboxAdded(AccountModel shared)
+        {
+            try { await _vm.CommitNewSharedMailboxAsync(shared); }
+            catch (Exception ex) { LogService.Log($"AccountManagerDialog: committing shared mailbox failed — {ex.Message}"); }
+        }
+
+        addVm.SharedMailboxAdded += OnSharedMailboxAdded;   // the add window closes itself on the same event
         // Modeless (Show), not ShowDialog: this window has an editable field and can sit over the main
         // window's live WebView2. Note the manager itself is modal (ShowDialog), so the editable field is
         // already inside a nested modal loop — the same position the manager's own text boxes occupy and
@@ -70,7 +79,7 @@ public partial class AccountManagerDialog : Window
         AddSharedButton.IsEnabled = false;
         window.Closed += (_, _) =>
         {
-            addVm.SharedMailboxAdded -= _vm.CommitNewSharedMailbox;   // pair the += so no ghost callback survives
+            addVm.SharedMailboxAdded -= OnSharedMailboxAdded;   // pair the += so no ghost callback survives
             AddSharedButton.IsEnabled = true;
             // Focus restoration (New-Window-Checklist): a modeless window does not reliably return focus
             // to its launcher, so put it back on the button that opened this dialog.


### PR DESCRIPTION
Part of #31. Second of the access-first shared-mailbox PRs (PR 1 = #512, the linked-account model + manual add). Behind the still-off `SharedMailboxes` flag — dark until live-verified after the app-registration scope is declared (asked in the #31 comment).

## What this does

Makes a **Graph-parent** shared mailbox connect and read its mail by borrowing the **parent account's** token, reading `/users/{SharedAddress}/…`. IMAP-parent shared mailboxes stay deferred to PR 3.

- **OAuthService** — new `GraphMailScopesShared` (`Mail.ReadWrite.Shared`, work/school only; must also be declared on the app registration). `DefaultScopesFor` returns it for a Graph-parent shared account. A `ResolveAccount` lookup + `ResolveTokenIdentity` resolve a credential-less shared account to its **parent's** cached MSAL sign-in across all three token methods. A shared account **never** triggers an interactive sign-in — a background sweep read must not open a sign-in window — it surfaces as *disconnected* instead.
- **GraphClient** — one rewrite point (`ApplySharedRoot`) turns a `/me`-relative path into `/users/{SharedAddress}` for a shared account, so `GraphMailService` keeps writing `/me` everywhere. A missing address yields a clean 404, never the parent's mailbox.
- **GraphMailService.ConnectAsync** — for a shared account, skips the `/me` identity call (it would 404 on the directory object, or clobber the shared address with the parent UPN) and probes a **mail** endpoint that fails the connect cleanly if the grant or address is bad.
- **MainViewModel** — the two connect predicates now include Graph-parent shared accounts. Per spec §5.1/§4.1, a shared mailbox gets **no live watcher** (its `.Shared` scopes can't hold change-notification subscriptions — the #456 sweep, which still includes it, is its only freshness) and **no new-mail/watched toasts**. Both suppressions are enforced and tested.
- **App** — wires the token resolver to the live account list.

## Review

Independent adversarial review before opening. It found two HIGH issues — both the same root: connecting shared accounts activated the watcher and toast paths the spec designed *off* for shared mailboxes. Both are fixed here (watcher excluded in `WireUpWatchers` **and** at the `GraphChangeNotifier` boundary; toasts guarded in `MaybeNotifyNewMail`/`MaybeNotifyWatchedMail`) and pinned with tests. Its LOW note (empty `SharedAddress` falling through to `/me`) is also addressed — the shared branch always rewrites now.

## Tests

Scope selection (shared → `.Shared`, IMAP-parent → IMAP); `/users/{shared}` routing + no address clobber; the connect predicate (Graph-parent connects, IMAP-parent deferred); the parent-token resolver (resolves, and throws→disconnected when the parent is gone); no-watcher-for-shared; and no-toast-for-shared. Main project builds clean in Release (0 analyzer warnings).

## Depends on

Live end-to-end verification needs the delegated `Mail.ReadWrite.Shared` permission declared on the app registration (requested in #31). The code and unit tests don't need it; it's dark until then.
