### PR TITLE
Take both halves of a click, and open one-message groups

### DIFF
--- a/QuickMail.Tests/MouseActivationTests.cs
+++ b/QuickMail.Tests/MouseActivationTests.cs
@@ -62,7 +62,7 @@ public class MouseActivationTests
             var label = Descendant<TextBlock>(Row(tree, inbox));
             Assert.NotNull(label);
 
-            Assert.Same(inbox.Folder, MouseActivation.FolderFromClick(label));
+            Assert.Same(inbox.Folder, FolderAt(label));
         });
     }
 
@@ -78,7 +78,7 @@ public class MouseActivationTests
             var run = Descendant<TextBlock>(Row(tree, inbox))?.Inlines.OfType<Run>().FirstOrDefault();
             Assert.NotNull(run);
 
-            Assert.Same(inbox.Folder, MouseActivation.FolderFromClick(run));
+            Assert.Same(inbox.Folder, FolderAt(run));
         });
     }
 
@@ -94,7 +94,7 @@ public class MouseActivationTests
             var label = Descendant<TextBlock>(Row(parentRow, child));
             Assert.NotNull(label);
 
-            Assert.Same(child.Folder, MouseActivation.FolderFromClick(label));
+            Assert.Same(child.Folder, FolderAt(label));
         });
     }
 
@@ -109,7 +109,7 @@ public class MouseActivationTests
             var expander = row.Template.FindName("Expander", row) as ToggleButton;
             Assert.NotNull(expander);
 
-            Assert.Null(MouseActivation.FolderFromClick(expander));
+            Assert.Null(FolderAt(expander));
         });
     }
 
@@ -122,8 +122,8 @@ public class MouseActivationTests
             var host = Descendant<ItemsPresenter>(tree);
             Assert.NotNull(host);
 
-            Assert.Null(MouseActivation.FolderFromClick(host));
-            Assert.Null(MouseActivation.FolderFromClick(tree));
+            Assert.Null(FolderAt(host));
+            Assert.Null(FolderAt(tree));
         });
     }
 
@@ -135,7 +135,7 @@ public class MouseActivationTests
             var bar = Descendant<ScrollBar>(tree);
             Assert.NotNull(bar);
 
-            Assert.Null(MouseActivation.FolderFromClick(bar));
+            Assert.Null(FolderAt(bar));
         });
     }
 
@@ -148,7 +148,7 @@ public class MouseActivationTests
             var label = Descendant<TextBlock>(Row(tree, roots[1]));
             Assert.NotNull(label);
 
-            Assert.Null(MouseActivation.FolderFromClick(label));
+            Assert.Null(FolderAt(label));
             Assert.Same(roots[1], MouseActivation.ItemFromClick<FolderTreeNode>(label));
         });
     }
@@ -163,13 +163,13 @@ public class MouseActivationTests
             DataContext = new FolderTreeNode { Label = "Work", Folder = Folder("Work", isHeader: true) },
         };
 
-        Assert.Null(MouseActivation.FolderFromClick(row));
+        Assert.Null(FolderAt(row));
     }
 
     [Fact]
     public void NoSource_ResolvesNothing()
     {
-        Assert.Null(MouseActivation.FolderFromClick(null));
+        Assert.Null(FolderAt(null));
         Assert.Null(MouseActivation.ItemFromClick<FolderTreeNode>(null));
         Assert.Null(MouseActivation.ItemFromClick<FolderTreeNode>("not a dependency object"));
     }
@@ -212,9 +212,164 @@ public class MouseActivationTests
             });
 
             Assert.True(seen is not null, "the button-up never reached the tree.");
-            Assert.Same(roots[0].Folder, MouseActivation.FolderFromClick(seen));
+            Assert.Same(roots[0].Folder, FolderAt(seen));
         });
     }
+
+    // ── A press and its release must land on the same row ────────────────────
+    //
+    // Found by an independent review of the first pass, which measured what the handlers actually
+    // did rather than reading them: every one of them ran twice on a double-click.
+
+    [Fact]
+    public void APressAndReleaseOnTheSameRow_Activates()
+    {
+        var tracker = new RowClickTracker();
+        var row = new object();
+
+        tracker.Press(row, clickCount: 1);
+
+        Assert.Same(row, tracker.Release(row));
+    }
+
+    [Fact]
+    public void ADoubleClick_ActivatesOnce()
+    {
+        // Two clicks deliver two button-ups. Unpaired, the second one opened a second message
+        // window in Window mode, and on the account list started a second connect that cancelled
+        // the first — leaving "Connection cancelled." on an account that had just connected.
+        var tracker = new RowClickTracker();
+        var row = new object();
+
+        tracker.Press(row, clickCount: 1);
+        Assert.Same(row, tracker.Release(row));
+
+        tracker.Press(row, clickCount: 2);
+
+        Assert.Null(tracker.Release(row));
+    }
+
+    [Fact]
+    public void APressOnOneRowReleasedOverAnother_ActivatesNeither()
+    {
+        // The list selects on the press, so activating the row under the release would leave the
+        // tree highlighting one folder while the message list showed another — the same split this
+        // whole change exists to remove, mirrored.
+        var tracker = new RowClickTracker();
+        var pressed = new object();
+        var released = new object();
+
+        tracker.Press(pressed, clickCount: 1);
+
+        Assert.Null(tracker.Release(released));
+    }
+
+    [Fact]
+    public void ADragAcrossRows_LeavesTheSelectionAlone()
+    {
+        // Drag from the first message to the fifth to select five, release, press Delete. The
+        // release used to activate the fifth row, and opening a message reduces an Extended
+        // selection to that one row — so Delete deleted one message, not five.
+        var tracker = new RowClickTracker();
+        var first = new object();
+        var fifth = new object();
+
+        tracker.Press(first, clickCount: 1);
+
+        Assert.Null(tracker.Release(fifth));
+    }
+
+    [Fact]
+    public void AReleaseWithNoPress_ActivatesNothing()
+    {
+        // A button-up that arrives without its press: released over the list after a drag that
+        // began somewhere else entirely.
+        Assert.Null(new RowClickTracker().Release(new object()));
+    }
+
+    [Fact]
+    public void OnePress_CannotActivateTwice()
+    {
+        var tracker = new RowClickTracker();
+        var row = new object();
+        tracker.Press(row, clickCount: 1);
+
+        Assert.Same(row, tracker.Release(row));
+        Assert.Null(tracker.Release(row));
+    }
+
+    [Fact]
+    public void NothingUnderThePress_ActivatesNothing()
+    {
+        // Pressing the empty space below the rows, then releasing over a row as the mouse drifts.
+        var tracker = new RowClickTracker();
+        tracker.Press(null, clickCount: 1);
+
+        Assert.Null(tracker.Release(null));
+        Assert.Null(tracker.Release(new object()));
+    }
+
+    // ── Single-message groups open, the same as Enter ────────────────────────
+
+    [Fact]
+    public void ASingleMessageConversation_OpensThatMessage()
+    {
+        // The gap the independent review caught. Enter on a one-message conversation opens the
+        // message rather than expanding a branch with one row in it; the click understood message
+        // rows only, and in Conversations view most top-level rows are single-message
+        // conversations — so most of that view still did nothing when clicked.
+        var message = Message();
+        var group = new ConversationGroup { NormalizedSubject = "Lunch", Messages = [message] };
+
+        Assert.Same(message, MouseActivation.ActivatableMessage(group));
+    }
+
+    [Fact]
+    public void ASingleMessageSenderGroup_OpensThatMessage()
+    {
+        // From and To views, whose Enter paths do the same for the same reason.
+        var message = Message();
+        var group = new SenderGroup { SenderKey = "alice@example.com", Messages = [message] };
+
+        Assert.Same(message, MouseActivation.ActivatableMessage(group));
+    }
+
+    [Theory]
+    [InlineData(2)]
+    [InlineData(5)]
+    public void AGroupHoldingMoreThanOneMessage_StaysSelectionOnly(int count)
+    {
+        // Enter toggles the branch here; a click leaves that to the chevron, as a tree click does
+        // everywhere in Windows. Opening the newest message instead would be a guess.
+        var messages = Enumerable.Range(0, count).Select(_ => Message()).ToList();
+
+        Assert.Null(MouseActivation.ActivatableMessage(
+            new ConversationGroup { NormalizedSubject = "Budget", Messages = messages }));
+        Assert.Null(MouseActivation.ActivatableMessage(
+            new SenderGroup { SenderKey = "alice@example.com", Messages = messages }));
+    }
+
+    [Fact]
+    public void AMessageRow_OpensItself()
+    {
+        var message = Message();
+
+        Assert.Same(message, MouseActivation.ActivatableMessage(message));
+    }
+
+    [Fact]
+    public void ARowThatIsNeither_OpensNothing()
+    {
+        Assert.Null(MouseActivation.ActivatableMessage(new FolderTreeNode { Label = "Inbox" }));
+        Assert.Null(MouseActivation.ActivatableMessage(null));
+    }
+
+    private static MailMessageSummary Message() => new()
+    {
+        MessageId = "1", AccountId = AccountId, FolderName = "INBOX",
+        From = "alice@example.com", Subject = "Hello",
+        Date = new DateTimeOffset(2026, 8, 20, 10, 0, 0, TimeSpan.Zero),
+    };
 
     // ── Multi-select gestures are not activations ───────────────────────────
 
@@ -295,6 +450,36 @@ public class MouseActivationTests
     }
 
     [Fact]
+    public void EveryClickActivatedListPairsThePressWithTheRelease()
+    {
+        // Six declarations: the message list, the folder tree, the account list, and the three
+        // grouped trees. A list wired for the release alone is a list where a double-click
+        // activates twice and a drag ends in an activation.
+        var declarations = Source("Views/MainWindow.xaml")
+            .Split("PreviewMouseLeftButtonDown=").Length - 1;
+
+        Assert.Equal(6, declarations);
+    }
+
+    [Fact]
+    public void TheFolderClickGoesThroughItsTracker()
+    {
+        Assert.Contains("_folderListClick.Release(", FolderClickHandler(), StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("Views/MainWindow.xaml.cs")]
+    [InlineData("Views/MessageWindow.xaml.cs")]
+    public void AttachmentsOpenOnTheLeftButtonOnly(string file)
+    {
+        // Control.MouseDoubleClick is raised for any button, so without this a double right-click
+        // shell-opens the file. Both attachment lists carry a context menu, which makes it awkward
+        // to reach rather than impossible.
+        Assert.Contains("if (e.ChangedButton != MouseButton.Left) return;",
+                        Source(file), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void TheMessageWindowsAttachmentListOpensOnDoubleClick()
     {
         Assert.Contains("MouseDoubleClick=\"AttachmentList_MouseDoubleClick\"",
@@ -346,6 +531,10 @@ public class MouseActivationTests
     private static string FolderClickHandler() =>
         Between(Source("Views/MainWindow.xaml.cs"),
                 "private async void FolderList_MouseLeftButtonUp", "\n    }");
+
+    // What the handler does in two steps: resolve the clicked row, then ask what it activates.
+    private static MailFolderModel? FolderAt(object? source) =>
+        MouseActivation.ActivatableFolder(MouseActivation.RowFromClick(source));
 
     // ── Harness ──────────────────────────────────────────────────────────────
 

--- a/QuickMail/Views/MainWindow.xaml
+++ b/QuickMail/Views/MainWindow.xaml
@@ -946,6 +946,7 @@
                          KeyboardNavigation.TabNavigation="Once"
                          GotKeyboardFocus="List_GotKeyboardFocus"
                          PreviewKeyDown="AccountList_PreviewKeyDown"
+                         PreviewMouseLeftButtonDown="AccountList_PreviewMouseLeftButtonDown"
                          MouseLeftButtonUp="AccountList_MouseLeftButtonUp">
 
                     <!-- Two-line item: account name + live status (connected/disconnected + inbox counts).
@@ -1005,6 +1006,7 @@
                           GotKeyboardFocus="FolderList_GotKeyboardFocus"
                           PreviewTextInput="FolderList_PreviewTextInput"
                           PreviewKeyDown="FolderList_PreviewKeyDown"
+                          PreviewMouseLeftButtonDown="FolderList_PreviewMouseLeftButtonDown"
                           MouseLeftButtonUp="FolderList_MouseLeftButtonUp">
                     <TreeView.Resources>
                         <HierarchicalDataTemplate DataType="{x:Type models:FolderTreeNode}"
@@ -1538,6 +1540,7 @@
                               GotKeyboardFocus="List_GotKeyboardFocus"
                               PreviewTextInput="MessageList_PreviewTextInput"
                               PreviewKeyDown="MessageList_PreviewKeyDown"
+                              PreviewMouseLeftButtonDown="MessageList_PreviewMouseLeftButtonDown"
                               MouseLeftButtonUp="MessageList_MouseLeftButtonUp">
                         <ListView.Style>
                             <Style TargetType="ListView" BasedOn="{StaticResource {x:Type ListView}}">
@@ -1728,6 +1731,7 @@
                               PreviewKeyDown="ConversationTree_PreviewKeyDown"
                               PreviewMouseRightButtonDown="ConversationTree_PreviewMouseRightButtonDown"
                               ContextMenuOpening="ConversationTree_ContextMenuOpening"
+                              PreviewMouseLeftButtonDown="GroupTree_PreviewMouseLeftButtonDown"
                               MouseLeftButtonUp="GroupTree_MouseLeftButtonUp">
                         <TreeView.Style>
                             <Style TargetType="TreeView" BasedOn="{StaticResource {x:Type TreeView}}">
@@ -1857,6 +1861,7 @@
                               PreviewKeyDown="SenderGroupTree_PreviewKeyDown"
                               PreviewMouseRightButtonDown="SenderGroupTree_PreviewMouseRightButtonDown"
                               ContextMenuOpening="SenderGroupTree_ContextMenuOpening"
+                              PreviewMouseLeftButtonDown="GroupTree_PreviewMouseLeftButtonDown"
                               MouseLeftButtonUp="GroupTree_MouseLeftButtonUp">
                         <TreeView.Style>
                             <Style TargetType="TreeView" BasedOn="{StaticResource {x:Type TreeView}}">
@@ -1986,6 +1991,7 @@
                               PreviewKeyDown="ToGroupTree_PreviewKeyDown"
                               PreviewMouseRightButtonDown="ToGroupTree_PreviewMouseRightButtonDown"
                               ContextMenuOpening="ToGroupTree_ContextMenuOpening"
+                              PreviewMouseLeftButtonDown="GroupTree_PreviewMouseLeftButtonDown"
                               MouseLeftButtonUp="GroupTree_MouseLeftButtonUp">
                         <TreeView.Style>
                             <Style TargetType="TreeView" BasedOn="{StaticResource {x:Type TreeView}}">

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -2684,13 +2684,39 @@ public partial class MainWindow : Window
         MessageList.ItemContainerGenerator.StatusChanged += OnStatusChanged;
     }
 
+    // One tracker per list: activating a row takes the press and the release landing on the same
+    // row, which is what holds a double-click to a single activation and stops a drag across the
+    // message list ending in one. See RowClickTracker for the three faults it fixes. The three
+    // grouped trees share a tracker because only ever one of them is on screen.
+    private readonly RowClickTracker _messageListClick = new();
+    private readonly RowClickTracker _folderListClick  = new();
+    private readonly RowClickTracker _accountListClick = new();
+    private readonly RowClickTracker _groupTreeClick   = new();
+
+    private void MessageList_PreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        => _messageListClick.Press(MouseActivation.RowFromClick(e.OriginalSource), e.ClickCount);
+
+    private void FolderList_PreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        => _folderListClick.Press(MouseActivation.RowFromClick(e.OriginalSource), e.ClickCount);
+
+    private void AccountList_PreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        => _accountListClick.Press(MouseActivation.RowFromClick(e.OriginalSource), e.ClickCount);
+
+    private void GroupTree_PreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        => _groupTreeClick.Press(MouseActivation.RowFromClick(e.OriginalSource), e.ClickCount);
+
     // Single click: open the message, the same as Enter does. Resolved from the clicked row rather
     // than from SelectedItem, so a click on the empty space below the last message is a no-op — it
     // used to re-open whatever was selected, which in Window mode meant a second message window.
     private async void MessageList_MouseLeftButtonUp(object sender, MouseButtonEventArgs e)
     {
+        // Released before the modifier check so a Ctrl+click cannot leave a press pending.
+        var row = _messageListClick.Release(MouseActivation.RowFromClick(e.OriginalSource));
+
+        // Ctrl and Shift build an Extended selection here; adding a message to one is not opening it.
         if (MouseActivation.ExtendsSelection(Keyboard.Modifiers)) return;
-        if (MouseActivation.ItemFromClick<MailMessageSummary>(e.OriginalSource) is { } summary)
+
+        if (row is MailMessageSummary summary)
             await OpenMessageFromListAsync(summary);
     }
 
@@ -2701,7 +2727,8 @@ public partial class MainWindow : Window
     // on showing the folder the user came from and the next F6 into the tree undid the highlight.
     private async void FolderList_MouseLeftButtonUp(object sender, MouseButtonEventArgs e)
     {
-        if (MouseActivation.FolderFromClick(e.OriginalSource) is { } folder)
+        var row = _folderListClick.Release(MouseActivation.RowFromClick(e.OriginalSource));
+        if (MouseActivation.ActivatableFolder(row) is { } folder)
             await _vm.SelectFolderCommand.ExecuteAsync(folder);
     }
 
@@ -2709,26 +2736,39 @@ public partial class MainWindow : Window
     // moved SelectedAccount on its own, which left the app naming an account it had never connected.
     private async void AccountList_MouseLeftButtonUp(object sender, MouseButtonEventArgs e)
     {
-        if (MouseActivation.ItemFromClick<AccountModel>(e.OriginalSource) is { } account)
+        var row = _accountListClick.Release(MouseActivation.RowFromClick(e.OriginalSource));
+        if (row is AccountModel account)
             await _vm.SelectAccountCommand.ExecuteAsync(account);
     }
 
     // Single click on a message in any of the grouped trees opens it, matching the flat message
-    // list. A click on a group header resolves to no message and just selects the header, and the
-    // expander chevron keeps its own click.
+    // list — and on a single-message group it opens that message, which is what Enter does there
+    // rather than expanding a branch holding one row. In Conversations view most rows are that
+    // shape, so a click that only understood message rows left most of the view inert. Groups
+    // holding more than one message stay plain selection: expanding is what the chevron is for.
     private async void GroupTree_MouseLeftButtonUp(object sender, MouseButtonEventArgs e)
     {
-        if (MouseActivation.ItemFromClick<MailMessageSummary>(e.OriginalSource) is not { } msg)
-            return;
+        var row = _groupTreeClick.Release(MouseActivation.RowFromClick(e.OriginalSource));
+
+        // Same reasoning as the flat list, for the same gesture on the same messages.
+        if (MouseActivation.ExtendsSelection(Keyboard.Modifiers)) return;
+
+        if (MouseActivation.ActivatableMessage(row) is not { } msg) return;
+
+        // Set explicitly: on a single-message group the tree's selection is the group, so nothing
+        // else has pointed SelectedMessage at the message about to open. The Enter path sets it
+        // there for the same reason.
         _vm.SelectedMessage = msg;
         await OpenMessageFromListAsync(msg);
     }
 
     // Attachments open on double-click — the gesture a file row has everywhere else in Windows.
     // Single click stays selection only, so clicking through a list of attachments does not launch
-    // each one in turn.
+    // each one in turn. Left button only: MouseDoubleClick is raised for any button, and a double
+    // right-click must not shell-open a file.
     private void ReadingPaneAttachmentList_MouseDoubleClick(object sender, MouseButtonEventArgs e)
     {
+        if (e.ChangedButton != MouseButton.Left) return;
         if (MouseActivation.ItemFromClick<AttachmentModel>(e.OriginalSource) is { } attachment)
             _vm.OpenAttachmentCommand.Execute(attachment);
     }

--- a/QuickMail/Views/MessageWindow.xaml.cs
+++ b/QuickMail/Views/MessageWindow.xaml.cs
@@ -769,8 +769,11 @@ public partial class MessageWindow : Window
 
     // Attachments open on double-click, the mouse counterpart of Enter above. Single click stays
     // selection only, so clicking down a list of attachments does not launch each one in turn.
+    // Left button only: MouseDoubleClick is raised for any button, and a double right-click must
+    // not shell-open a file.
     private void AttachmentList_MouseDoubleClick(object sender, MouseButtonEventArgs e)
     {
+        if (e.ChangedButton != MouseButton.Left) return;
         if (MouseActivation.ItemFromClick<AttachmentModel>(e.OriginalSource) is { } attachment)
             _ = _vm.OpenAttachmentCommand.ExecuteAsync(attachment);
     }

--- a/QuickMail/Views/MouseActivation.cs
+++ b/QuickMail/Views/MouseActivation.cs
@@ -71,13 +71,32 @@ internal static class MouseActivation
         (modifiers & (ModifierKeys.Control | ModifierKeys.Shift)) != 0;
 
     /// <summary>
-    /// The folder a click in the folder tree activates, or null when the click was not on a folder.
-    /// Account header nodes and synthetic path segments carry no folder — the same nodes Enter skips.
+    /// The row item a click landed on, whatever its type. What a press and its release are compared
+    /// on, so an activation can require both halves of the click to land on the same row.
     /// </summary>
-    public static MailFolderModel? FolderFromClick(object? originalSource) =>
-        ItemFromClick<FolderTreeNode>(originalSource)?.Folder is { IsHeader: false } folder
-            ? folder
-            : null;
+    public static object? RowFromClick(object? originalSource) => ItemFromClick<object>(originalSource);
+
+    /// <summary>
+    /// The folder this row activates, or null when the row is not one: account header nodes and
+    /// synthetic path segments carry no folder, and a folder marked as a header is one
+    /// SelectFolderAsync returns straight back out of — the same rows Enter skips.
+    /// </summary>
+    public static MailFolderModel? ActivatableFolder(object? row) =>
+        row is FolderTreeNode { Folder: { IsHeader: false } folder } ? folder : null;
+
+    /// <summary>
+    /// The message this row opens: its own message, or the one message of a single-message group.
+    /// A group row is not inert — Enter on a one-message conversation opens that message rather than
+    /// expanding a branch with nothing in it, and in Conversations view most rows are that shape, so
+    /// a click that only understood message rows left most of the view doing nothing.
+    /// </summary>
+    public static MailMessageSummary? ActivatableMessage(object? row) => row switch
+    {
+        MailMessageSummary message                 => message,
+        ConversationGroup { Messages.Count: 1 } cg => cg.Messages[0],
+        SenderGroup       { Messages.Count: 1 } sg => sg.Messages[0],
+        _                                          => null,
+    };
 
     // The visual tree is the one that matters — a click's OriginalSource is the rendered element —
     // but it is not continuous: a Run inside a TextBlock is a content element with no visual parent,
@@ -89,4 +108,41 @@ internal static class MouseActivation
         FrameworkContentElement fce                     => fce.Parent ?? fce.TemplatedParent,
         _                                               => null,
     };
+}
+
+/// <summary>
+/// Pairs a press with its release for one list, so activating a row takes both halves of a click
+/// landing on it.
+///
+/// <para>An unpaired button-up handler has three faults, all of which the first pass of this change
+/// shipped. A double-click delivers two button-ups, so every handler ran twice: two standalone
+/// windows for one message in Window mode, and on the account list a second connect that cancelled
+/// the first and left "Connection cancelled." on the status line of an account that had just
+/// connected. A press on one row released over another activated the row under the release while
+/// the list highlighted the row under the press — the same "selection says one thing, list shows
+/// another" split this whole change exists to remove. And a drag across the message list to select
+/// several messages ended by activating the last row, which collapsed the multi-selection back to
+/// one: Delete then deleted one message where the user had selected five.</para>
+/// </summary>
+internal sealed class RowClickTracker
+{
+    private object? _pressed;
+
+    /// <summary>
+    /// Records the row a press landed on. The second and later clicks of a multi-click record
+    /// nothing, which is what holds a double-click to a single activation — ClickCount is dependable
+    /// on the press, where WPF's own TreeViewItem reads it to toggle expansion.
+    /// </summary>
+    public void Press(object? row, int clickCount) => _pressed = clickCount == 1 ? row : null;
+
+    /// <summary>
+    /// The row this release activates: the pressed row, and only when the release landed on it too.
+    /// Clears the press either way, so one press can never activate twice.
+    /// </summary>
+    public object? Release(object? row)
+    {
+        var pressed = _pressed;
+        _pressed = null;
+        return pressed is not null && ReferenceEquals(pressed, row) ? pressed : null;
+    }
 }


### PR DESCRIPTION
Follow-up to #601, from an **independent** review of that merge — the review before it was the author re-reading their own change, which is how both of these got through. The reviewer measured what the handlers did with a standalone WPF probe rather than reasoning about them, and two findings are real bugs in what shipped.

## Every handler ran twice on a double-click

A double-click delivers two button-ups, and nothing checked. Measured: *"tree MouseLeftButtonUp handler invocations for a double-click: 2"*.

- **Window mode**: two standalone windows for one message. `OpenMessageTab` de-duplicates; `OpenMessageInNewWindow` does not.
- **Account list**: the second run cancels the first through `_connectCts`, so the first lands in the cancellation catch and writes **"Connection cancelled."** onto an account that had just connected.
- **Folder tree**: the folder loads twice while WPF's own `TreeViewItem` toggles the branch — it expands when `ClickCount` is even.

Double-clicking a list row is the most habitual mouse gesture there is, so this was going to be hit immediately by exactly the person who reported the original bug.

## Clicking a one-message conversation still did nothing

Enter on a group holding a single message opens that message rather than expanding a branch with one row in it — all three grouped trees do this. The click handler understood message rows only. In Conversations view most top-level rows *are* single-message conversations, so most of that view still did nothing when clicked: the exact complaint #601 set out to fix, left standing in the view where it is most visible.

## The fix

`RowClickTracker` pairs a press with its release. A row activates only when both halves of the click land on it, and the second and later clicks of a multi-click record no press. One mechanism closes three findings:

- a double-click activates once;
- a press on one row released over another activates neither — it used to activate the row under the release while the list highlighted the row under the press, the same "selection says one thing, list shows another" split this work exists to remove;
- a drag across the message list is left alone. It used to end by activating the last row, and opening a message reduces an Extended selection to that row — so selecting five messages by dragging and pressing Delete deleted one.

`ClickCount` is read on the press, where it is dependable and where WPF reads it itself.

Also from the review: `Control.MouseDoubleClick` is raised for any button, so both attachment lists now check for the left one rather than shell-opening a file on a double right-click.

## Deliberately not taken

- **Clicking an account still reconnects** rather than needing a double-click. The account list sits an inch below the folder tree; the two behaving differently is worse than the reconnect.
- **The two attachment handlers still dispose of their task differently** — each matches the Enter path in its own window, which matters more than matching each other.
- **The redundant `SelectedMessage` assignment** in the grouped trees is now load-bearing: on a single-message group the tree's selection is the group, so nothing else points `SelectedMessage` at the message about to open.

## Tests

45 in `MouseActivationTests` (was 28). New: the press/release pairing (same row, mismatched rows, double-click, drag, release with no press, one press cannot activate twice), single- and multi-message groups for both group types, and wiring guards that all six lists declare the press half and that both attachment handlers check the button.

Full suite: 3179 passed, 3 skipped.

Still not verified by clicking in the running app — the reporter's confirmation is the last step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)