### PR TITLE
Shared mailboxes PR 4: send-as over Graph (#31)

### DIFF
--- a/QuickMail.Tests/GraphSendMailServiceTests.cs
+++ b/QuickMail.Tests/GraphSendMailServiceTests.cs
@@ -49,6 +49,16 @@ public class GraphSendMailServiceTests
         BackendKind = BackendKind.MicrosoftGraph,
     };
 
+    private static AccountModel SharedGraphAccount() => new()
+    {
+        Id = Guid.NewGuid(),
+        Username = "support@contoso.com",
+        SharedAddress = "support@contoso.com",
+        IsShared = true,
+        ParentAccountId = Guid.NewGuid(),
+        BackendKind = BackendKind.MicrosoftGraph,
+    };
+
     /// <summary>The body is ASCII base64; decode it back to the raw MIME text.</summary>
     private static string DecodeMime(byte[] body) =>
         Encoding.UTF8.GetString(Convert.FromBase64String(Encoding.ASCII.GetString(body)));
@@ -65,6 +75,22 @@ public class GraphSendMailServiceTests
         Assert.Equal("text/plain", handler.ContentType);
         var mime = DecodeMime(handler.Body!);
         Assert.Contains("Subject: Hi there", mime);
+        Assert.Contains("alice@x.com", mime);
+    }
+
+    [Fact]
+    public async Task SendAsync_SharedMailbox_PostsToUsersSendMail_FromSharedAddress() // #31 PR 4
+    {
+        var (svc, handler) = Make();
+        var compose = new ComposeModel { To = "alice@x.com", Subject = "From shared", Body = "Hi" };
+
+        await svc.SendAsync(compose, SharedGraphAccount(), null, TestContext.Current.CancellationToken);
+
+        // Routed to the shared mailbox, not /me — GraphClient.ApplySharedRoot rewrites the path for a
+        // shared account, so send-as posts against /users/{SharedAddress}/sendMail.
+        Assert.Equal("https://graph.microsoft.com/v1.0/users/support@contoso.com/sendMail", handler.Url);
+        var mime = DecodeMime(handler.Body!);
+        Assert.Contains("support@contoso.com", mime);   // From carries the shared address
         Assert.Contains("alice@x.com", mime);
     }
 

--- a/QuickMail.Tests/OAuthServiceScopeSelectionTests.cs
+++ b/QuickMail.Tests/OAuthServiceScopeSelectionTests.cs
@@ -108,7 +108,10 @@ public class OAuthServiceScopeSelectionTests
         };
         Assert.Same(OAuthService.GraphMailScopesShared, OAuthService.DefaultScopesFor(account));
         Assert.Contains("https://graph.microsoft.com/Mail.ReadWrite.Shared", OAuthService.GraphMailScopesShared);
-        // Not the work/school set — a shared read never touches /me, so no User.Read etc.
+        // #31 PR 4: the shared default token also carries Mail.Send.Shared, so send-as works without a
+        // separate scope request (the non-shared work/school default likewise includes Mail.Send).
+        Assert.Contains("https://graph.microsoft.com/Mail.Send.Shared", OAuthService.GraphMailScopesShared);
+        // Not the work/school set — a shared read/send never touches /me, so no User.Read etc.
         Assert.DoesNotContain("https://graph.microsoft.com/User.Read", OAuthService.GraphMailScopesShared);
     }
 

--- a/QuickMail/Services/OAuthService.cs
+++ b/QuickMail/Services/OAuthService.cs
@@ -69,25 +69,17 @@ public class OAuthService : IOAuthService
         "https://graph.microsoft.com/User.Read",                  // /me profile read (GraphMailService)
     ];
 
-    // Shared mailboxes (#31, PR 2): a shared mailbox reads through its PARENT work/school account's
+    // Shared mailboxes (#31): a shared mailbox reads and sends through its PARENT work/school account's
     // token, but against the shared address's messages (/users/{SharedAddress}/…), which needs the
-    // delegated *.Shared* permission — Mail.ReadWrite.Shared covers read, mark-read, and (PR 3+) move.
+    // delegated *.Shared* permissions — Mail.ReadWrite.Shared covers read/mark-read/move, and
+    // Mail.Send.Shared covers send-as (PR 4). This is the shared account's DEFAULT scope set (like the
+    // work/school set above includes Mail.Send for a normal account), so a single token carries both;
+    // both were already granted at add time (GraphSharedMailboxConsentScopes), so no extra prompt.
     // WORK/SCHOOL ONLY: personal Microsoft accounts have no Exchange shared mailboxes, and the Add-shared
-    // dialog already excludes personal parents. Like the work/school scopes above, this is hand-maintained
-    // AND must be declared on the app registration (delegated Mail.ReadWrite.Shared) or the call 403s at
-    // runtime — see docs/ENTRA-APP-REGISTRATION.md and #31. Mail.Send.Shared (send-as) is PR 4, not here.
-    // No /me is ever called on the shared path, so User.Read is deliberately absent.
+    // dialog already excludes personal parents. Hand-maintained AND must be declared on the app
+    // registration or the call 403s at runtime — see docs/ENTRA-APP-REGISTRATION.md and #31. No /me is
+    // ever called on the shared path, so User.Read is deliberately absent.
     public static readonly string[] GraphMailScopesShared =
-    [
-        "https://graph.microsoft.com/Mail.ReadWrite.Shared",
-    ];
-
-    // The scopes CONSENTED when a shared mailbox is added (RequestSharedMailboxConsentAsync). Read AND
-    // send together, so the one consent covers PR 2 (read) and PR 4 (send-as) — the user is never
-    // re-prompted when sending ships. Both are declared on the app registration (Kelly). The ongoing
-    // read path still requests only GraphMailScopesShared; this wider set exists purely to drive the
-    // one-time consent up front.
-    public static readonly string[] GraphSharedMailboxConsentScopes =
     [
         "https://graph.microsoft.com/Mail.ReadWrite.Shared",
         "https://graph.microsoft.com/Mail.Send.Shared",
@@ -500,15 +492,17 @@ public class OAuthService : IOAuthService
 
     public async Task RequestSharedMailboxConsentAsync(AccountModel parent, CancellationToken ct = default)
     {
-        // #31: the one-time consent that lets a shared mailbox be read (and, from PR 4, sent as) through
-        // this PARENT account's token. Acquiring a token for the .Shared scopes drives it — silent if the
-        // grant already exists (e.g. the tenant admin-consented), otherwise the real Microsoft consent
-        // window, where the user consents, an admin grants for the org, or it is declined/pending. The
-        // token is discarded; the grant now lives in the MSAL cache, so the shared account's later silent
-        // acquisition succeeds. Runs on the PARENT (not IsShared), so the interactive fallback is allowed —
-        // a shared account is silent-only and would throw instead of prompting. A decline/pending consent
-        // throws MsalException up to the caller, which leaves the shared mailbox added-but-disconnected.
-        await GetAccessTokenAsync(parent, GraphSharedMailboxConsentScopes, ct);
+        // #31: the one-time consent that lets a shared mailbox be read and sent-as through this PARENT
+        // account's token. Consents the same scope set the shared account then uses per-token
+        // (GraphMailScopesShared = read + send), so one prompt covers everything. Acquiring a token for
+        // those scopes drives it — silent if the grant already exists (e.g. the tenant admin-consented),
+        // otherwise the real Microsoft consent window, where the user consents, an admin grants for the
+        // org, or it is declined/pending. The token is discarded; the grant now lives in the MSAL cache,
+        // so the shared account's later silent acquisition succeeds. Runs on the PARENT (not IsShared),
+        // so the interactive fallback is allowed — a shared account is silent-only and would throw
+        // instead. A decline/pending consent throws MsalException up to the caller, which leaves the
+        // shared mailbox added-but-disconnected.
+        await GetAccessTokenAsync(parent, GraphMailScopesShared, ct);
     }
 
     public async Task RequestCalendarConsentAsync(AccountModel account, CancellationToken ct = default)

--- a/QuickMail/Services/OAuthService.cs
+++ b/QuickMail/Services/OAuthService.cs
@@ -74,7 +74,7 @@ public class OAuthService : IOAuthService
     // delegated *.Shared* permissions — Mail.ReadWrite.Shared covers read/mark-read/move, and
     // Mail.Send.Shared covers send-as (PR 4). This is the shared account's DEFAULT scope set (like the
     // work/school set above includes Mail.Send for a normal account), so a single token carries both;
-    // both were already granted at add time (GraphSharedMailboxConsentScopes), so no extra prompt.
+    // both are granted together at add time via RequestSharedMailboxConsentAsync, so no extra prompt.
     // WORK/SCHOOL ONLY: personal Microsoft accounts have no Exchange shared mailboxes, and the Add-shared
     // dialog already excludes personal parents. Hand-maintained AND must be declared on the app
     // registration or the call 403s at runtime — see docs/ENTRA-APP-REGISTRATION.md and #31. No /me is


### PR DESCRIPTION
## Shared mailboxes PR 4: send-as over Graph (#31)

Fourth PR in the shared-mailboxes plan (#31). PR 2 (#600) landed Graph **read**; this closes the **send** path so a user can send *as* a shared mailbox.

### The change is small — because PR 2 + #600 did the heavy lifting

- `ComposeViewModel` already lists shared accounts in the From picker (unfiltered `LoadAccounts`).
- `SmtpService.SendAsync` already routes `BackendKind==MicrosoftGraph` → `GraphSendMailService`, whose `GraphClient.ApplySharedRoot` already rewrites `/me/sendMail` → `/users/{SharedAddress}/sendMail`.
- The **only** gap was the token: a shared account's default scope set was read-only.

So this PR:
- Widens `GraphMailScopesShared` to `[Mail.ReadWrite.Shared, Mail.Send.Shared]` — the shared account's default scope set now carries send, mirroring how the work/school default set includes `Mail.Send`.
- Removes the now-redundant `GraphSharedMailboxConsentScopes` array (identical to the widened default set) and points `RequestSharedMailboxConsentAsync` at `GraphMailScopesShared` — one source of truth for what a shared account consents to and acquires per token.

### Why widening the default scope is safe

A shared account's grant is established once, at add time, by `RequestSharedMailboxConsentAsync` requesting exactly `GraphMailScopesShared` — the same read+send superset every later token acquires. So the grant always covers both, or the account never connects. PR 2's consent already requested read+send together, so there are no read-only-grant shared accounts in the wild. MSAL silent acquisition validates against the *grant*, so a cache that only ever held read tokens silently upgrades to read+send. No read-path regression.

### Tests

- `SendAsync_SharedMailbox_PostsToUsersSendMail_FromSharedAddress` — asserts the POST goes to `.../users/support@contoso.com/sendMail` (distinct from the `/me/sendMail` pinned by the existing test, so the rewrite is genuinely exercised) and the From carries the shared address.
- `OAuthServiceScopeSelectionTests` updated to assert `Mail.Send.Shared` is in the shared scope set.
- Build clean (0 warnings). Targeted suites green.

### Independent review notes (addressed / tracked)

Ran an independent adversarial review on the committed diff. No blocking issues. One nit fixed in this PR (stale comment referencing the deleted array). Deferred/external items tracked for the pre-GA pass:
- **L2 (external, Kelly):** `Mail.Send.Shared` delegated must be declared on the app registration (ClientId bcdc84f1) or the call 403s — same class as PR 2's shared scopes.
- **L3 (pre-existing, deferred to PR 5):** disconnected / IMAP-parent shared accounts still appear in the From picker; should be excluded or produce a clear "disconnected" message rather than a raw token failure. Behind the default-off `SharedMailboxes` flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
