### PR TITLE
Fix #636: keep the sender's address with the cached message

### DIFF
--- a/QuickMail.Tests/DetailFromAddressRepairTests.cs
+++ b/QuickMail.Tests/DetailFromAddressRepairTests.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using QuickMail.Helpers;
+using QuickMail.Models;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// Issue #636: a detail cached before the from_addr column existed serves the summary's
+/// display-name-only From, so the same message showed a full address when opened from the server
+/// and a bare name when opened from cache. Those rows repair themselves on the next open.
+/// </summary>
+public class DetailFromAddressRepairTests
+{
+    private sealed class RecordingMail : StubImapMailServiceBase
+    {
+        public int ForegroundFetches;
+        public int BackgroundFetches;
+        public Exception? FetchThrows;
+        public string FreshFrom = "Kelly Ford <kelly@example.com>";
+
+        private Task<MailMessageDetail> Fetch(Guid accountId, string folderName, string messageId)
+        {
+            if (FetchThrows != null) return Task.FromException<MailMessageDetail>(FetchThrows);
+            return Task.FromResult(new MailMessageDetail
+            {
+                AccountId = accountId, FolderName = folderName, MessageId = messageId,
+                From = FreshFrom, PlainTextBody = "fresh body",
+            });
+        }
+
+        public override Task<MailMessageDetail> GetMessageDetailAsync(
+            Guid accountId, string folderName, string messageId, CancellationToken ct = default)
+        {
+            ForegroundFetches++;
+            return Fetch(accountId, folderName, messageId);
+        }
+
+        public override Task<MailMessageDetail> PrefetchMessageDetailAsync(
+            Guid accountId, string folderName, string messageId, CancellationToken ct = default)
+        {
+            BackgroundFetches++;
+            return Fetch(accountId, folderName, messageId);
+        }
+    }
+
+    private sealed class RecordingStore : StubLocalStoreService
+    {
+        public MailMessageDetail? Upserted;
+        public override Task UpsertDetailAsync(MailMessageDetail detail)
+        {
+            Upserted = detail;
+            return Task.CompletedTask;
+        }
+    }
+
+    private static MailMessageDetail Cached(string from) => new()
+    {
+        AccountId = Guid.NewGuid(), FolderName = "Inbox", MessageId = "1",
+        From = from, PlainTextBody = "cached body",
+    };
+
+    [Fact]
+    public async Task ANameOnlyFrom_IsRefetchedAndReCached()
+    {
+        var mail = new RecordingMail();
+        var store = new RecordingStore();
+
+        var result = await DetailFromAddressRepair.RepairAsync(
+            Cached("Kelly Ford"), store, mail, background: false, CancellationToken.None);
+
+        Assert.Equal("Kelly Ford <kelly@example.com>", result.From);
+        Assert.Equal(1, mail.ForegroundFetches);
+        Assert.Equal("Kelly Ford <kelly@example.com>", store.Upserted?.From);
+    }
+
+    [Fact]
+    public async Task AFromThatAlreadyHasAnAddress_IsLeftAlone()
+    {
+        var mail = new RecordingMail();
+        var store = new RecordingStore();
+
+        var result = await DetailFromAddressRepair.RepairAsync(
+            Cached("Kelly Ford <kelly@example.com>"), store, mail, background: false, CancellationToken.None);
+
+        Assert.Equal("Kelly Ford <kelly@example.com>", result.From);
+        Assert.Equal(0, mail.ForegroundFetches);
+        Assert.Null(store.Upserted);
+    }
+
+    [Fact]
+    public async Task AnEmptyFrom_IsLeftAlone()
+    {
+        // A detail whose summary row is gone — a deleted message whose cached body still backs a
+        // calendar event — reads as an empty From. Re-fetching it would fail on every open, and
+        // there was no From header to recover in the first place.
+        var mail = new RecordingMail();
+        var store = new RecordingStore();
+
+        var result = await DetailFromAddressRepair.RepairAsync(
+            Cached(string.Empty), store, mail, background: false, CancellationToken.None);
+
+        Assert.Equal(string.Empty, result.From);
+        Assert.Equal(0, mail.ForegroundFetches);
+    }
+
+    [Fact]
+    public async Task AFailedFetch_KeepsTheCachedMessage()
+    {
+        // POP3's cache is the only copy, and an IMAP message may be gone from the server. A
+        // name-only From is worse than a full one and far better than an empty message.
+        var mail = new RecordingMail { FetchThrows = new InvalidOperationException("gone") };
+        var store = new RecordingStore();
+
+        var result = await DetailFromAddressRepair.RepairAsync(
+            Cached("Kelly Ford"), store, mail, background: false, CancellationToken.None);
+
+        Assert.Equal("Kelly Ford", result.From);
+        Assert.Equal("cached body", result.PlainTextBody);
+        Assert.Null(store.Upserted);
+    }
+
+    [Fact]
+    public async Task TheBackgroundPath_UsesThePrefetchLease_SoPrefetchDoesNotMarkMessagesRead()
+    {
+        var mail = new RecordingMail();
+        var store = new RecordingStore();
+
+        await DetailFromAddressRepair.RepairAsync(
+            Cached("Kelly Ford"), store, mail, background: true, CancellationToken.None);
+
+        Assert.Equal(1, mail.BackgroundFetches);
+        Assert.Equal(0, mail.ForegroundFetches);
+    }
+}

--- a/QuickMail.Tests/StubServices.cs
+++ b/QuickMail.Tests/StubServices.cs
@@ -67,8 +67,11 @@ class StubImapMailServiceBase : IMailService
     // were actually visited (#516 startup sync scope) without reimplementing IMailService.
     public virtual Task<List<MailMessageSummary>> GetMessagesSinceDateAsync(Guid accountId, string folderName, DateTime since, CancellationToken ct = default) => _inner.GetMessagesSinceDateAsync(accountId, folderName, since, ct);
     public virtual Task<List<MailMessageSummary>> GetMessagesSinceAsync(Guid accountId, string folderName, string sinceMessageId, int initialCount, CancellationToken ct = default) => _inner.GetMessagesSinceAsync(accountId, folderName, sinceMessageId, initialCount, ct);
-    public Task<MailMessageDetail> GetMessageDetailAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default) => _inner.GetMessageDetailAsync(accountId, folderName, messageId, ct);
-    public Task<MailMessageDetail> PrefetchMessageDetailAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default) => _inner.PrefetchMessageDetailAsync(accountId, folderName, messageId, ct);
+    // Virtual: a double needs to serve a specific detail, and to tell the two apart — the #636
+    // repair must use the prefetch lease in the background so repairing a cached row does not
+    // mark it read behind the user's back.
+    public virtual Task<MailMessageDetail> GetMessageDetailAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default) => _inner.GetMessageDetailAsync(accountId, folderName, messageId, ct);
+    public virtual Task<MailMessageDetail> PrefetchMessageDetailAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default) => _inner.PrefetchMessageDetailAsync(accountId, folderName, messageId, ct);
     public Task MarkReadAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default) => _inner.MarkReadAsync(accountId, folderName, messageId, ct);
     public Task MarkReadBatchAsync(Guid accountId, string folderName, IList<string> messageIds, CancellationToken ct = default) => _inner.MarkReadBatchAsync(accountId, folderName, messageIds, ct);
     public Task SetMessageFlaggedAsync(Guid accountId, string folderName, string messageId, bool flagged, CancellationToken ct = default) => _inner.SetMessageFlaggedAsync(accountId, folderName, messageId, flagged, ct);

--- a/QuickMail.Tests/UnitTest1.cs
+++ b/QuickMail.Tests/UnitTest1.cs
@@ -605,6 +605,63 @@ public class LocalStoreServiceTests
     }
 
     [Fact]
+    public async Task DetailFrom_RoundTripsTheFullAddress_NotTheSummaryDisplayName()
+    {
+        // Issue #636: the detail row had no From column, so a cache-served open handed the reading
+        // pane, Properties and the reply To field the summary's display-name-only value. Opening the
+        // same message straight from IMAP gave the full address — the "sometimes" in the report.
+        var tempDir = Path.Combine(Path.GetTempPath(), $"QuickMailTests-{Guid.NewGuid():N}");
+        var store   = new LocalStoreService(new ProfileContext(tempDir));
+        store.Initialize();
+
+        var acct = Guid.NewGuid();
+        await store.UpsertSummariesAsync([new MailMessageSummary
+        {
+            MessageId = "7", AccountId = acct, FolderName = "Inbox",
+            From = "Kelly Ford",                       // display name alone, as the list column wants
+            Subject = "s", Date = DateTimeOffset.UtcNow,
+        }]);
+        await store.UpsertDetailAsync(new MailMessageDetail
+        {
+            MessageId = "7", AccountId = acct, FolderName = "Inbox",
+            From = "Kelly Ford <kelly@example.com>",
+            To = "you@example.com", PlainTextBody = "body",
+        });
+
+        var loaded = await store.LoadDetailAsync(acct, "Inbox", "7");
+        Assert.NotNull(loaded);
+        Assert.Equal("Kelly Ford <kelly@example.com>", loaded!.From);
+    }
+
+    [Fact]
+    public async Task DetailFrom_FallsBackToTheSummary_ForRowsWrittenBeforeFromAddrExisted()
+    {
+        // A detail row cached by an older build has from_addr = '' and cannot be repaired from the
+        // database — the address is stored nowhere else. Serving the summary's display name keeps
+        // such a message readable; MainViewModel re-fetches it on open to fill the address back in.
+        var tempDir = Path.Combine(Path.GetTempPath(), $"QuickMailTests-{Guid.NewGuid():N}");
+        var store   = new LocalStoreService(new ProfileContext(tempDir));
+        store.Initialize();
+
+        var acct = Guid.NewGuid();
+        await store.UpsertSummariesAsync([new MailMessageSummary
+        {
+            MessageId = "8", AccountId = acct, FolderName = "Inbox",
+            From = "Kelly Ford", Subject = "s", Date = DateTimeOffset.UtcNow,
+        }]);
+        await store.UpsertDetailAsync(new MailMessageDetail
+        {
+            MessageId = "8", AccountId = acct, FolderName = "Inbox",
+            From = string.Empty,                       // what a pre-#636 row looks like on disk
+            To = "you@example.com", PlainTextBody = "body",
+        });
+
+        var loaded = await store.LoadDetailAsync(acct, "Inbox", "8");
+        Assert.NotNull(loaded);
+        Assert.Equal("Kelly Ford", loaded!.From);
+    }
+
+    [Fact]
     public async Task CountSummariesByFolder_GroupsPerFolderForOneAccount()
     {
         // #462 sweep instrumentation: one grouped query yields every folder's cached count.

--- a/QuickMail/Helpers/DetailFromAddressRepair.cs
+++ b/QuickMail/Helpers/DetailFromAddressRepair.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using QuickMail.Models;
+using QuickMail.Services;
+
+namespace QuickMail.Helpers;
+
+/// <summary>
+/// Fills the sender's address back into a cache-served message detail that has only a display name.
+/// <para>
+/// Detail rows written before the <c>from_addr</c> column existed (issue #636) had no From of their
+/// own: <c>LocalStoreService.LoadDetailAsync</c> took it from <c>MessageSummary.from_disp</c>, which
+/// holds the display name alone because that is what the message list's From column wants. So the
+/// same message showed "Kelly Ford &lt;kelly@example.com&gt;" when opened straight from the server
+/// and "Kelly Ford" when served from cache — and a reply started from the cached copy addressed a
+/// bare name the address box could not turn into a chip.
+/// </para>
+/// <para>
+/// The address is stored nowhere else in the database, so such a row can only be repaired by
+/// re-fetching it. Lives here rather than on a view model because both cache-first load paths need
+/// it: the reading pane and tabs (MainViewModel) and standalone windows (MessageWindow).
+/// </para>
+/// </summary>
+public static class DetailFromAddressRepair
+{
+    /// <summary>
+    /// Returns <paramref name="detail"/> unchanged when its From already carries an address, and a
+    /// freshly fetched, re-cached copy when it does not.
+    /// <para>
+    /// An empty From is left alone: the message had no From header to recover, and a detail whose
+    /// summary row is gone — a deleted message whose cached body still backs a calendar event —
+    /// reads as empty here, so re-fetching it would fail on every open.
+    /// </para>
+    /// <para>
+    /// The cached detail is returned when the fetch fails, so a message deleted from the server, or
+    /// one on a POP3 account where the cache is the only copy, still opens. A name-only From is
+    /// worse than a full one and far better than an empty message.
+    /// </para>
+    /// </summary>
+    /// <param name="background">Use the background IMAP lease, for prefetch. Foreground fetches also
+    /// mark the message read, which is correct when the user is opening it and wrong when they are
+    /// not.</param>
+    public static async Task<MailMessageDetail> RepairAsync(
+        MailMessageDetail detail, ILocalStoreService store, IMailService mail,
+        bool background, CancellationToken ct)
+    {
+        if (string.IsNullOrEmpty(detail.From) || detail.From.Contains('@', StringComparison.Ordinal))
+            return detail;
+
+        try
+        {
+            var fresh = background
+                ? await mail.PrefetchMessageDetailAsync(
+                      detail.AccountId, detail.FolderName, detail.MessageId, ct)
+                : await mail.GetMessageDetailAsync(
+                      detail.AccountId, detail.FolderName, detail.MessageId, ct);
+            await store.UpsertDetailAsync(fresh);
+            return fresh;
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex)
+        {
+            LogService.Log($"DetailFromAddressRepair {detail.FolderName}/{detail.MessageId}", ex);
+            return detail;
+        }
+    }
+}

--- a/QuickMail/Helpers/MessagePropertiesBuilder.cs
+++ b/QuickMail/Helpers/MessagePropertiesBuilder.cs
@@ -14,7 +14,11 @@ public static class MessagePropertiesBuilder
     {
         var headers = new List<PropertyItem>
         {
-            new("From",       NoneIfBlank(summary.From)),
+            // Detail first: the summary's From is the display name alone, which is what the message
+            // list's From column wants but leaves Properties with no address to show (issue #636).
+            // The summary is the fallback for a message whose detail has not been loaded.
+            new("From",       NoneIfBlank(detail is not null && !string.IsNullOrWhiteSpace(detail.From)
+                                              ? detail.From : summary.From)),
             new("To",         NoneIfBlank(summary.To)),
             new("Cc",         detail is not null ? NoneIfBlank(detail.Cc) : "(not loaded)"),
             new("Reply-To",   detail is not null ? NoneIfBlank(detail.ReplyTo) : "(not loaded)"),

--- a/QuickMail/Services/LocalStoreService.cs
+++ b/QuickMail/Services/LocalStoreService.cs
@@ -211,6 +211,18 @@ public class LocalStoreService : ILocalStoreService
         // MessageDetail by CREATE/INSERT/DROP/RENAME against a fixed column list, so a column added
         // before it would be dropped again and stay missing for the rest of the session.
         RunMigration(conn, "ALTER TABLE MessageDetail ADD COLUMN mime_bytes BLOB DEFAULT NULL;");
+
+        // The sender's full address ("Kelly Ford <kelly@example.com>"), issue #636. The detail row
+        // used to have no From column at all: LoadDetailAsync read it from MessageSummary.from_disp,
+        // which holds the display name alone because that is what the message list's From column
+        // wants. So the same message showed a full address when opened straight from IMAP and a bare
+        // name when served from cache, and a reply composed from the cached copy addressed a name
+        // with no mailbox behind it.
+        //
+        // Rows written before this column keep an empty string; LoadDetailAsync falls back to
+        // from_disp for them, and MainViewModel re-fetches from the server on open so the row
+        // repairs itself. AFTER RunDataMigrations for the same reason as mime_bytes above.
+        RunMigration(conn, "ALTER TABLE MessageDetail ADD COLUMN from_addr TEXT NOT NULL DEFAULT '';");
     }
 
     // SQLite's PRAGMA user_version stores a single integer per database. We use it as a
@@ -882,9 +894,10 @@ public class LocalStoreService : ILocalStoreService
         await using var tx = await conn.BeginTransactionAsync();
         await using var cmd = conn.CreateCommand();
         cmd.CommandText = """
-            INSERT INTO MessageDetail(unique_id, account_id, folder_name, to_addr, cc, reply_to, plain_body, html_body, attachments_json, calendar_ics)
-            VALUES($uid, $aid, $fn, $to, $cc, $rt, $plain, $html, $attjson, $ics)
+            INSERT INTO MessageDetail(unique_id, account_id, folder_name, from_addr, to_addr, cc, reply_to, plain_body, html_body, attachments_json, calendar_ics)
+            VALUES($uid, $aid, $fn, $from, $to, $cc, $rt, $plain, $html, $attjson, $ics)
             ON CONFLICT(unique_id, account_id, folder_name) DO UPDATE SET
+                from_addr        = excluded.from_addr,
                 to_addr          = excluded.to_addr,
                 cc               = excluded.cc,
                 reply_to         = excluded.reply_to,
@@ -896,6 +909,7 @@ public class LocalStoreService : ILocalStoreService
         cmd.Parameters.AddWithValue("$uid",    detail.MessageId);
         cmd.Parameters.AddWithValue("$aid",    detail.AccountId.ToString());
         cmd.Parameters.AddWithValue("$fn",     detail.FolderName);
+        cmd.Parameters.AddWithValue("$from",   detail.From);
         cmd.Parameters.AddWithValue("$to",     detail.To);
         cmd.Parameters.AddWithValue("$cc",     detail.Cc);
         cmd.Parameters.AddWithValue("$rt",     detail.ReplyTo);
@@ -931,7 +945,7 @@ public class LocalStoreService : ILocalStoreService
         cmd.CommandText = """
             SELECT d.to_addr, d.cc, d.reply_to, d.plain_body, d.html_body,
                    s.from_disp, s.subject, s.date_ticks, s.is_read, d.attachments_json, d.calendar_ics,
-                   s.internet_message_id
+                   s.internet_message_id, d.from_addr
             FROM MessageDetail d
             LEFT JOIN MessageSummary s USING (unique_id, account_id, folder_name)
             WHERE d.unique_id=$uid AND d.account_id=$aid AND d.folder_name=$fn;
@@ -974,7 +988,11 @@ public class LocalStoreService : ILocalStoreService
             ReplyTo       = r.GetString(2),
             PlainTextBody = r.GetString(3),
             HtmlBody      = r.GetString(4),
-            From          = r.IsDBNull(5) ? string.Empty : r.GetString(5),
+            // The detail's own full address where the row has one; the summary's display-name-only
+            // column for rows written before from_addr existed (issue #636). MainViewModel re-fetches
+            // on open when what comes back has no address in it, so a legacy row repairs itself.
+            From          = FirstNonEmpty(r.IsDBNull(12) ? null : r.GetString(12),
+                                          r.IsDBNull(5)  ? null : r.GetString(5)),
             Subject       = r.IsDBNull(6) ? "(no subject)" : r.GetString(6),
             Date          = r.IsDBNull(7) ? DateTimeOffset.MinValue : new DateTimeOffset(r.GetInt64(7), TimeSpan.Zero),
             IsRead        = !r.IsDBNull(8) && r.GetInt64(8) != 0,
@@ -988,6 +1006,11 @@ public class LocalStoreService : ILocalStoreService
             CalendarInvite = string.IsNullOrWhiteSpace(calendarIcs) ? null : IcsModel.Parse(calendarIcs),
         };
     }
+
+    private static string FirstNonEmpty(string? preferred, string? fallback) =>
+        !string.IsNullOrWhiteSpace(preferred) ? preferred
+        : !string.IsNullOrWhiteSpace(fallback) ? fallback
+        : string.Empty;
 
     /// <summary>
     /// Stores (or clears, when <paramref name="mimeBytes"/> is null) the raw message bytes on an

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -5407,6 +5407,9 @@ public partial class MainViewModel : ObservableObject, IDisposable
                     summary.AccountId, summary.FolderName, summary.MessageId)
                     ?? await _imap.GetMessageDetailAsync(
                         summary.AccountId, summary.FolderName, summary.MessageId, token);
+                // A pre-from_addr cache row carries a bare display name where the sender's address
+                // belongs (issue #636); re-fetch it so the header and any reply get a real address.
+                detail = await RepairMissingFromAddressAsync(detail, background: false, token);
                 // Await (not fire-and-forget) so the detail is definitely in the cache
                 // before the user acts on the message (e.g. accepts a calendar invite).
                 // The calendar harvest reads calendar_ics from this row; if the store
@@ -5537,7 +5540,15 @@ public partial class MainViewModel : ObservableObject, IDisposable
         {
             var cached = await _localStore.LoadDetailAsync(
                 summary.AccountId, summary.FolderName, summary.MessageId);
-            if (cached != null || ct.IsCancellationRequested) return;
+            if (ct.IsCancellationRequested) return;
+            if (cached != null)
+            {
+                // Cached, but possibly a pre-from_addr row whose From is a bare display name
+                // (issue #636). Repairing it here means the reading pane and a reply get a real
+                // address without the user waiting for a fetch at open time.
+                await RepairMissingFromAddressAsync(cached, background: true, ct);
+                return;
+            }
 
             var detail = await _imap.PrefetchMessageDetailAsync(
                 summary.AccountId, summary.FolderName, summary.MessageId, ct);
@@ -7476,7 +7487,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
                           && MessageDetail?.AccountId == msg.AccountId
                           && MessageDetail?.FolderName == msg.FolderName)
                 ? MessageDetail
-                : await _localStore.LoadDetailAsync(msg.AccountId, msg.FolderName, msg.MessageId);
+                : await LoadDetailForPropertiesAsync(msg);
 
             var accountName = Accounts.FirstOrDefault(a => a.Id == msg.AccountId)?.AccountLabel
                               ?? "Unknown";
@@ -7636,6 +7647,22 @@ public partial class MainViewModel : ObservableObject, IDisposable
         ComposeRequested?.Invoke(model);
     }
 
+    /// <summary>Cached detail for the Properties dialog, repaired first so the From row shows a real
+    /// address rather than the display name the summary carries (issue #636).</summary>
+    private async Task<MailMessageDetail?> LoadDetailForPropertiesAsync(MailMessageSummary msg)
+    {
+        var detail = await _localStore.LoadDetailAsync(msg.AccountId, msg.FolderName, msg.MessageId);
+        if (detail == null) return null;
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        return await RepairMissingFromAddressAsync(detail, background: false, cts.Token);
+    }
+
+    /// <summary>Fills the sender's address back into a cache-served detail that has only a display
+    /// name (issue #636). See <see cref="DetailFromAddressRepair"/>.</summary>
+    private Task<MailMessageDetail> RepairMissingFromAddressAsync(
+        MailMessageDetail detail, bool background, CancellationToken ct) =>
+        DetailFromAddressRepair.RepairAsync(detail, _localStore, _imap, background, ct);
+
     // Returns MessageDetail if already loaded for the selected message,
     // otherwise fetches it (cache then IMAP) so compose can always proceed.
     // Deliberately bypasses SelectMessageCommand to avoid concurrent-execution
@@ -7669,6 +7696,11 @@ public partial class MainViewModel : ObservableObject, IDisposable
                 detail = await _imap.GetMessageDetailAsync(
                     summary.AccountId, summary.FolderName, summary.MessageId, cts.Token);
                 _localStore.UpsertDetailAsync(detail).LogFaults("local store: upsert detail");
+            }
+            else
+            {
+                using var repairCts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+                detail = await RepairMissingFromAddressAsync(detail, background: false, repairCts.Token);
             }
 
             return detail;

--- a/QuickMail/Views/MessageWindow.xaml.cs
+++ b/QuickMail/Views/MessageWindow.xaml.cs
@@ -310,6 +310,15 @@ public partial class MessageWindow : Window
                 detail = await _imap.GetMessageDetailAsync(
                     summary.AccountId, summary.FolderName, summary.MessageId, ct);
             }
+            else
+            {
+                // A detail cached before the from_addr column existed carries the summary's display
+                // name in place of the sender's address, so this window's From line — and a reply
+                // started from it — would show a bare name (issue #636). Re-fetching is the only
+                // repair: the address is stored nowhere else in the database.
+                detail = await DetailFromAddressRepair.RepairAsync(
+                    detail, _localStore, _imap, background: false, ct);
+            }
 
             ct.ThrowIfCancellationRequested();
             if (detail == null) return;

--- a/docs/release-notes-v0.8.43.md
+++ b/docs/release-notes-v0.8.43.md
@@ -17,6 +17,21 @@ It is counts and protocol names, nothing else: no address, no server name, no ac
 complete text before you send it, so you can read exactly what is going.
 ([#639](https://github.com/kellylford/QuickMail/issues/639))
 
+## Fixed: a sender's email address sometimes went missing
+
+Opening a message, or replying to one, sometimes showed the sender's full address — name and email
+address together, with Message Properties able to report it — and sometimes showed nothing but a
+name. Replying to one of the latter put a bare name in the **To** field, where it stayed as ordinary
+typed text instead of becoming an address you could act on.
+
+Which one you got depended on whether the message was being read from the server or from QuickMail's
+own copy on your PC, so the same message could behave either way at different times. QuickMail now
+keeps the sender's address with its copy of the message. Messages saved before this release get
+their address filled back in the next time they are opened.
+
+Message Properties also reports the sender's full address now, matching the **To** line right below
+it. ([#636](https://github.com/kellylford/QuickMail/issues/636))
+
 ---
 
 ## Reporting Issues


### PR DESCRIPTION
Fixes #636.

## Root cause

The `MessageDetail` table had **no From column**. `LocalStoreService.LoadDetailAsync` filled the detail's `From` from `MessageSummary.from_disp`, which holds the display name alone — that is what the message list's From column wants (`FormatAddressListDisplay`), and it is deliberately different from the full form the detail path builds (`FormatAddressList`).

So the same message showed:

- `Kelly Ford <kelly@example.com>` when opened straight from the server, and
- `Kelly Ford` when served from the local cache.

That is the "sometimes" in the report. Graph accounts are unaffected — Graph stores the full header string in both. IMAP and POP3 both split.

## What it broke

- Reading-pane and standalone-window From lines (both bind `MessageDetail.From`).
- The reply **To** field. A bare multi-word name fails MimeKit's parse, so `TokenizedAddressBox` drops it back into the input box as ordinary typed text — no chip, no address, no context menu. A single-word sender parses as an address with no `@`, is skipped, and vanishes silently.
- Message Properties, which was broken on *every* open, not just cache hits: `MessagePropertiesBuilder` read `summary.From` while the To row right below it used the full form.

## Measured on a real profile

- 18,839 of 23,824 cached summaries have a `from_disp` with no `@`.
- 209 of 244 cached details would serve a name-only From.
- 59 of those also have an empty Reply-To, so a reply addresses a bare name.

## The fix

- New `from_addr` column on `MessageDetail`, written by `UpsertDetailAsync`, preferred by `LoadDetailAsync`. The `ALTER` sits after `RunDataMigrations` for the same reason `mime_bytes` does — the 1→2 rebuild works against a fixed column list.
- Rows written before the column keep an empty `from_addr` and fall back to `from_disp`, so nothing regresses for them.
- Those rows cannot be repaired from the database — the address is stored nowhere else — so `DetailFromAddressRepair` re-fetches and re-caches on the next open, from every cache-first path: reading pane/tabs, Properties, compose's `EnsureDetail`, `MessageWindow`, and the background prefetch (which uses the prefetch lease so repairing does not mark anything read).
- An **empty** From is left alone: there was no From header to recover, and a detail whose summary row is gone — a deleted message whose cached body still backs a calendar event — reads as empty here, so re-fetching it would fail on every open.
- A **failed** fetch returns the cached detail. A POP3 cache is the only copy, and an IMAP message may be gone from the server; a name-only From beats a blank message.
- `MessagePropertiesBuilder` now takes From from the detail.

## Verification

- Migration applied to a copy of a real 21 MB profile database: `from_addr` added, legacy rows still load with bodies intact and the `from_disp` fallback in place.
- 7 new tests — `DetailFromAddressRepairTests` (5: refetch, already-good, empty, failed fetch, background lease) and 2 in `LocalStoreServiceTests` (round-trip, legacy fallback).
- Full suite: 3301 passed. The 2–3 failures are pre-existing WPF focus/layout flakes (`TabStripNavigationTests`, `ComposeWindowEnterSendGuardTests`, `AccountManagerTabOrderTests`) that fail on `main` too, with the failing member varying run to run.

Release note added to `docs/release-notes-v0.8.43.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)