### PR TITLE
Fix #631: the Applications key opens the attachment context menu

### DIFF
--- a/QuickMail.Tests/ContextMenuKeyTests.cs
+++ b/QuickMail.Tests/ContextMenuKeyTests.cs
@@ -1,0 +1,109 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+using QuickMail.Helpers;
+using QuickMail.ViewModels;
+using QuickMail.Views;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// The Applications key must reach Windows (issue #631).
+///
+/// <para>
+/// The attachment lists open their own ContextMenu from PreviewKeyDown so the window-level
+/// fallback cannot answer with the message menu instead. That is right for Shift+F10, whose
+/// WM_CONTEXTMENU is generated while DefWindowProc processes the key <em>down</em> — marking the
+/// key handled suppresses it, and the menu opened here is the only one. It is wrong for the
+/// Applications key, whose WM_CONTEXTMENU is generated on the key <em>up</em>: handling the key
+/// down suppresses nothing, the key up still produces a context-menu request, and it arrives at
+/// the popup that is by then holding focus and tears the menu straight back down. That is the
+/// reported symptom — the menu is announced and then immediately gone, so Shift+F10 is the only
+/// way to reach it.
+/// </para>
+///
+/// <para>
+/// Nothing about this is visible from reading the handler, which treats the two gestures as
+/// interchangeable, so the guard is worth having: the fix is a key that is deliberately
+/// <em>not</em> handled, and the obvious "improvement" is to add it back.
+/// </para>
+/// </summary>
+// Loads a real MainWindow, so it belongs in the collection that serializes window-loading tests:
+// two of them constructing a MainWindow at once race inside XAML loading (#590).
+[Collection("WpfTests")]
+public class ContextMenuKeyTests
+{
+    [Fact]
+    public void ShiftF10IsOpenedByTheControl()
+        => Assert.True(ContextMenuKeys.OpensMenuOnKeyDown(Key.F10, ModifierKeys.Shift));
+
+    [Theory]
+    // The whole point: Windows raises WM_CONTEXTMENU for Apps on key up, so the key down is left
+    // alone. Shift+Apps is how some keyboards report the key and must be left alone too.
+    [InlineData(Key.Apps, ModifierKeys.None)]
+    [InlineData(Key.Apps, ModifierKeys.Shift)]
+    // F10 on its own opens the menu bar; with Ctrl or Alt it is not the context-menu gesture.
+    [InlineData(Key.F10, ModifierKeys.None)]
+    [InlineData(Key.F10, ModifierKeys.Control)]
+    [InlineData(Key.F10, ModifierKeys.Alt)]
+    [InlineData(Key.Enter, ModifierKeys.None)]
+    public void EveryOtherKeyIsLeftToWindows(Key key, ModifierKeys modifiers)
+        => Assert.False(ContextMenuKeys.OpensMenuOnKeyDown(key, modifiers));
+
+    /// <summary>
+    /// End to end over the real reading-pane attachment list — the surface the bug was reported
+    /// against. Pressing the Applications key there must leave the event unhandled, so the key up
+    /// can produce the WM_CONTEXTMENU that opens the list's own menu through the platform path.
+    /// </summary>
+    [StaFact]
+    public void AppsKeyOnTheAttachmentListIsNotSwallowed()
+    {
+        WpfTestHost.EnsureStyles("AccessibleStyles", "ThemedControls");
+
+        var imap     = new StubImapMailService();
+        var accounts = new StubAccountService();
+        var creds    = new StubCredentialService();
+        var store    = new StubLocalStoreService();
+        var config   = new StubConfigService();
+        var registry = new StubCommandRegistry();
+
+        var vm = new MainViewModel(imap, accounts, creds, store, new StubOAuthService(),
+            new StubSyncService(), config, registry, new StubViewService(), new StubRuleService(),
+            new StubSmtpService());
+
+        var window = new MainWindow(vm, new StubSmtpService(), accounts, creds, imap,
+            new StubOAuthService(), registry, new StubContactService(), config, store,
+            new StubViewService(), new StubRuleService(), new StubTemplateService(),
+            new StubFeatureGate());
+        try
+        {
+            var list = window.FindName("ReadingPaneAttachmentList") as ListBox;
+            Assert.NotNull(list);
+            Assert.NotNull(list!.ContextMenu);
+
+            var args = new KeyEventArgs(Keyboard.PrimaryDevice, new StubPresentationSource(), 0, Key.Apps)
+            {
+                RoutedEvent = Keyboard.PreviewKeyDownEvent,
+            };
+            list.RaiseEvent(args);
+
+            Assert.False(args.Handled);
+            Assert.False(list.ContextMenu!.IsOpen);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    /// <summary>A never-shown window has no real PresentationSource; KeyEventArgs requires one.</summary>
+    private sealed class StubPresentationSource : PresentationSource
+    {
+        private Visual _root = new System.Windows.Shapes.Rectangle();
+        public override Visual RootVisual { get => _root; set => _root = value; }
+        public override bool IsDisposed => false;
+        protected override CompositionTarget GetCompositionTargetCore() => null!;
+    }
+}

--- a/QuickMail/Helpers/ContextMenuKeys.cs
+++ b/QuickMail/Helpers/ContextMenuKeys.cs
@@ -1,0 +1,49 @@
+using System.Windows.Input;
+
+namespace QuickMail.Helpers;
+
+/// <summary>
+/// Decides which keyboard context-menu gesture a control has to open its own <c>ContextMenu</c>
+/// for, and which one it must leave to Windows (issue #631).
+///
+/// <para>
+/// The two gestures do <em>not</em> reach an application the same way. <c>DefWindowProc</c> turns
+/// Shift+F10 into <c>WM_CONTEXTMENU</c> while processing the <em>key down</em>, but it turns the
+/// Applications key into <c>WM_CONTEXTMENU</c> only on the <em>key up</em>. A handler that opens
+/// the menu itself from <c>PreviewKeyDown</c> and marks the event handled therefore behaves
+/// completely differently for the two:
+/// </para>
+///
+/// <list type="bullet">
+///   <item><description>Shift+F10 — marking the key down handled keeps the message away from
+///   <c>DefWindowProc</c>, so no <c>WM_CONTEXTMENU</c> is ever generated and the menu opened here
+///   is the only one. This works, and is why the attachment lists open their menu directly: it
+///   stops <c>MainWindow.OnWindowContextMenuOpening</c> from answering with the message menu
+///   instead (commit da7714c).</description></item>
+///   <item><description>Applications key — the key down carries no <c>WM_CONTEXTMENU</c> to
+///   suppress, so handling it changes nothing about what follows. The key up still reaches
+///   <c>DefWindowProc</c>, which raises <c>WM_CONTEXTMENU</c> at the window that now has focus:
+///   the menu's own popup. A second context-menu request arriving at the open popup tears it back
+///   down, which is the reported symptom — the menu is announced and then immediately gone.
+///   </description></item>
+/// </list>
+///
+/// <para>
+/// So the Applications key must be left alone. Its <c>WM_CONTEXTMENU</c> routes
+/// <c>ContextMenuOpening</c> from the focused item up to the list, and WPF opens the list's own
+/// <c>ContextMenu</c> — the ordinary platform path, the same one every other list in the app
+/// relies on. <c>OnWindowContextMenuOpening</c> already bails out for the attachment lists, so
+/// nothing intercepts it on the way.
+/// </para>
+/// </summary>
+public static class ContextMenuKeys
+{
+    /// <summary>
+    /// True when the control must open its <c>ContextMenu</c> itself from <c>PreviewKeyDown</c>
+    /// and mark the key handled. False for every other key — including the Applications key,
+    /// which Windows delivers as <c>WM_CONTEXTMENU</c> on key up and which must not be
+    /// intercepted here.
+    /// </summary>
+    public static bool OpensMenuOnKeyDown(Key key, ModifierKeys modifiers)
+        => key == Key.F10 && modifiers == ModifierKeys.Shift;
+}

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -3659,15 +3659,18 @@ public partial class MainWindow : Window
             focusItem.Focus();
     }
 
-    // Shift+F10 / Apps: open the attachment ContextMenu directly so the window-level
+    // Shift+F10: open the attachment ContextMenu directly so the window-level
     // OnWindowContextMenuOpening fallback cannot intercept and open the message menu instead.
+    // The Applications key is deliberately NOT handled here — Windows raises WM_CONTEXTMENU for it
+    // on key up, so opening the menu on key down only gets it torn down again (issue #631). See
+    // ContextMenuKeys for the full account.
     // Enter opens the selected attachment; Alt+Enter shows its properties.
     private void ReadingPaneAttachmentList_PreviewKeyDown(object sender, KeyEventArgs e)
     {
         var key = e.Key == Key.System ? e.SystemKey : e.Key;
         LogService.Debug($"[ATTLOG] RPAttachList_PreviewKeyDown: eKey={e.Key}, sysKey={e.SystemKey}, computed={key}, mod={e.KeyboardDevice.Modifiers}");
 
-        if ((key == Key.F10 && e.KeyboardDevice.Modifiers == ModifierKeys.Shift) || key == Key.Apps)
+        if (ContextMenuKeys.OpensMenuOnKeyDown(key, e.KeyboardDevice.Modifiers))
         {
             LogService.Debug($"[ATTLOG] RPAttachList_PreviewKeyDown: opening ContextMenu directly, IsNull={ReadingPaneAttachmentList.ContextMenu == null}");
             if (ReadingPaneAttachmentList.ContextMenu != null)

--- a/QuickMail/Views/MessageWindow.xaml.cs
+++ b/QuickMail/Views/MessageWindow.xaml.cs
@@ -731,14 +731,16 @@ public partial class MessageWindow : Window
             focusItem.Focus();
     }
 
-    // Shift+F10 / Apps: open the attachment ContextMenu directly.
+    // Shift+F10: open the attachment ContextMenu directly. The Applications key is deliberately
+    // NOT handled here — Windows raises WM_CONTEXTMENU for it on key up, so opening the menu on key
+    // down only gets it torn down again (issue #631). See ContextMenuKeys for the full account.
     // Enter opens the selected attachment; Alt+Enter shows its properties.
     private void AttachmentList_PreviewKeyDown(object sender, KeyEventArgs e)
     {
         var key = e.Key == Key.System ? e.SystemKey : e.Key;
         LogService.Debug($"[ATTLOG] MsgWin_AttachList_PreviewKeyDown: eKey={e.Key}, sysKey={e.SystemKey}, computed={key}, mod={e.KeyboardDevice.Modifiers}");
 
-        if ((key == Key.F10 && e.KeyboardDevice.Modifiers == ModifierKeys.Shift) || key == Key.Apps)
+        if (ContextMenuKeys.OpensMenuOnKeyDown(key, e.KeyboardDevice.Modifiers))
         {
             LogService.Debug($"[ATTLOG] MsgWin_AttachList_PreviewKeyDown: opening ContextMenu directly, IsNull={AttachmentList.ContextMenu == null}");
             if (AttachmentList.ContextMenu != null)

--- a/docs/release-notes-v0.8.42.md
+++ b/docs/release-notes-v0.8.42.md
@@ -228,6 +228,22 @@ was the only thing that put it right.
 The count now updates as the mail does, on Microsoft 365 accounts as it already did on IMAP ones.
 ([#491](https://github.com/kellylford/QuickMail/issues/491))
 
+## Fixed: the Applications key did not open a context menu on an attachment
+
+The **Applications** key — the one some keyboards still carry between the right Alt and Ctrl keys —
+did nothing on the attachment list. A menu was announced and then gone again before anything could be
+done with it, which left **Shift+F10** as the only way in.
+
+The two keys reach a program differently: Windows turns Shift+F10 into a request for a context menu
+as the key goes down, and the Applications key into one as the key comes back up. The attachment list
+was opening its own menu on the way down, so with the Applications key a second request arrived a
+moment later and closed what had just opened.
+
+The attachment list now leaves that key to Windows, the way every other list in QuickMail already
+did. Both keys open the same menu — **Save…**, **Save All…**, **Open** — in the reading pane and in
+an open message window alike.
+([#631](https://github.com/kellylford/QuickMail/issues/631))
+
 ## Changed: Sign in is now the last thing you tab to
 
 In both **Add Account** and **Manage Accounts**, the **Sign in with Microsoft…** / **Sign in with


### PR DESCRIPTION
Fixes #631.

## The bug

The Applications key did nothing on the attachment list — a menu was announced and then gone again — leaving Shift+F10 as the only way in.

## Why

`ReadingPaneAttachmentList_PreviewKeyDown` (and its `MessageWindow` twin) opened the list's own `ContextMenu` and marked the key handled for **both** gestures. The two are not interchangeable:

- **Shift+F10** — `DefWindowProc` generates `WM_CONTEXTMENU` while processing the key **down**. Marking the key down handled suppresses it, so the menu opened here is the only one. This is what stops the window-level `OnWindowContextMenuOpening` fallback from answering with the *message* menu instead (da7714c).
- **Applications key** — `WM_CONTEXTMENU` is generated on the key **up**. Handling the key down suppresses nothing. The key up still produces a context-menu request, and by then keyboard focus is inside the menu's own popup, so the second request lands there and tears the menu back down.

## The fix

Leave the Applications key to Windows — the path every other list in QuickMail already uses. `OnWindowContextMenuOpening` already excludes the attachment list (`IsDescendantOf` matches the element itself as well as its children), and `MessageWindow` has no such fallback, so nothing intercepts it on the way. The menu's `PlacementTarget.*` bindings resolve the same either way; `MessageContextMenu` uses the identical idiom and is only ever opened through this path.

The decision moves into `Helpers/ContextMenuKeys` so the reason is recorded once and both call sites share it.

## Tests

`ContextMenuKeyTests` — the decision table, plus an end-to-end check that raises `Key.Apps` at the real reading-pane attachment list on a live `MainWindow` and asserts the event comes back unhandled with the menu still closed. Verified to fail against the old behaviour (3 of 8 red when `Key.Apps` is put back).

Full suite: 3296 passed, 1 pre-existing environment-dependent failure (`TabStripNavigationTests.SettingsDialog_EveryTabIsReachableWithTheArrowKeys` — "the headers did not wrap onto more than one row", depends on window width and text scaling), 3 skipped (opt-in input tests).

Release notes for v0.8.42 updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)