### PR TITLE
Fix #652: pin the Settings dialog's size before measuring its tab strip

### DIFF
--- a/QuickMail.Tests/TabStripNavigationTests.cs
+++ b/QuickMail.Tests/TabStripNavigationTests.cs
@@ -230,10 +230,26 @@ public class TabStripNavigationTests
         // The regression #528 reported, against the real dialog: its six tabs wrap onto two rows,
         // which is what broke geometric navigation. Pressing Right once per tab must visit every
         // one of them and come back to where it started.
+        //
+        // ThemedControls.xaml is merged rather than simulated (issue #652). It is what gives a tab
+        // header its real Padding, and without it the six headers are narrow enough to fit on one
+        // line — the layout that was never broken. An earlier version hand-stamped a guess at the
+        // themed values instead; the guess had already drifted from the style it was standing in for.
         EnsureApplication();
+        WpfTestHost.EnsureStyles("AccessibleStyles", "ThemedControls");
+
         var vm     = new SettingsViewModel(new StubConfigService(), new StubCommandRegistry());
         var dialog = new SettingsDialog(vm) { ShowActivated = false };
         dialog.Show();
+
+        // Pin the window to the size its XAML declares (issue #652). A process whose STARTUPINFO
+        // asks for SW_SHOWMAXIMIZED maximizes the first top-level window it shows, and the test host
+        // is sometimes launched that way — which put this dialog on a 1485-DIP work area, fitted all
+        // six headers on one row, and failed the premise assertion below every time on that machine
+        // while CI stayed green. RestoreBounds still held the declared 520x560 throughout, so the
+        // dialog was only being PLACED maximized; the app is not affected, since the flag reaches
+        // only a process's first window and never a dialog opened later.
+        dialog.WindowState = WindowState.Normal;
         TabOrderWalker.Drain();
         try
         {
@@ -242,16 +258,6 @@ public class TabStripNavigationTests
             var items = tabs!.Items.Cast<TabItem>().ToArray();
             Assert.Equal(6, items.Length);
 
-            // The test process merges AccessibleStyles.xaml but not ThemedControls.xaml, which is
-            // what gives a tab header its real Padding — without it the six headers are narrow
-            // enough to fit on one line, which is the layout that was never broken. Stamping the
-            // themed padding and font size on reproduces what the user has, so the walk below runs
-            // against the two-row strip #528 was reported against.
-            foreach (var item in items)
-            {
-                item.Padding  = new Thickness(12, 6, 12, 6);
-                item.FontSize = 13;
-            }
             dialog.UpdateLayout();
             TabOrderWalker.Drain();
 


### PR DESCRIPTION
Closes [#652](https://github.com/kellylford/QuickMail/issues/652). Test-only — no app change, no release note.

`SettingsDialog_EveryTabIsReachableWithTheArrowKeys` failed on every run on my machine while CI stayed green, which meant the only coverage of the [#528](https://github.com/kellylford/QuickMail/issues/528) fix was dead.

## Cause

The test shows the real dialog and asserts its six tab headers wrap onto two rows — the layout #528 was about — but never pinned the window's size. The window was coming up maximized:

```
Width=520  ActualWidth=1485  SizeToContent=Manual  WindowState=Maximized  dpi=2
RestoreBounds=24.5,24.5,520,560
```

`Width` and `RestoreBounds` are the declared 520, so the window was only being *placed* maximized — a process whose `STARTUPINFO` asks for `SW_SHOWMAXIMIZED` maximizes the first top-level window it shows, and the test host is sometimes launched that way. On a 1485-DIP work area all six headers fit on one row and the premise assertion failed before the navigation walk ever ran.

**Not an app bug.** That flag reaches only a process's first window, never a dialog opened later in the running app.

## Fix

Force `WindowState.Normal` after `Show()`. At the declared 520 the strip wraps as it should:

```
_General             x=10   y=42
_Advanced            x=148  y=42
_Keyboard Shortcuts  x=297  y=42
Start_up             x=10   y=10     <- wraps
_Windowing           x=157  y=10
A_ppearance          x=325  y=10
```

Also merges `ThemedControls` instead of simulating it. The test hand-stamped `Padding = 12,6,12,6` and `FontSize = 13` on each header, noting the process did not merge the themed style — `WpfTestHost.EnsureStyles` does, and several suites already use it. The guess had drifted: the real style sets `Padding 12,6` and leaves the font alone, so the headers were being measured a point larger than they ship.

## Verification

Both negative controls fire, so the test has teeth in both halves:

| Control | Result |
|---|---|
| `dialog.Width = 1200` after Show | premise assertion fails — `they did not (x = 10, 76, 153, 282, 345, 430)` |
| comment out `TabStripNavigation.Install()` | navigation walk fails |
| unmodified | passes |

Full suite: **3335 passed, 0 failed**, 3 skipped (the opt-in synthesized-input tests). That is the whole suite green, including `Pop3DialogTests.TheKeepMailCheckboxSpeaksWhatClearingItCosts`, which failed once during the #648 run under load and has not reproduced since.

🤖 Generated with [Claude Code](https://claude.com/claude-code)