### PR TITLE
Restrict shared-mailbox parents to work/school Microsoft; drop generic IMAP from scope (#31)

### DIFF
--- a/QuickMail.Tests/AddSharedMailboxViewModelTests.cs
+++ b/QuickMail.Tests/AddSharedMailboxViewModelTests.cs
@@ -9,15 +9,24 @@ namespace QuickMail.Tests;
 
 public class AddSharedMailboxViewModelTests
 {
+    // Work/school Microsoft on Graph (Microsoft OAuth). personal:true makes it a consumer account.
     private static AccountModel Graph(string name, bool personal = false) => new()
     {
         Id = Guid.NewGuid(), AccountName = name, Username = name.ToLowerInvariant() + "@work.com",
-        BackendKind = BackendKind.MicrosoftGraph, IsPersonalMicrosoftAccount = personal,
+        BackendKind = BackendKind.MicrosoftGraph, AuthType = AuthType.OAuth2Microsoft,
+        IsPersonalMicrosoftAccount = personal,
     };
+    // Work/school Microsoft on Exchange IMAP (Microsoft OAuth) — the IMAP-parent shared case.
+    private static AccountModel MsImap(string name) => new()
+    {
+        Id = Guid.NewGuid(), AccountName = name, Username = name.ToLowerInvariant() + "@work.com",
+        BackendKind = BackendKind.ImapSmtp, AuthType = AuthType.OAuth2Microsoft,
+    };
+    // A non-Microsoft IMAP account (password auth) — Gmail app-password, Fastmail, "Other", etc.
     private static AccountModel Imap(string name) => new()
     {
         Id = Guid.NewGuid(), AccountName = name, Username = name.ToLowerInvariant() + "@host.com",
-        BackendKind = BackendKind.ImapSmtp,
+        BackendKind = BackendKind.ImapSmtp, AuthType = AuthType.Password,
     };
     private static AccountModel SharedOf(AccountModel parent, string addr) => new()
     {
@@ -26,19 +35,37 @@ public class AddSharedMailboxViewModelTests
     };
 
     [Fact]
-    public void ParentOptions_ExcludeSharedAndPersonalMicrosoft()
+    public void ParentOptions_OnlyWorkSchoolMicrosoft() // #31 — shared mailboxes exist only there
     {
-        var work = Graph("Work");
-        var personal = Graph("Personal", personal: true);
-        var imap = Imap("Home");
-        var shared = SharedOf(work, "support@work.com");
+        var workGraph    = Graph("WorkGraph");                       // work/school MS on Graph → IN
+        var workImap     = MsImap("WorkImap");                       // work/school MS on Exchange IMAP → IN
+        var personalGraph = Graph("PersonalG", personal: true);     // personal MS on Graph → OUT
+        var personalImap = new AccountModel                          // personal MS on IMAP → OUT (the gap this closes)
+        {
+            Id = Guid.NewGuid(), AccountName = "PersonalI", Username = "me@outlook.com",
+            BackendKind = BackendKind.ImapSmtp, AuthType = AuthType.OAuth2Microsoft,
+            IsPersonalMicrosoftAccount = true,
+        };
+        var genericImap  = Imap("Fastmail");                        // non-Microsoft IMAP → OUT (RFC 2342, out of scope)
+        var google       = new AccountModel                          // Gmail via Google OAuth → OUT
+        {
+            Id = Guid.NewGuid(), AccountName = "Gmail", Username = "me@gmail.com",
+            BackendKind = BackendKind.ImapSmtp, AuthType = AuthType.OAuth2Google,
+        };
+        var pop3         = new AccountModel { Id = Guid.NewGuid(), AccountName = "Pop", Username = "me@pop.com", BackendKind = BackendKind.Pop3Smtp, AuthType = AuthType.Password };
+        var shared       = SharedOf(workGraph, "support@work.com"); // a shared account itself → OUT
 
-        var vm = new AddSharedMailboxViewModel([work, personal, imap, shared]);
+        var vm = new AddSharedMailboxViewModel(
+            [workGraph, workImap, personalGraph, personalImap, genericImap, google, pop3, shared]);
 
-        Assert.Contains(work, vm.ParentOptions);
-        Assert.Contains(imap, vm.ParentOptions);
-        Assert.DoesNotContain(personal, vm.ParentOptions);   // personal MS has no shared mailboxes
-        Assert.DoesNotContain(shared, vm.ParentOptions);     // a shared account can't be a parent
+        Assert.Contains(workGraph, vm.ParentOptions);
+        Assert.Contains(workImap, vm.ParentOptions);
+        Assert.DoesNotContain(personalGraph, vm.ParentOptions);   // personal MS has no shared mailboxes
+        Assert.DoesNotContain(personalImap, vm.ParentOptions);    // ...on IMAP either — the gap this fix closes
+        Assert.DoesNotContain(genericImap, vm.ParentOptions);     // non-Microsoft IMAP: RFC 2342 folders, not delegated mailboxes
+        Assert.DoesNotContain(google, vm.ParentOptions);
+        Assert.DoesNotContain(pop3, vm.ParentOptions);
+        Assert.DoesNotContain(shared, vm.ParentOptions);
     }
 
     [Fact]
@@ -49,7 +76,8 @@ public class AddSharedMailboxViewModelTests
         var undetected = new AccountModel
         {
             Id = Guid.NewGuid(), AccountName = "Undetected", Username = "me@outlook.com",
-            BackendKind = BackendKind.MicrosoftGraph, // IsPersonalMicrosoftAccount left null
+            BackendKind = BackendKind.MicrosoftGraph, AuthType = AuthType.OAuth2Microsoft,
+            // IsPersonalMicrosoftAccount left null — so only the consumer-domain guess can exclude it
         };
         var work = Graph("Work");
 
@@ -62,7 +90,7 @@ public class AddSharedMailboxViewModelTests
     [Fact]
     public void ShowGraphPollNote_TrueForGraphParent_FalseForImap()
     {
-        var vm = new AddSharedMailboxViewModel([Graph("Work"), Imap("Home")]);
+        var vm = new AddSharedMailboxViewModel([Graph("Work"), MsImap("Home")]);
 
         vm.SelectedParent = vm.ParentOptions.First(a => a.BackendKind == BackendKind.MicrosoftGraph);
         Assert.True(vm.ShowGraphPollNote);

--- a/QuickMail.Tests/Pop3AccountSetupTests.cs
+++ b/QuickMail.Tests/Pop3AccountSetupTests.cs
@@ -412,12 +412,13 @@ public class Pop3SharedMailboxTests
     [Fact]
     public void APop3AccountIsNotOfferedAsAParent()
     {
-        var imap = new AccountModel { Id = Guid.NewGuid(), AccountName = "IMAP", BackendKind = BackendKind.ImapSmtp };
-        var pop3 = new AccountModel { Id = Guid.NewGuid(), AccountName = "POP3", BackendKind = BackendKind.Pop3Smtp };
+        // A work/school Microsoft account is the eligible parent (#31); POP3 has no second mailbox.
+        var work = new AccountModel { Id = Guid.NewGuid(), AccountName = "Work", Username = "work@work.com", BackendKind = BackendKind.MicrosoftGraph, AuthType = AuthType.OAuth2Microsoft };
+        var pop3 = new AccountModel { Id = Guid.NewGuid(), AccountName = "POP3", Username = "me@pop.com", BackendKind = BackendKind.Pop3Smtp, AuthType = AuthType.Password };
 
-        var vm = new AddSharedMailboxViewModel([imap, pop3]);
+        var vm = new AddSharedMailboxViewModel([work, pop3]);
 
-        Assert.Contains(vm.ParentOptions, a => a.Id == imap.Id);
+        Assert.Contains(vm.ParentOptions, a => a.Id == work.Id);
         Assert.DoesNotContain(vm.ParentOptions, a => a.Id == pop3.Id);
     }
 }

--- a/QuickMail.Tests/UnitTest1.cs
+++ b/QuickMail.Tests/UnitTest1.cs
@@ -249,7 +249,7 @@ public class XamlParseTests
         EnsureApplication();
         // Guards the {StaticResource BoolToVisibility} converter being declared locally — a build
         // compiles the XAML but the converter only resolves at parse time (#31).
-        var vm = new AddSharedMailboxViewModel([new AccountModel { AccountName = "Work", BackendKind = BackendKind.MicrosoftGraph }]);
+        var vm = new AddSharedMailboxViewModel([new AccountModel { AccountName = "Work", Username = "work@work.com", BackendKind = BackendKind.MicrosoftGraph, AuthType = AuthType.OAuth2Microsoft }]);
         var window = new AddSharedMailboxWindow(vm);
         Assert.NotNull(window);
         window.Close();

--- a/QuickMail/ViewModels/AddSharedMailboxViewModel.cs
+++ b/QuickMail/ViewModels/AddSharedMailboxViewModel.cs
@@ -23,15 +23,22 @@ public partial class AddSharedMailboxViewModel : ObservableObject
         _allAccounts = accounts.ToList();
 
         // Only shared-capable accounts can host a shared mailbox: a work/school Microsoft 365 (Graph)
-        // account, or an IMAP account. A personal Microsoft account has no Exchange shared mailboxes,
-        // a POP3 account has no concept of a second mailbox at all (one maildrop, no folders, no
-        // access delegation), and a shared account can't itself be a parent. Personal is resolved via
-        // OAuthService.ResolveIsPersonalMicrosoftAccount (flag, else domain guess) so an undetected
-        // personal Graph account is excluded too — the same resolution scope selection uses.
+        // Only a WORK/SCHOOL Microsoft account can be a shared-mailbox parent — that is the sole place a
+        // shared mailbox exists. It applies whether the account is on Graph (reads via /users/{shared})
+        // or on IMAP-OAuth (Exchange IMAP, XOAUTH2 user={shared}), so the test is the Microsoft OAuth
+        // auth type, not the backend. Everything else is excluded because it genuinely has no shared
+        // mailbox to offer:
+        //   - Personal Microsoft (Outlook.com/Hotmail/Live), on Graph OR IMAP: consumer accounts are not
+        //     in an Exchange org and cannot be granted access to another mailbox. Resolved via
+        //     ResolveIsPersonalMicrosoftAccount (flag, else domain guess), the same as scope selection.
+        //   - Non-Microsoft IMAP (Gmail app-password, Yahoo, iCloud, Fastmail, "Other"): RFC 2342
+        //     "shared folders" are namespace folders inside the user's own connection, not a delegated
+        //     mailbox added by address — a different concept, deliberately out of scope (spec §4.2).
+        //   - POP3, and a shared account itself, have no second mailbox at all.
         ParentOptions = _allAccounts
             .Where(a => !a.IsShared
-                        && a.BackendKind != BackendKind.Pop3Smtp
-                        && !(a.BackendKind == BackendKind.MicrosoftGraph && OAuthService.ResolveIsPersonalMicrosoftAccount(a)))
+                        && a.AuthType == AuthType.OAuth2Microsoft
+                        && !OAuthService.ResolveIsPersonalMicrosoftAccount(a))
             .ToList();
 
         _selectedParent = ParentOptions.FirstOrDefault(a => a.Id == preferredParentId)
@@ -47,7 +54,7 @@ public partial class AddSharedMailboxViewModel : ObservableObject
     /// <summary>Shown when no account can host a shared mailbox. The Account Manager reports this in its
     /// status line instead of opening a dead-end dialog; the dialog also carries it as a fallback.</summary>
     public const string NoEligibleParentMessage =
-        "Add a Microsoft 365 (work or school) or IMAP account first — a shared mailbox reads through one of your accounts.";
+        "Add a Microsoft 365 work or school account first — a shared mailbox reads through one, and only work or school accounts have them.";
 
     public List<AccountModel> ParentOptions { get; }
 

--- a/docs/planning/shared-mailboxes-pm-dev-spec.md
+++ b/docs/planning/shared-mailboxes-pm-dev-spec.md
@@ -34,8 +34,10 @@ they add one.
   option; Outlook is the only thing that automaps it, and imperfectly.
 - **Team-mailbox member.** Shares `info@` / `sales@` with colleagues on Exchange. Wants it
   alongside personal mail but clearly separate.
-- **Small-business IMAP user.** A generic-IMAP host with a shared role mailbox exposed via
-  RFC 2342 NAMESPACE. Wants the same experience without Microsoft.
+
+(A "small-business generic-IMAP shared role mailbox" persona was considered and **dropped** — see
+§4.2: non-Microsoft IMAP "shared" is RFC 2342 namespace folders, not a delegated mailbox, and is
+out of scope. Both remaining personas are work/school Exchange, which is the whole feature.)
 
 ### 2.3 Why now
 
@@ -66,14 +68,20 @@ missing when #59 was written.
 | Feature | Setting / Shortcut | Default | Notes |
 |---|---|---|---|
 | Add shared mailbox by address | Command `account.addShared` (Account category, no default key) + button in Manage Accounts | — | The durable entry point; no EWS. |
-| Read shared mail | — | — | Graph `/users/{shared}/…` or IMAP `user=`, by parent backend. |
-| Send *from* shared mailbox | Shared address appears in compose `SenderAccounts` | — | Graph `sendMail` on `/users/{shared}` (`Mail.Send.Shared`) or IMAP-parent SMTP XOAUTH2 `user=`. |
+| Read shared mail | — | — | Work/school Microsoft only: Graph `/users/{shared}/…`, or Exchange-IMAP XOAUTH2 `user={shared}`, by the parent's backend. |
+| Send *from* shared mailbox | Shared address appears in compose `SenderAccounts` | — | Graph `sendMail` on `/users/{shared}` (`Mail.Send.Shared`) or Exchange-IMAP SMTP XOAUTH2 `user=`. |
 | Own top-level tree node | — | — | Sibling of real accounts; label "{name} (shared)". |
 | New-mail toast for shared mailbox | new per-account `NotifyOnNewMail` opt-in | **off** for shared | Global `NotifyOnNewMail` (`MainViewModel.cs:2678`) still governs real accounts; shared adds a per-account gate defaulting off. |
-| Generic-IMAP discovery | RFC 2342 `NAMESPACE` | — | For non-Microsoft IMAP only. |
 
 ### 4.2 Explicitly out of scope (v1)
 
+- **Non-Microsoft ("generic") IMAP shared access** — a shared mailbox is a work/school Exchange
+  concept. Consumer/other IMAP servers have no delegated mailbox added by address; RFC 2342
+  `NAMESPACE` exposes "Other Users"/"Shared" *folders* inside the user's own connection (governed by
+  RFC 4314 ACLs), which is a different concept that does not fit the separate-account model. Only
+  **work/school Microsoft** accounts (Graph or Exchange-IMAP) can be shared-mailbox parents; the
+  Add-shared dialog restricts eligibility to them. (Amended after PR 2; the original spec listed
+  generic-IMAP NAMESPACE in scope.)
 - **EWS auto-detection of automapped mailboxes** — deferred (EWS retirement, §13). Manual
   add-by-address is the v1 path. Revisit only if Microsoft ships a Graph enumeration API.
 - **No setting to include shared mail in the unified All Inboxes / All Mail views** — the
@@ -133,22 +141,26 @@ shared account routes through `MailServiceRouter` by its own id (`Services/MailS
 `RegisterAccount`), and the existing `RegisterAccountBackend` hook (`App.xaml.cs:460`,
 `MainViewModel.cs:1259`) already fires per account.
 
-**Decision: access follows the parent's backend.**
+**Decision: access follows the parent's backend — and the parent is always a work/school Microsoft
+account** (the only place a shared mailbox exists). Eligibility is enforced in
+`AddSharedMailboxViewModel` (parent must be `AuthType.OAuth2Microsoft` and not personal).
 - **Graph parent** → `/users/{SharedAddress}/…` with delegated `Mail.ReadWrite.Shared` and
-  `Mail.Send.Shared` (no admin consent). New scope constants in `OAuthService`; because
-  work/school uses `.default` (`OAuthService.cs:33-38`) these must **also** be declared on
-  the app registration or they're never granted. **Work/school only** — personal MS accounts
-  use `GraphMailScopesPersonal` and don't have Exchange shared mailboxes.
-- **IMAP parent** → XOAUTH2 `user={SharedAddress}` over the parent's token (read *and* SMTP send).
-- **Generic IMAP** → ordinary IMAP; RFC 2342 NAMESPACE for discovery.
+  `Mail.Send.Shared`. New scope constants in `OAuthService`, requested at add-time consent
+  (`RequestSharedMailboxConsentAsync`) and declared on the app registration.
+- **Exchange-IMAP parent** (work/school Microsoft on IMAP-OAuth) → XOAUTH2 `user={SharedAddress}`
+  over the parent's token (read *and* SMTP send). A shrinking case as Microsoft accounts move to
+  Graph (#529); PR 3.
+- **Generic (non-Microsoft) IMAP** → **out of scope** (§4.2): RFC 2342 shared *folders* are not a
+  delegated mailbox added by address and do not fit the separate-account model.
 
 **Decision: freshness is backend-conditional (corrects rev-1's blanket "no live watcher").**
 - **Graph parent:** `.Shared` scopes **do not support change-notification subscriptions**
   (that needs the app-only `Mail.Read`, admin-consented — out of scope). So a Graph shared
   mailbox has **no delta, no live watcher**; its only freshness is the #456 sweep
   (`StartFallbackSyncAsync`), which already iterates every account. Poll-interval, not instant.
-- **IMAP parent / generic IMAP:** an ordinary IMAP account with its own connection — it gets
-  **IMAP IDLE** like any account (`ImapMailService.cs:932`). Live, not poll-only.
+- **Exchange-IMAP parent** (work/school Microsoft on IMAP-OAuth): an ordinary IMAP account with its
+  own connection — it gets **IMAP IDLE** like any account (`ImapMailService.cs:932`). Live, not
+  poll-only.
 - Consequence: the "updates every few minutes, not instantly" caveat (§7) applies **only to
   Graph-backed** shared mailboxes; the add dialog shows it conditionally on the resolved
   backend.
@@ -299,11 +311,13 @@ shipping a feature that breaks in ~2 months. Manual add-by-address is the v1 pat
    `IsShared` exclusion, cascade removal. **No backend access yet** (the account exists and
    is navigable; folders empty until PR 2/3). Proves Approach B.
 2. **Graph read access.** `/users/{SharedAddress}/…` in `GraphMailService`; `.Shared` scope
-   consts; the `IsShared` → parent-token resolver. Behind the manual-add path; needs the scope
-   declared to run end-to-end.
-3. **IMAP read access + RFC 2342 NAMESPACE.** XOAUTH2 `user=` for an IMAP parent; NAMESPACE
-   for generic IMAP.
-4. **Send.** Graph `sendMail` on `/users/{shared}` (`Mail.Send.Shared`) + IMAP-parent SMTP
+   consts; the `IsShared` → parent-token resolver; add-time consent. DONE (#600). Parent
+   eligibility tightened to work/school Microsoft only (generic-IMAP dropped from scope, §4.2).
+3. **Exchange-IMAP read access.** XOAUTH2 `user={SharedAddress}` for a work/school Microsoft
+   IMAP-OAuth parent (much of the plumbing — parent-token resolver, `user=` from the shared
+   account's Username — already exists from PR 2; the main work is letting IMAP-parent shared
+   accounts connect). A shrinking case (#529). No generic-IMAP / NAMESPACE (out of scope, §4.2).
+4. **Send.** Graph `sendMail` on `/users/{shared}` (`Mail.Send.Shared`) + Exchange-IMAP SMTP
    XOAUTH2 `user=`; compose sender-identity wiring; send keyboard walkthrough (§6 Path C).
 5. **Toast opt-in + polish.** Per-account `NotifyOnNewMail` gate, docs (User Guide page + the
    poll-interval note), accessibility pass.


### PR DESCRIPTION
Part of #31. A small correctness fix + spec scope amendment, surfaced while live-testing #600.

## The bug

A shared mailbox is a **work/school Exchange** concept. The Add-shared parent-eligibility filter only excluded shared accounts, POP3, and personal-Microsoft-**Graph** — so it wrongly offered as shared-mailbox parents:
- a **personal Microsoft account on IMAP** (outlook.com on ImapSmtp), and
- **generic non-Microsoft IMAP** accounts (Fastmail, Yahoo, iCloud, Gmail-via-IMAP),

none of which can host a shared mailbox.

## The fix

Tighten eligibility to **work/school Microsoft only**:
```
!a.IsShared && a.AuthType == AuthType.OAuth2Microsoft && !OAuthService.ResolveIsPersonalMicrosoftAccount(a)
```
This admits work/school Microsoft on **Graph and Exchange-IMAP-OAuth** (keying on the auth type, not the backend), and excludes personal MS on any backend, generic/password IMAP, Google, POP3, and shared. The no-eligible-parent message is updated to match (no more "or IMAP account").

## Spec: drop generic-IMAP from scope

Non-Microsoft "generic" IMAP is moved **out of scope**. RFC 2342 `NAMESPACE` exposes "Other Users"/"Shared" *folders* inside the user's own connection (governed by RFC 4314 ACLs) — a different concept from a delegated mailbox added by address, and it doesn't fit the separate-account model. Amended §2 personas, §4.1/§4.2, §5.1, the freshness bullet, and the phases. **Work/school Exchange-IMAP (XOAUTH2 `user=`) stays in scope** for PR 3.

## Tests

`AddSharedMailboxViewModelTests` now pins the full eligibility matrix (work/school Graph + Exchange-IMAP in; personal any-backend, generic IMAP, Google, POP3, shared out), with the generic/password-IMAP exclusion positively asserted. `Pop3AccountSetupTests` and `UnitTest1` updated to use a valid work/school parent.

Independently reviewed (against the committed diff) — clean, no defects; 102 filtered tests pass; main builds with 0 analyzer warnings.
