### PR TITLE
In-app organization admin-consent action (#607)

### DIFF
--- a/QuickMail.Tests/AdminConsentUrlTests.cs
+++ b/QuickMail.Tests/AdminConsentUrlTests.cs
@@ -46,7 +46,8 @@ public class AdminConsentUrlTests
                  })
             Assert.Contains(expected, scopes);
 
-        // No Exchange Online (outlook.office.com) — those declared perms are stale and would 65006 the grant.
+        // No Exchange Online (outlook.office.com): requesting the full declared set at once 65006s on that
+        // resource, so the admin-consent request stays Graph-only (the correct scope for #607 regardless).
         Assert.DoesNotContain(scopes, s => s.Contains("outlook.office.com", StringComparison.OrdinalIgnoreCase));
         Assert.Equal(scopes.Length, scopes.Distinct().Count()); // deduped union
     }

--- a/QuickMail.Tests/AdminConsentUrlTests.cs
+++ b/QuickMail.Tests/AdminConsentUrlTests.cs
@@ -13,17 +13,42 @@ namespace QuickMail.Tests;
 public class AdminConsentUrlTests
 {
     [Fact]
-    public void BuildAdminConsentUrl_UsesV1OrganizationsAdminConsentEndpoint()
+    public void BuildAdminConsentUrl_UsesV2OrganizationsAdminConsentWithExplicitScopes()
     {
         var url = OAuthService.BuildAdminConsentUrl("state123");
 
-        // v1 /adminconsent (NOT /v2.0): consents the app's whole DECLARED permission set, no scope list.
-        Assert.StartsWith("https://login.microsoftonline.com/organizations/adminconsent?", url);
-        Assert.DoesNotContain("/v2.0/", url);
-        Assert.DoesNotContain("scope=", url);   // declared-perms grant carries no scope parameter
+        // v2.0 + explicit scope list (NOT v1 declared-perms): only these Graph scopes are consented, so the
+        // request never touches the app registration's stale Exchange Online perms (AADSTS65006).
+        Assert.StartsWith("https://login.microsoftonline.com/organizations/v2.0/adminconsent?", url);
+        Assert.Contains("scope=", url);
         Assert.Contains("client_id=bcdc84f1-d37c-4581-b14a-a01f7b3a1312", url);
         Assert.Contains("redirect_uri=http%3A%2F%2Flocalhost", url);
         Assert.Contains("state=state123", url);
+    }
+
+    [Fact]
+    public void BuildAdminConsentUrl_RequestsEveryGraphScope_AndNoExchangeScope()
+    {
+        var url = OAuthService.BuildAdminConsentUrl("s");
+        var scopes = Uri.UnescapeDataString(url.Split("scope=")[1].Split('&')[0]).Split(' ');
+
+        foreach (var expected in new[]
+                 {
+                     "https://graph.microsoft.com/Mail.ReadWrite",
+                     "https://graph.microsoft.com/Mail.Send",
+                     "https://graph.microsoft.com/MailboxSettings.ReadWrite",
+                     "https://graph.microsoft.com/User.Read",
+                     "https://graph.microsoft.com/Contacts.Read",
+                     "https://graph.microsoft.com/People.Read",
+                     "https://graph.microsoft.com/Calendars.ReadWrite",
+                     "https://graph.microsoft.com/Mail.ReadWrite.Shared",
+                     "https://graph.microsoft.com/Mail.Send.Shared",
+                 })
+            Assert.Contains(expected, scopes);
+
+        // No Exchange Online (outlook.office.com) — those declared perms are stale and would 65006 the grant.
+        Assert.DoesNotContain(scopes, s => s.Contains("outlook.office.com", StringComparison.OrdinalIgnoreCase));
+        Assert.Equal(scopes.Length, scopes.Distinct().Count()); // deduped union
     }
 
     [Fact]

--- a/QuickMail.Tests/AdminConsentUrlTests.cs
+++ b/QuickMail.Tests/AdminConsentUrlTests.cs
@@ -48,6 +48,18 @@ public class AdminConsentUrlTests
     }
 
     [Fact]
+    public void ParseRedirect_SurfacesAadErrorEvenWithoutState()
+    {
+        // Azure AD does not always echo state on an error redirect. An error is never a grant, so we
+        // report AAD's real description rather than a misleading "state mismatch".
+        var r = OAuthService.ParseAdminConsentRedirect(
+            new Uri("http://localhost/?error=access_denied&error_description=Consent+required"), "xyz");
+
+        Assert.Equal(AdminConsentStatus.Error, r!.Value.Status);
+        Assert.Equal("Consent required", r.Value.Error);
+    }
+
+    [Fact]
     public void ParseRedirect_StateMismatchIsErrorNeverSuccess() // CSRF guard
     {
         var r = OAuthService.ParseAdminConsentRedirect(

--- a/QuickMail.Tests/AdminConsentUrlTests.cs
+++ b/QuickMail.Tests/AdminConsentUrlTests.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Linq;
+using QuickMail.Services;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// #607: the pure core of the organization admin-consent flow — the /adminconsent URL builder and the
+/// redirect parser. These are the whole security-and-correctness surface (right endpoint, all scopes,
+/// state/CSRF guard, grant-vs-decline-vs-error), tested without MSAL or a WebView.
+/// </summary>
+public class AdminConsentUrlTests
+{
+    [Fact]
+    public void BuildAdminConsentUrl_UsesV1OrganizationsAdminConsentEndpoint()
+    {
+        var url = OAuthService.BuildAdminConsentUrl("state123");
+
+        // v1 /adminconsent (NOT /v2.0): consents the app's whole DECLARED permission set, no scope list.
+        Assert.StartsWith("https://login.microsoftonline.com/organizations/adminconsent?", url);
+        Assert.DoesNotContain("/v2.0/", url);
+        Assert.DoesNotContain("scope=", url);   // declared-perms grant carries no scope parameter
+        Assert.Contains("client_id=bcdc84f1-d37c-4581-b14a-a01f7b3a1312", url);
+        Assert.Contains("redirect_uri=http%3A%2F%2Flocalhost", url);
+        Assert.Contains("state=state123", url);
+    }
+
+    [Fact]
+    public void ParseRedirect_GrantedWhenAdminConsentTrueAndStateMatches()
+    {
+        var r = OAuthService.ParseAdminConsentRedirect(
+            new Uri("http://localhost/?admin_consent=True&tenant=abc&state=xyz"), "xyz");
+
+        Assert.NotNull(r);
+        Assert.Equal(AdminConsentStatus.Granted, r!.Value.Status);
+        Assert.Null(r.Value.Error);
+    }
+
+    [Fact]
+    public void ParseRedirect_ErrorCarriesDescription()
+    {
+        var r = OAuthService.ParseAdminConsentRedirect(
+            new Uri("http://localhost/?error=access_denied&error_description=Not+an+admin&state=xyz"), "xyz");
+
+        Assert.Equal(AdminConsentStatus.Error, r!.Value.Status);
+        Assert.Equal("Not an admin", r.Value.Error);
+    }
+
+    [Fact]
+    public void ParseRedirect_StateMismatchIsErrorNeverSuccess() // CSRF guard
+    {
+        var r = OAuthService.ParseAdminConsentRedirect(
+            new Uri("http://localhost/?admin_consent=True&state=WRONG"), "xyz");
+
+        Assert.Equal(AdminConsentStatus.Error, r!.Value.Status); // not Granted, despite admin_consent=True
+    }
+
+    [Fact]
+    public void ParseRedirect_DeclinedWhenLandsOnLocalhostWithoutGrant()
+    {
+        var r = OAuthService.ParseAdminConsentRedirect(
+            new Uri("http://localhost/?state=xyz"), "xyz");
+
+        Assert.Equal(AdminConsentStatus.Declined, r!.Value.Status);
+    }
+
+    [Fact]
+    public void ParseRedirect_NullWhileStillOnAzureAdPages()
+    {
+        // Not the localhost redirect yet — the caller keeps waiting rather than concluding anything.
+        var r = OAuthService.ParseAdminConsentRedirect(
+            new Uri("https://login.microsoftonline.com/organizations/oauth2/v2.0/authorize?x=1"), "xyz");
+
+        Assert.Null(r);
+    }
+}

--- a/QuickMail.Tests/UnitTest1.cs
+++ b/QuickMail.Tests/UnitTest1.cs
@@ -256,6 +256,17 @@ public class XamlParseTests
     }
 
     [StaFact]
+    public void AdminConsentWindow_XamlParsesWithoutException() // #607
+    {
+        EnsureApplication();
+        // Parameterless: constructing it parses the XAML (WebView2 host + theme resources); the WebView2
+        // async load is in Loaded, which does not fire on mere construction, so no runtime is needed.
+        var window = new AdminConsentWindow();
+        Assert.NotNull(window);
+        window.Close();
+    }
+
+    [StaFact]
     public void ComposeWindow_XamlParsesWithoutException()
     {
         EnsureApplication();

--- a/QuickMail/Services/AdminConsentResult.cs
+++ b/QuickMail/Services/AdminConsentResult.cs
@@ -1,0 +1,21 @@
+namespace QuickMail.Services;
+
+/// <summary>Outcome of the organization admin-consent flow (#607).</summary>
+public enum AdminConsentStatus
+{
+    /// <summary>The admin granted consent for the organization.</summary>
+    Granted,
+
+    /// <summary>The admin declined, cancelled, or closed the window before granting.</summary>
+    Declined,
+
+    /// <summary>Azure AD returned an error (e.g. the account is not an administrator).</summary>
+    Error,
+}
+
+/// <summary>
+/// Result of parsing the <c>http://localhost</c> redirect from the <c>/adminconsent</c> flow (#607).
+/// <see cref="Error"/> carries Azure AD's error description when <see cref="Status"/> is
+/// <see cref="AdminConsentStatus.Error"/>; it is null otherwise.
+/// </summary>
+public readonly record struct AdminConsentResult(AdminConsentStatus Status, string? Error);

--- a/QuickMail/Services/OAuthService.cs
+++ b/QuickMail/Services/OAuthService.cs
@@ -124,6 +124,29 @@ public class OAuthService : IOAuthService
         "https://graph.microsoft.com/Calendars.ReadWrite",
     ];
 
+    // #607: the full set of graph.microsoft.com delegated scopes QuickMail uses, for a one-shot org
+    // admin-consent. Union of every Graph capability — mail + rules + profile (GraphMailScopesWorkSchool),
+    // contacts, calendar, and shared-mailbox — deduped, so a Global Admin consents to everything QuickMail
+    // needs in ONE screen with no per-capability cascade. Order is stable (mail first) for a deterministic
+    // URL and tests.
+    //
+    // Graph-ONLY on purpose, and the admin-consent request MUST list these scopes explicitly (the v2.0
+    // endpoint) rather than consenting the app's whole declared set (the v1 /adminconsent endpoint). The
+    // app registration also declares Office 365 Exchange Online IMAP/SMTP permissions whose ids Exchange no
+    // longer offers, so a "consent everything declared" request fails the WHOLE grant with AADSTS65006
+    // ("resource 00000002-0000-0ff1-ce00-000000000000 had no entitlements matching…"). Listing only these
+    // Graph scopes never touches the Exchange resource, so it grants cleanly — verified live. (The stale
+    // EXO permission ids are an app-registration fix, Kelly's; #607 is Graph consent regardless — the IMAP
+    // path is legacy.) User.ReadBasic.All is intentionally absent: it is a forward-declared directory scope
+    // with no call site (see GraphMailScopesWorkSchool), so there is nothing to consent for it yet.
+    public static readonly string[] AllGraphAdminConsentScopes =
+        GraphMailScopesWorkSchool
+            .Concat(GraphContactScopes)
+            .Concat(GraphCalendarScopes)
+            .Concat(GraphMailScopesShared)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
     // Authoritative "is this a personal Microsoft account" signal: every consumer account lives in the
     // well-known MSA "consumers" tenant. Detected from the MSAL account at sign-in and persisted on
     // AccountModel (#233), so it's correct even for personal accounts on custom/vanity domains.
@@ -525,23 +548,21 @@ public class OAuthService : IOAuthService
     // tested; the View drives the WebView2 that navigates the URL and reports the redirect back.
 
     /// <summary>
-    /// The <c>/organizations/adminconsent</c> URL that grants QuickMail's permissions org-wide. This is the
-    /// v1 admin-consent endpoint: it consents the app's ENTIRE DECLARED permission set from the registration
-    /// (no <c>scope</c> parameter), which is exactly right for a tenant-wide grant — it covers everything
-    /// QuickMail may need in one screen, stays correct as declared permissions change (no hand-maintained
-    /// list), and crucially grants the permissions user sign-in deliberately never requests: forward-declared
-    /// directory scopes like <c>User.ReadBasic.All</c> that would dead-end a locked-down tenant's interactive
-    /// sign-in but are fine for an admin to consent (see the GraphMailScopesWorkSchool note). Uses
-    /// <c>/organizations</c> (not <c>/common</c> or a fixed tenant) so Azure AD resolves the tenant from the
-    /// admin's sign-in — no tenant id to type and no account needed first — and, being an admin-consent
-    /// request, it also CREATES the service principal, so it works on a tenant no user has touched.
-    /// <paramref name="state"/> is echoed back on the redirect and checked by
-    /// <see cref="ParseAdminConsentRedirect"/> (CSRF guard). Mirrors the manual "Option B" URL in the
-    /// User Guide's admin section, with a redirect + state added so the embedded WebView2 can read the outcome.
+    /// The <c>/organizations/v2.0/adminconsent</c> URL that grants <see cref="AllGraphAdminConsentScopes"/>
+    /// org-wide. Uses the v2.0 endpoint with an EXPLICIT scope list, NOT the v1 <c>/adminconsent</c> (which
+    /// consents the app's whole declared set): the registration also declares Exchange Online IMAP/SMTP
+    /// permissions whose ids Exchange no longer offers, so a "consent everything declared" request fails the
+    /// entire grant with AADSTS65006 — listing only these Graph scopes never touches that resource and grants
+    /// cleanly (verified live). Uses <c>/organizations</c> (not <c>/common</c> or a fixed tenant) so Azure AD
+    /// resolves the tenant from the admin's sign-in — no tenant id to type and no account needed first — and,
+    /// being an admin-consent request, it CREATES the service principal, so it works on a tenant no user has
+    /// touched. <paramref name="state"/> is echoed back on the redirect and checked by
+    /// <see cref="ParseAdminConsentRedirect"/> (CSRF guard).
     /// </summary>
     public static string BuildAdminConsentUrl(string state) =>
-        "https://login.microsoftonline.com/organizations/adminconsent" +
+        "https://login.microsoftonline.com/organizations/v2.0/adminconsent" +
         $"?client_id={ClientId}" +
+        $"&scope={Uri.EscapeDataString(string.Join(" ", AllGraphAdminConsentScopes))}" +
         $"&redirect_uri={Uri.EscapeDataString("http://localhost")}" +
         $"&state={Uri.EscapeDataString(state)}";
 

--- a/QuickMail/Services/OAuthService.cs
+++ b/QuickMail/Services/OAuthService.cs
@@ -558,15 +558,18 @@ public class OAuthService : IOAuthService
 
         var q = ParseQuery(redirect.Query);
 
-        // CSRF guard: a redirect whose state doesn't match the one we sent is never trusted as success.
-        if (!q.TryGetValue("state", out var state) || !string.Equals(state, expectedState, StringComparison.Ordinal))
-            return new AdminConsentResult(AdminConsentStatus.Error, "State mismatch on the admin-consent redirect.");
-
+        // Surface a real Azure AD error first, with its own description — an error is never a grant, so
+        // reporting it doesn't depend on the state check (and AAD does not always echo state on an error).
         if (q.TryGetValue("error", out var error))
         {
             var desc = q.TryGetValue("error_description", out var d) && !string.IsNullOrWhiteSpace(d) ? d : error;
             return new AdminConsentResult(AdminConsentStatus.Error, desc);
         }
+
+        // CSRF guard on the SUCCESS path: a redirect whose state doesn't match the one we sent is never
+        // trusted as a grant.
+        if (!q.TryGetValue("state", out var state) || !string.Equals(state, expectedState, StringComparison.Ordinal))
+            return new AdminConsentResult(AdminConsentStatus.Error, "State mismatch on the admin-consent redirect.");
 
         // admin_consent=True is the grant signal. Anything else on the localhost redirect (e.g. the admin
         // backed out to it without granting) is a decline rather than a spurious success.

--- a/QuickMail/Services/OAuthService.cs
+++ b/QuickMail/Services/OAuthService.cs
@@ -131,14 +131,17 @@ public class OAuthService : IOAuthService
     // URL and tests.
     //
     // Graph-ONLY on purpose, and the admin-consent request MUST list these scopes explicitly (the v2.0
-    // endpoint) rather than consenting the app's whole declared set (the v1 /adminconsent endpoint). The
-    // app registration also declares Office 365 Exchange Online IMAP/SMTP permissions whose ids Exchange no
-    // longer offers, so a "consent everything declared" request fails the WHOLE grant with AADSTS65006
-    // ("resource 00000002-0000-0ff1-ce00-000000000000 had no entitlements matching…"). Listing only these
-    // Graph scopes never touches the Exchange resource, so it grants cleanly — verified live. (The stale
-    // EXO permission ids are an app-registration fix, Kelly's; #607 is Graph consent regardless — the IMAP
-    // path is legacy.) User.ReadBasic.All is intentionally absent: it is a forward-declared directory scope
-    // with no call site (see GraphMailScopesWorkSchool), so there is nothing to consent for it yet.
+    // endpoint) rather than consenting the app's whole declared set (the v1 /adminconsent endpoint).
+    // OBSERVED: any flow that requests the FULL DECLARED SET at once — the v1 /adminconsent, and the old
+    // `.default` (#511) — returns AADSTS65006 involving the Office 365 Exchange Online resource
+    // ("resource 00000002-0000-0ff1-ce00-000000000000 had no entitlements matching…"), while every flow that
+    // requests EXPLICIT scopes by name works: Graph sign-in, IMAP sign-in (the two EXO scopes consent fine,
+    // incl. admin consent), and this v2.0 Graph-only adminconsent. The root cause of the full-set failure is
+    // UNRESOLVED — it is NOT a confirmed app-registration defect (the EXO perms are valid; they consent by
+    // name). Listing only these Graph scopes sidesteps it and is the correct scope for #607 regardless (the
+    // IMAP path is legacy). Verified live. User.ReadBasic.All is intentionally absent: it is a forward-
+    // declared directory scope with no call site (see GraphMailScopesWorkSchool), so there is nothing to
+    // consent for it yet.
     public static readonly string[] AllGraphAdminConsentScopes =
         GraphMailScopesWorkSchool
             .Concat(GraphContactScopes)
@@ -550,10 +553,10 @@ public class OAuthService : IOAuthService
     /// <summary>
     /// The <c>/organizations/v2.0/adminconsent</c> URL that grants <see cref="AllGraphAdminConsentScopes"/>
     /// org-wide. Uses the v2.0 endpoint with an EXPLICIT scope list, NOT the v1 <c>/adminconsent</c> (which
-    /// consents the app's whole declared set): the registration also declares Exchange Online IMAP/SMTP
-    /// permissions whose ids Exchange no longer offers, so a "consent everything declared" request fails the
-    /// entire grant with AADSTS65006 — listing only these Graph scopes never touches that resource and grants
-    /// cleanly (verified live). Uses <c>/organizations</c> (not <c>/common</c> or a fixed tenant) so Azure AD
+    /// consents the app's whole declared set): a full-declared-set request returns AADSTS65006 involving the
+    /// Exchange Online resource (cause unresolved — see the <see cref="AllGraphAdminConsentScopes"/> note),
+    /// whereas listing only these Graph scopes grants cleanly (verified live). Uses <c>/organizations</c>
+    /// (not <c>/common</c> or a fixed tenant) so Azure AD
     /// resolves the tenant from the admin's sign-in — no tenant id to type and no account needed first — and,
     /// being an admin-consent request, it CREATES the service principal, so it works on a tenant no user has
     /// touched. <paramref name="state"/> is echoed back on the redirect and checked by

--- a/QuickMail/Services/OAuthService.cs
+++ b/QuickMail/Services/OAuthService.cs
@@ -515,6 +515,83 @@ public class OAuthService : IOAuthService
         await GetAccessTokenAsync(account, GraphCalendarScopes, ct);
     }
 
+    // ── Organization admin consent (#607) ───────────────────────────────────────
+    // A Global Admin can grant every Graph scope QuickMail may need, org-wide, in ONE screen —
+    // before any user signs in. This is the /adminconsent ENDPOINT (an org grant), NOT a user sign-in:
+    // a plain /authorize sign-in only ever grants the signing-in user, requests a subset, and on an
+    // admin-gated tenant dead-ends (see #607). Unlike a user sign-in it also CREATES the service
+    // principal as part of the grant, so it works even when no user has ever launched QuickMail on the
+    // tenant. These are pure helpers (no MSAL, no UI) so the URL and the redirect handling are unit-
+    // tested; the View drives the WebView2 that navigates the URL and reports the redirect back.
+
+    /// <summary>
+    /// The <c>/organizations/adminconsent</c> URL that grants QuickMail's permissions org-wide. This is the
+    /// v1 admin-consent endpoint: it consents the app's ENTIRE DECLARED permission set from the registration
+    /// (no <c>scope</c> parameter), which is exactly right for a tenant-wide grant — it covers everything
+    /// QuickMail may need in one screen, stays correct as declared permissions change (no hand-maintained
+    /// list), and crucially grants the permissions user sign-in deliberately never requests: forward-declared
+    /// directory scopes like <c>User.ReadBasic.All</c> that would dead-end a locked-down tenant's interactive
+    /// sign-in but are fine for an admin to consent (see the GraphMailScopesWorkSchool note). Uses
+    /// <c>/organizations</c> (not <c>/common</c> or a fixed tenant) so Azure AD resolves the tenant from the
+    /// admin's sign-in — no tenant id to type and no account needed first — and, being an admin-consent
+    /// request, it also CREATES the service principal, so it works on a tenant no user has touched.
+    /// <paramref name="state"/> is echoed back on the redirect and checked by
+    /// <see cref="ParseAdminConsentRedirect"/> (CSRF guard). Mirrors the manual "Option B" URL in the
+    /// User Guide's admin section, with a redirect + state added so the embedded WebView2 can read the outcome.
+    /// </summary>
+    public static string BuildAdminConsentUrl(string state) =>
+        "https://login.microsoftonline.com/organizations/adminconsent" +
+        $"?client_id={ClientId}" +
+        $"&redirect_uri={Uri.EscapeDataString("http://localhost")}" +
+        $"&state={Uri.EscapeDataString(state)}";
+
+    /// <summary>
+    /// Interprets the <c>http://localhost</c> redirect the admin-consent flow lands on. Success is
+    /// <c>admin_consent=True</c> with the matching <paramref name="expectedState"/>; an <c>error</c> param is
+    /// a decline/failure; a mismatched or missing state is treated as an error (never as success). Returns
+    /// null when <paramref name="redirect"/> is not yet the localhost redirect (the caller keeps waiting).
+    /// </summary>
+    public static AdminConsentResult? ParseAdminConsentRedirect(Uri redirect, string expectedState)
+    {
+        if (!string.Equals(redirect.Host, "localhost", StringComparison.OrdinalIgnoreCase))
+            return null; // still on the AAD pages — not the redirect yet
+
+        var q = ParseQuery(redirect.Query);
+
+        // CSRF guard: a redirect whose state doesn't match the one we sent is never trusted as success.
+        if (!q.TryGetValue("state", out var state) || !string.Equals(state, expectedState, StringComparison.Ordinal))
+            return new AdminConsentResult(AdminConsentStatus.Error, "State mismatch on the admin-consent redirect.");
+
+        if (q.TryGetValue("error", out var error))
+        {
+            var desc = q.TryGetValue("error_description", out var d) && !string.IsNullOrWhiteSpace(d) ? d : error;
+            return new AdminConsentResult(AdminConsentStatus.Error, desc);
+        }
+
+        // admin_consent=True is the grant signal. Anything else on the localhost redirect (e.g. the admin
+        // backed out to it without granting) is a decline rather than a spurious success.
+        return q.TryGetValue("admin_consent", out var granted) &&
+               string.Equals(granted, "True", StringComparison.OrdinalIgnoreCase)
+            ? new AdminConsentResult(AdminConsentStatus.Granted, null)
+            : new AdminConsentResult(AdminConsentStatus.Declined, null);
+    }
+
+    // Minimal query-string parser (last value wins) — avoids a System.Web dependency for the few params
+    // the redirect carries. Lookup is case-insensitive. Query strings are form-encoded, so '+' means a
+    // space (Uri.UnescapeDataString handles %XX but not '+'); decode it as such before percent-unescaping.
+    private static Dictionary<string, string> ParseQuery(string query)
+    {
+        static string Decode(string s) => Uri.UnescapeDataString(s.Replace('+', ' '));
+        var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var pair in query.TrimStart('?').Split('&', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var eq = pair.IndexOf('=');
+            if (eq < 0) { result[Decode(pair)] = ""; continue; }
+            result[Decode(pair[..eq])] = Decode(pair[(eq + 1)..]);
+        }
+        return result;
+    }
+
     public async Task SignOutAsync(AccountModel account)
     {
         await EnsureTokenCacheAsync();

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -2687,6 +2687,13 @@ public partial class MainViewModel : ObservableObject, IDisposable
             id: "help.reportBug", category: "Help", title: "Report a Bug",
             execute: () => ReportBugRequested?.Invoke(this, EventArgs.Empty)));
 
+        // #607: a Global Admin grants QuickMail's Graph permissions org-wide in one screen. No default
+        // hotkey — it is a rare, one-time setup action, discoverable via the Help menu and the palette.
+        registry.Register(new CommandDefinition(
+            id: "help.adminConsent", category: "Help",
+            title: "Grant Admin Consent for Your Organization",
+            execute: () => AdminConsentRequested?.Invoke(this, EventArgs.Empty)));
+
         // help.connectionDiagnostics is deliberately NOT registered here. It is registered and
         // unregistered by ApplyConnectionDiagnosticsSetting so the command palette only offers it
         // while the feature is switched on, matching the Help menu. No default hotkey either way.
@@ -7235,6 +7242,10 @@ public partial class MainViewModel : ObservableObject, IDisposable
     public event EventHandler? TutorialRequested;
     public event EventHandler? AboutRequested;
     public event EventHandler? ReportBugRequested;
+
+    /// <summary>Raised when the user asks to grant organization admin consent (#607). The View opens the
+    /// AdminConsentWindow in response — the VM never opens windows.</summary>
+    public event EventHandler? AdminConsentRequested;
 
     /// <summary>Raised when the user asks for the Connection Diagnostics window.</summary>
     public event EventHandler? ConnectionDiagnosticsRequested;

--- a/QuickMail/Views/AdminConsentWindow.xaml
+++ b/QuickMail/Views/AdminConsentWindow.xaml
@@ -1,0 +1,31 @@
+<Window x:Class="QuickMail.Views.AdminConsentWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:wv2="clr-namespace:Microsoft.Web.WebView2.Wpf;assembly=Microsoft.Web.WebView2.Wpf"
+        Title="Grant admin consent for your organization"
+        AutomationProperties.Name="Grant admin consent for your organization"
+        Height="700" Width="720" MinHeight="420" MinWidth="480"
+        WindowStartupLocation="CenterOwner"
+        ShowInTaskbar="False"
+        Background="{DynamicResource Theme.WindowBackground}"
+        Foreground="{DynamicResource Theme.TextPrimary}"
+        FontFamily="{DynamicResource Theme.FontFamily}"
+        FontSize="{DynamicResource Theme.FontSizeBase}">
+    <DockPanel Margin="12">
+
+        <!-- Instruction / live status. Also spoken once as a Hint on open (code-behind), and the
+             outcome is announced as a Result when the flow finishes — a screen-reader user would not
+             otherwise find this static/updated text. -->
+        <TextBlock x:Name="StatusText" DockPanel.Dock="Top" TextWrapping="Wrap" Margin="0,0,0,8"
+                   Text="Sign in as a Global Administrator to grant QuickMail access for your whole organization. This is a one-time setup — afterwards everyone in your organization signs in with no consent prompts."/>
+
+        <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,8,0,0">
+            <Button x:Name="CloseBtn" Content="_Cancel" Click="CloseButton_Click" MinWidth="72"/>
+        </StackPanel>
+
+        <wv2:WebView2 x:Name="ConsentBrowser"
+                      AutomationProperties.Name="Microsoft admin consent"
+                      KeyboardNavigation.IsTabStop="True"/>
+
+    </DockPanel>
+</Window>

--- a/QuickMail/Views/AdminConsentWindow.xaml.cs
+++ b/QuickMail/Views/AdminConsentWindow.xaml.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Threading;
+using System.Windows;
+using System.Windows.Input;
+using Microsoft.Web.WebView2.Core;
+using QuickMail.Helpers;
+using QuickMail.Models;
+using QuickMail.Services;
+
+namespace QuickMail.Views;
+
+/// <summary>
+/// Organization admin-consent window (#607). Hosts a WebView2 that drives the
+/// <c>/organizations/v2.0/adminconsent</c> flow so a Global Admin grants every Graph scope QuickMail
+/// may need, org-wide, in one screen — before any user has signed in.
+///
+/// A LEAF window: no F6 ring and no command palette (there is nothing to cycle between but the one
+/// browser). Shown modeless (<c>Show()</c>) because it hosts a live WebView2 with editable content and
+/// opens over the main window's live reading-pane WebView2 — the GrabAddresses deadlock lesson. The
+/// outcome is self-contained: it is announced (Result) and shown in the status line; nothing in the app
+/// waits on a return value, so there is no result plumbing back to a caller.
+///
+/// Unlike the CSP-locked reading-pane WebView2s, this one deliberately PERMITS navigation — it is a real
+/// interactive Microsoft sign-in. It intercepts only the <c>http://localhost</c> redirect (via
+/// <see cref="OAuthService.ParseAdminConsentRedirect"/>) to read the outcome, and never injects a keydown
+/// script, so the Microsoft login form keeps its own Tab/Escape/typing.
+/// </summary>
+[SuppressMessage("Design", "CA1001", Justification = "_cts is cancelled and disposed in OnClosed; WPF never calls Dispose on a Window, so implementing IDisposable would be dead code.")]
+public partial class AdminConsentWindow : Window
+{
+    // Echoed on the redirect and verified by ParseAdminConsentRedirect (CSRF guard). A per-window value.
+    private readonly string _state = Guid.NewGuid().ToString("N");
+    private readonly CancellationTokenSource _cts = new();
+    private bool _completed;
+
+    public AdminConsentWindow()
+    {
+        InitializeComponent();
+        Loaded += OnLoaded;
+    }
+
+    private async void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        // The static instruction is invisible to a screen reader on open — speak it once as a Hint.
+        AccessibilityHelper.Announce(this, StatusText.Text, category: AnnouncementCategory.Hint);
+
+        try
+        {
+            var dataFolder = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "QuickMail", "WebView2AdminConsent");
+            var env = await CoreWebView2Environment.CreateAsync(null, dataFolder);
+            if (_cts.IsCancellationRequested) return;
+            await ConsentBrowser.EnsureCoreWebView2Async(env);
+            if (_cts.IsCancellationRequested) return;
+
+            ConsentBrowser.CoreWebView2.Settings.AreDevToolsEnabled = false;
+            ConsentBrowser.CoreWebView2.Settings.AreDefaultContextMenusEnabled = false;
+
+            ConsentBrowser.CoreWebView2.NavigationStarting += OnNavigationStarting;
+            ConsentBrowser.CoreWebView2.Navigate(OAuthService.BuildAdminConsentUrl(_state));
+        }
+        catch (Exception ex)
+        {
+            LogService.Log("AdminConsentWindow: failed to start the consent flow", ex);
+            Complete(new AdminConsentResult(AdminConsentStatus.Error, ex.Message));
+        }
+    }
+
+    private void OnNavigationStarting(object? sender, CoreWebView2NavigationStartingEventArgs args)
+    {
+        AdminConsentResult? result;
+        try { result = OAuthService.ParseAdminConsentRedirect(new Uri(args.Uri), _state); }
+        catch { return; } // an unparseable interstitial URL — let the flow continue
+
+        if (result is null) return; // still on the Azure AD pages — permit navigation
+
+        // We reached the http://localhost redirect. Nothing serves it, so cancel the navigation and
+        // read the outcome from its query instead.
+        args.Cancel = true;
+        // NavigationStarting fires on a WebView2 callback; marshal UI work to the dispatcher.
+        Dispatcher.BeginInvoke(() => Complete(result.Value));
+    }
+
+    private void Complete(AdminConsentResult result)
+    {
+        if (_completed) return;
+        _completed = true;
+
+        var text = result.Status switch
+        {
+            AdminConsentStatus.Granted =>
+                "Admin consent granted for your organization. Everyone can now sign in without consent prompts.",
+            AdminConsentStatus.Declined =>
+                "Admin consent was not granted. Nothing changed for your organization.",
+            _ => $"Admin consent could not be completed: {result.Error}",
+        };
+
+        // Show the outcome and move focus to the (now Close) button, so the result is both visible and,
+        // with the announce, spoken — then the user closes when ready (auto-closing risks cutting off the
+        // announcement). The browser is collapsed so the stale AAD page isn't left showing behind it.
+        StatusText.Text = text;
+        ConsentBrowser.Visibility = Visibility.Collapsed;
+        CloseBtn.Content = "_Close";
+        AccessibilityHelper.Announce(this, text, category: AnnouncementCategory.Result);
+        CloseBtn.Focus();
+        Keyboard.Focus(CloseBtn);
+    }
+
+    private void CloseButton_Click(object sender, RoutedEventArgs e) => Close();
+
+    protected override void OnPreviewKeyDown(KeyEventArgs e)
+    {
+        base.OnPreviewKeyDown(e);
+        if (e.Handled) return;
+
+        // Modeless: no DialogResult, so Escape is wired explicitly. Only fires when a WPF element (e.g.
+        // the Close button) has focus — Escape inside the WebView2 is the login page's own.
+        if (e.Key == Key.Escape)
+        {
+            Close();
+            e.Handled = true;
+        }
+    }
+
+    protected override void OnClosed(EventArgs e)
+    {
+        try { _cts.Cancel(); _cts.Dispose(); } catch { /* best effort */ }
+        if (ConsentBrowser.CoreWebView2 != null)
+            ConsentBrowser.CoreWebView2.NavigationStarting -= OnNavigationStarting;
+        ConsentBrowser.Dispose();
+        base.OnClosed(e);
+    }
+}

--- a/QuickMail/Views/AdminConsentWindow.xaml.cs
+++ b/QuickMail/Views/AdminConsentWindow.xaml.cs
@@ -60,6 +60,18 @@ public partial class AdminConsentWindow : Window
             ConsentBrowser.CoreWebView2.Settings.AreDefaultContextMenusEnabled = false;
 
             ConsentBrowser.CoreWebView2.NavigationStarting += OnNavigationStarting;
+
+            // Ancillary links on the Microsoft pages (Terms, Privacy & cookies, "Can't access your
+            // account?", "Create one") carry target="_blank" and raise NewWindowRequested instead of
+            // NavigationStarting. Left unhandled, WebView2 opens its own in-app popup; route them to the
+            // user's default browser via the scheme allow-list instead (issue #483). The consent flow
+            // itself stays in this window — only these secondary links leave.
+            ConsentBrowser.CoreWebView2.NewWindowRequested += (_, args) =>
+            {
+                args.Handled = true;
+                ExternalUriPolicy.TryOpenExternal(args.Uri);
+            };
+
             ConsentBrowser.CoreWebView2.Navigate(OAuthService.BuildAdminConsentUrl(_state));
         }
         catch (Exception ex)

--- a/QuickMail/Views/AdminConsentWindow.xaml.cs
+++ b/QuickMail/Views/AdminConsentWindow.xaml.cs
@@ -13,8 +13,8 @@ namespace QuickMail.Views;
 
 /// <summary>
 /// Organization admin-consent window (#607). Hosts a WebView2 that drives the
-/// <c>/organizations/v2.0/adminconsent</c> flow so a Global Admin grants every Graph scope QuickMail
-/// may need, org-wide, in one screen — before any user has signed in.
+/// <c>/organizations/adminconsent</c> flow so a Global Admin grants QuickMail's whole declared
+/// permission set, org-wide, in one screen — before any user has signed in.
 ///
 /// A LEAF window: no F6 ring and no command palette (there is nothing to cycle between but the one
 /// browser). Shown modeless (<c>Show()</c>) because it hosts a live WebView2 with editable content and

--- a/QuickMail/Views/AdminConsentWindow.xaml.cs
+++ b/QuickMail/Views/AdminConsentWindow.xaml.cs
@@ -13,8 +13,8 @@ namespace QuickMail.Views;
 
 /// <summary>
 /// Organization admin-consent window (#607). Hosts a WebView2 that drives the
-/// <c>/organizations/adminconsent</c> flow so a Global Admin grants QuickMail's whole declared
-/// permission set, org-wide, in one screen — before any user has signed in.
+/// <c>/organizations/v2.0/adminconsent</c> flow so a Global Admin grants the Graph scopes QuickMail
+/// uses, org-wide, in one screen — before any user has signed in.
 ///
 /// A LEAF window: no F6 ring and no command palette (there is nothing to cycle between but the one
 /// browser). Shown modeless (<c>Show()</c>) because it hosts a live WebView2 with editable content and

--- a/QuickMail/Views/MainWindow.xaml
+++ b/QuickMail/Views/MainWindow.xaml
@@ -744,6 +744,12 @@
                           Visibility="{Binding IsConnectionDiagnosticsEnabled, Converter={StaticResource BoolToVisibilityConverter}}"
                           Click="MenuConnectionDiagnostics_Click"/>
                 <Separator/>
+                <!-- #607: one-time org setup for a Global Admin — grants QuickMail's Graph permissions
+                     tenant-wide so users then sign in with no consent prompts. -->
+                <MenuItem Header="Grant Admin _Consent for Your Organization…"
+                          AutomationProperties.Name="Grant Admin Consent for Your Organization"
+                          Click="MenuAdminConsent_Click"/>
+                <Separator/>
                 <MenuItem Header="_About QuickMail"
                           AutomationProperties.Name="About QuickMail"
                           Click="MenuAbout_Click"/>

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -373,6 +373,7 @@ public partial class MainWindow : Window
         };
         vm.AboutRequested += (_, _) => ShowAboutDialog();
         vm.ReportBugRequested += (_, _) => ShowReportBugWindow();
+        vm.AdminConsentRequested += (_, _) => ShowAdminConsentWindow();
         vm.ConnectionDiagnosticsRequested += (_, _) => ShowConnectionDiagnosticsWindow();
         vm.PropertiesRequested += propertiesVm =>
         {
@@ -4025,6 +4026,22 @@ public partial class MainWindow : Window
     private void MenuConnectionDiagnostics_Click(object sender, RoutedEventArgs e)
     {
         ShowConnectionDiagnosticsWindow();
+    }
+
+    // #607: the org admin-consent window. Modeless for the same reason as the two above — it hosts a live
+    // WebView2 (the Microsoft consent page) opened over this window's live reading-pane WebView2, where a
+    // modal nested message loop can deadlock the UI thread. Focus returns to wherever it was on close.
+    private void ShowAdminConsentWindow()
+    {
+        var previousFocus = Keyboard.FocusedElement as IInputElement;
+        var window = new AdminConsentWindow { Owner = this };
+        window.Closed += (_, _) => previousFocus?.Focus();
+        window.Show();
+    }
+
+    private void MenuAdminConsent_Click(object sender, RoutedEventArgs e)
+    {
+        ShowAdminConsentWindow();
     }
 
     private void MenuAbout_Click(object sender, RoutedEventArgs e)

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -449,7 +449,7 @@ https://login.microsoftonline.com/organizations/adminconsent?client_id=bcdc84f1-
 
 Replace `organizations` with your tenant ID or a verified domain to target a specific tenant. Review the permission list Microsoft shows and approve. This grants consent tenant-wide in one step.
 
-**Option C — from inside QuickMail.** If you have QuickMail installed, choose **Help → Grant Admin Consent for Your Organization…**. Sign in as one of the admin roles above in the window that opens, review the permission list, and approve. This runs the same single-step consent as Option B without building a URL by hand, and it works even before anyone in your organization has added an account — the consent itself registers QuickMail in your tenant. QuickMail tells you when consent has been granted.
+**Option C — from inside QuickMail.** If you have QuickMail installed, choose **Help → Grant Admin Consent for Your Organization…**. Sign in as one of the admin roles above in the window that opens, review the permission list, and approve. This grants QuickMail's Microsoft Graph permissions tenant-wide in one step without building a URL by hand, and it works even before anyone in your organization has added an account — the consent itself registers QuickMail in your tenant. QuickMail tells you when consent has been granted.
 
 After approval, your users sign in normally with no further prompts.
 

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -449,6 +449,8 @@ https://login.microsoftonline.com/organizations/adminconsent?client_id=bcdc84f1-
 
 Replace `organizations` with your tenant ID or a verified domain to target a specific tenant. Review the permission list Microsoft shows and approve. This grants consent tenant-wide in one step.
 
+**Option C — from inside QuickMail.** If you have QuickMail installed, choose **Help → Grant Admin Consent for Your Organization…**. Sign in as one of the admin roles above in the window that opens, review the permission list, and approve. This runs the same single-step consent as Option B without building a URL by hand, and it works even before anyone in your organization has added an account — the consent itself registers QuickMail in your tenant. QuickMail tells you when consent has been granted.
+
 After approval, your users sign in normally with no further prompts.
 
 ### If you would rather not grant blanket approval


### PR DESCRIPTION
## In-app organization admin-consent action (#607, part 2)

Adds the missing path for onboarding an **admin-gated Microsoft 365 tenant**. Today such a tenant can't onboard QuickMail through ordinary user sign-in: user consent is blocked, the "needs admin approval" link only re-runs a user-token `/authorize` (partial scopes, discarded on the #202 identity mismatch), and a non-admin who backs out doesn't even create a service principal for an admin to pre-approve. This gives a Global Admin a one-click, org-wide grant.

### What it does

**Help → "Grant Admin Consent for Your Organization…"** opens a window hosting the Microsoft admin-consent page. The admin signs in, reviews the permission list, approves — and every user in the org then signs in with no prompts. Live-validated on a real tenant.

### Design decisions

- **v2.0 `/organizations/v2.0/adminconsent` with an explicit Graph scope list.** Requests exactly the Graph scopes QuickMail uses (mail + rules + profile + contacts + calendar + shared). This is the shape that was manually verified to work, and live testing confirmed it end-to-end. **Not** the v1 `/adminconsent` (declared-set) endpoint: requesting the full declared set at once returns AADSTS65006 citing the Exchange Online resource — the same failure the old `.default` had. (This is *not* a confirmed app-registration defect — the Exchange IMAP/SMTP permissions consent fine when requested explicitly by name, e.g. at IMAP sign-in; the root cause of the full-set path failing is unresolved. Requesting explicit Graph scopes sidesteps it, and #607 is about Graph consent regardless — the IMAP path is legacy.)
- `/organizations` lets Azure AD resolve the tenant from the admin's sign-in — no tenant to type, no account needed first — and an admin-consent request **creates the service principal**, so it works on a tenant no user has touched.
- **CSRF-guarded redirect handling** — `admin_consent=True` with a matching `state` is Granted; a real AAD `error` is surfaced with its description (even if AAD omits `state`); a mismatched state is never trusted as success; landing on localhost without a grant is Declined.
- **Leaf WebView2 window** — modeless (live WebView2 over the reading pane — the GrabAddresses deadlock lesson); permits the AAD navigation (unlike the CSP-locked panes); injects no keydown script so the Microsoft login keeps its own keys; routes `target=_blank`/popup links to the default browser via `ExternalUriPolicy` (#483); no F6 ring / palette (leaf). Outcome is announced (Result) and shown, focus on Close.
- **MVVM** — `help.adminConsent` command in the VM raises an event; the View opens the window. In the Command Palette; Alt+C mnemonic (collision-free in Help).

### Scope

**Part 2** of #607 (the admin-consent action). **Part 1** (fold all scopes into one sign-in) is deferred/reassessed: with org admin-consent in place, a pre-consented tenant makes every later user sign-in silent, so the per-capability cascade is already gone.

### Tests

`AdminConsentUrlTests` — v2.0 endpoint shape, the full Graph scope set + no Exchange scope, grant/decline/error, CSRF state-mismatch, error-without-state, still-on-AAD → null; `ExternalLinkWiringTests` covers the new window; plus a XAML-parse guard. Build clean.

### Review + live validation

Independent adversarial review — no Critical/High/Medium; its two Low items fixed. **Live-validated** on a real tenant: the initial v1 approach hit AADSTS65006 (fixed by switching to v2.0 explicit scopes), and the v2.0 flow then granted org-wide consent successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
