### PR TITLE
Label a new appointment with the calendar it was filed on (#569)

### DIFF
--- a/QuickMail.Tests/CalendarViewModelTests.cs
+++ b/QuickMail.Tests/CalendarViewModelTests.cs
@@ -1271,4 +1271,38 @@ public class CalendarViewModelTests
         Assert.Equal("Local", row.Summary);
         Assert.Equal(row.Uid, vm.SelectedEvent?.Uid);
     }
+
+    /// <summary>
+    /// The symptom #569 was reported against, end to end: with ONE of an account's calendars
+    /// selected in the folder tree, a new appointment saved to that account is in the list at once,
+    /// without an F5.
+    ///
+    /// <para>
+    /// This is the configuration the bug needed. The other save tests run with no
+    /// <c>SourceFilter</c>, and with no calendar-id filter <c>ApplyFilters</c> short-circuits, so
+    /// they pass whatever the row is tagged with. Here the filter is live, so an untagged row — what
+    /// the service stored before #569 — fails it and the appointment is missing from the very
+    /// calendar it was just filed on, until the next sync restamps it.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public async Task SaveNewEvent_WhileOneCalendarIsSelected_ShowsUnderThatCalendar()
+    {
+        var (vm, _, sync, account) = MakePushVm();
+        sync.DefaultCalendarId = "cal-default";
+        sync.DefaultCalendarName = "Calendar";
+        vm.SourceFilter = new MainViewModel.CalendarFilter(account.Id, "cal-default");
+        await vm.LoadAsync();
+
+        await vm.SaveNewEventAsync(new CalendarEvent
+        {
+            Uid = "local-tmp", AccountId = account.Id, Summary = "Dentist",
+            StartTimeTicks = DateTime.UtcNow.AddDays(3).Ticks,
+        });
+
+        var row = Assert.Single(vm.VisibleEvents);
+        Assert.Equal("Dentist", row.Summary);
+        Assert.Equal("cal-default", row.CalendarId);
+        Assert.Equal(row.Uid, vm.SelectedEvent?.Uid);
+    }
 }

--- a/QuickMail.Tests/GoogleCalendarSyncTests.cs
+++ b/QuickMail.Tests/GoogleCalendarSyncTests.cs
@@ -425,7 +425,55 @@ public class GoogleCalendarSyncTests : IDisposable
                                                               TestContext.Current.CancellationToken);
 
         Assert.Equal("gid-new", created.Uid);
-        Assert.Equal("gid-new", Assert.Single(await _store.LoadCalendarEventsAsync()).Uid);
+        var row = Assert.Single(await _store.LoadCalendarEventsAsync());
+        Assert.Equal("gid-new", row.Uid);
+        // Falls back to exactly what it was tagged with before any of this existed.
+        Assert.Equal("primary", row.CalendarId);
+        Assert.Equal(string.Empty, row.CalendarName);
+    }
+
+    /// <summary>
+    /// No entry flagged primary — a delegated or subscribe-only account. Google identifies the
+    /// primary calendar by the account's own address, so that is what to match on. Picking an
+    /// arbitrary calendar instead would file the appointment under a node it does not belong to,
+    /// which is worse than leaving it untagged: it would still be missing from the node the user is
+    /// on, and would now also appear under one it is not.
+    /// </summary>
+    [Fact]
+    public async Task CreateEvent_WhenNoCalendarIsFlaggedPrimary_MatchesTheAccountAddress()
+    {
+        var handler = new RecordingHandler(GoogleEventResponse("gid-new"), Json(@"{ ""items"": [ { ""id"": ""fam123@group.calendar.google.com"", ""summary"": ""Family"" }, { ""id"": ""kelly@gmail.com"", ""summary"": ""Kelly"" } ] }"));
+
+        await Service(handler).CreateEventAsync(GoogleAccount(), GoogleEvt("", ""),
+                                                TestContext.Current.CancellationToken);
+
+        var row = Assert.Single(await _store.LoadCalendarEventsAsync());
+        Assert.Equal("kelly@gmail.com", row.CalendarId);
+    }
+
+    /// <summary>A calendar the user has removed from their list is not a place to file anything.</summary>
+    [Fact]
+    public async Task CreateEvent_IgnoresADeletedPrimaryEntry()
+    {
+        var handler = new RecordingHandler(GoogleEventResponse("gid-new"), Json(@"{ ""items"": [ { ""id"": ""kelly@gmail.com"", ""summary"": ""Kelly"", ""primary"": true, ""deleted"": true } ] }"));
+
+        await Service(handler).CreateEventAsync(GoogleAccount(), GoogleEvt("", ""),
+                                                TestContext.Current.CancellationToken);
+
+        // Nothing usable, so the alias stands rather than a calendar the user has thrown away.
+        Assert.Equal("primary", Assert.Single(await _store.LoadCalendarEventsAsync()).CalendarId);
+    }
+
+    /// <summary>A nameless calendar still needs a label for the Calendar column to read.</summary>
+    [Fact]
+    public async Task CreateEvent_WhenThePrimaryCalendarHasNoName_LabelsItCalendar()
+    {
+        var handler = new RecordingHandler(GoogleEventResponse("gid-new"), Json(@"{ ""items"": [ { ""id"": ""kelly@gmail.com"", ""summary"": ""   "", ""primary"": true } ] }"));
+
+        await Service(handler).CreateEventAsync(GoogleAccount(), GoogleEvt("", ""),
+                                                TestContext.Current.CancellationToken);
+
+        Assert.Equal("Calendar", Assert.Single(await _store.LoadCalendarEventsAsync()).CalendarName);
     }
 
     [Fact]

--- a/QuickMail.Tests/GoogleCalendarSyncTests.cs
+++ b/QuickMail.Tests/GoogleCalendarSyncTests.cs
@@ -387,6 +387,47 @@ public class GoogleCalendarSyncTests : IDisposable
         Assert.DoesNotContain("/calendars/primary/", handler.Urls[0]);
     }
 
+    /// <summary>
+    /// A new appointment is TAGGED with the primary calendar's real id, not with the "primary"
+    /// alias the write used (#569).
+    ///
+    /// The alias is fine to write through, but it is not what anything else calls that calendar:
+    /// the read-down tags its rows with the real id, and so does the folder tree's per-calendar
+    /// node. A row left tagged "primary" therefore fails that node's filter and is invisible while
+    /// the user is looking at it — until the next sync's replace-slice restamps it with the real id
+    /// and it appears, which is exactly the "press F5 and now it shows up" the issue describes.
+    /// </summary>
+    [Fact]
+    public async Task CreateEvent_TagsTheRowWithThePrimaryCalendarsRealId()
+    {
+        var handler = new RecordingHandler(GoogleEventResponse("gid-new"), Json(@"{ ""items"": [ { ""id"": ""fam123@group.calendar.google.com"", ""summary"": ""Family"" }, { ""id"": ""kelly@gmail.com"", ""summary"": ""Kelly"", ""primary"": true } ] }"));
+
+        await Service(handler).CreateEventAsync(GoogleAccount(), GoogleEvt("", ""),
+                                                TestContext.Current.CancellationToken);
+
+        var row = Assert.Single(await _store.LoadCalendarEventsAsync());
+        Assert.Equal("kelly@gmail.com", row.CalendarId);
+        Assert.Equal("Kelly", row.CalendarName);   // so the Calendar column reads right at once
+    }
+
+    /// <summary>
+    /// The tag is a display concern, and the appointment is already on the server by the time it is
+    /// resolved, so a calendar list that cannot be fetched must not cost the user their save. The
+    /// row falls back to what it was tagged with before this existed.
+    /// </summary>
+    [Fact]
+    public async Task CreateEvent_WhenTheCalendarListFails_StillStoresTheAppointment()
+    {
+        var handler = new RecordingHandler(
+            GoogleEventResponse("gid-new"), Json("nope", HttpStatusCode.InternalServerError));
+
+        var created = await Service(handler).CreateEventAsync(GoogleAccount(), GoogleEvt("", ""),
+                                                              TestContext.Current.CancellationToken);
+
+        Assert.Equal("gid-new", created.Uid);
+        Assert.Equal("gid-new", Assert.Single(await _store.LoadCalendarEventsAsync()).Uid);
+    }
+
     [Fact]
     public async Task CreateEvent_BlankCalendarId_FallsBackToPrimary()
     {

--- a/QuickMail.Tests/GraphCalendarSyncServiceTests.cs
+++ b/QuickMail.Tests/GraphCalendarSyncServiceTests.cs
@@ -459,6 +459,61 @@ public class GraphCalendarSyncServiceTests : IDisposable
 
     // ── Create push (POST /me/events) ────────────────────────────────────────────
 
+    /// <summary>
+    /// A new appointment is tagged with the calendar it landed on (#569).
+    ///
+    /// POST /me/events files into the account's default calendar, and the read-down tags every row
+    /// with its calendar's real id — so an untagged created row fails the per-calendar folder-tree
+    /// node's filter and is invisible while the user is looking at that node, until the next
+    /// sync's replace-slice restamps it. That is the "press F5 and now it shows up" the issue
+    /// reports.
+    /// </summary>
+    [Fact]
+    public async Task CreateEvent_TagsTheRowWithTheDefaultCalendar()
+    {
+        var handler = new RecordingHandler(
+            Json(EventJson("srv-1", "Board meeting", "2026-08-01T14:00:00.0000000",
+                           "2026-08-01T15:00:00.0000000")),
+            Json(@"{ ""value"": [ { ""id"": ""cal-other"", ""name"": ""Team"", ""isDefaultCalendar"": false }, { ""id"": ""cal-default"", ""name"": ""Calendar"", ""isDefaultCalendar"": true } ] }"));
+
+        await Service(handler).CreateEventAsync(GraphAccount(), new CalendarEvent
+        {
+            Uid = "local-tmp", AccountId = _accountId, Summary = "Board meeting",
+            StartTimeTicks = new DateTime(2026, 8, 1, 14, 0, 0, DateTimeKind.Utc).Ticks,
+            EndTimeTicks   = new DateTime(2026, 8, 1, 15, 0, 0, DateTimeKind.Utc).Ticks,
+        }, TestContext.Current.CancellationToken);
+
+        var row = Assert.Single(await _store.LoadCalendarEventsAsync());
+        Assert.Equal("cal-default", row.CalendarId);
+        Assert.Equal("Calendar", row.CalendarName);
+    }
+
+    /// <summary>
+    /// Editing a synced appointment keeps its calendar tag. The edit used to map the server's reply
+    /// with no calendar id at all, wiping the tag to empty — so an appointment the user had just
+    /// edited dropped out of its own calendar's node until the next sync put it back. The Google
+    /// update path has preserved the tag all along; this is the Microsoft counterpart.
+    /// </summary>
+    [Fact]
+    public async Task UpdateEvent_KeepsTheCalendarTag()
+    {
+        var handler = new RecordingHandler(
+            Json(EventJson("srv-1", "Board meeting (moved)", "2026-08-01T15:00:00.0000000",
+                           "2026-08-01T16:00:00.0000000")));
+
+        await Service(handler).UpdateEventAsync(GraphAccount(), new CalendarEvent
+        {
+            Uid = "srv-1", AccountId = _accountId, Summary = "Board meeting (moved)",
+            CalendarId = "cal-team", CalendarName = "Team",
+            StartTimeTicks = new DateTime(2026, 8, 1, 15, 0, 0, DateTimeKind.Utc).Ticks,
+            EndTimeTicks   = new DateTime(2026, 8, 1, 16, 0, 0, DateTimeKind.Utc).Ticks,
+        }, TestContext.Current.CancellationToken);
+
+        var row = Assert.Single(await _store.LoadCalendarEventsAsync());
+        Assert.Equal("cal-team", row.CalendarId);
+        Assert.Equal("Team", row.CalendarName);
+    }
+
     [Fact]
     public async Task CreateEvent_Timed_PostsExpectedShape_AndStoresServerCopy()
     {
@@ -476,8 +531,11 @@ public class GraphCalendarSyncServiceTests : IDisposable
 
         var created = await service.CreateEventAsync(GraphAccount(), evt, TestContext.Current.CancellationToken);
 
-        Assert.Equal("POST", Assert.Single(handler.Methods));
+        // Two requests: the create, then the calendar-list lookup that tags the stored row with
+        // the calendar POST /me/events filed into (#569).
+        Assert.Equal(["POST", "GET"], handler.Methods);
         Assert.EndsWith("/me/events", handler.Urls[0]);
+        Assert.Contains("isDefaultCalendar", handler.Urls[1]);
         // Prefer header carries the machine's Windows zone (see Sync test); the body below still
         // sends explicit UTC start/end, so the created event's times are unambiguous.
         Assert.Equal($"outlook.timezone=\"{TimeZoneInfo.Local.Id}\"", handler.PreferHeaders[0]);

--- a/QuickMail.Tests/GraphCalendarSyncServiceTests.cs
+++ b/QuickMail.Tests/GraphCalendarSyncServiceTests.cs
@@ -474,7 +474,7 @@ public class GraphCalendarSyncServiceTests : IDisposable
         var handler = new RecordingHandler(
             Json(EventJson("srv-1", "Board meeting", "2026-08-01T14:00:00.0000000",
                            "2026-08-01T15:00:00.0000000")),
-            Json(@"{ ""value"": [ { ""id"": ""cal-other"", ""name"": ""Team"", ""isDefaultCalendar"": false }, { ""id"": ""cal-default"", ""name"": ""Calendar"", ""isDefaultCalendar"": true } ] }"));
+            Json(@"{ ""id"": ""cal-default"", ""name"": ""Calendar"" }"));
 
         await Service(handler).CreateEventAsync(GraphAccount(), new CalendarEvent
         {
@@ -486,6 +486,56 @@ public class GraphCalendarSyncServiceTests : IDisposable
         var row = Assert.Single(await _store.LoadCalendarEventsAsync());
         Assert.Equal("cal-default", row.CalendarId);
         Assert.Equal("Calendar", row.CalendarName);
+    }
+
+    /// <summary>
+    /// A default calendar that cannot be fetched leaves the row untagged rather than costing the
+    /// user their appointment, which is already on the server by the time this runs.
+    ///
+    /// Untagged, specifically — NOT tagged with some other calendar. Microsoft documents that
+    /// <c>/me/calendars</c> can omit the default calendar, and that their own default calendar
+    /// example carries <c>isDefaultCalendar: false</c>, so an enumerate-and-guess approach lands on
+    /// the wrong one. A wrongly tagged row is worse than an untagged one: still missing from the
+    /// node the user is on, and now also under a node it does not belong to.
+    /// </summary>
+    [Fact]
+    public async Task CreateEvent_WhenTheDefaultCalendarCannotBeResolved_StoresTheEventUntagged()
+    {
+        var handler = new RecordingHandler(
+            Json(EventJson("srv-1", "Board meeting", "2026-08-01T14:00:00.0000000",
+                           "2026-08-01T15:00:00.0000000")),
+            Json("nope", code: HttpStatusCode.InternalServerError));
+
+        var created = await Service(handler).CreateEventAsync(GraphAccount(), new CalendarEvent
+        {
+            Uid = "local-tmp", AccountId = _accountId, Summary = "Board meeting",
+            StartTimeTicks = new DateTime(2026, 8, 1, 14, 0, 0, DateTimeKind.Utc).Ticks,
+            EndTimeTicks   = new DateTime(2026, 8, 1, 15, 0, 0, DateTimeKind.Utc).Ticks,
+        }, TestContext.Current.CancellationToken);
+
+        Assert.Equal("srv-1", created.Uid);
+        var row = Assert.Single(await _store.LoadCalendarEventsAsync());
+        Assert.Equal("srv-1", row.Uid);
+        Assert.Equal(string.Empty, row.CalendarId);
+    }
+
+    /// <summary>A nameless calendar still needs a label for the Calendar column to read.</summary>
+    [Fact]
+    public async Task CreateEvent_WhenTheDefaultCalendarHasNoName_LabelsItCalendar()
+    {
+        var handler = new RecordingHandler(
+            Json(EventJson("srv-1", "Board meeting", "2026-08-01T14:00:00.0000000",
+                           "2026-08-01T15:00:00.0000000")),
+            Json(@"{ ""id"": ""cal-default"", ""name"": ""   "" }"));
+
+        await Service(handler).CreateEventAsync(GraphAccount(), new CalendarEvent
+        {
+            Uid = "local-tmp", AccountId = _accountId, Summary = "Board meeting",
+            StartTimeTicks = new DateTime(2026, 8, 1, 14, 0, 0, DateTimeKind.Utc).Ticks,
+            EndTimeTicks   = new DateTime(2026, 8, 1, 15, 0, 0, DateTimeKind.Utc).Ticks,
+        }, TestContext.Current.CancellationToken);
+
+        Assert.Equal("Calendar", Assert.Single(await _store.LoadCalendarEventsAsync()).CalendarName);
     }
 
     /// <summary>
@@ -535,7 +585,7 @@ public class GraphCalendarSyncServiceTests : IDisposable
         // the calendar POST /me/events filed into (#569).
         Assert.Equal(["POST", "GET"], handler.Methods);
         Assert.EndsWith("/me/events", handler.Urls[0]);
-        Assert.Contains("isDefaultCalendar", handler.Urls[1]);
+        Assert.Contains("/me/calendar?", handler.Urls[1]);   // singular: the default calendar itself
         // Prefer header carries the machine's Windows zone (see Sync test); the body below still
         // sends explicit UTC start/end, so the created event's times are unambiguous.
         Assert.Equal($"outlook.timezone=\"{TimeZoneInfo.Local.Id}\"", handler.PreferHeaders[0]);

--- a/QuickMail.Tests/StubServices.cs
+++ b/QuickMail.Tests/StubServices.cs
@@ -719,6 +719,14 @@ sealed class StubGraphCalendarSyncService : IGraphCalendarSyncService
     public StubCalendarService? CalendarStore { get; set; }
 
     /// <summary>
+    /// What the account's default calendar resolves to — what a created event with no chosen
+    /// calendar gets tagged with. Set it to a calendar a test also filters on, to exercise the
+    /// per-calendar folder-tree node that #569 was reported against.
+    /// </summary>
+    public string DefaultCalendarId { get; set; } = string.Empty;
+    public string DefaultCalendarName { get; set; } = string.Empty;
+
+    /// <summary>
     /// Runs when a pull happens, so a test can put into the store what the server "had" — the real
     /// service writes the fetched slice there before returning, and the caller reloads from it.
     /// </summary>
@@ -756,6 +764,13 @@ sealed class StubGraphCalendarSyncService : IGraphCalendarSyncService
             Summary = evt.Summary, Location = evt.Location, Description = evt.Description,
             StartTimeTicks = evt.StartTimeTicks, EndTimeTicks = evt.EndTimeTicks,
             IsAllDay = evt.IsAllDay, ResponseStatus = CalendarResponseStatus.Accepted,
+            // Tagged with the calendar it was filed on, as the real service does since #569. The
+            // save target names no calendar for a Google or Microsoft account, so the service
+            // resolves the account's default; DefaultCalendar stands in for that here. A stub that
+            // left this blank would model the BUG — a row that fails the per-calendar folder-tree
+            // node's filter and is invisible under the calendar it was just saved to.
+            CalendarId = string.IsNullOrEmpty(evt.CalendarId) ? DefaultCalendarId : evt.CalendarId,
+            CalendarName = string.IsNullOrEmpty(evt.CalendarId) ? DefaultCalendarName : evt.CalendarName,
         };
         CreatedEvents.Add(created);
         CalendarStore?.Upsert(created);

--- a/QuickMail/Services/Graph/GraphClient.cs
+++ b/QuickMail/Services/Graph/GraphClient.cs
@@ -83,6 +83,20 @@ public sealed class GraphClient : IDisposable
         return await resp.Content.ReadFromJsonAsync<T>(JsonOpts, ct);
     }
 
+    /// <summary>
+    /// GETs a single object with an explicit token scope set, optionally silent-only. The
+    /// scope-carrying counterpart of <see cref="GetAsync{T}(AccountModel, string, CancellationToken)"/>,
+    /// which acquires its token interactively — background and post-write calendar work must never
+    /// raise a sign-in, so it cannot use that one.
+    /// </summary>
+    public async Task<T?> GetAsync<T>(AccountModel account, string path,
+        string[]? scopes, bool silentOnly, CancellationToken ct = default)
+    {
+        using var resp = await SendAsync(account, HttpMethod.Get, path, null, scopes, silentOnly, headers: null, ct);
+        await EnsureSuccessAsync(resp, ct);
+        return await resp.Content.ReadFromJsonAsync<T>(JsonOpts, ct);
+    }
+
     /// <summary>GET a collection, following <c>@odata.nextLink</c> until exhausted.</summary>
     public Task<List<T>> GetAllPagesAsync<T>(AccountModel account, string path, CancellationToken ct = default)
         => GetAllPagesAsync<T>(account, path, null, ct);

--- a/QuickMail/Services/Graph/GraphDtos.cs
+++ b/QuickMail/Services/Graph/GraphDtos.cs
@@ -176,6 +176,13 @@ internal sealed class GraphCalendar
 {
     [JsonPropertyName("id")] public string Id { get; set; } = string.Empty;
     [JsonPropertyName("name")] public string? Name { get; set; }
+
+    /// <summary>
+    /// True for the calendar <c>POST /me/events</c> files into. A created event has to be tagged
+    /// with that calendar's real id, or it will not match the per-calendar folder-tree node the
+    /// user may be looking at (#569).
+    /// </summary>
+    [JsonPropertyName("isDefaultCalendar")] public bool IsDefaultCalendar { get; set; }
 }
 
 /// <summary>

--- a/QuickMail/Services/Graph/GraphDtos.cs
+++ b/QuickMail/Services/Graph/GraphDtos.cs
@@ -176,13 +176,6 @@ internal sealed class GraphCalendar
 {
     [JsonPropertyName("id")] public string Id { get; set; } = string.Empty;
     [JsonPropertyName("name")] public string? Name { get; set; }
-
-    /// <summary>
-    /// True for the calendar <c>POST /me/events</c> files into. A created event has to be tagged
-    /// with that calendar's real id, or it will not match the per-calendar folder-tree node the
-    /// user may be looking at (#569).
-    /// </summary>
-    [JsonPropertyName("isDefaultCalendar")] public bool IsDefaultCalendar { get; set; }
 }
 
 /// <summary>

--- a/QuickMail/Services/GraphCalendarSyncService.cs
+++ b/QuickMail/Services/GraphCalendarSyncService.cs
@@ -681,36 +681,58 @@ public sealed class GraphCalendarSyncService : IGraphCalendarSyncService
             var calendars = await _google!.GetCalendarListAsync(account.Username, ct);
             var primary = calendars.FirstOrDefault(
                 c => c.Primary && !c.Deleted && !string.IsNullOrEmpty(c.Id));
+            // No entry flagged primary — a delegated or subscribe-only account. Google's primary
+            // calendar is identified by the account's own address, so match on that rather than
+            // picking some arbitrary calendar, which would file the appointment under a node it
+            // does not belong to.
+            primary ??= calendars.FirstOrDefault(
+                c => !c.Deleted && string.Equals(c.Id, account.Username, StringComparison.OrdinalIgnoreCase));
             if (primary != null)
                 return (primary.Id, string.IsNullOrWhiteSpace(primary.Summary)
                     ? "Calendar" : primary.Summary.Trim());
         }
         catch (Exception ex)
         {
+            // Swallows cancellation too, deliberately: see DefaultGraphCalendarAsync — the
+            // appointment is already on the server, so the row has to be stored either way.
             LogService.Log($"CalendarSync: could not resolve the default Google calendar for {account.AccountLabel}", ex);
         }
         return (PrimaryCalendarAlias, string.Empty);
     }
 
     /// <summary>
-    /// The id and display name of the calendar <c>POST /me/events</c> files into. Best-effort for
-    /// the same reason as its Google counterpart: an untagged row beats a refused save.
+    /// The id and display name of the calendar <c>POST /me/events</c> files into.
+    ///
+    /// <para>
+    /// <c>GET /me/calendar</c> — singular — IS that calendar, so this is right by construction.
+    /// Enumerating <c>/me/calendars</c> and looking for <c>isDefaultCalendar</c> is not: Microsoft
+    /// documents that the collection can omit the default calendar altogether, and their own
+    /// example response for the default calendar carries <c>isDefaultCalendar: false</c>. Picking
+    /// some other calendar when the flag cannot be found would be worse than not tagging at all —
+    /// the appointment would still be missing from the node the user is on, and would now also show
+    /// under a node it does not belong to, with the wrong name in the Calendar column.
+    /// </para>
+    ///
+    /// <para>
+    /// Best-effort for the same reason as its Google counterpart: an untagged row beats a lost save.
+    /// </para>
     /// </summary>
     private async Task<(string Id, string Name)> DefaultGraphCalendarAsync(
         AccountModel account, CancellationToken ct)
     {
         try
         {
-            var calendars = await _graph.GetAllPagesAsync<GraphCalendar>(
-                account, "/me/calendars?$select=id,name,isDefaultCalendar",
-                OAuthService.GraphCalendarScopes, silentOnly: true, headers: null, ct);
-            var chosen = calendars.FirstOrDefault(c => c.IsDefaultCalendar && !string.IsNullOrEmpty(c.Id))
-                         ?? calendars.FirstOrDefault(c => !string.IsNullOrEmpty(c.Id));
-            if (chosen != null)
-                return (chosen.Id, string.IsNullOrWhiteSpace(chosen.Name) ? "Calendar" : chosen.Name.Trim());
+            var calendar = await _graph.GetAsync<GraphCalendar>(
+                account, "/me/calendar?$select=id,name",
+                OAuthService.GraphCalendarScopes, silentOnly: true, ct);
+            if (calendar != null && !string.IsNullOrEmpty(calendar.Id))
+                return (calendar.Id, string.IsNullOrWhiteSpace(calendar.Name) ? "Calendar" : calendar.Name.Trim());
         }
         catch (Exception ex)
         {
+            // Deliberately swallows cancellation too. The appointment is already on the server by
+            // the time this runs, so the row MUST be stored either way — abandoning it here would
+            // leave an event the user created existing on Microsoft's side and nowhere in QuickMail.
             LogService.Log($"GraphCalendarSync: could not resolve the default calendar for {account.AccountLabel}", ex);
         }
         return (string.Empty, string.Empty);

--- a/QuickMail/Services/GraphCalendarSyncService.cs
+++ b/QuickMail/Services/GraphCalendarSyncService.cs
@@ -592,7 +592,13 @@ public sealed class GraphCalendarSyncService : IGraphCalendarSyncService
         // Store the SERVER's copy (Uid = the Graph id), flagged is_graph — it shows up
         // immediately, and because it now exists on the server it survives (is re-fetched by)
         // the next replace-slice sync.
-        var mapped = MapEvent(created, account.Id);
+        //
+        // Tagged with the calendar it actually landed on. POST /me/events files into the account's
+        // default calendar, and the read-down tags every row with its calendar's real id — so a
+        // created row left untagged does not match the per-calendar tree node the user may be
+        // looking at, and stays invisible there until the next sync restamps it (#569).
+        var (tagId, tagName) = await DefaultGraphCalendarAsync(account, ct);
+        var mapped = MapEvent(created, account.Id, tagId, tagName);
         await _store.UpsertCalendarEventAsync(mapped);
         LogService.Log($"GraphCalendarSync: created event on {account.AccountLabel} ({mapped.Uid}).");
         return mapped;
@@ -614,7 +620,11 @@ public sealed class GraphCalendarSyncService : IGraphCalendarSyncService
             OAuthService.GraphCalendarScopes, silentOnly: true, UtcPreferHeader, ct)
             ?? throw new InvalidOperationException("Graph returned no event body for the updated event.");
 
-        var mapped = MapEvent(updated, account.Id);
+        // Carry the row's existing calendar tag through the edit. Without this an edit wiped it to
+        // empty, so an appointment the user had just edited dropped out of its own calendar's node
+        // until the next sync put the tag back — the Google update path preserves it for exactly
+        // this reason (see UpdateEvent_OnSecondaryCalendar_PatchesThatCalendar_AndKeepsTag).
+        var mapped = MapEvent(updated, account.Id, evt.CalendarId, evt.CalendarName);
         await _store.UpsertCalendarEventAsync(mapped);
         LogService.Log($"GraphCalendarSync: updated event on {account.AccountLabel} ({mapped.Uid}).");
         return mapped;
@@ -647,14 +657,77 @@ public sealed class GraphCalendarSyncService : IGraphCalendarSyncService
     // Target the calendar the event actually lives on. A blank CalendarId (e.g. a brand-new
     // event whose save target is the account's default) falls back to "primary". Using this for
     // update/delete is the fix for events on secondary Google calendars, which 404 against primary.
+    /// <summary>Google's stand-in for "whichever calendar is this account's own" on a write.</summary>
+    private const string PrimaryCalendarAlias = "primary";
+
     private static string GoogleCalendarId(CalendarEvent evt)
-        => string.IsNullOrWhiteSpace(evt.CalendarId) ? "primary" : evt.CalendarId;
+        => string.IsNullOrWhiteSpace(evt.CalendarId) ? PrimaryCalendarAlias : evt.CalendarId;
+
+    /// <summary>
+    /// The real id and display name of the calendar a Google write to <c>primary</c> lands on.
+    ///
+    /// <para>
+    /// Best-effort: a lookup that fails leaves the row tagged with the alias, which is what it was
+    /// tagged with before this existed. Tagging is a display concern — the appointment is already
+    /// safely on the server by the time this runs — and losing the save over it would be worse than
+    /// a row that waits for the next sync to be filed under the right node.
+    /// </para>
+    /// </summary>
+    private async Task<(string Id, string Name)> DefaultGoogleCalendarAsync(
+        AccountModel account, CancellationToken ct)
+    {
+        try
+        {
+            var calendars = await _google!.GetCalendarListAsync(account.Username, ct);
+            var primary = calendars.FirstOrDefault(
+                c => c.Primary && !c.Deleted && !string.IsNullOrEmpty(c.Id));
+            if (primary != null)
+                return (primary.Id, string.IsNullOrWhiteSpace(primary.Summary)
+                    ? "Calendar" : primary.Summary.Trim());
+        }
+        catch (Exception ex)
+        {
+            LogService.Log($"CalendarSync: could not resolve the default Google calendar for {account.AccountLabel}", ex);
+        }
+        return (PrimaryCalendarAlias, string.Empty);
+    }
+
+    /// <summary>
+    /// The id and display name of the calendar <c>POST /me/events</c> files into. Best-effort for
+    /// the same reason as its Google counterpart: an untagged row beats a refused save.
+    /// </summary>
+    private async Task<(string Id, string Name)> DefaultGraphCalendarAsync(
+        AccountModel account, CancellationToken ct)
+    {
+        try
+        {
+            var calendars = await _graph.GetAllPagesAsync<GraphCalendar>(
+                account, "/me/calendars?$select=id,name,isDefaultCalendar",
+                OAuthService.GraphCalendarScopes, silentOnly: true, headers: null, ct);
+            var chosen = calendars.FirstOrDefault(c => c.IsDefaultCalendar && !string.IsNullOrEmpty(c.Id))
+                         ?? calendars.FirstOrDefault(c => !string.IsNullOrEmpty(c.Id));
+            if (chosen != null)
+                return (chosen.Id, string.IsNullOrWhiteSpace(chosen.Name) ? "Calendar" : chosen.Name.Trim());
+        }
+        catch (Exception ex)
+        {
+            LogService.Log($"GraphCalendarSync: could not resolve the default calendar for {account.AccountLabel}", ex);
+        }
+        return (string.Empty, string.Empty);
+    }
 
     private async Task<CalendarEvent> CreateGoogleEventAsync(AccountModel account, CalendarEvent evt, CancellationToken ct)
     {
         var calId = GoogleCalendarId(evt);
         var created = await _google!.CreateEventAsync(account.Username, BuildGoogleWriteBody(evt), calId, ct);
-        var mapped = MapGoogleEvent(created, account.Id, calId, evt.CalendarName);
+        // "primary" is an alias, not an id: the read-down tags that same calendar's rows with its
+        // real id, so a row left tagged "primary" does not match the per-calendar tree node and
+        // stays invisible there until the next sync restamps it (#569). Resolve it. The write
+        // itself still goes to the alias, which is what the existing create tests pin.
+        var (tagId, tagName) = calId == PrimaryCalendarAlias
+            ? await DefaultGoogleCalendarAsync(account, ct)
+            : (calId, evt.CalendarName);
+        var mapped = MapGoogleEvent(created, account.Id, tagId, tagName);
         await _store.UpsertCalendarEventAsync(mapped);
         LogService.Log($"CalendarSync: created Google event on {account.AccountLabel} ({mapped.Uid}).");
         return mapped;

--- a/docs/release-notes-v0.8.42.md
+++ b/docs/release-notes-v0.8.42.md
@@ -147,15 +147,17 @@ The same fault had a second form on Microsoft 365 accounts: *editing* an appoint
 label off one that already had it, so an appointment you had just edited dropped out of the list
 until the next sync. Edits keep the label now, as they already did on Google accounts.
 
-This and the next item are the two halves of one complaint. Both looked identical from the outside —
-an appointment missing until F5 — but one is about an appointment you created in QuickMail and this
-is it; the other is about one you added somewhere else, and is below.
+This is one half of a complaint that came in twice. Both halves looked identical from the outside —
+an appointment missing until F5 — but they had different causes. This one is about an appointment
+you created in QuickMail; the other, **"the calendar did not ask the server when you opened it"**
+below, is about one you added somewhere else.
 ([#569](https://github.com/kellylford/QuickMail/issues/569),
 [#519](https://github.com/kellylford/QuickMail/issues/519))
 
 ## Fixed: the calendar did not ask the server when you opened it
 
-The other half of the report above, with the same symptom and a different cause. An appointment
+The other half of the complaint described under **"a new appointment was missing from the calendar
+it was filed on"** above: the same symptom, a different cause. An appointment
 added somewhere other than QuickMail — in Gmail or Outlook on the web, or on a phone — was not in
 the agenda when you opened the calendar. It turned up on its own eventually, because
 QuickMail checks connected calendars every fifteen minutes, but until then **F5** was the only way

--- a/docs/release-notes-v0.8.42.md
+++ b/docs/release-notes-v0.8.42.md
@@ -147,13 +147,17 @@ The same fault had a second form on Microsoft 365 accounts: *editing* an appoint
 label off one that already had it, so an appointment you had just edited dropped out of the list
 until the next sync. Edits keep the label now, as they already did on Google accounts.
 
+This and the next item are the two halves of one complaint. Both looked identical from the outside —
+an appointment missing until F5 — but one is about an appointment you created in QuickMail and this
+is it; the other is about one you added somewhere else, and is below.
 ([#569](https://github.com/kellylford/QuickMail/issues/569),
 [#519](https://github.com/kellylford/QuickMail/issues/519))
 
 ## Fixed: the calendar did not ask the server when you opened it
 
-An appointment added somewhere other than QuickMail — in Gmail or Outlook on the web, or on a phone
-— was not in the agenda when you opened the calendar. It turned up on its own eventually, because
+The other half of the report above, with the same symptom and a different cause. An appointment
+added somewhere other than QuickMail — in Gmail or Outlook on the web, or on a phone — was not in
+the agenda when you opened the calendar. It turned up on its own eventually, because
 QuickMail checks connected calendars every fifteen minutes, but until then **F5** was the only way
 to see it. The report was precise about it: *"I added an appointment to my Gmail calendar and it
 didn't show in the agenda view... Press F5 to refresh the list. Now it will show up."*

--- a/docs/release-notes-v0.8.42.md
+++ b/docs/release-notes-v0.8.42.md
@@ -130,6 +130,26 @@ This applies everywhere these fields are used — the **Starts** and **Ends** da
 repeat interval and **until** date, and **Go to Date** (**Ctrl+G**) in the calendar.
 ([#570](https://github.com/kellylford/QuickMail/issues/570))
 
+## Fixed: a new appointment was missing from the calendar it was filed on
+
+If you had one of your calendars selected in the folder tree — not **Calendar** at the top, but a
+particular calendar underneath it — an appointment you created went in, and then was not in the
+list. Pressing **F5** brought it into view. Reported twice, once as *"I added a new event in my
+default Gmail calendar. I looked for it and it didn't show up. I pressed F5 to refresh and then it
+showed up."*
+
+The appointment was saved correctly the whole time; it just was not labelled with the calendar it
+had gone onto, so the list you were looking at filtered it out. The next sync relabelled it and it
+appeared. QuickMail now labels a new appointment with its calendar as soon as it saves it, so it is
+in the list straight away — and the **Calendar** column reads correctly instead of coming up blank.
+
+The same fault had a second form on Microsoft 365 accounts: *editing* an appointment stripped the
+label off one that already had it, so an appointment you had just edited dropped out of the list
+until the next sync. Edits keep the label now, as they already did on Google accounts.
+
+([#569](https://github.com/kellylford/QuickMail/issues/569),
+[#519](https://github.com/kellylford/QuickMail/issues/519))
+
 ## Fixed: the calendar did not ask the server when you opened it
 
 An appointment added somewhere other than QuickMail — in Gmail or Outlook on the web, or on a phone


### PR DESCRIPTION
Fixes #569, and the second of the two causes behind #519. (The first — an appointment added *outside* QuickMail — was fixed in #626.)

## What was happening

For a Google or Microsoft account the appointment editor offers exactly one save target, at the
account level with **no calendar id**; only iCloud gets per-calendar targets. So every appointment
created in QuickMail was stored with a calendar tag that nothing else uses:

| path | stores `CalendarId` as |
|---|---|
| Google read-down (`SyncGoogleAccountAsync`) | the real calendar id, e.g. `kelly@gmail.com` |
| **Google create** | `"primary"` — `GoogleCalendarId`'s fallback for a blank id |
| Microsoft read-down | the real calendar id |
| **Microsoft create** | `""` — `MapEvent` called with no calendar id |

`CalendarViewModel.ApplyFilters` requires `e.CalendarId == c` for a per-calendar folder-tree node, so
a freshly created appointment failed that filter and was **invisible while the user was looking at
the very calendar it had just been filed on**. The next sync does a replace-slice, which restamps
the row with the real id — and it appears. That is #569's "press F5 and now it shows up", exactly.

It doesn't happen to everyone because the top **Calendar** node and the account-level node set no
calendar-id filter, so the appointment shows immediately there.

## The fix

Both create paths resolve the real calendar, after the write.

**Microsoft: `GET /me/calendar`** — singular. That endpoint *is* the default calendar, so the answer
is right by construction. Enumerating `/me/calendars` and looking for `isDefaultCalendar` is not
sound: Microsoft [documents that the collection can omit the default calendar entirely](https://learn.microsoft.com/en-us/troubleshoot/exchange/calendars/default-calendar-not-returned-by-graph-rest-api),
and their own [example response *for* the default calendar](https://learn.microsoft.com/en-us/graph/api/calendar-get?view=graph-rest-1.0)
carries `isDefaultCalendar: false`. An earlier revision of this PR did enumerate, and fell back to
an arbitrary calendar when no flag was found — which is **worse than not tagging at all**: the
appointment is still missing from the node the user is on, and now also appears under a node it does
not belong to, with the wrong name in the Calendar column. Credit to the review for catching it.

This needed a scope-carrying, silent-only `GetAsync` on `GraphClient` — the existing `GetAsync`
acquires its token interactively, which post-write calendar work must never do.

**Google: the `primary` flag** from the calendar list, falling back to the account's own address
(which is how Google identifies the primary calendar) when nothing is flagged — a delegated or
subscribe-only account. Not to an arbitrary calendar, for the reason above.

**Best-effort, and after the write.** The appointment is already safely on the server by then, and a
tag is a display concern, so a lookup that fails leaves the row tagged as it would have been before
rather than costing the user their save. Both catches swallow cancellation deliberately and say so:
abandoning the row would leave an event the user created existing at the provider and nowhere in
QuickMail. The Google write still goes to the `"primary"` alias, so the existing create-URL tests
are untouched by design.

## A third form of the same bug, on the Microsoft side

`UpdateEventAsync` mapped the server's reply with no calendar id, **wiping** the tag off an
already-synced row — so an appointment the user had just *edited* dropped out of its calendar's node
until the next sync put the tag back. The Google update path preserves the tag and has
`UpdateEvent_OnSecondaryCalendar_PatchesThatCalendar_AndKeepsTag` pinning it; Microsoft never got the
same treatment. Fixed, with the test Google has and Microsoft lacked.

## Verification

**Mutation-verified, eight ways.** Each fails its own test:

| mutation | test that catches it |
|---|---|
| revert the Google create tag | `CreateEvent_TagsTheRowWithThePrimaryCalendarsRealId` |
| revert the Graph create tag | `CreateEvent_TagsTheRowWithTheDefaultCalendar`, `CreateEvent_WhenTheDefaultCalendarHasNoName_LabelsItCalendar`, and `CreateEvent_Timed_…` (which asserts the request pair) |
| revert the Graph update preservation | `UpdateEvent_KeepsTheCalendarTag` |
| drop the account-address fallback | `CreateEvent_WhenNoCalendarIsFlaggedPrimary_MatchesTheAccountAddress` |
| drop the deleted-entry skip | `CreateEvent_IgnoresADeletedPrimaryEntry` |
| drop the Google blank-name fallback | `CreateEvent_WhenThePrimaryCalendarHasNoName_LabelsItCalendar` |
| drop the Graph blank-name fallback | `CreateEvent_WhenTheDefaultCalendarHasNoName_LabelsItCalendar` |
| stub stops tagging the created row | `SaveNewEvent_WhileOneCalendarIsSelected_ShowsUnderThatCalendar` |

That last one is the guard for the reported symptom end to end, and it needed a stub fix to be
writable at all: `StubGraphCalendarSyncService` built its "server copy" with no calendar tag —
modelling the *pre-fix* service — and every existing save test runs with `SourceFilter` unset, which
is the one configuration where the bug never reproduced.

Failure paths are covered too: a calendar lookup that fails still stores the appointment, untagged,
on both providers.

One thing worth stating plainly: whether `/me/calendar` and `/me/calendars` return the *same id* for
the same calendar is not confirmable without a live tenant. The failure direction is safe — a
divergent id would land the row on no node rather than the wrong one, degrading to the pre-fix
behaviour until the next sync restamps it — but it is worth one live check on a real Microsoft
account before this is assumed settled.

Tag consistency with the read-down is exact on both providers — same id source, same
`IsNullOrWhiteSpace → "Calendar"` and `.Trim()` normalisation — so the next replace-slice does not
silently relabel the row.

Full suite: **3270 passed, 0 failed**, 3 skipped.

## Not touched, deliberately

- **iCloud/CalDAV** does not have this bug: both write paths throw on a blank `CalendarId`, because
  iCloud accounts already get per-calendar save targets.
- **The editor's Calendar picker.** Offering per-calendar save targets for Google and Microsoft the
  way iCloud has them would also fix this — and would let you file an appointment on a calendar other
  than the default, which you cannot do today — but that is a feature, and this is the bug.

## Docs

Release-note section in `docs/release-notes-v0.8.42.md` (unreleased), cross-referenced with the #519
section already there so the two halves of the report read as one story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

