### PR TITLE
Fix #639: bug reports say which protocols the accounts use

### DIFF
--- a/QuickMail.Tests/BugReportAccountSummaryTests.cs
+++ b/QuickMail.Tests/BugReportAccountSummaryTests.cs
@@ -16,10 +16,11 @@ namespace QuickMail.Tests;
 
 public class BugReportAccountSummaryTests
 {
-    private static AccountModel Acct(BackendKind kind) => new()
+    private static AccountModel Acct(BackendKind kind, bool shared = false) => new()
     {
         Id           = Guid.NewGuid(),
         BackendKind  = kind,
+        IsShared     = shared,
         Username     = "someone@example.com",
         DisplayName  = "Someone Private",
         ImapHost     = "mail.private-host.example",
@@ -67,6 +68,38 @@ public class BugReportAccountSummaryTests
         Assert.Equal("0", MainViewModel.DescribeAccounts([]));
         Assert.Equal("0", MainViewModel.DescribeAccounts(null));
     }
+
+    /// <summary>
+    /// A shared mailbox is not one of the user's own accounts (#31) — it is a mailbox someone else
+    /// shared with one of them, read through that account's token. Folding them into a single count
+    /// reported three "accounts" for one account and two shared mailboxes, which is both misleading
+    /// and a wasted triage signal, since a shared mailbox diverges from an ordinary account.
+    /// </summary>
+    [Fact]
+    public void DescribeAccounts_CountsSharedMailboxesSeparately()
+    {
+        var result = MainViewModel.DescribeAccounts(
+        [
+            Acct(BackendKind.MicrosoftGraph),
+            Acct(BackendKind.MicrosoftGraph, shared: true),
+            Acct(BackendKind.MicrosoftGraph, shared: true),
+        ]);
+
+        Assert.Equal("1 (Microsoft 365), plus 2 shared mailboxes", result);
+    }
+
+    [Fact]
+    public void DescribeAccounts_SaysOneSharedMailboxInTheSingular()
+    {
+        var result = MainViewModel.DescribeAccounts(
+            [Acct(BackendKind.ImapSmtp), Acct(BackendKind.ImapSmtp, shared: true)]);
+
+        Assert.Equal("1 (IMAP), plus 1 shared mailbox", result);
+    }
+
+    [Fact]
+    public void DescribeAccounts_SaysNothingAboutSharedMailboxes_WhenThereAreNone()
+        => Assert.DoesNotContain("shared", MainViewModel.DescribeAccounts([Acct(BackendKind.ImapSmtp)]));
 
     /// <summary>
     /// The redaction boundary. This text goes into a public issue body, so nothing that identifies

--- a/QuickMail.Tests/BugReportAccountSummaryTests.cs
+++ b/QuickMail.Tests/BugReportAccountSummaryTests.cs
@@ -1,0 +1,86 @@
+// The account line in a bug report's Environment section — issue #639, found while triaging #637
+// (offline drafts), where "Graph or IMAP?" was unanswerable from the report and cost a source read.
+//
+// Two things are locked here: that the line says which protocols are in use, and that it says
+// NOTHING else. The string is published verbatim into a public GitHub issue, so an address, host
+// name, or display name leaking into it is a privacy defect, not a formatting nit — hence the
+// negative assertions, which are the point of the file rather than padding.
+
+using System;
+using System.Collections.Generic;
+using QuickMail.Models;
+using QuickMail.ViewModels;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+public class BugReportAccountSummaryTests
+{
+    private static AccountModel Acct(BackendKind kind) => new()
+    {
+        Id           = Guid.NewGuid(),
+        BackendKind  = kind,
+        Username     = "someone@example.com",
+        DisplayName  = "Someone Private",
+        ImapHost     = "mail.private-host.example",
+        Pop3Host     = "pop.private-host.example",
+    };
+
+    [Fact]
+    public void DescribeAccounts_ReportsCountAndKind_ForOneAccount()
+        => Assert.Equal("1 (IMAP)", MainViewModel.DescribeAccounts([Acct(BackendKind.ImapSmtp)]));
+
+    [Fact]
+    public void DescribeAccounts_NamesGraphAsMicrosoft365()
+        => Assert.Equal("1 (Microsoft 365)", MainViewModel.DescribeAccounts([Acct(BackendKind.MicrosoftGraph)]));
+
+    [Fact]
+    public void DescribeAccounts_NamesPop3()
+        => Assert.Equal("1 (POP3)", MainViewModel.DescribeAccounts([Acct(BackendKind.Pop3Smtp)]));
+
+    [Fact]
+    public void DescribeAccounts_CountsEveryAccount_ButListsEachKindOnce()
+    {
+        var result = MainViewModel.DescribeAccounts(
+            [Acct(BackendKind.ImapSmtp), Acct(BackendKind.ImapSmtp), Acct(BackendKind.MicrosoftGraph)]);
+
+        Assert.Equal("3 (IMAP, Microsoft 365)", result);
+    }
+
+    /// <summary>
+    /// Enum order, not account order: the same setup must produce the same line every time, or two
+    /// reports from one user read as two different configurations.
+    /// </summary>
+    [Fact]
+    public void DescribeAccounts_OrdersKindsIndependentlyOfAccountOrder()
+    {
+        var oneWay   = MainViewModel.DescribeAccounts([Acct(BackendKind.Pop3Smtp), Acct(BackendKind.ImapSmtp)]);
+        var otherWay = MainViewModel.DescribeAccounts([Acct(BackendKind.ImapSmtp), Acct(BackendKind.Pop3Smtp)]);
+
+        Assert.Equal(oneWay, otherWay);
+        Assert.Equal("2 (IMAP, POP3)", oneWay);
+    }
+
+    [Fact]
+    public void DescribeAccounts_ReturnsZero_WhenNoAccountsConfigured()
+    {
+        Assert.Equal("0", MainViewModel.DescribeAccounts([]));
+        Assert.Equal("0", MainViewModel.DescribeAccounts(null));
+    }
+
+    /// <summary>
+    /// The redaction boundary. This text goes into a public issue body, so nothing that identifies
+    /// the user or their servers may appear in it — whatever else the account object is carrying.
+    /// </summary>
+    [Fact]
+    public void DescribeAccounts_LeaksNoAddressHostOrDisplayName()
+    {
+        var result = MainViewModel.DescribeAccounts(
+            [Acct(BackendKind.ImapSmtp), Acct(BackendKind.MicrosoftGraph), Acct(BackendKind.Pop3Smtp)]);
+
+        Assert.DoesNotContain("example.com", result, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("private-host", result, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("Someone", result, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("@", result, StringComparison.Ordinal);
+    }
+}

--- a/QuickMail.Tests/BugReportAccountSummaryTests.cs
+++ b/QuickMail.Tests/BugReportAccountSummaryTests.cs
@@ -9,6 +9,7 @@
 using System;
 using System.Collections.Generic;
 using QuickMail.Models;
+using QuickMail.Services;
 using QuickMail.ViewModels;
 using Xunit;
 
@@ -16,6 +17,13 @@ namespace QuickMail.Tests;
 
 public class BugReportAccountSummaryTests
 {
+    private sealed class AccountsStub(params AccountModel[] accounts) : IAccountService
+    {
+        public List<AccountModel> LoadAccounts() => [.. accounts];
+        public void SaveAccounts(List<AccountModel> a) { }
+        public void SetDefaultAccount(Guid accountId) { }
+    }
+
     private static AccountModel Acct(BackendKind kind, bool shared = false) => new()
     {
         Id           = Guid.NewGuid(),
@@ -100,6 +108,53 @@ public class BugReportAccountSummaryTests
     [Fact]
     public void DescribeAccounts_SaysNothingAboutSharedMailboxes_WhenThereAreNone()
         => Assert.DoesNotContain("shared", MainViewModel.DescribeAccounts([Acct(BackendKind.ImapSmtp)]));
+
+    // ── The wiring ────────────────────────────────────────────────────────────
+    // Everything above tests DescribeAccounts, and BugReportServiceTests renders a hand-written
+    // BugReportContext. Neither observes the one line that joins them, so deleting
+    // "Accounts = DescribeAccounts(this.Accounts)" from CaptureBugReportContext left the whole
+    // suite green while the field went empty, BuildReportText dropped the line by its own
+    // empty-guard, and every report shipped without the account information again — #639 undone,
+    // silently. These two close that.
+
+    /// <summary>
+    /// The captured context actually carries the account line, for the real account list rather
+    /// than a literal a test wrote.
+    /// </summary>
+    [Fact]
+    public void CaptureBugReportContext_PopulatesTheAccountLine()
+    {
+        var vm = MakeViewModel(Acct(BackendKind.ImapSmtp), Acct(BackendKind.MicrosoftGraph));
+
+        Assert.Equal("2 (IMAP, Microsoft 365)", vm.CaptureBugReportContext().Accounts);
+    }
+
+    /// <summary>
+    /// And it reflects what is configured rather than a constant: a different account list has to
+    /// produce a different line, or an assignment of some fixed string would pass the test above.
+    /// </summary>
+    [Fact]
+    public void CaptureBugReportContext_ReflectsTheConfiguredAccounts()
+    {
+        var oneImap = MakeViewModel(Acct(BackendKind.ImapSmtp));
+        var withShared = MakeViewModel(
+            Acct(BackendKind.MicrosoftGraph), Acct(BackendKind.MicrosoftGraph, shared: true));
+
+        Assert.Equal("1 (IMAP)", oneImap.CaptureBugReportContext().Accounts);
+        Assert.Equal("1 (Microsoft 365), plus 1 shared mailbox",
+                     withShared.CaptureBugReportContext().Accounts);
+    }
+
+    private static MainViewModel MakeViewModel(params AccountModel[] accounts)
+    {
+        var vm = new MainViewModel(
+            new StubImapMailService(), new AccountsStub(accounts), new StubCredentialService(),
+            new StubLocalStoreService(), new StubOAuthService(), new StubSyncService(),
+            new StubConfigService(), new StubCommandRegistry(), new StubViewService(),
+            new StubRuleService(), new StubSmtpService());
+        vm.LoadAccountList();   // App does this before OnLoaded; Accounts is empty until it runs
+        return vm;
+    }
 
     /// <summary>
     /// The redaction boundary. This text goes into a public issue body, so nothing that identifies

--- a/QuickMail.Tests/BugReportServiceTests.cs
+++ b/QuickMail.Tests/BugReportServiceTests.cs
@@ -224,6 +224,7 @@ public class BugReportServiceTests
             View  = "Unread (Conversations)",
             Sort  = "Newest First",
             MessageOpenMode = "Window",
+            Accounts = "2 (IMAP, Microsoft 365)",
         };
 
         var text = service.BuildReportText(report);
@@ -232,6 +233,30 @@ public class BugReportServiceTests
         Assert.Contains("View: Unread (Conversations)", text);
         Assert.Contains("Sort: Newest First", text);
         Assert.Contains("Message open mode: Window", text);
+        Assert.Contains("Accounts: 2 (IMAP, Microsoft 365)", text);
+    }
+
+    /// <summary>
+    /// An older context object — or one captured before any account is loaded — leaves Accounts
+    /// empty, and an empty value must omit the line rather than render "Accounts: ". Same contract
+    /// the message-open-mode line has had since #350.
+    /// </summary>
+    [Fact]
+    public void BuildReportText_OmitsAccounts_WhenContextValueEmpty()
+    {
+        var service = MakeService(_ => new HttpResponseMessage(HttpStatusCode.OK), out _);
+        var report = SampleReport();
+        report.Context = new BugReportContext
+        {
+            Theme = "Parchment",
+            View  = "All (Messages)",
+            Sort  = "Newest First",
+            // Accounts stays empty
+        };
+
+        var text = service.BuildReportText(report);
+
+        Assert.DoesNotContain("Accounts:", text);
     }
 
     [Fact]

--- a/QuickMail/Models/BugReportModel.cs
+++ b/QuickMail/Models/BugReportModel.cs
@@ -35,12 +35,18 @@ public sealed class BugReportContext
     public string MessageOpenMode { get; set; } = string.Empty;
 
     /// <summary>
-    /// The configured accounts as a count plus the distinct protocols they connect over, e.g.
-    /// "2 (Microsoft 365, IMAP)". Behaviour now diverges by backend in draft handling, folder
-    /// semantics, rules, and attachment fetch, so a report that does not say which one is in use
-    /// costs a source read to triage (issue #639, found triaging #637).
-    /// <para>Protocol kind only — never an address, host name, or display name. This text is
-    /// published verbatim into a public issue.</para>
+    /// The user's own accounts as a count plus the distinct protocols they connect over, with any
+    /// shared mailboxes counted after them: <c>"2 (IMAP, Microsoft 365)"</c>, or
+    /// <c>"1 (Microsoft 365), plus 2 shared mailboxes"</c>. Behaviour now diverges by backend in
+    /// draft handling, folder semantics, rules, and attachment fetch, so a report that does not say
+    /// which one is in use costs a source read to triage (issue #639, found triaging #637).
+    /// <para>Protocols are listed in <see cref="BackendKind"/> order, not account order, so one
+    /// setup always renders one line and two reports from the same user are comparable. A second
+    /// producer of this field must keep that, or the field stops being comparable across reports —
+    /// which is the whole of its value. <see cref="ViewModels.MainViewModel.DescribeAccounts"/> is
+    /// the reference implementation.</para>
+    /// <para>Counts and protocol kinds only — never an address, host name, or display name. This
+    /// text is published verbatim into a public issue.</para>
     /// </summary>
     public string Accounts { get; set; } = string.Empty;
 }

--- a/QuickMail/Models/BugReportModel.cs
+++ b/QuickMail/Models/BugReportModel.cs
@@ -33,4 +33,14 @@ public sealed class BugReportContext
     /// (e.g. attachment behaviour differs by mode; see issue #350).
     /// </summary>
     public string MessageOpenMode { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The configured accounts as a count plus the distinct protocols they connect over, e.g.
+    /// "2 (Microsoft 365, IMAP)". Behaviour now diverges by backend in draft handling, folder
+    /// semantics, rules, and attachment fetch, so a report that does not say which one is in use
+    /// costs a source read to triage (issue #639, found triaging #637).
+    /// <para>Protocol kind only — never an address, host name, or display name. This text is
+    /// published verbatim into a public issue.</para>
+    /// </summary>
+    public string Accounts { get; set; } = string.Empty;
 }

--- a/QuickMail/Services/BugReportService.cs
+++ b/QuickMail/Services/BugReportService.cs
@@ -173,6 +173,8 @@ public partial class BugReportService : IBugReportService, IDisposable
             sb.AppendLine($"- Sort: {ctx.Sort}");
             if (!string.IsNullOrWhiteSpace(ctx.MessageOpenMode))
                 sb.AppendLine($"- Message open mode: {ctx.MessageOpenMode}");
+            if (!string.IsNullOrWhiteSpace(ctx.Accounts))
+                sb.AppendLine($"- Accounts: {ctx.Accounts}");
         }
 
         return sb.ToString();

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -1255,10 +1255,10 @@ public partial class MainViewModel : ObservableObject, IDisposable
     /// </summary>
     internal static string DescribeAccounts(IEnumerable<AccountModel>? accounts)
     {
-        var kinds = accounts?.Select(a => a.BackendKind).ToList() ?? [];
-        if (kinds.Count == 0) return "0";
+        var all = accounts?.ToList() ?? [];
+        if (all.Count == 0) return "0";
 
-        var distinct = kinds.Distinct().OrderBy(k => k).Select(k => k switch
+        var distinct = all.Select(a => a.BackendKind).Distinct().OrderBy(k => k).Select(k => k switch
         {
             BackendKind.MicrosoftGraph => "Microsoft 365",
             BackendKind.Pop3Smtp       => "POP3",
@@ -1266,7 +1266,19 @@ public partial class MainViewModel : ObservableObject, IDisposable
             _                          => k.ToString(),
         });
 
-        return $"{kinds.Count} ({string.Join(", ", distinct)})";
+        // Shared mailboxes are counted apart from the user's own accounts (#31). Folding them into
+        // one number is both misleading — three "accounts" can be one account and two mailboxes
+        // someone shared with it — and a wasted signal: a shared mailbox reads through its parent's
+        // token and diverges from an ordinary account in ways that are worth knowing up front.
+        var shared = all.Count(a => a.IsShared);
+        var line   = $"{all.Count - shared} ({string.Join(", ", distinct)})";
+
+        return shared switch
+        {
+            0 => line,
+            1 => line + ", plus 1 shared mailbox",
+            _ => line + $", plus {shared} shared mailboxes",
+        };
     }
 
     private string ViewModeName => ViewMode switch

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -1240,7 +1240,34 @@ public partial class MainViewModel : ObservableObject, IDisposable
             Models.MessageOpenMode.Window      => "Window",
             _                                  => MessageOpenMode.ToString(),
         },
+        Accounts = DescribeAccounts(this.Accounts),
     };
+
+    /// <summary>
+    /// The account line for a bug report's Environment section: how many accounts are configured
+    /// and which protocols they connect over, e.g. "2 (Microsoft 365, IMAP)". Backend now changes
+    /// behaviour in draft handling, folder semantics, rules, and attachment fetch, so a report that
+    /// omits it costs a source read to triage (#639).
+    /// <para>Protocol kind only — no address, host name, or display name goes near this string: it
+    /// is published verbatim into a public issue. Kinds are listed in enum order rather than
+    /// account order so the same setup always produces the same line.</para>
+    /// Pure/static so the redaction boundary is unit-testable without standing up the view model.
+    /// </summary>
+    internal static string DescribeAccounts(IEnumerable<AccountModel>? accounts)
+    {
+        var kinds = accounts?.Select(a => a.BackendKind).ToList() ?? [];
+        if (kinds.Count == 0) return "0";
+
+        var distinct = kinds.Distinct().OrderBy(k => k).Select(k => k switch
+        {
+            BackendKind.MicrosoftGraph => "Microsoft 365",
+            BackendKind.Pop3Smtp       => "POP3",
+            BackendKind.ImapSmtp       => "IMAP",
+            _                          => k.ToString(),
+        });
+
+        return $"{kinds.Count} ({string.Join(", ", distinct)})";
+    }
 
     private string ViewModeName => ViewMode switch
     {

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -1245,12 +1245,15 @@ public partial class MainViewModel : ObservableObject, IDisposable
 
     /// <summary>
     /// The account line for a bug report's Environment section: how many accounts are configured
-    /// and which protocols they connect over, e.g. "2 (Microsoft 365, IMAP)". Backend now changes
-    /// behaviour in draft handling, folder semantics, rules, and attachment fetch, so a report that
-    /// omits it costs a source read to triage (#639).
+    /// and which protocols they connect over — <c>"2 (IMAP, Microsoft 365)"</c>, or
+    /// <c>"1 (Microsoft 365), plus 2 shared mailboxes"</c>. Backend now changes behaviour in draft
+    /// handling, folder semantics, rules, and attachment fetch, so a report that omits it costs a
+    /// source read to triage (#639).
     /// <para>Protocol kind only — no address, host name, or display name goes near this string: it
-    /// is published verbatim into a public issue. Kinds are listed in enum order rather than
-    /// account order so the same setup always produces the same line.</para>
+    /// is published verbatim into a public issue. Kinds are listed in <see cref="BackendKind"/>
+    /// order rather than account order so the same setup always produces the same line; the
+    /// examples above are in that order (ImapSmtp precedes MicrosoftGraph), and
+    /// <c>DescribeAccounts_OrdersKindsIndependentlyOfAccountOrder</c> pins it.</para>
     /// Pure/static so the redaction boundary is unit-testable without standing up the view model.
     /// </summary>
     internal static string DescribeAccounts(IEnumerable<AccountModel>? accounts)

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -1632,7 +1632,7 @@ Choose this option when you **don't mind sending an email** and want a **persona
 
 ### What's included in a report — and what's never included
 
-Alongside what you type, an in-app report (options 1 and 2) adds a short **Environment** section so a problem can be reproduced in the right context: the QuickMail version, your Windows version, the .NET runtime version, the active color theme, the current view, the current sort order, the message open mode (reading pane, tab, or window), and how many accounts you have set up together with the mail protocols they connect over — for example `2 (IMAP, Microsoft 365)`. That last line is the protocol names only: no address, server name, or account name is included.
+Alongside what you type, an in-app report (options 1 and 2) adds a short **Environment** section so a problem can be reproduced in the right context: the QuickMail version, your Windows version, the .NET runtime version, the active color theme, the current view, the current sort order, the message open mode (reading pane, tab, or window), and how many accounts you have set up together with the mail protocols they connect over — for example `2 (IMAP, Microsoft 365)`. Any shared mailboxes are counted separately, as in `2 (Microsoft 365), plus 1 shared mailbox`, since a shared mailbox is not one of your own accounts. That last line is counts and protocol names only: no address, server name, or account name is included.
 
 **No message content, email addresses, account settings, passwords, or log file content is ever collected or sent.** The Preview shows the full report verbatim, so you always see exactly what is included before it leaves your computer.
 

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -1632,7 +1632,7 @@ Choose this option when you **don't mind sending an email** and want a **persona
 
 ### What's included in a report — and what's never included
 
-Alongside what you type, an in-app report (options 1 and 2) adds a short **Environment** section so a problem can be reproduced in the right context: the QuickMail version, your Windows version, the .NET runtime version, the active color theme, the current view, the current sort order, and the message open mode (reading pane, tab, or window).
+Alongside what you type, an in-app report (options 1 and 2) adds a short **Environment** section so a problem can be reproduced in the right context: the QuickMail version, your Windows version, the .NET runtime version, the active color theme, the current view, the current sort order, the message open mode (reading pane, tab, or window), and how many accounts you have set up together with the mail protocols they connect over — for example `2 (IMAP, Microsoft 365)`. That last line is the protocol names only: no address, server name, or account name is included.
 
 **No message content, email addresses, account settings, passwords, or log file content is ever collected or sent.** The Preview shows the full report verbatim, so you always see exactly what is included before it leaves your computer.
 

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -75,7 +75,7 @@
 </div>
 
 <h1>QuickMail Privacy Policy</h1>
-<p class="effective">Effective date: August 25, 2026. Replaces the version dated June 17, 2026.</p>
+<p class="effective">Effective date: August 27, 2026. Replaces the version dated August 25, 2026.</p>
 
 <div class="callout">
   <strong>Short version:</strong> QuickMail is a Windows desktop application with no servers of its own.
@@ -347,12 +347,15 @@
 <ul>
   <li>What you typed: a summary and what happened, plus — if you fill them in — what you expected and steps to reproduce</li>
   <li>An environment section: the QuickMail version, your Windows version, the .NET runtime version, the
-      active theme, the current view, the current sort order, and the message open mode</li>
+      active theme, the current view, the current sort order, the message open mode, and how many accounts
+      you have set up together with the mail protocols they connect over (IMAP, POP3, or Microsoft 365) &mdash;
+      the protocol names only, never an address, a server name, or an account display name</li>
 </ul>
 <p>A report never contains:</p>
 <ul>
   <li>Message content, subjects, or email addresses</li>
-  <li>Your account settings, server names, passwords, or tokens</li>
+  <li>Your email addresses, server names, passwords, or tokens &mdash; the only account detail a report
+      carries is the protocol each account connects over, and a count of how many there are</li>
   <li>Any part of the log files or any screenshot</li>
   <li>Your name or contact details — QuickMail does not ask for them, so a sent report is anonymous and
       cannot be followed up</li>

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -348,8 +348,9 @@
   <li>What you typed: a summary and what happened, plus — if you fill them in — what you expected and steps to reproduce</li>
   <li>An environment section: the QuickMail version, your Windows version, the .NET runtime version, the
       active theme, the current view, the current sort order, the message open mode, and how many accounts
-      you have set up together with the mail protocols they connect over (IMAP, POP3, or Microsoft 365) &mdash;
-      the protocol names only, never an address, a server name, or an account display name</li>
+      you have set up, how many shared mailboxes if any, and the mail protocols they connect over (IMAP,
+      POP3, or Microsoft 365) &mdash; counts and protocol names only, never an address, a server name, or
+      an account display name</li>
 </ul>
 <p>A report never contains:</p>
 <ul>

--- a/docs/release-notes-v0.8.43.md
+++ b/docs/release-notes-v0.8.43.md
@@ -11,8 +11,9 @@ an account connected over IMAP, over POP3, and through Microsoft 365 genuinely b
 from one another, so a report that leaves it out can take a while to place.
 
 Reports now include one more line — how many accounts you have set up and the protocols they use,
-for example *"2 (IMAP, Microsoft 365)"*. It is the protocol names and a count, nothing else: no
-address, no server name, no account name. As always the **Preview** in the report window shows the
+for example *"2 (IMAP, Microsoft 365)"*. Shared mailboxes are counted on their own, as in *"2
+(Microsoft 365), plus 1 shared mailbox"*, because a shared mailbox is not one of your own accounts.
+It is counts and protocol names, nothing else: no address, no server name, no account name. As always the **Preview** in the report window shows the
 complete text before you send it, so you can read exactly what is going.
 ([#639](https://github.com/kellylford/QuickMail/issues/639))
 

--- a/docs/release-notes-v0.8.43.md
+++ b/docs/release-notes-v0.8.43.md
@@ -2,6 +2,20 @@
 
 <!-- Add "What is new" sections here (Changed/Fixed/New), then the Reporting Issues footer, then the Download footer last. -->
 
+## Changed: a bug report now says which kind of account you use
+
+A report sent with **Report a Bug** already describes the setting it happened in — your QuickMail
+version, your Windows version, the theme, the view, the sort order, and where messages open. It did
+not say how your accounts connect, and that turns out to be one of the first things worth knowing:
+an account connected over IMAP, over POP3, and through Microsoft 365 genuinely behave differently
+from one another, so a report that leaves it out can take a while to place.
+
+Reports now include one more line — how many accounts you have set up and the protocols they use,
+for example *"2 (IMAP, Microsoft 365)"*. It is the protocol names and a count, nothing else: no
+address, no server name, no account name. As always the **Preview** in the report window shows the
+complete text before you send it, so you can read exactly what is going.
+([#639](https://github.com/kellylford/QuickMail/issues/639))
+
 ---
 
 ## Reporting Issues


### PR DESCRIPTION
Closes #639.

Triaging #637 needed one fact the report did not carry: Graph or IMAP. Backend now changes behavior in draft handling, folder semantics, rules, and attachment fetch, so the Environment section gains one line:

```
- Accounts: 2 (IMAP, Microsoft 365)
```

The user's own accounts as a count plus the distinct protocols in use. Shared mailboxes are counted separately — `1 (Microsoft 365), plus 2 shared mailboxes` — since a shared mailbox is not one of the user's own accounts and reads through its parent's token, which is worth knowing up front when triaging. The clause is omitted when there are none.

Nothing else goes in the string. No address, host name, or display name, because the block is published verbatim into a public issue. Kinds render in `BackendKind` order rather than account order, so one setup always produces one line and two reports from the same user never read as two different configurations.

### Changes

- **`BugReportContext.Accounts`** — a pre-rendered string, matching the shape `Theme`/`View`/`Sort`/`MessageOpenMode` already use, rather than introducing structured data into this context. Its doc comment carries the ordering contract for any future producer, since comparability across reports is the whole of the field's value.
- **`MainViewModel.DescribeAccounts`** — `internal static`, following `AccountsNeedingConnect`, so the redaction boundary is unit-testable without standing up the view model. `CaptureBugReportContext` populates it.
- **`BugReportService`** — emits the line only when non-empty. A context captured before accounts load, or an older one, omits it rather than rendering a bare `Accounts: ` — the same contract the message-open-mode line has had since #350.

### Tests

`BugReportAccountSummaryTests` covers count, kind naming, dedup, stable ordering, shared-mailbox counting and its singular/plural forms, and the empty case. Two of them matter more than the rest:

- A **negative test** asserting no address, host, or display name survives into the output, given an account object carrying all three. That is the redaction boundary, and it is the point of the file rather than padding.
- Two tests on **`CaptureBugReportContext`** itself, so the line joining `DescribeAccounts` to the report is pinned rather than assumed — one that the field is populated, one that it tracks the configured accounts so a fixed string would not pass. Verified by mutation: with the wiring removed both fail.

### Docs

- **`docs/privacy.html`** — the environment list names the new line, and the "never contains" bullet moved from "your account settings" to "your email addresses, server names, passwords, or tokens", with an explicit note that protocol plus count is the only account detail carried. Leaving the old wording would have made the policy false. New effective date (August 27, 2026).
- **`docs/USER-GUIDE.md`** — same addition in the Reporting Issues section, with the example and the limits.
- **`docs/release-notes-v0.8.43.md`** — a short user-facing section, placed before the Reporting Issues footer per the house ordering.

`CHANGELOG.md` is deliberately untouched: it stopped being maintained after v0.7.6 (June 2026), and `docs/release-notes-vX.Y.Z.md` is the live artifact. Say the word if you'd rather it be revived and I'll backfill separately.

### Verification

Release build of `QuickMail.csproj`: 0 errors, 0 CA warnings. Targeted test runs green; CI carries the full suite.

One deviation from the issue text: it sketched raw enum names (`MicrosoftGraph`, `ImapSmtp`). The implementation uses the labels `AccountPropertiesBuilder` already shows users — "Microsoft 365", "IMAP", "POP3" — so the report reads the same way the Account Properties dialog does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
