### PR TITLE
Alt+Down / Alt+Up move to the next unread message (#617)

### DIFF
--- a/QuickMail.Tests/TreeViewItemRealizerTests.cs
+++ b/QuickMail.Tests/TreeViewItemRealizerTests.cs
@@ -36,7 +36,7 @@ public class TreeViewItemRealizerTests
 
     // Mirrors the real trees' configuration. Returns the tree and the window holding it; the
     // window must be shown, because virtualization only realizes containers during a real layout.
-    private static (TreeView Tree, Window Window) BuildTree(List<Group> groups)
+    private static (TreeView Tree, Window Window) BuildTree(List<Group> groups, bool nestedListInHeader = false)
     {
         var tree = new TreeView { ItemsSource = groups };
         VirtualizingPanel.SetIsVirtualizing(tree, true);
@@ -49,6 +49,15 @@ public class TreeViewItemRealizerTests
             var text = new FrameworkElementFactory(typeof(TextBlock));
             text.SetBinding(TextBlock.TextProperty, new Binding("Name"));
             rowFactory.AppendChild(text);
+        }
+        if (nestedListInHeader)
+        {
+            // A ListBox's default items panel IS a VirtualizingStackPanel with IsItemsHost=true, and
+            // the real TreeViewItem template puts PART_Header before ItemsHost — so a depth-first or
+            // IsItemsHost-only search reaches this one first and answers with a stranger's panel.
+            var list = new FrameworkElementFactory(typeof(ListBox));
+            list.SetValue(ItemsControl.ItemsSourceProperty, new[] { "a", "b" });
+            rowFactory.AppendChild(list);
         }
         tree.ItemTemplate = new HierarchicalDataTemplate
         {
@@ -109,11 +118,14 @@ public class TreeViewItemRealizerTests
             var landed = TreeViewItemRealizer.FocusMessage(
                 tree, groupIndex: 60, groups[60], groups[60].Messages[7], messageIndex: 7);
 
-            Assert.True(landed);
+            Assert.Equal(GroupedMessageFocus.Message, landed);
             var groupTvi = Assert.IsType<TreeViewItem>(tree.ItemContainerGenerator.ContainerFromItem(groups[60]));
             var msgTvi   = Assert.IsType<TreeViewItem>(groupTvi.ItemContainerGenerator.ContainerFromItem(groups[60].Messages[7]));
             Assert.True(msgTvi.IsSelected);
-            Assert.Same(msgTvi, Keyboard.FocusedElement);
+            // FocusManager over Keyboard.FocusedElement deliberately: the latter answers only while
+            // the test's window holds Win32 activation, which nothing on a shared machine guarantees.
+            // AddressBookFilterMenuTests asserts the Keyboard form and is the suite's one flaky test.
+            Assert.Same(msgTvi, FocusManager.GetFocusedElement(window));
         }
         finally { window.Close(); }
     }
@@ -130,7 +142,7 @@ public class TreeViewItemRealizerTests
             var landed = TreeViewItemRealizer.FocusMessage(
                 tree, groupIndex: 30, groups[30], groups[30].Messages[4], messageIndex: 4);
 
-            Assert.True(landed);
+            Assert.Equal(GroupedMessageFocus.Message, landed);
             // TwoWay-bound, so the model records it and the expansion survives a rebuild.
             Assert.True(groups[30].IsExpanded);
         }
@@ -147,7 +159,7 @@ public class TreeViewItemRealizerTests
             var landed = TreeViewItemRealizer.FocusMessage(
                 tree, groupIndex: 99, groups[99], groups[99].Messages[19], messageIndex: 19);
 
-            Assert.True(landed);
+            Assert.Equal(GroupedMessageFocus.Message, landed);
         }
         finally { window.Close(); }
     }
@@ -162,24 +174,53 @@ public class TreeViewItemRealizerTests
         var (tree, window) = BuildTree(groups);
         try
         {
-            Assert.False(TreeViewItemRealizer.FocusMessage(tree, groupIndex, groups[0], "nope", messageIndex));
+            Assert.Equal(
+                GroupedMessageFocus.None,
+                TreeViewItemRealizer.FocusMessage(tree, groupIndex, groups[0], "nope", messageIndex));
         }
         finally { window.Close(); }
     }
 
     [StaFact]
-    public void FindItemsHost_ReturnsTheTreesOwnPanel_NotANestedOne()
+    public void FindItemsHost_ReturnsTheOwnersPanel_NotOneNestedInItsHeader()
     {
+        // The nested ListBox is the whole point: its panel is a VirtualizingStackPanel with
+        // IsItemsHost true, so only an ownership test can tell the two apart. Without one this
+        // returns the ListBox's panel and BringIndexIntoViewPublic(msgIdx) is called on a two-item
+        // list — an ArgumentOutOfRangeException out of a key handler.
         var groups = BuildGroups(10, 5);
-        var (tree, window) = BuildTree(groups);
+        var (tree, window) = BuildTree(groups, nestedListInHeader: true);
         try
         {
-            var host = TreeViewItemRealizer.FindItemsHost(tree);
-            Assert.NotNull(host);
-            Assert.True(host!.IsItemsHost);
-            // The tree's own host holds the group containers, one per root item.
-            Assert.IsType<TreeViewItem>(host.Children[0]);
-            Assert.Same(tree.ItemContainerGenerator.ContainerFromIndex(0), host.Children[0]);
+            var treeHost = TreeViewItemRealizer.FindItemsHost(tree);
+            Assert.NotNull(treeHost);
+            Assert.Same(tree, ItemsControl.GetItemsOwner(treeHost));
+            Assert.Same(tree.ItemContainerGenerator.ContainerFromIndex(0), treeHost!.Children[0]);
+
+            var groupTvi = (TreeViewItem)tree.ItemContainerGenerator.ContainerFromIndex(0);
+            groupTvi.IsExpanded = true;
+            tree.UpdateLayout();
+
+            var groupHost = TreeViewItemRealizer.FindItemsHost(groupTvi);
+            Assert.NotNull(groupHost);
+            Assert.Same(groupTvi, ItemsControl.GetItemsOwner(groupHost));
+            Assert.Equal(groups[0].Messages.Count, groupHost!.Children.Count);
+        }
+        finally { window.Close(); }
+    }
+
+    [StaFact]
+    public void FocusMessage_StillLands_WhenTheHeaderTemplateHoldsItsOwnList()
+    {
+        // End-to-end version of the above: with an IsItemsHost-only search this throws.
+        var groups = BuildGroups(60, 20);
+        var (tree, window) = BuildTree(groups, nestedListInHeader: true);
+        try
+        {
+            Assert.Equal(
+                GroupedMessageFocus.Message,
+                TreeViewItemRealizer.FocusMessage(
+                    tree, groupIndex: 40, groups[40], groups[40].Messages[9], messageIndex: 9));
         }
         finally { window.Close(); }
     }

--- a/QuickMail.Tests/TreeViewItemRealizerTests.cs
+++ b/QuickMail.Tests/TreeViewItemRealizerTests.cs
@@ -1,0 +1,186 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Input;
+using QuickMail.Helpers;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// Guards <see cref="TreeViewItemRealizer"/> against the fault that produced it (issue #617):
+/// landing focus on a message inside a group that virtualization has not built a container for.
+///
+/// <para>The tree here is configured exactly as the three real grouped trees are in
+/// MainWindow.xaml — <c>IsVirtualizing</c>, <c>VirtualizationMode=Recycling</c>,
+/// <c>CanContentScroll=True</c>, a <c>HierarchicalDataTemplate</c>, and <c>IsExpanded</c> bound
+/// TwoWay in the container style — because every one of those is load-bearing for what is asserted.</para>
+/// </summary>
+public class TreeViewItemRealizerTests
+{
+    private sealed class Group
+    {
+        public string Name { get; init; } = "";
+        public List<string> Messages { get; init; } = [];
+        public bool IsExpanded { get; set; }
+    }
+
+    private static List<Group> BuildGroups(int groups, int perGroup) =>
+        Enumerable.Range(0, groups).Select(g => new Group
+        {
+            Name     = $"g{g}",
+            Messages = Enumerable.Range(0, perGroup).Select(m => $"g{g}m{m}").ToList(),
+        }).ToList();
+
+    // Mirrors the real trees' configuration. Returns the tree and the window holding it; the
+    // window must be shown, because virtualization only realizes containers during a real layout.
+    private static (TreeView Tree, Window Window) BuildTree(List<Group> groups)
+    {
+        var tree = new TreeView { ItemsSource = groups };
+        VirtualizingPanel.SetIsVirtualizing(tree, true);
+        VirtualizingPanel.SetVirtualizationMode(tree, VirtualizationMode.Recycling);
+        ScrollViewer.SetCanContentScroll(tree, true);
+
+        var rowFactory = new FrameworkElementFactory(typeof(StackPanel));
+        for (var i = 0; i < 3; i++)   // a three-line row, as the real templates have
+        {
+            var text = new FrameworkElementFactory(typeof(TextBlock));
+            text.SetBinding(TextBlock.TextProperty, new Binding("Name"));
+            rowFactory.AppendChild(text);
+        }
+        tree.ItemTemplate = new HierarchicalDataTemplate
+        {
+            ItemsSource = new Binding("Messages"),
+            VisualTree  = rowFactory,
+        };
+
+        var containerStyle = new Style(typeof(TreeViewItem));
+        containerStyle.Setters.Add(new Setter(TreeViewItem.IsExpandedProperty,
+            new Binding("IsExpanded") { Mode = BindingMode.TwoWay }));
+        tree.ItemContainerStyle = containerStyle;
+
+        var window = new Window
+        {
+            Width = 500, Height = 600, Content = tree,
+            ShowInTaskbar = false, WindowStyle = WindowStyle.None,
+            Left = -4000, Top = -4000,      // off-screen: this must not steal the user's display
+        };
+        window.Show();
+        tree.UpdateLayout();
+        return (tree, window);
+    }
+
+    /// <summary>
+    /// The fact the whole helper exists for. A TreeView showing a HierarchicalDataTemplate scrolls
+    /// in pixels even with CanContentScroll="True", so a row index handed to ScrollToVerticalOffset
+    /// moves the viewport by about one row instead of by that many rows. If this ever starts
+    /// reporting Item, the far simpler scroll-and-wait approach becomes viable again — but until
+    /// then, code that scrolls by row index is silently broken.
+    /// </summary>
+    [StaFact]
+    public void HierarchicalTreeScrollsInPixels_NotRows()
+    {
+        var (tree, window) = BuildTree(BuildGroups(100, 20));
+        try
+        {
+            Assert.Equal(ScrollUnit.Pixel, VirtualizingPanel.GetScrollUnit(tree));
+
+            var scroller = tree.Template.FindName("_tv_scrollviewer_", tree) as ScrollViewer;
+            Assert.NotNull(scroller);
+            // 100 rows in an extent far larger than 100 is the same statement in numbers.
+            Assert.True(scroller!.ExtentHeight > 100 * 4,
+                $"extent {scroller.ExtentHeight} looks item-based, not pixel-based");
+        }
+        finally { window.Close(); }
+    }
+
+    [StaFact]
+    public void FocusMessage_LandsOnAMessageInAGroupBelowTheViewport()
+    {
+        var groups = BuildGroups(100, 20);
+        var (tree, window) = BuildTree(groups);
+        try
+        {
+            // Nothing near group 60 is realized at rest — that is the state the old code gave up in.
+            Assert.Null(tree.ItemContainerGenerator.ContainerFromItem(groups[60]));
+
+            var landed = TreeViewItemRealizer.FocusMessage(
+                tree, groupIndex: 60, groups[60], groups[60].Messages[7], messageIndex: 7);
+
+            Assert.True(landed);
+            var groupTvi = Assert.IsType<TreeViewItem>(tree.ItemContainerGenerator.ContainerFromItem(groups[60]));
+            var msgTvi   = Assert.IsType<TreeViewItem>(groupTvi.ItemContainerGenerator.ContainerFromItem(groups[60].Messages[7]));
+            Assert.True(msgTvi.IsSelected);
+            Assert.Same(msgTvi, Keyboard.FocusedElement);
+        }
+        finally { window.Close(); }
+    }
+
+    [StaFact]
+    public void FocusMessage_ExpandsAClosedGroup()
+    {
+        var groups = BuildGroups(40, 10);
+        var (tree, window) = BuildTree(groups);
+        try
+        {
+            Assert.False(groups[30].IsExpanded);
+
+            var landed = TreeViewItemRealizer.FocusMessage(
+                tree, groupIndex: 30, groups[30], groups[30].Messages[4], messageIndex: 4);
+
+            Assert.True(landed);
+            // TwoWay-bound, so the model records it and the expansion survives a rebuild.
+            Assert.True(groups[30].IsExpanded);
+        }
+        finally { window.Close(); }
+    }
+
+    [StaFact]
+    public void FocusMessage_ReachesTheLastMessageOfTheLastGroup()
+    {
+        var groups = BuildGroups(100, 20);
+        var (tree, window) = BuildTree(groups);
+        try
+        {
+            var landed = TreeViewItemRealizer.FocusMessage(
+                tree, groupIndex: 99, groups[99], groups[99].Messages[19], messageIndex: 19);
+
+            Assert.True(landed);
+        }
+        finally { window.Close(); }
+    }
+
+    [StaTheory]
+    [InlineData(-1, 0)]     // group not in the collection (IndexOf miss)
+    [InlineData(100, 0)]    // group index past the end
+    [InlineData(5, -1)]     // negative message index
+    public void FocusMessage_OutOfRangeIsRefused_NotThrown(int groupIndex, int messageIndex)
+    {
+        var groups = BuildGroups(100, 20);
+        var (tree, window) = BuildTree(groups);
+        try
+        {
+            Assert.False(TreeViewItemRealizer.FocusMessage(tree, groupIndex, groups[0], "nope", messageIndex));
+        }
+        finally { window.Close(); }
+    }
+
+    [StaFact]
+    public void FindItemsHost_ReturnsTheTreesOwnPanel_NotANestedOne()
+    {
+        var groups = BuildGroups(10, 5);
+        var (tree, window) = BuildTree(groups);
+        try
+        {
+            var host = TreeViewItemRealizer.FindItemsHost(tree);
+            Assert.NotNull(host);
+            Assert.True(host!.IsItemsHost);
+            // The tree's own host holds the group containers, one per root item.
+            Assert.IsType<TreeViewItem>(host.Children[0]);
+            Assert.Same(tree.ItemContainerGenerator.ContainerFromIndex(0), host.Children[0]);
+        }
+        finally { window.Close(); }
+    }
+}

--- a/QuickMail.Tests/UnreadNavigatorTests.cs
+++ b/QuickMail.Tests/UnreadNavigatorTests.cs
@@ -1,0 +1,165 @@
+using System.Collections.Generic;
+using System.Linq;
+using QuickMail.Helpers;
+using QuickMail.Models;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// Tests for <see cref="UnreadNavigator"/> — the Alt+Down / Alt+Up "next unread message" search
+/// (issue #617). Pure list logic, deliberately kept out of MainWindow so it is testable without
+/// a TreeView: the window contributes only focus and expansion on top of these answers.
+/// </summary>
+public class UnreadNavigatorTests
+{
+    // "u" = unread, "r" = read. One character per message keeps each case's shape readable.
+    private static List<MailMessageSummary> Msgs(string pattern) =>
+        pattern.Select((c, i) => new MailMessageSummary
+        {
+            MessageId = i.ToString(),
+            Subject   = $"m{i}",
+            IsRead    = c == 'r',
+        }).ToList();
+
+    private static ConversationGroup Group(string subject, string pattern) =>
+        new() { NormalizedSubject = subject, Messages = Msgs(pattern) };
+
+    // ── Flat list ────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("rurur",  0, 1)]   // from a read row, the next unread is below it
+    [InlineData("rurur",  1, 3)]   // standing on an unread row does not answer with itself
+    [InlineData("rurur",  3, -1)]  // nothing unread further down
+    [InlineData("rrrrr",  0, -1)]  // nothing unread at all
+    [InlineData("urrrr", -1, 0)]   // no selection: the search starts above the first row
+    public void FindNextUnread_Forward(string pattern, int from, int expected) =>
+        Assert.Equal(expected, UnreadNavigator.FindNextUnread(Msgs(pattern), from, forward: true));
+
+    [Theory]
+    [InlineData("rurur", 4, 3)]
+    [InlineData("rurur", 3, 1)]
+    [InlineData("rurur", 1, -1)]
+    [InlineData("rrrrr", 4, -1)]
+    [InlineData("rrrru", 5, 4)]    // no selection: the search starts below the last row
+    public void FindNextUnread_Backward(string pattern, int from, int expected) =>
+        Assert.Equal(expected, UnreadNavigator.FindNextUnread(Msgs(pattern), from, forward: false));
+
+    [Fact]
+    public void FindNextUnread_DoesNotWrap()
+    {
+        var messages = Msgs("urrrr");
+        // The one unread message is at the top, and the selection is at the bottom. Wrapping
+        // would find it; not wrapping is the contract, so that running out says so instead.
+        Assert.Equal(-1, UnreadNavigator.FindNextUnread(messages, 4, forward: true));
+    }
+
+    [Fact]
+    public void FindNextUnread_EmptyList_ReturnsNotFound()
+    {
+        Assert.Equal(-1, UnreadNavigator.FindNextUnread(Msgs(""), -1, forward: true));
+        Assert.Equal(-1, UnreadNavigator.FindNextUnread(Msgs(""),  0, forward: false));
+    }
+
+    // ── Grouped views ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Flatten_PutsMessagesInTreeOrder()
+    {
+        var a = Group("a", "rr");
+        var b = Group("b", "u");
+        var flat = UnreadNavigator.Flatten([a, b], g => g.Messages);
+
+        Assert.Equal(3, flat.Count);
+        Assert.Equal([a, a, b], flat.Select(e => e.Group));
+        Assert.Equal([0, 1, 0],  flat.Select(e => e.MessageIndex));
+    }
+
+    [Fact]
+    public void Flatten_IncludesCollapsedGroups()
+    {
+        // Expansion state is not consulted: the caller expands whatever group it lands in, so a
+        // collapsed conversation holding the only unread message must still be reachable.
+        var collapsed = Group("collapsed", "u");
+        collapsed.IsExpanded = false;
+
+        var flat = UnreadNavigator.Flatten([collapsed], g => g.Messages);
+        Assert.Equal(0, UnreadNavigator.FindNextUnread(flat, e => e.Message.IsUnread, -1, forward: true));
+    }
+
+    [Fact]
+    public void FindNextUnread_CrossesGroupBoundaries()
+    {
+        var a = Group("a", "rr");
+        var b = Group("b", "ru");
+        var flat = UnreadNavigator.Flatten([a, b], g => g.Messages);
+
+        var idx = UnreadNavigator.FindNextUnread(flat, e => e.Message.IsUnread, 0, forward: true);
+        Assert.Equal(3, idx);
+        Assert.Same(b, flat[idx].Group);
+        Assert.Equal(1, flat[idx].MessageIndex);
+    }
+
+    [Fact]
+    public void IndexOfMessage_FindsTheSelectedMessage()
+    {
+        var a = Group("a", "ru");
+        var flat = UnreadNavigator.Flatten([a], g => g.Messages);
+
+        Assert.Equal(1, UnreadNavigator.IndexOfMessage(flat, a.Messages[1]));
+        Assert.Equal(-1, UnreadNavigator.IndexOfMessage(flat, Msgs("u")[0]));
+    }
+
+    [Fact]
+    public void IndexOfGroupStart_IsTheGroupsFirstMessage()
+    {
+        var a = Group("a", "rr");
+        var b = Group("b", "ru");
+        var flat = UnreadNavigator.Flatten([a, b], g => g.Messages);
+
+        Assert.Equal(0, UnreadNavigator.IndexOfGroupStart(flat, a));
+        Assert.Equal(2, UnreadNavigator.IndexOfGroupStart(flat, b));
+        Assert.Equal(-1, UnreadNavigator.IndexOfGroupStart(flat, Group("absent", "u")));
+    }
+
+    [Fact]
+    public void FromGroupHeader_DownConsidersTheGroupsOwnMessages()
+    {
+        // A header sits above its own messages, so Alt+Down from it behaves like Down arrow:
+        // the group's first message is the next row, and is eligible.
+        var a = Group("a", "ur");
+        var flat = UnreadNavigator.Flatten([a], g => g.Messages);
+        var start = UnreadNavigator.IndexOfGroupStart(flat, a);
+
+        var from = UnreadNavigator.SearchOriginForGroupHeader(start, forward: true);
+        Assert.Equal(0, UnreadNavigator.FindNextUnread(flat, e => e.Message.IsUnread, from, forward: true));
+    }
+
+    [Fact]
+    public void FromGroupHeader_UpSkipsTheGroupsOwnMessages()
+    {
+        // Going up from a header must leave the group entirely — its messages are all below it.
+        var a = Group("a", "ru");
+        var b = Group("b", "uu");
+        var flat = UnreadNavigator.Flatten([a, b], g => g.Messages);
+        var start = UnreadNavigator.IndexOfGroupStart(flat, b);
+
+        var from = UnreadNavigator.SearchOriginForGroupHeader(start, forward: false);
+        var idx  = UnreadNavigator.FindNextUnread(flat, e => e.Message.IsUnread, from, forward: false);
+
+        Assert.Same(a, flat[idx].Group);
+        Assert.Equal(1, flat[idx].MessageIndex);
+    }
+
+    [Fact]
+    public void SearchOriginForNoSelection_SearchesTheWholeViewEitherWay()
+    {
+        var flat = UnreadNavigator.Flatten([Group("a", "uru")], g => g.Messages);
+
+        var down = UnreadNavigator.SearchOriginForNoSelection(flat.Count, forward: true);
+        var up   = UnreadNavigator.SearchOriginForNoSelection(flat.Count, forward: false);
+
+        Assert.Equal(0, UnreadNavigator.FindNextUnread(flat, e => e.Message.IsUnread, down, forward: true));
+        Assert.Equal(2, UnreadNavigator.FindNextUnread(flat, e => e.Message.IsUnread, up,   forward: false));
+    }
+}

--- a/QuickMail.Tests/UnreadNavigatorTests.cs
+++ b/QuickMail.Tests/UnreadNavigatorTests.cs
@@ -76,15 +76,24 @@ public class UnreadNavigatorTests
     }
 
     [Fact]
-    public void Flatten_IncludesCollapsedGroups()
+    public void Flatten_IsBlindToExpansionState()
     {
-        // Expansion state is not consulted: the caller expands whatever group it lands in, so a
-        // collapsed conversation holding the only unread message must still be reachable.
-        var collapsed = Group("collapsed", "u");
+        // Guards against anyone later teaching Flatten to skip closed groups. It must not: the
+        // caller expands whatever group it lands in, so a collapsed conversation holding the only
+        // unread message has to stay reachable. Both states must flatten identically.
+        var collapsed = Group("g", "ru");
         collapsed.IsExpanded = false;
+        var expanded = Group("g", "ru");
+        expanded.IsExpanded = true;
 
-        var flat = UnreadNavigator.Flatten([collapsed], g => g.Messages);
-        Assert.Equal(0, UnreadNavigator.FindNextUnread(flat, e => e.Message.IsUnread, -1, forward: true));
+        var closed = UnreadNavigator.Flatten([collapsed], g => g.Messages);
+        var open   = UnreadNavigator.Flatten([expanded],  g => g.Messages);
+
+        Assert.Equal(open.Count, closed.Count);
+        Assert.Equal(
+            UnreadNavigator.FindNextUnread(open,   e => e.Message.IsUnread, -1, forward: true),
+            UnreadNavigator.FindNextUnread(closed, e => e.Message.IsUnread, -1, forward: true));
+        Assert.Equal(1, UnreadNavigator.FindNextUnread(closed, e => e.Message.IsUnread, -1, forward: true));
     }
 
     [Fact]

--- a/QuickMail/Helpers/TreeViewItemRealizer.cs
+++ b/QuickMail/Helpers/TreeViewItemRealizer.cs
@@ -33,25 +33,27 @@ public static class TreeViewItemRealizer
 {
     /// <summary>
     /// Selects and focuses <paramref name="message"/>, expanding <paramref name="group"/> if it is
-    /// closed. Returns true when focus landed on the message.
-    /// <para>When the message container still cannot be produced, focus lands on the group header
-    /// instead and this returns false: somewhere inside the tree, next to what was asked for, beats
-    /// leaving focus wherever it was with nothing to show for the keystroke.</para>
+    /// closed.
+    /// <para>The three outcomes are distinguished because the caller has to treat them differently:
+    /// only <see cref="GroupedMessageFocus.None"/> leaves focus where it was, and only that case
+    /// needs anything said about it. Landing on the header is a focus move the platform reports on
+    /// its own.</para>
     /// </summary>
     /// <param name="groupIndex">The group's index in the tree's own <c>ItemsSource</c>.</param>
     /// <param name="messageIndex">The message's index within the group.</param>
-    public static bool FocusMessage(
+    public static GroupedMessageFocus FocusMessage(
         TreeView tree, int groupIndex, object group, object message, int messageIndex)
     {
-        if (groupIndex < 0 || groupIndex >= tree.Items.Count || messageIndex < 0) return false;
+        if (groupIndex < 0 || groupIndex >= tree.Items.Count || messageIndex < 0)
+            return GroupedMessageFocus.None;
 
         // Realize the group's own container. Nothing below can happen until this exists.
-        if (FindItemsHost(tree) is not { } rootPanel) return false;
+        if (FindItemsHost(tree) is not { } rootPanel) return GroupedMessageFocus.None;
         rootPanel.BringIndexIntoViewPublic(groupIndex);
         tree.UpdateLayout();
 
         if (tree.ItemContainerGenerator.ContainerFromItem(group) is not TreeViewItem groupTvi)
-            return false;
+            return GroupedMessageFocus.None;
 
         if (!groupTvi.IsExpanded)
         {
@@ -71,29 +73,49 @@ public static class TreeViewItemRealizer
             msgTvi.IsSelected = true;
             msgTvi.Focus();
             msgTvi.BringIntoView();
-            return true;
+            return GroupedMessageFocus.Message;
         }
 
+        // Somewhere inside the tree, next to what was asked for, beats leaving focus where it was
+        // with nothing to show for the keystroke.
         groupTvi.IsSelected = true;
         groupTvi.Focus();
-        return false;
+        return GroupedMessageFocus.Group;
     }
 
     /// <summary>
-    /// The virtualizing panel holding <paramref name="root"/>'s <em>own</em> items.
-    /// <para>The <c>IsItemsHost</c> test is what keeps this from returning a panel that belongs to
-    /// something nested in an item's template. Depth-first order alone is not enough of a guarantee
-    /// to rest on: a header template that ever gained an items control would silently start
-    /// answering here.</para>
+    /// The virtualizing panel holding <paramref name="owner"/>'s <em>own</em> items.
+    /// <para>The ownership test is <c>ItemsControl.GetItemsOwner</c>, not <c>IsItemsHost</c>: a panel
+    /// nested inside an item's template is the items host of <em>that</em> control, so
+    /// <c>IsItemsHost</c> is true for it too and would not exclude it. Nor does depth-first order
+    /// save us — the real <c>TreeViewItem</c> template puts <c>PART_Header</c> before
+    /// <c>ItemsHost</c>, so a header that ever gained a list would be reached first and
+    /// <c>BringIndexIntoViewPublic</c> would then be called on a stranger's panel, throwing out of a
+    /// key handler as soon as that list held fewer items than the group.</para>
     /// </summary>
-    public static VirtualizingStackPanel? FindItemsHost(DependencyObject? root)
-    {
-        if (root == null) return null;
-        if (root is VirtualizingStackPanel { IsItemsHost: true } host) return host;
+    public static VirtualizingStackPanel? FindItemsHost(ItemsControl owner) => Search(owner);
 
-        var count = VisualTreeHelper.GetChildrenCount(root);
+    private static VirtualizingStackPanel? Search(DependencyObject node, ItemsControl? owner = null)
+    {
+        owner ??= node as ItemsControl;
+        if (node is VirtualizingStackPanel panel
+            && ReferenceEquals(ItemsControl.GetItemsOwner(panel), owner))
+            return panel;
+
+        var count = VisualTreeHelper.GetChildrenCount(node);
         for (var i = 0; i < count; i++)
-            if (FindItemsHost(VisualTreeHelper.GetChild(root, i)) is { } found) return found;
+            if (Search(VisualTreeHelper.GetChild(node, i), owner) is { } found) return found;
         return null;
     }
+}
+
+/// <summary>Where <see cref="TreeViewItemRealizer.FocusMessage"/> left keyboard focus.</summary>
+public enum GroupedMessageFocus
+{
+    /// <summary>Focus did not move. The only outcome that needs announcing.</summary>
+    None,
+    /// <summary>Focus landed on the group header — the message container could not be produced.</summary>
+    Group,
+    /// <summary>Focus landed on the message, which is what was asked for.</summary>
+    Message,
 }

--- a/QuickMail/Helpers/TreeViewItemRealizer.cs
+++ b/QuickMail/Helpers/TreeViewItemRealizer.cs
@@ -1,0 +1,99 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Media;
+
+namespace QuickMail.Helpers;
+
+/// <summary>
+/// Puts selection and focus on one message inside one group of a virtualized grouped tree
+/// (Conversations, From, To), creating the containers it needs on the way.
+///
+/// <para>
+/// The obvious approach — scroll the target into the viewport and let the layout pass generate the
+/// container — does not work here, and quietly did nothing for years. A <c>TreeView</c> showing a
+/// <c>HierarchicalDataTemplate</c> uses hierarchical virtualization, which scrolls in <em>pixels</em>
+/// whatever <c>ScrollViewer.CanContentScroll</c> says: measured on the real templates,
+/// <c>VirtualizingPanel.GetScrollUnit</c> reports <c>Pixel</c> and the extent works out at about
+/// 48px per group row. Code that computed a row index and passed it to
+/// <c>ScrollToVerticalOffset</c> therefore moved the viewport by roughly one row when it meant
+/// sixty, the container it was waiting for never appeared, and the caller gave up without moving
+/// focus and without saying anything. Worse, on an already-correct viewport that same call dragged
+/// the tree back toward the top. See <c>TreeViewItemRealizerTests</c>, which pins the pixel-unit
+/// fact so a future change cannot re-tempt anyone into the index-offset version.
+/// </para>
+///
+/// <para>
+/// <see cref="VirtualizingStackPanel.BringIndexIntoViewPublic"/> is the supported way to ask a
+/// virtualizing panel for a container by index. It is synchronous, so no dispatcher retry ladder is
+/// needed — which also means the caller finds out whether it worked.
+/// </para>
+/// </summary>
+public static class TreeViewItemRealizer
+{
+    /// <summary>
+    /// Selects and focuses <paramref name="message"/>, expanding <paramref name="group"/> if it is
+    /// closed. Returns true when focus landed on the message.
+    /// <para>When the message container still cannot be produced, focus lands on the group header
+    /// instead and this returns false: somewhere inside the tree, next to what was asked for, beats
+    /// leaving focus wherever it was with nothing to show for the keystroke.</para>
+    /// </summary>
+    /// <param name="groupIndex">The group's index in the tree's own <c>ItemsSource</c>.</param>
+    /// <param name="messageIndex">The message's index within the group.</param>
+    public static bool FocusMessage(
+        TreeView tree, int groupIndex, object group, object message, int messageIndex)
+    {
+        if (groupIndex < 0 || groupIndex >= tree.Items.Count || messageIndex < 0) return false;
+
+        // Realize the group's own container. Nothing below can happen until this exists.
+        if (FindItemsHost(tree) is not { } rootPanel) return false;
+        rootPanel.BringIndexIntoViewPublic(groupIndex);
+        tree.UpdateLayout();
+
+        if (tree.ItemContainerGenerator.ContainerFromItem(group) is not TreeViewItem groupTvi)
+            return false;
+
+        if (!groupTvi.IsExpanded)
+        {
+            groupTvi.IsExpanded = true;
+            tree.UpdateLayout();   // generates the child items host
+        }
+
+        // The child panel exists only once the group is expanded, and virtualizes independently.
+        if (FindItemsHost(groupTvi) is { } childPanel && messageIndex < groupTvi.Items.Count)
+        {
+            childPanel.BringIndexIntoViewPublic(messageIndex);
+            tree.UpdateLayout();
+        }
+
+        if (groupTvi.ItemContainerGenerator.ContainerFromItem(message) is TreeViewItem msgTvi)
+        {
+            msgTvi.IsSelected = true;
+            msgTvi.Focus();
+            msgTvi.BringIntoView();
+            return true;
+        }
+
+        groupTvi.IsSelected = true;
+        groupTvi.Focus();
+        return false;
+    }
+
+    /// <summary>
+    /// The virtualizing panel holding <paramref name="root"/>'s <em>own</em> items.
+    /// <para>The <c>IsItemsHost</c> test is what keeps this from returning a panel that belongs to
+    /// something nested in an item's template. Depth-first order alone is not enough of a guarantee
+    /// to rest on: a header template that ever gained an items control would silently start
+    /// answering here.</para>
+    /// </summary>
+    public static VirtualizingStackPanel? FindItemsHost(DependencyObject? root)
+    {
+        if (root == null) return null;
+        if (root is VirtualizingStackPanel { IsItemsHost: true } host) return host;
+
+        var count = VisualTreeHelper.GetChildrenCount(root);
+        for (var i = 0; i < count; i++)
+            if (FindItemsHost(VisualTreeHelper.GetChild(root, i)) is { } found) return found;
+        return null;
+    }
+}

--- a/QuickMail/Helpers/UnreadNavigator.cs
+++ b/QuickMail/Helpers/UnreadNavigator.cs
@@ -95,9 +95,13 @@ public static class UnreadNavigator
 
     /// <summary>
     /// Where a search out from the selected group header starts. A header sits above its own
-    /// messages, so moving down considers the group's first message and moving up starts at the
-    /// row above the header — matching what Down and Up arrow do from the same place.
+    /// messages, so moving down considers the group's first message and moving up starts before
+    /// the header, leaving the group entirely.
     /// </summary>
+    /// <remarks>This matches Down and Up arrow from an <em>expanded</em> header. From a collapsed
+    /// one it deliberately diverges: Down arrow steps over the group to the next header, while this
+    /// descends into it and the caller expands it — finding the unread message inside a closed
+    /// conversation is the point of the command, not a side effect.</remarks>
     public static int SearchOriginForGroupHeader(int groupStartIndex, bool forward) =>
         forward ? groupStartIndex - 1 : groupStartIndex;
 

--- a/QuickMail/Helpers/UnreadNavigator.cs
+++ b/QuickMail/Helpers/UnreadNavigator.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+using QuickMail.Models;
+
+namespace QuickMail.Helpers;
+
+/// <summary>
+/// One message as it appears in a grouped view: the group whose node holds it, its position
+/// inside that group, and the message itself. Flattening a grouped view into a list of these
+/// puts every message in the order the tree shows them, so a search for the next unread one
+/// is the same scan in a tree as it is in the flat message list.
+/// </summary>
+/// <remarks>Collapsed groups are included — <see cref="UnreadNavigator"/> is what decides
+/// where to land, and the caller expands whatever group it lands in.</remarks>
+public sealed record GroupedMessageRef<TGroup>(TGroup Group, int MessageIndex, MailMessageSummary Message);
+
+/// <summary>
+/// Finds the nearest unread message above or below a starting position. Pure list logic, kept
+/// out of the window so it can be tested without standing up a TreeView (issue #617).
+/// </summary>
+public static class UnreadNavigator
+{
+    /// <summary>
+    /// Index of the nearest item satisfying <paramref name="isUnread"/> strictly past
+    /// <paramref name="fromIndex"/> — below it when <paramref name="forward"/>, above it
+    /// otherwise — or -1 when there is none. The search never wraps: reaching the end is
+    /// the answer "there are no more", not "start again from the other end".
+    /// </summary>
+    /// <param name="fromIndex">The position to search out from. It is excluded from the
+    /// search, so -1 searches the whole list forwards and <c>items.Count</c> searches the
+    /// whole list backwards.</param>
+    public static int FindNextUnread<T>(IReadOnlyList<T> items, Func<T, bool> isUnread, int fromIndex, bool forward)
+    {
+        ArgumentNullException.ThrowIfNull(items);
+        ArgumentNullException.ThrowIfNull(isUnread);
+
+        if (forward)
+        {
+            for (var i = Math.Max(fromIndex + 1, 0); i < items.Count; i++)
+                if (isUnread(items[i])) return i;
+        }
+        else
+        {
+            for (var i = Math.Min(fromIndex - 1, items.Count - 1); i >= 0; i--)
+                if (isUnread(items[i])) return i;
+        }
+        return -1;
+    }
+
+    /// <summary>The flat-message-list overload of <see cref="FindNextUnread{T}"/>.</summary>
+    public static int FindNextUnread(IReadOnlyList<MailMessageSummary> messages, int fromIndex, bool forward) =>
+        FindNextUnread(messages, m => m.IsUnread, fromIndex, forward);
+
+    /// <summary>
+    /// Every message in <paramref name="groups"/> in the order the tree shows them: each group's
+    /// messages in group order, groups in collection order.
+    /// </summary>
+    public static List<GroupedMessageRef<TGroup>> Flatten<TGroup>(
+        IEnumerable<TGroup> groups,
+        Func<TGroup, IReadOnlyList<MailMessageSummary>> messagesOf)
+    {
+        ArgumentNullException.ThrowIfNull(groups);
+        ArgumentNullException.ThrowIfNull(messagesOf);
+
+        var flat = new List<GroupedMessageRef<TGroup>>();
+        foreach (var group in groups)
+        {
+            var messages = messagesOf(group);
+            for (var i = 0; i < messages.Count; i++)
+                flat.Add(new GroupedMessageRef<TGroup>(group, i, messages[i]));
+        }
+        return flat;
+    }
+
+    /// <summary>Position of <paramref name="message"/> in a flattened view, or -1 when it is not in it.</summary>
+    public static int IndexOfMessage<TGroup>(IReadOnlyList<GroupedMessageRef<TGroup>> flat, MailMessageSummary message)
+    {
+        ArgumentNullException.ThrowIfNull(flat);
+        for (var i = 0; i < flat.Count; i++)
+            if (ReferenceEquals(flat[i].Message, message)) return i;
+        return -1;
+    }
+
+    /// <summary>
+    /// Position of <paramref name="group"/>'s first message in a flattened view, or -1 when the
+    /// group holds no messages or is not in the view.
+    /// </summary>
+    public static int IndexOfGroupStart<TGroup>(IReadOnlyList<GroupedMessageRef<TGroup>> flat, TGroup group)
+    {
+        ArgumentNullException.ThrowIfNull(flat);
+        for (var i = 0; i < flat.Count; i++)
+            if (ReferenceEquals(flat[i].Group, group)) return i;
+        return -1;
+    }
+
+    /// <summary>
+    /// Where a search out from the selected group header starts. A header sits above its own
+    /// messages, so moving down considers the group's first message and moving up starts at the
+    /// row above the header — matching what Down and Up arrow do from the same place.
+    /// </summary>
+    public static int SearchOriginForGroupHeader(int groupStartIndex, bool forward) =>
+        forward ? groupStartIndex - 1 : groupStartIndex;
+
+    /// <summary>
+    /// Where a search starts when nothing is selected: before the first row going down, past the
+    /// last row going up, so the whole view is searched either way.
+    /// </summary>
+    public static int SearchOriginForNoSelection(int itemCount, bool forward) => forward ? -1 : itemCount;
+}

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -4588,10 +4588,26 @@ public partial class MainWindow : Window
     /// </summary>
     private void GoToUnread(bool forward)
     {
-        // The calendar has no unread mail, and in Tab mode a message tab covers the list. Either
-        // way the panel this would move through is not on screen — reachable only from the palette,
-        // which runs a command without consulting IsAvailable.
-        if (_vm.IsCalendarView) return;
+        // Both guards are reachable only from the palette, which runs a command without consulting
+        // IsAvailable. Neither is silent: a command that declines to act has to say so, for the same
+        // reason running out of unread mail does.
+        //
+        // Tab mode is IsMessageListAreaVisible, not MessageList.IsVisible: an active message tab
+        // hides the list by collapsing its grid row to zero height, which leaves Visibility — and so
+        // IsVisible — untouched. Focusing a row in a zero-height list strands the user on something
+        // they cannot see or scroll to.
+        if (_vm.IsCalendarView)
+        {
+            AccessibilityHelper.Announce(this, "No unread messages. The calendar is open.",
+                category: AnnouncementCategory.Result);
+            return;
+        }
+        if (!_vm.IsMessageListAreaVisible)
+        {
+            AccessibilityHelper.Announce(this, "No unread messages. The message list is not showing.",
+                category: AnnouncementCategory.Result);
+            return;
+        }
 
         if (_vm.IsConversationsView)
             GoToUnreadInGroupTree(ConversationTree, _vm.Conversations, g => g.Messages, (g, i) => FocusConversationMessage(g, i), forward);
@@ -4605,14 +4621,22 @@ public partial class MainWindow : Window
 
     private void GoToUnreadInMessageList(bool forward)
     {
-        if (!MessageList.IsVisible) return;
-
         var messages = _vm.Messages;
 
-        // SelectedIndex is the first row of an Extended selection, and -1 when nothing is
-        // selected at all — in which case the search covers the whole list from the near end.
-        var from = MessageList.SelectedIndex >= 0
-            ? MessageList.SelectedIndex
+        // The focused row, not SelectedIndex: SelectedIndex is the FIRST item added to an Extended
+        // selection, not the topmost one, and ExtendMessageSelection builds Shift+Up selections by
+        // adding rows downward-to-upward. Searching out from SelectedIndex after Shift+Up therefore
+        // started below the caret, and Alt+Up could land on a message below where the user was.
+        // Same resolution order ExtendMessageSelection uses, for the same reason.
+        var focusedIndex = Keyboard.FocusedElement is ListViewItem focusedRow
+            ? MessageList.ItemContainerGenerator.IndexFromContainer(focusedRow)
+            : -1;
+        if (focusedIndex < 0) focusedIndex = MessageList.SelectedIndex;
+
+        // Still -1 when nothing is selected at all: the search then covers the whole list from
+        // whichever end it is travelling away from.
+        var from = focusedIndex >= 0
+            ? focusedIndex
             : UnreadNavigator.SearchOriginForNoSelection(messages.Count, forward);
 
         var idx = UnreadNavigator.FindNextUnread(messages, from, forward);
@@ -4632,8 +4656,6 @@ public partial class MainWindow : Window
         Action<TGroup, int> focusMessage,
         bool forward) where TGroup : class
     {
-        if (!tree.IsVisible) return;
-
         var flat = UnreadNavigator.Flatten(groups, messagesOf);
 
         int from;
@@ -4703,6 +4725,13 @@ public partial class MainWindow : Window
         return null;
     }
 
+    /// <summary>
+    /// How many scroll-then-wait passes the group-tree focus helpers make before settling for
+    /// whatever container exists. Two covers the worst real case — scroll the group in, expand it,
+    /// scroll the message in — without letting a tree that never realizes a container loop forever.
+    /// </summary>
+    private const int MaxGroupFocusAttempts = 2;
+
     // Scrolls a SenderGroup-based tree so that the message at msgIdx within targetGroup
     // is within the virtual viewport, ensuring its container is generated on the next layout
     // pass. Uses item-based scroll offsets (CanContentScroll="True").
@@ -4739,20 +4768,27 @@ public partial class MainWindow : Window
         FindScrollViewer(tree)?.ScrollToVerticalOffset(offset);
     }
 
-    private void FocusSenderGroupMessage(SenderGroup group, int msgIdx, bool isRetry = false)
+    private void FocusSenderGroupMessage(SenderGroup group, int msgIdx, int attempt = 0)
     {
         var target   = group.Messages[msgIdx];
         var groupTvi = SenderGroupTree.ItemContainerGenerator.ContainerFromItem(group) as TreeViewItem;
         if (groupTvi == null)
         {
-            if (!isRetry)
-                Dispatcher.InvokeAsync(() => FocusSenderGroupMessage(group, msgIdx, true), DispatcherPriority.Background);
+            // The group is outside the virtualized viewport, so its container does not exist and
+            // waiting will not create one — scroll it in, exactly as the message-level branch below
+            // already does, and let the layout pass generate it before the retry runs. Until #617 the
+            // only caller was the group-boundary jump, which acts on the selected (therefore realized)
+            // group; next-unread crosses group boundaries, so it targets distant groups routinely and
+            // the bare retry left it doing nothing at all past the first screenful.
+            if (attempt >= MaxGroupFocusAttempts) return;
+            ScrollSenderGroupMessageIntoView(SenderGroupTree, _vm.SenderGroups, group, msgIdx);
+            Dispatcher.InvokeAsync(() => FocusSenderGroupMessage(group, msgIdx, attempt + 1), DispatcherPriority.Background);
             return;
         }
         if (!groupTvi.IsExpanded) groupTvi.IsExpanded = true;
         var msgTvi = groupTvi.ItemContainerGenerator.ContainerFromItem(target) as TreeViewItem;
         if (msgTvi != null) { msgTvi.IsSelected = true; msgTvi.Focus(); return; }
-        if (!isRetry)
+        if (attempt < MaxGroupFocusAttempts)
         {
             // After a full rebuild the TreeView scroll resets to 0. Scroll the target into
             // the viewport now; the resulting layout pass (Render priority) generates its
@@ -4801,20 +4837,27 @@ public partial class MainWindow : Window
         _vm.PropertyChanged += OnPropertyChanged;
     }
 
-    private void FocusToGroupMessage(SenderGroup group, int msgIdx, bool isRetry = false)
+    private void FocusToGroupMessage(SenderGroup group, int msgIdx, int attempt = 0)
     {
         var target   = group.Messages[msgIdx];
         var groupTvi = ToGroupTree.ItemContainerGenerator.ContainerFromItem(group) as TreeViewItem;
         if (groupTvi == null)
         {
-            if (!isRetry)
-                Dispatcher.InvokeAsync(() => FocusToGroupMessage(group, msgIdx, true), DispatcherPriority.Background);
+            // The group is outside the virtualized viewport, so its container does not exist and
+            // waiting will not create one — scroll it in, exactly as the message-level branch below
+            // already does, and let the layout pass generate it before the retry runs. Until #617 the
+            // only caller was the group-boundary jump, which acts on the selected (therefore realized)
+            // group; next-unread crosses group boundaries, so it targets distant groups routinely and
+            // the bare retry left it doing nothing at all past the first screenful.
+            if (attempt >= MaxGroupFocusAttempts) return;
+            ScrollSenderGroupMessageIntoView(ToGroupTree, _vm.ToGroups, group, msgIdx);
+            Dispatcher.InvokeAsync(() => FocusToGroupMessage(group, msgIdx, attempt + 1), DispatcherPriority.Background);
             return;
         }
         if (!groupTvi.IsExpanded) groupTvi.IsExpanded = true;
         var msgTvi = groupTvi.ItemContainerGenerator.ContainerFromItem(target) as TreeViewItem;
         if (msgTvi != null) { msgTvi.IsSelected = true; msgTvi.Focus(); return; }
-        if (!isRetry)
+        if (attempt < MaxGroupFocusAttempts)
         {
             ScrollSenderGroupMessageIntoView(ToGroupTree, _vm.ToGroups, group, msgIdx);
             Dispatcher.InvokeAsync(() =>
@@ -4860,20 +4903,27 @@ public partial class MainWindow : Window
         _vm.PropertyChanged += OnPropertyChanged;
     }
 
-    private void FocusConversationMessage(ConversationGroup group, int msgIdx, bool isRetry = false)
+    private void FocusConversationMessage(ConversationGroup group, int msgIdx, int attempt = 0)
     {
         var target   = group.Messages[msgIdx];
         var groupTvi = ConversationTree.ItemContainerGenerator.ContainerFromItem(group) as TreeViewItem;
         if (groupTvi == null)
         {
-            if (!isRetry)
-                Dispatcher.InvokeAsync(() => FocusConversationMessage(group, msgIdx, true), DispatcherPriority.Background);
+            // The group is outside the virtualized viewport, so its container does not exist and
+            // waiting will not create one — scroll it in, exactly as the message-level branch below
+            // already does, and let the layout pass generate it before the retry runs. Until #617 the
+            // only caller was the group-boundary jump, which acts on the selected (therefore realized)
+            // group; next-unread crosses group boundaries, so it targets distant groups routinely and
+            // the bare retry left it doing nothing at all past the first screenful.
+            if (attempt >= MaxGroupFocusAttempts) return;
+            ScrollConversationMessageIntoView(ConversationTree, _vm.Conversations, group, msgIdx);
+            Dispatcher.InvokeAsync(() => FocusConversationMessage(group, msgIdx, attempt + 1), DispatcherPriority.Background);
             return;
         }
         if (!groupTvi.IsExpanded) groupTvi.IsExpanded = true;
         var msgTvi = groupTvi.ItemContainerGenerator.ContainerFromItem(target) as TreeViewItem;
         if (msgTvi != null) { msgTvi.IsSelected = true; msgTvi.Focus(); return; }
-        if (!isRetry)
+        if (attempt < MaxGroupFocusAttempts)
         {
             ScrollConversationMessageIntoView(ConversationTree, _vm.Conversations, group, msgIdx);
             Dispatcher.InvokeAsync(() =>

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -4596,15 +4596,16 @@ public partial class MainWindow : Window
         // hides the list by collapsing its grid row to zero height, which leaves Visibility — and so
         // IsVisible — untouched. Focusing a row in a zero-height list strands the user on something
         // they cannot see or scroll to.
+        // Neither says "no unread messages": no search has run, and there may be plenty.
         if (_vm.IsCalendarView)
         {
-            AccessibilityHelper.Announce(this, "No unread messages. The calendar is open.",
+            AccessibilityHelper.Announce(this, "Cannot move to an unread message while the calendar is open.",
                 category: AnnouncementCategory.Result);
             return;
         }
         if (!_vm.IsMessageListAreaVisible)
         {
-            AccessibilityHelper.Announce(this, "No unread messages. The message list is not showing.",
+            AccessibilityHelper.Announce(this, "Cannot move to an unread message while the message list is hidden.",
                 category: AnnouncementCategory.Result);
             return;
         }
@@ -4711,97 +4712,29 @@ public partial class MainWindow : Window
 
     // ── Message-level focus helpers for grouped views ────────────────────────
 
-    // Finds the ScrollViewer inside a TreeView so we can set the scroll offset directly.
-    private static System.Windows.Controls.ScrollViewer? FindScrollViewer(System.Windows.DependencyObject d)
+    // All three delegate to TreeViewItemRealizer, which explains why realizing the container by
+    // index is the only thing that works here and why the scroll-and-wait version this replaced
+    // silently did nothing whenever the target group sat outside the viewport (#617).
+
+    private void FocusSenderGroupMessage(SenderGroup group, int msgIdx)
     {
-        int n = System.Windows.Media.VisualTreeHelper.GetChildrenCount(d);
-        for (int i = 0; i < n; i++)
-        {
-            var child = System.Windows.Media.VisualTreeHelper.GetChild(d, i);
-            if (child is System.Windows.Controls.ScrollViewer sv) return sv;
-            var found = FindScrollViewer(child);
-            if (found != null) return found;
-        }
-        return null;
+        if (msgIdx < 0 || msgIdx >= group.Messages.Count) return;
+        TreeViewItemRealizer.FocusMessage(
+            SenderGroupTree, _vm.SenderGroups.IndexOf(group), group, group.Messages[msgIdx], msgIdx);
     }
 
-    /// <summary>
-    /// How many scroll-then-wait passes the group-tree focus helpers make before settling for
-    /// whatever container exists. Two covers the worst real case — scroll the group in, expand it,
-    /// scroll the message in — without letting a tree that never realizes a container loop forever.
-    /// </summary>
-    private const int MaxGroupFocusAttempts = 2;
-
-    // Scrolls a SenderGroup-based tree so that the message at msgIdx within targetGroup
-    // is within the virtual viewport, ensuring its container is generated on the next layout
-    // pass. Uses item-based scroll offsets (CanContentScroll="True").
-    private static void ScrollSenderGroupMessageIntoView(
-        TreeView tree,
-        IEnumerable<SenderGroup> groups,
-        SenderGroup targetGroup,
-        int msgIdx)
+    private void FocusToGroupMessage(SenderGroup group, int msgIdx)
     {
-        int offset = 0;
-        foreach (var g in groups)
-        {
-            offset++; // group header
-            if (ReferenceEquals(g, targetGroup)) { offset += msgIdx; break; }
-            if (g.IsExpanded) offset += g.Messages.Count;
-        }
-        FindScrollViewer(tree)?.ScrollToVerticalOffset(offset);
+        if (msgIdx < 0 || msgIdx >= group.Messages.Count) return;
+        TreeViewItemRealizer.FocusMessage(
+            ToGroupTree, _vm.ToGroups.IndexOf(group), group, group.Messages[msgIdx], msgIdx);
     }
 
-    // Same for ConversationGroup-based trees.
-    private static void ScrollConversationMessageIntoView(
-        TreeView tree,
-        IEnumerable<ConversationGroup> groups,
-        ConversationGroup targetGroup,
-        int msgIdx)
+    private void FocusConversationMessage(ConversationGroup group, int msgIdx)
     {
-        int offset = 0;
-        foreach (var g in groups)
-        {
-            offset++;
-            if (ReferenceEquals(g, targetGroup)) { offset += msgIdx; break; }
-            if (g.IsExpanded) offset += g.Messages.Count;
-        }
-        FindScrollViewer(tree)?.ScrollToVerticalOffset(offset);
-    }
-
-    private void FocusSenderGroupMessage(SenderGroup group, int msgIdx, int attempt = 0)
-    {
-        var target   = group.Messages[msgIdx];
-        var groupTvi = SenderGroupTree.ItemContainerGenerator.ContainerFromItem(group) as TreeViewItem;
-        if (groupTvi == null)
-        {
-            // The group is outside the virtualized viewport, so its container does not exist and
-            // waiting will not create one — scroll it in, exactly as the message-level branch below
-            // already does, and let the layout pass generate it before the retry runs. Until #617 the
-            // only caller was the group-boundary jump, which acts on the selected (therefore realized)
-            // group; next-unread crosses group boundaries, so it targets distant groups routinely and
-            // the bare retry left it doing nothing at all past the first screenful.
-            if (attempt >= MaxGroupFocusAttempts) return;
-            ScrollSenderGroupMessageIntoView(SenderGroupTree, _vm.SenderGroups, group, msgIdx);
-            Dispatcher.InvokeAsync(() => FocusSenderGroupMessage(group, msgIdx, attempt + 1), DispatcherPriority.Background);
-            return;
-        }
-        if (!groupTvi.IsExpanded) groupTvi.IsExpanded = true;
-        var msgTvi = groupTvi.ItemContainerGenerator.ContainerFromItem(target) as TreeViewItem;
-        if (msgTvi != null) { msgTvi.IsSelected = true; msgTvi.Focus(); return; }
-        if (attempt < MaxGroupFocusAttempts)
-        {
-            // After a full rebuild the TreeView scroll resets to 0. Scroll the target into
-            // the viewport now; the resulting layout pass (Render priority) generates its
-            // container before the Background-priority retry runs.
-            ScrollSenderGroupMessageIntoView(SenderGroupTree, _vm.SenderGroups, group, msgIdx);
-            Dispatcher.InvokeAsync(() =>
-            {
-                var t2 = groupTvi.ItemContainerGenerator.ContainerFromItem(target) as TreeViewItem;
-                if (t2 != null) { t2.IsSelected = true; t2.Focus(); }
-                else             { groupTvi.IsSelected = true; groupTvi.Focus(); }
-            }, DispatcherPriority.Background);
-        }
-        else { groupTvi.IsSelected = true; groupTvi.Focus(); }
+        if (msgIdx < 0 || msgIdx >= group.Messages.Count) return;
+        TreeViewItemRealizer.FocusMessage(
+            ConversationTree, _vm.Conversations.IndexOf(group), group, group.Messages[msgIdx], msgIdx);
     }
 
     private void LandOnSenderMessageAfterRebuild(string senderKey, int msgIdx, int fallbackGroupIdx)
@@ -4837,38 +4770,6 @@ public partial class MainWindow : Window
         _vm.PropertyChanged += OnPropertyChanged;
     }
 
-    private void FocusToGroupMessage(SenderGroup group, int msgIdx, int attempt = 0)
-    {
-        var target   = group.Messages[msgIdx];
-        var groupTvi = ToGroupTree.ItemContainerGenerator.ContainerFromItem(group) as TreeViewItem;
-        if (groupTvi == null)
-        {
-            // The group is outside the virtualized viewport, so its container does not exist and
-            // waiting will not create one — scroll it in, exactly as the message-level branch below
-            // already does, and let the layout pass generate it before the retry runs. Until #617 the
-            // only caller was the group-boundary jump, which acts on the selected (therefore realized)
-            // group; next-unread crosses group boundaries, so it targets distant groups routinely and
-            // the bare retry left it doing nothing at all past the first screenful.
-            if (attempt >= MaxGroupFocusAttempts) return;
-            ScrollSenderGroupMessageIntoView(ToGroupTree, _vm.ToGroups, group, msgIdx);
-            Dispatcher.InvokeAsync(() => FocusToGroupMessage(group, msgIdx, attempt + 1), DispatcherPriority.Background);
-            return;
-        }
-        if (!groupTvi.IsExpanded) groupTvi.IsExpanded = true;
-        var msgTvi = groupTvi.ItemContainerGenerator.ContainerFromItem(target) as TreeViewItem;
-        if (msgTvi != null) { msgTvi.IsSelected = true; msgTvi.Focus(); return; }
-        if (attempt < MaxGroupFocusAttempts)
-        {
-            ScrollSenderGroupMessageIntoView(ToGroupTree, _vm.ToGroups, group, msgIdx);
-            Dispatcher.InvokeAsync(() =>
-            {
-                var t2 = groupTvi.ItemContainerGenerator.ContainerFromItem(target) as TreeViewItem;
-                if (t2 != null) { t2.IsSelected = true; t2.Focus(); }
-                else             { groupTvi.IsSelected = true; groupTvi.Focus(); }
-            }, DispatcherPriority.Background);
-        }
-        else { groupTvi.IsSelected = true; groupTvi.Focus(); }
-    }
 
     private void LandOnToMessageAfterRebuild(string senderKey, int msgIdx, int fallbackGroupIdx)
     {
@@ -4903,38 +4804,6 @@ public partial class MainWindow : Window
         _vm.PropertyChanged += OnPropertyChanged;
     }
 
-    private void FocusConversationMessage(ConversationGroup group, int msgIdx, int attempt = 0)
-    {
-        var target   = group.Messages[msgIdx];
-        var groupTvi = ConversationTree.ItemContainerGenerator.ContainerFromItem(group) as TreeViewItem;
-        if (groupTvi == null)
-        {
-            // The group is outside the virtualized viewport, so its container does not exist and
-            // waiting will not create one — scroll it in, exactly as the message-level branch below
-            // already does, and let the layout pass generate it before the retry runs. Until #617 the
-            // only caller was the group-boundary jump, which acts on the selected (therefore realized)
-            // group; next-unread crosses group boundaries, so it targets distant groups routinely and
-            // the bare retry left it doing nothing at all past the first screenful.
-            if (attempt >= MaxGroupFocusAttempts) return;
-            ScrollConversationMessageIntoView(ConversationTree, _vm.Conversations, group, msgIdx);
-            Dispatcher.InvokeAsync(() => FocusConversationMessage(group, msgIdx, attempt + 1), DispatcherPriority.Background);
-            return;
-        }
-        if (!groupTvi.IsExpanded) groupTvi.IsExpanded = true;
-        var msgTvi = groupTvi.ItemContainerGenerator.ContainerFromItem(target) as TreeViewItem;
-        if (msgTvi != null) { msgTvi.IsSelected = true; msgTvi.Focus(); return; }
-        if (attempt < MaxGroupFocusAttempts)
-        {
-            ScrollConversationMessageIntoView(ConversationTree, _vm.Conversations, group, msgIdx);
-            Dispatcher.InvokeAsync(() =>
-            {
-                var t2 = groupTvi.ItemContainerGenerator.ContainerFromItem(target) as TreeViewItem;
-                if (t2 != null) { t2.IsSelected = true; t2.Focus(); }
-                else             { groupTvi.IsSelected = true; groupTvi.Focus(); }
-            }, DispatcherPriority.Background);
-        }
-        else { groupTvi.IsSelected = true; groupTvi.Focus(); }
-    }
 
     private void LandOnConversationMessageAfterRebuild(string normalizedSubject, int msgIdx, int fallbackGroupIdx)
     {

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -1027,6 +1027,24 @@ public partial class MainWindow : Window
             defaultKey: Key.OemPeriod, defaultModifiers: ModifierKeys.Shift,
             isAvailable: IsGroupedViewActive));
 
+        // Alt+Down / Alt+Up, gated on message-area focus for the reason the bare-K flag command
+        // is (#255): unavailable leaves e.Handled false, so Alt+Down still opens the dropdown of
+        // whatever ComboBox the user is actually in. The palette runs commands without consulting
+        // IsAvailable, so gating costs nothing there.
+        _registry.Register(new CommandDefinition(
+            id: "mail.nextUnread", category: "Mail", title: "Next Unread Message",
+            execute: GoToNextUnread,
+            defaultKey: Key.Down, defaultModifiers: ModifierKeys.Alt,
+            description: "Move to the nearest unread message below the current one.",
+            isAvailable: IsMessageAreaFocused));
+
+        _registry.Register(new CommandDefinition(
+            id: "mail.previousUnread", category: "Mail", title: "Previous Unread Message",
+            execute: GoToPreviousUnread,
+            defaultKey: Key.Up, defaultModifiers: ModifierKeys.Alt,
+            description: "Move to the nearest unread message above the current one.",
+            isAvailable: IsMessageAreaFocused));
+
         _registry.Register(new CommandDefinition(
             id: "mail.selectAll", category: "Mail", title: "Select All Messages",
             execute: SelectAllMessages,
@@ -4554,6 +4572,96 @@ public partial class MainWindow : Window
                 FocusToGroupMessage(group, first ? 0 : group.Messages.Count - 1);
         }
     }
+
+    // ── Next / previous unread message (Alt+Down / Alt+Up) ──────────────────
+
+    private void GoToNextUnread()     => GoToUnread(forward: true);
+    private void GoToPreviousUnread() => GoToUnread(forward: false);
+
+    /// <summary>
+    /// Moves the selection to the nearest unread message below (<paramref name="forward"/>) or
+    /// above the current one, and puts focus on it. In the grouped views the search runs over
+    /// every message the tree holds, collapsed groups included, and the group it lands in is
+    /// expanded — the same thing <see cref="JumpToGroupBoundary"/> does (issue #617).
+    /// <para>The search does not wrap. Running out of unread mail is announced, because nothing
+    /// moving is the one outcome the platform does not report on its own.</para>
+    /// </summary>
+    private void GoToUnread(bool forward)
+    {
+        // The calendar has no unread mail, and in Tab mode a message tab covers the list. Either
+        // way the panel this would move through is not on screen — reachable only from the palette,
+        // which runs a command without consulting IsAvailable.
+        if (_vm.IsCalendarView) return;
+
+        if (_vm.IsConversationsView)
+            GoToUnreadInGroupTree(ConversationTree, _vm.Conversations, g => g.Messages, (g, i) => FocusConversationMessage(g, i), forward);
+        else if (_vm.IsFromView)
+            GoToUnreadInGroupTree(SenderGroupTree, _vm.SenderGroups, g => g.Messages, (g, i) => FocusSenderGroupMessage(g, i), forward);
+        else if (_vm.IsToView)
+            GoToUnreadInGroupTree(ToGroupTree, _vm.ToGroups, g => g.Messages, (g, i) => FocusToGroupMessage(g, i), forward);
+        else
+            GoToUnreadInMessageList(forward);
+    }
+
+    private void GoToUnreadInMessageList(bool forward)
+    {
+        if (!MessageList.IsVisible) return;
+
+        var messages = _vm.Messages;
+
+        // SelectedIndex is the first row of an Extended selection, and -1 when nothing is
+        // selected at all — in which case the search covers the whole list from the near end.
+        var from = MessageList.SelectedIndex >= 0
+            ? MessageList.SelectedIndex
+            : UnreadNavigator.SearchOriginForNoSelection(messages.Count, forward);
+
+        var idx = UnreadNavigator.FindNextUnread(messages, from, forward);
+        if (idx < 0) { AnnounceNoMoreUnread(forward); return; }
+
+        // Assigning SelectedIndex replaces an Extended selection rather than adding to it, so the
+        // message landed on is the only one selected — what arrowing onto it would have done.
+        MessageList.SelectedIndex = idx;
+        MessageList.ScrollIntoView(MessageList.Items[idx]);
+        FocusItemAt(idx);
+    }
+
+    private void GoToUnreadInGroupTree<TGroup>(
+        TreeView tree,
+        IReadOnlyList<TGroup> groups,
+        Func<TGroup, IReadOnlyList<MailMessageSummary>> messagesOf,
+        Action<TGroup, int> focusMessage,
+        bool forward) where TGroup : class
+    {
+        if (!tree.IsVisible) return;
+
+        var flat = UnreadNavigator.Flatten(groups, messagesOf);
+
+        int from;
+        switch (tree.SelectedItem)
+        {
+            case MailMessageSummary msg when UnreadNavigator.IndexOfMessage(flat, msg) is var i and >= 0:
+                from = i;
+                break;
+            case TGroup group when UnreadNavigator.IndexOfGroupStart(flat, group) is var start and >= 0:
+                from = UnreadNavigator.SearchOriginForGroupHeader(start, forward);
+                break;
+            default:
+                from = UnreadNavigator.SearchOriginForNoSelection(flat.Count, forward);
+                break;
+        }
+
+        var idx = UnreadNavigator.FindNextUnread(flat, e => e.Message.IsUnread, from, forward);
+        if (idx < 0) { AnnounceNoMoreUnread(forward); return; }
+
+        focusMessage(flat[idx].Group, flat[idx].MessageIndex);
+    }
+
+    // "Below"/"above" rather than "newer"/"older": which of those a direction means depends on the
+    // sort, but the direction on screen is the same whichever way the list is sorted.
+    private void AnnounceNoMoreUnread(bool forward) =>
+        AccessibilityHelper.Announce(this,
+            forward ? "No unread messages below." : "No unread messages above.",
+            category: AnnouncementCategory.Result);
 
     // ── Mark as Read ─────────────────────────────────────────────────────────
 

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -4654,7 +4654,7 @@ public partial class MainWindow : Window
         TreeView tree,
         IReadOnlyList<TGroup> groups,
         Func<TGroup, IReadOnlyList<MailMessageSummary>> messagesOf,
-        Action<TGroup, int> focusMessage,
+        Func<TGroup, int, GroupedMessageFocus> focusMessage,
         bool forward) where TGroup : class
     {
         var flat = UnreadNavigator.Flatten(groups, messagesOf);
@@ -4676,7 +4676,11 @@ public partial class MainWindow : Window
         var idx = UnreadNavigator.FindNextUnread(flat, e => e.Message.IsUnread, from, forward);
         if (idx < 0) { AnnounceNoMoreUnread(forward); return; }
 
-        focusMessage(flat[idx].Group, flat[idx].MessageIndex);
+        // Only None is announced. Landing on the group header instead of the message is still a
+        // focus move, and the platform reports that one itself.
+        if (focusMessage(flat[idx].Group, flat[idx].MessageIndex) == GroupedMessageFocus.None)
+            AccessibilityHelper.Announce(this, "Could not move to the unread message.",
+                category: AnnouncementCategory.Result);
     }
 
     // "Below"/"above" rather than "newer"/"older": which of those a direction means depends on the
@@ -4716,24 +4720,24 @@ public partial class MainWindow : Window
     // index is the only thing that works here and why the scroll-and-wait version this replaced
     // silently did nothing whenever the target group sat outside the viewport (#617).
 
-    private void FocusSenderGroupMessage(SenderGroup group, int msgIdx)
+    private GroupedMessageFocus FocusSenderGroupMessage(SenderGroup group, int msgIdx)
     {
-        if (msgIdx < 0 || msgIdx >= group.Messages.Count) return;
-        TreeViewItemRealizer.FocusMessage(
+        if (msgIdx < 0 || msgIdx >= group.Messages.Count) return GroupedMessageFocus.None;
+        return TreeViewItemRealizer.FocusMessage(
             SenderGroupTree, _vm.SenderGroups.IndexOf(group), group, group.Messages[msgIdx], msgIdx);
     }
 
-    private void FocusToGroupMessage(SenderGroup group, int msgIdx)
+    private GroupedMessageFocus FocusToGroupMessage(SenderGroup group, int msgIdx)
     {
-        if (msgIdx < 0 || msgIdx >= group.Messages.Count) return;
-        TreeViewItemRealizer.FocusMessage(
+        if (msgIdx < 0 || msgIdx >= group.Messages.Count) return GroupedMessageFocus.None;
+        return TreeViewItemRealizer.FocusMessage(
             ToGroupTree, _vm.ToGroups.IndexOf(group), group, group.Messages[msgIdx], msgIdx);
     }
 
-    private void FocusConversationMessage(ConversationGroup group, int msgIdx)
+    private GroupedMessageFocus FocusConversationMessage(ConversationGroup group, int msgIdx)
     {
-        if (msgIdx < 0 || msgIdx >= group.Messages.Count) return;
-        TreeViewItemRealizer.FocusMessage(
+        if (msgIdx < 0 || msgIdx >= group.Messages.Count) return GroupedMessageFocus.None;
+        return TreeViewItemRealizer.FocusMessage(
             ConversationTree, _vm.Conversations.IndexOf(group), group, group.Messages[msgIdx], msgIdx);
     }
 

--- a/docs/KEYBOARD-SHORTCUTS.md
+++ b/docs/KEYBOARD-SHORTCUTS.md
@@ -40,6 +40,8 @@
 | K | `mail.toggleFlag` | Toggle Flag |
 | Ctrl+Shift+K | `mail.pickFlag` | Pick Flag… |
 | *(unassigned)* | `mail.openFlagManager` | Manage Flags… |
+| Alt+Down | `mail.nextUnread` | Next Unread Message — the nearest unread message below the current one, in the flat list or a group tree (message-area focus only) |
+| Alt+Up | `mail.previousUnread` | Previous Unread Message — the nearest unread message above the current one (message-area focus only) |
 | Shift+, | `mail.jumpToFirstInGroup` | First Message in Group |
 | Shift+. | `mail.jumpToLastInGroup` | Last Message in Group |
 | *(unassigned)* | `mail.acceptInvite` | Accept Invitation |

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -609,9 +609,10 @@ yourself.
 Below and above mean what they say on screen: which of them is newer depends on how the folder is
 sorted.
 
-Both keys act while you are in the message list or a group tree. They do nothing inside the reading
-pane, in an open message window, or while a message tab is showing — in a message window, **Alt+Left**
-and **Alt+Right** already move to the previous and next message.
+Both keys act while you are in the message list or a group tree. They do not move you inside the
+reading pane, in an open message window, or while a message tab is showing — in a message window,
+**Alt+Left** and **Alt+Right** already move to the previous and next message. Run one from the
+command palette somewhere it cannot act and QuickMail says why rather than doing nothing quietly.
 
 Neither wraps around. When there is no unread message left in the direction you are going, nothing
 moves and QuickMail says "No unread messages below" or "No unread messages above", so that running

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -593,6 +593,25 @@ Press `Ctrl+Shift+V` (or use the **View** menu) to switch how messages are group
 - **From** — messages grouped by sender
 - **To** — messages grouped by recipient
 
+### Moving to the Next Unread Message
+
+`Alt+Down` moves to the nearest unread message below where you are; `Alt+Up` moves to the nearest
+one above. They are also **Next Unread Message** and **Previous Unread Message** in the command
+palette, and you can give them different keys in **File → Settings → Keyboard Shortcuts**.
+
+In the **Messages** view they move down or up the list, skipping everything already read. In
+**Conversations**, **From**, and **To** they run through every message in the tree in the order it
+is shown — so they cross from one conversation or sender into the next, and a group that is closed
+is opened so the message inside it can take focus.
+
+Both work from the message list or a group tree. Below and above mean what they say on screen: which
+of them is newer depends on how the folder is sorted.
+
+Neither wraps around. When there is no unread message left in the direction you are going, nothing
+moves and QuickMail says "No unread messages below" or "No unread messages above", so that running
+out is never mistaken for a key that did not register. (That is a **Result** announcement — see
+[Screen Reader Announcements](#screen-reader-announcements) if you have those switched off.)
+
 ### Each Folder Remembers How You Left It
 
 Folders do not all want the same treatment. An inbox reads well grouped into **Conversations**; a
@@ -1888,6 +1907,8 @@ Every announcement is optional and controlled by the settings above. No custom s
 | `Ctrl+Shift+L` | Rules Manager |
 | `Ctrl+,` | Settings |
 | `F1` | User Guide |
+| `Alt+Down` | Next unread message |
+| `Alt+Up` | Previous unread message |
 | `Shift+,` | First message in group |
 | `Shift+.` | Last message in group |
 | `Escape` | Close contact mail results (message list focus) |

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -600,12 +600,18 @@ one above. They are also **Next Unread Message** and **Previous Unread Message**
 palette, and you can give them different keys in **File → Settings → Keyboard Shortcuts**.
 
 In the **Messages** view they move down or up the list, skipping everything already read. In
-**Conversations**, **From**, and **To** they run through every message in the tree in the order it
-is shown — so they cross from one conversation or sender into the next, and a group that is closed
-is opened so the message inside it can take focus.
+**Conversations**, **From**, and **To** they run through every message the tree holds, in group
+order — so they cross from one conversation or sender into the next rather than stopping at the end
+of the one you are in. Closed groups are searched too, and a closed group holding the unread message
+is opened so that message can take focus. It stays open afterwards, like any group you open
+yourself.
 
-Both work from the message list or a group tree. Below and above mean what they say on screen: which
-of them is newer depends on how the folder is sorted.
+Below and above mean what they say on screen: which of them is newer depends on how the folder is
+sorted.
+
+Both keys act while you are in the message list or a group tree. They do nothing inside the reading
+pane, in an open message window, or while a message tab is showing — in a message window, **Alt+Left**
+and **Alt+Right** already move to the previous and next message.
 
 Neither wraps around. When there is no unread message left in the direction you are going, nothing
 moves and QuickMail says "No unread messages below" or "No unread messages above", so that running

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -609,10 +609,14 @@ yourself.
 Below and above mean what they say on screen: which of them is newer depends on how the folder is
 sorted.
 
-Both keys act while you are in the message list or a group tree. They do not move you inside the
-reading pane, in an open message window, or while a message tab is showing — in a message window,
-**Alt+Left** and **Alt+Right** already move to the previous and next message. Run one from the
-command palette somewhere it cannot act and QuickMail says why rather than doing nothing quietly.
+Both keys act while you are in the message list or a group tree — including when you are moving
+through the list with the reading pane open beside it. They do nothing while focus is inside the
+reading pane itself, and an open message window has its own keys: **Alt+Left** and **Alt+Right**
+already move to the previous and next message there.
+
+While a message tab is showing there is no list to move through, and the two actions are not offered
+in that window's command palette. Start one from the main window's palette while the calendar is
+open, or while a message tab covers the list, and QuickMail says why instead of going quiet.
 
 Neither wraps around. When there is no unread message left in the direction you are going, nothing
 moves and QuickMail says "No unread messages below" or "No unread messages above", so that running

--- a/docs/release-notes-v0.8.42.md
+++ b/docs/release-notes-v0.8.42.md
@@ -24,10 +24,11 @@ Three details worth knowing:
 - **Neither wraps around.** Reaching the end says "No unread messages below" — QuickMail does not
   quietly start again from the top, and nothing moving is never left unexplained.
 - **They stay out of the way of everything else.** The keys act while you are in the message list or
-  a group tree, so Alt+Down still opens a drop-down list when that is what you are on. They do not
-  move you in the reading pane, in an open message window, or while a message tab is showing; in a
-  message window Alt+Left and Alt+Right already move between messages. Started from the command
-  palette somewhere they cannot act, they say why instead of going quiet.
+  a group tree — the reading pane can be open beside it — so Alt+Down still opens a drop-down list
+  when that is what you are on. They do nothing while focus is inside the reading pane itself, and an
+  open message window has its own keys: Alt+Left and Alt+Right already move between messages there.
+  Started from the palette where there is no list to move through, they say why instead of going
+  quiet.
 
 ([#617](https://github.com/kellylford/QuickMail/issues/617))
 

--- a/docs/release-notes-v0.8.42.md
+++ b/docs/release-notes-v0.8.42.md
@@ -24,9 +24,10 @@ Three details worth knowing:
 - **Neither wraps around.** Reaching the end says "No unread messages below" — QuickMail does not
   quietly start again from the top, and nothing moving is never left unexplained.
 - **They stay out of the way of everything else.** The keys act while you are in the message list or
-  a group tree, so Alt+Down still opens a drop-down list when that is what you are on. They do
-  nothing in the reading pane, in an open message window, or while a message tab is showing; in a
-  message window Alt+Left and Alt+Right already move between messages.
+  a group tree, so Alt+Down still opens a drop-down list when that is what you are on. They do not
+  move you in the reading pane, in an open message window, or while a message tab is showing; in a
+  message window Alt+Left and Alt+Right already move between messages. Started from the command
+  palette somewhere they cannot act, they say why instead of going quiet.
 
 ([#617](https://github.com/kellylford/QuickMail/issues/617))
 

--- a/docs/release-notes-v0.8.42.md
+++ b/docs/release-notes-v0.8.42.md
@@ -1,5 +1,31 @@
 # QuickMail v0.8.42 Release Notes
 
+## New: a key that goes straight to the next unread message
+
+A user wrote in asking for one, mentioning that Space did this in the mail program they came from.
+Until now the only way to find unread mail in a long folder was to arrow through everything you had
+already read.
+
+**Alt+Down** goes to the nearest unread message below where you are. **Alt+Up** goes to the nearest
+one above. Both are also in the Command Palette (**Ctrl+Shift+P**) as **Next Unread Message** and
+**Previous Unread Message**, and either can be given a key of your own in **File → Settings →
+Keyboard Shortcuts**.
+
+They work in every view. In **Messages** they move down or up the list, skipping what you have read.
+In **Conversations**, **From**, and **To** they run through the messages in the order the tree shows
+them, so they cross from one conversation or sender into the next rather than stopping at the end of
+the one you are in — and a group that is closed is opened so the unread message inside it can take
+focus.
+
+Two details worth knowing:
+
+- **Neither wraps around.** Reaching the end says "No unread messages below" — QuickMail does not
+  quietly start again from the top, and nothing moving is never left unexplained.
+- **They stay out of the way of everything else.** The keys act only while you are in the message
+  list or a group tree, so Alt+Down still opens a drop-down list when that is what you are on.
+
+([#617](https://github.com/kellylford/QuickMail/issues/617))
+
 ## New: expanding and collapsing folders
 
 Until now the only way to open or close a folder was Right and Left arrow on the folder itself, one

--- a/docs/release-notes-v0.8.42.md
+++ b/docs/release-notes-v0.8.42.md
@@ -12,17 +12,21 @@ one above. Both are also in the Command Palette (**Ctrl+Shift+P**) as **Next Unr
 Keyboard Shortcuts**.
 
 They work in every view. In **Messages** they move down or up the list, skipping what you have read.
-In **Conversations**, **From**, and **To** they run through the messages in the order the tree shows
-them, so they cross from one conversation or sender into the next rather than stopping at the end of
-the one you are in — and a group that is closed is opened so the unread message inside it can take
-focus.
+In **Conversations**, **From**, and **To** they run through every message the tree holds, in group
+order, so they cross from one conversation or sender into the next rather than stopping at the end of
+the one you are in.
 
-Two details worth knowing:
+Three details worth knowing:
 
+- **A closed group is searched, and opened.** An unread message inside a conversation you have not
+  opened is still found, and the conversation opens so that message can take focus. It stays open
+  afterwards, the same as one you opened yourself.
 - **Neither wraps around.** Reaching the end says "No unread messages below" — QuickMail does not
   quietly start again from the top, and nothing moving is never left unexplained.
-- **They stay out of the way of everything else.** The keys act only while you are in the message
-  list or a group tree, so Alt+Down still opens a drop-down list when that is what you are on.
+- **They stay out of the way of everything else.** The keys act while you are in the message list or
+  a group tree, so Alt+Down still opens a drop-down list when that is what you are on. They do
+  nothing in the reading pane, in an open message window, or while a message tab is showing; in a
+  message window Alt+Left and Alt+Right already move between messages.
 
 ([#617](https://github.com/kellylford/QuickMail/issues/617))
 


### PR DESCRIPTION
Closes #617.

A user wrote in asking for a key that jumps to the next unread message, mentioning that Space did this in the mail program they came from. Until now the only way to find unread mail in a long folder was to arrow past everything already read.

## What this adds

Two registered commands — so both appear in the Command Palette and can be rebound in **File → Settings → Keyboard Shortcuts**:

| Key | Command ID | Title |
|---|---|---|
| Alt+Down | `mail.nextUnread` | Next Unread Message |
| Alt+Up | `mail.previousUnread` | Previous Unread Message |

**Messages view** — moves the selection to the nearest unread row in that direction and focuses it, exactly as arrowing onto it would (a multi-row Extended selection is replaced, not extended).

**Conversations / From / To** — the search runs over the flattened tree order, so it crosses group boundaries rather than stopping at the end of the group the selection is in. The group it lands in is expanded first; this reuses `FocusConversationMessage` / `FocusSenderGroupMessage` / `FocusToGroupMessage`, which already do the expand-and-focus dance for `Shift+,` and `Shift+.`.

From a **selected group header** the search origin matches what the arrow keys do from the same place: down considers the group's own first message (the next row on screen), up leaves the group entirely (its messages are all below the header).

## Decisions worth reviewing

- **No wrap.** Reaching the end announces "No unread messages below" / "above" as a `Result`, because nothing moving is the one outcome the platform does not report on its own. Landing *on* a message is left to the platform's own focus reporting, per the announcement rules in CLAUDE.md.
- **Gated on message-area focus**, for the reason the bare-K flag command is (#255): leaving the command unavailable keeps `e.Handled` false, so Alt+Down still opens the dropdown of whatever ComboBox the user is in. The palette runs commands without consulting `IsAvailable`, so the gate costs nothing for discoverability — and `GoToUnread` carries its own calendar and hidden-panel guards for that path.
- **"Below"/"above" rather than "newer"/"older"** in the announcement: which of those a direction means depends on the folder's sort, but the direction on screen does not.

## Tests

List logic lives in `QuickMail/Helpers/UnreadNavigator.cs` so it is testable without standing up a TreeView. `UnreadNavigatorTests` — 20 cases covering both directions, group boundaries, collapsed groups, header origins, the empty list, and the no-wrap contract.

Full suite: 3233 passed, 0 failed, 3 skipped.

## Docs

- `docs/USER-GUIDE.md` — new **Moving to the Next Unread Message** section, plus both keys in the shortcut table.
- `docs/KEYBOARD-SHORTCUTS.md` — both rows in the registered shortcut table.
- `docs/release-notes-v0.8.42.md` — new section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)