### PR TITLE
Shared mailboxes PR 5: Graph-only parents + per-account notification opt-in (#31)

### DIFF
--- a/QuickMail.Tests/AddSharedMailboxViewModelTests.cs
+++ b/QuickMail.Tests/AddSharedMailboxViewModelTests.cs
@@ -35,12 +35,12 @@ public class AddSharedMailboxViewModelTests
     };
 
     [Fact]
-    public void ParentOptions_OnlyWorkSchoolMicrosoft() // #31 — shared mailboxes exist only there
+    public void ParentOptions_OnlyWorkSchoolMicrosoftGraph() // #31 PR 5 — shared mailboxes are Graph-only
     {
         var workGraph    = Graph("WorkGraph");                       // work/school MS on Graph → IN
-        var workImap     = MsImap("WorkImap");                       // work/school MS on Exchange IMAP → IN
+        var workImap     = MsImap("WorkImap");                       // work/school MS on Exchange IMAP → OUT (PR 3 dropped)
         var personalGraph = Graph("PersonalG", personal: true);     // personal MS on Graph → OUT
-        var personalImap = new AccountModel                          // personal MS on IMAP → OUT (the gap this closes)
+        var personalImap = new AccountModel                          // personal MS on IMAP → OUT
         {
             Id = Guid.NewGuid(), AccountName = "PersonalI", Username = "me@outlook.com",
             BackendKind = BackendKind.ImapSmtp, AuthType = AuthType.OAuth2Microsoft,
@@ -59,9 +59,9 @@ public class AddSharedMailboxViewModelTests
             [workGraph, workImap, personalGraph, personalImap, genericImap, google, pop3, shared]);
 
         Assert.Contains(workGraph, vm.ParentOptions);
-        Assert.Contains(workImap, vm.ParentOptions);
+        Assert.DoesNotContain(workImap, vm.ParentOptions);        // work/school on IMAP: dropped in PR 3, Graph-only now
         Assert.DoesNotContain(personalGraph, vm.ParentOptions);   // personal MS has no shared mailboxes
-        Assert.DoesNotContain(personalImap, vm.ParentOptions);    // ...on IMAP either — the gap this fix closes
+        Assert.DoesNotContain(personalImap, vm.ParentOptions);    // ...on IMAP either
         Assert.DoesNotContain(genericImap, vm.ParentOptions);     // non-Microsoft IMAP: RFC 2342 folders, not delegated mailboxes
         Assert.DoesNotContain(google, vm.ParentOptions);
         Assert.DoesNotContain(pop3, vm.ParentOptions);
@@ -88,14 +88,19 @@ public class AddSharedMailboxViewModelTests
     }
 
     [Fact]
-    public void ShowGraphPollNote_TrueForGraphParent_FalseForImap()
+    public void ShowGraphPollNote_TrueForGraphParent_FalseOtherwise()
     {
-        var vm = new AddSharedMailboxViewModel([Graph("Work"), MsImap("Home")]);
+        // Parents are Graph-only now, so the only eligible parent shows the poll note. The false branch is
+        // the property's defensive guard: assigning a non-Graph account directly still returns false.
+        var vm = new AddSharedMailboxViewModel([Graph("Work")]);
 
         vm.SelectedParent = vm.ParentOptions.First(a => a.BackendKind == BackendKind.MicrosoftGraph);
         Assert.True(vm.ShowGraphPollNote);
 
-        vm.SelectedParent = vm.ParentOptions.First(a => a.BackendKind == BackendKind.ImapSmtp);
+        vm.SelectedParent = MsImap("Home");   // not from ParentOptions — a defensive non-Graph selection
+        Assert.False(vm.ShowGraphPollNote);
+
+        vm.SelectedParent = null;
         Assert.False(vm.ShowGraphPollNote);
     }
 

--- a/QuickMail.Tests/ReconnectConditionTests.cs
+++ b/QuickMail.Tests/ReconnectConditionTests.cs
@@ -55,8 +55,10 @@ public class ReconnectConditionTests
     }
 
     [Fact]
-    public void ImapParentSharedMailbox_IsNotConnected() // #31 — deferred to PR 3 (XOAUTH2 user=)
+    public void ImapParentSharedMailbox_IsNotConnected() // #31 — shared is Graph-only (IMAP PR 3 dropped)
     {
+        // Shared mailboxes are Graph-only for v1; an IMAP-backed shared account should never be created
+        // (parent eligibility is Graph-only), and if one somehow exists it must not connect.
         var id = Guid.NewGuid();
         var shared = new AccountModel { Id = id, IsShared = true, BackendKind = BackendKind.ImapSmtp };
         var result = MainViewModel.AccountsNeedingConnect([shared], _ => false, _ => false);

--- a/QuickMail.Tests/SharedMailboxModelTests.cs
+++ b/QuickMail.Tests/SharedMailboxModelTests.cs
@@ -45,6 +45,20 @@ public class SharedMailboxModelTests
         Assert.False(back.IsShared);
         Assert.Null(back.ParentAccountId);
         Assert.Null(back.SharedAddress);
+        Assert.False(back.NotifyOnNewMail);   // #31 PR 5: notify opt-in defaults off, no migration
+    }
+
+    [Fact]
+    public void NotifyOnNewMail_RoundTripsThroughJson() // #31 PR 5
+    {
+        var back = RoundTrip(new AccountModel
+        {
+            AccountName = "Support", Username = "support@bits-acb.org",
+            BackendKind = BackendKind.MicrosoftGraph, IsShared = true,
+            SharedAddress = "support@bits-acb.org", NotifyOnNewMail = true,
+        });
+
+        Assert.True(back.NotifyOnNewMail);
     }
 
     [Fact]

--- a/QuickMail.Tests/SharedMailboxModelTests.cs
+++ b/QuickMail.Tests/SharedMailboxModelTests.cs
@@ -49,6 +49,20 @@ public class SharedMailboxModelTests
     }
 
     [Fact]
+    public void ManagerListAccessibleName_QualifiesSharedMailbox() // #31 PR 5
+    {
+        var shared = new AccountModel { AccountName = "Support", Username = "support@work.com", IsShared = true };
+        var normal = new AccountModel { AccountName = "Work", Username = "me@work.com" };
+        var sharedDefault = new AccountModel { AccountName = "Support", IsShared = true, IsDefault = true };
+
+        Assert.Equal("Support, shared mailbox", shared.ManagerListAccessibleName);
+        Assert.Equal("Work", normal.ManagerListAccessibleName);                       // no qualifier for a normal account
+        Assert.Equal("Support, shared mailbox - default", sharedDefault.ManagerListAccessibleName);
+        // Deliberately no connection/unread state — unlike AccessibleName — so the editor list stays quiet.
+        Assert.DoesNotContain("connected", shared.ManagerListAccessibleName);
+    }
+
+    [Fact]
     public void NotifyOnNewMail_RoundTripsThroughJson() // #31 PR 5
     {
         var back = RoundTrip(new AccountModel

--- a/QuickMail.Tests/SharedMailboxNotifyOptInTests.cs
+++ b/QuickMail.Tests/SharedMailboxNotifyOptInTests.cs
@@ -1,0 +1,95 @@
+using System;
+using QuickMail.Models;
+using QuickMail.Services;
+using QuickMail.ViewModels;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// #31 PR 5: the shared-mailbox new-mail notification opt-in on <see cref="AccountManagerViewModel"/>.
+/// The checkbox's Click handler calls <see cref="AccountManagerViewModel.SetNotifyOnNewMail"/>, which
+/// applies to the SELECTED account only, is a no-op for a normal or null selection, and writes to the
+/// account currently selected (not a previously selected one).
+/// </summary>
+public class SharedMailboxNotifyOptInTests
+{
+    private static readonly ProviderCatalog Catalog = new();
+
+    private static AccountManagerViewModel Manager(params AccountModel[] accounts)
+    {
+        var vm = new AccountManagerViewModel(
+            new StubAccountService(), new StubCredentialService(), new StubImapMailService(),
+            new StubOAuthService(), new StubLocalStoreService(), new StubConfigService(),
+            new StubFeatureGate(), Catalog);
+        foreach (var a in accounts) vm.Accounts.Add(a);
+        return vm;
+    }
+
+    private static AccountModel Parent(string name) => new()
+    {
+        Id = Guid.NewGuid(), AccountName = name, Username = name.ToLowerInvariant() + "@work.com",
+        BackendKind = BackendKind.MicrosoftGraph, AuthType = AuthType.OAuth2Microsoft,
+    };
+    private static AccountModel SharedOf(AccountModel parent, string addr) => new()
+    {
+        Id = Guid.NewGuid(), AccountName = addr, Username = addr, SharedAddress = addr,
+        IsShared = true, ParentAccountId = parent.Id, BackendKind = parent.BackendKind,
+    };
+
+    [Fact]
+    public void SetNotifyOnNewMail_OnSharedAccount_AppliesToThatAccount()
+    {
+        var parent = Parent("Work");
+        var shared = SharedOf(parent, "support@work.com");
+        var vm = Manager(parent, shared);
+        vm.SelectedAccount = shared;
+
+        vm.SetNotifyOnNewMail(true);
+
+        Assert.True(shared.NotifyOnNewMail);
+        vm.SetNotifyOnNewMail(false);
+        Assert.False(shared.NotifyOnNewMail);
+    }
+
+    [Fact]
+    public void SetNotifyOnNewMail_OnNormalAccount_IsNoOp()
+    {
+        var normal = Parent("Work");
+        var vm = Manager(normal);
+        vm.SelectedAccount = normal;
+
+        vm.SetNotifyOnNewMail(true);
+
+        Assert.False(normal.NotifyOnNewMail);   // the opt-in is meaningless for a normal account
+    }
+
+    [Fact]
+    public void SetNotifyOnNewMail_WritesToCurrentSelection_NotAPreviousOne()
+    {
+        var parent = Parent("Work");
+        var sharedA = SharedOf(parent, "a@work.com");
+        var sharedB = SharedOf(parent, "b@work.com");
+        var vm = Manager(parent, sharedA, sharedB);
+
+        vm.SelectedAccount = sharedA;   // select A, then switch to B before toggling
+        vm.SelectedAccount = sharedB;
+        vm.SetNotifyOnNewMail(true);
+
+        Assert.False(sharedA.NotifyOnNewMail);   // A untouched
+        Assert.True(sharedB.NotifyOnNewMail);    // only the current selection changes
+    }
+
+    [Fact]
+    public void SelectingSharedAccount_ReflectsItsNotifyState_InTheCheckbox()
+    {
+        var parent = Parent("Work");
+        var shared = SharedOf(parent, "support@work.com");
+        shared.NotifyOnNewMail = true;
+        var vm = Manager(parent, shared);
+
+        vm.SelectedAccount = shared;
+
+        Assert.True(vm.NotifyOnNewMail);   // OnSelectedAccountChanged mirrors the account's saved value
+    }
+}

--- a/QuickMail.Tests/WatchedConversationsPhase2Tests.cs
+++ b/QuickMail.Tests/WatchedConversationsPhase2Tests.cs
@@ -514,11 +514,11 @@ public class WatchedConversationsPhase2Tests
     }
 
     [Fact]
-    public void SharedMailbox_ProducesNoToast_EvenWithNotificationsOn() // #31 PR 2, spec §4.1
+    public void SharedMailbox_ProducesNoToast_ByDefault_EvenWithNotificationsOn() // #31 PR 2/5, spec §4.1
     {
-        // Now that shared accounts connect (PR 2), the #456 sweep delivers their inbox arrivals to the
-        // notify path. A shared mailbox is someone else's inbox you also watch, so it must not toast —
-        // the same incoming that produces two toasts for a normal account (test above) produces none.
+        // A shared mailbox is off by DEFAULT (NotifyOnNewMail unset): the #456 sweep delivers its inbox
+        // arrivals to the notify path, but the same incoming that produces two toasts for a normal account
+        // (test above) produces none — even with the global notification switches on.
         var (vm, watch, toasts, _) = MakeNotifyVm();
         watch.Watch("Budget Review");
         var shared = new AccountModel
@@ -526,6 +526,7 @@ public class WatchedConversationsPhase2Tests
             Id = Guid.NewGuid(), AccountName = "Support", Username = "support@example.com",
             AuthType = AuthType.OAuth2Microsoft, IsShared = true, ParentAccountId = AccountA,
             SharedAddress = "support@example.com", BackendKind = BackendKind.MicrosoftGraph,
+            // NotifyOnNewMail defaults false → excluded from toasts.
         };
         var incoming = new[] { Msg("1", "Re: Budget Review"), Msg("2", "Something unrelated") };
 
@@ -533,6 +534,32 @@ public class WatchedConversationsPhase2Tests
         vm.MaybeNotifyNewMail(shared, incoming);
 
         Assert.Empty(toasts.Toasts);
+    }
+
+    [Fact]
+    public void SharedMailbox_WithPerAccountOptIn_Toasts() // #31 PR 5
+    {
+        // The per-account opt-in (NotifyOnNewMail = true) adds a shared mailbox back into the notification
+        // set, so the same incoming now produces the watched + new-mail toasts a normal account gets. The
+        // global switches (on here, via MakeNotifyVm) still govern.
+        var (vm, watch, toasts, _) = MakeNotifyVm();
+        watch.Watch("Budget Review");
+        var shared = new AccountModel
+        {
+            Id = Guid.NewGuid(), AccountName = "Support", Username = "support@example.com",
+            AuthType = AuthType.OAuth2Microsoft, IsShared = true, ParentAccountId = AccountA,
+            SharedAddress = "support@example.com", BackendKind = BackendKind.MicrosoftGraph,
+            NotifyOnNewMail = true,   // opt-in ON
+        };
+        var incoming = new[] { Msg("1", "Re: Budget Review"), Msg("2", "Something unrelated") };
+
+        vm.MaybeNotifyWatchedMail(shared, incoming);
+        vm.MaybeNotifyNewMail(shared, incoming);
+
+        // Watched claims the matching subject; new-mail toasts the remainder — exactly the normal-account
+        // behaviour, now reached because the shared mailbox opted in.
+        Assert.Contains(toasts.Toasts, t => t.Kind == "watched" && t.Subjects.Contains("Re: Budget Review"));
+        Assert.Contains(toasts.Toasts, t => t.Kind == "new"     && t.Subjects.Contains("Something unrelated"));
     }
 
     [Fact]

--- a/QuickMail/Models/AccountModel.cs
+++ b/QuickMail/Models/AccountModel.cs
@@ -283,6 +283,23 @@ public partial class AccountModel : ObservableObject
     public string AccountLabelWithDefault => IsDefault ? $"{AccountLabel} - default" : AccountLabel;
 
     /// <summary>
+    /// Accessible name for the Account Manager list item (#31 PR 5): the label plus the "shared mailbox"
+    /// qualifier so a screen-reader user can tell a shared mailbox from a normal account without selecting
+    /// it — matching the main-window account list. Unlike <see cref="AccessibleName"/> it omits the live
+    /// connection/unread state, which is monitoring detail the editor list doesn't need; it keeps the
+    /// "- default" marker so that distinction is still spoken.
+    /// </summary>
+    public string ManagerListAccessibleName
+    {
+        get
+        {
+            var shared = IsShared ? ", shared mailbox" : "";
+            var def = IsDefault ? " - default" : "";
+            return $"{AccountLabel}{shared}{def}";
+        }
+    }
+
+    /// <summary>
     /// Short status line shown below the account name in the account list, and as a tooltip.
     /// TotalUnread covers all folders.
     /// Examples: "Disconnected", "Connected", "Connected — 1,630 unread"

--- a/QuickMail/Models/AccountModel.cs
+++ b/QuickMail/Models/AccountModel.cs
@@ -241,6 +241,16 @@ public partial class AccountModel : ObservableObject
     public string? SharedAddress { get; set; }
 
     /// <summary>
+    /// Per-account new-mail notification opt-in for a shared mailbox (#31 PR 5). Shared mailboxes are
+    /// excluded from new-mail and watched-conversation toasts by default — they are often high-volume role
+    /// mailboxes and a user rarely wants a toast for each one. Turning this on adds THIS shared mailbox
+    /// back into the notification set; the global master switches (<c>ConfigModel.NotifyOnNewMail</c> /
+    /// <c>NotifyOnWatchedConversation</c>) still govern, so a toast fires only when both are on. Ignored
+    /// for a normal account (the global switch alone governs those). Defaults false; no migration.
+    /// </summary>
+    public bool NotifyOnNewMail { get; set; }
+
+    /// <summary>
     /// The shared mailboxes (#31) that read through <paramref name="parent"/>, taken from
     /// <paramref name="all"/>. Empty when <paramref name="parent"/> is itself shared — a shared mailbox
     /// is never a parent. Both account-delete paths (the Account Manager and the main-window account

--- a/QuickMail/ViewModels/AccountManagerViewModel.cs
+++ b/QuickMail/ViewModels/AccountManagerViewModel.cs
@@ -89,6 +89,15 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
     // SyncContacts / SyncCalendar are inherited from AccountEditorViewModel (shared with Add Account).
 
     /// <summary>
+    /// #31 PR 5: per-account new-mail notification opt-in for a shared mailbox. Bound to the checkbox in
+    /// the shared-only editor block; mirrors <see cref="AccountModel.NotifyOnNewMail"/> for the selected
+    /// account. Assigned (not toggled) in <see cref="OnSelectedAccountChanged"/>; the checkbox's Click
+    /// handler calls <see cref="SetNotifyOnNewMail"/> to apply and persist on real user interaction only.
+    /// </summary>
+    [ObservableProperty]
+    private bool _notifyOnNewMail;
+
+    /// <summary>
     /// Calendar sync (#282) is offered for a superset of contact sync: Microsoft and Google (calendar
     /// API), plus iCloud accounts (CalDAV via the account's app-specific password). Other password/IMAP
     /// accounts show no checkbox.
@@ -171,6 +180,7 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
         Signature = value.Signature;
         SyncContacts = value.SyncContacts;
         SyncCalendar = value.SyncCalendar;
+        NotifyOnNewMail = value.NotifyOnNewMail;   // #31 PR 5: shared-mailbox notify opt-in for the checkbox
         // Restore the persisted personal-account flag (#233) so a re-auth resolves personal-vs-work from
         // the tenant-derived truth, not the domain guess — the vanity-domain personal case the
         // single-consent fold (#544) most needs.
@@ -291,6 +301,23 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
             StatusText = $"Calendar sync not enabled: {ex.Message}";
             LogService.Log($"AccountManager: calendar-sync enable failed for {account.AccountLabel} — {ex.Message}");
         }
+    }
+
+    /// <summary>
+    /// #31 PR 5: applies the shared-mailbox new-mail notification opt-in immediately and persists it —
+    /// no Save step, mirroring the contact/calendar-sync toggles. Called from the checkbox's Click handler
+    /// (real user interaction only, never the programmatic assignment in <see cref="OnSelectedAccountChanged"/>).
+    /// Returns without side effects if the selection isn't a shared account. <paramref name="enabled"/> is
+    /// the new checkbox state.
+    /// </summary>
+    public void SetNotifyOnNewMail(bool enabled)
+    {
+        if (SelectedAccount is not { IsShared: true } account) return;   // box shows only for shared; defensive
+        account.NotifyOnNewMail = enabled;
+        SaveAccountsPreservingConversionMarkers();
+        StatusText = enabled
+            ? "New-mail notifications enabled for this shared mailbox."
+            : "New-mail notifications disabled for this shared mailbox.";
     }
 
     public AddAccountViewModel CreateAddAccountViewModel() =>

--- a/QuickMail/ViewModels/AddSharedMailboxViewModel.cs
+++ b/QuickMail/ViewModels/AddSharedMailboxViewModel.cs
@@ -22,22 +22,25 @@ public partial class AddSharedMailboxViewModel : ObservableObject
     {
         _allAccounts = accounts.ToList();
 
-        // Only shared-capable accounts can host a shared mailbox: a work/school Microsoft 365 (Graph)
-        // Only a WORK/SCHOOL Microsoft account can be a shared-mailbox parent — that is the sole place a
-        // shared mailbox exists. It applies whether the account is on Graph (reads via /users/{shared})
-        // or on IMAP-OAuth (Exchange IMAP, XOAUTH2 user={shared}), so the test is the Microsoft OAuth
-        // auth type, not the backend. Everything else is excluded because it genuinely has no shared
-        // mailbox to offer:
-        //   - Personal Microsoft (Outlook.com/Hotmail/Live), on Graph OR IMAP: consumer accounts are not
-        //     in an Exchange org and cannot be granted access to another mailbox. Resolved via
-        //     ResolveIsPersonalMicrosoftAccount (flag, else domain guess), the same as scope selection.
+        // Only a WORK/SCHOOL Microsoft 365 account ON THE GRAPH BACKEND can be a shared-mailbox parent.
+        // Shared mailboxes are Graph-only for v1: a shared mailbox reads via /users/{shared} on the
+        // parent's Graph token, and Graph is the default and strictly better backend for a work/school
+        // account (mail-only folder taxonomy, immutable ids, delta). The IMAP-parent path (XOAUTH2
+        // user={shared}) was built and then dropped (#31 PR 3) — a work/school account on IMAP is a
+        // legacy/testing configuration with no real users, so it is not offered as a parent. Everything
+        // else is excluded because it has no shared mailbox to offer:
+        //   - Personal Microsoft (Outlook.com/Hotmail/Live): consumer accounts are not in an Exchange org
+        //     and cannot be granted access to another mailbox. Resolved via ResolveIsPersonalMicrosoftAccount
+        //     (flag, else domain guess), the same as scope selection.
         //   - Non-Microsoft IMAP (Gmail app-password, Yahoo, iCloud, Fastmail, "Other"): RFC 2342
         //     "shared folders" are namespace folders inside the user's own connection, not a delegated
         //     mailbox added by address — a different concept, deliberately out of scope (spec §4.2).
-        //   - POP3, and a shared account itself, have no second mailbox at all.
+        //   - A work/school account on the IMAP or POP3 backend, and a shared account itself: no Graph
+        //     token to borrow (IMAP dropped per PR 3; POP3 has no second mailbox at all).
         ParentOptions = _allAccounts
             .Where(a => !a.IsShared
                         && a.AuthType == AuthType.OAuth2Microsoft
+                        && a.BackendKind == BackendKind.MicrosoftGraph
                         && !OAuthService.ResolveIsPersonalMicrosoftAccount(a))
             .ToList();
 
@@ -70,8 +73,10 @@ public partial class AddSharedMailboxViewModel : ObservableObject
     [NotifyCanExecuteChangedFor(nameof(AddCommand))]
     private AccountModel? _selectedParent;
 
-    /// <summary>Graph shared mailboxes have no live watcher — only the #456 sweep. True for a Graph
-    /// parent (shows the poll caption and drives its Hint announce); false for an IMAP parent (IDLE).</summary>
+    /// <summary>Graph shared mailboxes have no live watcher — only the #456 sweep — so they update on the
+    /// poll interval, not instantly. Shows the poll caption and drives its Hint announce. Since parents are
+    /// now Graph-only (#31 PR 3/5), this is true for every eligible parent; kept as a guard against a null
+    /// or (defensively) non-Graph selection.</summary>
     public bool ShowGraphPollNote => SelectedParent?.BackendKind == BackendKind.MicrosoftGraph;
 
     /// <summary>The poll caption for a Graph parent. Shown visibly AND spoken once as a Hint when the

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -3831,10 +3831,10 @@ public partial class MainViewModel : ObservableObject, IDisposable
     // Settings change takes effect without a restart.
     internal void MaybeNotifyNewMail(AccountModel account, IReadOnlyList<MailMessageSummary> incoming)
     {
-        // #31: no new-mail toast for a shared mailbox. Now that shared accounts connect (PR 2) the #456
-        // sweep delivers their inbox arrivals here, but a shared mailbox is someone else's inbox you also
-        // watch — it stays off, defaulting off, until the per-account opt-in ships (spec §4.1, PR 5).
-        if (account.IsShared) return;
+        // #31: a shared mailbox is excluded from new-mail toasts by default — it is often a high-volume role
+        // mailbox and the #456 sweep would toast for each arrival. The per-account opt-in (PR 5) adds it back
+        // in; the global master switch below still governs, so a shared mailbox toasts only when both are on.
+        if (account.IsShared && !account.NotifyOnNewMail) return;
         if (_notifications is not { IsSupported: true }) return;
         if (!_configService.Load().NotifyOnNewMail) return;
 
@@ -3894,7 +3894,9 @@ public partial class MainViewModel : ObservableObject, IDisposable
     // argument for this pair of methods and is not observable from any public surface.
     internal void MaybeNotifyWatchedMail(AccountModel account, IReadOnlyList<MailMessageSummary> incoming)
     {
-        if (account.IsShared) return;   // #31: no toast for a shared mailbox (spec §4.1) — see MaybeNotifyNewMail
+        // #31: a shared mailbox is off by default here too; its per-account opt-in (PR 5) covers watched
+        // conversations as well as new mail. The global watched-conversation switch below still governs.
+        if (account.IsShared && !account.NotifyOnNewMail) return;
         if (_notifications is not { IsSupported: true }) return;
         if (_watchService == null) return;
         if (!_configService.Load().NotifyOnWatchedConversation) return;

--- a/QuickMail/Views/AccountManagerDialog.xaml
+++ b/QuickMail/Views/AccountManagerDialog.xaml
@@ -78,7 +78,7 @@
                      BorderThickness="1">
                 <ListBox.ItemContainerStyle>
                     <Style TargetType="ListBoxItem">
-                        <Setter Property="AutomationProperties.Name" Value="{Binding AccountLabelWithDefault}"/>
+                        <Setter Property="AutomationProperties.Name" Value="{Binding ManagerListAccessibleName}"/>
                     </Style>
                 </ListBox.ItemContainerStyle>
                 <ListBox.ItemTemplate>

--- a/QuickMail/Views/AccountManagerDialog.xaml
+++ b/QuickMail/Views/AccountManagerDialog.xaml
@@ -154,6 +154,15 @@
                              IsReadOnlyCaretVisible="True"
                              TextWrapping="Wrap"
                              AutomationProperties.LabeledBy="{Binding ElementName=LblSharedParent}"/>
+
+                    <!-- #31 PR 5: a shared mailbox is excluded from new-mail toasts by default (it is often a
+                         high-volume role mailbox). This opt-in adds it back in; the global new-mail
+                         notification switch in Settings still governs. Applied immediately (no Save step). -->
+                    <CheckBox x:Name="SharedNotifyCheckBox"
+                              Content="_Notify me of new mail in this shared mailbox"
+                              IsChecked="{Binding NotifyOnNewMail}"
+                              Click="SharedNotifyCheckBox_Click"
+                              Margin="0,8,0,0"/>
                 </StackPanel>
 
                 <!-- #31: the whole editable connection surface (password, OAuth sign-in) is hidden for a

--- a/QuickMail/Views/AccountManagerDialog.xaml
+++ b/QuickMail/Views/AccountManagerDialog.xaml
@@ -57,7 +57,7 @@
                         CommandParameter="{Binding SelectedAccount}"
                         AutomationProperties.Name="Set as default"
                         MinWidth="75" Margin="0,0,4,0" TabIndex="3"/>
-                <Button Content="Add _shared…"
+                <Button Content="Add shared mail_box…"
                         x:Name="AddSharedButton"
                         Click="AddSharedMailboxButton_Click"
                         AutomationProperties.Name="Add shared mailbox"
@@ -159,7 +159,7 @@
                          high-volume role mailbox). This opt-in adds it back in; the global new-mail
                          notification switch in Settings still governs. Applied immediately (no Save step). -->
                     <CheckBox x:Name="SharedNotifyCheckBox"
-                              Content="_Notify me of new mail in this shared mailbox"
+                              Content="Notify me of new _mail in this shared mailbox"
                               IsChecked="{Binding NotifyOnNewMail}"
                               Click="SharedNotifyCheckBox_Click"
                               Margin="0,8,0,0"/>

--- a/QuickMail/Views/AccountManagerDialog.xaml.cs
+++ b/QuickMail/Views/AccountManagerDialog.xaml.cs
@@ -257,4 +257,13 @@ public partial class AccountManagerDialog : Window
         if (sender is CheckBox { IsChecked: { } isChecked })
             await _vm.SetCalendarSyncAsync(isChecked);
     }
+
+    // The shared-mailbox "Notify me of new mail" checkbox (#31 PR 5) applies immediately and persists,
+    // same pattern as the sync toggles. Click fires only on real user interaction, so the programmatic
+    // assignment in OnSelectedAccountChanged does not re-trigger it.
+    private void SharedNotifyCheckBox_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is CheckBox { IsChecked: { } isChecked })
+            _vm.SetNotifyOnNewMail(isChecked);
+    }
 }

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -376,7 +376,7 @@ Server settings sit behind the same **Advanced settings** expander as in Add Acc
 
 ### Removing an account
 
-Select the account and press **Delete**. There is no confirmation step, and the removal happens at once: QuickMail forgets the account's password from Windows Credential Manager, deletes the mail it had cached, removes any contacts synced from it, and for Microsoft and Google accounts signs out as well. You hear "Account deleted. Cleaning up…", then "Account deleted." when the tidying has finished.
+Select the account and press **Delete**. For an ordinary account there is no confirmation step, and the removal happens at once: QuickMail forgets the account's password from Windows Credential Manager, deletes the mail it had cached, removes any contacts synced from it, and for Microsoft and Google accounts signs out as well. You hear "Account deleted. Cleaning up…", then "Account deleted." when the tidying has finished. (Deleting an account that a shared mailbox reads through does ask first, because it removes the shared mailbox too — see [Shared mailboxes](#shared-mailboxes).)
 
 **Nothing is deleted from the mail server.** Removing an account removes it from QuickMail only — add it again and your mail is still there.
 

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -380,6 +380,22 @@ Select the account and press **Delete**. There is no confirmation step, and the 
 
 **Nothing is deleted from the mail server.** Removing an account removes it from QuickMail only — add it again and your mail is still there.
 
+### Shared mailboxes
+
+A shared mailbox is a mailbox several people read and send from — a `support@`, `info@`, or `sales@` address that belongs to a team rather than a person. If your organization has given you access to one, you can add it to QuickMail and it appears as its own mailbox in the folder tree, alongside your own accounts.
+
+Shared mailboxes are a **Microsoft 365 work or school** feature. You add one through an account you already have: QuickMail reads and sends the shared mailbox using your existing sign-in, so there is no separate password and no separate sign-in for it. Personal Outlook.com accounts and non-Microsoft (IMAP) accounts do not have shared mailboxes, so the option is offered only when you have a work or school Microsoft 365 account to read it through.
+
+**To add a shared mailbox:** open **Account Manager** (Tools menu), activate **Add shared mailbox**, choose the work or school account that has access to it if you are asked, and type the shared mailbox's email address. Press **Add**. The mailbox connects using that account and its folders load. You do not need access to a password — access comes from your own account's permission to the mailbox, which your organization grants.
+
+**Reading and sending.** A shared mailbox reads like any other: select it in the folder tree and open its folders. To send from it, choose the shared address in the **From** list when composing — the message goes out as the shared mailbox, not as you.
+
+**Freshness.** A shared mailbox updates on a timer rather than the instant new mail arrives: **shared mailboxes update every few minutes, not instantly.** Your own mailboxes still update live; only the shared one waits for the next check.
+
+**New-mail notifications are off for a shared mailbox by default.** A shared mailbox is often a busy team address, so QuickMail does not pop a notification for every message that lands in it. If you do want notifications for a particular shared mailbox, select it in Account Manager and turn on **Notify me of new mail in this shared mailbox**. The main **Show a Notification When New Mail Arrives** setting still has to be on for any notification to appear.
+
+**Removing.** Removing the account that a shared mailbox reads through also removes the shared mailbox — you are told which shared mailboxes will go when you delete their parent account. Removing a shared mailbox on its own leaves the account it read through untouched.
+
 ---
 
 ## For Microsoft 365 Administrators and Tenant Owners
@@ -1450,6 +1466,8 @@ New-mail notifications and the option to keep QuickMail running in the notificat
 When this setting is on, QuickMail shows a Windows notification as new mail arrives in any inbox. The notification is announced by screen readers and appears in the Windows notification center, which you open with **Win+N** on Windows 11 (or **Win+A** on Windows 10). Pressing **Enter** on a notification brings QuickMail to the foreground and opens that message.
 
 If multiple messages arrive together, the notification shows a count ("5 new messages") and brings QuickMail to the foreground when activated. Single-message notifications show the sender's name and subject and open that message.
+
+**Shared mailboxes are an exception:** they do not notify by default, even with this setting on, because a shared mailbox is often a busy team address. To get notifications for a specific shared mailbox, turn on **Notify me of new mail in this shared mailbox** for it in Account Manager. This setting still has to be on for those notifications to appear. See [Shared mailboxes](#shared-mailboxes).
 
 Notifications require **Windows 10 1809 or later**.
 


### PR DESCRIPTION
## Shared mailboxes PR 5: polish (#31)

Final polish PR for shared mailboxes, scoped to two cohesive changes plus docs. Two larger items — the disconnected-shared From-picker filter and a Reconnect action — are split into follow-ups (#614, #615). Still behind the default-off `SharedMailboxes` flag.

### 1. Graph-only parent eligibility (f9286fe)

Shared mailboxes are Graph-only for v1 (the IMAP-parent path was built and dropped — see #612 — because a work/school account on IMAP is a legacy/testing config with no real users). `AddSharedMailboxViewModel.ParentOptions` now requires `BackendKind == MicrosoftGraph`, so a work/school account on IMAP/POP3 is no longer offered as a parent — closing the dead affordance where an IMAP parent could be picked but the shared mailbox could never connect.

### 2. Per-account new-mail notification opt-in (bb3ef15)

Shared mailboxes are excluded from new-mail and watched-conversation toasts by default (they're often high-volume role mailboxes). This adds a per-account opt-in:
- `AccountModel.NotifyOnNewMail` (bool, default false, no migration).
- The toast guards change from `if (IsShared) return;` to `if (IsShared && !NotifyOnNewMail) return;`. The global master switches still govern, so a shared mailbox toasts only when **both** its opt-in and the global setting are on. Normal accounts are unaffected.
- Account Manager: a "Notify me of new mail in this shared mailbox" checkbox (Alt+N) in the shared-only editor block, applied immediately and persisted with no Save step — same pattern as the contact/calendar-sync toggles.

### Docs

New "Shared mailboxes" User Guide section (what they are, work/school-only, add/read/send, the poll-interval caveat, the notify opt-in, cascade removal) and a shared-mailbox note in Notifications. The "Removing an account" line is qualified — a shared-mailbox parent does ask first.

> ⚠️ **Release-process note:** the User Guide now documents shared mailboxes, so the `SharedMailboxes` feature flag must be **on** before the release that publishes the guide, or the published guide describes a feature users can't see.

### Tests

- `ParentOptions_OnlyWorkSchoolMicrosoftGraph` (work/school-on-IMAP flipped to excluded); `ShowGraphPollNote` reworked.
- `SharedMailbox_WithPerAccountOptIn_Toasts` (opt-in on → toasts) alongside the default-off no-toast test; `NotifyOnNewMail` JSON round-trip.
- `SharedMailboxNotifyOptInTests` — the VM `SetNotifyOnNewMail` apply-path (correct account, no-op for normal/null, current-selection-only).
- Build clean (0 warnings); targeted suites green.

### Independent review

Ran an independent adversarial review on the two commits — no Critical/High/Medium findings; the toast-gate truth table, checkbox persistence/stale-state, access-key collisions, and doc accuracy were all traced and verified. Its Low (no VM-level test) and nit (doc "no confirmation step") are addressed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
