### PR TITLE
Correct why the Settings dialog opened maximized

### DIFF
--- a/QuickMail.Tests/TabStripNavigationTests.cs
+++ b/QuickMail.Tests/TabStripNavigationTests.cs
@@ -242,13 +242,17 @@ public class TabStripNavigationTests
         var dialog = new SettingsDialog(vm) { ShowActivated = false };
         dialog.Show();
 
-        // Pin the window to the size its XAML declares (issue #652). A process whose STARTUPINFO
-        // asks for SW_SHOWMAXIMIZED maximizes the first top-level window it shows, and the test host
-        // is sometimes launched that way — which put this dialog on a 1485-DIP work area, fitted all
-        // six headers on one row, and failed the premise assertion below every time on that machine
-        // while CI stayed green. RestoreBounds still held the declared 520x560 throughout, so the
-        // dialog was only being PLACED maximized; the app is not affected, since the flag reaches
-        // only a process's first window and never a dialog opened later.
+        // Pin the window to the size its XAML declares (issue #652). Windows 11 26H2 added
+        // Settings > Accessibility > Visual effects > "Open apps maximized", which opens every app
+        // window maximized — a developer running with it on gets this dialog on the full work area
+        // (1485 DIPs at 200% scaling here), where all six headers fit on one row, so the premise
+        // assertion below failed every run on that machine while CI stayed green. Width and
+        // RestoreBounds still held the declared 520x560: the window is only PLACED maximized.
+        //
+        // The setting reaches EVERY window, not just a process's first, so any future test with a
+        // geometry premise has to pin its window the same way. It is an accessibility setting a real
+        // user turns on deliberately — the app is expected to work under it, and a test that quietly
+        // depends on the opposite is testing the developer's Settings app, not QuickMail.
         dialog.WindowState = WindowState.Normal;
         TabOrderWalker.Drain();
         try


### PR DESCRIPTION
Comment-only correction to [#653](https://github.com/kellylford/QuickMail/pull/653) / [#652](https://github.com/kellylford/QuickMail/issues/652). No behavior change.

I diagnosed the maximized dialog as a `STARTUPINFO` `SW_SHOWMAXIMIZED` flag inherited by the test host. **That was wrong.**

Windows 11 26H2 added **Settings → Accessibility → Visual effects → "Open apps maximized"** — *"Automatically open app windows maximized when they open"* — in Experimental build 26340.9233 and Beta build 26220.9223 on 21 August 2026. The machine this failed on runs 10.0.26340 and has the setting on.

The fix itself is unchanged, and is more clearly right than I argued: the test must pin its own window rather than inherit whatever the developer's Settings say.

But the reassurance I attached to it was wrong in a way worth correcting in the file. `STARTUPINFO` reaches only a process's *first* window, so I wrote that a dialog opened later could never be affected. **This setting reaches every window.** Two consequences, now recorded in the comment:

- Any future test with a geometry premise has to pin its window the same way.
- QuickMail is expected to work with the setting on. It is an accessibility setting a user turns on deliberately, so a test that quietly depends on the opposite is testing the developer's Settings app, not QuickMail.

I audited the rest of the suite for other geometry premises: `TabStripNavigationTests` is the only one. The single `ActualWidth` reference in `Pop3DialogTests` is diagnostic text inside a failure message, not an assertion.

Sources: [Windows Insider Blog, 21 Aug 2026](https://blogs.windows.com/windows-insider/2026/08/21/announcing-new-builds-for-21-august-2026/) · [Build 26340.9233 release notes](https://learn.microsoft.com/en-us/windows-insider/release-notes/experimental/preview-build-26340-9233)

🤖 Generated with [Claude Code](https://claude.com/claude-code)