### PR TITLE
Delete the grouped-tree controller's unused half

### DIFF
--- a/QuickMail/Views/GroupedMessageTreeController.cs
+++ b/QuickMail/Views/GroupedMessageTreeController.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
@@ -13,25 +12,24 @@ using QuickMail.ViewModels;
 namespace QuickMail.Views;
 
 /// <summary>
-/// Encapsulates the common event-handler logic shared by the three grouped-message
-/// TreeViews (ConversationTree, SenderGroupTree, ToGroupTree).  Each tree wires
-/// its own PreviewKeyDown because the group-type and delete-command differ, but
-/// the remaining handlers (GotKeyboardFocus, SelectedItemChanged, PreviewTextInput,
-/// PreviewMouseRightButtonDown, ContextMenuOpening, FocusFirstItem, LandOnAfterRebuild,
-/// FocusMessage, LandOnMessageAfterRebuild) are identical in structure.
+/// The event-handler logic the three grouped-message TreeViews (ConversationTree,
+/// SenderGroupTree, ToGroupTree) share verbatim. Each tree still wires its own PreviewKeyDown,
+/// because the group type and the delete command differ.
 /// </summary>
+/// <remarks>
+/// This deliberately covers only the handlers that are genuinely identical. It once also carried
+/// FocusMessage, LandOnAfterRebuild, LandOnMessageAfterRebuild and OnContextMenuOpening, none of
+/// which anything ever called — MainWindow kept its own copies throughout. The first three were
+/// worse than merely unused: they used the shape that assumes a container can be waited for, which
+/// is false for a group outside the virtualized viewport, and were left behind when MainWindow's
+/// copies moved to <see cref="Helpers.TreeViewItemRealizer"/> (#617). Anything that needs to focus
+/// a message inside a group belongs there, not here.
+/// </remarks>
 public class GroupedMessageTreeController
 {
     private readonly TreeView _tree;
     private readonly MainViewModel _vm;
     private readonly string _logName;
-    private readonly string _collectionPropertyName;
-    private readonly Func<int> _getCollectionCount;
-    private readonly Func<object?, int> _getItemIndex;
-    private readonly Func<int, object?> _getItemAt;
-    private readonly Func<object, string> _getGroupKey;
-    private readonly Func<string, object?> _findGroupByKey;
-    private readonly Func<object, IReadOnlyList<MailMessageSummary>> _getGroupMessages;
     private readonly Func<IEnumerable<object>> _getVisibleItems;
     private readonly Func<TreeView, object?, List<object>, string?, bool> _tryHandleTypeAhead;
 
@@ -39,26 +37,12 @@ public class GroupedMessageTreeController
         TreeView tree,
         MainViewModel vm,
         string logName,
-        string collectionPropertyName,
-        Func<int> getCollectionCount,
-        Func<object?, int> getItemIndex,
-        Func<int, object?> getItemAt,
-        Func<object, string> getGroupKey,
-        Func<string, object?> findGroupByKey,
-        Func<object, IReadOnlyList<MailMessageSummary>> getGroupMessages,
         Func<IEnumerable<object>> getVisibleItems,
         Func<TreeView, object?, List<object>, string?, bool> tryHandleTypeAhead)
     {
         _tree = tree;
         _vm = vm;
         _logName = logName;
-        _collectionPropertyName = collectionPropertyName;
-        _getCollectionCount = getCollectionCount;
-        _getItemIndex = getItemIndex;
-        _getItemAt = getItemAt;
-        _getGroupKey = getGroupKey;
-        _findGroupByKey = findGroupByKey;
-        _getGroupMessages = getGroupMessages;
         _getVisibleItems = getVisibleItems;
         _tryHandleTypeAhead = tryHandleTypeAhead;
     }
@@ -112,142 +96,11 @@ public class GroupedMessageTreeController
         }
     }
 
-    // ── ContextMenuOpening ────────────────────────────────────────────────────
-
-    public void OnContextMenuOpening(object sender, ContextMenuEventArgs e, string groupContextMenuKey, string messageContextMenuKey)
-    {
-        switch (_tree.SelectedItem)
-        {
-            case null:
-                e.Handled = true;
-                break;
-            default:
-                // If the selected item is a group type (not MailMessageSummary), use the group menu;
-                // otherwise use the message menu.
-                if (_tree.SelectedItem is MailMessageSummary)
-                    _tree.ContextMenu = (ContextMenu)((FrameworkElement)sender).FindResource(messageContextMenuKey);
-                else
-                    _tree.ContextMenu = (ContextMenu)((FrameworkElement)sender).FindResource(groupContextMenuKey);
-                break;
-        }
-    }
-
     // ── FocusFirstItem ────────────────────────────────────────────────────────
 
     public void FocusFirstItem()
     {
         if (_tree.Items.Count == 0) { _tree.Focus(); return; }
         _tree.Dispatcher.InvokeAsync(_tree.Focus, DispatcherPriority.Input);
-    }
-
-    // ── LandOnAfterRebuild ────────────────────────────────────────────────────
-
-    public void LandOnAfterRebuild(int targetIdx)
-    {
-        LogService.Debug($"[FOCUS] LandOn{_logName}: registered listener targetIdx={targetIdx}");
-        void OnPropertyChanged(object? sender, PropertyChangedEventArgs e)
-        {
-            if (e.PropertyName != _collectionPropertyName) return;
-            _vm.PropertyChanged -= OnPropertyChanged;
-            LogService.Debug($"[FOCUS] LandOn{_logName}: listener fired count={_getCollectionCount()} targetIdx={targetIdx}");
-            _tree.Dispatcher.InvokeAsync(() =>
-            {
-                var count = _getCollectionCount();
-                if (count == 0)
-                {
-                    LogService.Debug($"[FOCUS] LandOn{_logName}: dispatch skipped — collection empty");
-                    return;
-                }
-                var idx = Math.Max(0, Math.Min(targetIdx, count - 1));
-                var item = _getItemAt(idx);
-                if (item != null && _tree.ItemContainerGenerator.ContainerFromItem(item) is TreeViewItem tvi)
-                {
-                    LogService.Debug($"[FOCUS] LandOn{_logName}: tvi.Focus() idx={idx}");
-                    tvi.IsSelected = true;
-                    tvi.Focus();
-                }
-                else
-                {
-                    LogService.Debug($"[FOCUS] LandOn{_logName}: container not realized idx={idx} — retry at Background");
-                    _tree.Dispatcher.InvokeAsync(() =>
-                    {
-                        if (item != null && _tree.ItemContainerGenerator.ContainerFromItem(item) is TreeViewItem tvi2)
-                        {
-                            LogService.Debug($"[FOCUS] LandOn{_logName}: retry tvi.Focus() idx={idx}");
-                            tvi2.IsSelected = true;
-                            tvi2.Focus();
-                        }
-                        else
-                        {
-                            LogService.Debug($"[FOCUS] LandOn{_logName}: retry also failed idx={idx} — giving up");
-                        }
-                    }, DispatcherPriority.Background);
-                }
-            }, DispatcherPriority.Input);
-        }
-        _vm.PropertyChanged += OnPropertyChanged;
-    }
-
-    // ── FocusMessage ──────────────────────────────────────────────────────────
-
-    public void FocusMessage(object group, int msgIdx, bool isRetry = false)
-    {
-        var messages = _getGroupMessages(group);
-        var target = messages[msgIdx];
-        var groupTvi = _tree.ItemContainerGenerator.ContainerFromItem(group) as TreeViewItem;
-        if (groupTvi == null)
-        {
-            if (!isRetry)
-                _tree.Dispatcher.InvokeAsync(() => FocusMessage(group, msgIdx, true), DispatcherPriority.Background);
-            return;
-        }
-        if (!groupTvi.IsExpanded) groupTvi.IsExpanded = true;
-        var msgTvi = groupTvi.ItemContainerGenerator.ContainerFromItem(target) as TreeViewItem;
-        if (msgTvi != null) { msgTvi.IsSelected = true; msgTvi.Focus(); return; }
-        if (!isRetry)
-            _tree.Dispatcher.InvokeAsync(() =>
-            {
-                var t2 = groupTvi.ItemContainerGenerator.ContainerFromItem(target) as TreeViewItem;
-                if (t2 != null) { t2.IsSelected = true; t2.Focus(); }
-                else { groupTvi.IsSelected = true; groupTvi.Focus(); }
-            }, DispatcherPriority.Background);
-        else { groupTvi.IsSelected = true; groupTvi.Focus(); }
-    }
-
-    // ── LandOnMessageAfterRebuild ─────────────────────────────────────────────
-
-    public void LandOnMessageAfterRebuild(string groupKey, int msgIdx, int fallbackGroupIdx)
-    {
-        void OnPropertyChanged(object? sender, PropertyChangedEventArgs e)
-        {
-            if (e.PropertyName != _collectionPropertyName) return;
-            _vm.PropertyChanged -= OnPropertyChanged;
-            _tree.Dispatcher.InvokeAsync(() =>
-            {
-                var group = _findGroupByKey(groupKey);
-                if (group != null)
-                {
-                    var messages = _getGroupMessages(group);
-                    if (messages.Count > 0)
-                        FocusMessage(group, Math.Min(msgIdx, messages.Count - 1));
-                }
-                else
-                {
-                    var count = _getCollectionCount();
-                    if (count == 0) return;
-                    var idx = Math.Max(0, Math.Min(fallbackGroupIdx, count - 1));
-                    var fallback = _getItemAt(idx);
-                    if (fallback != null && _tree.ItemContainerGenerator.ContainerFromItem(fallback) is TreeViewItem tvi)
-                    { tvi.IsSelected = true; tvi.Focus(); }
-                    else
-                        _tree.Dispatcher.InvokeAsync(() =>
-                        {
-                            if (fallback != null && _tree.ItemContainerGenerator.ContainerFromItem(fallback) is TreeViewItem tvi2)
-                            { tvi2.IsSelected = true; tvi2.Focus(); }
-                        }, DispatcherPriority.Background);
-                }
-            }, DispatcherPriority.Input);
-        }
-        _vm.PropertyChanged += OnPropertyChanged;
     }
 }

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -581,40 +581,16 @@ public partial class MainWindow : Window
         // ── Grouped-message tree controllers ──────────────────────────────────
         _convTreeController = new GroupedMessageTreeController(
             ConversationTree, _vm, "ConvTree",
-            nameof(MainViewModel.Conversations),
-            () => _vm.Conversations.Count,
-            item => item is ConversationGroup g ? _vm.Conversations.IndexOf(g) : -1,
-            idx => _vm.Conversations[idx],
-            g => ((ConversationGroup)g).NormalizedSubject,
-            key => _vm.Conversations.FirstOrDefault(c =>
-                string.Equals(c.NormalizedSubject, key, StringComparison.OrdinalIgnoreCase)),
-            g => ((ConversationGroup)g).Messages,
             () => GetVisibleConversationItems(_vm.Conversations),
             TryHandleMessageTreeTypeAhead);
 
         _senderTreeController = new GroupedMessageTreeController(
             SenderGroupTree, _vm, "SenderTree",
-            nameof(MainViewModel.SenderGroups),
-            () => _vm.SenderGroups.Count,
-            item => item is SenderGroup g ? _vm.SenderGroups.IndexOf(g) : -1,
-            idx => _vm.SenderGroups[idx],
-            g => ((SenderGroup)g).SenderKey,
-            key => _vm.SenderGroups.FirstOrDefault(g =>
-                string.Equals(g.SenderKey, key, StringComparison.OrdinalIgnoreCase)),
-            g => ((SenderGroup)g).Messages,
             () => GetVisibleSenderItems(_vm.SenderGroups),
             TryHandleMessageTreeTypeAhead);
 
         _toTreeController = new GroupedMessageTreeController(
             ToGroupTree, _vm, "ToTree",
-            nameof(MainViewModel.ToGroups),
-            () => _vm.ToGroups.Count,
-            item => item is SenderGroup g ? _vm.ToGroups.IndexOf(g) : -1,
-            idx => _vm.ToGroups[idx],
-            g => ((SenderGroup)g).SenderKey,
-            key => _vm.ToGroups.FirstOrDefault(g =>
-                string.Equals(g.SenderKey, key, StringComparison.OrdinalIgnoreCase)),
-            g => ((SenderGroup)g).Messages,
             () => GetVisibleSenderItems(_vm.ToGroups),
             TryHandleMessageTreeTypeAhead);
     }

--- a/docs/planning/roadmap-branch-review.md
+++ b/docs/planning/roadmap-branch-review.md
@@ -18,11 +18,12 @@ The following issues from this review have been addressed:
 | QUALITY-5 | ✅ Fixed | `TutorialOverlay.SetViewModel` now stores the handler in a field and unsubscribes before re-subscribing, preventing event subscription leaks on restart. |
 | QUALITY-7 | ✅ Fixed | Added `LIMITATION:` comment to `IcsModel.ParseIcsDateTime` documenting that TZID parameters are ignored. |
 | QUALITY-8 | ✅ Fixed | `TutorialViewModel.Start()` now notifies `CurrentStepNumber` in addition to `CurrentStep`. |
+| DESIGN-1 | ✅ Fixed | Removed `OnContextMenuOpening` from `GroupedMessageTreeController`, along with `FocusMessage`, `LandOnAfterRebuild` and `LandOnMessageAfterRebuild` — none of the four had a call site. The three `*Tree_ContextMenuOpening` handlers in `MainWindow` keep their own implementations, which is the "remove it" arm of the two options below. Seven constructor parameters went with them (2026-08-23). |
 | DOC-1 | ✅ Fixed | Added missing entries to CLAUDE.md shortcut table: `mail.acceptInvite`, `mail.declineInvite`, `mail.tentativeInvite`, `help.keyboardTutorial`. Added note about compose window's private `CommandRegistry`. |
 
 **Not addressed (deferred):**
 - BUG-3 (false positive test) — low priority, no production impact
-- DESIGN-1 through DESIGN-4 — design observations, not bugs
+- DESIGN-2 through DESIGN-4 — design observations, not bugs
 - QUALITY-4, QUALITY-6 — very low priority
 - TEST-1 through TEST-5 — test coverage gaps
 - DOC-2 — addressed via QUALITY-7 comment
@@ -147,12 +148,20 @@ Assert.Equal("T1 Modified", all[0].Title);
 ## DESIGN & ARCHITECTURE ISSUES
 
 ### DESIGN-1 — `GroupedMessageTreeController.OnContextMenuOpening` exists but is never called  
+**Status:** ✅ Fixed 2026-08-23 — removed, together with three more uncalled members of the same class.  
 **Severity:** Low (dead code)  
 **File:** `QuickMail/Views/GroupedMessageTreeController.cs:666-682`
 
 The refactoring to `GroupedMessageTreeController` extracted `GotKeyboardFocus`, `SelectedItemChanged`, `PreviewTextInput`, `PreviewMouseRightButtonDown`, and `FocusFirstItem` handlers. The controller also defines `OnContextMenuOpening`, but the three `*Tree_ContextMenuOpening` handlers in `MainWindow.xaml.cs` still have their own inline implementations and do not delegate to the controller. The `OnContextMenuOpening` method is dead code.
 
 Either remove `OnContextMenuOpening` from the controller, or complete the extraction and replace the inline handlers with controller delegation.
+
+Resolved by removing it. The audit that followed found three more members in the same class with no
+call site — `FocusMessage`, `LandOnAfterRebuild`, `LandOnMessageAfterRebuild` — which mattered more
+than the dead-code tidiness: they used the wait-for-a-container shape that cannot work for a group
+outside the virtualized viewport, so wiring any of them up after #617 would have silently
+reintroduced the fault that issue fixed. The inline `*Tree_ContextMenuOpening` handlers in
+`MainWindow` are unchanged.
 
 ---
 


### PR DESCRIPTION
`GroupedMessageTreeController` declared nine public members. Five are wired up; four have never been called from anywhere — `MainWindow` kept its own copies throughout.

## Why this is worth doing now, not just tidy

The dead four are `OnContextMenuOpening`, `FocusMessage`, `LandOnAfterRebuild` and `LandOnMessageAfterRebuild`. The last three are not merely unused — they use the shape that assumes a missing container can be waited for:

```csharp
if (ContainerFromItem(group) is not TreeViewItem) { retry once at Background; return; }
```

That is false for a group outside the virtualized viewport, where no container exists and none will be created without asking for one *by index*. `MainWindow`'s copies moved to `Helpers/TreeViewItemRealizer` in #617; these were left behind holding the version that silently does nothing, ready for whoever wired them up next.

## What the deletion cascades into

Removing them leaves **seven of the twelve constructor parameters feeding nothing**: `collectionPropertyName`, `getCollectionCount`, `getItemIndex`, `getItemAt`, `getGroupKey`, `findGroupByKey`, `getGroupMessages`. Two of those — `getItemIndex` and `getGroupKey` — were already never read by anything at all.

The constructor drops from twelve parameters to five, and each of the three call sites in `MainWindow` from eleven lines to four:

```csharp
_convTreeController = new GroupedMessageTreeController(
    ConversationTree, _vm, "ConvTree",
    () => GetVisibleConversationItems(_vm.Conversations),
    TryHandleMessageTreeTypeAhead);
```

The class comment now states what the type covers, and its remarks say where message focusing actually lives, so the next person does not rebuild the trap.

## Verification

No behaviour change — nothing called what was removed. Build clean with no unused-field warnings; smoke passes; suite green apart from the `AddressBookFilterMenuTests` flake, which is fixed separately in #624 and is not affected by this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)