### PR TITLE
Fix #644: the address book speaks its contact rows

### DIFF
--- a/QuickMail.Tests/AddressBookRowSpeechTests.cs
+++ b/QuickMail.Tests/AddressBookRowSpeechTests.cs
@@ -16,6 +16,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Windows;
+using System.Windows.Automation;
 using System.Windows.Automation.Peers;
 using System.Windows.Controls;
 using System.Windows.Threading;
@@ -85,6 +86,59 @@ public class AddressBookRowSpeechTests
             AssertNoTypeNames(names);
         }
         finally { Cleanup(window, dir); }
+    }
+
+    /// <summary>
+    /// The mechanism, not just the outcome. For the Groups and group-members lists the composed
+    /// name happens to equal the item's ToString(), so the peer-name tests above still pass if
+    /// someone moves AutomationProperties.Name back inside the DataTemplate — the ToString()
+    /// fallback silently covers for it, and #644 comes back the next time a list gains a richer
+    /// name than its ToString(). This asserts what actually has to be true: every realized row
+    /// CONTAINER carries the name itself.
+    /// </summary>
+    [StaFact]
+    public void EveryList_PutsTheNameOnTheRowContainer_NotInsideTheTemplate()
+    {
+        var (window, dir) = BuildWindow();
+        try
+        {
+            AssertContainersAreNamed(window, "ContactList");
+
+            SelectGroupsTab(window);
+            AssertContainersAreNamed(window, "GroupsList");
+
+            var groups = window.FindName("GroupsList") as ListView;
+            Assert.NotNull(groups);
+            groups!.SelectedItem = groups.Items.Cast<GroupModel>().First(g => g.Name == "Work");
+            window.UpdateLayout();
+            Drain();
+
+            AssertContainersAreNamed(window, "GroupMembersList");
+        }
+        finally { Cleanup(window, dir); }
+    }
+
+    private static void AssertContainersAreNamed(Window window, string listName)
+    {
+        var list = window.FindName(listName) as ListView;
+        Assert.NotNull(list);
+        list!.UpdateLayout();
+        Drain();
+
+        var containers = list.Items
+            .Cast<object>()
+            .Select(item => list.ItemContainerGenerator.ContainerFromItem(item) as ListViewItem)
+            .ToList();
+
+        Assert.NotEmpty(containers);
+        foreach (var container in containers)
+        {
+            Assert.NotNull(container);
+            Assert.False(
+                string.IsNullOrWhiteSpace(AutomationProperties.GetName(container!)),
+                $"A row container in {listName} has no AutomationProperties.Name — the name is " +
+                "inside the DataTemplate again, where a screen reader never reads it (issue #644).");
+        }
     }
 
     // ── helpers ──────────────────────────────────────────────────────────────

--- a/QuickMail.Tests/AddressBookRowSpeechTests.cs
+++ b/QuickMail.Tests/AddressBookRowSpeechTests.cs
@@ -1,0 +1,180 @@
+// Issue #644: the address book's contact rows were announced as
+// "QuickMail.Models.ContactModel 1 of 35".
+//
+// The composed accessible name was set on a Grid *inside* the DataTemplate. A screen
+// reader reads the item's automation peer, whose name comes from the ROW CONTAINER
+// (the ListViewItem) and, failing that, from the item's ToString() — never from an
+// element inside the template. Every other list in the app puts the name on the
+// container via an ItemContainerStyle setter; these three did not.
+//
+// These tests read the live ListViewItemAutomationPeer names — the ground truth a
+// screen reader speaks — rather than eyeballing the template, which is what let this
+// ship: on screen the rows looked (and still look) perfect.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Windows;
+using System.Windows.Automation.Peers;
+using System.Windows.Controls;
+using System.Windows.Threading;
+using QuickMail.Models;
+using QuickMail.Services;
+using QuickMail.ViewModels;
+using QuickMail.Views;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+// Part of the WpfTests collection so it never runs concurrently with another WPF/STA
+// test: this class Show()s a real Window on its own STA thread (issue #211).
+[Collection("WpfTests")]
+public class AddressBookRowSpeechTests
+{
+    [StaFact]
+    public void ContactList_ItemPeerNames_SpeakTheContact()
+    {
+        var (window, dir) = BuildWindow();
+        try
+        {
+            var names = ItemPeerNames(window, "ContactList");
+
+            // The stamped AccessibleName: name, address, and which book it came from.
+            Assert.Contains("Alice Adams, alice@example.com, Local address book", names);
+
+            // A prior-recipient contact has no display name; the address carries the row.
+            Assert.Contains("zeta@example.com, Local address book", names);
+
+            AssertNoTypeNames(names);
+        }
+        finally { Cleanup(window, dir); }
+    }
+
+    [StaFact]
+    public void GroupsList_ItemPeerNames_SpeakTheGroup()
+    {
+        var (window, dir) = BuildWindow();
+        try
+        {
+            SelectGroupsTab(window);
+            var names = ItemPeerNames(window, "GroupsList");
+
+            Assert.Contains(names, n => n.StartsWith("Work", StringComparison.Ordinal));
+            AssertNoTypeNames(names);
+        }
+        finally { Cleanup(window, dir); }
+    }
+
+    [StaFact]
+    public void GroupMembersList_ItemPeerNames_SpeakTheMember()
+    {
+        var (window, dir) = BuildWindow();
+        try
+        {
+            SelectGroupsTab(window);
+
+            var groups = window.FindName("GroupsList") as ListView;
+            Assert.NotNull(groups);
+            groups!.SelectedItem = groups.Items.Cast<GroupModel>().First(g => g.Name == "Work");
+            window.UpdateLayout();
+            Drain();
+
+            var names = ItemPeerNames(window, "GroupMembersList");
+            Assert.Contains("Alice Adams <alice@example.com>", names);
+            AssertNoTypeNames(names);
+        }
+        finally { Cleanup(window, dir); }
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private static (AddressBookWindow window, string dir) BuildWindow()
+    {
+        // MainWindow-derived item container styles resolve against the implicit styles in
+        // ThemedControls, merged at runtime by ThemeService before the first window exists.
+        WpfTestHost.EnsureStyles("AccessibleStyles", "ThemedControls");
+
+        var dir = Path.Combine(Path.GetTempPath(), $"QM-AddressBookSpeech-{Guid.NewGuid():N}");
+        var svc = new ContactService(new ProfileContext(dir));
+
+        foreach (var (name, email) in new[]
+                 {
+                     ("Alice Adams", "alice@example.com"),
+                     ("Bob Baker",   "bob@example.com"),
+                     ("",            "zeta@example.com"),
+                 })
+        {
+            svc.UpsertContactAsync(new ContactModel { DisplayName = name, EmailAddress = email })
+               .GetAwaiter().GetResult();
+        }
+
+        var workId = svc.CreateGroupAsync("Work").GetAwaiter().GetResult();
+        var alice  = svc.LoadAllContactsAsync().GetAwaiter().GetResult()
+                        .First(c => c.EmailAddress == "alice@example.com");
+        svc.AddMemberAsync(workId, alice.Id).GetAwaiter().GetResult();
+
+        var vm = new AddressBookViewModel(svc);
+        var window = new AddressBookWindow(vm)
+        {
+            WindowStyle = WindowStyle.None, ShowInTaskbar = false, ShowActivated = false,
+        };
+        vm.LoadAsync().GetAwaiter().GetResult();
+        window.Show();
+        window.UpdateLayout();
+        Drain();
+        return (window, dir);
+    }
+
+    private static void SelectGroupsTab(Window window)
+    {
+        var tabs = window.FindName("MainTabs") as TabControl;
+        Assert.NotNull(tabs);
+        tabs!.SelectedIndex = 1;
+        window.UpdateLayout();
+        Drain();
+    }
+
+    /// <summary>
+    /// The names a screen reader speaks for the rows of the named list: the live item
+    /// automation peers, not the template's rendered text.
+    /// </summary>
+    private static List<string> ItemPeerNames(Window window, string listName)
+    {
+        var list = window.FindName(listName) as ListView;
+        Assert.NotNull(list);
+        list!.UpdateLayout();
+        Drain();
+
+        // ListView's item peer type varies with GridView, so read every child peer's name
+        // rather than filtering on a concrete peer type.
+        return (UIElementAutomationPeer.CreatePeerForElement(list).GetChildren() ?? [])
+            .Select(p => p.GetName())
+            .Where(n => !string.IsNullOrWhiteSpace(n))
+            .ToList();
+    }
+
+    /// <summary>The failure mode of #644: the row announced as its CLR type name.</summary>
+    private static void AssertNoTypeNames(List<string> names)
+    {
+        Assert.NotEmpty(names);
+        foreach (var n in names)
+            Assert.DoesNotContain("QuickMail.", n, StringComparison.Ordinal);
+    }
+
+    private static void Cleanup(Window window, string dir)
+    {
+        window.Close();
+        try { if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true); } catch { }
+    }
+
+    // Pumps the STA dispatcher until all queued work down to SystemIdle priority (layout,
+    // container generation, peer realization) has run.
+    private static void Drain()
+    {
+        var frame = new DispatcherFrame();
+        Dispatcher.CurrentDispatcher.BeginInvoke(
+            DispatcherPriority.SystemIdle, new Action(() => frame.Continue = false));
+        Dispatcher.PushFrame(frame);
+    }
+}

--- a/QuickMail.Tests/SelectorItemAccessibilityTests.cs
+++ b/QuickMail.Tests/SelectorItemAccessibilityTests.cs
@@ -127,6 +127,14 @@ public class SelectorItemAccessibilityTests
         var group = new GroupModel { Name = "Team" };
         Assert.Equal(group.Display, group.ToString());
 
+        // Contacts (issue #644). The address book stamps a richer AccessibleName onto the row
+        // container, but every other contact list falls back to ToString() — which read
+        // "QuickMail.Models.ContactModel" until this override existed.
+        Assert.Equal("Alice Adams <alice@example.com>",
+            new ContactModel { DisplayName = "Alice Adams", EmailAddress = "alice@example.com" }.ToString());
+        Assert.Equal("zeta@example.com",
+            new ContactModel { DisplayName = "", EmailAddress = "zeta@example.com" }.ToString());
+
         // Message List Fields chooser: the row-type ComboBox and the field ListBox. The field
         // rows render a CheckBox, which drives only the visual — the item's name is ToString().
         // Watched Conversations manager: the row must speak its label, count, and when it was
@@ -334,6 +342,7 @@ public class SelectorItemAccessibilityTests
             new MessageTemplate { Title = "Alpha" }.ToString(),
             new MailRule { Name = "Alpha" }.ToString(),
             new GroupModel { Name = "Alpha" }.ToString(),
+            new ContactModel { DisplayName = "Alpha", EmailAddress = "alpha@example.com" }.ToString(),
             new ProviderCatalog().Other.ToString(),
             new ConnectionAccountRow
             {

--- a/QuickMail/Models/ContactModel.cs
+++ b/QuickMail/Models/ContactModel.cs
@@ -100,4 +100,14 @@ public class ContactModel
     public string TypeAheadText => string.IsNullOrWhiteSpace(DisplayName)
         ? EmailAddress
         : DisplayName;
+
+    /// <summary>
+    /// Display text, and the last-resort accessible name for a contact row (issue #644).
+    /// A data-bound Selector item's UIA Name falls back to <c>ToString()</c> when the row
+    /// container carries no <c>AutomationProperties.Name</c> — without this override a
+    /// screen reader reads "QuickMail.Models.ContactModel". Lists that compose a richer
+    /// name (the address book stamps <see cref="AccessibleName"/>) still win; this is the
+    /// floor, not the ceiling.
+    /// </summary>
+    public override string ToString() => Display;
 }

--- a/QuickMail/QuickMail.csproj
+++ b/QuickMail/QuickMail.csproj
@@ -15,9 +15,9 @@
          System.Windows(.Media) types this codebase uses unqualified (Point, Size, Color, Brush,
          Application, MessageBox, ...). -->
     <UseWindowsForms>true</UseWindowsForms>
-    <Version>0.8.43</Version>
-    <AssemblyVersion>0.8.43</AssemblyVersion>
-    <FileVersion>0.8.43</FileVersion>
+    <Version>0.8.44</Version>
+    <AssemblyVersion>0.8.44</AssemblyVersion>
+    <FileVersion>0.8.44</FileVersion>
     <!-- Velopack needs a hand-written Main that runs VelopackApp.Build().Run() before WPF
          initializes (install/update/uninstall hooks run and may exit the process). App.xaml
          therefore compiles as Page (no generated Main) and the entry point is declared here. -->

--- a/QuickMail/Views/AddressBookWindow.xaml
+++ b/QuickMail/Views/AddressBookWindow.xaml
@@ -261,6 +261,11 @@
                         <ListView.ItemContainerStyle>
                             <Style TargetType="ListViewItem" BasedOn="{StaticResource {x:Type ListViewItem}}">
                                 <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+                                <!-- The spoken name must land on the ROW CONTAINER, not on an element
+                                     inside the DataTemplate: a screen reader reads the item peer, whose
+                                     name comes from the container and otherwise falls back to the item's
+                                     ToString() — "QuickMail.Models.ContactModel" (issue #644). -->
+                                <Setter Property="AutomationProperties.Name" Value="{Binding AccessibleName}"/>
                             </Style>
                         </ListView.ItemContainerStyle>
                         <ListView.ItemTemplate>
@@ -268,7 +273,7 @@
                                 <!-- Name | Email | Account columns. The row's accessible name is the
                                      composed field data (concise or labeled per setting), so a screen
                                      reader hears one utterance rather than three cells. -->
-                                <Grid AutomationProperties.Name="{Binding AccessibleName}">
+                                <Grid>
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="Auto" MinWidth="120" SharedSizeGroup="ContactNameCol"/>
                                         <ColumnDefinition Width="*"/>
@@ -316,12 +321,13 @@
                             <ListView.ItemContainerStyle>
                                 <Style TargetType="ListViewItem" BasedOn="{StaticResource {x:Type ListViewItem}}">
                                     <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+                                    <!-- On the container, not the template child — see the contact list above. -->
+                                    <Setter Property="AutomationProperties.Name" Value="{Binding Display}"/>
                                 </Style>
                             </ListView.ItemContainerStyle>
                             <ListView.ItemTemplate>
                                 <DataTemplate>
-                                    <StackPanel Orientation="Horizontal"
-                                                AutomationProperties.Name="{Binding Display}">
+                                    <StackPanel Orientation="Horizontal">
                                         <TextBlock Text="{Binding Name}" FontWeight="SemiBold"/>
                                         <TextBlock Text="  "/>
                                         <TextBlock Text="{Binding Display, Converter={x:Static local:GroupSubtitleConverter.Instance}}"
@@ -371,12 +377,13 @@
                             <ListView.ItemContainerStyle>
                                 <Style TargetType="ListViewItem" BasedOn="{StaticResource {x:Type ListViewItem}}">
                                     <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+                                    <!-- On the container, not the template child — see the contact list above. -->
+                                    <Setter Property="AutomationProperties.Name" Value="{Binding Display}"/>
                                 </Style>
                             </ListView.ItemContainerStyle>
                             <ListView.ItemTemplate>
                                 <DataTemplate>
-                                    <StackPanel Orientation="Horizontal"
-                                                AutomationProperties.Name="{Binding Display}">
+                                    <StackPanel Orientation="Horizontal">
                                         <TextBlock Text="{Binding DisplayName}" FontWeight="SemiBold"/>
                                         <TextBlock Text="  &lt;"/>
                                         <TextBlock Text="{Binding EmailAddress}" Opacity="0.75"/>

--- a/docs/release-notes-v0.8.44.md
+++ b/docs/release-notes-v0.8.44.md
@@ -1,0 +1,53 @@
+# QuickMail v0.8.44 Release Notes
+
+## Fixed: the address book reads out contacts again
+
+Moving through the list of contacts in the address book announced every row as
+*"QuickMail.Models.ContactModel"* followed by its position — the same seven words for all 35 of
+your contacts, with no way to tell one from the next except by opening it. The Groups list and
+the list of a group's members had the same fault waiting in them.
+
+The rows carried the right text all along; it was attached to the wrong part of the row. Screen
+readers read a list row's name from the row itself, and the address book had put the name on
+something drawn inside the row instead — which looks identical on screen, and is why this went
+unnoticed. Every other list in QuickMail already put it in the right place; these three now do
+too.
+
+A contact row reads as its name, its address, and where it came from — *"Alice Adams,
+alice@example.com, Local address book"* — or with each part labelled, if you have turned on field
+labels in the contact list. A contact saved with no name reads as its address. Groups read as
+their name and size, and a group's members read as name and address.
+
+As a safety net for any list of contacts anywhere in QuickMail, a contact with nothing else to say
+for itself now falls back to reading its name and address rather than its internal type name, so
+this particular kind of silence cannot come back through some other list.
+([#644](https://github.com/kellylford/QuickMail/issues/644))
+
+---
+
+## Reporting Issues
+
+Found a problem or have a suggestion? There are three ways to reach us — pick the one that fits:
+
+1. **Report a Bug → Send** (Help menu, inside QuickMail). Files the report for you anonymously — it includes no email address or other identifying information, so there is no way to follow up with you. **Best when you don't want any follow-up.**
+2. **Report a Bug → Copy report and open GitHub** (Help menu). Opens a pre-filled issue that you submit under your own GitHub account, so your GitHub contact information is attached. **Best when you have a GitHub account and want automatic filing plus direct contact.**
+3. **Email** [support@theideaplace.net](mailto:support@theideaplace.net). **Best when you don't mind sending email and want a personal follow-up.**
+
+Full details, including exactly what a report contains (and what it never contains), are in the [Reporting Issues section of the User Guide](https://kellylford.github.io/QuickMail/reporting-issues.html).
+
+---
+
+## Download
+
+There are four downloads. Take a regular one unless you know your PC has an ARM processor — to check, open **Settings → System → About** and read **System type**.
+
+| Download | When to use |
+|----------|-------------|
+| [**QuickMail-0.8.44-win.msi**](https://github.com/kellylford/QuickMail/releases/download/v0.8.44/QuickMail-0.8.44-win.msi) — Windows installer | Recommended for most users. A standard setup wizard with license agreement; installs per-user with no elevation required, adds the WebView2 Runtime if missing, and enables automatic updates. |
+| [**QuickMail-0.8.44-win-arm64.msi**](https://github.com/kellylford/QuickMail/releases/download/v0.8.44/QuickMail-0.8.44-win-arm64.msi) — Windows installer, ARM | The same installer for PCs with an ARM processor, such as the Snapdragon X models of Surface Laptop and Surface Pro. |
+| [**QuickMail.exe**](https://github.com/kellylford/QuickMail/releases/download/v0.8.44/QuickMail.exe) — standalone portable executable | No installation required. Copy it anywhere and run. |
+| [**QuickMail-arm64.exe**](https://github.com/kellylford/QuickMail/releases/download/v0.8.44/QuickMail-arm64.exe) — standalone portable executable, ARM | The portable version for PCs with an ARM processor. |
+
+The regular downloads run on every supported PC, ARM ones included — just not as quickly there. The ARM downloads will not start at all on a non-ARM PC, so if you are unsure, the regular one is the safe guess.
+
+All downloads include the .NET 8 runtime — you do not need to install .NET separately.

--- a/docs/release-notes-v0.8.44.md
+++ b/docs/release-notes-v0.8.44.md
@@ -3,9 +3,10 @@
 ## Fixed: the address book reads out contacts again
 
 Moving through the list of contacts in the address book announced every row as
-*"QuickMail.Models.ContactModel"* followed by its position — the same seven words for all 35 of
-your contacts, with no way to tell one from the next except by opening it. The Groups list and
-the list of a group's members had the same fault waiting in them.
+*"QuickMail.Models.ContactModel"* followed by its position — the same thing for all 35 of your
+contacts, with no way to tell one from the next except by opening it. The list of a group's
+members was silent in exactly the same way. The Groups list happened to escape it, but only by
+accident: it had the same underlying fault and was one small edit away from going silent too.
 
 The rows carried the right text all along; it was attached to the wrong part of the row. Screen
 readers read a list row's name from the row itself, and the address book had put the name on
@@ -15,8 +16,9 @@ too.
 
 A contact row reads as its name, its address, and where it came from — *"Alice Adams,
 alice@example.com, Local address book"* — or with each part labelled, if you have turned on field
-labels in the contact list. A contact saved with no name reads as its address. Groups read as
-their name and size, and a group's members read as name and address.
+labels in the contact list. A contact saved with no name reads as its address and where it came
+from. A group reads as its name and how many members it has, and a group's member reads as name
+and address.
 
 As a safety net for any list of contacts anywhere in QuickMail, a contact with nothing else to say
 for itself now falls back to reading its name and address rather than its internal type name, so


### PR DESCRIPTION
Closes [#644](https://github.com/kellylford/QuickMail/issues/644).

## The bug

Arrowing the address book's contact list announced every row as `QuickMail.Models.ContactModel`, followed by its position — the same text for all 35 contacts.

## Root cause

The composed accessible name was set on a `Grid` **inside** the `DataTemplate`:

```xml
<DataTemplate>
    <Grid AutomationProperties.Name="{Binding AccessibleName}">
```

A screen reader reads the item's automation peer, whose name comes from the **row container** (`ListViewItem`) and, failing that, from the item's `ToString()`. An element inside the template never contributes it. `ContactModel` had no `ToString()` override, so the fallback was the CLR type name.

This is the failure mode `CLAUDE.md` already warns about ("The composed spoken string must land on the row CONTAINER") and that `SelectorItemAccessibilityTests` was built to guard — but the guard covered only the item types' `ToString()`, and `ContactModel` was never registered there.

All three lists in `AddressBookWindow` had the name in the wrong place. Groups only *sounded* right because `GroupModel` already overrides `ToString()`; group members were silent in exactly the same way as contacts.

## The fix

1. **`AddressBookWindow.xaml`** — move `AutomationProperties.Name` from the template child onto the `ItemContainerStyle` setter for the contact, group, and group-member lists. That is where every other list in the app already puts it (`MainWindow`, `RulesManagerWindow`, `GroupManagerWindow`, `AccountManagerDialog`, …).
2. **`ContactModel.ToString()`** → `Display` (`"Alice Adams <alice@example.com>"`, or the bare address when there is no name). The floor for any contact list that composes no richer name; the address book's stamped `AccessibleName` still wins.

## Audit

Swept every `DataTemplate` in the app for a misplaced `AutomationProperties.Name`. The only other hits are `CheckBox`es inside `ItemsControl`s (`GrabAddressesDialog`, `ForwardAttachmentDialogWindow`) and close-buttons inside tab templates (`MainWindow`, `TabListWindow`) — in each of those the named element *is* the focusable one, so they are correct. The address book was the only offender.

## Tests

`AddressBookRowSpeechTests` (new) builds a real `AddressBookWindow` and reads the **live `ListViewItem` automation peer names** for all three lists — the ground truth a screen reader speaks, not the rendered template. Confirmed failing before the fix:

```
Assert.Contains() Failure: Item not found in collection
Collection: ["QuickMail.Models.ContactModel"]
Not found:  "Alice Adams, alice@example.com, Local address book"
```

`ContactModel` also joins the per-type `ToString()` guards in `SelectorItemAccessibilityTests`.

Full suite: 3332 passed, 2 failed — `TabStripNavigationTests.SettingsDialog_EveryTabIsReachableWithTheArrowKeys` and `Pop3DialogTests.TheKeepMailCheckboxSpeaksWhatClearingItCosts`. Both **reproduce on unmodified `main`** (verified in a detached baseline worktree at `f52efd9`); neither is touched by this change.

## Release

Starts the 0.8.44 cycle: version bump and `docs/release-notes-v0.8.44.md` with this fix as the first entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)