### PR TITLE
Use support@theideaplace.net as the support address

### DIFF
--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -1608,7 +1608,7 @@ QuickMail improves because people report problems and suggest changes. There are
 |-----|-------|-----------|-----------|
 | **1. Report a Bug → Send** | Help menu, in QuickMail | No | You want to report a problem but don't want any follow-up. |
 | **2. Report a Bug → Copy report and open GitHub** | Help menu, in QuickMail | Yes (via GitHub) | You have a GitHub account and want automatic filing plus direct contact. |
-| **3. Email** | `quickmailissues@theideaplace.net` | Yes (by email) | You'd rather use email and want a personal reply. |
+| **3. Email** | `support@theideaplace.net` | Yes (by email) | You'd rather use email and want a personal reply. |
 
 ### 1. Report a Bug — Send it directly (no account needed, anonymous)
 
@@ -1626,7 +1626,7 @@ Choose this option when you **have a GitHub account** and want automatic bug rep
 
 ### 3. Email us (personal follow-up)
 
-If you'd rather not use the in-app tool at all, email **[quickmailissues@theideaplace.net](mailto:quickmailissues@theideaplace.net)**. Describe the problem in your own words — the more detail (what you did, what happened, what you expected), the better.
+If you'd rather not use the in-app tool at all, email **[support@theideaplace.net](mailto:support@theideaplace.net)**. Describe the problem in your own words — the more detail (what you did, what happened, what you expected), the better.
 
 Choose this option when you **don't mind sending an email** and want a **personal follow-up**.
 

--- a/docs/github-release-download-numbers.md
+++ b/docs/github-release-download-numbers.md
@@ -444,6 +444,6 @@ Have a question about this article, a correction to it, or a problem with QuickM
 
 1. **Report a Bug → Send** (Help menu, inside QuickMail). Files the report for you anonymously — it includes no email address or other identifying information, so there is no way to follow up with you. **Best when you don't want any follow-up.**
 2. **Report a Bug → Copy report and open GitHub** (Help menu). Opens a pre-filled issue that you submit under your own GitHub account, so your GitHub contact information is attached. **Best when you have a GitHub account and want automatic filing plus direct contact.**
-3. **Email** [quickmailissues@theideaplace.net](mailto:quickmailissues@theideaplace.net). **Best when you don't mind sending email and want a personal follow-up.**
+3. **Email** [support@theideaplace.net](mailto:support@theideaplace.net). **Best when you don't mind sending email and want a personal follow-up.**
 
 Full details, including exactly what a report contains (and what it never contains), are in the [Reporting Issues section of the User Guide](https://kellylford.github.io/QuickMail/reporting-issues.html).

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -367,7 +367,7 @@
 </p>
 <p>
   The Help menu also offers <strong>Copy report and open GitHub</strong>, which files under your own GitHub
-  account, and you can email <a href="mailto:quickmailissues@theideaplace.net">quickmailissues@theideaplace.net</a>
+  account, and you can email <a href="mailto:support@theideaplace.net">support@theideaplace.net</a>
   instead. Both attach your identity by design, so a reply is possible; the in-app <strong>Send</strong> path
   does not.
 </p>

--- a/docs/release-notes-v0.8.42.md
+++ b/docs/release-notes-v0.8.42.md
@@ -256,6 +256,12 @@ A related bug went with it: an account with only **Sync calendar** checked used 
 plain mail sign-in and a separate calendar prompt. Either box now triggers the fold.
 ([#544](https://github.com/kellylford/QuickMail/issues/544))
 
+## Changed: a new email address for reaching us
+
+The email address for questions, bug reports, and anything else you would rather send by mail is now
+**[support@theideaplace.net](mailto:support@theideaplace.net)**, replacing the address used in earlier
+releases. The in-app **Help → Report a Bug** paths are unchanged.
+
 ---
 
 ## Reporting Issues
@@ -264,7 +270,7 @@ Found a problem or have a suggestion? There are three ways to reach us — pick 
 
 1. **Report a Bug → Send** (Help menu, inside QuickMail). Files the report for you anonymously — it includes no email address or other identifying information, so there is no way to follow up with you. **Best when you don't want any follow-up.**
 2. **Report a Bug → Copy report and open GitHub** (Help menu). Opens a pre-filled issue that you submit under your own GitHub account, so your GitHub contact information is attached. **Best when you have a GitHub account and want automatic filing plus direct contact.**
-3. **Email** [quickmailissues@theideaplace.net](mailto:quickmailissues@theideaplace.net). **Best when you don't mind sending email and want a personal follow-up.**
+3. **Email** [support@theideaplace.net](mailto:support@theideaplace.net). **Best when you don't mind sending email and want a personal follow-up.**
 
 Full details, including exactly what a report contains (and what it never contains), are in the [Reporting Issues section of the User Guide](https://kellylford.github.io/QuickMail/reporting-issues.html).
 

--- a/docs/reporting-issues-footer.md
+++ b/docs/reporting-issues-footer.md
@@ -15,6 +15,6 @@ Found a problem or have a suggestion? There are three ways to reach us — pick 
 
 1. **Report a Bug → Send** (Help menu, inside QuickMail). Files the report for you anonymously — it includes no email address or other identifying information, so there is no way to follow up with you. **Best when you don't want any follow-up.**
 2. **Report a Bug → Copy report and open GitHub** (Help menu). Opens a pre-filled issue that you submit under your own GitHub account, so your GitHub contact information is attached. **Best when you have a GitHub account and want automatic filing plus direct contact.**
-3. **Email** [quickmailissues@theideaplace.net](mailto:quickmailissues@theideaplace.net). **Best when you don't mind sending email and want a personal follow-up.**
+3. **Email** [support@theideaplace.net](mailto:support@theideaplace.net). **Best when you don't mind sending email and want a personal follow-up.**
 
 Full details, including exactly what a report contains (and what it never contains), are in the [Reporting Issues section of the User Guide](https://kellylford.github.io/QuickMail/reporting-issues.html).


### PR DESCRIPTION
Changes the address people write to from `quickmailissues@theideaplace.net` to `support@theideaplace.net`.

Updated:
- `docs/reporting-issues-footer.md` — the canonical footer every release note copies
- `docs/USER-GUIDE.md` — the Reporting Issues table and the email paragraph (needs a Pages republish)
- `docs/privacy.html` — the bug-report contact line
- `docs/github-release-download-numbers.md` — the article's Reporting Issues footer
- `docs/release-notes-v0.8.42.md` — the footer, plus a short **Changed** section naming the new address

Release notes for 0.8.33 through 0.8.41 keep the old address on purpose: they are a record of what shipped and are not republished.

Docs only — no code paths touched. The in-app **Help → Report a Bug** flows never carried an email address.

🤖 Generated with [Claude Code](https://claude.com/claude-code)