### PR TITLE
Make mouse clicks activate what they land on

### DIFF
--- a/QuickMail.Tests/MouseActivationTests.cs
+++ b/QuickMail.Tests/MouseActivationTests.cs
@@ -1,0 +1,422 @@
+// Mouse clicks in the main window's lists and trees — reported by a sighted user as "clicking a
+// folder does not select the folder".
+//
+// What was actually happening: the click did move the tree's selection, and the row highlighted.
+// Nothing else followed. QuickMail is keyboard-first, and every list here activates on Enter through
+// a handler that reads SelectedItem; the mouse had no equivalent path. So the message list went on
+// showing the folder the user came from, and the next F6 back into the tree snapped the highlight
+// back to the folder that was really open — the click undone in front of them.
+//
+// The fix resolves the row from the element that was clicked, never from SelectedItem. That
+// distinction is the point of most of these tests: the expander chevron, the scroll bar and the
+// empty space below the last row do not move the selection, so a SelectedItem-based handler would
+// activate whatever happened to be selected beforehand. The flat message list did exactly that.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Markup;
+using System.Windows.Media;
+using System.Windows.Threading;
+using QuickMail.Models;
+using QuickMail.Views;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+[Collection("WpfTests")]
+public class MouseActivationTests
+{
+    private static readonly Guid AccountId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    private static MailFolderModel Folder(string name, bool isHeader = false) => new()
+    {
+        FullName = name, DisplayName = name, AccountId = AccountId, IsHeader = isHeader,
+    };
+
+    // Inbox (a real folder) with one child, plus an account header that carries no folder — the
+    // three node shapes the tree actually contains.
+    private static List<FolderTreeNode> Nodes()
+    {
+        var child = new FolderTreeNode { Label = "Projects", Folder = Folder("INBOX/Projects") };
+        var inbox = new FolderTreeNode { Label = "Inbox", Folder = Folder("INBOX"), IsExpanded = true };
+        inbox.Children.Add(child);
+        var header = new FolderTreeNode { Label = "Work", IsHeader = true, AccountId = AccountId };
+        return [inbox, header];
+    }
+
+    // ── The folder tree ──────────────────────────────────────────────────────
+
+    [StaFact]
+    public void ClickingAFolderLabel_ResolvesThatFolder()
+    {
+        InFolderTree((tree, roots) =>
+        {
+            var inbox = roots[0];
+            var label = Descendant<TextBlock>(Row(tree, inbox));
+            Assert.NotNull(label);
+
+            Assert.Same(inbox.Folder, MouseActivation.FolderFromClick(label));
+        });
+    }
+
+    [StaFact]
+    public void ClickingTextInsideARow_ResolvesTheRow_EvenThoughARunHasNoVisualParent()
+    {
+        // A Run is a content element: VisualTreeHelper.GetParent throws on it rather than returning
+        // its TextBlock. Message subjects in the grouped trees are drawn from Runs, so a walk that
+        // only knows the visual tree finds no row at all for the most ordinary click there.
+        InFolderTree((tree, roots) =>
+        {
+            var inbox = roots[0];
+            var run = Descendant<TextBlock>(Row(tree, inbox))?.Inlines.OfType<Run>().FirstOrDefault();
+            Assert.NotNull(run);
+
+            Assert.Same(inbox.Folder, MouseActivation.FolderFromClick(run));
+        });
+    }
+
+    [StaFact]
+    public void ClickingAChildRow_ResolvesTheChild_NotItsParent()
+    {
+        // Child rows are nested inside the parent's container, so the nearest row has to win.
+        // Resolving to the outermost one would open the parent whenever a subfolder is clicked.
+        InFolderTree((tree, roots) =>
+        {
+            var parentRow = Row(tree, roots[0]);
+            var child = roots[0].Children[0];
+            var label = Descendant<TextBlock>(Row(parentRow, child));
+            Assert.NotNull(label);
+
+            Assert.Same(child.Folder, MouseActivation.FolderFromClick(label));
+        });
+    }
+
+    [StaFact]
+    public void ClickingTheExpanderChevron_ResolvesNothing()
+    {
+        // Expanding a branch is not opening a folder. The chevron does not move the selection
+        // either, so a SelectedItem-based handler would have fetched the previously open folder.
+        InFolderTree((tree, roots) =>
+        {
+            var row = Row(tree, roots[0]);
+            var expander = row.Template.FindName("Expander", row) as ToggleButton;
+            Assert.NotNull(expander);
+
+            Assert.Null(MouseActivation.FolderFromClick(expander));
+        });
+    }
+
+    [StaFact]
+    public void ClickingTheEmptySpaceBelowTheRows_ResolvesNothing()
+    {
+        // The click lands on the items host: inside the tree, on no row.
+        InFolderTree((tree, _) =>
+        {
+            var host = Descendant<ItemsPresenter>(tree);
+            Assert.NotNull(host);
+
+            Assert.Null(MouseActivation.FolderFromClick(host));
+            Assert.Null(MouseActivation.FolderFromClick(tree));
+        });
+    }
+
+    [StaFact]
+    public void ClickingTheScrollBar_ResolvesNothing()
+    {
+        InFolderTree((tree, _) =>
+        {
+            var bar = Descendant<ScrollBar>(tree);
+            Assert.NotNull(bar);
+
+            Assert.Null(MouseActivation.FolderFromClick(bar));
+        });
+    }
+
+    [StaFact]
+    public void ClickingAnAccountHeaderRow_ResolvesNoFolder()
+    {
+        // Header nodes carry no folder — the same nodes Enter skips.
+        InFolderTree((tree, roots) =>
+        {
+            var label = Descendant<TextBlock>(Row(tree, roots[1]));
+            Assert.NotNull(label);
+
+            Assert.Null(MouseActivation.FolderFromClick(label));
+            Assert.Same(roots[1], MouseActivation.ItemFromClick<FolderTreeNode>(label));
+        });
+    }
+
+    [StaFact]
+    public void AFolderMarkedAsAHeader_IsNotActivated()
+    {
+        // SelectFolderAsync returns immediately for one of these, so activating it would be a click
+        // that visibly does nothing — the bug this whole change is about.
+        var row = new TreeViewItem
+        {
+            DataContext = new FolderTreeNode { Label = "Work", Folder = Folder("Work", isHeader: true) },
+        };
+
+        Assert.Null(MouseActivation.FolderFromClick(row));
+    }
+
+    [Fact]
+    public void NoSource_ResolvesNothing()
+    {
+        Assert.Null(MouseActivation.FolderFromClick(null));
+        Assert.Null(MouseActivation.ItemFromClick<FolderTreeNode>(null));
+        Assert.Null(MouseActivation.ItemFromClick<FolderTreeNode>("not a dependency object"));
+    }
+
+    [StaFact]
+    public void ARowHoldingAnotherKindOfItem_ResolvesNothing()
+    {
+        // A group header in the conversation tree, clicked while looking for a message: the row
+        // resolves, its item is not a message, and the click stays plain selection.
+        var row = new TreeViewItem { DataContext = new FolderTreeNode { Label = "Inbox" } };
+
+        Assert.Null(MouseActivation.ItemFromClick<MailMessageSummary>(row));
+    }
+
+    // ── Multi-select gestures are not activations ───────────────────────────
+
+    [Theory]
+    [InlineData(ModifierKeys.Control)]
+    [InlineData(ModifierKeys.Shift)]
+    [InlineData(ModifierKeys.Control | ModifierKeys.Shift)]
+    public void ModifierClicksExtendTheSelection(ModifierKeys modifiers)
+    {
+        // The message list is Extended-selection. Ctrl+clicking five messages to delete them used
+        // to open all five on the way past — five message windows, in Window mode.
+        Assert.True(MouseActivation.ExtendsSelection(modifiers));
+    }
+
+    [Theory]
+    [InlineData(ModifierKeys.None)]
+    [InlineData(ModifierKeys.Alt)]
+    public void APlainClickActivates(ModifierKeys modifiers)
+    {
+        Assert.False(MouseActivation.ExtendsSelection(modifiers));
+    }
+
+    [Fact]
+    public void TheMessageListSkipsModifierClicks()
+    {
+        Assert.Contains("if (MouseActivation.ExtendsSelection(Keyboard.Modifiers)) return;",
+                        MessageListClickHandler(), StringComparison.Ordinal);
+    }
+
+    // ── The account list (a ListBox, the other container shape) ──────────────
+
+    [StaFact]
+    public void ClickingAnAccountRow_ResolvesThatAccount()
+    {
+        var accounts = new List<AccountModel>
+        {
+            new() { Id = AccountId, AccountName = "Work", Username = "kelly@example.com" },
+        };
+        var list = new ListBox { ItemsSource = accounts, DisplayMemberPath = "AccountName" };
+
+        InWindow(list, () =>
+        {
+            var row = list.ItemContainerGenerator.ContainerFromItem(accounts[0]) as ListBoxItem;
+            Assert.NotNull(row);
+            var label = Descendant<TextBlock>(row!);
+            Assert.NotNull(label);
+
+            Assert.Same(accounts[0], MouseActivation.ItemFromClick<AccountModel>(label));
+            Assert.Null(MouseActivation.ItemFromClick<AccountModel>(list));
+        });
+    }
+
+    // ── Wiring: every pane that activates on Enter also activates on the mouse ──
+    //
+    // Read from source. The handlers live on MainWindow, which no test here stands up — and the
+    // helper above cannot tell whether anything is calling it.
+
+    [Theory]
+    [InlineData("FolderList", "MouseLeftButtonUp=\"FolderList_MouseLeftButtonUp\"")]
+    [InlineData("AccountList", "MouseLeftButtonUp=\"AccountList_MouseLeftButtonUp\"")]
+    [InlineData("MessageList", "MouseLeftButtonUp=\"MessageList_MouseLeftButtonUp\"")]
+    [InlineData("the attachment list", "MouseDoubleClick=\"ReadingPaneAttachmentList_MouseDoubleClick\"")]
+    public void MainWindowWiresTheMouseHandler(string pane, string attribute)
+    {
+        Assert.True(Source("Views/MainWindow.xaml").Contains(attribute, StringComparison.Ordinal),
+                    pane + " no longer declares " + attribute);
+    }
+
+    [Fact]
+    public void AllThreeGroupedTreesWireTheMouseHandler()
+    {
+        // Conversations, From and To. A fix applied to one tree and not the others is the "works
+        // from one view only" incompleteness the feature checklist calls out.
+        var declarations = Source("Views/MainWindow.xaml")
+            .Split("MouseLeftButtonUp=\"GroupTree_MouseLeftButtonUp\"").Length - 1;
+
+        Assert.Equal(3, declarations);
+    }
+
+    [Fact]
+    public void TheMessageWindowsAttachmentListOpensOnDoubleClick()
+    {
+        Assert.Contains("MouseDoubleClick=\"AttachmentList_MouseDoubleClick\"",
+                        Source("Views/MessageWindow.xaml"), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ClickingAFolderRunsTheSameCommandAsEnter()
+    {
+        // Both paths go through SelectFolderCommand, so a click gets the view reset, the account
+        // switch and the fetch — not a bare assignment to SelectedFolder that leaves the app naming
+        // a folder it never loaded.
+        Assert.Contains("await _vm.SelectFolderCommand.ExecuteAsync(folder);",
+                        FolderClickHandler(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TheFolderTreeStillHasNoSelectedItemChangedHandler()
+    {
+        // The tempting one-line fix, and the wrong one: arrow keys move TreeView.SelectedItem, so
+        // loading on selection change would fetch every folder the user arrows past. Enter commits;
+        // the mouse click is its own gesture.
+        var xaml = Source("Views/MainWindow.xaml");
+        var folderTree = Between(xaml, "x:Name=\"FolderList\"", "</TreeView>");
+
+        Assert.DoesNotContain("SelectedItemChanged", folderTree, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TheFolderClickDoesNotReadTheTreesSelection()
+    {
+        // Same reason the message list stopped: the chevron and the scroll bar do not move the
+        // selection, so SelectedItem is the wrong question to ask about a click.
+        Assert.DoesNotContain("SelectedItem", FolderClickHandler(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TheMessageListNoLongerActivatesWhateverIsSelected()
+    {
+        // Regression: the handler read MessageList.SelectedItem, so a click on the empty space below
+        // the last row re-opened the selected message — a second window in Window mode.
+        Assert.DoesNotContain("SelectedItem", MessageListClickHandler(), StringComparison.Ordinal);
+    }
+
+    private static string MessageListClickHandler() =>
+        Between(Source("Views/MainWindow.xaml.cs"),
+                "private async void MessageList_MouseLeftButtonUp", "\n    }");
+
+    private static string FolderClickHandler() =>
+        Between(Source("Views/MainWindow.xaml.cs"),
+                "private async void FolderList_MouseLeftButtonUp", "\n    }");
+
+    // ── Harness ──────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Builds the folder tree in a shown window — containers only exist once laid out — hands it to
+    /// <paramref name="test"/>, and closes the window afterwards.
+    /// </summary>
+    private static void InFolderTree(Action<TreeView, List<FolderTreeNode>> test)
+    {
+        var roots = Nodes();
+        var tree = new TreeView { ItemsSource = roots };
+        tree.Resources.Add(new DataTemplateKey(typeof(FolderTreeNode)), RowTemplate());
+
+        InWindow(tree, () => test(tree, roots));
+    }
+
+    // Shaped like the real one: a Run inside a TextBlock, so the content-element hop is exercised by
+    // every test here and not only by the one that names it.
+    private static HierarchicalDataTemplate RowTemplate() =>
+        (HierarchicalDataTemplate)XamlReader.Parse(
+            "<HierarchicalDataTemplate " +
+            "xmlns=\"http://schemas.microsoft.com/winfx/2006/xaml/presentation\" " +
+            "ItemsSource=\"{Binding Children}\">" +
+            "<StackPanel Orientation=\"Horizontal\">" +
+            "<TextBlock><Run Text=\"{Binding Label, Mode=OneWay}\"/></TextBlock>" +
+            "</StackPanel></HierarchicalDataTemplate>");
+
+    private static void InWindow(FrameworkElement content, Action test)
+    {
+        // ThemedControls carries the TreeViewItem template that owns the expander chevron — the
+        // chrome one of these tests clicks on.
+        WpfTestHost.EnsureStyles("AccessibleStyles", "ThemedControls");
+
+        var window = new Window
+        {
+            WindowStyle = WindowStyle.None, ShowInTaskbar = false, ShowActivated = false,
+            Width = 300, Height = 400, Content = content,
+        };
+        window.Show();
+        try
+        {
+            window.UpdateLayout();
+            Drain();
+            test();
+        }
+        finally { window.Close(); }
+    }
+
+    private static void Drain()
+    {
+        var frame = new DispatcherFrame();
+        Dispatcher.CurrentDispatcher.BeginInvoke(
+            DispatcherPriority.SystemIdle, new Action(() => frame.Continue = false));
+        Dispatcher.PushFrame(frame);
+    }
+
+    private static TreeViewItem Row(ItemsControl parent, FolderTreeNode node)
+    {
+        parent.UpdateLayout();
+        var row = parent.ItemContainerGenerator.ContainerFromItem(node) as TreeViewItem;
+        Assert.True(row is not null, "no container was realized for '" + node.Label + "'.");
+        row!.ApplyTemplate();
+        row.UpdateLayout();
+        return row;
+    }
+
+    private static T? Descendant<T>(DependencyObject root) where T : DependencyObject
+    {
+        for (var i = 0; i < VisualTreeHelper.GetChildrenCount(root); i++)
+        {
+            var child = VisualTreeHelper.GetChild(root, i);
+            // Stop at a nested row: a parent's descendants include its children's whole subtrees,
+            // and returning one of those would test the wrong row.
+            if (child is TreeViewItem or ListBoxItem) continue;
+            if (child is T hit) return hit;
+            if (Descendant<T>(child) is { } deeper) return deeper;
+        }
+        return null;
+    }
+
+    private static string Between(string text, string start, string end)
+    {
+        var from = text.IndexOf(start, StringComparison.Ordinal);
+        Assert.True(from >= 0, "'" + start + "' is gone from the source.");
+        var rest = text[from..];
+        var to = rest.IndexOf(end, StringComparison.Ordinal);
+        Assert.True(to >= 0, "'" + end + "' never follows '" + start + "'.");
+        return rest[..to];
+    }
+
+    private static string Source(string relativePath)
+    {
+        var path = Path.Combine(RepoRoot(), "QuickMail", relativePath.Replace('/', Path.DirectorySeparatorChar));
+        Assert.True(File.Exists(path), path + " not found.");
+        return File.ReadAllText(path);
+    }
+
+    private static string RepoRoot()
+    {
+        var dir = AppContext.BaseDirectory;
+        while (dir != null && !File.Exists(Path.Combine(dir, "QuickMail.sln")))
+            dir = Path.GetDirectoryName(dir);
+        Assert.True(dir is not null, "QuickMail.sln not found above " + AppContext.BaseDirectory);
+        return dir!;
+    }
+}

--- a/QuickMail.Tests/MouseActivationTests.cs
+++ b/QuickMail.Tests/MouseActivationTests.cs
@@ -184,6 +184,38 @@ public class MouseActivationTests
         Assert.Null(MouseActivation.ItemFromClick<MailMessageSummary>(row));
     }
 
+    [StaFact]
+    public void AClickOnARow_ReachesAHandlerOnTheTreeItself()
+    {
+        // The assumption the folder fix rests on: TreeViewItem handles the button-DOWN (that is how
+        // it selects), and nothing marks the button-up handled — so a handler declared on the
+        // TreeView sees the click. If that stopped being true the fix would be inert, the app would
+        // build, every other test here would pass, and clicking a folder would do nothing again.
+        //
+        // Raised as Mouse.MouseUpEvent, which is the bubbling event WPF actually routes.
+        // MouseLeftButtonUp is Direct: UIElement re-raises it on each element the MouseUp bubbles
+        // through, so raising MouseLeftButtonUp here directly would travel nowhere and prove nothing.
+        InFolderTree((tree, roots) =>
+        {
+            var row = Row(tree, roots[0]);
+            var label = Descendant<TextBlock>(row);
+            Assert.NotNull(label);
+
+            object? seen = null;
+            tree.AddHandler(UIElement.MouseLeftButtonUpEvent,
+                            new MouseButtonEventHandler((_, e) => seen = e.OriginalSource));
+
+            label!.RaiseEvent(new MouseButtonEventArgs(Mouse.PrimaryDevice, 0, MouseButton.Left)
+            {
+                RoutedEvent = Mouse.MouseUpEvent,
+                Source = label,
+            });
+
+            Assert.True(seen is not null, "the button-up never reached the tree.");
+            Assert.Same(roots[0].Folder, MouseActivation.FolderFromClick(seen));
+        });
+    }
+
     // ── Multi-select gestures are not activations ───────────────────────────
 
     [Theory]

--- a/QuickMail/Views/MainWindow.xaml
+++ b/QuickMail/Views/MainWindow.xaml
@@ -945,7 +945,8 @@
                          TabIndex="1"
                          KeyboardNavigation.TabNavigation="Once"
                          GotKeyboardFocus="List_GotKeyboardFocus"
-                         PreviewKeyDown="AccountList_PreviewKeyDown">
+                         PreviewKeyDown="AccountList_PreviewKeyDown"
+                         MouseLeftButtonUp="AccountList_MouseLeftButtonUp">
 
                     <!-- Two-line item: account name + live status (connected/disconnected + inbox counts).
                          AutomationProperties.Name on the container announces the full detail to screen
@@ -1003,7 +1004,8 @@
                           KeyboardNavigation.TabNavigation="Once"
                           GotKeyboardFocus="FolderList_GotKeyboardFocus"
                           PreviewTextInput="FolderList_PreviewTextInput"
-                          PreviewKeyDown="FolderList_PreviewKeyDown">
+                          PreviewKeyDown="FolderList_PreviewKeyDown"
+                          MouseLeftButtonUp="FolderList_MouseLeftButtonUp">
                     <TreeView.Resources>
                         <HierarchicalDataTemplate DataType="{x:Type models:FolderTreeNode}"
                                                   ItemsSource="{Binding Children}">
@@ -1223,7 +1225,8 @@
                                      KeyboardNavigation.DirectionalNavigation="Contained"
                                      AutomationProperties.Name="Attachments"
                                      PreviewKeyDown="ReadingPaneAttachmentList_PreviewKeyDown"
-                                     GotKeyboardFocus="ReadingPaneAttachmentList_GotKeyboardFocus">
+                                     GotKeyboardFocus="ReadingPaneAttachmentList_GotKeyboardFocus"
+                                     MouseDoubleClick="ReadingPaneAttachmentList_MouseDoubleClick">
                                 <ListBox.ItemContainerStyle>
                                     <Style TargetType="ListBoxItem">
                                         <Setter Property="AutomationProperties.Name" Value="{Binding AccessibleName}"/>
@@ -1724,7 +1727,8 @@
                               PreviewTextInput="ConversationTree_PreviewTextInput"
                               PreviewKeyDown="ConversationTree_PreviewKeyDown"
                               PreviewMouseRightButtonDown="ConversationTree_PreviewMouseRightButtonDown"
-                              ContextMenuOpening="ConversationTree_ContextMenuOpening">
+                              ContextMenuOpening="ConversationTree_ContextMenuOpening"
+                              MouseLeftButtonUp="GroupTree_MouseLeftButtonUp">
                         <TreeView.Style>
                             <Style TargetType="TreeView" BasedOn="{StaticResource {x:Type TreeView}}">
                                 <Setter Property="Visibility" Value="{Binding IsConversationsView, Converter={StaticResource BoolToVisibilityConverter}}"/>
@@ -1852,7 +1856,8 @@
                               PreviewTextInput="SenderGroupTree_PreviewTextInput"
                               PreviewKeyDown="SenderGroupTree_PreviewKeyDown"
                               PreviewMouseRightButtonDown="SenderGroupTree_PreviewMouseRightButtonDown"
-                              ContextMenuOpening="SenderGroupTree_ContextMenuOpening">
+                              ContextMenuOpening="SenderGroupTree_ContextMenuOpening"
+                              MouseLeftButtonUp="GroupTree_MouseLeftButtonUp">
                         <TreeView.Style>
                             <Style TargetType="TreeView" BasedOn="{StaticResource {x:Type TreeView}}">
                                 <Setter Property="Visibility" Value="{Binding IsFromView, Converter={StaticResource BoolToVisibilityConverter}}"/>
@@ -1980,7 +1985,8 @@
                               PreviewTextInput="ToGroupTree_PreviewTextInput"
                               PreviewKeyDown="ToGroupTree_PreviewKeyDown"
                               PreviewMouseRightButtonDown="ToGroupTree_PreviewMouseRightButtonDown"
-                              ContextMenuOpening="ToGroupTree_ContextMenuOpening">
+                              ContextMenuOpening="ToGroupTree_ContextMenuOpening"
+                              MouseLeftButtonUp="GroupTree_MouseLeftButtonUp">
                         <TreeView.Style>
                             <Style TargetType="TreeView" BasedOn="{StaticResource {x:Type TreeView}}">
                                 <Setter Property="Visibility" Value="{Binding IsToView, Converter={StaticResource BoolToVisibilityConverter}}"/>

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -2684,11 +2684,53 @@ public partial class MainWindow : Window
         MessageList.ItemContainerGenerator.StatusChanged += OnStatusChanged;
     }
 
-    // Single click: load message into the reading pane (standard reading-pane UX).
+    // Single click: open the message, the same as Enter does. Resolved from the clicked row rather
+    // than from SelectedItem, so a click on the empty space below the last message is a no-op — it
+    // used to re-open whatever was selected, which in Window mode meant a second message window.
     private async void MessageList_MouseLeftButtonUp(object sender, MouseButtonEventArgs e)
     {
-        if (MessageList.SelectedItem is MailMessageSummary summary)
+        if (MouseActivation.ExtendsSelection(Keyboard.Modifiers)) return;
+        if (MouseActivation.ItemFromClick<MailMessageSummary>(e.OriginalSource) is { } summary)
             await OpenMessageFromListAsync(summary);
+    }
+
+    // Single click on a folder loads it, the same as Enter — minus the move to the message panel,
+    // which is a keyboard affordance: the mouse user is looking at the tree they just clicked.
+    // Without this the click only highlighted the row (the tree has no SelectedItemChanged handler,
+    // deliberately — arrowing must not fetch every folder it passes over), so the message list went
+    // on showing the folder the user came from and the next F6 into the tree undid the highlight.
+    private async void FolderList_MouseLeftButtonUp(object sender, MouseButtonEventArgs e)
+    {
+        if (MouseActivation.FolderFromClick(e.OriginalSource) is { } folder)
+            await _vm.SelectFolderCommand.ExecuteAsync(folder);
+    }
+
+    // Single click on an account connects it, the same as Enter. The ListBox's SelectedItem binding
+    // moved SelectedAccount on its own, which left the app naming an account it had never connected.
+    private async void AccountList_MouseLeftButtonUp(object sender, MouseButtonEventArgs e)
+    {
+        if (MouseActivation.ItemFromClick<AccountModel>(e.OriginalSource) is { } account)
+            await _vm.SelectAccountCommand.ExecuteAsync(account);
+    }
+
+    // Single click on a message in any of the grouped trees opens it, matching the flat message
+    // list. A click on a group header resolves to no message and just selects the header, and the
+    // expander chevron keeps its own click.
+    private async void GroupTree_MouseLeftButtonUp(object sender, MouseButtonEventArgs e)
+    {
+        if (MouseActivation.ItemFromClick<MailMessageSummary>(e.OriginalSource) is not { } msg)
+            return;
+        _vm.SelectedMessage = msg;
+        await OpenMessageFromListAsync(msg);
+    }
+
+    // Attachments open on double-click — the gesture a file row has everywhere else in Windows.
+    // Single click stays selection only, so clicking through a list of attachments does not launch
+    // each one in turn.
+    private void ReadingPaneAttachmentList_MouseDoubleClick(object sender, MouseButtonEventArgs e)
+    {
+        if (MouseActivation.ItemFromClick<AttachmentModel>(e.OriginalSource) is { } attachment)
+            _vm.OpenAttachmentCommand.Execute(attachment);
     }
 
     // Ctrl+Shift+M = Archive (issue #318). Used by the message list and all three group trees when

--- a/QuickMail/Views/MessageWindow.xaml
+++ b/QuickMail/Views/MessageWindow.xaml
@@ -190,7 +190,8 @@
                          KeyboardNavigation.DirectionalNavigation="Contained"
                          AutomationProperties.Name="Attachments"
                          PreviewKeyDown="AttachmentList_PreviewKeyDown"
-                         GotKeyboardFocus="AttachmentList_GotKeyboardFocus">
+                         GotKeyboardFocus="AttachmentList_GotKeyboardFocus"
+                         MouseDoubleClick="AttachmentList_MouseDoubleClick">
                     <ListBox.ItemContainerStyle>
                         <Style TargetType="ListBoxItem">
                             <Setter Property="AutomationProperties.Name" Value="{Binding AccessibleName}"/>

--- a/QuickMail/Views/MessageWindow.xaml.cs
+++ b/QuickMail/Views/MessageWindow.xaml.cs
@@ -767,6 +767,14 @@ public partial class MessageWindow : Window
         }
     }
 
+    // Attachments open on double-click, the mouse counterpart of Enter above. Single click stays
+    // selection only, so clicking down a list of attachments does not launch each one in turn.
+    private void AttachmentList_MouseDoubleClick(object sender, MouseButtonEventArgs e)
+    {
+        if (MouseActivation.ItemFromClick<AttachmentModel>(e.OriginalSource) is { } attachment)
+            _ = _vm.OpenAttachmentCommand.ExecuteAsync(attachment);
+    }
+
     // Alt+A (window.focusAttachments, issue #350): move focus to this message's attachment list.
     // GotKeyboardFocus selects the first item so the screen reader lands on an attachment rather
     // than the empty list shell. When the message has none, announce it instead of moving focus

--- a/QuickMail/Views/MouseActivation.cs
+++ b/QuickMail/Views/MouseActivation.cs
@@ -1,0 +1,92 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Input;
+using System.Windows.Media;
+using QuickMail.Models;
+
+namespace QuickMail.Views;
+
+/// <summary>
+/// Resolves which row a mouse click landed on, for the lists and trees that activate on a click
+/// as well as on Enter.
+///
+/// <para>Why this exists: QuickMail is keyboard-first, and every list activates on Enter through a
+/// handler that reads <c>SelectedItem</c>. The mouse cannot borrow that path. A left-click moves the
+/// selection and nothing more — the folder tree deliberately has no <c>SelectedItemChanged</c>
+/// handler (arrowing through folders must not fetch every folder it passes over), so clicking a
+/// folder highlighted the row and left the message list showing the folder the user came from, and
+/// the next F6 into the tree snapped the highlight back to the folder that was really open. Clicking
+/// a folder was, in effect, a no-op.</para>
+///
+/// <para>Reading <c>SelectedItem</c> from the mouse handler instead would work for a plain click and
+/// be wrong everywhere else: the expander chevron and the flag hit area do not move the selection,
+/// and neither does empty space below the last row, so a click there would activate whatever was
+/// selected beforehand — the flat message list did exactly that, re-opening the selected message
+/// when the user clicked below the list. The row is therefore resolved from the element that was
+/// actually clicked.</para>
+/// </summary>
+internal static class MouseActivation
+{
+    /// <summary>
+    /// The data item of the row containing <paramref name="originalSource"/> (a mouse event's
+    /// <see cref="RoutedEventArgs.OriginalSource"/>), or null when the click landed on row chrome
+    /// that owns its own action, on empty space below the rows, or on a row whose item is not a
+    /// <typeparamref name="TItem"/> (a group header in one of the grouped trees, say).
+    /// </summary>
+    public static TItem? ItemFromClick<TItem>(object? originalSource) where TItem : class
+    {
+        var node = originalSource as DependencyObject;
+        while (node != null)
+        {
+            switch (node)
+            {
+                // Chrome that acts on its own: the expander chevron, the tab strip's close button,
+                // a scroll bar or its thumb. A click there is not an activation of the row.
+                case ButtonBase or ScrollBar or Thumb:
+                    return null;
+
+                // The row. ListViewItem derives from ListBoxItem, so both arrive here.
+                case TreeViewItem or ListBoxItem:
+                    return (node as FrameworkElement)?.DataContext as TItem;
+
+                // Reached the list itself without crossing a row: empty space below the items.
+                case ItemsControl:
+                    return null;
+            }
+
+            node = ParentOf(node);
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// True when the modifiers make a click a selection gesture rather than an activation. The
+    /// message list is Extended-selection, so Ctrl+click and Shift+click build a multi-message
+    /// selection — every message added to one used to be opened as well, which in Window mode meant
+    /// a window per message on the way to a multi-message delete.
+    /// </summary>
+    public static bool ExtendsSelection(ModifierKeys modifiers) =>
+        (modifiers & (ModifierKeys.Control | ModifierKeys.Shift)) != 0;
+
+    /// <summary>
+    /// The folder a click in the folder tree activates, or null when the click was not on a folder.
+    /// Account header nodes and synthetic path segments carry no folder — the same nodes Enter skips.
+    /// </summary>
+    public static MailFolderModel? FolderFromClick(object? originalSource) =>
+        ItemFromClick<FolderTreeNode>(originalSource)?.Folder is { IsHeader: false } folder
+            ? folder
+            : null;
+
+    // The visual tree is the one that matters — a click's OriginalSource is the rendered element —
+    // but it is not continuous: a Run inside a TextBlock is a content element with no visual parent,
+    // and VisualTreeHelper.GetParent throws on anything that is not a Visual. Step over those
+    // through the logical/host link so a click on message subject text still finds its row.
+    private static DependencyObject? ParentOf(DependencyObject node) => node switch
+    {
+        Visual or System.Windows.Media.Media3D.Visual3D => VisualTreeHelper.GetParent(node),
+        FrameworkContentElement fce                     => fce.Parent ?? fce.TemplatedParent,
+        _                                               => null,
+    };
+}


### PR DESCRIPTION
Reported by a sighted user: **clicking a folder does not select the folder.** The click did move the tree's selection and the row highlighted, but nothing followed. QuickMail is keyboard-first and every list in the main window activates on Enter, through a handler that reads `SelectedItem`; the mouse had no equivalent path anywhere. So the message list went on showing the folder the user came from, and the next F6 back into the tree ran `SyncFolderTreeSelection` and snapped the highlight back to the folder that was really open — the click undone in front of them.

Five surfaces had the same gap, and the one existing mouse handler was wrong in two ways.

| Surface | Before | Now |
|---|---|---|
| Folder tree | click selected, never loaded | click loads the folder, through `SelectFolderCommand` — the command Enter uses |
| Account list | click moved `SelectedAccount` through the ListBox binding, never connected | click connects |
| Conversations / From / To trees | click selected a message, never opened it (the flat list did) | click opens it |
| Attachment lists (reading pane, message window) | Enter only | double-click opens |
| Flat message list | read `SelectedItem`, so a click on the empty space below the last row re-opened the selected message — a second window in Window mode | resolves the clicked row; empty space is a no-op |
| Flat message list | Ctrl+click and Shift+click also *opened* each message — a window per message on the way to a multi-message delete | modifier clicks extend the selection only |

## How

`Views/MouseActivation.cs` resolves the row from the element that was clicked, never from `SelectedItem` — that distinction is the point: the expander chevron, the scroll bar and empty space do not move the selection, so a `SelectedItem`-based handler activates whatever happened to be selected beforehand. It steps over content elements too (a `Run` has no visual parent, and the grouped trees draw message subjects from Runs). The handlers in `MainWindow.xaml.cs` are thin adapters onto the same VM commands Enter uses.

The folder tree still has **no** `SelectedItemChanged` handler, deliberately: arrow keys move `TreeView.SelectedItem`, so loading on selection change would fetch every folder the user arrows past. Enter commits; the click is its own gesture. A test pins that.

Keyboard behaviour is untouched — no command registrations, no shortcuts, no announcements, no `AutomationProperties` changes.

## Tests

`MouseActivationTests` — 27 tests. Resolution against real realized containers (label, Run, child row, chevron, scroll bar, empty space, account header), both container shapes, the modifier gestures, and wiring guards that each pane still declares its handler (all three grouped trees among them) and that neither the folder nor the message handler goes back to reading `SelectedItem`.

Full suite: 3161 passed, 3 skipped (the opt-in synthesized-input tests).

Not verified by clicking in the running app — worth a confirmation from the reporter.

## Deliberately out of scope

Both already have a working mouse path via buttons: the calendar event list has no double-click (Enter there means "open source message", not "edit", so the right gesture is a design call), and the manager dialogs (Address Book, Rules, Views, Flags, Groups, Themes) have no double-click-to-edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)