### PR TITLE
Release notes for 0.8.42: the mouse fixes

### DIFF
--- a/docs/release-notes-v0.8.42.md
+++ b/docs/release-notes-v0.8.42.md
@@ -41,6 +41,32 @@ Three details worth knowing:
 Expansion is not remembered between runs — QuickMail still starts with each account open.
 ([#590](https://github.com/kellylford/QuickMail/issues/590))
 
+## Fixed: the mouse did nothing in the folder tree
+
+Selecting a folder with the mouse left the folder highlighted and nothing else: the message list
+went on showing the folder you came from, and moving back to the tree with **F6** put the highlight
+back on the folder that was really open, as though the mouse had never been used. Reported by a
+sighted user as *"clicking on folders does not select the folders"*, which is exactly what it
+looked like.
+
+The cause was that QuickMail is built keyboard-first, and every one of these lists was wired to
+**Enter** only. They all respond to the mouse now:
+
+- **Folders** open on a single click, the same as Enter — with the difference that Enter also moves
+  you on to the message list, and a click leaves you looking at the tree you just used.
+- **Accounts** connect on a single click.
+- **Messages in the Conversations, From and To views** open on a single click, which they already
+  did in the plain message list.
+- **Attachments** open on a double click, in both the reading pane and an open message window.
+
+Two smaller mouse faults went with them. In the message list, selecting several messages with
+**Ctrl** or **Shift** held used to open each one as you added it — in Window mode, that meant a
+window per message on the way to deleting them; those now only add to the selection. And a click on
+the empty space below the last message no longer re-opens whichever message was selected.
+
+Nothing about the keyboard changed: no shortcut, no announcement, and no reading order is different
+from 0.8.41. ([#601](https://github.com/kellylford/QuickMail/pull/601))
+
 ## Fixed: Microsoft 365 unread counts went stale until you refreshed
 
 On a Microsoft 365 account, the unread count beside a folder only changed when the whole folder list


### PR DESCRIPTION
Adds a section to `docs/release-notes-v0.8.42.md` for the mouse work merged in #601 — the folder-tree report that started it, the four other lists that had the same gap, and the two smaller message-list faults that went with them.

Placed after the folder expand/collapse section and before the Microsoft 365 unread-count fix, so the release still reads new-then-fixed-then-changed with the two footers last.

It links #601 rather than an issue: the report came in directly rather than through the tracker, so there is no issue number to point at.

Ends by saying that no shortcut, announcement or reading order changed, since for most of the people reading these notes that is the part that matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)