### PR TITLE
Enable shared mailboxes by default for the 0.8.42 release (#31)

### DIFF
--- a/QuickMail.Tests/GraphBackendGateTests.cs
+++ b/QuickMail.Tests/GraphBackendGateTests.cs
@@ -502,13 +502,13 @@ public class ConfigFeatureGateTests
             .IsEnabled(FeatureFlag.GraphBackend));
 
     [Fact]
-    public void Default_SharedMailboxesOff() // #31: off while the multi-PR feature is built
-        => Assert.False(new ConfigFeatureGate(new ConfigModel(), Array.Empty<string>())
+    public void Default_SharedMailboxesOn() // #31: on by default as of 0.8.42 — feature shipped
+        => Assert.True(new ConfigFeatureGate(new ConfigModel(), Array.Empty<string>())
             .IsEnabled(FeatureFlag.SharedMailboxes));
 
     [Fact]
-    public void Config_EnablesSharedMailboxes() // testers turn it on with SharedMailboxes=true
-        => Assert.True(new ConfigFeatureGate(ConfigWith("SharedMailboxes", "true"), Array.Empty<string>())
+    public void Config_DisablesSharedMailboxes() // a user can still hide it with SharedMailboxes=false
+        => Assert.False(new ConfigFeatureGate(ConfigWith("SharedMailboxes", "false"), Array.Empty<string>())
             .IsEnabled(FeatureFlag.SharedMailboxes));
 }
 

--- a/QuickMail/Models/FeatureFlag.cs
+++ b/QuickMail/Models/FeatureFlag.cs
@@ -74,10 +74,10 @@ public enum FeatureFlag
     /// exclusion, the connect-skip, cascade removal — is data-driven off a shared account that only the
     /// button can produce; with no shared account, every IsShared branch is a no-op.
     ///
-    /// Default: false while the feature is built across multiple PRs (PR 1 is the linked-account model
-    /// and manual add only — no backend access yet, so a shared node has no folders). Turn it on to
-    /// test with SharedMailboxes=true under [features] in config.ini, or --feature SharedMailboxes at
-    /// launch. Flips to true by default once the feature is complete.
+    /// Default: true as of 0.8.42 — the feature is complete across its PRs (linked-account model,
+    /// reading and send-as, per-account notification opt-in, and parent-account consent). Set
+    /// SharedMailboxes=false under [features] in config.ini, or --no-feature SharedMailboxes at launch,
+    /// to hide it again.
     /// </summary>
     SharedMailboxes,
 

--- a/QuickMail/Services/ConfigFeatureGate.cs
+++ b/QuickMail/Services/ConfigFeatureGate.cs
@@ -32,10 +32,10 @@ public class ConfigFeatureGate : IFeatureGate
         // On by default: server-rule list/create/edit/delete/reorder and the unified per-account rules
         // window are complete and tested (#333). Set ServerRules=false under [features] to hide it again.
         [FeatureFlag.ServerRules]  = true,
-        // Off while shared mailboxes (#31) is built across multiple PRs — the "Add shared…" button, the
-        // sole creation path, stays hidden until the feature is whole. Set SharedMailboxes=true under
-        // [features] to test.
-        [FeatureFlag.SharedMailboxes] = false,
+        // On by default as of 0.8.42: shared mailboxes (#31) is complete across its PRs — the "Add
+        // shared…" button, reading, send-as, per-account notification opt-in, and the parent-account
+        // consent path are all shipped. Set SharedMailboxes=false under [features] to hide it again.
+        [FeatureFlag.SharedMailboxes] = true,
         // Off until POP3 (#128) has run against real servers. The local store holds the only copy of
         // POP3 mail, so the cost of a wrong assumption is a user's mail, not a re-sync. Set
         // Pop3Backend=true under [features] to test.

--- a/QuickMail/ViewModels/AccountManagerViewModel.cs
+++ b/QuickMail/ViewModels/AccountManagerViewModel.cs
@@ -122,7 +122,7 @@ public partial class AccountManagerViewModel : AccountEditorViewModel
         && _featureGate.IsEnabled(FeatureFlag.MicrosoftGraphMigration);
 
     /// <summary>#31: gates the "Add shared…" button — the sole path that can create a shared mailbox.
-    /// Off by default while the multi-PR feature is built (see <see cref="FeatureFlag.SharedMailboxes"/>).</summary>
+    /// On by default as of 0.8.42 (see <see cref="FeatureFlag.SharedMailboxes"/>).</summary>
     public bool IsSharedMailboxesEnabled => _featureGate.IsEnabled(FeatureFlag.SharedMailboxes);
 
     public AccountManagerViewModel(

--- a/docs/release-notes-v0.8.42.md
+++ b/docs/release-notes-v0.8.42.md
@@ -1,5 +1,23 @@
 # QuickMail v0.8.42 Release Notes
 
+## New: shared mailboxes
+
+If your organization has given you access to a shared mailbox — a `support@`, `info@`, or `sales@` address a team reads together — you can now add it to QuickMail, and it appears as its own mailbox in the folder tree, alongside your own accounts.
+
+You add one through an account you already have: open **Account Manager**, choose **Add shared mailbox**, pick the Microsoft 365 work or school account that has access to it, and type the shared mailbox's address. There is no separate password and no separate sign-in — QuickMail reads and sends the shared mailbox using the permission your organization already granted your own account.
+
+- **Reading** works like any other mailbox — select it in the folder tree and open its folders.
+- **Sending as the shared mailbox** is a matter of choosing its address in the **From** list when you compose.
+- **New-mail notifications are off by default** for a shared mailbox, since it's often a busy team address. Turn on **Notify me of new mail in this shared mailbox** for a particular one in Account Manager if you want them (the main new-mail notification setting still has to be on).
+
+Two things worth knowing: a shared mailbox **updates every few minutes, not the instant mail arrives** (your own mailboxes still update live), and shared mailboxes are a **Microsoft 365 work or school** feature — personal Outlook.com accounts don't have them. Removing the account a shared mailbox reads through also removes the shared mailbox; QuickMail tells you first. ([#31](https://github.com/kellylford/QuickMail/issues/31))
+
+## New: an administrator can approve QuickMail for a whole organization
+
+Work or school organizations often require an administrator to approve a new app before anyone can sign in. QuickMail now has an in-app way to do it: **Help → Grant Admin Consent for Your Organization**. An administrator signs in there once, approves for the whole organization, and afterwards everyone signs in with no prompts — no hand-built URLs or portal digging.
+
+The approval also works from an ordinary sign-in now: everything QuickMail needs is requested together, so an administrator adding their own account (or approving at the "needs admin approval" screen) grants it all in one pass. And if you sign in as an administrator to approve and QuickMail notices it isn't the account you were adding, it no longer dead-ends — it tells you the approval is saved and offers to sign you back in as yourself. ([#607](https://github.com/kellylford/QuickMail/issues/607))
+
 ## New: a key that goes straight to the next unread message
 
 A user wrote in asking for one, mentioning that Space did this in the mail program they came from.
@@ -264,13 +282,20 @@ back on to recover.
 The contact and calendar permissions are now folded into the mail sign-in, so one screen lists all
 three together. This applies when the account is set to connect over **Microsoft 365 (Graph)** —
 which you choose under **Advanced settings → Connection method**; a personal account left on the
-standard IMAP connection is unaffected. Work and school accounts are deliberately left as they were:
-on a tenant that restricts consent, asking for everything at once would end the whole sign-in rather
-than just the extra part, and the account would never be added at all.
+standard IMAP connection is unaffected. A personal account folds in only what you asked for — mail,
+plus contacts or calendar if you checked those. Work and school accounts fold everything into their
+sign-in as well, but for a different purpose: so an administrator can approve the whole set for the
+organization in one pass (see *An administrator can approve QuickMail for a whole organization*,
+above). Someone without the authority to approve it all is simply signed in with mail only, rather
+than being turned away.
 
 A related bug went with it: an account with only **Sync calendar** checked used to fall through to a
 plain mail sign-in and a separate calendar prompt. Either box now triggers the fold.
 ([#544](https://github.com/kellylford/QuickMail/issues/544))
+
+## Personal accounts can connect over Microsoft 365 (Graph)
+
+A personal Outlook.com, Hotmail, or Live.com account can connect over **Microsoft 365 (Graph)** instead of IMAP — choose it under **Advanced settings → Connection method** when you add the account. Graph is the more capable connection, and a future version of QuickMail will make it the default for Microsoft accounts; for now personal accounts stay on the standard IMAP connection unless you choose Graph yourself.
 
 ## Changed: a new email address for reaching us
 


### PR DESCRIPTION
Flips `FeatureFlag.SharedMailboxes` to **on by default** for the v0.8.42 release. The feature is complete across its PRs — the "Add shared…" button, reading, send-as, per-account new-mail notification opt-in, and the parent-account (Graph-only) consent path all shipped and have dedicated tests. Users who don't want it can still hide it with `SharedMailboxes=false` under `[features]`.

## Changes
- **ConfigFeatureGate**: `SharedMailboxes` default `false → true` (comment updated with the off-switch).
- **ConfigFeatureGateTests**: `Default_SharedMailboxesOff` → `Default_SharedMailboxesOn`; `Config_EnablesSharedMailboxes` → `Config_DisablesSharedMailboxes` (the meaningful override direction now the default is on).
- **FeatureFlag.cs / AccountManagerViewModel.cs**: refreshed now-stale "off by default while built" doc comments.
- **Release notes**: shared-mailbox section present (with admin-consent and personal-Graph); corrected the #544 paragraph that still claimed work/school sign-in does *not* fold all scopes — #619 changed that.

Docs verified: shared mailboxes is covered in both the release notes and USER-GUIDE.md.

## Verification
- Release build clean (0 warnings/errors — no CA analyzer trip).
- `ConfigFeatureGateTests` 13/13, `SharedMailboxButtonGateTests` 2/2.
- Independent review run before opening: no blockers. Confirmed no other test/config/doc assumed the flag was off, and that with no shared account created every `IsShared` branch is a no-op — so nothing changes for users who never add one.

Closes #31.