### PR TITLE
Fold full Graph scope set into work/school sign-in (#607 part 1)

### DIFF
--- a/QuickMail.Tests/AccountEditorSignInTests.cs
+++ b/QuickMail.Tests/AccountEditorSignInTests.cs
@@ -159,8 +159,12 @@ public class AccountEditorSignInTests
     }
 
     [Fact]
-    public async Task MicrosoftSignIn_NoSyncRequested_UsesPlainSignIn()
+    public async Task MicrosoftSignIn_AlwaysUsesFoldingEntryPoint_EvenWithNoSync() // #607 part 1
     {
+        // The caller no longer branches on the sync opt-ins — it always goes through the folding entry
+        // point, which decides the extras itself (the full set for a work/school Graph account so an admin
+        // can consent everything org-wide in one sign-in; the opt-ins for personal; none for IMAP). With no
+        // extras it behaves as a plain sign-in, so calling it unconditionally is safe.
         var (vm, oauth) = NewVm();
         vm.Username = "user@contoso.com";
         oauth.ReturnUsername = "user@contoso.com";
@@ -169,7 +173,7 @@ public class AccountEditorSignInTests
 
         await vm.SignInMicrosoftCommand.ExecuteAsync(null);
 
-        Assert.False(oauth.WithContactsPathUsed);
+        Assert.True(oauth.WithContactsPathUsed);
     }
 
     // #544 review finding 3: the known personal flag must reach the sign-in, or the fold's personal check

--- a/QuickMail.Tests/OAuthServiceScopeSelectionTests.cs
+++ b/QuickMail.Tests/OAuthServiceScopeSelectionTests.cs
@@ -273,9 +273,10 @@ public class OAuthServiceScopeSelectionTests
         Assert.DoesNotContain("https://graph.microsoft.com/Mail.ReadWrite", scopes);
     }
 
-    // The account-level gate: consent is folded into the mail sign-in ONLY for personal accounts. A
-    // work/school account returns empty so its opted-in contact/calendar consent stays on the graceful
-    // post-add path and never dead-ends a consent-restricted tenant's whole sign-in (review finding).
+    // The account-level fold policy (#607 part 1): a WORK/SCHOOL Graph account folds the FULL extra set
+    // (contacts + calendar + shared) regardless of opt-ins, so an admin consents everything org-wide in one
+    // sign-in (the mail-only retry in SignInInteractiveAsync keeps a non-admin from dead-ending). A PERSONAL
+    // account folds only its opt-ins (no org model). IMAP folds nothing (cross-resource, #239).
 
     [Fact]
     public void FoldForSignIn_PersonalAccount_FoldsTheOptIns()
@@ -301,27 +302,43 @@ public class OAuthServiceScopeSelectionTests
     }
 
     [Fact]
-    public void FoldForSignIn_WorkSchoolAccount_FoldsNothing_EvenWhenBothOptedIn()
+    public void FoldForSignIn_WorkSchoolAccount_FoldsTheFullSet_RegardlessOfOptIns() // #607 part 1
     {
-        // The regression guard: folding these into a consent-restricted tenant's mail sign-in would
-        // dead-end the whole sign-in. Work/school must stay on the graceful post-add consent path.
+        // Work/school folds EVERYTHING beyond the primary mail scopes (contacts + calendar + shared),
+        // regardless of the sync opt-ins, so an admin consents the whole set org-wide in one sign-in.
+        // Even with both opt-ins OFF the full extra set is folded.
         var account = new AccountModel
         {
             BackendKind = BackendKind.MicrosoftGraph, Username = "user@contoso.com",
-            SyncContacts = true, SyncCalendar = true,
+            SyncContacts = false, SyncCalendar = false,
         };
-        Assert.Empty(OAuthService.ExtraConsentScopesForMicrosoftSignIn(account));
+        var extras = OAuthService.ExtraConsentScopesForMicrosoftSignIn(account);
+
+        // Exactly the non-mail Graph scopes: contacts + calendar + shared, and NOT the primary mail scopes.
+        var expected = OAuthService.GraphContactScopes
+            .Concat(OAuthService.GraphCalendarScopes)
+            .Concat(OAuthService.GraphMailScopesShared)
+            .OrderBy(s => s);
+        Assert.Equal(expected, extras.OrderBy(s => s));
+        Assert.DoesNotContain("https://graph.microsoft.com/Mail.ReadWrite", extras); // primary, not an extra
+        // Primary + extras == the standalone admin-consent set, so both paths cover the same permissions.
+        var full = OAuthService.GraphMailScopesWorkSchool.Concat(extras).OrderBy(s => s);
+        Assert.Equal(OAuthService.AllGraphAdminConsentScopes.OrderBy(s => s), full);
     }
 
     [Fact]
-    public void FoldForSignIn_WorkAccountOnConsumerLookingDomain_ByFlagFalse_FoldsNothing()
+    public void FoldForSignIn_WorkAccountOnConsumerLookingDomain_ByFlagFalse_FoldsTheFullSet() // #607 part 1
     {
+        // Flag says work/school even on a consumer-looking domain → treated as work/school → full fold.
         var account = new AccountModel
         {
             BackendKind = BackendKind.MicrosoftGraph, Username = "user@outlook.com",
-            IsPersonalMicrosoftAccount = false, SyncContacts = true, SyncCalendar = true,
+            IsPersonalMicrosoftAccount = false, SyncContacts = false, SyncCalendar = false,
         };
-        Assert.Empty(OAuthService.ExtraConsentScopesForMicrosoftSignIn(account));
+        var extras = OAuthService.ExtraConsentScopesForMicrosoftSignIn(account);
+        Assert.Contains("https://graph.microsoft.com/Contacts.Read", extras);
+        Assert.Contains("https://graph.microsoft.com/Calendars.ReadWrite", extras);
+        Assert.Contains("https://graph.microsoft.com/Mail.ReadWrite.Shared", extras);
     }
 
     [Fact]

--- a/QuickMail/Services/OAuthService.cs
+++ b/QuickMail/Services/OAuthService.cs
@@ -457,42 +457,52 @@ public class OAuthService : IOAuthService
     }
 
     public Task<OAuthResult> SignInInteractiveWithContactsAsync(AccountModel account, CancellationToken ct = default)
-        // Microsoft: sign in for mail AND — for a PERSONAL account only — fold the requested contact/
-        // calendar consent into the same interactive prompt via WithExtraScopesToConsent, so a personal
-        // account (no admin-consent model) is prompted once instead of once per capability. The extra
-        // grants land in the token cache, so the post-add RequestContactsConsentAsync /
-        // RequestCalendarConsentAsync calls then acquire silently.
+        // Microsoft: sign in for mail AND fold extra Graph consent into the same interactive prompt via
+        // WithExtraScopesToConsent, so the whole set is approved in one screen instead of once per
+        // capability. The extra grants land in the token cache, so the post-add RequestContactsConsentAsync /
+        // RequestCalendarConsentAsync calls (and shared-mailbox reads) then acquire silently. What gets
+        // folded is decided by ExtraConsentScopesForMicrosoftSignIn: for a WORK/SCHOOL Graph account the FULL
+        // set (contacts + calendar + shared), so an admin can grant everything org-wide in one sign-in
+        // (#607); for a PERSONAL account only the opted-into scopes; for IMAP nothing.
         //
-        // We DELIBERATELY do NOT fold for work/school. On a tenant that disables user consent and hasn't
-        // admin-consented contacts/calendar, surfacing those scopes at the mail sign-in would dead-end the
-        // WHOLE interactive acquisition — no token, so the account is never added. The unfolded path
-        // degrades gracefully instead: mail signs in, the account is added, and only the post-add
-        // RequestContactsConsentAsync dead-ends (caught in AccountManagerViewModel, which just disables
-        // contact sync). This is the same admin-consent dead-end hazard the mail scope list avoids for
-        // User.ReadBasic.All. Folding only ever helped personal accounts anyway — work/school usually has
-        // admin pre-consent, so its post-add consent is already silent.
-        //
-        // (Pre-#511 nothing could be folded because work/school signed in with `.default`, which can't be
-        // combined with explicit scopes; both paths use explicit Graph scopes now, so personal folds
-        // cleanly. The account carries the two opt-in bits from the editor VM.)
+        // The work/school fold is safe on a consent-restricted tenant because SignInInteractiveAsync retries
+        // MAIL-ONLY if the folded acquisition fails: a non-admin who can't consent the extras still gets a
+        // working mail account, and the extras fall back to their own post-add consent. (Earlier this method
+        // folded for personal only, to avoid dead-ending work/school on such tenants; the mail-only retry —
+        // #544 — now provides that graceful fallback, so folding the full set for work/school is what unlocks
+        // one-pass admin consent without dead-ending anyone.) When there are no extras it attaches no
+        // WithExtraScopesToConsent, i.e. behaves as a plain sign-in — safe to call unconditionally.
         => SignInInteractiveAsync(account, DefaultScopesFor(account), firstConnect: true,
             ExtraConsentScopesForMicrosoftSignIn(account), ct);
 
     // The extra Graph scopes to fold into THIS account's mail sign-in consent, or empty when none should
-    // be folded. Two gates, both required:
-    //   • Graph backend — the primary mail scopes must be graph.microsoft.com, so the folded contact/
-    //     calendar scopes ride the SAME resource. A personal Microsoft account DEFAULTS to the IMAP backend
-    //     (outlook.office.com mail scopes); folding graph.microsoft.com scopes onto that sign-in is a
-    //     cross-resource authorize the MSA + outlook.office.com path handles badly (#239) — and it is the
-    //     DEFAULT consumer onboarding path, not an edge case. Only a Graph sign-in folds.
-    //   • Personal — work/school returns empty so its opted-in consent stays on the graceful post-add path
-    //     and never dead-ends a consent-restricted tenant's sign-in (see SignInInteractiveWithContactsAsync).
+    // be folded. Gated first on the Graph backend: the primary mail scopes must be graph.microsoft.com so
+    // the folded scopes ride the SAME resource. A personal Microsoft account DEFAULTS to the IMAP backend
+    // (outlook.office.com); folding graph.microsoft.com scopes onto that sign-in is a cross-resource
+    // authorize the MSA + outlook.office.com path handles badly (#239), so IMAP returns empty. Among Graph
+    // accounts, work/school folds the full set and personal folds only its opt-ins — see the body.
     // Personal is resolved via ResolveIsPersonalMicrosoftAccount (persisted flag, else the domain guess),
     // the same resolution DefaultScopesFor uses.
     internal static string[] ExtraConsentScopesForMicrosoftSignIn(AccountModel account)
-        => account.BackendKind == BackendKind.MicrosoftGraph && ResolveIsPersonalMicrosoftAccount(account)
-            ? MicrosoftExtraConsentScopes(account.SyncContacts, account.SyncCalendar)
-            : Array.Empty<string>();
+    {
+        if (account.BackendKind != BackendKind.MicrosoftGraph) return Array.Empty<string>();
+
+        // #607 part 1: a WORK/SCHOOL Graph sign-in folds in EVERYTHING QuickMail uses beyond the primary
+        // mail scopes (contacts + calendar + shared), regardless of the sync opt-ins — so if the person
+        // signing in is (or has) an admin, the consent screen shows the full set with the "consent for your
+        // organization" option, and they grant it ALL org-wide in this one sign-in. Then no later user hits
+        // a per-capability consent wall, and nobody has to find the Help-menu admin-consent action. Primary
+        // (GraphMailScopesWorkSchool) + these extras == AllGraphAdminConsentScopes, so the fold and the
+        // standalone admin-consent request cover the same set. A non-admin who can't consent them falls back
+        // to a mail-only account via the retry in SignInInteractiveAsync; usage stays gated by the sync
+        // opt-ins and the shared-mailbox feature flag, so an unused grant is harmless.
+        if (!ResolveIsPersonalMicrosoftAccount(account))
+            return AllGraphAdminConsentScopes.Except(GraphMailScopesWorkSchool, StringComparer.OrdinalIgnoreCase).ToArray();
+
+        // PERSONAL Microsoft: no admin/org model, so folding everything would only over-ask an individual
+        // with no upside. Fold only what they opted into (least-privilege), as before (#544).
+        return MicrosoftExtraConsentScopes(account.SyncContacts, account.SyncCalendar);
+    }
 
     // The extra Graph scopes to pre-consent alongside the mail sign-in for the two opt-in bits. Empty
     // when neither is requested (the caller then attaches no WithExtraScopesToConsent). Pure and

--- a/QuickMail/ViewModels/AccountEditorViewModel.cs
+++ b/QuickMail/ViewModels/AccountEditorViewModel.cs
@@ -719,9 +719,12 @@ public abstract partial class AccountEditorViewModel : ObservableObject
                 SyncContacts = SyncContacts, SyncCalendar = SyncCalendar,
                 IsPersonalMicrosoftAccount = IsPersonalMicrosoftAccount,
             };
-            var result = (SyncContacts || SyncCalendar)
-                ? await OAuthService.SignInInteractiveWithContactsAsync(tempAccount, CancellationToken.None)
-                : await OAuthService.SignInInteractiveAsync(tempAccount, CancellationToken.None);
+            // Always go through the folding entry point: it decides the extra scopes itself
+            // (ExtraConsentScopesForMicrosoftSignIn) — the full set for a work/school Graph account so an
+            // admin can consent everything org-wide in one sign-in (#607), the opted-into scopes for a
+            // personal account, and none for IMAP. When there are no extras it behaves exactly like a plain
+            // sign-in (no WithExtraScopesToConsent attached), so this is safe to call unconditionally.
+            var result = await OAuthService.SignInInteractiveWithContactsAsync(tempAccount, CancellationToken.None);
 
             // #202: guard against a DIFFERENT identity completing sign-in than the one entered —
             // typically an admin signing in to approve consent in an admin-approval tenant. Adopting


### PR DESCRIPTION
## Fold the full Graph scope set into work/school sign-in (#607, part 1)

Stacked on #618 (uses `AllGraphAdminConsentScopes` from it). Base will retarget to `main` once #618 merges.

### What it does

When a **work/school** Microsoft account signs in, QuickMail now requests **everything it uses** — mail + rules + profile (primary), plus **contacts + calendar + shared** (folded via `WithExtraScopesToConsent`) — **regardless of the sync opt-ins**. So if the person signing in is (or has) an admin, the consent screen shows the full set with the **"consent for your organization"** option, and they grant it all org-wide in that one sign-in.

This closes the discoverability gap: an admin who's just adding their own account doesn't have to know about the Help-menu admin-consent action (#618) — they can consent everything right there. Primary + folded extras == `AllGraphAdminConsentScopes`, so this and the standalone admin-consent action cover the same permission set.

### Why it's safe (the concern this used to guard against)

The code previously folded **nothing** for work/school, deliberately — folding scopes a user can't consent to would dead-end the whole sign-in on a consent-restricted tenant. The **mail-only retry** (#544) now provides the graceful fallback: if the folded acquisition fails, `SignInInteractiveAsync` retries mail-only, so a non-admin still gets a working mail account and the extras fall back to their own post-add consent. That retry is what makes folding the full set safe now.

A second prompt only occurs in one narrow, transitional case — a non-admin on a tenant where **mail** is already consented but the extras aren't (a partial state). Folding is exactly what prevents that state going forward: the first admin grants everything, so no one else is ever prompted.

### Scope

- **Personal** accounts unchanged (opt-in-gated fold only — no admin/org model, so folding everything would just over-ask an individual).
- **IMAP** folds nothing (cross-resource, #239).
- The sign-in caller now always uses the folding entry point; it attaches no extra scopes when there are none, so it's a plain sign-in in those cases.

### Tests

Work/school fold tests flipped from "folds nothing" to "folds the full set regardless of opt-ins" (+ that primary + extras == `AllGraphAdminConsentScopes`); the caller test updated to the always-fold entry point. Personal/IMAP paths unchanged and still pinned. Build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
