### PR TITLE
Offline drafts and an Outbox for #637 (part 1 of 3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,7 @@ Users access the guide via **Help** → **Open User Guide** (F1). The link in `M
 ## Architecture
 
 Manual DI root in `App.xaml.cs` — no container. Services wired in `OnStartup`:
-`ProfileContext` → `AccountService` → `CredentialService` → `OAuthService` → `ImapService` → `SmtpService` → `ConfigService` → `LocalStoreService` → `ContactService` → `TemplateService` → `RuleService` → `SyncService` → `ViewService` → `CommandRegistry` → `MainViewModel` → `MainWindow`.
+`ProfileContext` → `AccountService` → `CredentialService` → `OAuthService` → `ImapService` → `SmtpService` → `ConfigService` → `LocalStoreService` → `ContactService` → `TemplateService` → `RuleService` → `SyncService` → `OutboxService` → `ViewService` → `CommandRegistry` → `MainViewModel` → `MainWindow`.
 
 Every service has a matching interface in `Services/I*.cs`. See `docs/ARCHITECTURE.md` for full service descriptions, runtime modes, and virtual folder sentinels.
 

--- a/QuickMail.Tests/ComposeViewModelAutoSaveTests.cs
+++ b/QuickMail.Tests/ComposeViewModelAutoSaveTests.cs
@@ -147,11 +147,17 @@ sealed class RecordingMailService : IMailService
     public string? LastReplaceMessageId { get; private set; }
     public bool AppendDraftThrows { get; set; }
 
+    /// <summary>When set, AppendDraftAsync throws exactly this — e.g. a SocketException to stand in
+    /// for an unreachable server (#637), which the plain AppendDraftThrows (an
+    /// InvalidOperationException, "the server answered") deliberately is not.</summary>
+    public Exception? AppendDraftFailure { get; set; }
+
     public Task<string?> FindDraftsFolderNameAsync(Guid accountId, CancellationToken ct = default) =>
         Task.FromResult<string?>("Drafts");
 
     public Task<string> AppendDraftAsync(Guid accountId, ComposeModel draft, string? replaceMessageId, CancellationToken ct = default)
     {
+        if (AppendDraftFailure != null) throw AppendDraftFailure;
         if (AppendDraftThrows) throw new InvalidOperationException("simulated append failure");
         AppendDraftCalls++;
         LastReplaceMessageId = replaceMessageId;

--- a/QuickMail.Tests/ComposeViewModelOutboxTests.cs
+++ b/QuickMail.Tests/ComposeViewModelOutboxTests.cs
@@ -50,6 +50,8 @@ public class ComposeViewModelOutboxTests
         }
     }
 
+    private static SocketException Unreachable() => new((int)SocketError.HostUnreachable);
+
     private sealed class NoDraftsFolderMail : StubImapMailServiceBase
     {
         public override Task<string?> FindDraftsFolderNameAsync(Guid accountId, CancellationToken ct = default)
@@ -62,7 +64,7 @@ public class ComposeViewModelOutboxTests
     public async Task SaveDraft_WhenTheServerFails_KeepsTheDraftOnThisComputer()
     {
         var h = new Harness();
-        h.Mail.AppendDraftThrows = true;
+        h.Mail.AppendDraftFailure = Unreachable();
 
         await h.Vm.SaveDraftCommand.ExecuteAsync(null);
 
@@ -80,7 +82,7 @@ public class ComposeViewModelOutboxTests
     public async Task SaveDraft_Twice_ReplacesTheSameLocalRow()
     {
         var h = new Harness();
-        h.Mail.AppendDraftThrows = true;
+        h.Mail.AppendDraftFailure = Unreachable();
 
         await h.Vm.SaveDraftCommand.ExecuteAsync(null);
         h.Vm.Subject = "Lunch (moved)";
@@ -95,11 +97,11 @@ public class ComposeViewModelOutboxTests
     public async Task SaveDraft_ServerSuccessAfterALocalSave_RemovesTheLocalRow()
     {
         var h = new Harness();
-        h.Mail.AppendDraftThrows = true;
+        h.Mail.AppendDraftFailure = Unreachable();
         await h.Vm.SaveDraftCommand.ExecuteAsync(null);
         var localId = h.Outbox.Enqueued[0].Id;
 
-        h.Mail.AppendDraftThrows = false;
+        h.Mail.AppendDraftFailure = null;
         await h.Vm.SaveDraftCommand.ExecuteAsync(null);
 
         Assert.Equal(("Draft saved.", AnnouncementCategory.Result), h.Status.Last);
@@ -125,7 +127,7 @@ public class ComposeViewModelOutboxTests
     public async Task SaveDraft_WithoutAnOutbox_FailsTheWayItAlwaysDid()
     {
         var h = new Harness(withOutbox: false);
-        h.Mail.AppendDraftThrows = true;
+        h.Mail.AppendDraftFailure = Unreachable();
 
         await h.Vm.SaveDraftCommand.ExecuteAsync(null);
 
@@ -151,12 +153,12 @@ public class ComposeViewModelOutboxTests
     public async Task SaveDraft_WhenTheLocalStoreAlsoFails_ReportsTheServerFailure()
     {
         var h = new Harness();
-        h.Mail.AppendDraftThrows = true;
+        h.Mail.AppendDraftFailure = Unreachable();
         h.Outbox.EnqueueFailure = new InvalidOperationException("disk full");
 
         await h.Vm.SaveDraftCommand.ExecuteAsync(null);
 
-        Assert.Contains("simulated append failure", h.Status.Last.Text, StringComparison.Ordinal);
+        Assert.StartsWith("Save draft failed:", h.Status.Last.Text, StringComparison.Ordinal);
         Assert.Equal(DraftSaveOutcome.Failed, h.Vm.LastSaveOutcome);
     }
 
@@ -211,7 +213,7 @@ public class ComposeViewModelOutboxTests
     public async Task Send_SupersedesTheLocalDraftRow()
     {
         var h = new Harness();
-        h.Mail.AppendDraftThrows = true;
+        h.Mail.AppendDraftFailure = Unreachable();
         await h.Vm.SaveDraftCommand.ExecuteAsync(null);
         var draftRow = h.Outbox.Enqueued[0].Id;
 
@@ -228,7 +230,7 @@ public class ComposeViewModelOutboxTests
     public async Task Send_SuccessAfterALocalSave_RemovesTheLocalRow()
     {
         var h = new Harness();
-        h.Mail.AppendDraftThrows = true;
+        h.Mail.AppendDraftFailure = Unreachable();
         await h.Vm.SaveDraftCommand.ExecuteAsync(null);
         var localId = h.Outbox.Enqueued[0].Id;
 
@@ -258,7 +260,7 @@ public class ComposeViewModelOutboxTests
     public async Task AutoSave_FallsBackLocallyAndSaysSoOnce()
     {
         var h = new Harness();
-        h.Mail.AppendDraftThrows = true;
+        h.Mail.AppendDraftFailure = Unreachable();
         var notices = 0;
         h.Vm.AutoSaveNotice += _ => notices++;
         var failures = 0;
@@ -280,18 +282,18 @@ public class ComposeViewModelOutboxTests
     public async Task AutoSave_ServerSuccess_ResetsTheNoticeAndRemovesTheLocalRow()
     {
         var h = new Harness();
-        h.Mail.AppendDraftThrows = true;
+        h.Mail.AppendDraftFailure = Unreachable();
         var notices = 0;
         h.Vm.AutoSaveNotice += _ => notices++;
         await h.Vm.AutoSaveAsync();
 
-        h.Mail.AppendDraftThrows = false;
+        h.Mail.AppendDraftFailure = null;
         h.Vm.Body = "edited";
         await h.Vm.AutoSaveAsync();
         Assert.Single(h.Outbox.Removed);
         Assert.StartsWith("Auto-saved", h.Vm.AutoSaveText, StringComparison.Ordinal);
 
-        h.Mail.AppendDraftThrows = true;
+        h.Mail.AppendDraftFailure = Unreachable();
         h.Vm.Body = "edited again";
         await h.Vm.AutoSaveAsync();
         Assert.Equal(2, notices);
@@ -313,11 +315,95 @@ public class ComposeViewModelOutboxTests
             Body = "text",
         });
         h.Vm.SenderAccount = h.Account;
-        h.Mail.AppendDraftThrows = true;
+        h.Mail.AppendDraftFailure = Unreachable();
 
         await h.Vm.SaveDraftCommand.ExecuteAsync(null);
 
         Assert.Equal("outbox-abc", Assert.Single(h.Outbox.Enqueued).ExistingId);
         Assert.DoesNotContain("-- Kelly", h.Vm.Body, StringComparison.Ordinal);
+    }
+
+    // ── Review fixes ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SaveDraft_WhenTheServerRefuses_FailsInTheWindowInsteadOfQueuing()
+    {
+        // Over quota, a rejected append: the server answered. Queuing it would fail again on every
+        // auto-save and announce a failure each time.
+        var h = new Harness();
+        h.Mail.AppendDraftFailure = new MailKit.Net.Imap.ImapCommandException(
+            MailKit.Net.Imap.ImapCommandResponse.No, "NO [OVERQUOTA] Not enough space");
+
+        await h.Vm.SaveDraftCommand.ExecuteAsync(null);
+
+        Assert.StartsWith("Save draft failed:", h.Status.Last.Text, StringComparison.Ordinal);
+        Assert.Equal(DraftSaveOutcome.Failed, h.Vm.LastSaveOutcome);
+        Assert.Empty(h.Outbox.Enqueued);
+        Assert.True(h.Vm.IsDirty);
+    }
+
+    [Fact]
+    public async Task SaveDraft_ThatReturnsEarly_CountsAsFailedSoTheWindowStaysOpen()
+    {
+        var h = new Harness();
+        h.Mail.AppendDraftFailure = Unreachable();
+        await h.Vm.SaveDraftCommand.ExecuteAsync(null);
+        Assert.Equal(DraftSaveOutcome.SavedLocally, h.Vm.LastSaveOutcome);
+
+        // A stale success must not let a refused save close the window and lose the message.
+        h.Vm.Attachments.Add(new AttachmentModel { FileName = "huge.iso", FileSize = 30_000_000, Content = [1] });
+        await h.Vm.SaveDraftCommand.ExecuteAsync(null);
+
+        Assert.Equal(DraftSaveOutcome.Failed, h.Vm.LastSaveOutcome);
+        Assert.Contains("25 MB", h.Status.Last.Text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ALocallyKeptDraftIsHeldWhileTheWindowIsOpenAndReleasedWhenItCloses()
+    {
+        var h = new Harness();
+        h.Mail.AppendDraftFailure = Unreachable();
+
+        await h.Vm.SaveDraftCommand.ExecuteAsync(null);
+        var id = h.Outbox.Enqueued[0].Id;
+        Assert.Contains(id, h.Outbox.Held);
+
+        h.Vm.Dispose();
+        Assert.DoesNotContain(id, h.Outbox.Held);
+    }
+
+    [Fact]
+    public void AComposeReopenedFromTheOutboxHoldsItsRow()
+    {
+        var h = new Harness();
+        h.Vm.Seed(new ComposeModel { AccountId = h.Account.Id, OutboxId = "outbox-held", To = "a@example.com" });
+        Assert.Contains("outbox-held", h.Outbox.Held);
+    }
+
+    [Fact]
+    public async Task AQueuedReplyIsStillAReply()
+    {
+        var h = new Harness();
+        h.Vm.Seed(new ComposeModel { AccountId = h.Account.Id, Kind = ComposeKind.Reply, To = "a@example.com", InReplyToMessageId = "<p@x>" });
+        h.Vm.SenderAccount = h.Account;
+        h.Smtp.SendFailure = new SocketException((int)SocketError.HostUnreachable);
+
+        await h.Vm.SendCommand.ExecuteAsync(null);
+
+        Assert.Equal(ComposeKind.Reply, Assert.Single(h.Outbox.Enqueued).Compose.Kind);
+    }
+
+    [Fact]
+    public async Task ASendThatTimesOutWhileOnlineFailsInTheWindow()
+    {
+        var h = new Harness();
+        h.Connectivity.IsOnline = true;
+        h.Smtp.SendFailure = new OperationCanceledException();
+
+        await h.Vm.SendCommand.ExecuteAsync(null);
+
+        Assert.Equal("Send timed out after 30 seconds. Try again.", h.Status.Last.Text);
+        Assert.Empty(h.Outbox.Enqueued);
+        Assert.Equal(0, h.CloseRequests);
     }
 }

--- a/QuickMail.Tests/ComposeViewModelOutboxTests.cs
+++ b/QuickMail.Tests/ComposeViewModelOutboxTests.cs
@@ -1,0 +1,323 @@
+using System;
+using System.Linq;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using MailKit.Net.Smtp;
+using QuickMail.Models;
+using QuickMail.Services;
+using QuickMail.ViewModels;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// Issue #637: on airport wifi, Save Draft and Send both used to end in a failure message and a
+/// window that would not close. The compose window now tries the server first and falls back to
+/// the local Outbox, and a send that never reached the server is queued rather than failed. What
+/// is pinned here is the boundary: a server that answered "no" still fails in the window.
+/// </summary>
+public class ComposeViewModelOutboxTests
+{
+    private sealed class Harness
+    {
+        public StubSmtpService Smtp { get; } = new();
+        public RecordingMailService Mail { get; } = new();
+        public StubOutboxService Outbox { get; } = new();
+        public StubConnectivityService Connectivity { get; } = new();
+        public AccountModel Account { get; } = new()
+        {
+            Id = Guid.NewGuid(),
+            Username = "kelly@example.com",
+            AuthType = AuthType.OAuth2Google,
+        };
+        public ComposeViewModel Vm { get; }
+        public StatusAnnouncementRecorder Status { get; }
+        public int CloseRequests { get; private set; }
+
+        public Harness(IMailService? mail = null, bool withOutbox = true, bool withConnectivity = true)
+        {
+            Vm = new ComposeViewModel(Smtp, new StubAccountService(), new StubCredentialService(),
+                mail ?? Mail, new StubTemplateService(),
+                outbox: withOutbox ? Outbox : null,
+                connectivity: withConnectivity ? Connectivity : null);
+            Status = StatusAnnouncementRecorder.Watch(Vm);
+            Vm.CloseRequested += () => CloseRequests++;
+            Vm.SenderAccount = Account;
+            Vm.To = "someone@example.com";
+            Vm.Subject = "Lunch";
+            Vm.Body = "Friday?";
+        }
+    }
+
+    private sealed class NoDraftsFolderMail : StubImapMailServiceBase
+    {
+        public override Task<string?> FindDraftsFolderNameAsync(Guid accountId, CancellationToken ct = default)
+            => Task.FromResult<string?>(null);
+    }
+
+    // ── Save Draft ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SaveDraft_WhenTheServerFails_KeepsTheDraftOnThisComputer()
+    {
+        var h = new Harness();
+        h.Mail.AppendDraftThrows = true;
+
+        await h.Vm.SaveDraftCommand.ExecuteAsync(null);
+
+        Assert.Equal(("Draft saved on this computer. It will upload when you're online.", AnnouncementCategory.Result), h.Status.Last);
+        Assert.Equal(DraftSaveOutcome.SavedLocally, h.Vm.LastSaveOutcome);
+        Assert.False(h.Vm.IsDirty);
+        var queued = Assert.Single(h.Outbox.Enqueued);
+        Assert.Equal(OutboxKind.Draft, queued.Kind);
+        Assert.Equal(h.Account.Id, queued.AccountId);
+        Assert.Equal("Lunch", queued.Compose.Subject);
+        Assert.Null(queued.ExistingId);
+    }
+
+    [Fact]
+    public async Task SaveDraft_Twice_ReplacesTheSameLocalRow()
+    {
+        var h = new Harness();
+        h.Mail.AppendDraftThrows = true;
+
+        await h.Vm.SaveDraftCommand.ExecuteAsync(null);
+        h.Vm.Subject = "Lunch (moved)";
+        await h.Vm.SaveDraftCommand.ExecuteAsync(null);
+
+        Assert.Equal(2, h.Outbox.Enqueued.Count);
+        Assert.Equal(h.Outbox.Enqueued[0].Id, h.Outbox.Enqueued[1].ExistingId);
+        Assert.Single(h.Outbox.Items);
+    }
+
+    [Fact]
+    public async Task SaveDraft_ServerSuccessAfterALocalSave_RemovesTheLocalRow()
+    {
+        var h = new Harness();
+        h.Mail.AppendDraftThrows = true;
+        await h.Vm.SaveDraftCommand.ExecuteAsync(null);
+        var localId = h.Outbox.Enqueued[0].Id;
+
+        h.Mail.AppendDraftThrows = false;
+        await h.Vm.SaveDraftCommand.ExecuteAsync(null);
+
+        Assert.Equal(("Draft saved.", AnnouncementCategory.Result), h.Status.Last);
+        Assert.Equal(DraftSaveOutcome.SavedToServer, h.Vm.LastSaveOutcome);
+        Assert.Equal([localId], h.Outbox.Removed);
+        Assert.Equal(1, h.Mail.AppendDraftCalls);
+    }
+
+    [Fact]
+    public async Task SaveDraft_WithNoDraftsFolder_StillKeepsTheDraftLocally()
+    {
+        // The text the user typed outranks folder purity: the Outbox row fails on upload with this
+        // reason and stays reopenable, instead of the message being discarded on close.
+        var h = new Harness(mail: new NoDraftsFolderMail());
+
+        await h.Vm.SaveDraftCommand.ExecuteAsync(null);
+
+        Assert.Equal(DraftSaveOutcome.SavedLocally, h.Vm.LastSaveOutcome);
+        Assert.Single(h.Outbox.Enqueued);
+    }
+
+    [Fact]
+    public async Task SaveDraft_WithoutAnOutbox_FailsTheWayItAlwaysDid()
+    {
+        var h = new Harness(withOutbox: false);
+        h.Mail.AppendDraftThrows = true;
+
+        await h.Vm.SaveDraftCommand.ExecuteAsync(null);
+
+        Assert.StartsWith("Save draft failed:", h.Status.Last.Text, StringComparison.Ordinal);
+        Assert.Equal(AnnouncementCategory.Result, h.Status.Last.Category);
+        Assert.Equal(DraftSaveOutcome.Failed, h.Vm.LastSaveOutcome);
+        Assert.True(h.Vm.IsDirty);
+    }
+
+    [Fact]
+    public async Task SaveDraft_WhenTheOutboxIsUnavailable_ReportsTheMissingDraftsFolder()
+    {
+        var h = new Harness(mail: new NoDraftsFolderMail());
+        h.Outbox.IsAvailable = false;   // --online mode
+
+        await h.Vm.SaveDraftCommand.ExecuteAsync(null);
+
+        Assert.Equal("No Drafts folder found on this account.", h.Status.Last.Text);
+        Assert.Equal(DraftSaveOutcome.Failed, h.Vm.LastSaveOutcome);
+    }
+
+    [Fact]
+    public async Task SaveDraft_WhenTheLocalStoreAlsoFails_ReportsTheServerFailure()
+    {
+        var h = new Harness();
+        h.Mail.AppendDraftThrows = true;
+        h.Outbox.EnqueueFailure = new InvalidOperationException("disk full");
+
+        await h.Vm.SaveDraftCommand.ExecuteAsync(null);
+
+        Assert.Contains("simulated append failure", h.Status.Last.Text, StringComparison.Ordinal);
+        Assert.Equal(DraftSaveOutcome.Failed, h.Vm.LastSaveOutcome);
+    }
+
+    // ── Send ────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Send_WhenTheServerCannotBeReached_QueuesAndCloses()
+    {
+        var h = new Harness();
+        h.Smtp.SendFailure = new SocketException((int)SocketError.HostUnreachable);
+
+        await h.Vm.SendCommand.ExecuteAsync(null);
+
+        Assert.Equal(("Message queued. It will be sent when you're online.", AnnouncementCategory.Result), h.Status.Last);
+        Assert.True(h.Vm.IsSent);
+        Assert.False(h.Vm.IsDirty);
+        Assert.Equal(1, h.CloseRequests);
+        var queued = Assert.Single(h.Outbox.Enqueued);
+        Assert.Equal(OutboxKind.Send, queued.Kind);
+    }
+
+    [Fact]
+    public async Task Send_WhenTheServerRejects_StillFailsInTheWindow()
+    {
+        var h = new Harness();
+        h.Smtp.SendFailure = new SmtpCommandException(SmtpErrorCode.RecipientNotAccepted,
+            SmtpStatusCode.MailboxUnavailable, "550 no such user");
+
+        await h.Vm.SendCommand.ExecuteAsync(null);
+
+        Assert.StartsWith("Send failed:", h.Status.Last.Text, StringComparison.Ordinal);
+        Assert.False(h.Vm.IsSent);
+        Assert.Equal(0, h.CloseRequests);
+        Assert.Empty(h.Outbox.Enqueued);
+    }
+
+    [Fact]
+    public async Task Send_WhenTheAccountIsKnownOffline_QueuesWithoutTrying()
+    {
+        var h = new Harness();
+        h.Connectivity.SetAccount(h.Account.Id, false);
+
+        await h.Vm.SendCommand.ExecuteAsync(null);
+
+        Assert.Empty(h.Smtp.Sent);
+        Assert.Single(h.Outbox.Enqueued);
+        Assert.True(h.Vm.IsSent);
+        Assert.Equal(1, h.CloseRequests);
+    }
+
+    [Fact]
+    public async Task Send_SupersedesTheLocalDraftRow()
+    {
+        var h = new Harness();
+        h.Mail.AppendDraftThrows = true;
+        await h.Vm.SaveDraftCommand.ExecuteAsync(null);
+        var draftRow = h.Outbox.Enqueued[0].Id;
+
+        h.Smtp.SendFailure = new SocketException((int)SocketError.TimedOut);
+        await h.Vm.SendCommand.ExecuteAsync(null);
+
+        var send = h.Outbox.Enqueued[1];
+        Assert.Equal(OutboxKind.Send, send.Kind);
+        Assert.Equal(draftRow, send.ExistingId);
+        Assert.Single(h.Outbox.Items);
+    }
+
+    [Fact]
+    public async Task Send_SuccessAfterALocalSave_RemovesTheLocalRow()
+    {
+        var h = new Harness();
+        h.Mail.AppendDraftThrows = true;
+        await h.Vm.SaveDraftCommand.ExecuteAsync(null);
+        var localId = h.Outbox.Enqueued[0].Id;
+
+        await h.Vm.SendCommand.ExecuteAsync(null);
+
+        Assert.Single(h.Smtp.Sent);
+        Assert.Equal([localId], h.Outbox.Removed);
+        Assert.Equal(1, h.CloseRequests);
+    }
+
+    [Fact]
+    public async Task Send_WithoutAnOutbox_FailsTheWayItAlwaysDid()
+    {
+        var h = new Harness(withOutbox: false);
+        h.Smtp.SendFailure = new SocketException((int)SocketError.HostUnreachable);
+
+        await h.Vm.SendCommand.ExecuteAsync(null);
+
+        Assert.StartsWith("Send failed:", h.Status.Last.Text, StringComparison.Ordinal);
+        Assert.False(h.Vm.IsSent);
+        Assert.Equal(0, h.CloseRequests);
+    }
+
+    // ── Auto-save ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task AutoSave_FallsBackLocallyAndSaysSoOnce()
+    {
+        var h = new Harness();
+        h.Mail.AppendDraftThrows = true;
+        var notices = 0;
+        h.Vm.AutoSaveNotice += _ => notices++;
+        var failures = 0;
+        h.Vm.AutoSaveFailed += _ => failures++;
+
+        await h.Vm.AutoSaveAsync();
+        h.Vm.Body = "Friday? Or Monday.";
+        await h.Vm.AutoSaveAsync();
+
+        Assert.Equal(1, notices);
+        Assert.Equal(0, failures);
+        Assert.StartsWith("Kept on this computer", h.Vm.AutoSaveText, StringComparison.Ordinal);
+        Assert.Equal(2, h.Outbox.Enqueued.Count);
+        Assert.Single(h.Outbox.Items);
+        Assert.False(h.Vm.IsDirty);
+    }
+
+    [Fact]
+    public async Task AutoSave_ServerSuccess_ResetsTheNoticeAndRemovesTheLocalRow()
+    {
+        var h = new Harness();
+        h.Mail.AppendDraftThrows = true;
+        var notices = 0;
+        h.Vm.AutoSaveNotice += _ => notices++;
+        await h.Vm.AutoSaveAsync();
+
+        h.Mail.AppendDraftThrows = false;
+        h.Vm.Body = "edited";
+        await h.Vm.AutoSaveAsync();
+        Assert.Single(h.Outbox.Removed);
+        Assert.StartsWith("Auto-saved", h.Vm.AutoSaveText, StringComparison.Ordinal);
+
+        h.Mail.AppendDraftThrows = true;
+        h.Vm.Body = "edited again";
+        await h.Vm.AutoSaveAsync();
+        Assert.Equal(2, notices);
+    }
+
+    // ── Reopened from the Outbox ────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SeededFromAnOutboxRow_SavesBackIntoThatRowAndSkipsTheSignature()
+    {
+        var h = new Harness();
+        h.Account.Signature = "-- Kelly";
+        h.Vm.Seed(new ComposeModel
+        {
+            AccountId = h.Account.Id,
+            OutboxId = "outbox-abc",
+            To = "someone@example.com",
+            Subject = "Reopened",
+            Body = "text",
+        });
+        h.Vm.SenderAccount = h.Account;
+        h.Mail.AppendDraftThrows = true;
+
+        await h.Vm.SaveDraftCommand.ExecuteAsync(null);
+
+        Assert.Equal("outbox-abc", Assert.Single(h.Outbox.Enqueued).ExistingId);
+        Assert.DoesNotContain("-- Kelly", h.Vm.Body, StringComparison.Ordinal);
+    }
+}

--- a/QuickMail.Tests/ComposeWindowCloseTests.cs
+++ b/QuickMail.Tests/ComposeWindowCloseTests.cs
@@ -1,0 +1,110 @@
+using System.Threading.Tasks;
+using System.Windows;
+using QuickMail.Models;
+using QuickMail.ViewModels;
+using QuickMail.Views;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// Issue #637: a compose window with unsaved changes used to refuse to close whenever the server
+/// save failed — the user on airport wifi was left holding a window they could not close without
+/// losing the message. The close decision now reads <see cref="ComposeViewModel.LastSaveOutcome"/>:
+/// a draft kept on this computer lets the window close; only a draft that went nowhere keeps it open.
+/// </summary>
+[Collection("WpfTests")]
+public class ComposeWindowCloseTests
+{
+    /// <summary>Fails like an unreachable server, after yielding like one: a real save never completes
+    /// synchronously, and the close flow depends on that — its continuation runs after the Closing
+    /// event has returned, so its own Close() is a fresh call rather than a re-entrant one WPF ignores.</summary>
+    private sealed class YieldingUnreachableMail : StubImapMailServiceBase
+    {
+        public override async Task<string?> FindDraftsFolderNameAsync(System.Guid accountId, System.Threading.CancellationToken ct = default)
+        {
+            await Task.Yield();
+            return "Drafts";
+        }
+        public override async Task<string> AppendDraftAsync(System.Guid accountId, ComposeModel draft, string? replaceMessageId, System.Threading.CancellationToken ct = default)
+        {
+            await Task.Yield();
+            throw new System.Net.Sockets.SocketException((int)System.Net.Sockets.SocketError.HostUnreachable);
+        }
+    }
+
+    /// <summary>Pumps the dispatcher until the queued continuations have run.</summary>
+    private static void DoEvents()
+    {
+        var frame = new System.Windows.Threading.DispatcherFrame();
+        System.Windows.Threading.Dispatcher.CurrentDispatcher.BeginInvoke(
+            System.Windows.Threading.DispatcherPriority.ApplicationIdle, () => frame.Continue = false);
+        System.Windows.Threading.Dispatcher.PushFrame(frame);
+    }
+
+    private static (ComposeWindow Window, ComposeViewModel Vm, StubOutboxService Outbox) NewWindow(bool outboxAvailable)
+    {
+        // Without this the continuations after the yield land on the thread pool, where the
+        // window's Close() is a cross-thread call swallowed by the async void handler.
+        System.Threading.SynchronizationContext.SetSynchronizationContext(
+            new System.Windows.Threading.DispatcherSynchronizationContext(System.Windows.Threading.Dispatcher.CurrentDispatcher));
+        var mail = new YieldingUnreachableMail();
+        var outbox = new StubOutboxService { IsAvailable = outboxAvailable };
+        var vm = new ComposeViewModel(
+            new StubSmtpService(),
+            new StubAccountService(),
+            new StubCredentialService(),
+            mail,
+            new StubTemplateService(),
+            outbox: outbox);
+        vm.SenderAccount = new AccountModel { Username = "kelly@example.com", AuthType = AuthType.OAuth2Google };
+        vm.To = "someone@example.com";   // dirty, so the close prompt runs
+        var window = new ComposeWindow(vm, new StubContactService(), new StubTemplateService(), new StubConfigService())
+        {
+            WindowStyle = WindowStyle.None,
+            ShowInTaskbar = false,
+            ShowActivated = false,
+            ConfirmSaveOnClose = () => Task.FromResult<bool?>(true),   // the user chose Save
+        };
+        return (window, vm, outbox);
+    }
+
+    [StaFact]
+    public void ADraftKeptOnThisComputerLetsTheWindowClose()
+    {
+        var (window, vm, outbox) = NewWindow(outboxAvailable: true);
+        var closed = 0;
+        window.Closed += (_, _) => closed++;
+
+        window.Close();
+        DoEvents();
+
+        Assert.Equal(DraftSaveOutcome.SavedLocally, vm.LastSaveOutcome);
+        Assert.Single(outbox.Enqueued);
+        Assert.Equal(1, closed);
+    }
+
+    [StaFact]
+    public void ADraftThatWentNowhereKeepsTheWindowOpen()
+    {
+        var (window, vm, outbox) = NewWindow(outboxAvailable: false);
+        var closed = 0;
+        window.Closed += (_, _) => closed++;
+        try
+        {
+            window.Close();
+            DoEvents();
+
+            Assert.Equal(DraftSaveOutcome.Failed, vm.LastSaveOutcome);
+            Assert.Empty(outbox.Enqueued);
+            Assert.Equal(0, closed);
+        }
+        finally
+        {
+            // Discard so the test leaves no zombie window holding the process open.
+            window.ConfirmSaveOnClose = () => Task.FromResult<bool?>(false);
+            window.Close();
+            DoEvents();
+        }
+    }
+}

--- a/QuickMail.Tests/ConnectionFailureTests.cs
+++ b/QuickMail.Tests/ConnectionFailureTests.cs
@@ -1,0 +1,116 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using MailKit;
+using MailKit.Net.Imap;
+using MailKit.Net.Smtp;
+using MailKit.Security;
+using QuickMail.Services;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// The classifier is the one decision that separates "queue it and try later" from "show the user
+/// the error". Getting a transport failure wrong strands a message in the compose window on airport
+/// wifi; getting a server rejection wrong hides a bounced address inside the Outbox. Both directions
+/// are pinned here for every type the send, draft and reading paths can throw.
+/// </summary>
+public class ConnectionFailureTests
+{
+    public static IEnumerable<object[]> Transport() => Rows(
+        new SocketException((int)SocketError.HostUnreachable),
+        new IOException("connection reset"),
+        new TimeoutException(),
+        new ServiceNotConnectedException(),
+        new ImapProtocolException("bye"),
+        new SmtpProtocolException("bye"),
+        new AccountNotConnectedException(Guid.NewGuid()),
+        new HttpRequestException("name resolution failed"),
+        new HttpRequestException("gateway", null, HttpStatusCode.ServiceUnavailable),
+        new HttpRequestException("gateway", null, HttpStatusCode.BadGateway),
+        new HttpRequestException("gateway", null, HttpStatusCode.GatewayTimeout),
+        new WebException("dns", WebExceptionStatus.NameResolutionFailure),
+        new InvalidOperationException("wrapper", new SocketException((int)SocketError.TimedOut)),
+        new AggregateException(new SocketException((int)SocketError.TimedOut)),
+        new AggregateException(new InvalidOperationException("outer", new IOException("inner")))
+    );
+
+    public static IEnumerable<object[]> ServerAnswered() => Rows(
+        new SmtpCommandException(SmtpErrorCode.RecipientNotAccepted, SmtpStatusCode.MailboxUnavailable, "550 no such user"),
+        new ImapCommandException(ImapCommandResponse.No, "NO [ALERT] denied"),
+        new MailKit.Security.AuthenticationException("bad password"),
+        new SaslException("XOAUTH2", SaslErrorCode.InvalidChallenge, "denied"),
+        new InteractiveSignInRequiredException("sign in"),
+        new HttpRequestException("unauthorized", null, HttpStatusCode.Unauthorized),
+        new HttpRequestException("not found", null, HttpStatusCode.NotFound),
+        new HttpRequestException("throttled", null, HttpStatusCode.TooManyRequests),
+        new HttpRequestException("bad request", null, HttpStatusCode.BadRequest),
+        new HttpRequestException("server error", null, HttpStatusCode.InternalServerError),
+        new FileNotFoundException("attachment gone"),
+        new InvalidOperationException("Network is disabled in --ui-probe mode; sending is forbidden."),
+        new ArgumentException("nonsense"),
+        // A server rejection wrapped around a transport failure is still a rejection: the server spoke.
+        new SmtpCommandException(SmtpErrorCode.MessageNotAccepted, SmtpStatusCode.TransactionFailed, "554",
+            new SocketException((int)SocketError.ConnectionReset))
+    );
+
+    private static IEnumerable<object[]> Rows(params Exception[] exceptions) => exceptions.Select(e => new object[] { e });
+
+    [Theory]
+    [MemberData(nameof(Transport))]
+    public void TransportFailuresQueue(Exception ex)
+    {
+        Assert.True(ConnectionFailure.IsConnectionFailure(ex));
+    }
+
+    [Theory]
+    [MemberData(nameof(ServerAnswered))]
+    public void ServerRejectionsDoNot(Exception ex)
+    {
+        Assert.False(ConnectionFailure.IsConnectionFailure(ex));
+    }
+
+    [Fact]
+    public void TimeoutCancellationIsTransport()
+    {
+        // The compose window sends under a 30-second CancellationTokenSource; when that fires the
+        // caller's own token is still live, so the cancellation means "the server never answered".
+        using var callerCts = new CancellationTokenSource();
+        Assert.True(ConnectionFailure.IsConnectionFailure(new OperationCanceledException(), callerCts.Token));
+        Assert.True(ConnectionFailure.IsConnectionFailure(new TaskCanceledException(), callerCts.Token));
+    }
+
+    [Fact]
+    public void UserCancellationIsNotTransport()
+    {
+        using var callerCts = new CancellationTokenSource();
+        callerCts.Cancel();
+        Assert.False(ConnectionFailure.IsConnectionFailure(new OperationCanceledException(callerCts.Token), callerCts.Token));
+    }
+
+    [Fact]
+    public void HttpTimeoutWrappingATimeoutExceptionIsTransport()
+    {
+        // HttpClient on .NET 8 reports its own timeout as TaskCanceledException with an inner TimeoutException.
+        var ex = new TaskCanceledException("The request was canceled due to the configured HttpClient.Timeout",
+            new TimeoutException());
+        Assert.True(ConnectionFailure.IsConnectionFailure(ex));
+    }
+
+    [Fact]
+    public void AccountNotConnectedCarriesTheAccountId()
+    {
+        var id = Guid.NewGuid();
+        var ex = new AccountNotConnectedException(id);
+        Assert.Equal(id, ex.AccountId);
+        Assert.Contains(id.ToString(), ex.Message, StringComparison.Ordinal);
+        // It stays an InvalidOperationException so existing catch blocks keep working.
+        Assert.IsAssignableFrom<InvalidOperationException>(ex);
+    }
+}

--- a/QuickMail.Tests/FolderTreeNodeTests.cs
+++ b/QuickMail.Tests/FolderTreeNodeTests.cs
@@ -89,4 +89,18 @@ public class FolderTreeNodeTests
 
         Assert.DoesNotContain(nameof(FolderTreeNode.IsExpanded), changed);
     }
+    [Fact]
+    public void OutboxCountsWaitingItems_NeverUnread()
+    {
+        // The Outbox count is mail waiting to leave (#637): "3 unread" on it would be a lie the
+        // screen reader repeats on every visit.
+        var node = new FolderTreeNode
+        {
+            Folder = new MailFolderModel { FullName = "\0Outbox", DisplayName = "Outbox", Kind = SpecialFolderKind.Outbox, UnreadCount = 3 },
+            Label  = "Outbox",
+        };
+        Assert.Equal("Outbox, 3 waiting", node.AutomationName);
+        Assert.Equal("3 waiting", node.ItemStatusLabel);
+        Assert.Equal("(3)", node.UnreadDisplay);
+    }
 }

--- a/QuickMail.Tests/GraphMailServiceTests.cs
+++ b/QuickMail.Tests/GraphMailServiceTests.cs
@@ -554,7 +554,9 @@ public class GraphMailServiceTests
     {
         var (svc, _) = Make(url => (HttpStatusCode.OK, "{}"));
         // No ConnectAsync first → the account isn't registered, so token resolution can't proceed.
-        await Assert.ThrowsAsync<InvalidOperationException>(
+        // The typed exception (an InvalidOperationException) is what lets callers tell "not
+        // connected" from every other invalid-operation without matching the message text (#637).
+        await Assert.ThrowsAsync<AccountNotConnectedException>(
             () => svc.GetFoldersAsync(Guid.NewGuid(), TestContext.Current.CancellationToken));
     }
 }

--- a/QuickMail.Tests/LocalStoreServiceMigrationTests.cs
+++ b/QuickMail.Tests/LocalStoreServiceMigrationTests.cs
@@ -208,6 +208,22 @@ public class LocalStoreServiceMigrationTests
     }
 
     [Fact]
+    public void Migration_FromV1_AddsTheOutboxTables()
+    {
+        // The Outbox (#637) is additive: a profile upgraded from the oldest schema gains both tables
+        // on the same Initialize() that runs the v2 rebuild, and the rebuild still completes.
+        var dir = NewTempDir();
+        var dbPath = Path.Combine(dir, "mail.db");
+        SeedV1Database(dbPath, Guid.NewGuid());
+
+        new LocalStoreService(new ProfileContext(dir)).Initialize();
+
+        Assert.True(TableExists(dbPath, "Outbox"));
+        Assert.True(TableExists(dbPath, "OutboxAttachment"));
+        Assert.Equal("TEXT", ColumnType(dbPath, "MessageSummary", "unique_id"));
+    }
+
+    [Fact]
     public async Task GetMaxMessageKey_IsNumericMax()
     {
         // Seeded via v1 then migrated (v5 clears summaries), so insert fresh rows post-migration

--- a/QuickMail.Tests/MainViewModelOutboxTests.cs
+++ b/QuickMail.Tests/MainViewModelOutboxTests.cs
@@ -1,0 +1,286 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using QuickMail.Models;
+using QuickMail.Services;
+using QuickMail.ViewModels;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// The Outbox virtual folder (#637): where mail written offline waits, and the one place the user
+/// can see, reopen, remove or push it. These pin its placement in the tree, what its rows say, and
+/// that Enter and Delete on it go to the queue rather than to any server.
+/// </summary>
+public class MainViewModelOutboxTests
+{
+    private static readonly Guid Work = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid Home = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    private static AccountModel Account(Guid id, string label) => new()
+    {
+        Id = id, AccountName = label, Username = label.ToLowerInvariant() + "@example.com", AuthType = AuthType.OAuth2Microsoft,
+    };
+
+    private static OutboxItem Row(Guid account, OutboxKind kind, string subject, int minutesAgo, OutboxState state = OutboxState.Pending) => new()
+    {
+        Id = OutboxItem.NewId(), AccountId = account, Kind = kind, State = state, Subject = subject,
+        To = "to@example.com", CreatedUtc = DateTimeOffset.UtcNow.AddMinutes(-minutesAgo),
+    };
+
+    private sealed class Fixture
+    {
+        public StubOutboxService Outbox { get; } = new();
+        public CommandRegistry Registry { get; } = new();
+        public MainViewModel Vm { get; }
+
+        public Fixture(bool onlineMode = false, bool withOutbox = true)
+        {
+            var folders = new Dictionary<Guid, List<MailFolderModel>>
+            {
+                [Work] = [new MailFolderModel { AccountId = Work, FullName = "INBOX", DisplayName = "Inbox", Kind = SpecialFolderKind.Inbox }],
+            };
+            Vm = new MainViewModel(
+                new FolderedMailService(folders, []), new StubAccountService(), new StubCredentialService(),
+                new StubLocalStoreService(), new StubOAuthService(), new StubSyncService(),
+                new StubConfigService(), Registry, new StubViewService(),
+                new StubRuleService(), new StubSmtpService(),
+                onlineMode: onlineMode,
+                outboxService: withOutbox ? Outbox : null);
+            Vm.Accounts.Add(Account(Work, "Work"));
+            Vm.Accounts.Add(Account(Home, "Home"));
+        }
+
+        public async Task ConnectAsync() => await Vm.ConnectAllAccountsAsync();
+
+        public Task SelectOutboxAsync() => Vm.SelectFolderCommand.ExecuteAsync(MainViewModel.OutboxFolder);
+    }
+
+    // ── Placement ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task TheOutboxIsTheLastChildOfTheAllMailGroup()
+    {
+        var f = new Fixture();
+        await f.ConnectAsync();
+
+        var group = f.Vm.FolderTree.First(n => n.IsHeader && n.Label == "All Mail");
+        Assert.Equal("Outbox", group.Children.Last().Label);
+        Assert.Contains(f.Vm.Folders, x => x.FullName == MainViewModel.OutboxFolder.FullName);
+    }
+
+    [Fact]
+    public async Task OnlineModeHasNoOutbox()
+    {
+        var f = new Fixture(onlineMode: true);
+        await f.ConnectAsync();
+
+        var group = f.Vm.FolderTree.First(n => n.IsHeader && n.Label == "All Mail");
+        Assert.DoesNotContain(group.Children, c => c.Label == "Outbox");
+        Assert.DoesNotContain(f.Vm.Folders, x => x.FullName == MainViewModel.OutboxFolder.FullName);
+    }
+
+    [Fact]
+    public async Task NoOutboxServiceMeansNoOutboxFolder()
+    {
+        var f = new Fixture(withOutbox: false);
+        await f.ConnectAsync();
+
+        var group = f.Vm.FolderTree.First(n => n.IsHeader && n.Label == "All Mail");
+        Assert.DoesNotContain(group.Children, c => c.Label == "Outbox");
+    }
+
+    [Fact]
+    public void TheOutboxIsNeverAStartupFolderOrASavedViewTarget()
+    {
+        Assert.DoesNotContain(MainViewModel.AllVirtualFolders, v => v.FullName == MainViewModel.OutboxFolder.FullName);
+        Assert.Equal('\0', MainViewModel.OutboxFolder.FullName[0]);
+        Assert.Equal(SpecialFolderKind.Outbox, MainViewModel.OutboxFolder.Kind);
+    }
+
+    [Fact]
+    public async Task TheTreeNodeCountsWaitingItems()
+    {
+        var f = new Fixture();
+        f.Outbox.Items.Add(Row(Work, OutboxKind.Send, "one", 1));
+        f.Outbox.Items.Add(Row(Home, OutboxKind.Draft, "two", 2));
+        await f.ConnectAsync();
+
+        var node = f.Vm.FolderTree.First(n => n.IsHeader && n.Label == "All Mail").Children.Last();
+        Assert.Equal("Outbox, 2 waiting", node.AutomationName);
+
+        f.Outbox.Items.Clear();
+        f.Outbox.RaiseChanged();
+        Assert.Equal("Outbox", node.AutomationName);
+    }
+
+    // ── Listing ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SelectingTheOutboxListsTheQueueNewestFirstWithTheStateLeadingTheSubject()
+    {
+        var f = new Fixture();
+        f.Outbox.Items.Add(Row(Work, OutboxKind.Send, "Older", 10));
+        f.Outbox.Items.Add(Row(Home, OutboxKind.Draft, "Newer", 1));
+        f.Outbox.Items.Add(Row(Work, OutboxKind.Send, "Bounced", 5, OutboxState.Failed));
+        f.Outbox.Items[2].LastError = "550 no such user";
+        await f.ConnectAsync();
+
+        await f.SelectOutboxAsync();
+
+        Assert.True(f.Vm.IsSelectedFolderOutbox);
+        Assert.Equal(
+            ["Waiting to upload draft: Newer", "Failed: 550 no such user: Bounced", "Waiting to send: Older"],
+            f.Vm.Messages.Select(m => m.Subject));
+        Assert.Equal(["Home", "Work", "Work"], f.Vm.Messages.Select(m => m.From));
+        Assert.All(f.Vm.Messages, m => Assert.Equal(MainViewModel.OutboxFolder.FullName, m.FolderName));
+        Assert.All(f.Vm.Messages, m => Assert.True(m.IsRead));
+        Assert.Equal("3 items in Outbox.", f.Vm.StatusText);
+        Assert.False(f.Vm.IsBusy);
+    }
+
+    [Fact]
+    public async Task AnEmptyOutboxSaysSo()
+    {
+        var f = new Fixture();
+        await f.ConnectAsync();
+
+        await f.SelectOutboxAsync();
+
+        Assert.Empty(f.Vm.Messages);
+        Assert.Equal("Outbox is empty.", f.Vm.StatusText);
+    }
+
+    // ── Open ─────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task EnterOnARowReopensItInComposeWithItsOutboxId()
+    {
+        var f = new Fixture();
+        var row = Row(Work, OutboxKind.Send, "Lunch", 1);
+        f.Outbox.Items.Add(row);
+        f.Outbox.Composes[row.Id] = new ComposeModel { AccountId = Work, Subject = "Lunch", Bcc = "secret@example.com", Mode = ComposeMode.Markdown };
+        await f.ConnectAsync();
+        await f.SelectOutboxAsync();
+        ComposeModel? opened = null;
+        f.Vm.ComposeRequested += m => opened = m;
+
+        f.Vm.SelectedMessage = f.Vm.Messages[0];
+        await f.Vm.OpenOutboxItemCommand.ExecuteAsync(null);
+
+        Assert.NotNull(opened);
+        Assert.Equal(row.Id, opened.OutboxId);
+        Assert.Equal("secret@example.com", opened.Bcc);
+        Assert.Equal(ComposeMode.Markdown, opened.Mode);
+    }
+
+    [Fact]
+    public async Task EnterOnAVanishedRowSaysSoAndRelists()
+    {
+        var f = new Fixture();
+        var row = Row(Work, OutboxKind.Send, "Lunch", 1);
+        f.Outbox.Items.Add(row);
+        await f.ConnectAsync();
+        await f.SelectOutboxAsync();
+        f.Vm.SelectedMessage = f.Vm.Messages[0];
+        f.Outbox.Items.Clear();   // sent by a drain in the meantime; no compose stored
+
+        await f.Vm.OpenOutboxItemCommand.ExecuteAsync(null);
+
+        Assert.Equal("Outbox is empty.", f.Vm.StatusText);
+        Assert.Empty(f.Vm.Messages);
+    }
+
+    // ── Delete ───────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task DeleteRemovesFromTheQueueAfterAsking()
+    {
+        var f = new Fixture();
+        f.Outbox.Items.Add(Row(Work, OutboxKind.Send, "Keep", 3));
+        f.Outbox.Items.Add(Row(Work, OutboxKind.Send, "Drop", 1));
+        await f.ConnectAsync();
+        await f.SelectOutboxAsync();
+        var asked = new List<(string Prompt, string Title)>();
+        f.Vm.ConfirmationRequested = (prompt, title) => { asked.Add((prompt, title)); return true; };
+        var drop = f.Vm.Messages.First(m => m.Subject.EndsWith("Drop", StringComparison.Ordinal));
+
+        await f.Vm.DeleteMessagesAsync([drop]);
+
+        var ask = Assert.Single(asked);
+        Assert.Equal("Remove from Outbox", ask.Title);
+        Assert.Contains("has not been sent", ask.Prompt, StringComparison.Ordinal);
+        Assert.Equal([drop.MessageId], f.Outbox.Removed);
+        Assert.Equal("Waiting to send: Keep", Assert.Single(f.Vm.Messages).Subject);
+        Assert.Equal("1 Outbox item removed.", f.Vm.StatusText);
+    }
+
+    [Fact]
+    public async Task DecliningTheQuestionRemovesNothing()
+    {
+        var f = new Fixture();
+        f.Outbox.Items.Add(Row(Work, OutboxKind.Send, "Keep", 1));
+        await f.ConnectAsync();
+        await f.SelectOutboxAsync();
+        f.Vm.ConfirmationRequested = (_, _) => false;
+
+        await f.Vm.DeleteMessagesAsync([f.Vm.Messages[0]]);
+
+        Assert.Empty(f.Outbox.Removed);
+        Assert.Single(f.Vm.Messages);
+    }
+
+    // ── Send Outbox Now and drain summaries ──────────────────────────────────────
+
+    [Fact]
+    public async Task SendOutboxNowIsRegisteredWithNoDefaultKeyAndForcesADrain()
+    {
+        var f = new Fixture();
+        await f.ConnectAsync();
+        var cmd = f.Registry.FindById("mail.sendOutboxNow");
+        Assert.NotNull(cmd);
+        Assert.Equal("Mail", cmd.Category);
+        Assert.Equal(System.Windows.Input.Key.None, cmd.DefaultKey);
+
+        await f.Vm.SendOutboxNowCommand.ExecuteAsync(null);
+
+        Assert.Equal([true], f.Outbox.Flushes);
+        Assert.Equal("Outbox is empty.", f.Vm.StatusText);
+    }
+
+    [Fact]
+    public async Task ADrainIsAnnouncedOnceAsAWhole()
+    {
+        var f = new Fixture();
+        await f.ConnectAsync();
+
+        f.Outbox.RaiseFlushCompleted(new OutboxFlushResult(2, 1, 0, 0));
+
+        Assert.Equal("Outbox: 2 messages sent, 1 draft uploaded.", f.Vm.StatusText);
+    }
+
+    [Theory]
+    [InlineData(1, 0, 0, "Outbox: 1 message sent.")]
+    [InlineData(0, 1, 0, "Outbox: 1 draft uploaded.")]
+    [InlineData(2, 3, 0, "Outbox: 2 messages sent, 3 drafts uploaded.")]
+    [InlineData(1, 0, 1, "Outbox: 1 message sent. 1 failed. See the Outbox folder.")]
+    [InlineData(0, 0, 2, "Outbox: 2 failed. See the Outbox folder.")]
+    public void FlushSummaryWording(int sent, int drafts, int failed, string expected)
+    {
+        Assert.Equal(expected, MainViewModel.SummariseFlush(new OutboxFlushResult(sent, drafts, failed, 0)));
+    }
+
+    [Fact]
+    public void DisposeUnsubscribesFromTheQueue()
+    {
+        var f = new Fixture();
+        f.Vm.Dispose();
+        var before = f.Vm.StatusText;
+
+        f.Outbox.RaiseFlushCompleted(new OutboxFlushResult(1, 0, 0, 0));
+
+        Assert.Equal(before, f.Vm.StatusText);
+    }
+}

--- a/QuickMail.Tests/MainViewModelOutboxTests.cs
+++ b/QuickMail.Tests/MainViewModelOutboxTests.cs
@@ -273,6 +273,95 @@ public class MainViewModelOutboxTests
     }
 
     [Fact]
+    public async Task DeleteKeepsTheSelectionEvenThoughTheQueueRelistsInline()
+    {
+        // The real service raises Changed inline on the UI thread from RemoveAsync; the relist
+        // used to clear the list under the removal and strand focus.
+        var f = new Fixture();
+        f.Outbox.RaiseChangedOnRemove = true;
+        f.Outbox.Items.Add(Row(Work, OutboxKind.Send, "Third", 1));
+        f.Outbox.Items.Add(Row(Work, OutboxKind.Send, "Second", 2));
+        f.Outbox.Items.Add(Row(Work, OutboxKind.Send, "First", 3));
+        await f.ConnectAsync();
+        await f.SelectOutboxAsync();
+        f.Vm.ConfirmationRequested = (_, _) => true;
+        var second = f.Vm.Messages[1];
+
+        await f.Vm.DeleteMessagesAsync([second]);
+
+        Assert.Equal(2, f.Vm.Messages.Count);
+        Assert.NotNull(f.Vm.SelectedMessage);
+        Assert.EndsWith("First", f.Vm.SelectedMessage.Subject, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ADrainRelistsTheOutboxWithoutLosingTheSelection()
+    {
+        var f = new Fixture();
+        f.Outbox.Items.Add(Row(Work, OutboxKind.Send, "A", 2));
+        f.Outbox.Items.Add(Row(Work, OutboxKind.Send, "B", 1));
+        await f.ConnectAsync();
+        await f.SelectOutboxAsync();
+        f.Vm.SelectedMessage = f.Vm.Messages[1];   // "A"
+        var selectedId = f.Vm.SelectedMessage.MessageId;
+
+        f.Outbox.RaiseChanged();
+
+        Assert.Equal(selectedId, f.Vm.SelectedMessage?.MessageId);
+    }
+
+    [Fact]
+    public async Task SendOutboxNowWhileUnreachableSaysSoRatherThanBusy()
+    {
+        var f = new Fixture();
+        await f.ConnectAsync();
+        f.Outbox.NextFlushResult = new OutboxFlushResult(0, 0, 0, 0, Deferred: 1);
+
+        await f.Vm.SendOutboxNowCommand.ExecuteAsync(null);
+
+        Assert.Equal("Could not reach the server. The Outbox will try again when you're online.", f.Vm.StatusText);
+    }
+
+    [Fact]
+    public async Task AnAutomaticDrainIsBackgroundProgressAManualOneIsAResult()
+    {
+        var f = new Fixture();
+        await f.ConnectAsync();
+        var categories = new List<AnnouncementCategory>();
+        f.Vm.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(MainViewModel.StatusText) && f.Vm.StatusText.StartsWith("Outbox:", StringComparison.Ordinal))
+                categories.Add(f.Vm.StatusAnnouncementCategory);
+        };
+
+        f.Outbox.RaiseFlushCompleted(new OutboxFlushResult(1, 0, 0, 0));
+        Assert.Equal([AnnouncementCategory.Status], categories);
+
+        // The manual command's completion arrives while the command is still awaiting the drain.
+        f.Outbox.NextFlushResult = new OutboxFlushResult(1, 0, 0, 0);
+        f.Outbox.RaiseFlushCompletedDuringFlush = true;
+        await f.Vm.SendOutboxNowCommand.ExecuteAsync(null);
+        Assert.Equal([AnnouncementCategory.Status, AnnouncementCategory.Result], categories);
+    }
+
+    [Fact]
+    public async Task ReplyOnAnOutboxRowSaysToUseEnter()
+    {
+        var f = new Fixture();
+        f.Outbox.Items.Add(Row(Work, OutboxKind.Send, "Lunch", 1));
+        await f.ConnectAsync();
+        await f.SelectOutboxAsync();
+        f.Vm.SelectedMessage = f.Vm.Messages[0];
+        var opened = 0;
+        f.Vm.ComposeRequested += _ => opened++;
+
+        await f.Vm.ReplyCommand.ExecuteAsync(null);
+
+        Assert.Equal(0, opened);
+        Assert.Equal(MainViewModel.OutboxRowHint, f.Vm.StatusText);
+    }
+
+    [Fact]
     public void DisposeUnsubscribesFromTheQueue()
     {
         var f = new Fixture();

--- a/QuickMail.Tests/OutboxServiceTests.cs
+++ b/QuickMail.Tests/OutboxServiceTests.cs
@@ -192,7 +192,7 @@ public class OutboxServiceTests
 
         var result = await svc.FlushAsync();
 
-        Assert.Equal(new OutboxFlushResult(0, 0, 0, 1), result);
+        Assert.Equal(new OutboxFlushResult(0, 0, 0, 0, Deferred: 1), result);
         Assert.Empty(f.Completed);
         var row = await svc.GetAsync(id);
         Assert.NotNull(row);
@@ -436,6 +436,79 @@ public class OutboxServiceTests
         // Raising after dispose must not throw and must not start work on a disposed service.
         f.Connectivity.RaiseOnlineChanged(true);
         Assert.Equal(0, f.Connectivity.OnlineChangedSubscribers);
+    }
+
+    [Fact]
+    public async Task ARowLeftSendingByACrashIsGivenBackToTheQueue()
+    {
+        var f = new Fixture();
+        using var svc = f.Build();
+        var id = await svc.EnqueueSendAsync(f.Compose(), f.Account.Id, null);
+        // The previous process died mid-send: the row says Sending and nobody will finish it.
+        await f.Store.UpdateOutboxStateAsync(id, OutboxState.Sending, 1, null, null);
+
+        var result = await svc.FlushAsync();
+
+        Assert.Equal(1, result.Sent);
+        Assert.Empty(await svc.ListAsync());
+    }
+
+    [Fact]
+    public async Task ARowHeldByAComposeWindowIsNeverDrainedEvenWhenForced()
+    {
+        var f = new Fixture();
+        using var svc = f.Build();
+        var id = await svc.EnqueueSendAsync(f.Compose(), f.Account.Id, null);
+        svc.Hold(id);
+
+        Assert.Equal(1, (await svc.FlushAsync()).Skipped);
+        Assert.Equal(1, (await svc.FlushAsync(force: true)).Skipped);
+        Assert.Empty(f.Smtp.Sent);
+
+        svc.Release(id);
+        Assert.Equal(1, (await svc.FlushAsync()).Sent);
+    }
+
+    [Fact]
+    public async Task AForcedDrainThatCannotReachTheServerLeavesTheScheduleAlone()
+    {
+        var f = new Fixture();
+        using var svc = f.Build();
+        f.Smtp.SendFailure = Unreachable();
+        var id = await svc.EnqueueSendAsync(f.Compose(), f.Account.Id, null);
+
+        var forced = await svc.FlushAsync(force: true);
+
+        Assert.Equal(1, forced.Deferred);
+        Assert.Equal(0, forced.Skipped);
+        var row = await svc.GetAsync(id);
+        Assert.NotNull(row);
+        Assert.Equal(OutboxState.Pending, row.State);
+        Assert.Equal(0, row.Attempts);          // Send Outbox Now is not a strike against the row
+        Assert.Null(row.NextAttemptUtc);
+    }
+
+    [Fact]
+    public async Task ARowRewrittenWhileItWasBeingSentIsKeptForTheNextDrain()
+    {
+        var f = new Fixture();
+        var gate = new TaskCompletionSource();
+        var slowSmtp = new GatedSmtp(gate.Task);
+        using var svc = new OutboxService(f.Store, f.Mail, slowSmtp, new ListAccountService(f.Account),
+            new PasswordCredentialService("pw"), null, onlineMode: false);
+        var id = await svc.EnqueueSendAsync(f.Compose("first wording"), f.Account.Id, null);
+
+        var drain = svc.FlushAsync();
+        await slowSmtp.Started.Task;
+        // The user saved a newer version into the same row while the old one was on the wire.
+        await svc.EnqueueDraftAsync(f.Compose("second wording"), f.Account.Id, id);
+        gate.SetResult();
+        var result = await drain;
+
+        Assert.Equal(1, result.Sent);
+        var kept = Assert.Single(await svc.ListAsync());
+        Assert.Equal("second wording", kept.Subject);
+        Assert.Equal(OutboxState.Pending, kept.State);
     }
 
     [Theory]

--- a/QuickMail.Tests/OutboxServiceTests.cs
+++ b/QuickMail.Tests/OutboxServiceTests.cs
@@ -1,0 +1,451 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using MailKit.Net.Smtp;
+using QuickMail.Models;
+using QuickMail.Services;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// The drain is what turns "queued" into "sent" once the network is back (#637). These run against
+/// the real <see cref="LocalStoreService"/> on a temp profile with the send and mail services
+/// stubbed, so what is asserted is the service's own bookkeeping: which rows it touches, what
+/// state it leaves them in, and what it tells the rest of the app afterwards.
+/// </summary>
+public class OutboxServiceTests
+{
+    private static LocalStoreService NewStore()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), $"QuickMailOutboxSvc-{Guid.NewGuid():N}");
+        var store = new LocalStoreService(new ProfileContext(dir));
+        store.Initialize();
+        return store;
+    }
+
+    private sealed class ListAccountService(params AccountModel[] accounts) : IAccountService
+    {
+        private readonly List<AccountModel> _accounts = [.. accounts];
+        public List<AccountModel> LoadAccounts() => [.. _accounts];
+        public void SaveAccounts(List<AccountModel> accounts) { }
+        public void SetDefaultAccount(Guid accountId) { }
+    }
+
+    private sealed class PasswordCredentialService(string? password) : ICredentialService
+    {
+        public void SavePassword(Guid accountId, string password) { }
+        public string? GetPassword(Guid accountId) => password;
+        public void DeletePassword(Guid accountId) { }
+        public void SaveSecret(string key, string value) { }
+        public string? GetSecret(string key) => null;
+        public void DeleteSecret(string key) { }
+    }
+
+    /// <summary>Records draft and sent-folder traffic, with knobs to make each leg fail.</summary>
+    private sealed class RecordingMailService : StubImapMailServiceBase
+    {
+        public string? DraftsFolder { get; set; } = "Drafts";
+        public Exception? AppendDraftFailure { get; set; }
+        public List<(ComposeModel Draft, string? Replaced)> AppendedDrafts { get; } = [];
+        public List<ComposeModel> AppendedToSent { get; } = [];
+        public List<(string Folder, string Id)> Trashed { get; } = [];
+        public Exception? SentAppendFailure { get; set; }
+
+        public override Task<string?> FindDraftsFolderNameAsync(Guid accountId, CancellationToken ct = default)
+            => Task.FromResult(DraftsFolder);
+
+        public override Task<string> AppendDraftAsync(Guid accountId, ComposeModel draft, string? replaceMessageId, CancellationToken ct = default)
+        {
+            if (AppendDraftFailure != null) return Task.FromException<string>(AppendDraftFailure);
+            AppendedDrafts.Add((draft, replaceMessageId));
+            return Task.FromResult("77");
+        }
+
+        public override Task AppendToSentAsync(Guid accountId, ComposeModel sent, CancellationToken ct = default)
+        {
+            if (SentAppendFailure != null) return Task.FromException(SentAppendFailure);
+            AppendedToSent.Add(sent);
+            return Task.CompletedTask;
+        }
+
+        public override Task MoveToTrashAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default)
+        {
+            Trashed.Add((folderName, messageId));
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class Fixture
+    {
+        public LocalStoreService Store { get; } = NewStore();
+        public RecordingMailService Mail { get; } = new();
+        public StubSmtpService Smtp { get; } = new();
+        public StubConnectivityService Connectivity { get; } = new();
+        public AccountModel Account { get; } = new() { AccountName = "Work", Username = "kelly@example.com", AuthType = AuthType.Password };
+        public List<OutboxFlushResult> Completed { get; } = [];
+        public int ChangedCount { get; private set; }
+
+        public OutboxService Build(string? password = "pw", bool onlineMode = false, bool withConnectivity = true)
+        {
+            var svc = new OutboxService(Store, Mail, Smtp, new ListAccountService(Account),
+                new PasswordCredentialService(password), withConnectivity ? Connectivity : null, onlineMode);
+            svc.FlushCompleted += r => Completed.Add(r);
+            svc.Changed += () => ChangedCount++;
+            return svc;
+        }
+
+        public ComposeModel Compose(string subject = "Hello") => new()
+        {
+            AccountId = Account.Id,
+            To = "to@example.com",
+            Subject = subject,
+            Body = "body",
+            DraftMessageId = "4242",
+            DraftFolderName = "Drafts",
+        };
+    }
+
+    private static SocketException Unreachable() => new((int)SocketError.HostUnreachable);
+
+    private static SmtpCommandException Rejected()
+        => new(SmtpErrorCode.RecipientNotAccepted, SmtpStatusCode.MailboxUnavailable, "550 no such user");
+
+    [Fact]
+    public async Task EnqueueTwiceWithTheSameIdKeepsOneRow()
+    {
+        var f = new Fixture();
+        using var svc = f.Build();
+
+        var id = await svc.EnqueueDraftAsync(f.Compose("first"), f.Account.Id, existingId: null);
+        var again = await svc.EnqueueDraftAsync(f.Compose("second"), f.Account.Id, existingId: id);
+
+        Assert.Equal(id, again);
+        var one = Assert.Single(await svc.ListAsync());
+        Assert.Equal("second", one.Subject);
+        Assert.Equal(OutboxKind.Draft, one.Kind);
+        Assert.Equal(2, f.ChangedCount);
+    }
+
+    [Fact]
+    public async Task EnqueueSendOverADraftRowTurnsItIntoASend()
+    {
+        var f = new Fixture();
+        using var svc = f.Build();
+
+        var id = await svc.EnqueueDraftAsync(f.Compose(), f.Account.Id, null);
+        await svc.EnqueueSendAsync(f.Compose(), f.Account.Id, id);
+
+        var one = Assert.Single(await svc.ListAsync());
+        Assert.Equal(OutboxKind.Send, one.Kind);
+        Assert.Equal(OutboxState.Pending, one.State);
+        Assert.Equal("4242", one.ReplaceDraftId);
+    }
+
+    [Fact]
+    public async Task FlushSendsFilesInSentTrashesTheServerDraftAndRemovesTheRow()
+    {
+        var f = new Fixture();
+        using var svc = f.Build();
+        await svc.EnqueueSendAsync(f.Compose(), f.Account.Id, null);
+
+        var result = await svc.FlushAsync();
+
+        Assert.Equal(new OutboxFlushResult(1, 0, 0, 0), result);
+        var sent = Assert.Single(f.Smtp.Sent);
+        Assert.Equal("Hello", sent.Compose.Subject);
+        Assert.Equal(f.Account.Id, sent.Account.Id);
+        Assert.Single(f.Mail.AppendedToSent);
+        Assert.Equal(("Drafts", "4242"), Assert.Single(f.Mail.Trashed));
+        Assert.Empty(await svc.ListAsync());
+        Assert.Equal(result, Assert.Single(f.Completed));
+    }
+
+    [Fact]
+    public async Task FlushUploadsADraftReplacingTheServerCopy()
+    {
+        var f = new Fixture();
+        using var svc = f.Build();
+        await svc.EnqueueDraftAsync(f.Compose(), f.Account.Id, null);
+
+        var result = await svc.FlushAsync();
+
+        Assert.Equal(new OutboxFlushResult(0, 1, 0, 0), result);
+        var (draft, replaced) = Assert.Single(f.Mail.AppendedDrafts);
+        Assert.Equal("4242", replaced);
+        Assert.Equal("Drafts", draft.DraftFolderName);
+        Assert.Empty(f.Smtp.Sent);
+        Assert.Empty(await svc.ListAsync());
+    }
+
+    [Fact]
+    public async Task ATransportFailureLeavesTheRowPendingWithBackoff()
+    {
+        var f = new Fixture();
+        using var svc = f.Build();
+        f.Smtp.SendFailure = Unreachable();
+        var id = await svc.EnqueueSendAsync(f.Compose(), f.Account.Id, null);
+
+        var result = await svc.FlushAsync();
+
+        Assert.Equal(new OutboxFlushResult(0, 0, 0, 1), result);
+        Assert.Empty(f.Completed);
+        var row = await svc.GetAsync(id);
+        Assert.NotNull(row);
+        Assert.Equal(OutboxState.Pending, row.State);
+        Assert.Equal(1, row.Attempts);
+        Assert.NotNull(row.NextAttemptUtc);
+        Assert.True(row.NextAttemptUtc > DateTimeOffset.UtcNow.AddMinutes(1));
+        Assert.Contains("Waiting to send", row.StateDisplay, StringComparison.Ordinal);
+
+        // Inside the backoff window the row is not retried, even though the network is "back".
+        f.Smtp.SendFailure = null;
+        var second = await svc.FlushAsync();
+        Assert.Equal(1, second.Skipped);
+        Assert.Empty(f.Smtp.Sent);
+
+        // Send Outbox Now ignores the backoff.
+        var forced = await svc.FlushAsync(force: true);
+        Assert.Equal(1, forced.Sent);
+        Assert.Single(f.Smtp.Sent);
+    }
+
+    [Fact]
+    public async Task AServerRejectionParksTheRowAsFailedUntilForced()
+    {
+        var f = new Fixture();
+        using var svc = f.Build();
+        f.Smtp.SendFailure = Rejected();
+        var id = await svc.EnqueueSendAsync(f.Compose(), f.Account.Id, null);
+
+        var result = await svc.FlushAsync();
+
+        Assert.Equal(new OutboxFlushResult(0, 0, 1, 0), result);
+        Assert.Equal(result, Assert.Single(f.Completed));
+        var row = await svc.GetAsync(id);
+        Assert.NotNull(row);
+        Assert.Equal(OutboxState.Failed, row.State);
+        Assert.StartsWith("Failed: ", row.StateDisplay, StringComparison.Ordinal);
+        Assert.Contains("550", row.LastError, StringComparison.Ordinal);
+
+        // A plain drain leaves it alone; the user has to ask.
+        f.Smtp.SendFailure = null;
+        Assert.Equal(0, (await svc.FlushAsync()).Sent);
+        Assert.Equal(1, (await svc.FlushAsync(force: true)).Sent);
+        Assert.Empty(await svc.ListAsync());
+    }
+
+    [Fact]
+    public async Task NoDraftsFolderIsAPermanentFailureWithAReasonTheUserCanRead()
+    {
+        var f = new Fixture();
+        using var svc = f.Build();
+        f.Mail.DraftsFolder = null;
+        var compose = f.Compose();
+        compose.DraftFolderName = null;
+        var id = await svc.EnqueueDraftAsync(compose, f.Account.Id, null);
+
+        var result = await svc.FlushAsync();
+
+        Assert.Equal(1, result.Failed);
+        var row = await svc.GetAsync(id);
+        Assert.NotNull(row);
+        Assert.Equal(OutboxState.Failed, row.State);
+        Assert.Equal("No Drafts folder found on this account.", row.LastError);
+    }
+
+    [Fact]
+    public async Task MissingPasswordIsAPermanentFailure()
+    {
+        var f = new Fixture();
+        using var svc = f.Build(password: null);
+        var id = await svc.EnqueueSendAsync(f.Compose(), f.Account.Id, null);
+
+        await svc.FlushAsync();
+
+        var row = await svc.GetAsync(id);
+        Assert.NotNull(row);
+        Assert.Equal(OutboxState.Failed, row.State);
+        Assert.Equal("No password stored for this account.", row.LastError);
+        Assert.Empty(f.Smtp.Sent);
+    }
+
+    [Fact]
+    public async Task AKnownOfflineAccountIsSkippedUnlessForced()
+    {
+        var f = new Fixture();
+        using var svc = f.Build();
+        f.Connectivity.SetAccount(f.Account.Id, false);
+        await svc.EnqueueSendAsync(f.Compose(), f.Account.Id, null);
+
+        var result = await svc.FlushAsync();
+        Assert.Equal(1, result.Skipped);
+        Assert.Empty(f.Smtp.Sent);
+
+        var forced = await svc.FlushAsync(force: true);
+        Assert.Equal(1, forced.Sent);
+    }
+
+    [Fact]
+    public async Task SentAppendFailureDoesNotFailTheRow()
+    {
+        var f = new Fixture();
+        using var svc = f.Build();
+        f.Mail.SentAppendFailure = new InvalidOperationException("no Sent folder");
+        await svc.EnqueueSendAsync(f.Compose(), f.Account.Id, null);
+
+        var result = await svc.FlushAsync();
+
+        Assert.Equal(1, result.Sent);
+        Assert.Empty(await svc.ListAsync());
+    }
+
+    [Fact]
+    public async Task ItemsDrainOldestFirst()
+    {
+        var f = new Fixture();
+        using var svc = f.Build();
+        var first = await svc.EnqueueSendAsync(f.Compose("first"), f.Account.Id, null);
+        var row = await f.Store.LoadOutboxItemAsync(first);
+        row!.CreatedUtc = DateTimeOffset.UtcNow.AddMinutes(-5);
+        await f.Store.UpsertOutboxItemAsync(row, f.Compose("first"));
+        await svc.EnqueueSendAsync(f.Compose("second"), f.Account.Id, null);
+
+        await svc.FlushAsync();
+
+        Assert.Equal(["first", "second"], f.Smtp.Sent.Select(s => s.Compose.Subject));
+    }
+
+    [Fact]
+    public async Task FlushAccountOnlyTouchesThatAccount()
+    {
+        var f = new Fixture();
+        using var svc = f.Build();
+        var other = Guid.NewGuid();
+        await svc.EnqueueSendAsync(f.Compose("mine"), f.Account.Id, null);
+        var otherCompose = f.Compose("theirs");
+        otherCompose.AccountId = other;
+        await svc.EnqueueSendAsync(otherCompose, other, null);
+
+        var result = await svc.FlushAccountAsync(f.Account.Id);
+
+        Assert.Equal(1, result.Sent);
+        Assert.Equal("mine", Assert.Single(f.Smtp.Sent).Compose.Subject);
+        Assert.Equal("theirs", Assert.Single(await svc.ListAsync()).Subject);
+    }
+
+    [Fact]
+    public async Task RemoveReportsWhetherTheRowExisted()
+    {
+        var f = new Fixture();
+        using var svc = f.Build();
+        var id = await svc.EnqueueSendAsync(f.Compose(), f.Account.Id, null);
+
+        Assert.True(await svc.RemoveAsync(id));
+        Assert.False(await svc.RemoveAsync(id));
+        Assert.Equal(0, await svc.CountAsync());
+    }
+
+    [Fact]
+    public async Task ConcurrentFlushIsSkippedNotQueued()
+    {
+        var f = new Fixture();
+        using var svc = f.Build();
+        var gate = new TaskCompletionSource();
+        var slowSmtp = new GatedSmtp(gate.Task);
+        using var slow = new OutboxService(f.Store, f.Mail, slowSmtp, new ListAccountService(f.Account),
+            new PasswordCredentialService("pw"), null, onlineMode: false);
+        await slow.EnqueueSendAsync(f.Compose(), f.Account.Id, null);
+
+        var first = slow.FlushAsync();
+        await slowSmtp.Started.Task;
+        var second = await slow.FlushAsync();
+        Assert.Equal(1, second.Skipped);
+        Assert.Equal(0, second.Sent);
+
+        gate.SetResult();
+        Assert.Equal(1, (await first).Sent);
+    }
+
+    private sealed class GatedSmtp(Task gate) : ISendMailService
+    {
+        public TaskCompletionSource Started { get; } = new();
+        public async Task SendAsync(ComposeModel compose, AccountModel account, string? password, CancellationToken ct = default)
+        {
+            Started.TrySetResult();
+            await gate;
+        }
+        public Task SendIcsReplyAsync(string icsReplyContent, AccountModel account, string? password, string organizerEmail, CancellationToken ct = default) => Task.CompletedTask;
+        public Task VerifyAsync(AccountModel account, string? password, CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task OnlineModeNeverTouchesTheStore()
+    {
+        var f = new Fixture();
+        using var svc = new OutboxService(new ThrowingStore(), f.Mail, f.Smtp, new ListAccountService(f.Account),
+            new PasswordCredentialService("pw"), null, onlineMode: true);
+
+        Assert.False(svc.IsAvailable);
+        await Assert.ThrowsAsync<InvalidOperationException>(() => svc.EnqueueSendAsync(f.Compose(), f.Account.Id, null));
+        await Assert.ThrowsAsync<InvalidOperationException>(() => svc.EnqueueDraftAsync(f.Compose(), f.Account.Id, null));
+        Assert.Empty(await svc.ListAsync());
+        Assert.Equal(0, await svc.CountAsync());
+        Assert.Equal(OutboxFlushResult.Nothing, await svc.FlushAsync());
+        Assert.Null(await svc.LoadComposeAsync("outbox-x"));
+    }
+
+    /// <summary>What every ILocalStoreService call does in --online mode: throw.</summary>
+    private sealed class ThrowingStore : StubLocalStoreService
+    {
+        public override Task UpsertOutboxItemAsync(OutboxItem item, ComposeModel compose) => throw new InvalidOperationException("no store");
+        public override Task<List<OutboxItem>> LoadOutboxItemsAsync() => throw new InvalidOperationException("no store");
+        public override Task<OutboxItem?> LoadOutboxItemAsync(string id) => throw new InvalidOperationException("no store");
+        public override Task<ComposeModel?> LoadOutboxComposeAsync(string id) => throw new InvalidOperationException("no store");
+        public override Task<int> CountOutboxItemsAsync() => throw new InvalidOperationException("no store");
+    }
+
+    [Fact]
+    public async Task ComingBackOnlineDrainsWithoutBeingAsked()
+    {
+        var f = new Fixture();
+        using var svc = f.Build();
+        await svc.EnqueueSendAsync(f.Compose(), f.Account.Id, null);
+
+        f.Connectivity.RaiseOnlineChanged(true);
+
+        // The reconnect drain is debounced by a couple of seconds so several accounts returning
+        // together start one drain, not one each.
+        var deadline = DateTime.UtcNow.AddSeconds(10);
+        while (f.Smtp.Sent.Count == 0 && DateTime.UtcNow < deadline)
+            await Task.Delay(50);
+        Assert.Single(f.Smtp.Sent);
+        Assert.Single(f.Completed);
+    }
+
+    [Fact]
+    public void DisposeUnsubscribesFromConnectivity()
+    {
+        var f = new Fixture();
+        var svc = f.Build();
+        svc.Dispose();
+        // Raising after dispose must not throw and must not start work on a disposed service.
+        f.Connectivity.RaiseOnlineChanged(true);
+        Assert.Equal(0, f.Connectivity.OnlineChangedSubscribers);
+    }
+
+    [Theory]
+    [InlineData(1, 2)]
+    [InlineData(2, 4)]
+    [InlineData(4, 16)]
+    [InlineData(5, 32)]
+    [InlineData(9, 32)]
+    public void BackoffDoublesAndCaps(int attempts, int minutes)
+    {
+        Assert.Equal(TimeSpan.FromMinutes(minutes), OutboxService.Backoff(attempts));
+    }
+}

--- a/QuickMail.Tests/OutboxStoreTests.cs
+++ b/QuickMail.Tests/OutboxStoreTests.cs
@@ -1,0 +1,217 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using QuickMail.Models;
+using QuickMail.Services;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// The Outbox tables (#637) hold the only copy of a message written offline, so these run against
+/// the real <see cref="LocalStoreService"/> on a temp profile rather than the stub: a hand-written
+/// fake store would happily pass tests the shipping SQL fails. What matters most is that a row
+/// reopens in the compose window with nothing lost — Bcc, the Markdown source, the mode, the reply
+/// linkage and the attachment bytes — because a MIME round-trip loses every one of those.
+/// </summary>
+public class OutboxStoreTests
+{
+    private static LocalStoreService NewStore()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), $"QuickMailOutbox-{Guid.NewGuid():N}");
+        var store = new LocalStoreService(new ProfileContext(dir));
+        store.Initialize();
+        return store;
+    }
+
+    private static ComposeModel FullCompose(Guid accountId) => new()
+    {
+        Kind = ComposeKind.Reply,
+        AccountId = accountId,
+        To = "to@example.com",
+        Cc = "cc@example.com",
+        Bcc = "secret@example.com",
+        Subject = "Lunch Friday",
+        Body = "# Heading\n\nMarkdown *source*",
+        Mode = ComposeMode.Markdown,
+        HtmlBody = "<html><body><h1>Heading</h1></body></html>",
+        InReplyToMessageId = "<parent@example.com>",
+        DraftMessageId = "4242",
+        DraftFolderName = "Drafts",
+        Attachments =
+        [
+            new AttachmentModel { FileName = "a.txt", ContentType = "text/plain", FileSize = 3, Content = [1, 2, 3] },
+            new AttachmentModel { FileName = "b.bin", ContentType = "application/octet-stream", Content = [9, 8, 7, 6] },
+            // Never downloaded: nothing to send later, so it must be dropped rather than stored as empty.
+            new AttachmentModel { FileName = "ghost.pdf", ContentType = "application/pdf", FileSize = 100, PartSpecifier = "2" },
+        ],
+    };
+
+    private static OutboxItem Item(Guid accountId, OutboxKind kind, ComposeModel compose) => new()
+    {
+        Id = OutboxItem.NewId(),
+        AccountId = accountId,
+        Kind = kind,
+        Subject = compose.Subject,
+        To = compose.To,
+        Cc = compose.Cc,
+        Bcc = compose.Bcc,
+        ReplaceDraftId = compose.DraftMessageId,
+        DraftFolderName = compose.DraftFolderName,
+    };
+
+    [Fact]
+    public async Task ComposeRoundTripsLosslessly()
+    {
+        var store = NewStore();
+        var account = Guid.NewGuid();
+        var compose = FullCompose(account);
+        var item = Item(account, OutboxKind.Send, compose);
+
+        await store.UpsertOutboxItemAsync(item, compose);
+        var back = await store.LoadOutboxComposeAsync(item.Id);
+
+        Assert.NotNull(back);
+        Assert.Equal(ComposeKind.Reply, back.Kind);
+        Assert.Equal(account, back.AccountId);
+        Assert.Equal("secret@example.com", back.Bcc);
+        Assert.Equal("# Heading\n\nMarkdown *source*", back.Body);
+        Assert.Equal(ComposeMode.Markdown, back.Mode);
+        Assert.Equal(compose.HtmlBody, back.HtmlBody);
+        Assert.Equal("<parent@example.com>", back.InReplyToMessageId);
+        Assert.Equal("4242", back.DraftMessageId);
+        Assert.Equal("Drafts", back.DraftFolderName);
+        Assert.Equal(item.Id, back.OutboxId);
+    }
+
+    [Fact]
+    public async Task AttachmentsRehydrateByteEqualInOrderAndUnloadedOnesAreDropped()
+    {
+        var store = NewStore();
+        var account = Guid.NewGuid();
+        var compose = FullCompose(account);
+        var item = Item(account, OutboxKind.Draft, compose);
+
+        await store.UpsertOutboxItemAsync(item, compose);
+        var back = await store.LoadOutboxComposeAsync(item.Id);
+
+        Assert.NotNull(back);
+        Assert.Equal(["a.txt", "b.bin"], back.Attachments.Select(a => a.FileName));
+        Assert.Equal([1, 2, 3], back.Attachments[0].Content);
+        Assert.Equal([9, 8, 7, 6], back.Attachments[1].Content);
+        Assert.Equal("text/plain", back.Attachments[0].ContentType);
+        Assert.Equal(3, back.Attachments[0].FileSize);
+        // FileSize was 0 on the way in; the stored size is the byte length.
+        Assert.Equal(4, back.Attachments[1].FileSize);
+        Assert.All(back.Attachments, a => Assert.True(a.IsLoaded));
+        Assert.True(item.HasAttachments);
+    }
+
+    [Fact]
+    public async Task ListingIsNewestFirstWithoutJsonOrBlobs()
+    {
+        var store = NewStore();
+        var account = Guid.NewGuid();
+        var older = Item(account, OutboxKind.Draft, new ComposeModel { Subject = "older" });
+        older.CreatedUtc = DateTimeOffset.UtcNow.AddMinutes(-10);
+        var newer = Item(account, OutboxKind.Send, new ComposeModel { Subject = "newer" });
+        newer.CreatedUtc = DateTimeOffset.UtcNow;
+
+        await store.UpsertOutboxItemAsync(older, new ComposeModel { Subject = "older" });
+        await store.UpsertOutboxItemAsync(newer, new ComposeModel { Subject = "newer" });
+
+        var list = await store.LoadOutboxItemsAsync();
+        Assert.Equal(["newer", "older"], list.Select(i => i.Subject));
+        Assert.Equal(OutboxKind.Send, list[0].Kind);
+        Assert.Equal(OutboxState.Pending, list[0].State);
+        Assert.False(list[0].HasAttachments);
+        Assert.Equal(2, await store.CountOutboxItemsAsync());
+    }
+
+    [Fact]
+    public async Task UpsertWithTheSameIdReplacesRatherThanDuplicates()
+    {
+        var store = NewStore();
+        var account = Guid.NewGuid();
+        var compose = FullCompose(account);
+        var item = Item(account, OutboxKind.Draft, compose);
+        await store.UpsertOutboxItemAsync(item, compose);
+
+        // Second save: fewer attachments, a new subject, and the kind flips to Send.
+        compose.Subject = "Lunch Friday (moved)";
+        compose.Attachments.RemoveAt(1);
+        item.Subject = compose.Subject;
+        item.Kind = OutboxKind.Send;
+        await store.UpsertOutboxItemAsync(item, compose);
+
+        var list = await store.LoadOutboxItemsAsync();
+        var one = Assert.Single(list);
+        Assert.Equal("Lunch Friday (moved)", one.Subject);
+        Assert.Equal(OutboxKind.Send, one.Kind);
+        var back = await store.LoadOutboxComposeAsync(item.Id);
+        Assert.NotNull(back);
+        Assert.Equal(["a.txt"], back.Attachments.Select(a => a.FileName));
+    }
+
+    [Fact]
+    public async Task StateUpdateAndDeleteCascade()
+    {
+        var store = NewStore();
+        var account = Guid.NewGuid();
+        var compose = FullCompose(account);
+        var item = Item(account, OutboxKind.Send, compose);
+        await store.UpsertOutboxItemAsync(item, compose);
+
+        var next = DateTimeOffset.UtcNow.AddMinutes(4);
+        await store.UpdateOutboxStateAsync(item.Id, OutboxState.Failed, 3, "550 no such user", next);
+        var loaded = await store.LoadOutboxItemAsync(item.Id);
+        Assert.NotNull(loaded);
+        Assert.Equal(OutboxState.Failed, loaded.State);
+        Assert.Equal(3, loaded.Attempts);
+        Assert.Equal("550 no such user", loaded.LastError);
+        Assert.Equal(next.UtcTicks, loaded.NextAttemptUtc!.Value.UtcTicks);
+        Assert.Equal("Failed: 550 no such user", loaded.StateDisplay);
+
+        await store.DeleteOutboxItemAsync(item.Id);
+        Assert.Null(await store.LoadOutboxItemAsync(item.Id));
+        Assert.Null(await store.LoadOutboxComposeAsync(item.Id));
+        Assert.Equal(0, await store.CountOutboxItemsAsync());
+        // Deleting again is a no-op, not an error.
+        await store.DeleteOutboxItemAsync(item.Id);
+    }
+
+    [Fact]
+    public async Task AccountDeleteIsScopedAndClearingCacheLeavesTheOutboxAlone()
+    {
+        var store = NewStore();
+        var doomed = Guid.NewGuid();
+        var kept = Guid.NewGuid();
+        await store.UpsertOutboxItemAsync(Item(doomed, OutboxKind.Send, new ComposeModel { Subject = "d" }), FullCompose(doomed));
+        await store.UpsertOutboxItemAsync(Item(kept, OutboxKind.Send, new ComposeModel { Subject = "k" }), FullCompose(kept));
+
+        // The Graph immutable-id rebuild clears cached mail; queued mail is not cache.
+        await store.ClearCachedMailAsync([doomed, kept]);
+        Assert.Equal(2, await store.CountOutboxItemsAsync());
+
+        await store.DeleteAccountDataAsync(doomed);
+        var remaining = Assert.Single(await store.LoadOutboxItemsAsync());
+        Assert.Equal(kept, remaining.AccountId);
+        var back = await store.LoadOutboxComposeAsync(remaining.Id);
+        Assert.NotNull(back);
+        Assert.Equal(2, back.Attachments.Count);
+    }
+
+    [Theory]
+    [InlineData(OutboxKind.Send, OutboxState.Pending, "Waiting to send")]
+    [InlineData(OutboxKind.Draft, OutboxState.Pending, "Waiting to upload draft")]
+    [InlineData(OutboxKind.Send, OutboxState.Sending, "Sending…")]
+    [InlineData(OutboxKind.Draft, OutboxState.Sending, "Uploading draft…")]
+    [InlineData(OutboxKind.Send, OutboxState.Failed, "Failed")]
+    public void StateDisplayWording(OutboxKind kind, OutboxState state, string expected)
+    {
+        var item = new OutboxItem { Kind = kind, State = state, Subject = "s" };
+        Assert.Equal(expected, item.StateDisplay);
+        Assert.Equal($"{expected}: s", item.ToString());
+    }
+}

--- a/QuickMail.Tests/StubServices.cs
+++ b/QuickMail.Tests/StubServices.cs
@@ -315,6 +315,40 @@ class StubLocalStoreService : ILocalStoreService
         if (Pop3Uidls.TryGetValue(accountId, out var set)) set.ExceptWith(uidls);
         return Task.CompletedTask;
     }
+    /// <summary>In-memory Outbox rows (#637), keyed by id, so compose and main-window tests can
+    /// assert what was queued without SQLite. Functional: upsert replaces, delete removes, and the
+    /// compose comes back with <see cref="ComposeModel.OutboxId"/> stamped like the real store.</summary>
+    public Dictionary<string, (OutboxItem Item, ComposeModel Compose)> OutboxRows { get; } = new(StringComparer.Ordinal);
+    public virtual Task UpsertOutboxItemAsync(OutboxItem item, ComposeModel compose)
+    {
+        item.HasAttachments = compose.Attachments.Any(a => a.IsLoaded);
+        item.UpdatedUtc = DateTimeOffset.UtcNow;
+        if (item.CreatedUtc == default) item.CreatedUtc = item.UpdatedUtc;
+        OutboxRows[item.Id] = (item, compose);
+        return Task.CompletedTask;
+    }
+    public virtual Task<List<OutboxItem>> LoadOutboxItemsAsync()
+        => Task.FromResult(OutboxRows.Values.Select(v => v.Item).OrderByDescending(i => i.CreatedUtc).ToList());
+    public virtual Task<OutboxItem?> LoadOutboxItemAsync(string id)
+        => Task.FromResult(OutboxRows.TryGetValue(id, out var row) ? row.Item : null);
+    public virtual Task<ComposeModel?> LoadOutboxComposeAsync(string id)
+    {
+        if (!OutboxRows.TryGetValue(id, out var row)) return Task.FromResult<ComposeModel?>(null);
+        row.Compose.OutboxId = id;
+        return Task.FromResult<ComposeModel?>(row.Compose);
+    }
+    public virtual Task UpdateOutboxStateAsync(string id, OutboxState state, int attempts, string? lastError, DateTimeOffset? nextAttemptUtc)
+    {
+        if (OutboxRows.TryGetValue(id, out var row))
+        {
+            row.Item.State = state; row.Item.Attempts = attempts; row.Item.LastError = lastError;
+            row.Item.NextAttemptUtc = nextAttemptUtc; row.Item.UpdatedUtc = DateTimeOffset.UtcNow;
+        }
+        return Task.CompletedTask;
+    }
+    public virtual Task DeleteOutboxItemAsync(string id) { OutboxRows.Remove(id); return Task.CompletedTask; }
+    public virtual Task<int> CountOutboxItemsAsync() => Task.FromResult(OutboxRows.Count);
+
     public virtual Task<string> GetMaxMessageKeyAsync(Guid accountId, string folderName) => Task.FromResult("0");
     public virtual Task<HashSet<string>> GetAllMessageIdsAsync(Guid accountId, string folderName) => Task.FromResult(new HashSet<string>());
     public virtual Task<Dictionary<string, bool>> LoadFolderReadStatesAsync(Guid accountId, string folderName) => Task.FromResult(new Dictionary<string, bool>());

--- a/QuickMail.Tests/StubServices.cs
+++ b/QuickMail.Tests/StubServices.cs
@@ -75,7 +75,7 @@ class StubImapMailServiceBase : IMailService
     public Task MarkReadAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default) => _inner.MarkReadAsync(accountId, folderName, messageId, ct);
     public Task MarkReadBatchAsync(Guid accountId, string folderName, IList<string> messageIds, CancellationToken ct = default) => _inner.MarkReadBatchAsync(accountId, folderName, messageIds, ct);
     public Task SetMessageFlaggedAsync(Guid accountId, string folderName, string messageId, bool flagged, CancellationToken ct = default) => _inner.SetMessageFlaggedAsync(accountId, folderName, messageId, flagged, ct);
-    public Task MoveToTrashAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default) => _inner.MoveToTrashAsync(accountId, folderName, messageId, ct);
+    public virtual Task MoveToTrashAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default) => _inner.MoveToTrashAsync(accountId, folderName, messageId, ct);
     public Task MoveToTrashBatchAsync(Guid accountId, string folderName, IList<string> messageIds, CancellationToken ct = default) => _inner.MoveToTrashBatchAsync(accountId, folderName, messageIds, ct);
     public Task PermanentlyDeleteBatchAsync(Guid accountId, string folderName, IList<string> messageIds, CancellationToken ct = default) => _inner.PermanentlyDeleteBatchAsync(accountId, folderName, messageIds, ct);
     public Task NoOpAsync(Guid accountId, CancellationToken ct = default) => _inner.NoOpAsync(accountId, ct);
@@ -86,9 +86,9 @@ class StubImapMailServiceBase : IMailService
     public Task<IReadOnlyDictionary<string, string>> FetchPreviewsAsync(Guid accountId, string folderName, IList<string> messageIds, int maxLines, CancellationToken ct = default) => _inner.FetchPreviewsAsync(accountId, folderName, messageIds, maxLines, ct);
     public Task<int> PollAsync(Guid accountId, string folderName, CancellationToken ct = default) => _inner.PollAsync(accountId, folderName, ct);
     public Task<(int Total, int Unread)> GetInboxStatusAsync(Guid accountId, CancellationToken ct = default) => _inner.GetInboxStatusAsync(accountId, ct);
-    public Task<string?> FindDraftsFolderNameAsync(Guid accountId, CancellationToken ct = default) => _inner.FindDraftsFolderNameAsync(accountId, ct);
-    public Task<string> AppendDraftAsync(Guid accountId, ComposeModel draft, string? replaceMessageId, CancellationToken ct = default) => _inner.AppendDraftAsync(accountId, draft, replaceMessageId, ct);
-    public Task AppendToSentAsync(Guid accountId, ComposeModel sent, CancellationToken ct = default) => _inner.AppendToSentAsync(accountId, sent, ct);
+    public virtual Task<string?> FindDraftsFolderNameAsync(Guid accountId, CancellationToken ct = default) => _inner.FindDraftsFolderNameAsync(accountId, ct);
+    public virtual Task<string> AppendDraftAsync(Guid accountId, ComposeModel draft, string? replaceMessageId, CancellationToken ct = default) => _inner.AppendDraftAsync(accountId, draft, replaceMessageId, ct);
+    public virtual Task AppendToSentAsync(Guid accountId, ComposeModel sent, CancellationToken ct = default) => _inner.AppendToSentAsync(accountId, sent, ct);
     public Task<byte[]> DownloadAttachmentAsync(Guid accountId, string folderName, string messageId, string partSpecifier, CancellationToken ct = default) => _inner.DownloadAttachmentAsync(accountId, folderName, messageId, partSpecifier, ct);
     // Virtual: a double needs to make the server refuse, so a test can tell "it worked" from "it
     // was recorded anyway" — which is the whole of the remembered-destination rule (#515).
@@ -582,6 +582,109 @@ sealed class StubRuleService : IRuleService
     public Task<List<MailMessageSummary>> ApplyRulesToExistingAsync(
         ILocalStoreService store, IReadOnlyDictionary<Guid, string> inboxFolderByAccount, CancellationToken ct)
         => Task.FromResult(new List<MailMessageSummary>());
+}
+
+/// <summary>
+/// Records what the compose window and main window queue (#637) without a store, and lets a test
+/// decide whether the Outbox is "available" (it is not in --online mode) and whether an enqueue
+/// blows up, the way a broken SQLite file would.
+/// </summary>
+sealed class StubOutboxService : IOutboxService
+{
+    public bool IsAvailable { get; set; } = true;
+    public Exception? EnqueueFailure { get; set; }
+    public List<(OutboxKind Kind, ComposeModel Compose, Guid AccountId, string? ExistingId, string Id)> Enqueued { get; } = [];
+    public List<string> Removed { get; } = [];
+    public List<OutboxItem> Items { get; } = [];
+    public Dictionary<string, ComposeModel> Composes { get; } = new(StringComparer.Ordinal);
+    public List<bool> Flushes { get; } = [];
+    public OutboxFlushResult NextFlushResult { get; set; } = OutboxFlushResult.Nothing;
+
+    public event Action? Changed;
+    public event Action<OutboxFlushResult>? FlushCompleted;
+
+    public void RaiseChanged() => Changed?.Invoke();
+    public void RaiseFlushCompleted(OutboxFlushResult r) => FlushCompleted?.Invoke(r);
+
+    private Task<string> Enqueue(OutboxKind kind, ComposeModel compose, Guid accountId, string? existingId)
+    {
+        if (!IsAvailable) throw new InvalidOperationException("The Outbox is not available in --online mode.");
+        if (EnqueueFailure != null) return Task.FromException<string>(EnqueueFailure);
+        var id = existingId ?? OutboxItem.NewId();
+        Enqueued.Add((kind, compose, accountId, existingId, id));
+        Items.RemoveAll(i => i.Id == id);
+        Items.Add(new OutboxItem { Id = id, AccountId = accountId, Kind = kind, Subject = compose.Subject, To = compose.To, CreatedUtc = DateTimeOffset.UtcNow });
+        Composes[id] = compose;
+        return Task.FromResult(id);
+    }
+    public Task<string> EnqueueDraftAsync(ComposeModel compose, Guid accountId, string? existingId, CancellationToken ct = default)
+        => Enqueue(OutboxKind.Draft, compose, accountId, existingId);
+    public Task<string> EnqueueSendAsync(ComposeModel compose, Guid accountId, string? existingId, CancellationToken ct = default)
+        => Enqueue(OutboxKind.Send, compose, accountId, existingId);
+    public Task<IReadOnlyList<OutboxItem>> ListAsync(CancellationToken ct = default)
+        => Task.FromResult<IReadOnlyList<OutboxItem>>([.. Items.OrderByDescending(i => i.CreatedUtc)]);
+    public Task<OutboxItem?> GetAsync(string id, CancellationToken ct = default)
+        => Task.FromResult(Items.FirstOrDefault(i => i.Id == id));
+    public Task<ComposeModel?> LoadComposeAsync(string id, CancellationToken ct = default)
+    {
+        if (!Composes.TryGetValue(id, out var c)) return Task.FromResult<ComposeModel?>(null);
+        c.OutboxId = id;
+        return Task.FromResult<ComposeModel?>(c);
+    }
+    public Task<bool> RemoveAsync(string id, CancellationToken ct = default)
+    {
+        Removed.Add(id);
+        var existed = Items.RemoveAll(i => i.Id == id) > 0;
+        Composes.Remove(id);
+        return Task.FromResult(existed);
+    }
+    public Task<int> CountAsync(CancellationToken ct = default) => Task.FromResult(Items.Count);
+    public Task<OutboxFlushResult> FlushAsync(bool force = false, CancellationToken ct = default)
+    {
+        Flushes.Add(force);
+        return Task.FromResult(NextFlushResult);
+    }
+    public Task<OutboxFlushResult> FlushAccountAsync(Guid accountId, bool force = false, CancellationToken ct = default)
+        => FlushAsync(force, ct);
+}
+
+/// <summary>
+/// A settable stand-in for the app's online/offline state (#637). Tests flip accounts and the
+/// machine signal and raise the events by hand; the notes fed back by the code under test are
+/// recorded so a test can assert which failure sites report what.
+/// </summary>
+sealed class StubConnectivityService : IConnectivityService
+{
+    private readonly Dictionary<Guid, AccountConnectivity> _accounts = [];
+    public bool IsNetworkAvailable { get; set; } = true;
+    private bool? _isOnline;
+    public bool IsOnline
+    {
+        get => _isOnline ?? (IsNetworkAvailable && !(_accounts.Count > 0 && _accounts.Values.All(s => s == AccountConnectivity.Offline)));
+        set => _isOnline = value;
+    }
+    public List<(Guid AccountId, string Source, bool Reachable)> Notes { get; } = [];
+
+    public void SetAccount(Guid accountId, bool online) => _accounts[accountId] = online ? AccountConnectivity.Online : AccountConnectivity.Offline;
+    public bool IsAccountOnline(Guid accountId) => IsNetworkAvailable && AccountState(accountId) != AccountConnectivity.Offline;
+    public AccountConnectivity AccountState(Guid accountId) => _accounts.TryGetValue(accountId, out var s) ? s : AccountConnectivity.Unknown;
+    public void NoteAccountReachable(Guid accountId, string source) { _accounts[accountId] = AccountConnectivity.Online; Notes.Add((accountId, source, true)); }
+    public void NoteAccountUnreachable(Guid accountId, string source) { _accounts[accountId] = AccountConnectivity.Offline; Notes.Add((accountId, source, false)); }
+    public void NoteOperationOutcome(Guid accountId, Exception? ex, string source, CancellationToken callerToken = default)
+    {
+        if (ex != null && ConnectionFailure.IsConnectionFailure(ex, callerToken)) NoteAccountUnreachable(accountId, source);
+        else NoteAccountReachable(accountId, source);
+    }
+    public void Forget(Guid accountId) => _accounts.Remove(accountId);
+
+    public event Action<bool>? OnlineChanged;
+    public event Action<Guid, bool>? AccountOnlineChanged;
+    public event Action<bool>? NetworkAvailabilityChanged;
+
+    public int OnlineChangedSubscribers => OnlineChanged?.GetInvocationList().Length ?? 0;
+    public void RaiseOnlineChanged(bool online) { _isOnline = online; OnlineChanged?.Invoke(online); }
+    public void RaiseAccountOnlineChanged(Guid accountId, bool online) { SetAccount(accountId, online); AccountOnlineChanged?.Invoke(accountId, online); }
+    public void RaiseNetworkAvailabilityChanged(bool available) { IsNetworkAvailable = available; NetworkAvailabilityChanged?.Invoke(available); }
 }
 
 sealed class StubSyncService : ISyncService

--- a/QuickMail.Tests/StubServices.cs
+++ b/QuickMail.Tests/StubServices.cs
@@ -631,17 +631,28 @@ sealed class StubOutboxService : IOutboxService
         c.OutboxId = id;
         return Task.FromResult<ComposeModel?>(c);
     }
+    /// <summary>When set, RemoveAsync raises Changed inline the way the real service does.</summary>
+    public bool RaiseChangedOnRemove { get; set; }
     public Task<bool> RemoveAsync(string id, CancellationToken ct = default)
     {
         Removed.Add(id);
         var existed = Items.RemoveAll(i => i.Id == id) > 0;
         Composes.Remove(id);
+        Held.Remove(id);
+        if (existed && RaiseChangedOnRemove) Changed?.Invoke();
         return Task.FromResult(existed);
     }
+    public HashSet<string> Held { get; } = new(StringComparer.Ordinal);
+    public void Hold(string id) => Held.Add(id);
+    public void Release(string id) => Held.Remove(id);
     public Task<int> CountAsync(CancellationToken ct = default) => Task.FromResult(Items.Count);
+    /// <summary>When set, FlushAsync raises FlushCompleted with NextFlushResult before returning,
+    /// as the real drain does when anything reached an outcome.</summary>
+    public bool RaiseFlushCompletedDuringFlush { get; set; }
     public Task<OutboxFlushResult> FlushAsync(bool force = false, CancellationToken ct = default)
     {
         Flushes.Add(force);
+        if (RaiseFlushCompletedDuringFlush && NextFlushResult.Any) FlushCompleted?.Invoke(NextFlushResult);
         return Task.FromResult(NextFlushResult);
     }
     public Task<OutboxFlushResult> FlushAccountAsync(Guid accountId, bool force = false, CancellationToken ct = default)

--- a/QuickMail/App.xaml.cs
+++ b/QuickMail/App.xaml.cs
@@ -511,7 +511,7 @@ public partial class App : Application
             mainVm.ApplyConnectionDiagnosticsSetting(startupCfg.ConnectionDiagnostics);
             mainVm.LoadAccountList(accounts);
 
-            var mainWindow = new MainWindow(mainVm, effectiveSmtp, accountService, credentialService, effectiveMail, effectiveOAuth, commandRegistry, contactService, configService, localStore, viewService, ruleService, templateService, featureGate, flagService, customDictionary, themeService, _bugReportService, _notificationService, contactSyncService, graphCalendarSync, serverRuleService, providerCatalog, _autoDiscoverService, _truthProbe, rowLayoutService, watchService);
+            var mainWindow = new MainWindow(mainVm, effectiveSmtp, accountService, credentialService, effectiveMail, effectiveOAuth, commandRegistry, contactService, configService, localStore, viewService, ruleService, templateService, featureGate, flagService, customDictionary, themeService, _bugReportService, _notificationService, contactSyncService, graphCalendarSync, serverRuleService, providerCatalog, _autoDiscoverService, _truthProbe, rowLayoutService, watchService, outboxService);
 
             // Clicking a new-mail toast brings QuickMail to the foreground and opens the referenced
             // message. OnActivated may fire on a background thread, so marshal to the UI thread first.

--- a/QuickMail/App.xaml.cs
+++ b/QuickMail/App.xaml.cs
@@ -499,7 +499,8 @@ public partial class App : Application
                 truthProbe: probeMode ? null : _truthProbe,
                 rowLayoutService: rowLayoutService,
                 watchService: watchService,
-                folderViewState: folderViewState);
+                folderViewState: folderViewState,
+                outboxService: outboxService);
             mainVm.RegisterAccountBackend = a => { if (!probeMode) mailRouter.RegisterAccount(a.Id, BackendFor(a)); };
             // #31: a credential-less shared mailbox borrows its parent account's token. The resolver runs
             // on background sweep threads, so it goes through ResolveAccountById — a thread-safe snapshot

--- a/QuickMail/App.xaml.cs
+++ b/QuickMail/App.xaml.cs
@@ -44,6 +44,7 @@ public partial class App : Application
     private ImapMailService? _imapBackend;
     private GraphMailService? _graphBackend;
     private Pop3MailService? _pop3Backend;
+    private OutboxService? _outboxService;
     private UpdateCheckService? _updateCheckService;
     private ThemeService? _themeService;
     private BugReportService? _bugReportService;
@@ -385,6 +386,12 @@ public partial class App : Application
             // Reuses the shared GraphClient (no own disposables), so no disposal wiring needed.
             var serverRuleService = new GraphServerRuleService(accountService, graphBackend.Client);
             var syncService = new SyncService(effectiveMail, localStore, configService, ruleService, probeMode: probeMode);
+            // The Outbox (#637): mail written while the server could not be reached. Drains through the
+            // same router and send service as a live send, so a queued message leaves exactly as an
+            // online one would have. Connectivity arrives with PR 2; until then it drains on startup,
+            // on the fallback sync tick, and on Send Outbox Now.
+            _outboxService = new OutboxService(localStore, effectiveMail, effectiveSmtp, accountService, credentialService, connectivity: null, onlineMode: onlineMode);
+            var outboxService = _outboxService;
             // The one-time immutable-id wipe emptied these accounts' store, so their first re-sync would
             // read old mail as new and re-run rules over it on upgrade day. Baseline it (#366/N5).
             if (immutableIdRebuilt) syncService.SeedRebuildBaseline(rebuiltGraphAccountIds);
@@ -533,6 +540,7 @@ public partial class App : Application
     {
         _changeNotifier?.Dispose(); // stops all watchers (IDLE + Graph poll) + severs the event chain
         _graphNotifier?.Dispose();  // disposes the Graph poll CTS (StopWatchers already ran; idempotent)
+        _outboxService?.Dispose();  // cancels an in-flight drain before the pools it sends through go away
         _imapBackend?.Dispose();    // closes connection pools (StopWatchers already ran, and is idempotent)
         _graphBackend?.Dispose();   // releases GraphClient/HttpClient; after the notifiers, which poll through its client
         _pop3Backend?.Dispose();    // releases the per-account session locks (POP3 holds no open connection)

--- a/QuickMail/Models/ComposeModel.cs
+++ b/QuickMail/Models/ComposeModel.cs
@@ -45,5 +45,30 @@ public class ComposeModel
     /// <summary>Folder name of the existing draft (null when composing new).</summary>
     public string? DraftFolderName { get; set; }
 
+    /// <summary>
+    /// Id of the local Outbox row this compose was opened from, or that it last saved into (null when
+    /// nothing is queued). A save or send replaces that row instead of queuing another (issue #637).
+    /// </summary>
+    public string? OutboxId { get; set; }
+
     public List<AttachmentModel> Attachments { get; set; } = [];
+
+    /// <summary>A shallow copy with no attachments — what the Outbox stores as JSON, keeping the bytes in their own rows.</summary>
+    public ComposeModel WithoutAttachments() => new()
+    {
+        Kind = Kind,
+        AccountId = AccountId,
+        To = To,
+        Cc = Cc,
+        Bcc = Bcc,
+        Subject = Subject,
+        Body = Body,
+        Mode = Mode,
+        HtmlBody = HtmlBody,
+        InReplyToMessageId = InReplyToMessageId,
+        DraftMessageId = DraftMessageId,
+        DraftFolderName = DraftFolderName,
+        OutboxId = OutboxId,
+        Attachments = [],
+    };
 }

--- a/QuickMail/Models/ComposeModel.cs
+++ b/QuickMail/Models/ComposeModel.cs
@@ -72,3 +72,14 @@ public class ComposeModel
         Attachments = [],
     };
 }
+
+/// <summary>How the last Save Draft in a compose window ended (#637).</summary>
+public enum DraftSaveOutcome
+{
+    None,
+    SavedToServer,
+    /// <summary>The server could not be reached; the draft is in the local Outbox awaiting upload.</summary>
+    SavedLocally,
+    /// <summary>Neither the server nor the local store took it. The window must not close and lose it.</summary>
+    Failed,
+}

--- a/QuickMail/Models/FolderTreeNode.cs
+++ b/QuickMail/Models/FolderTreeNode.cs
@@ -46,7 +46,7 @@ public sealed class FolderTreeNode : INotifyPropertyChanged
     /// Do not move the count back out of the Name without checking with a screen-reader user first.
     /// </summary>
     public string AutomationName =>
-        ShowUnread ? $"{Label}, {Folder!.UnreadCount} unread"
+        ShowUnread ? $"{Label}, {Folder!.UnreadCount} {CountNoun}"
         : IsDefaultCalendar ? $"{Label}, default calendar"
         : IsSharedAccount ? $"{Label}, shared mailbox"
         : Label;
@@ -79,13 +79,17 @@ public sealed class FolderTreeNode : INotifyPropertyChanged
     // archived mail, so they're hidden here to avoid a misleading count (issue #227).
     private bool ShowUnread => Folder is { UnreadCount: > 0, SuppressUnreadCount: false };
 
+    // The Outbox count is mail waiting to leave, not mail waiting to be read (#637): "3 unread" on it
+    // would be a lie the screen reader repeats on every visit.
+    private string CountNoun => Folder?.Kind == SpecialFolderKind.Outbox ? "waiting" : "unread";
+
     /// <summary>
     /// UIA ItemStatus string used by AutomationProperties.ItemStatus on the TreeViewItem.
     /// Announced by screen readers after the folder name, e.g. "3 unread".
     /// Empty for folders with no unread messages and for header/group nodes.
     /// </summary>
     public string ItemStatusLabel =>
-        ShowUnread ? $"{Folder!.UnreadCount} unread" : string.Empty;
+        ShowUnread ? $"{Folder!.UnreadCount} {CountNoun}" : string.Empty;
 
     /// <summary>
     /// Visual unread badge shown next to the folder label, e.g. "(5)".

--- a/QuickMail/Models/MailFolderModel.cs
+++ b/QuickMail/Models/MailFolderModel.cs
@@ -6,7 +6,9 @@ namespace QuickMail.Models;
 // content that also lives in real folders, so they are deprioritized when picking the representative
 // copy for a deduplicated aggregate view (see MessageDeduplicator). They are NOT excluded from sync —
 // [Gmail]/All Mail is the only home of archived mail, so excluding it would lose messages.
-public enum SpecialFolderKind { None, Inbox, Sent, Drafts, Trash, Junk, AllMail, Important, Starred, Archive }
+// Outbox is appended last: the value is persisted as an integer in the Folder table, so existing
+// members must keep their positions. Only the virtual Outbox sentinel carries it (issue #637).
+public enum SpecialFolderKind { None, Inbox, Sent, Drafts, Trash, Junk, AllMail, Important, Starred, Archive, Outbox }
 
 public class MailFolderModel
 {

--- a/QuickMail/Models/OutboxItem.cs
+++ b/QuickMail/Models/OutboxItem.cs
@@ -1,0 +1,67 @@
+using System;
+
+namespace QuickMail.Models;
+
+/// <summary>What a queued Outbox row is waiting to do.</summary>
+public enum OutboxKind
+{
+    /// <summary>Upload to the account's Drafts folder.</summary>
+    Draft = 0,
+    /// <summary>Send, then file in Sent and trash any server draft it replaces.</summary>
+    Send = 1,
+}
+
+/// <summary>Where a queued Outbox row is in its life.</summary>
+public enum OutboxState
+{
+    /// <summary>Waiting for a connection (or for its backoff to elapse).</summary>
+    Pending = 0,
+    /// <summary>A drain is working on it right now.</summary>
+    Sending = 1,
+    /// <summary>The server answered and refused; only a manual retry or a reopen-and-send moves it.</summary>
+    Failed = 2,
+}
+
+/// <summary>
+/// One row of the local Outbox: a message or draft written on this computer while the server could
+/// not be reached (issue #637). The compose model itself lives in the store as JSON plus attachment
+/// blobs; this is the listing shape, denormalised so the Outbox folder can be drawn without parsing.
+/// </summary>
+public sealed class OutboxItem
+{
+    public const string IdPrefix = "outbox-";
+
+    public static string NewId() => IdPrefix + Guid.NewGuid().ToString("N");
+
+    public string Id { get; set; } = string.Empty;
+    public Guid AccountId { get; set; }
+    public OutboxKind Kind { get; set; }
+    public OutboxState State { get; set; }
+    public DateTimeOffset CreatedUtc { get; set; }
+    public DateTimeOffset UpdatedUtc { get; set; }
+    public int Attempts { get; set; }
+    public string? LastError { get; set; }
+    /// <summary>Earliest time the next automatic attempt may run; null means eligible now.</summary>
+    public DateTimeOffset? NextAttemptUtc { get; set; }
+    /// <summary>Server draft this row replaces on upload, or trashes after a send. Null when none.</summary>
+    public string? ReplaceDraftId { get; set; }
+    public string? DraftFolderName { get; set; }
+    public string Subject { get; set; } = string.Empty;
+    public string To { get; set; } = string.Empty;
+    public string Cc { get; set; } = string.Empty;
+    public string Bcc { get; set; } = string.Empty;
+    public bool HasAttachments { get; set; }
+
+    /// <summary>What the Outbox folder shows for this row's state.</summary>
+    public string StateDisplay => (Kind, State) switch
+    {
+        (_, OutboxState.Failed)             => string.IsNullOrWhiteSpace(LastError) ? "Failed" : $"Failed: {LastError}",
+        (OutboxKind.Send, OutboxState.Sending)  => "Sending…",
+        (OutboxKind.Draft, OutboxState.Sending) => "Uploading draft…",
+        (OutboxKind.Send, _)                => "Waiting to send",
+        (OutboxKind.Draft, _)               => "Waiting to upload draft",
+        _                                   => "Waiting",
+    };
+
+    public override string ToString() => $"{StateDisplay}: {Subject}";
+}

--- a/QuickMail/Services/ConnectionFailure.cs
+++ b/QuickMail/Services/ConnectionFailure.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Threading;
+using MailKit;
+using MailKit.Net.Imap;
+using MailKit.Net.Smtp;
+using MailKit.Security;
+
+namespace QuickMail.Services;
+
+/// <summary>
+/// Thrown by a mail backend when an operation is attempted on an account that has no live session.
+/// A typed exception rather than a message string, so callers deciding "is this offline?" can match
+/// on the type (<see cref="ConnectionFailure.IsConnectionFailure"/>) instead of the text.
+/// </summary>
+public sealed class AccountNotConnectedException : InvalidOperationException
+{
+    public AccountNotConnectedException() : base("Account is not connected.") { }
+    public AccountNotConnectedException(string message) : base(message) { }
+    public AccountNotConnectedException(string message, Exception innerException) : base(message, innerException) { }
+    public AccountNotConnectedException(Guid accountId) : base($"Account {accountId} is not connected.")
+    {
+        AccountId = accountId;
+    }
+
+    public Guid AccountId { get; }
+}
+
+/// <summary>
+/// Decides whether an exception means "the server could not be reached" (queue the work and try again
+/// when the network is back) or "the server answered and said no" (the user has to see it). Shared by
+/// the compose window, the Outbox, and the reading path so all three agree on what offline looks like.
+/// </summary>
+/// <remarks>
+/// <see cref="ImapMailService"/> keeps its own narrower <c>IsConnectionDrop</c> predicate: that one
+/// decides whether a pooled connection is worth retrying once, which is a different question.
+/// </remarks>
+public static class ConnectionFailure
+{
+    /// <summary>
+    /// True when <paramref name="ex"/>, or anything in its inner chain, is a transport failure.
+    /// </summary>
+    /// <param name="ex">The exception to classify.</param>
+    /// <param name="callerToken">
+    /// The caller's own cancellation token. An <see cref="OperationCanceledException"/> counts as a
+    /// timeout (a transport failure) only when this token did not fire; if the caller cancelled, it is
+    /// not a verdict about the network at all.
+    /// </param>
+    public static bool IsConnectionFailure(Exception ex, CancellationToken callerToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(ex);
+
+        // A server that answered — even to say no — is reachable. Any such exception anywhere in the
+        // chain settles it, whatever else is wrapped around it.
+        var sawTransport = false;
+        foreach (var e in Flatten(ex))
+        {
+            if (IsServerAnswered(e))
+                return false;
+            if (e is OperationCanceledException)
+            {
+                if (callerToken.IsCancellationRequested)
+                    return false;
+                sawTransport = true;
+                continue;
+            }
+            if (IsTransport(e))
+                sawTransport = true;
+        }
+        return sawTransport;
+    }
+
+    private static bool IsServerAnswered(Exception e) => e switch
+    {
+        SmtpCommandException => true,
+        ImapCommandException => true,
+        MailKit.Security.AuthenticationException => true,   // includes SaslException
+        InteractiveSignInRequiredException => true,
+        HttpRequestException { StatusCode: { } status } => !IsGatewayFailure(status),
+        FileNotFoundException or DirectoryNotFoundException or PathTooLongException or DriveNotFoundException => true,
+        _ => false,
+    };
+
+    private static bool IsTransport(Exception e) => e switch
+    {
+        SocketException => true,
+        IOException => true,
+        TimeoutException => true,
+        ServiceNotConnectedException => true,
+        ImapProtocolException => true,
+        SmtpProtocolException => true,
+        SslHandshakeException => true,      // captive portals answer TLS with the wrong certificate
+        AccountNotConnectedException => true,
+        WebException => true,
+        HttpRequestException { StatusCode: null } => true,
+        HttpRequestException { StatusCode: { } status } => IsGatewayFailure(status),
+        _ => false,
+    };
+
+    // 502/503/504 come from a proxy or gateway that could not reach the real service — transport, not
+    // an answer from the mail server itself.
+    private static bool IsGatewayFailure(HttpStatusCode status) =>
+        status is HttpStatusCode.BadGateway or HttpStatusCode.ServiceUnavailable or HttpStatusCode.GatewayTimeout;
+
+    private static IEnumerable<Exception> Flatten(Exception root)
+    {
+        var stack = new Stack<Exception>();
+        stack.Push(root);
+        var seen = new HashSet<Exception>(ReferenceEqualityComparer.Instance);
+        while (stack.Count > 0)
+        {
+            var e = stack.Pop();
+            if (!seen.Add(e)) continue;
+            yield return e;
+            if (e is AggregateException agg)
+            {
+                foreach (var inner in agg.InnerExceptions)
+                    stack.Push(inner);
+            }
+            else if (e.InnerException != null)
+            {
+                stack.Push(e.InnerException);
+            }
+        }
+    }
+}

--- a/QuickMail/Services/GraphMailService.cs
+++ b/QuickMail/Services/GraphMailService.cs
@@ -166,7 +166,7 @@ public class GraphMailService : IMailService, IConnectionProbe
     private AccountModel Account(Guid accountId)
         => _accounts.TryGetValue(accountId, out var a)
             ? a
-            : throw new InvalidOperationException($"Graph account {accountId} is not connected.");
+            : throw new AccountNotConnectedException(accountId);
 
     // ── Folders ──────────────────────────────────────────────────────────────────
     public async Task<List<MailFolderModel>> GetFoldersAsync(Guid accountId, CancellationToken ct = default)

--- a/QuickMail/Services/IConnectivityService.cs
+++ b/QuickMail/Services/IConnectivityService.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Threading;
+
+namespace QuickMail.Services;
+
+/// <summary>What the app currently believes about one account's reachability.</summary>
+public enum AccountConnectivity
+{
+    /// <summary>No operation has reported either way yet. Treated as online, optimistically.</summary>
+    Unknown,
+    Online,
+    Offline,
+}
+
+/// <summary>
+/// The app's one answer to "are we online?" (issue #637). Two inputs feed it: the machine-level
+/// network signal from Windows, and the outcome of real operations against each account. Neither
+/// alone is enough — a captive portal looks like a working network until a mail server fails to
+/// answer, and a single account's outage must not mark the whole app offline while another account
+/// is fine.
+/// </summary>
+/// <remarks>
+/// The service is <b>told</b> by the code that talks to servers; it does not subscribe to the mail
+/// backends itself. Every event fires on a ThreadPool or timer thread; subscribers that touch UI
+/// state must marshal.
+/// </remarks>
+public interface IConnectivityService
+{
+    /// <summary>Windows reports a usable network interface. Raw, undebounced.</summary>
+    bool IsNetworkAvailable { get; }
+
+    /// <summary>
+    /// Network available and not every known account offline. Going offline is debounced so a
+    /// momentary blip does not announce itself; coming back online is immediate.
+    /// </summary>
+    bool IsOnline { get; }
+
+    /// <summary>True unless this account has been reported unreachable and not since reachable, or the network is down.</summary>
+    bool IsAccountOnline(Guid accountId);
+
+    AccountConnectivity AccountState(Guid accountId);
+
+    /// <summary>An operation against the account succeeded. Idempotent; a change is journaled with its source.</summary>
+    void NoteAccountReachable(Guid accountId, string source);
+
+    /// <summary>An operation against the account failed to reach the server. Idempotent.</summary>
+    void NoteAccountUnreachable(Guid accountId, string source);
+
+    /// <summary>
+    /// Classifies <paramref name="ex"/>: a connection failure marks the account unreachable; anything
+    /// else, including null (success), marks it reachable — a server that answered "no" is a server
+    /// that answered.
+    /// </summary>
+    void NoteOperationOutcome(Guid accountId, Exception? ex, string source, CancellationToken callerToken = default);
+
+    /// <summary>The account was removed; forget its state.</summary>
+    void Forget(Guid accountId);
+
+    /// <summary>Fires on each change of <see cref="IsOnline"/>: false after the debounce, true at once.</summary>
+    event Action<bool>? OnlineChanged;
+
+    /// <summary>Fires once per flip of an account between online and offline.</summary>
+    event Action<Guid, bool>? AccountOnlineChanged;
+
+    /// <summary>The raw machine-level signal, undebounced — what a reconnect should react to.</summary>
+    event Action<bool>? NetworkAvailabilityChanged;
+}

--- a/QuickMail/Services/ILocalStoreService.cs
+++ b/QuickMail/Services/ILocalStoreService.cs
@@ -258,4 +258,28 @@ public interface ILocalStoreService
 
     /// <summary>Persists the Graph delta cursor for an account+folder, replacing any existing value.</summary>
     Task SetDeltaTokenAsync(Guid accountId, string folderId, string deltaToken);
+
+    // ── Outbox (#637) ────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Writes or replaces one queued item: the row, the compose model as JSON (attachments stripped),
+    /// and every loaded attachment as its own blob row, in one transaction. Sets
+    /// <see cref="OutboxItem.HasAttachments"/> and <see cref="OutboxItem.UpdatedUtc"/> on the way.
+    /// </summary>
+    Task UpsertOutboxItemAsync(OutboxItem item, ComposeModel compose);
+
+    /// <summary>Every queued item across all accounts, newest first. Reads no JSON and no blobs.</summary>
+    Task<List<OutboxItem>> LoadOutboxItemsAsync();
+
+    Task<OutboxItem?> LoadOutboxItemAsync(string id);
+
+    /// <summary>The stored compose model with attachment bytes rehydrated and <see cref="ComposeModel.OutboxId"/> set; null when the row is gone.</summary>
+    Task<ComposeModel?> LoadOutboxComposeAsync(string id);
+
+    Task UpdateOutboxStateAsync(string id, OutboxState state, int attempts, string? lastError, DateTimeOffset? nextAttemptUtc);
+
+    /// <summary>Removes the row and its attachment blobs. A missing id is a no-op.</summary>
+    Task DeleteOutboxItemAsync(string id);
+
+    Task<int> CountOutboxItemsAsync();
 }

--- a/QuickMail/Services/IOutboxService.cs
+++ b/QuickMail/Services/IOutboxService.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using QuickMail.Models;
+
+namespace QuickMail.Services;
+
+/// <summary>What one drain of the Outbox did.</summary>
+public sealed record OutboxFlushResult(int Sent, int DraftsUploaded, int Failed, int Skipped)
+{
+    public static readonly OutboxFlushResult Nothing = new(0, 0, 0, 0);
+
+    /// <summary>True when at least one item reached a final outcome this drain.</summary>
+    public bool Any => Sent + DraftsUploaded + Failed > 0;
+}
+
+/// <summary>
+/// The local queue of mail written while the server could not be reached (issue #637): drafts
+/// waiting to upload and messages waiting to send. The compose window enqueues; a drain runs when
+/// connectivity returns, on the fallback sync tick, and on the Send Outbox Now command.
+/// </summary>
+public interface IOutboxService
+{
+    /// <summary>False in <c>--online</c> mode, where there is no local store to queue into. Enqueue throws then.</summary>
+    bool IsAvailable { get; }
+
+    /// <summary>
+    /// Stores (or, with <paramref name="existingId"/>, replaces) a draft to upload later. Returns the
+    /// row id; pass it back on the next save so repeated saves keep one row.
+    /// </summary>
+    Task<string> EnqueueDraftAsync(ComposeModel compose, Guid accountId, string? existingId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Stores (or replaces) a message to send later. <paramref name="existingId"/> may name a draft
+    /// row — the row becomes a send, so a queued draft never outlives the message it became.
+    /// </summary>
+    Task<string> EnqueueSendAsync(ComposeModel compose, Guid accountId, string? existingId, CancellationToken ct = default);
+
+    /// <summary>Every queued item across all accounts, newest first.</summary>
+    Task<IReadOnlyList<OutboxItem>> ListAsync(CancellationToken ct = default);
+
+    Task<OutboxItem?> GetAsync(string id, CancellationToken ct = default);
+
+    /// <summary>The stored compose model, attachments included, with <see cref="ComposeModel.OutboxId"/> set. Null when the row is gone.</summary>
+    Task<ComposeModel?> LoadComposeAsync(string id, CancellationToken ct = default);
+
+    /// <summary>Removes a row. Returns false when it was already gone.</summary>
+    Task<bool> RemoveAsync(string id, CancellationToken ct = default);
+
+    Task<int> CountAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Drains every eligible item: pending rows whose backoff has elapsed, on accounts not known to
+    /// be offline. <paramref name="force"/> ignores the backoff, the connectivity check and retries
+    /// failed rows too — the user asked. A drain already in progress makes this one return at once
+    /// with <see cref="OutboxFlushResult.Skipped"/> set.
+    /// </summary>
+    Task<OutboxFlushResult> FlushAsync(bool force = false, CancellationToken ct = default);
+
+    /// <summary>As <see cref="FlushAsync"/>, for one account.</summary>
+    Task<OutboxFlushResult> FlushAccountAsync(Guid accountId, bool force = false, CancellationToken ct = default);
+
+    /// <summary>Raised (on whatever thread did the work) whenever rows are added, removed, or change state.</summary>
+    event Action? Changed;
+
+    /// <summary>Raised once per drain that reached at least one final outcome — never per item.</summary>
+    event Action<OutboxFlushResult>? FlushCompleted;
+}

--- a/QuickMail/Services/IOutboxService.cs
+++ b/QuickMail/Services/IOutboxService.cs
@@ -6,8 +6,12 @@ using QuickMail.Models;
 
 namespace QuickMail.Services;
 
-/// <summary>What one drain of the Outbox did.</summary>
-public sealed record OutboxFlushResult(int Sent, int DraftsUploaded, int Failed, int Skipped)
+/// <summary>
+/// What one drain of the Outbox did. Skipped counts rows the drain did not attempt (not yet due,
+/// held open in a compose window, or a drain already running); Deferred counts rows it attempted
+/// and could not reach the server for.
+/// </summary>
+public sealed record OutboxFlushResult(int Sent, int DraftsUploaded, int Failed, int Skipped, int Deferred = 0)
 {
     public static readonly OutboxFlushResult Nothing = new(0, 0, 0, 0);
 
@@ -47,6 +51,15 @@ public interface IOutboxService
 
     /// <summary>Removes a row. Returns false when it was already gone.</summary>
     Task<bool> RemoveAsync(string id, CancellationToken ct = default);
+
+    /// <summary>
+    /// Keeps a row out of every drain while a compose window has it open: sending it meanwhile
+    /// would send stale content and then delete the edit in progress. Released when the window
+    /// closes, or the row is removed.
+    /// </summary>
+    void Hold(string id);
+
+    void Release(string id);
 
     Task<int> CountAsync(CancellationToken ct = default);
 

--- a/QuickMail/Services/ImapMailService.cs
+++ b/QuickMail/Services/ImapMailService.cs
@@ -1102,12 +1102,12 @@ public class ImapMailService : IMailService, IChangeNotifier, IConnectionProbe
         if (!_pools.TryGetValue(accountId, out var pool))
         {
             if (!_accounts.TryGetValue(accountId, out var account))
-                throw new InvalidOperationException($"Account {accountId} is not connected.");
+                throw new AccountNotConnectedException(accountId);
 
             _passwords.TryGetValue(accountId, out var password);
             await ConnectAsync(account, password, ct);
             if (!_pools.TryGetValue(accountId, out pool))
-                throw new InvalidOperationException($"Account {accountId} is not connected.");
+                throw new AccountNotConnectedException(accountId);
         }
 
         return await pool.RentAsync(priority, ct);

--- a/QuickMail/Services/LocalStoreService.Outbox.cs
+++ b/QuickMail/Services/LocalStoreService.Outbox.cs
@@ -1,0 +1,233 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
+using QuickMail.Models;
+
+namespace QuickMail.Services;
+
+/// <summary>The Outbox tables (#637): see the DDL comment in <see cref="Initialize"/>.</summary>
+public partial class LocalStoreService
+{
+    // Enum names rather than numbers, so renumbering ComposeMode/ComposeKind cannot silently
+    // change what a queued message means; nulls dropped so the JSON stays small.
+    private static readonly JsonSerializerOptions OutboxJson = new()
+    {
+        Converters = { new JsonStringEnumConverter() },
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    private const string OutboxItemColumns =
+        "id, account_id, kind, state, created_ticks, updated_ticks, attempts, last_error, " +
+        "next_attempt_ticks, replace_draft_id, draft_folder_name, subject, to_addr, cc, bcc, has_attachments";
+
+    public async Task UpsertOutboxItemAsync(OutboxItem item, ComposeModel compose)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+        ArgumentNullException.ThrowIfNull(compose);
+        if (string.IsNullOrEmpty(item.Id))
+            throw new ArgumentException("An Outbox item needs an id.", nameof(item));
+
+        // Only attachments whose bytes are in memory can be sent later; an unloaded one (a forward
+        // whose download never completed) would be dropped by MimeMessageBuilder anyway.
+        var loaded = compose.Attachments.Where(a => a.IsLoaded).ToList();
+        item.HasAttachments = loaded.Count > 0;
+        item.UpdatedUtc = DateTimeOffset.UtcNow;
+        if (item.CreatedUtc == default) item.CreatedUtc = item.UpdatedUtc;
+
+        var json = JsonSerializer.Serialize(compose.WithoutAttachments(), OutboxJson);
+
+        await using var conn = await OpenAsync();
+        await using var tx = await conn.BeginTransactionAsync();
+
+        await using (var cmd = conn.CreateCommand())
+        {
+            cmd.CommandText = $"""
+                INSERT INTO Outbox({OutboxItemColumns}, compose_json)
+                VALUES ($id, $aid, $kind, $state, $created, $updated, $attempts, $err,
+                        $next, $replace, $dfolder, $subject, $to, $cc, $bcc, $hasAtt, $json)
+                ON CONFLICT(id) DO UPDATE SET
+                    account_id = excluded.account_id,
+                    kind = excluded.kind,
+                    state = excluded.state,
+                    updated_ticks = excluded.updated_ticks,
+                    attempts = excluded.attempts,
+                    last_error = excluded.last_error,
+                    next_attempt_ticks = excluded.next_attempt_ticks,
+                    replace_draft_id = excluded.replace_draft_id,
+                    draft_folder_name = excluded.draft_folder_name,
+                    subject = excluded.subject,
+                    to_addr = excluded.to_addr,
+                    cc = excluded.cc,
+                    bcc = excluded.bcc,
+                    has_attachments = excluded.has_attachments,
+                    compose_json = excluded.compose_json;
+                """;
+            cmd.Parameters.AddWithValue("$id",       item.Id);
+            cmd.Parameters.AddWithValue("$aid",      item.AccountId.ToString());
+            cmd.Parameters.AddWithValue("$kind",     (int)item.Kind);
+            cmd.Parameters.AddWithValue("$state",    (int)item.State);
+            cmd.Parameters.AddWithValue("$created",  item.CreatedUtc.UtcTicks);
+            cmd.Parameters.AddWithValue("$updated",  item.UpdatedUtc.UtcTicks);
+            cmd.Parameters.AddWithValue("$attempts", item.Attempts);
+            cmd.Parameters.AddWithValue("$err",      (object?)item.LastError ?? DBNull.Value);
+            cmd.Parameters.AddWithValue("$next",     item.NextAttemptUtc.HasValue ? item.NextAttemptUtc.Value.UtcTicks : DBNull.Value);
+            cmd.Parameters.AddWithValue("$replace",  (object?)item.ReplaceDraftId ?? DBNull.Value);
+            cmd.Parameters.AddWithValue("$dfolder",  (object?)item.DraftFolderName ?? DBNull.Value);
+            cmd.Parameters.AddWithValue("$subject",  item.Subject ?? string.Empty);
+            cmd.Parameters.AddWithValue("$to",       item.To ?? string.Empty);
+            cmd.Parameters.AddWithValue("$cc",       item.Cc ?? string.Empty);
+            cmd.Parameters.AddWithValue("$bcc",      item.Bcc ?? string.Empty);
+            cmd.Parameters.AddWithValue("$hasAtt",   item.HasAttachments ? 1 : 0);
+            cmd.Parameters.AddWithValue("$json",     json);
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        await using (var del = conn.CreateCommand())
+        {
+            del.CommandText = "DELETE FROM OutboxAttachment WHERE outbox_id = $id;";
+            del.Parameters.AddWithValue("$id", item.Id);
+            await del.ExecuteNonQueryAsync();
+        }
+
+        for (var i = 0; i < loaded.Count; i++)
+        {
+            var att = loaded[i];
+            await using var ins = conn.CreateCommand();
+            ins.CommandText =
+                "INSERT INTO OutboxAttachment(outbox_id, ordinal, file_name, content_type, size, content) " +
+                "VALUES ($id, $ord, $name, $type, $size, $bytes);";
+            ins.Parameters.AddWithValue("$id",    item.Id);
+            ins.Parameters.AddWithValue("$ord",   i);
+            ins.Parameters.AddWithValue("$name",  att.FileName ?? string.Empty);
+            ins.Parameters.AddWithValue("$type",  att.ContentType ?? "application/octet-stream");
+            ins.Parameters.AddWithValue("$size",  att.FileSize > 0 ? att.FileSize : att.Content!.LongLength);
+            ins.Parameters.AddWithValue("$bytes", att.Content!);
+            await ins.ExecuteNonQueryAsync();
+        }
+
+        await tx.CommitAsync();
+    }
+
+    public async Task<List<OutboxItem>> LoadOutboxItemsAsync()
+    {
+        await using var conn = await OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"SELECT {OutboxItemColumns} FROM Outbox ORDER BY created_ticks DESC;";
+        var list = new List<OutboxItem>();
+        await using var r = await cmd.ExecuteReaderAsync();
+        while (await r.ReadAsync())
+            list.Add(ReadOutboxItem(r));
+        return list;
+    }
+
+    public async Task<OutboxItem?> LoadOutboxItemAsync(string id)
+    {
+        await using var conn = await OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"SELECT {OutboxItemColumns} FROM Outbox WHERE id = $id;";
+        cmd.Parameters.AddWithValue("$id", id);
+        await using var r = await cmd.ExecuteReaderAsync();
+        return await r.ReadAsync() ? ReadOutboxItem(r) : null;
+    }
+
+    public async Task<ComposeModel?> LoadOutboxComposeAsync(string id)
+    {
+        await using var conn = await OpenAsync();
+
+        string? json;
+        await using (var cmd = conn.CreateCommand())
+        {
+            cmd.CommandText = "SELECT compose_json FROM Outbox WHERE id = $id;";
+            cmd.Parameters.AddWithValue("$id", id);
+            json = await cmd.ExecuteScalarAsync() as string;
+        }
+        if (json == null) return null;
+
+        var compose = JsonSerializer.Deserialize<ComposeModel>(json, OutboxJson);
+        if (compose == null) return null;
+        compose.OutboxId = id;
+        compose.Attachments = [];
+
+        await using (var cmd = conn.CreateCommand())
+        {
+            cmd.CommandText =
+                "SELECT file_name, content_type, size, content FROM OutboxAttachment " +
+                "WHERE outbox_id = $id ORDER BY ordinal;";
+            cmd.Parameters.AddWithValue("$id", id);
+            await using var r = await cmd.ExecuteReaderAsync();
+            while (await r.ReadAsync())
+            {
+                compose.Attachments.Add(new AttachmentModel
+                {
+                    FileName    = r.GetString(0),
+                    ContentType = r.GetString(1),
+                    FileSize    = r.GetInt64(2),
+                    Content     = (byte[])r[3],
+                });
+            }
+        }
+        return compose;
+    }
+
+    public async Task UpdateOutboxStateAsync(
+        string id, OutboxState state, int attempts, string? lastError, DateTimeOffset? nextAttemptUtc)
+    {
+        await using var conn = await OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText =
+            "UPDATE Outbox SET state = $state, attempts = $attempts, last_error = $err, " +
+            "next_attempt_ticks = $next, updated_ticks = $updated WHERE id = $id;";
+        cmd.Parameters.AddWithValue("$state",    (int)state);
+        cmd.Parameters.AddWithValue("$attempts", attempts);
+        cmd.Parameters.AddWithValue("$err",      (object?)lastError ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("$next",     nextAttemptUtc.HasValue ? nextAttemptUtc.Value.UtcTicks : DBNull.Value);
+        cmd.Parameters.AddWithValue("$updated",  DateTimeOffset.UtcNow.UtcTicks);
+        cmd.Parameters.AddWithValue("$id",       id);
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    public async Task DeleteOutboxItemAsync(string id)
+    {
+        await using var conn = await OpenAsync();
+        await using var tx = await conn.BeginTransactionAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText =
+            "DELETE FROM OutboxAttachment WHERE outbox_id = $id;" +
+            "DELETE FROM Outbox WHERE id = $id;";
+        cmd.Parameters.AddWithValue("$id", id);
+        await cmd.ExecuteNonQueryAsync();
+        await tx.CommitAsync();
+    }
+
+    public async Task<int> CountOutboxItemsAsync()
+    {
+        await using var conn = await OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT COUNT(*) FROM Outbox;";
+        return Convert.ToInt32(await cmd.ExecuteScalarAsync());
+    }
+
+    private static OutboxItem ReadOutboxItem(SqliteDataReader r) => new()
+    {
+        Id              = r.GetString(0),
+        AccountId       = Guid.Parse(r.GetString(1)),
+        Kind            = (OutboxKind)r.GetInt32(2),
+        State           = (OutboxState)r.GetInt32(3),
+        CreatedUtc      = new DateTimeOffset(r.GetInt64(4), TimeSpan.Zero),
+        UpdatedUtc      = new DateTimeOffset(r.GetInt64(5), TimeSpan.Zero),
+        Attempts        = r.GetInt32(6),
+        LastError       = r.IsDBNull(7) ? null : r.GetString(7),
+        NextAttemptUtc  = r.IsDBNull(8) ? null : new DateTimeOffset(r.GetInt64(8), TimeSpan.Zero),
+        ReplaceDraftId  = r.IsDBNull(9) ? null : r.GetString(9),
+        DraftFolderName = r.IsDBNull(10) ? null : r.GetString(10),
+        Subject         = r.GetString(11),
+        To              = r.GetString(12),
+        Cc              = r.GetString(13),
+        Bcc             = r.GetString(14),
+        HasAttachments  = r.GetInt32(15) != 0,
+    };
+}

--- a/QuickMail/Services/LocalStoreService.cs
+++ b/QuickMail/Services/LocalStoreService.cs
@@ -11,7 +11,7 @@ using QuickMail.Models;
 
 namespace QuickMail.Services;
 
-public class LocalStoreService : ILocalStoreService
+public partial class LocalStoreService : ILocalStoreService
 {
     private readonly string _connectionString;
     private readonly string _dbPath;
@@ -193,6 +193,46 @@ public class LocalStoreService : ILocalStoreService
                 account_id TEXT NOT NULL,
                 uidl       TEXT NOT NULL,
                 PRIMARY KEY (account_id, uidl)
+            );
+            """;
+        cmd.ExecuteNonQuery();
+
+        // Outbox (#637): mail written on this computer while the server could not be reached — drafts
+        // waiting to upload and messages waiting to send. The compose model is kept as JSON so a row
+        // reopens in the compose window losslessly (Bcc, Markdown source, mode, reply linkage all
+        // survive, which a MIME round-trip loses); attachment bytes sit in their own rows so listing
+        // the Outbox never reads them. User-authored, not cache: ClearCachedMailAsync leaves these
+        // alone and only DeleteAccountDataAsync removes them. Additive, so no user_version bump.
+        cmd.CommandText = """
+            CREATE TABLE IF NOT EXISTS Outbox (
+                id                 TEXT    NOT NULL PRIMARY KEY,
+                account_id         TEXT    NOT NULL,
+                kind               INTEGER NOT NULL,
+                state              INTEGER NOT NULL DEFAULT 0,
+                created_ticks      INTEGER NOT NULL,
+                updated_ticks      INTEGER NOT NULL,
+                attempts           INTEGER NOT NULL DEFAULT 0,
+                last_error         TEXT    DEFAULT NULL,
+                next_attempt_ticks INTEGER DEFAULT NULL,
+                replace_draft_id   TEXT    DEFAULT NULL,
+                draft_folder_name  TEXT    DEFAULT NULL,
+                subject            TEXT    NOT NULL DEFAULT '',
+                to_addr            TEXT    NOT NULL DEFAULT '',
+                cc                 TEXT    NOT NULL DEFAULT '',
+                bcc                TEXT    NOT NULL DEFAULT '',
+                has_attachments    INTEGER NOT NULL DEFAULT 0,
+                compose_json       TEXT    NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_outbox_created ON Outbox(created_ticks DESC);
+
+            CREATE TABLE IF NOT EXISTS OutboxAttachment (
+                outbox_id    TEXT    NOT NULL,
+                ordinal      INTEGER NOT NULL,
+                file_name    TEXT    NOT NULL DEFAULT '',
+                content_type TEXT    NOT NULL DEFAULT 'application/octet-stream',
+                size         INTEGER NOT NULL DEFAULT 0,
+                content      BLOB    NOT NULL,
+                PRIMARY KEY (outbox_id, ordinal)
             );
             """;
         cmd.ExecuteNonQuery();
@@ -571,7 +611,9 @@ public class LocalStoreService : ILocalStoreService
             "DELETE FROM CalendarEvent     WHERE account_id = $aid;" +
             "DELETE FROM Folder            WHERE account_id = $aid;" +
             "DELETE FROM Pop3CollectedUidl WHERE account_id = $aid;" +
-            "DELETE FROM CalendarSource    WHERE account_id = $aid;";
+            "DELETE FROM CalendarSource    WHERE account_id = $aid;" +
+            "DELETE FROM OutboxAttachment WHERE outbox_id IN (SELECT id FROM Outbox WHERE account_id = $aid);" +
+            "DELETE FROM Outbox            WHERE account_id = $aid;";
         cmd.Parameters.AddWithValue("$aid", accountId.ToString());
         await cmd.ExecuteNonQueryAsync();
         await tx.CommitAsync();

--- a/QuickMail/Services/OutboxService.cs
+++ b/QuickMail/Services/OutboxService.cs
@@ -1,0 +1,384 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using QuickMail.Models;
+
+namespace QuickMail.Services;
+
+/// <summary>
+/// See <see cref="IOutboxService"/>. Rows live in the local store; this class owns the drain: one at
+/// a time, oldest first, each item marked Sending while it is worked on so the Outbox folder shows
+/// progress, and each failure classified through <see cref="ConnectionFailure"/> so a dead network
+/// keeps a row pending with backoff while a server rejection parks it as Failed for the user.
+/// </summary>
+public sealed class OutboxService : IOutboxService, IDisposable
+{
+    private static readonly TimeSpan SendTimeout       = TimeSpan.FromSeconds(60);
+    private static readonly TimeSpan DraftTimeout      = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan SentAppendTimeout = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan TrashTimeout      = TimeSpan.FromSeconds(15);
+    private static readonly TimeSpan ReconnectDebounce = TimeSpan.FromSeconds(2);
+    private const int MaxBackoffMinutes = 32;
+
+    private readonly ILocalStoreService _store;
+    private readonly IMailService _mail;
+    private readonly ISendMailService _send;
+    private readonly IAccountService _accounts;
+    private readonly ICredentialService _credentials;
+    private readonly IConnectivityService? _connectivity;
+    private readonly bool _onlineMode;
+
+    private readonly SemaphoreSlim _drain = new(1, 1);
+    private readonly CancellationTokenSource _lifetime = new();
+    private CancellationTokenSource? _reconnectDebounce;
+    private bool _disposed;
+
+    public OutboxService(
+        ILocalStoreService store,
+        IMailService mail,
+        ISendMailService send,
+        IAccountService accounts,
+        ICredentialService credentials,
+        IConnectivityService? connectivity,
+        bool onlineMode)
+    {
+        _store        = store;
+        _mail         = mail;
+        _send         = send;
+        _accounts     = accounts;
+        _credentials  = credentials;
+        _connectivity = connectivity;
+        _onlineMode   = onlineMode;
+
+        if (_connectivity != null)
+        {
+            _connectivity.OnlineChanged        += OnOnlineChanged;
+            _connectivity.AccountOnlineChanged += OnAccountOnlineChanged;
+        }
+    }
+
+    public bool IsAvailable => !_onlineMode;
+
+    public event Action? Changed;
+    public event Action<OutboxFlushResult>? FlushCompleted;
+
+    // ── Enqueue ─────────────────────────────────────────────────────────────────
+
+    public Task<string> EnqueueDraftAsync(ComposeModel compose, Guid accountId, string? existingId, CancellationToken ct = default)
+        => EnqueueAsync(compose, accountId, existingId, OutboxKind.Draft, ct);
+
+    public Task<string> EnqueueSendAsync(ComposeModel compose, Guid accountId, string? existingId, CancellationToken ct = default)
+        => EnqueueAsync(compose, accountId, existingId, OutboxKind.Send, ct);
+
+    private async Task<string> EnqueueAsync(ComposeModel compose, Guid accountId, string? existingId, OutboxKind kind, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(compose);
+        ThrowIfUnavailable();
+        ct.ThrowIfCancellationRequested();
+
+        OutboxItem? item = null;
+        if (!string.IsNullOrEmpty(existingId))
+            item = await _store.LoadOutboxItemAsync(existingId);
+
+        // A replaced row keeps its id and creation time; everything else is re-derived from the
+        // compose so the listing never shows a stale subject. State resets to Pending: a Failed row
+        // the user reopened, edited and saved again deserves a fresh attempt.
+        item ??= new OutboxItem { Id = OutboxItem.NewId(), CreatedUtc = DateTimeOffset.UtcNow };
+        item.AccountId       = accountId;
+        item.Kind            = kind;
+        item.State           = OutboxState.Pending;
+        item.Attempts        = 0;
+        item.LastError       = null;
+        item.NextAttemptUtc  = null;
+        item.ReplaceDraftId  = string.IsNullOrEmpty(compose.DraftMessageId) ? null : compose.DraftMessageId;
+        item.DraftFolderName = compose.DraftFolderName;
+        item.Subject         = compose.Subject ?? string.Empty;
+        item.To              = compose.To ?? string.Empty;
+        item.Cc              = compose.Cc ?? string.Empty;
+        item.Bcc             = compose.Bcc ?? string.Empty;
+
+        await _store.UpsertOutboxItemAsync(item, compose);
+        RaiseChanged();
+        return item.Id;
+    }
+
+    // ── Read / remove ───────────────────────────────────────────────────────────
+
+    public async Task<IReadOnlyList<OutboxItem>> ListAsync(CancellationToken ct = default)
+    {
+        if (!IsAvailable) return [];
+        return await _store.LoadOutboxItemsAsync();
+    }
+
+    public Task<OutboxItem?> GetAsync(string id, CancellationToken ct = default)
+        => IsAvailable ? _store.LoadOutboxItemAsync(id) : Task.FromResult<OutboxItem?>(null);
+
+    public Task<ComposeModel?> LoadComposeAsync(string id, CancellationToken ct = default)
+        => IsAvailable ? _store.LoadOutboxComposeAsync(id) : Task.FromResult<ComposeModel?>(null);
+
+    public async Task<bool> RemoveAsync(string id, CancellationToken ct = default)
+    {
+        if (!IsAvailable) return false;
+        var existed = await _store.LoadOutboxItemAsync(id) != null;
+        await _store.DeleteOutboxItemAsync(id);
+        if (existed) RaiseChanged();
+        return existed;
+    }
+
+    public Task<int> CountAsync(CancellationToken ct = default)
+        => IsAvailable ? _store.CountOutboxItemsAsync() : Task.FromResult(0);
+
+    // ── Drain ───────────────────────────────────────────────────────────────────
+
+    public Task<OutboxFlushResult> FlushAsync(bool force = false, CancellationToken ct = default)
+        => FlushCoreAsync(null, force, ct);
+
+    public Task<OutboxFlushResult> FlushAccountAsync(Guid accountId, bool force = false, CancellationToken ct = default)
+        => FlushCoreAsync(accountId, force, ct);
+
+    private async Task<OutboxFlushResult> FlushCoreAsync(Guid? onlyAccount, bool force, CancellationToken ct)
+    {
+        if (!IsAvailable || _disposed) return OutboxFlushResult.Nothing;
+
+        // A drain already running will pick up anything eligible; a second one would race it for
+        // the same rows. Report that this call did nothing rather than queue behind it.
+        if (!await _drain.WaitAsync(0, ct))
+            return OutboxFlushResult.Nothing with { Skipped = 1 };
+
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(_lifetime.Token, ct);
+        var token = linked.Token;
+        int sent = 0, drafts = 0, failed = 0, skipped = 0;
+        try
+        {
+            var items = await _store.LoadOutboxItemsAsync();
+            var now = DateTimeOffset.UtcNow;
+            // Oldest first, so messages leave in the order they were written.
+            foreach (var item in Enumerable.Reverse(items))
+            {
+                token.ThrowIfCancellationRequested();
+                if (onlyAccount.HasValue && item.AccountId != onlyAccount.Value) continue;
+                if (!IsEligible(item, now, force)) { skipped++; continue; }
+
+                var outcome = await ProcessOneAsync(item, token);
+                switch (outcome)
+                {
+                    case Outcome.Sent:          sent++;   break;
+                    case Outcome.DraftUploaded: drafts++; break;
+                    case Outcome.Failed:        failed++; break;
+                    default:                    skipped++; break;
+                }
+            }
+        }
+        finally
+        {
+            _drain.Release();
+        }
+
+        var result = new OutboxFlushResult(sent, drafts, failed, skipped);
+        RaiseChanged();
+        if (result.Any)
+        {
+            try { FlushCompleted?.Invoke(result); }
+            catch (Exception ex) { LogService.Log("Outbox: FlushCompleted handler", ex); }
+        }
+        return result;
+    }
+
+    private bool IsEligible(OutboxItem item, DateTimeOffset now, bool force)
+    {
+        if (force) return item.State != OutboxState.Sending;
+        if (item.State != OutboxState.Pending) return false;
+        if (item.NextAttemptUtc is { } next && next > now) return false;
+        if (_connectivity != null && !_connectivity.IsAccountOnline(item.AccountId)) return false;
+        return true;
+    }
+
+    private enum Outcome { Sent, DraftUploaded, Failed, Deferred, Vanished }
+
+    private async Task<Outcome> ProcessOneAsync(OutboxItem item, CancellationToken token)
+    {
+        var compose = await _store.LoadOutboxComposeAsync(item.Id);
+        if (compose == null) return Outcome.Vanished;
+
+        await _store.UpdateOutboxStateAsync(item.Id, OutboxState.Sending, item.Attempts, item.LastError, null);
+        RaiseChanged();
+
+        try
+        {
+            if (item.Kind == OutboxKind.Draft)
+            {
+                await UploadDraftAsync(item, compose, token);
+                await _store.DeleteOutboxItemAsync(item.Id);
+                LogService.Log($"Outbox: draft {item.Id} uploaded");
+                return Outcome.DraftUploaded;
+            }
+
+            await SendAsync(item, compose, token);
+            await _store.DeleteOutboxItemAsync(item.Id);
+            LogService.Log($"Outbox: message {item.Id} sent");
+            return Outcome.Sent;
+        }
+        catch (OperationCanceledException) when (token.IsCancellationRequested)
+        {
+            // Shutdown or the caller gave up: leave the row exactly as it was.
+            await _store.UpdateOutboxStateAsync(item.Id, OutboxState.Pending, item.Attempts, item.LastError, item.NextAttemptUtc);
+            throw;
+        }
+        catch (PermanentOutboxFailure ex)
+        {
+            await _store.UpdateOutboxStateAsync(item.Id, OutboxState.Failed, item.Attempts + 1, ex.Message, null);
+            LogService.Log($"Outbox: {item.Kind} {item.Id} failed permanently: {ex.Message}");
+            return Outcome.Failed;
+        }
+        catch (Exception ex)
+        {
+            if (ConnectionFailure.IsConnectionFailure(ex, token))
+            {
+                var attempts = item.Attempts + 1;
+                var next = DateTimeOffset.UtcNow + Backoff(attempts);
+                await _store.UpdateOutboxStateAsync(item.Id, OutboxState.Pending, attempts, ex.Message, next);
+                LogService.Log($"Outbox: {item.Kind} {item.Id} deferred (attempt {attempts}, next {next:u})", ex);
+                return Outcome.Deferred;
+            }
+
+            await _store.UpdateOutboxStateAsync(item.Id, OutboxState.Failed, item.Attempts + 1, ex.Message, null);
+            LogService.Log($"Outbox: {item.Kind} {item.Id} failed", ex);
+            return Outcome.Failed;
+        }
+    }
+
+    private async Task UploadDraftAsync(OutboxItem item, ComposeModel compose, CancellationToken token)
+    {
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(token);
+        cts.CancelAfter(DraftTimeout);
+
+        var folder = item.DraftFolderName ?? await _mail.FindDraftsFolderNameAsync(item.AccountId, cts.Token);
+        if (folder == null)
+            throw new PermanentOutboxFailure("No Drafts folder found on this account.");
+
+        compose.DraftMessageId  = item.ReplaceDraftId;
+        compose.DraftFolderName = folder;
+        await _mail.AppendDraftAsync(item.AccountId, compose, item.ReplaceDraftId, cts.Token);
+    }
+
+    private async Task SendAsync(OutboxItem item, ComposeModel compose, CancellationToken token)
+    {
+        var account = _accounts.LoadAccounts().FirstOrDefault(a => a.Id == item.AccountId)
+            ?? throw new PermanentOutboxFailure("The account this message was written from no longer exists.");
+
+        var password = _credentials.GetPassword(account.Id);
+        if (string.IsNullOrEmpty(password) && account.AuthType == AuthType.Password)
+            throw new PermanentOutboxFailure("No password stored for this account.");
+
+        using (var cts = CancellationTokenSource.CreateLinkedTokenSource(token))
+        {
+            cts.CancelAfter(SendTimeout);
+            await _send.SendAsync(compose, account, password, cts.Token);
+        }
+
+        // The same two best-effort steps ComposeViewModel.SendAsync performs after a live send:
+        // file a copy in Sent, and trash the server draft this message grew out of. Neither can
+        // un-send the message, so neither is allowed to fail the row.
+        try
+        {
+            using var sentCts = CancellationTokenSource.CreateLinkedTokenSource(token);
+            sentCts.CancelAfter(SentAppendTimeout);
+            await _mail.AppendToSentAsync(account.Id, compose, sentCts.Token);
+        }
+        catch (Exception ex) when (!token.IsCancellationRequested)
+        {
+            LogService.Log($"Outbox: {item.Id} sent, but appending to Sent failed", ex);
+        }
+
+        if (!string.IsNullOrEmpty(item.ReplaceDraftId) && !string.IsNullOrEmpty(item.DraftFolderName))
+        {
+            try
+            {
+                using var delCts = CancellationTokenSource.CreateLinkedTokenSource(token);
+                delCts.CancelAfter(TrashTimeout);
+                await _mail.MoveToTrashAsync(account.Id, item.DraftFolderName, item.ReplaceDraftId, delCts.Token);
+            }
+            catch (Exception ex) when (!token.IsCancellationRequested)
+            {
+                LogService.Log($"Outbox: {item.Id} sent, but trashing its server draft failed", ex);
+            }
+        }
+    }
+
+    internal static TimeSpan Backoff(int attempts)
+        => TimeSpan.FromMinutes(Math.Min(Math.Pow(2, Math.Max(1, attempts)), MaxBackoffMinutes));
+
+    // ── Connectivity triggers ───────────────────────────────────────────────────
+
+    private void OnOnlineChanged(bool online)
+    {
+        if (online) ScheduleReconnectFlush();
+    }
+
+    private void OnAccountOnlineChanged(Guid accountId, bool online)
+    {
+        if (online) ScheduleReconnectFlush();
+    }
+
+    // Several accounts coming back within a second or two would otherwise start several drains; the
+    // first wins the semaphore and the rest report Skipped, which is harmless but noisy in the log.
+    private void ScheduleReconnectFlush()
+    {
+        if (_disposed || !IsAvailable) return;
+        var previous = Interlocked.Exchange(ref _reconnectDebounce, null);
+        previous?.Cancel();
+        previous?.Dispose();
+
+        var cts = CancellationTokenSource.CreateLinkedTokenSource(_lifetime.Token);
+        _reconnectDebounce = cts;
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await Task.Delay(ReconnectDebounce, cts.Token);
+                await FlushAsync(force: false, cts.Token);
+            }
+            catch (OperationCanceledException) { }
+            catch (Exception ex) { LogService.Log("Outbox: flush after reconnect", ex); }
+        });
+    }
+
+    // ── Plumbing ────────────────────────────────────────────────────────────────
+
+    private void ThrowIfUnavailable()
+    {
+        if (!IsAvailable)
+            throw new InvalidOperationException("The Outbox is not available in --online mode: there is no local store to keep the message in.");
+    }
+
+    private void RaiseChanged()
+    {
+        try { Changed?.Invoke(); }
+        catch (Exception ex) { LogService.Log("Outbox: Changed handler", ex); }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        if (_connectivity != null)
+        {
+            _connectivity.OnlineChanged        -= OnOnlineChanged;
+            _connectivity.AccountOnlineChanged -= OnAccountOnlineChanged;
+        }
+        _lifetime.Cancel();
+        _lifetime.Dispose();
+        _reconnectDebounce?.Dispose();
+        _drain.Dispose();
+    }
+
+    /// <summary>The server (or the account setup) has settled the matter; retrying will not help.</summary>
+    private sealed class PermanentOutboxFailure : Exception
+    {
+        public PermanentOutboxFailure() { }
+        public PermanentOutboxFailure(string message) : base(message) { }
+        public PermanentOutboxFailure(string message, Exception innerException) : base(message, innerException) { }
+    }
+}

--- a/QuickMail/Services/OutboxService.cs
+++ b/QuickMail/Services/OutboxService.cs
@@ -32,7 +32,10 @@ public sealed class OutboxService : IOutboxService, IDisposable
 
     private readonly SemaphoreSlim _drain = new(1, 1);
     private readonly CancellationTokenSource _lifetime = new();
+    private readonly HashSet<string> _held = new(StringComparer.Ordinal);
+    private readonly object _heldGate = new();
     private CancellationTokenSource? _reconnectDebounce;
+    private bool _staleRowsReset;
     private bool _disposed;
 
     public OutboxService(
@@ -104,6 +107,25 @@ public sealed class OutboxService : IOutboxService, IDisposable
         return item.Id;
     }
 
+    // ── Hold ────────────────────────────────────────────────────────────────────
+
+    public void Hold(string id)
+    {
+        if (string.IsNullOrEmpty(id)) return;
+        lock (_heldGate) _held.Add(id);
+    }
+
+    public void Release(string id)
+    {
+        if (string.IsNullOrEmpty(id)) return;
+        lock (_heldGate) _held.Remove(id);
+    }
+
+    private bool IsHeld(string id)
+    {
+        lock (_heldGate) return _held.Contains(id);
+    }
+
     // ── Read / remove ───────────────────────────────────────────────────────────
 
     public async Task<IReadOnlyList<OutboxItem>> ListAsync(CancellationToken ct = default)
@@ -123,6 +145,7 @@ public sealed class OutboxService : IOutboxService, IDisposable
         if (!IsAvailable) return false;
         var existed = await _store.LoadOutboxItemAsync(id) != null;
         await _store.DeleteOutboxItemAsync(id);
+        Release(id);
         if (existed) RaiseChanged();
         return existed;
     }
@@ -149,10 +172,25 @@ public sealed class OutboxService : IOutboxService, IDisposable
 
         using var linked = CancellationTokenSource.CreateLinkedTokenSource(_lifetime.Token, ct);
         var token = linked.Token;
-        int sent = 0, drafts = 0, failed = 0, skipped = 0;
+        int sent = 0, drafts = 0, failed = 0, skipped = 0, deferred = 0;
+        var touched = false;
         try
         {
             var items = await _store.LoadOutboxItemsAsync();
+
+            // A row still marked Sending when no drain has run this session was interrupted by a
+            // crash or an exit mid-send; nothing will ever finish it. Give it back to the queue.
+            if (!_staleRowsReset)
+            {
+                _staleRowsReset = true;
+                foreach (var stale in items.Where(i => i.State == OutboxState.Sending))
+                {
+                    stale.State = OutboxState.Pending;
+                    await _store.UpdateOutboxStateAsync(stale.Id, OutboxState.Pending, stale.Attempts, stale.LastError, null);
+                    touched = true;
+                }
+            }
+
             var now = DateTimeOffset.UtcNow;
             // Oldest first, so messages leave in the order they were written.
             foreach (var item in Enumerable.Reverse(items))
@@ -161,13 +199,15 @@ public sealed class OutboxService : IOutboxService, IDisposable
                 if (onlyAccount.HasValue && item.AccountId != onlyAccount.Value) continue;
                 if (!IsEligible(item, now, force)) { skipped++; continue; }
 
-                var outcome = await ProcessOneAsync(item, token);
+                touched = true;
+                var outcome = await ProcessOneAsync(item, force, token);
                 switch (outcome)
                 {
-                    case Outcome.Sent:          sent++;   break;
-                    case Outcome.DraftUploaded: drafts++; break;
-                    case Outcome.Failed:        failed++; break;
-                    default:                    skipped++; break;
+                    case Outcome.Sent:          sent++;     break;
+                    case Outcome.DraftUploaded: drafts++;   break;
+                    case Outcome.Failed:        failed++;   break;
+                    case Outcome.Deferred:      deferred++; break;
+                    default:                    skipped++;  break;
                 }
             }
         }
@@ -176,8 +216,8 @@ public sealed class OutboxService : IOutboxService, IDisposable
             _drain.Release();
         }
 
-        var result = new OutboxFlushResult(sent, drafts, failed, skipped);
-        RaiseChanged();
+        var result = new OutboxFlushResult(sent, drafts, failed, skipped, deferred);
+        if (touched) RaiseChanged();
         if (result.Any)
         {
             try { FlushCompleted?.Invoke(result); }
@@ -188,6 +228,9 @@ public sealed class OutboxService : IOutboxService, IDisposable
 
     private bool IsEligible(OutboxItem item, DateTimeOffset now, bool force)
     {
+        // A row open in a compose window belongs to the user until that window closes: sending it
+        // now would send stale content and then delete the edit they are making.
+        if (IsHeld(item.Id)) return false;
         if (force) return item.State != OutboxState.Sending;
         if (item.State != OutboxState.Pending) return false;
         if (item.NextAttemptUtc is { } next && next > now) return false;
@@ -197,7 +240,7 @@ public sealed class OutboxService : IOutboxService, IDisposable
 
     private enum Outcome { Sent, DraftUploaded, Failed, Deferred, Vanished }
 
-    private async Task<Outcome> ProcessOneAsync(OutboxItem item, CancellationToken token)
+    private async Task<Outcome> ProcessOneAsync(OutboxItem item, bool force, CancellationToken token)
     {
         var compose = await _store.LoadOutboxComposeAsync(item.Id);
         if (compose == null) return Outcome.Vanished;
@@ -210,14 +253,12 @@ public sealed class OutboxService : IOutboxService, IDisposable
             if (item.Kind == OutboxKind.Draft)
             {
                 await UploadDraftAsync(item, compose, token);
-                await _store.DeleteOutboxItemAsync(item.Id);
-                LogService.Log($"Outbox: draft {item.Id} uploaded");
+                await FinishRowAsync(item, "draft uploaded");
                 return Outcome.DraftUploaded;
             }
 
             await SendAsync(item, compose, token);
-            await _store.DeleteOutboxItemAsync(item.Id);
-            LogService.Log($"Outbox: message {item.Id} sent");
+            await FinishRowAsync(item, "message sent");
             return Outcome.Sent;
         }
         catch (OperationCanceledException) when (token.IsCancellationRequested)
@@ -236,6 +277,14 @@ public sealed class OutboxService : IOutboxService, IDisposable
         {
             if (ConnectionFailure.IsConnectionFailure(ex, token))
             {
+                if (force)
+                {
+                    // The user asked and the network was not there. That is not a strike against the
+                    // row: leave the automatic schedule exactly as it was.
+                    await _store.UpdateOutboxStateAsync(item.Id, OutboxState.Pending, item.Attempts, ex.Message, item.NextAttemptUtc);
+                    LogService.Log($"Outbox: {item.Kind} {item.Id} still unreachable on a manual drain", ex);
+                    return Outcome.Deferred;
+                }
                 var attempts = item.Attempts + 1;
                 var next = DateTimeOffset.UtcNow + Backoff(attempts);
                 await _store.UpdateOutboxStateAsync(item.Id, OutboxState.Pending, attempts, ex.Message, next);
@@ -247,6 +296,23 @@ public sealed class OutboxService : IOutboxService, IDisposable
             LogService.Log($"Outbox: {item.Kind} {item.Id} failed", ex);
             return Outcome.Failed;
         }
+    }
+
+    /// <summary>
+    /// Removes the row the server now holds — unless a newer save replaced it while the drain was
+    /// working (the row is no longer marked Sending). Then the new content stays queued for the
+    /// next drain rather than being deleted on the strength of the old content having gone out.
+    /// </summary>
+    private async Task FinishRowAsync(OutboxItem item, string what)
+    {
+        var current = await _store.LoadOutboxItemAsync(item.Id);
+        if (current != null && current.State != OutboxState.Sending)
+        {
+            LogService.Log($"Outbox: {what} for {item.Id}, but the row was rewritten meanwhile; keeping the newer copy queued");
+            return;
+        }
+        await _store.DeleteOutboxItemAsync(item.Id);
+        LogService.Log($"Outbox: {what} ({item.Id})");
     }
 
     private async Task UploadDraftAsync(OutboxItem item, ComposeModel compose, CancellationToken token)

--- a/QuickMail/ViewModels/ComposeViewModel.cs
+++ b/QuickMail/ViewModels/ComposeViewModel.cs
@@ -23,6 +23,8 @@ public partial class ComposeViewModel : ObservableObject, IDisposable
     private readonly IMailService _imap;
     private readonly ITemplateService _templateService;
     private readonly IMarkdownService _markdown;
+    private readonly IOutboxService? _outbox;
+    private readonly IConnectivityService? _connectivity;
 
     [ObservableProperty] private string _to = string.Empty;
     [ObservableProperty] private string _cc = string.Empty;
@@ -143,8 +145,26 @@ public partial class ComposeViewModel : ObservableObject, IDisposable
     private string? _inReplyToMessageId;
     private string? _draftMessageId;
     private string? _draftFolderName;
+    /// <summary>The local Outbox row this compose owns (#637): the one it was opened from, or the one
+    /// its last offline save went into. Every later save or send replaces that row.</summary>
+    private string? _outboxId;
     private bool _isDirty;
     private bool _isSent;
+
+    /// <summary>
+    /// How the last Save Draft ended. The window reads this to decide whether a close may go ahead —
+    /// it used to string-match "failed" in the status text, which missed "No Drafts folder found"
+    /// and discarded the message (#637).
+    /// </summary>
+    public DraftSaveOutcome LastSaveOutcome { get; private set; } = DraftSaveOutcome.None;
+
+    /// <summary>
+    /// Raised once when auto-save first has to keep the draft on this computer instead of the
+    /// server, so the window can say so (Status category) without nagging every interval. Reset by
+    /// the next server save.
+    /// </summary>
+    public event Action<string>? AutoSaveNotice;
+    private bool _localAutoSaveNoticed;
     private ComposeMode _seededMode = ComposeMode.PlainText;
     private string? _seededHtmlBody;
 
@@ -170,7 +190,8 @@ public partial class ComposeViewModel : ObservableObject, IDisposable
     /// </summary>
     public IAccountService AccountService => _accountService;
 
-    public ComposeViewModel(ISendMailService smtp, IAccountService accountService, ICredentialService credentials, IMailService imap, ITemplateService templateService, IMarkdownService? markdown = null)
+    public ComposeViewModel(ISendMailService smtp, IAccountService accountService, ICredentialService credentials, IMailService imap, ITemplateService templateService, IMarkdownService? markdown = null,
+        IOutboxService? outbox = null, IConnectivityService? connectivity = null)
     {
         _smtp = smtp;
         _accountService = accountService;
@@ -178,6 +199,8 @@ public partial class ComposeViewModel : ObservableObject, IDisposable
         _imap = imap;
         _templateService = templateService;
         _markdown = markdown ?? new MarkdownService();
+        _outbox = outbox;
+        _connectivity = connectivity;
         _attachments.CollectionChanged += (_, _) =>
         {
             _isDirty = true;
@@ -197,6 +220,7 @@ public partial class ComposeViewModel : ObservableObject, IDisposable
         _inReplyToMessageId = model.InReplyToMessageId;
         _draftMessageId     = model.DraftMessageId;
         _draftFolderName    = model.DraftFolderName;
+        _outboxId           = model.OutboxId;
         ComposeKind         = model.Kind;
         OnPropertyChanged(nameof(WindowTitle));
 
@@ -223,9 +247,9 @@ public partial class ComposeViewModel : ObservableObject, IDisposable
                         ?? SenderAccounts.FirstOrDefault(a => a.IsDefault)
                         ?? SenderAccounts.FirstOrDefault();
 
-        // Auto-append signature if this is a new compose (not a draft re-open) and the
+        // Auto-append signature if this is a new compose (not a draft or Outbox re-open) and the
         // account has a signature configured. Drafts already have the signature in the body.
-        if (model.DraftMessageId == null && SenderAccount != null && !string.IsNullOrWhiteSpace(SenderAccount.Signature))
+        if (model.DraftMessageId == null && model.OutboxId == null && SenderAccount != null && !string.IsNullOrWhiteSpace(SenderAccount.Signature))
         {
             var sig = SenderAccount.Signature;
             // Add separator if body already has content (reply/forward)
@@ -259,20 +283,89 @@ public partial class ComposeViewModel : ObservableObject, IDisposable
         try
         {
             await SaveDraftCoreAsync(account);
+            await ForgetLocalCopyAsync();
+            LastSaveOutcome = DraftSaveOutcome.SavedToServer;
             SetStatusOutcome("Draft saved.");
-        }
-        catch (DraftFolderMissingException)
-        {
-            SetStatusOutcome("No Drafts folder found on this account.");
         }
         catch (Exception ex)
         {
-            SetStatusOutcome($"Save draft failed: {ex.Message}");
+            // Server first, this computer second (#637). The text the user typed is worth more than
+            // folder purity, so even "no Drafts folder" keeps the draft locally: the Outbox row will
+            // fail on upload with that reason and stay reopenable, instead of the message being
+            // discarded when the window closes.
+            if (await TryKeepDraftLocallyAsync(account))
+            {
+                LastSaveOutcome = DraftSaveOutcome.SavedLocally;
+                SetStatusOutcome("Draft saved on this computer. It will upload when you're online.");
+            }
+            else
+            {
+                LastSaveOutcome = DraftSaveOutcome.Failed;
+                SetStatusOutcome(ex is DraftFolderMissingException
+                    ? "No Drafts folder found on this account."
+                    : $"Save draft failed: {ex.Message}");
+            }
         }
         finally
         {
             IsBusy = false;
         }
+    }
+
+    /// <summary>
+    /// Writes the compose into the local Outbox as a draft, replacing the row it already owns.
+    /// False when there is no Outbox (<c>--online</c> mode) or the store itself failed — the caller
+    /// then reports the original server failure. Own try/catch: a local-store failure must never
+    /// hide the server failure it was standing in for.
+    /// </summary>
+    private async Task<bool> TryKeepDraftLocallyAsync(AccountModel account)
+    {
+        if (_outbox?.IsAvailable != true) return false;
+        try
+        {
+            var compose = BuildComposeModel(account.Id);
+            _outboxId = await _outbox.EnqueueDraftAsync(compose, account.Id, _outboxId);
+            _isDirty = false;
+            return true;
+        }
+        catch (Exception ex)
+        {
+            LogService.Log("SaveDraft: keeping the draft locally failed", ex);
+            return false;
+        }
+    }
+
+    /// <summary>The server now holds this message, so the local Outbox row is redundant. Best effort.</summary>
+    private async Task ForgetLocalCopyAsync()
+    {
+        if (_outboxId == null || _outbox == null) return;
+        var id = _outboxId;
+        _outboxId = null;
+        try { await _outbox.RemoveAsync(id); }
+        catch (Exception ex) { LogService.Log("Compose: removing the local Outbox copy failed", ex); }
+    }
+
+    /// <summary>
+    /// Queues the message in the local Outbox to be sent when the server is reachable (#637).
+    /// Supersedes any draft row this compose owns. False when there is no Outbox or it failed.
+    /// </summary>
+    private async Task<bool> QueueSendAsync(ComposeModel compose, AccountModel account)
+    {
+        if (_outbox?.IsAvailable != true) return false;
+        try
+        {
+            _outboxId = await _outbox.EnqueueSendAsync(compose, account.Id, _outboxId);
+        }
+        catch (Exception ex)
+        {
+            LogService.Log("Send: queueing the message in the Outbox failed", ex);
+            return false;
+        }
+        _isSent = true;
+        _isDirty = false;
+        SetStatusOutcome("Message queued. It will be sent when you're online.");
+        CloseRequested?.Invoke();
+        return true;
     }
 
     /// <summary>Uploads the current compose state as a draft, replacing any previous draft.</summary>
@@ -341,12 +434,28 @@ public partial class ComposeViewModel : ObservableObject, IDisposable
         try
         {
             await SaveDraftCoreAsync(account, _autoSaveCts.Token);
+            await ForgetLocalCopyAsync();
             AutoSaveText = $"Auto-saved {DateTime.Now:t}";
             _autoSaveFailureAnnounced = false;
+            _localAutoSaveNoticed = false;
+        }
+        catch (OperationCanceledException) when (_autoSaveCts.IsCancellationRequested)
+        {
+            // The window is closing; its own close-time save decides what happens to the draft.
         }
         catch (Exception ex)
         {
             LogService.Log("AutoSaveAsync: draft auto-save failed", ex);
+            if (await TryKeepDraftLocallyAsync(account))
+            {
+                AutoSaveText = $"Kept on this computer {DateTime.Now:t}";
+                if (!_localAutoSaveNoticed)
+                {
+                    _localAutoSaveNoticed = true;
+                    AutoSaveNotice?.Invoke("Auto-save is keeping your draft on this computer until you're online.");
+                }
+                return;
+            }
             AutoSaveText = "Auto-save failed";
             if (!_autoSaveFailureAnnounced)
             {
@@ -418,10 +527,27 @@ public partial class ComposeViewModel : ObservableObject, IDisposable
         {
             var compose = BuildComposeModel(account.Id);
 
+            // Known offline: no point holding the window for a 30-second timeout (#637).
+            if (_connectivity?.IsAccountOnline(account.Id) == false && _outbox?.IsAvailable == true
+                && await QueueSendAsync(compose, account))
+                return;
+
             using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
-            await _smtp.SendAsync(compose, account, password, cts.Token);
+            try
+            {
+                await _smtp.SendAsync(compose, account, password, cts.Token);
+            }
+            catch (Exception ex) when (ConnectionFailure.IsConnectionFailure(ex, CancellationToken.None))
+            {
+                // The server never answered. A rejection (bad address, refused login) is not
+                // caught here and still fails in the window, where the user can fix it.
+                if (await QueueSendAsync(compose, account))
+                    return;
+                throw;
+            }
             SetStatusOutcome("Message sent.");
             _isSent = true;
+            await ForgetLocalCopyAsync();
 
             // Append to Sent folder (best-effort — fire and forget so it doesn't block the UI).
             // Providers that auto-save sent mail (e.g. Gmail) may produce a duplicate; that is

--- a/QuickMail/ViewModels/ComposeViewModel.cs
+++ b/QuickMail/ViewModels/ComposeViewModel.cs
@@ -221,6 +221,8 @@ public partial class ComposeViewModel : ObservableObject, IDisposable
         _draftMessageId     = model.DraftMessageId;
         _draftFolderName    = model.DraftFolderName;
         _outboxId           = model.OutboxId;
+        // Reopened from the Outbox: the row is ours until this window closes (#637).
+        if (_outboxId != null) _outbox?.Hold(_outboxId);
         ComposeKind         = model.Kind;
         OnPropertyChanged(nameof(WindowTitle));
 
@@ -265,15 +267,20 @@ public partial class ComposeViewModel : ObservableObject, IDisposable
     [RelayCommand]
     private async Task SaveDraftAsync()
     {
+        // Every exit sets an outcome: the window's close prompt reads it, and a stale success from
+        // an earlier save would otherwise let a refused save close the window and lose the message.
+        LastSaveOutcome = DraftSaveOutcome.None;
         var account = SenderAccount;
         if (account == null)
         {
+            LastSaveOutcome = DraftSaveOutcome.Failed;
             SetStatusOutcome("Please select a sender account.");
             return;
         }
 
         if (Attachments.Sum(a => a.FileSize) > 25_000_000)
         {
+            LastSaveOutcome = DraftSaveOutcome.Failed;
             SetStatusOutcome("Total attachment size exceeds 25 MB. Please remove some attachments.");
             return;
         }
@@ -289,11 +296,13 @@ public partial class ComposeViewModel : ObservableObject, IDisposable
         }
         catch (Exception ex)
         {
-            // Server first, this computer second (#637). The text the user typed is worth more than
-            // folder purity, so even "no Drafts folder" keeps the draft locally: the Outbox row will
-            // fail on upload with that reason and stay reopenable, instead of the message being
-            // discarded when the window closes.
-            if (await TryKeepDraftLocallyAsync(account))
+            // Server first, this computer second (#637) — but only when the server could not be
+            // reached. A server that answered and refused (over quota, a rejected append) is an error
+            // the user has to see, not something to queue and fail again every auto-save. The one
+            // deliberate exception is "no Drafts folder": the text the user typed is worth more than
+            // folder purity, so it is kept locally, fails on upload with that reason, and stays
+            // reopenable instead of being discarded when the window closes.
+            if (ShouldKeepLocally(ex) && await TryKeepDraftLocallyAsync(account))
             {
                 LastSaveOutcome = DraftSaveOutcome.SavedLocally;
                 SetStatusOutcome("Draft saved on this computer. It will upload when you're online.");
@@ -318,6 +327,9 @@ public partial class ComposeViewModel : ObservableObject, IDisposable
     /// then reports the original server failure. Own try/catch: a local-store failure must never
     /// hide the server failure it was standing in for.
     /// </summary>
+    private static bool ShouldKeepLocally(Exception ex)
+        => ex is DraftFolderMissingException || ConnectionFailure.IsConnectionFailure(ex, CancellationToken.None);
+
     private async Task<bool> TryKeepDraftLocallyAsync(AccountModel account)
     {
         if (_outbox?.IsAvailable != true) return false;
@@ -325,6 +337,8 @@ public partial class ComposeViewModel : ObservableObject, IDisposable
         {
             var compose = BuildComposeModel(account.Id);
             _outboxId = await _outbox.EnqueueDraftAsync(compose, account.Id, _outboxId);
+            // Ours while this window is open: a drain must not upload or send it from under the edit.
+            _outbox.Hold(_outboxId);
             _isDirty = false;
             return true;
         }
@@ -341,6 +355,7 @@ public partial class ComposeViewModel : ObservableObject, IDisposable
         if (_outboxId == null || _outbox == null) return;
         var id = _outboxId;
         _outboxId = null;
+        _outbox.Release(id);
         try { await _outbox.RemoveAsync(id); }
         catch (Exception ex) { LogService.Log("Compose: removing the local Outbox copy failed", ex); }
     }
@@ -401,6 +416,8 @@ public partial class ComposeViewModel : ObservableObject, IDisposable
     {
         _autoSaveCts.Cancel();
         _autoSaveCts.Dispose();
+        // The window is gone; whatever row it held can be drained now (#637).
+        if (_outboxId != null) _outbox?.Release(_outboxId);
         GC.SuppressFinalize(this);
     }
 
@@ -446,7 +463,7 @@ public partial class ComposeViewModel : ObservableObject, IDisposable
         catch (Exception ex)
         {
             LogService.Log("AutoSaveAsync: draft auto-save failed", ex);
-            if (await TryKeepDraftLocallyAsync(account))
+            if (ShouldKeepLocally(ex) && await TryKeepDraftLocallyAsync(account))
             {
                 AutoSaveText = $"Kept on this computer {DateTime.Now:t}";
                 if (!_localAutoSaveNoticed)
@@ -536,6 +553,14 @@ public partial class ComposeViewModel : ObservableObject, IDisposable
             try
             {
                 await _smtp.SendAsync(compose, account, password, cts.Token);
+            }
+            catch (OperationCanceledException) when (_connectivity is { IsOnline: true })
+            {
+                // Thirty seconds with the app online is a slow upload, not an outage: a large
+                // attachment on a thin uplink. Queuing it would say "when you're online" to someone
+                // who is, and could send twice if the server had already taken the data.
+                SetStatusOutcome("Send timed out after 30 seconds. Try again.");
+                return;
             }
             catch (Exception ex) when (ConnectionFailure.IsConnectionFailure(ex, CancellationToken.None))
             {
@@ -875,6 +900,9 @@ public partial class ComposeViewModel : ObservableObject, IDisposable
 
         return new ComposeModel
         {
+            // Kind and the Outbox row travel with the model so a queued reply reopens as a reply.
+            Kind                = ComposeKind,
+            OutboxId            = _outboxId,
             AccountId           = accountId,
             To                  = To,
             Cc                  = Cc,

--- a/QuickMail/ViewModels/MainViewModel.Outbox.cs
+++ b/QuickMail/ViewModels/MainViewModel.Outbox.cs
@@ -1,0 +1,247 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.Input;
+using QuickMail.Helpers;
+using QuickMail.Models;
+using QuickMail.Services;
+
+namespace QuickMail.ViewModels;
+
+/// <summary>
+/// The Outbox virtual folder (#637): every draft waiting to upload and message waiting to send,
+/// across all accounts, read from the local queue. Enter reopens a row in the compose window;
+/// Delete removes it from the queue; Send Outbox Now drains it on demand.
+/// </summary>
+public partial class MainViewModel
+{
+    private readonly IOutboxService? _outbox;
+
+    /// <summary>
+    /// Mail written while the server could not be reached (#637): drafts waiting to upload and
+    /// messages waiting to send, across all accounts, read from the local store only. Deliberately
+    /// absent from <see cref="AllVirtualFolders"/>: it is never a startup folder and never the
+    /// subject of a saved view. Not shown in --online mode, which has no store to queue into.
+    /// </summary>
+    // "\0" rather than "\u0000": a fixed one-character escape, so it cannot swallow a following hex
+    // digit the way "\x00" can (see the sentinel comment in MainViewModel.cs). Same NUL either way.
+    public static readonly MailFolderModel OutboxFolder = new()
+    {
+        FullName    = "\0Outbox",
+        DisplayName = "Outbox",
+        Kind        = SpecialFolderKind.Outbox,
+    };
+
+    /// <summary>True when the Outbox exists at all: a queue is wired and there is a store behind it.</summary>
+    private bool ShowOutboxFolder => !OnlineMode && _outbox is { IsAvailable: true };
+
+    /// <summary>True when the Outbox folder is selected; the window routes Enter to <see cref="OpenOutboxItemCommand"/>.</summary>
+    public bool IsSelectedFolderOutbox =>
+        SelectedFolder != null &&
+        string.Equals(SelectedFolder.FullName, OutboxFolder.FullName, StringComparison.Ordinal);
+
+    /// <summary>
+    /// The queue as message rows. The state leads the subject ("Waiting to send: Lunch Friday") so
+    /// it is shown and spoken under every row layout — the preview column can be turned off, the
+    /// subject cannot. From is the account the message leaves from, which for outgoing mail is the
+    /// "who" that matters.
+    /// </summary>
+    private async Task<List<MailMessageSummary>> BuildOutboxSummariesAsync()
+    {
+        if (_outbox == null) return [];
+        var items = await _outbox.ListAsync();
+        var labels = Accounts.ToDictionary(a => a.Id, a => a.AccountLabel);
+        return items.Select(i => new MailMessageSummary
+        {
+            MessageId         = i.Id,
+            AccountId         = i.AccountId,
+            FolderName        = OutboxFolder.FullName,
+            FolderDisplayName = OutboxFolder.DisplayName,
+            From              = labels.GetValueOrDefault(i.AccountId, "Unknown account"),
+            To                = i.To,
+            Subject           = $"{i.StateDisplay}: {i.Subject}",
+            Date              = i.CreatedUtc,
+            IsRead            = true,
+            HasAttachments    = i.HasAttachments,
+            Preview           = i.StateDisplay,
+        }).ToList();
+    }
+
+    private async Task FetchOutboxAsync()
+    {
+        var loadVersion = Interlocked.Increment(ref _folderLoadVersion);
+        var expectedFolder = SelectedFolder;
+        Messages.Clear();
+        StatusText = "Loading Outbox…";
+        IsBusy = true;
+
+        _folderCts?.Cancel();
+        ReplaceCts(ref _folderCts, out var ct);
+
+        try
+        {
+            var rows = await BuildOutboxSummariesAsync();
+            ct.ThrowIfCancellationRequested();
+            if (!IsCurrentFolderLoad(loadVersion, expectedFolder)) return;
+
+            SetMessages(rows);
+            var n = Messages.Count;
+            StatusText = n == 0 ? "Outbox is empty." : $"{n} {(n == 1 ? "item" : "items")} in Outbox.";
+        }
+        catch (OperationCanceledException)
+        {
+            if (loadVersion == _folderLoadVersion)
+                StatusText = "Outbox load cancelled.";
+        }
+        catch (Exception ex)
+        {
+            LogService.Log("FetchOutbox failed", ex);
+            StatusText = "Could not load the Outbox.";
+        }
+        finally
+        {
+            if (loadVersion == _folderLoadVersion)
+                IsBusy = false;
+        }
+    }
+
+    /// <summary>
+    /// Puts the queue length on the Outbox tree node. A local read, so it runs before any connect
+    /// and again on every change. The node words it "waiting", never "unread".
+    /// </summary>
+    private async Task RefreshOutboxCountAsync()
+    {
+        if (!ShowOutboxFolder) return;
+        int count;
+        try { count = await _outbox!.CountAsync(); }
+        catch (Exception ex) { LogService.Log("Outbox: count", ex); return; }
+
+        OutboxFolder.UnreadCount = count;
+        var node = FolderTree == null ? null
+            : FlattenAllNodes(FolderTree).FirstOrDefault(n => ReferenceEquals(n.Folder, OutboxFolder));
+        node?.NotifyUnreadChanged();
+    }
+
+    /// <summary>Enter on an Outbox row: reopen it in the compose window, with everything it was saved with.</summary>
+    [RelayCommand]
+    private async Task OpenOutboxItemAsync()
+    {
+        var id = SelectedMessage?.MessageId;
+        if (id == null || _outbox == null) return;
+
+        ComposeModel? compose;
+        try { compose = await _outbox.LoadComposeAsync(id); }
+        catch (Exception ex)
+        {
+            LogService.Log("Outbox: open item", ex);
+            SetStatus("Could not open that Outbox item.", AnnouncementCategory.Result);
+            return;
+        }
+
+        if (compose == null)
+        {
+            // Sent or removed since the list was drawn.
+            SetStatus("That Outbox item is no longer there.", AnnouncementCategory.Result);
+            await FetchOutboxAsync();
+            return;
+        }
+        ComposeRequested?.Invoke(compose);
+    }
+
+    /// <summary>
+    /// Delete on Outbox rows. Unlike an ordinary delete this asks first: there is no Trash to get
+    /// the message back from, and it has never been anywhere but this computer.
+    /// </summary>
+    private async Task RemoveOutboxItemsAsync(IReadOnlyList<MailMessageSummary> rows)
+    {
+        if (_outbox == null || rows.Count == 0) return;
+
+        var n = rows.Count;
+        var prompt = n == 1
+            ? "Remove this message from the Outbox? It has not been sent and will be discarded."
+            : $"Remove these {n} messages from the Outbox? They have not been sent and will be discarded.";
+        if (ConfirmationRequested != null && !ConfirmationRequested(prompt, "Remove from Outbox"))
+            return;
+
+        var minIdx = rows.Min(m => Messages.IndexOf(m));
+        foreach (var row in rows)
+        {
+            Messages.Remove(row);
+            try { await _outbox.RemoveAsync(row.MessageId); }
+            catch (Exception ex) { LogService.Log($"Outbox: remove {row.MessageId}", ex); }
+        }
+        var removedIds = new HashSet<string>(rows.Select(r => r.MessageId), StringComparer.Ordinal);
+        _rawMessages.RemoveAll(m => m.FolderName == OutboxFolder.FullName && removedIds.Contains(m.MessageId));
+        RebuildActiveGroupView();
+
+        if (ViewMode == ViewMode.Messages && Messages.Count > 0)
+        {
+            SelectedMessage = Messages[Math.Max(0, Math.Min(minIdx, Messages.Count - 1))];
+            MessageListFocusRequested?.Invoke();
+        }
+        else
+        {
+            SelectedMessage = null;
+        }
+
+        await RefreshOutboxCountAsync();
+        SetStatus(n == 1 ? "1 Outbox item removed." : $"{n} Outbox items removed.", AnnouncementCategory.MessageAction);
+    }
+
+    /// <summary>Send Outbox Now: a drain that ignores backoff, retries failed rows, and does not wait for a connectivity signal.</summary>
+    [RelayCommand]
+    private async Task SendOutboxNowAsync()
+    {
+        if (!ShowOutboxFolder) return;
+        SetStatus("Sending Outbox…", AnnouncementCategory.Status);
+
+        OutboxFlushResult result;
+        try { result = await _outbox!.FlushAsync(force: true); }
+        catch (Exception ex)
+        {
+            LogService.Log("Outbox: Send Outbox Now", ex);
+            SetStatus($"Outbox: {ex.Message}", AnnouncementCategory.Result);
+            return;
+        }
+
+        // Anything that reached an outcome is announced by the FlushCompleted handler, once.
+        if (!result.Any)
+            SetStatus(result.Skipped > 0 ? "Outbox is already sending." : "Outbox is empty.", AnnouncementCategory.Result);
+    }
+
+    /// <summary>The fallback sync tick's drain: never lets a queue problem stop the sweep.</summary>
+    private async Task DrainOutboxQuietlyAsync(CancellationToken ct)
+    {
+        if (!ShowOutboxFolder) return;
+        try { await _outbox!.FlushAsync(ct: ct).ConfigureAwait(false); }
+        catch (OperationCanceledException) { }
+        catch (Exception ex) { LogService.Log("Outbox: fallback-tick drain", ex); }
+    }
+
+    private void OnOutboxChanged() => _ui.Post(() =>
+    {
+        RefreshOutboxCountAsync().LogFaults("Outbox count");
+        if (IsSelectedFolderOutbox)
+            FetchOutboxAsync().LogFaults("Outbox relist");
+    });
+
+    private void OnOutboxFlushCompleted(OutboxFlushResult result) => _ui.Post(() =>
+    {
+        SetStatus(SummariseFlush(result), AnnouncementCategory.Result);
+        RefreshOutboxCountAsync().LogFaults("Outbox count");
+    });
+
+    /// <summary>One sentence per drain, never one per item: "Outbox: 2 messages sent, 1 draft uploaded."</summary>
+    internal static string SummariseFlush(OutboxFlushResult r)
+    {
+        var parts = new List<string>(2);
+        if (r.Sent > 0)           parts.Add($"{r.Sent} {(r.Sent == 1 ? "message" : "messages")} sent");
+        if (r.DraftsUploaded > 0) parts.Add($"{r.DraftsUploaded} {(r.DraftsUploaded == 1 ? "draft" : "drafts")} uploaded");
+        var text = parts.Count > 0 ? $"Outbox: {string.Join(", ", parts)}." : "Outbox:";
+        if (r.Failed > 0)
+            text += $" {r.Failed} failed. See the Outbox folder.";
+        return text;
+    }
+}

--- a/QuickMail/ViewModels/MainViewModel.Outbox.cs
+++ b/QuickMail/ViewModels/MainViewModel.Outbox.cs
@@ -25,7 +25,7 @@ public partial class MainViewModel
     /// absent from <see cref="AllVirtualFolders"/>: it is never a startup folder and never the
     /// subject of a saved view. Not shown in --online mode, which has no store to queue into.
     /// </summary>
-    // "\0" rather than "\u0000": a fixed one-character escape, so it cannot swallow a following hex
+    // "\0" rather than " ": a fixed one-character escape, so it cannot swallow a following hex
     // digit the way "\x00" can (see the sentinel comment in MainViewModel.cs). Same NUL either way.
     public static readonly MailFolderModel OutboxFolder = new()
     {
@@ -34,6 +34,9 @@ public partial class MainViewModel
         Kind        = SpecialFolderKind.Outbox,
     };
 
+    /// <summary>What every message command other than Enter and Delete says on an Outbox row.</summary>
+    internal const string OutboxRowHint = "This message is waiting in the Outbox. Press Enter to open it in the compose window.";
+
     /// <summary>True when the Outbox exists at all: a queue is wired and there is a store behind it.</summary>
     private bool ShowOutboxFolder => !OnlineMode && _outbox is { IsAvailable: true };
 
@@ -41,6 +44,17 @@ public partial class MainViewModel
     public bool IsSelectedFolderOutbox =>
         SelectedFolder != null &&
         string.Equals(SelectedFolder.FullName, OutboxFolder.FullName, StringComparison.Ordinal);
+
+    private static bool IsOutboxRow(MailMessageSummary? summary)
+        => summary != null && string.Equals(summary.FolderName, OutboxFolder.FullName, StringComparison.Ordinal);
+
+    // True while a Send Outbox Now is in flight, so its outcome is announced as the result of the
+    // user's action; automatic drains are background progress.
+    private bool _manualOutboxDrain;
+
+    // True while Delete is removing rows itself, so the queue's Changed event does not relist the
+    // Outbox out from under the removal (the real service raises it inline on the UI thread).
+    private bool _suppressOutboxRelist;
 
     /// <summary>
     /// The queue as message rows. The state leads the subject ("Waiting to send: Lunch Friday") so
@@ -87,8 +101,7 @@ public partial class MainViewModel
             if (!IsCurrentFolderLoad(loadVersion, expectedFolder)) return;
 
             SetMessages(rows);
-            var n = Messages.Count;
-            StatusText = n == 0 ? "Outbox is empty." : $"{n} {(n == 1 ? "item" : "items")} in Outbox.";
+            StatusText = OutboxCountText(Messages.Count);
         }
         catch (OperationCanceledException)
         {
@@ -105,6 +118,33 @@ public partial class MainViewModel
             if (loadVersion == _folderLoadVersion)
                 IsBusy = false;
         }
+    }
+
+    private static string OutboxCountText(int n)
+        => n == 0 ? "Outbox is empty." : $"{n} {(n == 1 ? "item" : "items")} in Outbox.";
+
+    /// <summary>
+    /// Refreshes the Outbox listing in place after the queue changed, keeping the user's selection
+    /// (by row id, else by position) instead of clearing the list out from under their focus — a
+    /// drain flips each row through "Sending…" and the listing follows.
+    /// </summary>
+    private async Task RelistOutboxPreservingSelectionAsync()
+    {
+        if (!IsSelectedFolderOutbox) return;
+        var selectedId = SelectedMessage?.MessageId;
+        var selectedIndex = SelectedMessage != null ? Messages.IndexOf(SelectedMessage) : -1;
+
+        List<MailMessageSummary> rows;
+        try { rows = await BuildOutboxSummariesAsync(); }
+        catch (Exception ex) { LogService.Log("Outbox relist", ex); return; }
+        if (!IsSelectedFolderOutbox) return;
+
+        SetMessages(rows);
+        StatusText = OutboxCountText(Messages.Count);
+        if (Messages.Count == 0) { SelectedMessage = null; return; }
+
+        var byId = selectedId == null ? null : Messages.FirstOrDefault(m => m.MessageId == selectedId);
+        SelectedMessage = byId ?? Messages[Math.Clamp(selectedIndex, 0, Messages.Count - 1)];
     }
 
     /// <summary>
@@ -144,9 +184,11 @@ public partial class MainViewModel
         {
             // Sent or removed since the list was drawn.
             SetStatus("That Outbox item is no longer there.", AnnouncementCategory.Result);
-            await FetchOutboxAsync();
+            await RelistOutboxPreservingSelectionAsync();
             return;
         }
+        // Held from here until the compose window closes, so no drain sends it from under the edit.
+        _outbox.Hold(id);
         ComposeRequested?.Invoke(compose);
     }
 
@@ -166,14 +208,22 @@ public partial class MainViewModel
             return;
 
         var minIdx = rows.Min(m => Messages.IndexOf(m));
-        foreach (var row in rows)
+        _suppressOutboxRelist = true;
+        try
         {
-            Messages.Remove(row);
-            try { await _outbox.RemoveAsync(row.MessageId); }
-            catch (Exception ex) { LogService.Log($"Outbox: remove {row.MessageId}", ex); }
+            foreach (var row in rows)
+            {
+                Messages.Remove(row);
+                try { await _outbox.RemoveAsync(row.MessageId); }
+                catch (Exception ex) { LogService.Log($"Outbox: remove {row.MessageId}", ex); }
+            }
+        }
+        finally
+        {
+            _suppressOutboxRelist = false;
         }
         var removedIds = new HashSet<string>(rows.Select(r => r.MessageId), StringComparer.Ordinal);
-        _rawMessages.RemoveAll(m => m.FolderName == OutboxFolder.FullName && removedIds.Contains(m.MessageId));
+        _rawMessages.RemoveAll(m => IsOutboxRow(m) && removedIds.Contains(m.MessageId));
         RebuildActiveGroupView();
 
         if (ViewMode == ViewMode.Messages && Messages.Count > 0)
@@ -198,6 +248,7 @@ public partial class MainViewModel
         SetStatus("Sending Outbox…", AnnouncementCategory.Status);
 
         OutboxFlushResult result;
+        _manualOutboxDrain = true;
         try { result = await _outbox!.FlushAsync(force: true); }
         catch (Exception ex)
         {
@@ -205,10 +256,15 @@ public partial class MainViewModel
             SetStatus($"Outbox: {ex.Message}", AnnouncementCategory.Result);
             return;
         }
+        finally { _manualOutboxDrain = false; }
 
         // Anything that reached an outcome is announced by the FlushCompleted handler, once.
-        if (!result.Any)
-            SetStatus(result.Skipped > 0 ? "Outbox is already sending." : "Outbox is empty.", AnnouncementCategory.Result);
+        if (result.Any) return;
+        SetStatus(
+            result.Deferred > 0 ? "Could not reach the server. The Outbox will try again when you're online."
+            : result.Skipped > 0 ? "Outbox is busy: a drain is already running, or every item is open in a compose window."
+            : "Outbox is empty.",
+            AnnouncementCategory.Result);
     }
 
     /// <summary>The fallback sync tick's drain: never lets a queue problem stop the sweep.</summary>
@@ -222,16 +278,22 @@ public partial class MainViewModel
 
     private void OnOutboxChanged() => _ui.Post(() =>
     {
+        if (_suppressOutboxRelist) return;
         RefreshOutboxCountAsync().LogFaults("Outbox count");
-        if (IsSelectedFolderOutbox)
-            FetchOutboxAsync().LogFaults("Outbox relist");
+        RelistOutboxPreservingSelectionAsync().LogFaults("Outbox relist");
     });
 
-    private void OnOutboxFlushCompleted(OutboxFlushResult result) => _ui.Post(() =>
+    private void OnOutboxFlushCompleted(OutboxFlushResult result)
     {
-        SetStatus(SummariseFlush(result), AnnouncementCategory.Result);
-        RefreshOutboxCountAsync().LogFaults("Outbox count");
-    });
+        // Read on the raising thread: the manual command's own await is what clears it, and that
+        // continuation cannot run before this handler returns.
+        var category = _manualOutboxDrain ? AnnouncementCategory.Result : AnnouncementCategory.Status;
+        _ui.Post(() =>
+        {
+            SetStatus(SummariseFlush(result), category);
+            RefreshOutboxCountAsync().LogFaults("Outbox count");
+        });
+    }
 
     /// <summary>One sentence per drain, never one per item: "Outbox: 2 messages sent, 1 draft uploaded."</summary>
     internal static string SummariseFlush(OutboxFlushResult r)

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -156,6 +156,11 @@ public partial class MainViewModel : ObservableObject, IDisposable
     {
         if (_screenshotCapture != null)
             _screenshotCapture.EnabledChanged -= OnScreenshotCaptureEnabledChanged;
+        if (_outbox != null)
+        {
+            _outbox.Changed        -= OnOutboxChanged;
+            _outbox.FlushCompleted -= OnOutboxFlushCompleted;
+        }
         if (_rowLayoutService != null && _onRowLayoutsChanged != null)
         {
             _rowLayoutService.LayoutsChanged -= _onRowLayoutsChanged;
@@ -760,6 +765,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
                string.Equals(folder.FullName, AllTrashFolder.FullName, StringComparison.Ordinal) ||
                string.Equals(folder.FullName, AllArchiveFolder.FullName, StringComparison.Ordinal) ||
                string.Equals(folder.FullName, AllFlaggedFolder.FullName, StringComparison.Ordinal) ||
+               string.Equals(folder.FullName, OutboxFolder.FullName, StringComparison.Ordinal) ||
                string.Equals(folder.FullName, AllWatchedFolder.FullName, StringComparison.Ordinal) ||
                IsCalendarFolderName(folder.FullName);
     }
@@ -1697,9 +1703,16 @@ public partial class MainViewModel : ObservableObject, IDisposable
         IScreenshotCaptureService? screenshotCapture = null,
         IRowLayoutService? rowLayoutService = null,
         IWatchService? watchService = null,
-        IFolderViewStateService? folderViewState = null)
+        IFolderViewStateService? folderViewState = null,
+        IOutboxService? outboxService = null)
     {
         _folderViewState = folderViewState;
+        _outbox = outboxService;
+        if (_outbox != null)
+        {
+            _outbox.Changed        += OnOutboxChanged;
+            _outbox.FlushCompleted += OnOutboxFlushCompleted;
+        }
         _watchService = watchService;
         _rowLayoutService = rowLayoutService;
         _truthProbe = truthProbe;
@@ -2590,6 +2603,13 @@ public partial class MainViewModel : ObservableObject, IDisposable
             execute: () => EmptyTrashCommand.Execute(null),
             defaultKey: Key.E, defaultModifiers: ModifierKeys.Control | ModifierKeys.Shift));
 
+        // No default key: a rare, deliberate action that the Outbox drains on its own anyway (#637).
+        registry.Register(new CommandDefinition(
+            id: "mail.sendOutboxNow", category: "Mail", title: "Send Outbox Now",
+            description: "Try to send queued messages and upload queued drafts right away",
+            execute: () => SendOutboxNowCommand.Execute(null),
+            isAvailable: () => ShowOutboxFolder));
+
         // Ctrl+Shift+W, not Ctrl+W: Ctrl+W already closes a tab / the reading pane / a child window.
         registry.Register(new CommandDefinition(
             id: "mail.toggleWatch", category: "Mail", title: "Watch Conversation",
@@ -2936,6 +2956,10 @@ public partial class MainViewModel : ObservableObject, IDisposable
         if (folder.AccountId != Guid.Empty && folder.FullName.Length > 0 && folder.FullName[0] != '\0')
             return await _localStore.LoadFolderSummariesAsync(folder.AccountId, folder.FullName);
 
+        // The Outbox is local by definition (#637); its listing needs no network at any time.
+        if (string.Equals(folder.FullName, OutboxFolder.FullName, StringComparison.Ordinal))
+            return await BuildOutboxSummariesAsync();
+
         // Any other sentinel (All Flagged, Watched, a view, contact mail…) has no cheap cached
         // form here; fall back to the whole cache and let the post-connect refresh narrow it.
         return ExcludeSharedMail(await _localStore.LoadAllSummariesAsync());
@@ -3129,6 +3153,10 @@ public partial class MainViewModel : ObservableObject, IDisposable
         // Signal that the startup connect finished so a notification click that cold-started the app
         // (its account wasn't connected yet when the toast was activated) can now open its message.
         StartupConnectCompleted?.Invoke();
+
+        // Anything queued while the app was closed goes out now that accounts are up (#637). The
+        // reconnect-driven drain cannot see a cold start, so this is its startup counterpart.
+        _outbox?.FlushAsync(ct: ct).LogFaults("startup Outbox drain");
 
         // Contact sync (issue #256): best-effort, fire-and-forget, after mail accounts have connected
         // so their OAuth tokens are warm — contact-scope acquisition is then silent (no sign-in popup).
@@ -3439,6 +3467,10 @@ public partial class MainViewModel : ObservableObject, IDisposable
                 // anyone who chose it to avoid exactly that (metered or locked-down networks).
                 await ReconcileCurrentFolderAsync(ct).ConfigureAwait(false);
 
+                // Queued mail rides the same timer (#637): a network that came back without Windows
+                // noticing, or an account that reconnected quietly, still drains within one poll.
+                await DrainOutboxQuietlyAsync(ct).ConfigureAwait(false);
+
                 // Snapshot EVERY non-excluded folder for EVERY account (all backends). Non-Inbox folders
                 // have no live watcher — Graph's delta poll and IMAP's IDLE both cover only the Inbox —
                 // so mail a server-side rule files into a custom folder at delivery is invisible until the
@@ -3620,6 +3652,11 @@ public partial class MainViewModel : ObservableObject, IDisposable
             // otherwise never let an aggregate see these messages. Shared mailboxes are excluded here
             // too (#31), so the live path agrees with the cache read in FetchWatchedAsync.
             relevant = incoming.Where(m => IsWatchedMessage(m) && !IsSharedAccountId(m.AccountId));
+        }
+        else if (selected.FullName == OutboxFolder.FullName)
+        {
+            // The Outbox lists the local queue, never synced mail (#637).
+            relevant = [];
         }
         else if (IsFolderScopedAggregate(selected.FullName))
         {
@@ -4653,6 +4690,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
             // folder instead of the live singleton.
             AllArchiveFolder, AllTrashFolder, AllFlaggedFolder, AllWatchedFolder
         };
+        if (ShowOutboxFolder) items.Add(OutboxFolder);
 
         foreach (var account in Accounts)
         {
@@ -4679,6 +4717,9 @@ public partial class MainViewModel : ObservableObject, IDisposable
         }
 
         BuildFolderTree();
+
+        // The Outbox count is a local read, so it is right from the first tree the user sees (#637).
+        RefreshOutboxCountAsync().LogFaults("Outbox count");
     }
 
     private void BuildFolderTree()
@@ -4813,6 +4854,8 @@ public partial class MainViewModel : ObservableObject, IDisposable
         allMailGroup.Children.Add(new FolderTreeNode { Folder = AllTrashFolder,   Label = AllTrashFolder.DisplayName });
         allMailGroup.Children.Add(new FolderTreeNode { Folder = AllFlaggedFolder, Label = AllFlaggedFolder.DisplayName });
         allMailGroup.Children.Add(new FolderTreeNode { Folder = AllWatchedFolder, Label = AllWatchedFolder.DisplayName });
+        if (ShowOutboxFolder)
+            allMailGroup.Children.Add(new FolderTreeNode { Folder = OutboxFolder, Label = OutboxFolder.DisplayName });
         roots.Add(allMailGroup);
 
         foreach (var account in Accounts)
@@ -5937,6 +5980,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
         if (IsFolderScopedAggregate(folder.FullName))     return FetchVirtualFolderAsync(folder.FullName);
         if (folder.FullName == AllFlaggedFolder.FullName) return FetchAllFlaggedAsync();
         if (folder.FullName == AllWatchedFolder.FullName) return FetchWatchedAsync();
+        if (folder.FullName == OutboxFolder.FullName)     return FetchOutboxAsync();
         if (TryGetAccountIdFromSentinel(folder.FullName, out var accountId)) return FetchAccountAllMailAsync(accountId);
         if (TryGetContactMailFromSentinel(folder.FullName, out var contactAddress, out var contactDirection))
             return FetchContactMailAsync(contactAddress, contactDirection);
@@ -6984,6 +7028,15 @@ public partial class MainViewModel : ObservableObject, IDisposable
     public async Task DeleteMessagesAsync(IReadOnlyList<MailMessageSummary> toDelete)
     {
         if (toDelete.Count == 0) return;
+
+        // Outbox rows have no server copy and no Trash to recover from; the Outbox code path asks
+        // first and removes from the queue (#637). A list shows one folder, so the selection is all
+        // Outbox or none of it.
+        if (toDelete.All(m => m.FolderName == OutboxFolder.FullName))
+        {
+            await RemoveOutboxItemsAsync(toDelete);
+            return;
+        }
 
         var minIdx = toDelete.Min(m => Messages.IndexOf(m));
         var label  = toDelete.Count == 1 ? "message" : $"{toDelete.Count} messages";

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -5423,6 +5423,15 @@ public partial class MainViewModel : ObservableObject, IDisposable
     private async Task SelectMessageAsync(MailMessageSummary? summary)
     {
         if (summary == null) return;
+        // An Outbox row has no server message behind it and no reading-pane form; Enter opens it in
+        // the compose window (#637).
+        if (IsOutboxRow(summary))
+        {
+            SelectedMessage = summary;
+            MessageDetail   = null;
+            IsMessageOpen   = false;
+            return;
+        }
         if (SelectedAccount?.Id != summary.AccountId)
             SelectedAccount = Accounts.FirstOrDefault(a => a.Id == summary.AccountId) ?? SelectedAccount;
         if (SelectedAccount == null) return;
@@ -7188,6 +7197,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
     {
         if (SelectedGroupMessages() is { } group) { await ArchiveMessagesAsync(group); return; }
         if (SelectedMessage == null) return;
+        if (IsOutboxRow(SelectedMessage)) { SetStatus(OutboxRowHint, AnnouncementCategory.Result); return; }
         await ArchiveMessagesAsync([SelectedMessage]);
     }
 
@@ -7724,6 +7734,11 @@ public partial class MainViewModel : ObservableObject, IDisposable
     {
         var summary = SelectedMessage;
         if (summary == null) return null;
+        if (IsOutboxRow(summary))
+        {
+            SetStatus(OutboxRowHint, AnnouncementCategory.Result);
+            return null;
+        }
 
         // Fast path: detail already loaded for this exact message.
         if (MessageDetail != null &&

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -5557,7 +5557,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
             LogService.Debug($"Prefetched msgId={summary.MessageId} folder={summary.FolderName}");
         }
         catch (OperationCanceledException) { /* expected on switch */ }
-        catch (InvalidOperationException ex) when (ex.Message.Contains("not connected"))
+        catch (AccountNotConnectedException)
         {
             // Prefetch raced startup or a disconnect; the next prefetch trigger
             // (folder load, message open) will retry once the account is up.

--- a/QuickMail/Views/ComposeWindow.xaml.cs
+++ b/QuickMail/Views/ComposeWindow.xaml.cs
@@ -246,6 +246,8 @@ public partial class ComposeWindow : Window
         // only; a failure is announced once (Status category) by the VM event.
         vm.AutoSaveFailed += message =>
             AccessibilityHelper.Announce(this, message, category: AnnouncementCategory.Status);
+        vm.AutoSaveNotice += message =>
+            AccessibilityHelper.Announce(this, message, category: AnnouncementCategory.Status);
         var cfg = _configService.Load();
         if (cfg.AutoSaveDrafts)
         {
@@ -696,7 +698,10 @@ public partial class ComposeWindow : Window
 
         // decision == true: save the draft first
         await _vm.SaveDraftCommand.ExecuteAsync(null);
-        if (_vm.StatusText.Contains("failed", StringComparison.OrdinalIgnoreCase))
+        // Only when neither the server nor the local Outbox took the draft does the window stay open
+        // (--online mode, or SQLite itself is broken). Deciding this by string-matching "failed" in
+        // the status text missed "No Drafts folder found" and discarded the message (#637).
+        if (_vm.LastSaveOutcome == DraftSaveOutcome.Failed)
             return;
 
         Closing -= OnWindowClosing;

--- a/QuickMail/Views/ComposeWindow.xaml.cs
+++ b/QuickMail/Views/ComposeWindow.xaml.cs
@@ -701,7 +701,7 @@ public partial class ComposeWindow : Window
         // Only when neither the server nor the local Outbox took the draft does the window stay open
         // (--online mode, or SQLite itself is broken). Deciding this by string-matching "failed" in
         // the status text missed "No Drafts folder found" and discarded the message (#637).
-        if (_vm.LastSaveOutcome == DraftSaveOutcome.Failed)
+        if (_vm.LastSaveOutcome is not (DraftSaveOutcome.SavedToServer or DraftSaveOutcome.SavedLocally))
             return;
 
         Closing -= OnWindowClosing;

--- a/QuickMail/Views/MainWindow.xaml
+++ b/QuickMail/Views/MainWindow.xaml
@@ -369,6 +369,9 @@
                 <MenuItem Header="Empty _Trash"
                           Command="{Binding EmptyTrashCommand}"
                           InputGestureText="Ctrl+Shift+E"/>
+                <!-- No gesture: the Outbox drains on its own when the connection returns (#637). -->
+                <MenuItem Header="Send _Outbox Now"
+                          Command="{Binding SendOutboxNowCommand}"/>
                 <Separator/>
                 <!-- Click, not Command: the target depends on which group tree is selected, which
                      only the window can resolve (see WatchTargetSubject). Dimmed rather than

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -5253,6 +5253,12 @@ public partial class MainWindow : Window
     /// </summary>
     private async Task OpenMessageFromListAsync(MailMessageSummary summary)
     {
+        // An Outbox row is a message that has not gone anywhere yet; it reopens in compose (#637).
+        if (_vm.IsSelectedFolderOutbox)
+        {
+            await _vm.OpenOutboxItemCommand.ExecuteAsync(null);
+            return;
+        }
         if (_vm.IsSelectedFolderDrafts)
         {
             await _vm.OpenDraftCommand.ExecuteAsync(null);

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -168,6 +168,8 @@ public partial class MainWindow : Window
     private readonly IThemeService? _themeService;
     private readonly IBugReportService? _bugReportService;
     private readonly ConnectionTruthProbe? _truthProbe;
+    private readonly IOutboxService? _outbox;
+    private readonly IConnectivityService? _connectivity;
     private readonly INotificationService? _notificationService;
 
     // ── Close-to-tray / run-in-background ──────────────────────────────────────
@@ -232,7 +234,9 @@ public partial class MainWindow : Window
         IAutoDiscoverService? autoDiscover = null,
         ConnectionTruthProbe? truthProbe = null,
         IRowLayoutService? rowLayoutService = null,
-        IWatchService? watchService = null)
+        IWatchService? watchService = null,
+        IOutboxService? outbox = null,
+        IConnectivityService? connectivity = null)
     {
         _vm = vm;
         _watchService = watchService;
@@ -264,6 +268,8 @@ public partial class MainWindow : Window
         _bugReportService = bugReportService;
 
         _truthProbe       = truthProbe;
+        _outbox           = outbox;
+        _connectivity     = connectivity;
         InitializeComponent();
         DataContext = vm;
 
@@ -5193,7 +5199,7 @@ public partial class MainWindow : Window
         // Compose windows are modeless, so the one-turn delay is imperceptible.
         Dispatcher.InvokeAsync(() =>
         {
-            var composeVm = new ComposeViewModel(_smtp, _accountService, _credentials, _imap, _templateService);
+            var composeVm = new ComposeViewModel(_smtp, _accountService, _credentials, _imap, _templateService, outbox: _outbox, connectivity: _connectivity);
             composeVm.Seed(composeModel);
             var window = new ComposeWindow(composeVm, _contactService, _templateService, _configService, _customDictionary, _themeService);
             composeVm.CloseRequested += window.Close;
@@ -6171,7 +6177,7 @@ public partial class MainWindow : Window
         ComposeWindow GetOrOpenCompose()
         {
             if (pending?.IsLoaded == true) return pending;
-            var cvm = new ComposeViewModel(_smtp, _accountService, _credentials, _imap, _templateService);
+            var cvm = new ComposeViewModel(_smtp, _accountService, _credentials, _imap, _templateService, outbox: _outbox, connectivity: _connectivity);
             // Seed with an empty new-message model so the sender-account list is populated and the
             // default account + signature are applied — same as the normal "New message" path. Without
             // this the From picker is empty and the user can't choose who to send from (a pre-existing

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,7 +3,7 @@
 ## Service Layer
 
 **App.xaml.cs** is the manual DI composition root — no container. Services are wired in `OnStartup` in dependency order:
-`ProfileContext` → `AccountService` → `CredentialService` → `ConfigService` → `ProviderCatalog` → `AutoDiscoverService` → `OAuthService` → `ImapService` → `SmtpService` → `LocalStoreService` → `ContactService` → `TemplateService` → `RuleService` → `SyncService` → `ViewService` → `CommandRegistry` → `MainViewModel` → `MainWindow`.
+`ProfileContext` → `AccountService` → `CredentialService` → `ConfigService` → `ProviderCatalog` → `AutoDiscoverService` → `OAuthService` → `ImapService` → `SmtpService` → `LocalStoreService` → `ContactService` → `TemplateService` → `RuleService` → `SyncService` → `OutboxService` → `ViewService` → `CommandRegistry` → `MainViewModel` → `MainWindow`.
 
 Every service has a matching interface in `Services/I*.cs`, making them fully substitutable in tests.
 
@@ -14,6 +14,10 @@ Every service has a matching interface in `Services/I*.cs`, making them fully su
 **BugReportService** submits **Help → Report a Bug** through a Cloudflare Worker relay rather than to the GitHub API directly, so no GitHub credential ships inside the executable and user-filed issues are authored by a bot rather than the maintainer. It falls back to clipboard + a pre-filled `issues/new` URL whenever the relay is unavailable — including every local build, which carries no relay credentials by design. Operations and troubleshooting: [BUG-REPORTING.md](BUG-REPORTING.md). Relay setup: [`relay/README.md`](../relay/README.md).
 
 **SyncService** runs background IMAP sync. It raises `FolderSynced`, `MessagesRemoved`, and `RulesApplied` events; `MainViewModel` subscribes and merges new data into observable collections. UI is populated from the SQLite cache immediately, then background sync fills gaps.
+
+**OutboxService** (#637) is the local queue of mail written while the server could not be reached: drafts waiting to upload and messages waiting to send. Rows live in the `Outbox` and `OutboxAttachment` tables as the compose model (JSON) plus attachment blobs — the model rather than MIME, because a MIME round-trip loses Bcc, the Markdown source, the compose mode and the reply linkage. `ComposeViewModel` tries the server first and enqueues on failure; the drain (`FlushAsync`) runs one at a time, oldest first, through the same router and send service as a live send, and classifies every failure with `ConnectionFailure.IsConnectionFailure`: a transport failure keeps the row pending with doubling backoff, a server rejection parks it as Failed for the user. Drains are triggered by the startup connect, the fallback sync tick, the Send Outbox Now command, and (through `IConnectivityService`) a reconnect. `MainViewModel` shows the queue as the `\0Outbox` virtual folder.
+
+**ConnectionFailure** is the one shared answer to "could the server be reached?": a server that answered — even to say no (`SmtpCommandException`, `ImapCommandException`, an HTTP status other than 502/503/504, an authentication failure) — is reachable; a transport failure anywhere in the exception chain (`SocketException`, `IOException`, a timeout, `ServiceNotConnectedException`, `AccountNotConnectedException`) is not. `ImapMailService.IsConnectionDrop` is deliberately separate: it decides whether a pooled connection is worth one transparent retry, a narrower question.
 
 **OAuthService** wraps MSAL (`Microsoft.Identity.Client`) for Microsoft 365 / Outlook OAuth2. Token refresh is handled automatically; passwords for OAuth accounts are not stored in Credential Manager.
 
@@ -74,7 +78,7 @@ QuickMail has startup flags that alter which services are available. New code th
 | Flag | Effect on services |
 |---|---|
 | *(normal)* | All services available. SQLite schema fully created. `LocalStoreService` returns cached data. |
-| `--online` | SQLite schema is **not created**. `LocalStoreService` methods will throw `SqliteException` on any call. All data must come from the backend (IMAP or Graph). |
+| `--online` | SQLite schema is **not created**. `LocalStoreService` methods will throw `SqliteException` on any call. All data must come from the backend (IMAP or Graph). No Outbox: `IOutboxService.IsAvailable` is false, the Outbox folder is not shown, and a draft save or send that cannot reach the server fails in the compose window as it always did. |
 | `--profileDir <path>` | All file-based services use the alternate path. No effect on availability. |
 
 **Graph accounts in `--online` mode:** fully supported, no behavioral difference. `GraphMailService` has **no `ILocalStoreService` dependency** — every read goes straight to the Graph REST API, so the uncreated SQLite schema never matters. (`GraphMailServiceTests.GraphMailService_HasNoLocalStoreDependency_SoOnlineModeWorks` guards this structurally.) The local-store-first / backend-fallback pattern below lives in `MainViewModel`, which dispatches the fallback through the `MailServiceRouter` to whichever backend owns the account.
@@ -112,6 +116,7 @@ Virtual folders use `FullName` sentinel strings starting with `\x00` to distingu
 | `\x00AllArchive` | Every account's archive destination |
 | `\x00AllFlagged` | Flagged messages across all accounts |
 | `\x00AccountMail:{guid}` | All folders for one account |
+| `\x00Outbox` | Queued drafts and sends across all accounts (#637), read from the local store only. Not a folder-scoped aggregate, never a startup folder, never a saved-view target; absent in `--online` mode. Enter reopens a row in compose, Delete removes it from the queue. |
 
 Trash, Junk, Sent, and Drafts are excluded from `\x00AllMail` via `folder.ExcludeFromAllMail`. When a virtual folder is selected, `MainViewModel` queries multiple real folders and merges results sorted newest-first.
 

--- a/docs/KEYBOARD-SHORTCUTS.md
+++ b/docs/KEYBOARD-SHORTCUTS.md
@@ -26,6 +26,7 @@
 | Ctrl+Q | `mail.markRead` | Mark as Read |
 | F5 | `mail.refresh` | Refresh |
 | Ctrl+Shift+E | `mail.emptyTrash` | Empty Trash |
+| *(unassigned)* | `mail.sendOutboxNow` | Send Outbox Now — tries every queued message and draft right away, including ones marked Failed (#637) |
 | Ctrl+Shift+W | `mail.toggleWatch` | Watch Conversation — watches the selected message's conversation, or unwatches it if already watched. On a Conversations group header it acts on that group; on a From/To group header it is unavailable (a sender group spans many conversations) |
 | *(unassigned)* | `mail.watchManager` | Watched Conversations… (review, rename, stop watching) |
 | *(unassigned)* | `view.filterWatched` | Show Watched Conversations Only |
@@ -153,6 +154,8 @@ editable, because changing it would silently change which messages the watch col
 **Window title** is `"{subject or kind} - {mode} - QuickMail"` (e.g. "Lunch Friday - HTML - QuickMail") so the taskbar and Alt+Tab identify the message and editing format. `WindowTitle` is notified on both Subject and CurrentMode changes.
 
 **Draft autosave**: compose windows auto-save dirty composes as drafts on a `DispatcherTimer` (config keys `AutoSaveDrafts`, default on, and `AutoSaveIntervalSeconds`, default 120, clamped 30–600; both editable in Settings → General → Composing). `ComposeViewModel.AutoSaveAsync` is quiet by design: success only updates the visual `AutoSaveText` status ("Auto-saved 3:42 PM") with **no announcement**; a failure raises `AutoSaveFailed` once (announced with `AnnouncementCategory.Status`) and re-arms after the next success. Autosave skips template edits, untouched composes, and composes with no recipient/subject/body/attachment. The palette command `compose.announceAutoSave` ("Announce Last Auto-Save") speaks the last autosave time on demand.
+
+**Offline (#637)**: no new compose gestures. `Ctrl+S` and auto-save fall back to the local Outbox when the server cannot be reached ("Draft saved on this computer. It will upload when you're online.", `Result`; auto-save says "Auto-save is keeping your draft on this computer until you're online." once, `Status`). `Alt+S` queues the message and closes the window when the server never answered ("Message queued. It will be sent when you're online.", `Result`); a server that answered and refused still fails in the window. `Escape` with unsaved changes → Save closes the window once the draft is kept locally; it stays open only when `ComposeViewModel.LastSaveOutcome` is `Failed` (nowhere took it — `--online` mode, or a broken store). The main window's `mail.sendOutboxNow` drains the queue on demand.
 
 **Compose modes** (`ComposeMode`: PlainText / Markdown / Html) are switched with `Ctrl+Shift+1/2/3`, the View menu, or the mode ComboBox in the status row. Plain Text and Markdown edit in `BodyBox` (TextBox); HTML mode edits in `RichBodyBox` — a native WPF `RichTextBox`, deliberately **not** WebView2 `contenteditable`, so screen readers stay in their normal edit cursor with no virtual cursor.
 

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -940,9 +940,27 @@ Press `Ctrl+K` to check every address in the To, Cc, and Bcc fields. QuickMail l
 
 ### Auto-Save Drafts
 
-QuickMail saves your compose as a draft automatically every 2 minutes (on by default). A quiet status line in the compose window shows "Auto-saved 3:42 PM" after each save — no announcement interrupts your writing. If a save fails, it is announced once. You can check the last auto-save time from the command palette: **Ctrl+Shift+P → Announce Last Auto-Save**.
+QuickMail saves your compose as a draft automatically every 2 minutes (on by default). A quiet status line in the compose window shows "Auto-saved 3:42 PM" after each save — no announcement interrupts your writing. When the server cannot be reached, the status line reads "Kept on this computer 3:42 PM" instead and that is announced once; see [Working Offline: Drafts and the Outbox](#working-offline-drafts-and-the-outbox). If a save fails entirely, it is announced once. You can check the last auto-save time from the command palette: **Ctrl+Shift+P → Announce Last Auto-Save**.
 
 Control auto-save in **Settings → General → Composing**: turn it off, change the interval (30 seconds to 10 minutes), and set the default compose mode for new messages.
+
+### Working Offline: Drafts and the Outbox
+
+A dropped connection no longer traps your message in the compose window. QuickMail always tries your account first and falls back to this computer only when the server does not answer:
+
+- **Save Draft** (`Ctrl+S`) and auto-save keep the draft on this computer when the server cannot be reached. You hear "Draft saved on this computer. It will upload when you're online." The draft goes to your account's Drafts folder the next time QuickMail connects.
+- **Send** (`Alt+S`) queues the message when the server cannot be reached. You hear "Message queued. It will be sent when you're online.", the window closes, and the message leaves the moment a connection returns. A server that answers and refuses the message — a bad address, a rejected login — still fails in the window, where you can fix it.
+- **Closing** a window with unsaved changes and choosing Save keeps the draft on this computer if the server is unreachable, and the window closes. It stays open only when the draft could be saved nowhere at all.
+
+Everything waiting lives in the **Outbox**, the last entry in the All Mail group of the folder tree. The folder's count is spoken as "waiting" rather than "unread". Each row shows the account it will leave from, and its subject starts with its state: "Waiting to send", "Waiting to upload draft", "Sending…", or "Failed" followed by the reason.
+
+| In the Outbox | What happens |
+|---------------|--------------|
+| `Enter` on a row | Reopens it in the compose window, exactly as it was written — recipients, Bcc, attachments, and compose mode included. Saving or sending from there replaces the queued copy. |
+| `Delete` on a row | Asks first, then removes it from the queue. There is no Trash to recover from: the message has never been anywhere but this computer. |
+| **Send Outbox Now** (Message menu, or `Ctrl+Shift+P` → Send Outbox Now) | Tries every queued item right away, including any marked Failed. |
+
+The Outbox drains on its own when QuickMail connects at startup, when the connection returns, and on each background sync. A drain is announced once as a whole, for example "Outbox: 2 messages sent, 1 draft uploaded." A message the server refused stays in the Outbox marked "Failed" with the reason, until you reopen and fix it, or remove it. The Outbox is not available in `--online` mode, which runs without the local store.
 
 ### Forwarding with Attachments
 
@@ -1479,6 +1497,7 @@ The direction matters, so it is worth being blunt about it: a **two-way** item i
 | **Calendar events** | Mostly two-way | Single (non-repeating) events on a connected calendar can be created, edited, and deleted from QuickMail. Repeating events, meeting invitations, and the events your provider manages for you are [download only](#events-your-account-will-not-let-quickmail-change). |
 | **Meeting responses** | Two-way | Accept, Tentative, and Decline are emailed to the organizer and update your calendar. |
 | **Mail rules** | This computer only | Rules run inside QuickMail as mail arrives. They are not server rules — your provider does not know about them, and they do nothing while QuickMail is closed. |
+| **The Outbox** | This computer only, until sent | Messages and drafts queued while the server was unreachable wait in QuickMail's data folder and go to your account the next time it connects. No other program sees them until then. See [Working Offline: Drafts and the Outbox](#working-offline-drafts-and-the-outbox). |
 | **Everything else in QuickMail** | This computer only | Settings, themes, keyboard customizations, signatures, message templates, saved views, message-list field choices, contact groups, and the contacts you typed in yourself. |
 
 ### If something you changed came back


### PR DESCRIPTION
Part 1 of 3 for #637 (offline support). This is the p0: composing while the server cannot be reached, with an Outbox that sends and uploads when it can. Part 2 adds real offline detection and reading fixes; part 3 adds the offline-bodies setting.

PR #642 was not used. This takes the smaller shape agreed in planning: **server first, local fallback**. The Drafts folder stays server truth; nothing is reconciled between two copies.

## What changes for the user

- **Save Draft** (`Ctrl+S`) and auto-save try the server as today. When it cannot be reached, the draft is kept on this computer and uploaded on the next connection. Announced as "Draft saved on this computer. It will upload when you're online." (Result). Auto-save says "Kept on this computer 3:42 PM" in the status row and announces once (Status).
- **Send** (`Alt+S`) queues the message and closes the window when the server never answered: "Message queued. It will be sent when you're online." A server that answered and refused (bad address, rejected login) still fails in the window.
- **Closing with unsaved changes → Save** now closes once the draft is kept locally. The window stays open only when the draft could be saved nowhere. The old check string-matched "failed" in the status text, which missed "No Drafts folder found" and discarded the message.
- **Outbox**, last in the All Mail group. Rows show the account and a state-led subject ("Waiting to send: Lunch Friday", "Failed: 550 no such user: …"). The tree node counts "3 waiting", never "unread". Enter reopens in compose with Bcc, mode and attachments intact; Delete asks, then removes from the queue; **Send Outbox Now** (Message menu, palette; no default key) forces a drain including Failed rows.
- Drains run after the startup connect, on the fallback sync tick, on the command, and (once part 2 lands) on reconnect. One announcement per drain: "Outbox: 2 messages sent, 1 draft uploaded."
- `--online` mode has no Outbox; both paths fail in the window exactly as before.

## How

- `ConnectionFailure.IsConnectionFailure` is the one shared classifier: a server that answered, even to say no, is reachable; a transport failure anywhere in the chain is not. The IMAP and Graph backends throw a typed `AccountNotConnectedException` instead of a message string.
- Two additive SQLite tables, `Outbox` and `OutboxAttachment`. The compose model is stored as JSON plus attachment blobs rather than MIME, because a MIME round-trip loses Bcc, the Markdown source, the compose mode and the reply linkage. Queued mail is not cache: `ClearCachedMailAsync` leaves it alone.
- `OutboxService` drains one at a time, oldest first, through the same router and send service as a live send. Transport failure → pending with doubling backoff (2 → 32 min); rejection → Failed until forced.
- `ComposeViewModel` gains optional `IOutboxService` / `IConnectivityService` parameters, so no existing test changed. `MainViewModel` gains the virtual folder through eight of the non-unified registration points (deliberately not `AllVirtualFolders`: never a startup folder or a saved-view target).

## Tests

- New: `ConnectionFailureTests` (33 cases), `OutboxStoreTests`, `OutboxServiceTests`, `ComposeViewModelOutboxTests`, `ComposeWindowCloseTests` (STA), `MainViewModelOutboxTests`, plus cases in `LocalStoreServiceMigrationTests` and `FolderTreeNodeTests`.
- Full suite: 3442 passed, 3 skipped (the opt-in input tests). One existing test updated to expect the typed exception.
- No new Selector-bound item types (Outbox rows are still `MailMessageSummary`), so nothing to add to `SelectorItemAccessibilityTests`.

## Not verified here, please check before merge

I could not run the real app against a live account from this worktree, so the manual walkthrough in the plan is outstanding:

1. Wifi off, compose, `Ctrl+S` → the "saved on this computer" text; `Escape` closes without a prompt; Outbox shows "1 waiting".
2. Wifi off, `Alt+S` → "Message queued…" and the window closes.
3. Wifi on, then **Send Outbox Now** (automatic reconnect drains arrive with part 2) → "Outbox: 1 message sent, 1 draft uploaded."; the draft is in the server Drafts folder, the message in Sent and delivered.
4. Online, send to an address the server rejects → "Send failed: …", window open, Outbox untouched.
5. Enter on an Outbox row reopens compose with Bcc, mode and attachments; Delete asks and removes.
6. `--online`: wifi off, Save Draft and Send show the old failure texts and the window stays open; no Outbox node.

## Docs

User guide (Working Offline section, What Syncs row), keyboard shortcuts, architecture (OutboxService, ConnectionFailure, `--online` note, virtual folder row), CLAUDE.md wiring order. `docs/privacy.html` unchanged: no new host, scope, or bug-report field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
