### PR TITLE
Download recent Inbox bodies for offline reading (#637, part 3 of 3)

### DIFF
--- a/QuickMail.Tests/AllArchiveVirtualFolderTests.cs
+++ b/QuickMail.Tests/AllArchiveVirtualFolderTests.cs
@@ -29,6 +29,7 @@ public class AllArchiveVirtualFolderTests
         public event Action<IReadOnlyList<MailMessageSummary>>? FolderReadStatesReconciled;
         public event Action<int>? RulesApplied;
         public event Action<int, int>? SyncProgressChanged;
+        public event Action<int, int>? OfflineBodyProgressChanged;
 #pragma warning restore CS0067
         public event Action<IReadOnlyList<MailMessageSummary>>? FolderSynced;
 
@@ -45,6 +46,7 @@ public class AllArchiveVirtualFolderTests
         public Task<int> ReconcileFolderAsync(AccountModel account, MailFolderModel folder, CancellationToken ct) => Task.FromResult(0);
         public DateTimeOffset? LastSyncedUtc(Guid accountId) => null;
         public void SeedRebuildBaseline(IEnumerable<Guid> accountIds) { }
+        public Task BackfillOfflineBodiesAsync(IEnumerable<AccountModel> accounts, IReadOnlyDictionary<Guid, List<MailFolderModel>> cachedFolders, CancellationToken ct) => Task.CompletedTask;
     }
 
     private static readonly Guid AccountA = Guid.Parse("11111111-1111-1111-1111-111111111111");

--- a/QuickMail.Tests/AllArchiveVirtualFolderTests.cs
+++ b/QuickMail.Tests/AllArchiveVirtualFolderTests.cs
@@ -30,6 +30,7 @@ public class AllArchiveVirtualFolderTests
         public event Action<int>? RulesApplied;
         public event Action<int, int>? SyncProgressChanged;
         public event Action<int, int>? OfflineBodyProgressChanged;
+    public event Action<int, int>? OfflineBodyPassCompleted;
 #pragma warning restore CS0067
         public event Action<IReadOnlyList<MailMessageSummary>>? FolderSynced;
 

--- a/QuickMail.Tests/ConfigServiceSaveTests.cs
+++ b/QuickMail.Tests/ConfigServiceSaveTests.cs
@@ -326,4 +326,18 @@ public class ConfigServiceSaveTests
         var reloaded = new ConfigService(profile).Load();
         Assert.NotNull(reloaded);
     }
+    [Fact]
+    public void SaveThenLoad_RoundTripsOfflineBodyDays()
+    {
+        // #637: off by default, and a chosen window survives a restart.
+        var profile = MakeTempProfile();
+        var service = new ConfigService(profile);
+        Assert.Equal(0, service.Load().OfflineBodyDays);
+
+        var config = service.Load();
+        config.OfflineBodyDays = 30;
+        service.Save(config);
+
+        Assert.Equal(30, new ConfigService(profile).Load().OfflineBodyDays);
+    }
 }

--- a/QuickMail.Tests/MainViewModelFlagTests.cs
+++ b/QuickMail.Tests/MainViewModelFlagTests.cs
@@ -95,6 +95,7 @@ public class MainViewModelFlagTests
         public event Action<IReadOnlyList<MailMessageSummary>>? FolderReadStatesReconciled;
         public event Action<int>? RulesApplied;
         public event Action<int, int>? SyncProgressChanged;
+        public event Action<int, int>? OfflineBodyProgressChanged;
 #pragma warning restore CS0067
         public void Fire(IReadOnlyList<MailMessageSummary> messages) => FolderSynced?.Invoke(messages);
         public Task SyncAllAccountsAsync(IEnumerable<AccountModel> accounts, IReadOnlyDictionary<Guid, List<MailFolderModel>> cachedFolders, CancellationToken ct) => Task.CompletedTask;
@@ -103,6 +104,7 @@ public class MainViewModelFlagTests
         public Task<int> ReconcileFolderAsync(AccountModel account, MailFolderModel folder, CancellationToken ct) => Task.FromResult(0);
         public Task<IReadOnlyList<MailMessageSummary>> SyncFolderFullAsync(AccountModel account, MailFolderModel folder, CancellationToken ct) => Task.FromResult<IReadOnlyList<MailMessageSummary>>(Array.Empty<MailMessageSummary>());
         public void SeedRebuildBaseline(IEnumerable<Guid> accountIds) { }
+        public Task BackfillOfflineBodiesAsync(IEnumerable<AccountModel> accounts, IReadOnlyDictionary<Guid, List<MailFolderModel>> cachedFolders, CancellationToken ct) => Task.CompletedTask;
         public DateTimeOffset? LastSyncedUtc(Guid accountId) => null;
     }
 

--- a/QuickMail.Tests/MainViewModelFlagTests.cs
+++ b/QuickMail.Tests/MainViewModelFlagTests.cs
@@ -96,6 +96,7 @@ public class MainViewModelFlagTests
         public event Action<int>? RulesApplied;
         public event Action<int, int>? SyncProgressChanged;
         public event Action<int, int>? OfflineBodyProgressChanged;
+    public event Action<int, int>? OfflineBodyPassCompleted;
 #pragma warning restore CS0067
         public void Fire(IReadOnlyList<MailMessageSummary> messages) => FolderSynced?.Invoke(messages);
         public Task SyncAllAccountsAsync(IEnumerable<AccountModel> accounts, IReadOnlyDictionary<Guid, List<MailFolderModel>> cachedFolders, CancellationToken ct) => Task.CompletedTask;

--- a/QuickMail.Tests/SessionFeaturesTests.cs
+++ b/QuickMail.Tests/SessionFeaturesTests.cs
@@ -241,6 +241,7 @@ public class IdleNewMailTests
         public event Action<int>? RulesApplied;
         public event Action<int, int>? SyncProgressChanged;
         public event Action<int, int>? OfflineBodyProgressChanged;
+    public event Action<int, int>? OfflineBodyPassCompleted;
 #pragma warning restore CS0067
 
         public Task SyncAllAccountsAsync(IEnumerable<AccountModel> accounts,

--- a/QuickMail.Tests/SessionFeaturesTests.cs
+++ b/QuickMail.Tests/SessionFeaturesTests.cs
@@ -240,6 +240,7 @@ public class IdleNewMailTests
         public event Action<IReadOnlyList<MailMessageSummary>>? FolderReadStatesReconciled;
         public event Action<int>? RulesApplied;
         public event Action<int, int>? SyncProgressChanged;
+        public event Action<int, int>? OfflineBodyProgressChanged;
 #pragma warning restore CS0067
 
         public Task SyncAllAccountsAsync(IEnumerable<AccountModel> accounts,
@@ -265,6 +266,7 @@ public class IdleNewMailTests
             => Task.FromResult<IReadOnlyList<MailMessageSummary>>(Array.Empty<MailMessageSummary>());
 
         public void SeedRebuildBaseline(IEnumerable<Guid> accountIds) { }
+        public Task BackfillOfflineBodiesAsync(IEnumerable<AccountModel> accounts, IReadOnlyDictionary<Guid, List<MailFolderModel>> cachedFolders, CancellationToken ct) => Task.CompletedTask;
         public DateTimeOffset? LastSyncedUtc(Guid accountId) => null;
     }
 

--- a/QuickMail.Tests/SettingsViewModelTests.cs
+++ b/QuickMail.Tests/SettingsViewModelTests.cs
@@ -123,6 +123,25 @@ public class SettingsViewModelTests
         Assert.Equal(100, loadedConfig.InitialSyncCount);
     }
 
+    [Fact]
+    public void OfflineBodyDays_RoundTripsThroughConfig()
+    {
+        // Off by default (#637): nobody's mail.db grows until they ask.
+        var configService = new StubConfigService();
+        var registry = new StubCommandRegistry();
+        Assert.Equal(0, new SettingsViewModel(configService, registry).OfflineBodyDays);
+
+        var cfg = configService.Load();
+        cfg.OfflineBodyDays = 30;
+        configService.Save(cfg);
+        var vm = new SettingsViewModel(configService, registry);
+        Assert.Equal(30, vm.OfflineBodyDays);
+
+        vm.OfflineBodyDays = 7;
+        vm.SaveCommand.Execute(null);
+        Assert.Equal(7, configService.Load().OfflineBodyDays);
+    }
+
     // ── CalDAV calendar source ──────────────────────────────────────────────────
 
     private sealed class RecordingCredentialService : ICredentialService

--- a/QuickMail.Tests/StubServices.cs
+++ b/QuickMail.Tests/StubServices.cs
@@ -349,6 +349,8 @@ class StubLocalStoreService : ILocalStoreService
     public virtual Task DeleteOutboxItemAsync(string id) { OutboxRows.Remove(id); return Task.CompletedTask; }
     public virtual Task<int> CountOutboxItemsAsync() => Task.FromResult(OutboxRows.Count);
 
+    public virtual Task<List<string>> GetMessageIdsMissingDetailAsync(Guid accountId, string folderName, DateTimeOffset since, int limit)
+        => Task.FromResult(new List<string>());
     public virtual Task<string> GetMaxMessageKeyAsync(Guid accountId, string folderName) => Task.FromResult("0");
     public virtual Task<HashSet<string>> GetAllMessageIdsAsync(Guid accountId, string folderName) => Task.FromResult(new HashSet<string>());
     public virtual Task<Dictionary<string, bool>> LoadFolderReadStatesAsync(Guid accountId, string folderName) => Task.FromResult(new Dictionary<string, bool>());
@@ -706,7 +708,15 @@ sealed class StubSyncService : ISyncService
     public event Action<IReadOnlyList<MailMessageSummary>>? FolderReadStatesReconciled;
     public event Action<int>? RulesApplied;
     public event Action<int, int>? SyncProgressChanged;
+    public event Action<int, int>? OfflineBodyProgressChanged;
 #pragma warning restore CS0067
+    /// <summary>Every backfill request (#637), so a test can assert Settings triggered one.</summary>
+    public int BackfillCalls { get; private set; }
+    public Task BackfillOfflineBodiesAsync(IEnumerable<AccountModel> accounts, IReadOnlyDictionary<Guid, List<MailFolderModel>> cachedFolders, CancellationToken ct)
+    {
+        BackfillCalls++;
+        return Task.CompletedTask;
+    }
     public Task SyncAllAccountsAsync(IEnumerable<AccountModel> accounts, IReadOnlyDictionary<Guid, List<MailFolderModel>> cachedFolders, CancellationToken ct) => Task.CompletedTask;
     public Task<IReadOnlyList<MailMessageSummary>> SyncOneFolderAsync(AccountModel account, MailFolderModel folder, CancellationToken ct) => Task.FromResult<IReadOnlyList<MailMessageSummary>>(Array.Empty<MailMessageSummary>());
     public Task<IReadOnlyList<MailMessageSummary>> SyncOneFolderOnlineAsync(AccountModel account, MailFolderModel folder, CancellationToken ct) => Task.FromResult<IReadOnlyList<MailMessageSummary>>(Array.Empty<MailMessageSummary>());

--- a/QuickMail.Tests/StubServices.cs
+++ b/QuickMail.Tests/StubServices.cs
@@ -82,7 +82,7 @@ class StubImapMailServiceBase : IMailService
     public Task<int> CountTrashMessagesAsync(Guid accountId, CancellationToken ct = default) => _inner.CountTrashMessagesAsync(accountId, ct);
     public Task<int> EmptyTrashAsync(Guid accountId, CancellationToken ct = default) => _inner.EmptyTrashAsync(accountId, ct);
     public Task<IList<string>> GetFolderMessageIdsAsync(Guid accountId, string folderName, CancellationToken ct = default) => _inner.GetFolderMessageIdsAsync(accountId, folderName, ct);
-    public Task<IReadOnlyList<(string Id, DateTimeOffset ReceivedUtc, bool IsRead)>> GetFolderMessageIdDatesAsync(Guid accountId, string folderName, CancellationToken ct = default) => _inner.GetFolderMessageIdDatesAsync(accountId, folderName, ct);
+    public virtual Task<IReadOnlyList<(string Id, DateTimeOffset ReceivedUtc, bool IsRead)>> GetFolderMessageIdDatesAsync(Guid accountId, string folderName, CancellationToken ct = default) => _inner.GetFolderMessageIdDatesAsync(accountId, folderName, ct);
     public Task<IReadOnlyDictionary<string, string>> FetchPreviewsAsync(Guid accountId, string folderName, IList<string> messageIds, int maxLines, CancellationToken ct = default) => _inner.FetchPreviewsAsync(accountId, folderName, messageIds, maxLines, ct);
     public Task<int> PollAsync(Guid accountId, string folderName, CancellationToken ct = default) => _inner.PollAsync(accountId, folderName, ct);
     public Task<(int Total, int Unread)> GetInboxStatusAsync(Guid accountId, CancellationToken ct = default) => _inner.GetInboxStatusAsync(accountId, ct);
@@ -709,6 +709,7 @@ sealed class StubSyncService : ISyncService
     public event Action<int>? RulesApplied;
     public event Action<int, int>? SyncProgressChanged;
     public event Action<int, int>? OfflineBodyProgressChanged;
+    public event Action<int, int>? OfflineBodyPassCompleted;
 #pragma warning restore CS0067
     /// <summary>Every backfill request (#637), so a test can assert Settings triggered one.</summary>
     public int BackfillCalls { get; private set; }

--- a/QuickMail.Tests/SyncServiceOfflineBodiesTests.cs
+++ b/QuickMail.Tests/SyncServiceOfflineBodiesTests.cs
@@ -1,0 +1,244 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using QuickMail.Models;
+using QuickMail.Services;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// The offline-bodies pass (#637): with the setting on, sync caches the bodies of recent Inbox mail
+/// that has none, newest first, and nothing else — not older mail, not other folders, not accounts
+/// that keep whole messages already, and not an account the app knows is unreachable. Real store on
+/// a temp profile, so the query that drives it is the shipping SQL.
+/// </summary>
+public class SyncServiceOfflineBodiesTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly LocalStoreService _store;
+    private readonly StubConfigService _config = new();
+    private readonly StubConnectivityService _connectivity = new();
+    private readonly Guid _accountId = Guid.NewGuid();
+    private readonly MailFolderModel _inbox = new() { FullName = "INBOX", DisplayName = "Inbox", Kind = SpecialFolderKind.Inbox };
+    private readonly MailFolderModel _projects = new() { FullName = "Projects", DisplayName = "Projects" };
+
+    public SyncServiceOfflineBodiesTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"qm-offline-bodies-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        _store = new LocalStoreService(new ProfileContext(_tempDir));
+        _store.Initialize();
+        _inbox.AccountId = _accountId;
+        _projects.AccountId = _accountId;
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); } catch { }
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>Records every body fetch and can fail one the way a dead network does.</summary>
+    private sealed class RecordingPrefetchMail : StubImapMailServiceBase
+    {
+        public List<string> Prefetched { get; } = [];
+        public string? FailOn { get; set; }
+        public List<MailMessageSummary> Arrivals { get; } = [];
+
+        public override Task<MailMessageDetail> PrefetchMessageDetailAsync(Guid accountId, string folderName, string messageId, CancellationToken ct = default)
+        {
+            if (messageId == FailOn) throw new SocketException((int)SocketError.HostUnreachable);
+            Prefetched.Add(messageId);
+            return Task.FromResult(new MailMessageDetail
+            {
+                MessageId = messageId, AccountId = accountId, FolderName = folderName,
+                From = "a <a@example.com>", PlainTextBody = $"body {messageId}",
+            });
+        }
+
+        public override Task<List<MailMessageSummary>> GetMessagesSinceAsync(Guid accountId, string folderName, string sinceMessageId, int initialCount, CancellationToken ct = default)
+            => Task.FromResult(Arrivals.ToList());
+    }
+
+    private AccountModel Account(BackendKind backend = BackendKind.ImapSmtp, bool shared = false) => new()
+    {
+        Id = _accountId, AccountName = "Test", Username = "t@example.com", ImapHost = "host", BackendKind = backend, IsShared = shared,
+    };
+
+    private MailMessageSummary Summary(string id, string folder, int daysAgo) => new()
+    {
+        MessageId = id, AccountId = _accountId, FolderName = folder, From = "a <a@example.com>",
+        Subject = id, IsRead = true, Date = DateTimeOffset.UtcNow.AddDays(-daysAgo),
+    };
+
+    private async Task SeedAsync(params MailMessageSummary[] rows) => await _store.UpsertSummariesAsync(rows);
+
+    private async Task SeedBodyAsync(string id, string folder)
+        => await _store.UpsertDetailAsync(new MailMessageDetail { MessageId = id, AccountId = _accountId, FolderName = folder, PlainTextBody = "cached" });
+
+    private (SyncService Sync, RecordingPrefetchMail Mail, List<(int Done, int Total)> Progress) Build(int offlineBodyDays, int syncDays = 30)
+    {
+        var cfg = _config.Load();
+        cfg.OfflineBodyDays = offlineBodyDays;
+        cfg.SyncDays = syncDays;
+        _config.Save(cfg);
+        var mail = new RecordingPrefetchMail();
+        var sync = new SyncService(mail, _store, _config, new StubRuleService(), connectivity: _connectivity);
+        var progress = new List<(int, int)>();
+        sync.OfflineBodyProgressChanged += (d, t) => progress.Add((d, t));
+        return (sync, mail, progress);
+    }
+
+    private Dictionary<Guid, List<MailFolderModel>> Folders() => new() { [_accountId] = [_inbox, _projects] };
+
+    [Fact]
+    public async Task OffFetchesNothing()
+    {
+        await SeedAsync(Summary("a", "INBOX", 1));
+        var (sync, mail, progress) = Build(offlineBodyDays: 0);
+
+        await sync.BackfillOfflineBodiesAsync([Account()], Folders(), CancellationToken.None);
+
+        Assert.Empty(mail.Prefetched);
+        Assert.Empty(progress);
+    }
+
+    [Fact]
+    public async Task FetchesOnlyInWindowInboxMailWithoutABody_NewestFirst()
+    {
+        await SeedAsync(
+            Summary("old", "INBOX", 20),          // outside a 7-day window
+            Summary("cached", "INBOX", 2),        // has a body already
+            Summary("older-new", "INBOX", 5),
+            Summary("newest", "INBOX", 1),
+            Summary("elsewhere", "Projects", 1)); // not an Inbox
+        await SeedBodyAsync("cached", "INBOX");
+        var (sync, mail, progress) = Build(offlineBodyDays: 7);
+
+        await sync.BackfillOfflineBodiesAsync([Account()], Folders(), CancellationToken.None);
+
+        Assert.Equal(["newest", "older-new"], mail.Prefetched);
+        Assert.NotNull(await _store.LoadDetailAsync(_accountId, "INBOX", "newest"));
+        Assert.Equal((0, 2), progress.First());
+        Assert.Equal((2, 2), progress.Last());
+    }
+
+    [Fact]
+    public async Task ASecondPassHasNothingLeftToDo()
+    {
+        await SeedAsync(Summary("a", "INBOX", 1));
+        var (sync, mail, _) = Build(offlineBodyDays: 7);
+        await sync.BackfillOfflineBodiesAsync([Account()], Folders(), CancellationToken.None);
+        Assert.Single(mail.Prefetched);
+
+        await sync.BackfillOfflineBodiesAsync([Account()], Folders(), CancellationToken.None);
+
+        Assert.Single(mail.Prefetched);
+    }
+
+    [Theory]
+    [InlineData(0, 30, 0)]
+    [InlineData(30, 7, 7)]
+    [InlineData(30, 0, 30)]
+    [InlineData(7, 30, 7)]
+    [InlineData(90, 90, 90)]
+    public void TheWindowIsNeverWiderThanTheSyncRange(int offlineBodyDays, int syncDays, int expected)
+    {
+        var cfg = new ConfigModel { OfflineBodyDays = offlineBodyDays, SyncDays = syncDays };
+        Assert.Equal(expected, cfg.EffectiveOfflineBodyDays);
+    }
+
+    [Fact]
+    public async Task Pop3AndSharedAccountsAreSkipped()
+    {
+        await SeedAsync(Summary("a", "INBOX", 1));
+        var (sync, mail, _) = Build(offlineBodyDays: 7);
+
+        await sync.BackfillOfflineBodiesAsync([Account(BackendKind.Pop3Smtp)], Folders(), CancellationToken.None);
+        await sync.BackfillOfflineBodiesAsync([Account(shared: true)], Folders(), CancellationToken.None);
+
+        Assert.Empty(mail.Prefetched);
+    }
+
+    [Fact]
+    public async Task AnAccountKnownOfflineIsSkipped()
+    {
+        await SeedAsync(Summary("a", "INBOX", 1));
+        _connectivity.SetAccount(_accountId, false);
+        var (sync, mail, _) = Build(offlineBodyDays: 7);
+
+        await sync.BackfillOfflineBodiesAsync([Account()], Folders(), CancellationToken.None);
+
+        Assert.Empty(mail.Prefetched);
+    }
+
+    [Fact]
+    public async Task AConnectionFailureStopsTheAccountAndReportsIt()
+    {
+        await SeedAsync(Summary("first", "INBOX", 1), Summary("second", "INBOX", 2));
+        var (sync, mail, progress) = Build(offlineBodyDays: 7);
+        mail.FailOn = "first";
+
+        await sync.BackfillOfflineBodiesAsync([Account()], Folders(), CancellationToken.None);
+
+        Assert.Empty(mail.Prefetched);   // "second" was never tried
+        Assert.Contains((_accountId, "offline-bodies", false), _connectivity.Notes);
+        Assert.Equal((2, 2), progress.Last());   // the pass still reports itself finished
+    }
+
+    [Fact]
+    public async Task CancellationStopsThePass()
+    {
+        await SeedAsync(Summary("a", "INBOX", 1));
+        var (sync, mail, _) = Build(offlineBodyDays: 7);
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => sync.BackfillOfflineBodiesAsync([Account()], Folders(), cts.Token));
+
+        Assert.Empty(mail.Prefetched);
+    }
+
+    [Fact]
+    public async Task AnInboxArrivalGetsItsBodyWithoutWaitingForASweep()
+    {
+        var (sync, mail, _) = Build(offlineBodyDays: 7);
+        mail.Arrivals.Add(Summary("arrived", "INBOX", 0));
+
+        await sync.SyncOneFolderAsync(Account(), _inbox, CancellationToken.None);
+
+        var deadline = DateTime.UtcNow.AddSeconds(10);
+        while (mail.Prefetched.Count == 0 && DateTime.UtcNow < deadline)
+            await Task.Delay(25);
+        Assert.Equal(["arrived"], mail.Prefetched);
+    }
+
+    [Fact]
+    public async Task AnArrivalOutsideTheWindowOrWithTheSettingOffIsLeftAlone()
+    {
+        var (sync, mail, _) = Build(offlineBodyDays: 0);
+        mail.Arrivals.Add(Summary("arrived", "INBOX", 0));
+        await sync.SyncOneFolderAsync(Account(), _inbox, CancellationToken.None);
+        await Task.Delay(200);
+        Assert.Empty(mail.Prefetched);
+    }
+
+    [Fact]
+    public async Task TheStoreQueryOrdersNewestFirstAndHonoursTheLimit()
+    {
+        await SeedAsync(Summary("d3", "INBOX", 3), Summary("d1", "INBOX", 1), Summary("d2", "INBOX", 2), Summary("d40", "INBOX", 40));
+        await SeedBodyAsync("d2", "INBOX");
+
+        var ids = await _store.GetMessageIdsMissingDetailAsync(_accountId, "INBOX", DateTimeOffset.UtcNow.AddDays(-7), limit: 10);
+        Assert.Equal(["d1", "d3"], ids);
+
+        var limited = await _store.GetMessageIdsMissingDetailAsync(_accountId, "INBOX", DateTimeOffset.UtcNow.AddDays(-7), limit: 1);
+        Assert.Equal(["d1"], limited);
+    }
+}

--- a/QuickMail.Tests/SyncServiceOfflineBodiesTests.cs
+++ b/QuickMail.Tests/SyncServiceOfflineBodiesTests.cs
@@ -63,6 +63,17 @@ public class SyncServiceOfflineBodiesTests : IDisposable
 
         public override Task<List<MailMessageSummary>> GetMessagesSinceAsync(Guid accountId, string folderName, string sinceMessageId, int initialCount, CancellationToken ct = default)
             => Task.FromResult(Arrivals.ToList());
+
+        /// <summary>What the startup sync sees on the server; without it the id-diff pass reads an
+        /// empty listing as "everything was deleted remotely" and purges the seeded rows.</summary>
+        public List<MailMessageSummary> OnServer { get; } = [];
+
+        public override Task<IReadOnlyList<(string Id, DateTimeOffset ReceivedUtc, bool IsRead)>> GetFolderMessageIdDatesAsync(Guid accountId, string folderName, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(string, DateTimeOffset, bool)>>(
+                [.. OnServer.Where(m => m.FolderName == folderName).Select(m => (m.MessageId, m.Date, m.IsRead))]);
+
+        public override Task<List<MailMessageSummary>> GetMessagesSinceDateAsync(Guid accountId, string folderName, DateTime since, CancellationToken ct = default)
+            => Task.FromResult(OnServer.Where(m => m.FolderName == folderName).ToList());
     }
 
     private AccountModel Account(BackendKind backend = BackendKind.ImapSmtp, bool shared = false) => new()
@@ -81,6 +92,9 @@ public class SyncServiceOfflineBodiesTests : IDisposable
     private async Task SeedBodyAsync(string id, string folder)
         => await _store.UpsertDetailAsync(new MailMessageDetail { MessageId = id, AccountId = _accountId, FolderName = folder, PlainTextBody = "cached" });
 
+    /// <summary>Every (downloaded, planned) a pass ended with.</summary>
+    private readonly List<(int Downloaded, int Planned)> _completed = [];
+
     private (SyncService Sync, RecordingPrefetchMail Mail, List<(int Done, int Total)> Progress) Build(int offlineBodyDays, int syncDays = 30)
     {
         var cfg = _config.Load();
@@ -88,9 +102,13 @@ public class SyncServiceOfflineBodiesTests : IDisposable
         cfg.SyncDays = syncDays;
         _config.Save(cfg);
         var mail = new RecordingPrefetchMail();
-        var sync = new SyncService(mail, _store, _config, new StubRuleService(), connectivity: _connectivity);
+        var sync = new SyncService(mail, _store, _config, new StubRuleService(), connectivity: _connectivity)
+        {
+            FetchPacing = TimeSpan.Zero,
+        };
         var progress = new List<(int, int)>();
         sync.OfflineBodyProgressChanged += (d, t) => progress.Add((d, t));
+        sync.OfflineBodyPassCompleted += (d, t) => _completed.Add((d, t));
         return (sync, mail, progress);
     }
 
@@ -125,7 +143,59 @@ public class SyncServiceOfflineBodiesTests : IDisposable
         Assert.Equal(["newest", "older-new"], mail.Prefetched);
         Assert.NotNull(await _store.LoadDetailAsync(_accountId, "INBOX", "newest"));
         Assert.Equal((0, 2), progress.First());
-        Assert.Equal((2, 2), progress.Last());
+        // Intermediate progress never claims the pass is over; the completion event does, once.
+        Assert.DoesNotContain((2, 2), progress);
+        Assert.Equal([(2, 2)], _completed);
+    }
+
+    [Fact]
+    public async Task TheStartupSyncRunsThePassBehindThePreviews()
+    {
+        // The wiring, not the pass: SyncAllAccountsAsync → post-sync trickle → bodies.
+        var (sync, mail, _) = Build(offlineBodyDays: 7);
+        mail.OnServer.Add(Summary("a", "INBOX", 1));
+
+        await sync.SyncAllAccountsAsync([Account()], Folders(), CancellationToken.None);
+        var deadline = DateTime.UtcNow.AddSeconds(10);
+        while (_completed.Count == 0 && DateTime.UtcNow < deadline)
+            await Task.Delay(25);
+
+        Assert.Equal(["a"], mail.Prefetched);
+        Assert.Equal([(1, 1)], _completed);
+    }
+
+    [Fact]
+    public async Task APassStopsAtTheCapAndTheNextOnePicksUpTheRest()
+    {
+        var rows = Enumerable.Range(0, SyncService.MaxBodiesPerPass + 1)
+            .Select(i => Summary($"m{i:D4}", "INBOX", 0)).ToArray();
+        await SeedAsync(rows);
+        var (sync, mail, _) = Build(offlineBodyDays: 7);
+
+        await sync.BackfillOfflineBodiesAsync([Account()], Folders(), CancellationToken.None);
+        Assert.Equal(SyncService.MaxBodiesPerPass, mail.Prefetched.Count);
+        Assert.Equal([(SyncService.MaxBodiesPerPass, SyncService.MaxBodiesPerPass)], _completed);
+
+        await sync.BackfillOfflineBodiesAsync([Account()], Folders(), CancellationToken.None);
+        Assert.Equal(SyncService.MaxBodiesPerPass + 1, mail.Prefetched.Count);
+        Assert.Equal(SyncService.MaxBodiesPerPass + 1, mail.Prefetched.Distinct().Count());
+    }
+
+    [Fact]
+    public async Task OnlyOnePassRunsAtATime()
+    {
+        await SeedAsync(Summary("a", "INBOX", 1), Summary("b", "INBOX", 2));
+        var (sync, mail, _) = Build(offlineBodyDays: 7);
+        sync.FetchPacing = TimeSpan.FromMilliseconds(150);
+
+        var first = sync.BackfillOfflineBodiesAsync([Account()], Folders(), CancellationToken.None);
+        await Task.Delay(50);
+        await sync.BackfillOfflineBodiesAsync([Account()], Folders(), CancellationToken.None);   // skipped: one already running
+        await first;
+
+        Assert.Equal(2, mail.Prefetched.Count);
+        Assert.Equal(2, mail.Prefetched.Distinct().Count());
+        Assert.Single(_completed);
     }
 
     [Fact]
@@ -188,7 +258,10 @@ public class SyncServiceOfflineBodiesTests : IDisposable
 
         Assert.Empty(mail.Prefetched);   // "second" was never tried
         Assert.Contains((_accountId, "offline-bodies", false), _connectivity.Notes);
-        Assert.Equal((2, 2), progress.Last());   // the pass still reports itself finished
+        // The pass reports what it actually cached, so the view model says nothing rather than
+        // "Downloaded 2 messages" after the server went away.
+        Assert.Equal([(0, 2)], _completed);
+        Assert.Equal([(0, 2)], progress);
     }
 
     [Fact]
@@ -220,11 +293,40 @@ public class SyncServiceOfflineBodiesTests : IDisposable
     }
 
     [Fact]
-    public async Task AnArrivalOutsideTheWindowOrWithTheSettingOffIsLeftAlone()
+    public async Task AnArrivalWithTheSettingOffIsLeftAlone()
     {
         var (sync, mail, _) = Build(offlineBodyDays: 0);
         mail.Arrivals.Add(Summary("arrived", "INBOX", 0));
         await sync.SyncOneFolderAsync(Account(), _inbox, CancellationToken.None);
+        await Task.Delay(200);
+        Assert.Empty(mail.Prefetched);
+    }
+
+    [Fact]
+    public async Task AnArrivalOutsideTheWindowIsLeftAlone()
+    {
+        // An IDLE fetch of the last 50 can carry mail older than the window (a folder that just
+        // had a lot moved into it); only the in-window ones get bodies.
+        var (sync, mail, _) = Build(offlineBodyDays: 7);
+        mail.Arrivals.Add(Summary("old", "INBOX", 20));
+        mail.Arrivals.Add(Summary("new", "INBOX", 1));
+        await sync.SyncOneFolderAsync(Account(), _inbox, CancellationToken.None);
+
+        var deadline = DateTime.UtcNow.AddSeconds(10);
+        while (mail.Prefetched.Count == 0 && DateTime.UtcNow < deadline)
+            await Task.Delay(25);
+        await Task.Delay(100);
+        Assert.Equal(["new"], mail.Prefetched);
+    }
+
+    [Fact]
+    public async Task TheSweepPathDoesNotHook_ThePassCoversIt()
+    {
+        // SyncFolderFullAsync (the periodic sweep) and the startup sync run the pass themselves;
+        // hooking there would fetch the whole first window twice.
+        var (sync, mail, _) = Build(offlineBodyDays: 7);
+        mail.Arrivals.Add(Summary("swept", "INBOX", 1));
+        await sync.SyncFolderFullAsync(Account(), _inbox, CancellationToken.None);
         await Task.Delay(200);
         Assert.Empty(mail.Prefetched);
     }

--- a/QuickMail.Tests/WatchedConversationsTests.cs
+++ b/QuickMail.Tests/WatchedConversationsTests.cs
@@ -43,6 +43,7 @@ public class WatchedConversationsTests
         public event Action<IReadOnlyList<MailMessageSummary>>? FolderReadStatesReconciled;
         public event Action<int>? RulesApplied;
         public event Action<int, int>? SyncProgressChanged;
+        public event Action<int, int>? OfflineBodyProgressChanged;
 #pragma warning restore CS0067
         public event Action<IReadOnlyList<MailMessageSummary>>? FolderSynced;
 
@@ -59,6 +60,7 @@ public class WatchedConversationsTests
         public Task<int> ReconcileFolderAsync(AccountModel a, MailFolderModel f, CancellationToken ct) => Task.FromResult(0);
         public DateTimeOffset? LastSyncedUtc(Guid accountId) => null;
         public void SeedRebuildBaseline(IEnumerable<Guid> accountIds) { }
+        public Task BackfillOfflineBodiesAsync(IEnumerable<AccountModel> accounts, IReadOnlyDictionary<Guid, List<MailFolderModel>> cachedFolders, CancellationToken ct) => Task.CompletedTask;
     }
 
     private static (MainViewModel Vm, StubWatchService Watch, RaisableSync Sync) MakeVm(

--- a/QuickMail.Tests/WatchedConversationsTests.cs
+++ b/QuickMail.Tests/WatchedConversationsTests.cs
@@ -44,6 +44,7 @@ public class WatchedConversationsTests
         public event Action<int>? RulesApplied;
         public event Action<int, int>? SyncProgressChanged;
         public event Action<int, int>? OfflineBodyProgressChanged;
+    public event Action<int, int>? OfflineBodyPassCompleted;
 #pragma warning restore CS0067
         public event Action<IReadOnlyList<MailMessageSummary>>? FolderSynced;
 

--- a/QuickMail/App.xaml.cs
+++ b/QuickMail/App.xaml.cs
@@ -391,7 +391,7 @@ public partial class App : Application
             // Server-side (Exchange/Graph) Inbox rules — read/manage a Graph account's messageRules.
             // Reuses the shared GraphClient (no own disposables), so no disposal wiring needed.
             var serverRuleService = new GraphServerRuleService(accountService, graphBackend.Client);
-            var syncService = new SyncService(effectiveMail, localStore, configService, ruleService, probeMode: probeMode);
+            var syncService = new SyncService(effectiveMail, localStore, configService, ruleService, probeMode: probeMode, connectivity: _connectivity);
             // The Outbox (#637): mail written while the server could not be reached. Drains through the
             // same router and send service as a live send, so a queued message leaves exactly as an
             // online one would have. It drains on reconnect, after the startup connect, on the fallback

--- a/QuickMail/Models/ConfigModel.cs
+++ b/QuickMail/Models/ConfigModel.cs
@@ -133,6 +133,18 @@ public class ConfigModel
     /// </summary>
     public int MailSyncPollMinutes { get; set; } = 5;
 
+    /// <summary>
+    /// Days of recent Inbox mail whose full bodies sync downloads for offline reading (#637).
+    /// 0 (the default) is off: bodies are cached only as messages are opened or prefetched.
+    /// Offered as 0, 7, 30 or 90; never wider than <see cref="SyncDays"/> when that is set.
+    /// Attachments are not included — they are fetched when opened and need a connection.
+    /// </summary>
+    public int OfflineBodyDays { get; set; } = 0;
+
+    /// <summary>The offline-bodies window actually used: <see cref="OfflineBodyDays"/> capped by <see cref="SyncDays"/>.</summary>
+    public int EffectiveOfflineBodyDays =>
+        OfflineBodyDays <= 0 ? 0 : SyncDays <= 0 ? OfflineBodyDays : Math.Min(OfflineBodyDays, SyncDays);
+
     // ── Appearance ────────────────────────────────────────────────────────────────
 
     /// <summary>

--- a/QuickMail/Services/ConfigService.cs
+++ b/QuickMail/Services/ConfigService.cs
@@ -244,6 +244,9 @@ public class ConfigService : IConfigService
                         if (int.TryParse(value, out var msp))
                             config.MailSyncPollMinutes = msp <= 0 ? 0 : Math.Clamp(msp, 1, 120);
                         break;
+                    case "offlinebodydays":
+                        if (int.TryParse(value, out var obd)) config.OfflineBodyDays = Math.Max(0, obd);
+                        break;
                     case "appearancethemeid":
                         if (!string.IsNullOrWhiteSpace(value)) config.AppearanceThemeId = value;
                         break;
@@ -456,6 +459,10 @@ public class ConfigService : IConfigService
         sb.AppendLine();
 
         sb.AppendLine($"MailSyncPollMinutes = {(config.MailSyncPollMinutes <= 0 ? 0 : Math.Clamp(config.MailSyncPollMinutes, 1, 120))}");
+        sb.AppendLine($"OfflineBodyDays = {Math.Max(0, config.OfflineBodyDays)}");
+        sb.AppendLine("# Days of recent Inbox mail whose full text is downloaded for reading offline.");
+        sb.AppendLine("# 0 (default) is off; 7, 30 or 90 keep that many days. Never wider than SyncDays.");
+        sb.AppendLine("# Attachments are not included.");
         sb.AppendLine("# Fallback mail-sync interval (minutes) behind IMAP IDLE.");
         sb.AppendLine("# Periodically re-syncs inboxes so new mail still arrives if the server never");
         sb.AppendLine("# pushes or the IDLE connection dies, and read/flag changes from other clients");

--- a/QuickMail/Services/ILocalStoreService.cs
+++ b/QuickMail/Services/ILocalStoreService.cs
@@ -140,6 +140,13 @@ public interface ILocalStoreService
     Task<HashSet<string>> GetExistingMessageIdsAsync(Guid accountId, string folderName, IEnumerable<string> messageIds);
 
     /// <summary>
+    /// Ids of summaries in the folder dated <paramref name="since"/> or later that have no
+    /// MessageDetail row, newest first, at most <paramref name="limit"/>. Drives the offline-bodies
+    /// pass (#637).
+    /// </summary>
+    Task<List<string>> GetMessageIdsMissingDetailAsync(Guid accountId, string folderName, DateTimeOffset since, int limit);
+
+    /// <summary>
     /// Counts all message summaries stored for the given account.
     /// Returns 0 if the account has no messages or does not exist.
     /// </summary>

--- a/QuickMail/Services/ISyncService.cs
+++ b/QuickMail/Services/ISyncService.cs
@@ -88,15 +88,23 @@ public interface ISyncService
 
     /// <summary>
     /// Fired on the UI thread as the offline-bodies pass (#637) downloads message bodies:
-    /// (done, total), where total is what this pass set out to fetch. Fires (total, total) last.
+    /// (done, total), where total is what this pass set out to fetch. Intermediate only; done is
+    /// always below total here.
     /// </summary>
     event Action<int, int>? OfflineBodyProgressChanged;
 
     /// <summary>
+    /// Fired once, on the UI thread, when an offline-bodies pass ends: (downloaded, planned).
+    /// downloaded is what was actually cached; it is below planned when a server went away.
+    /// </summary>
+    event Action<int, int>? OfflineBodyPassCompleted;
+
+    /// <summary>
     /// The offline-bodies pass on its own (#637): downloads the bodies of recent Inbox messages
     /// inside <see cref="ConfigModel.EffectiveOfflineBodyDays"/> that have no cached body yet, for
-    /// the given (connected) accounts. A no-op when the setting is off. Sync runs it after every
-    /// full sweep; Settings runs it when the window is widened.
+    /// the given (connected) accounts. A no-op when the setting is off, and when a pass is already
+    /// running. Sync runs it after the startup sync; the view model runs it after each periodic
+    /// sweep and when Settings widens the window.
     /// </summary>
     Task BackfillOfflineBodiesAsync(
         IEnumerable<AccountModel> accounts,

--- a/QuickMail/Services/ISyncService.cs
+++ b/QuickMail/Services/ISyncService.cs
@@ -87,6 +87,23 @@ public interface ISyncService
     void SeedRebuildBaseline(IEnumerable<Guid> accountIds);
 
     /// <summary>
+    /// Fired on the UI thread as the offline-bodies pass (#637) downloads message bodies:
+    /// (done, total), where total is what this pass set out to fetch. Fires (total, total) last.
+    /// </summary>
+    event Action<int, int>? OfflineBodyProgressChanged;
+
+    /// <summary>
+    /// The offline-bodies pass on its own (#637): downloads the bodies of recent Inbox messages
+    /// inside <see cref="ConfigModel.EffectiveOfflineBodyDays"/> that have no cached body yet, for
+    /// the given (connected) accounts. A no-op when the setting is off. Sync runs it after every
+    /// full sweep; Settings runs it when the window is widened.
+    /// </summary>
+    Task BackfillOfflineBodiesAsync(
+        IEnumerable<AccountModel> accounts,
+        IReadOnlyDictionary<Guid, List<MailFolderModel>> cachedFolders,
+        CancellationToken ct);
+
+    /// <summary>
     /// Returns the UTC time of the last completed sync for the given account,
     /// or null if the account has never been synced in this session.
     /// </summary>

--- a/QuickMail/Services/LocalStoreService.OfflineBodies.cs
+++ b/QuickMail/Services/LocalStoreService.OfflineBodies.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace QuickMail.Services;
+
+/// <summary>The offline-bodies pass's one query (#637).</summary>
+public partial class LocalStoreService
+{
+    public async Task<List<string>> GetMessageIdsMissingDetailAsync(Guid accountId, string folderName, DateTimeOffset since, int limit)
+    {
+        await using var conn = await OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        // Both tables share the composite primary key, so the join is index-backed. Newest first:
+        // if the pass is cut short, the mail most likely to be read is what got cached.
+        cmd.CommandText = """
+            SELECT s.unique_id
+            FROM MessageSummary s
+            LEFT JOIN MessageDetail d
+              ON d.unique_id = s.unique_id AND d.account_id = s.account_id AND d.folder_name = s.folder_name
+            WHERE s.account_id = $aid AND s.folder_name = $fn AND s.date_ticks >= $since AND d.unique_id IS NULL
+            ORDER BY s.date_ticks DESC
+            LIMIT $limit;
+            """;
+        cmd.Parameters.AddWithValue("$aid",   accountId.ToString());
+        cmd.Parameters.AddWithValue("$fn",    folderName);
+        cmd.Parameters.AddWithValue("$since", since.UtcTicks);
+        cmd.Parameters.AddWithValue("$limit", Math.Max(0, limit));
+
+        var ids = new List<string>();
+        await using var r = await cmd.ExecuteReaderAsync();
+        while (await r.ReadAsync())
+            ids.Add(r.GetString(0));
+        return ids;
+    }
+}

--- a/QuickMail/Services/SyncService.OfflineBodies.cs
+++ b/QuickMail/Services/SyncService.OfflineBodies.cs
@@ -12,8 +12,9 @@ namespace QuickMail.Services;
 /// <summary>
 /// The offline-bodies pass (#637): when <see cref="ConfigModel.OfflineBodyDays"/> is set, sync
 /// downloads the full bodies of recent Inbox messages that have no cached body yet, so they read
-/// offline. Runs after every full sweep (behind the previews), on each Inbox arrival, and on demand
-/// when Settings widens the window. Attachments are not included; POP3 already keeps whole messages.
+/// offline. Runs after the startup sync (behind the previews), after each periodic sweep, on each
+/// IDLE Inbox arrival, and on demand when Settings widens the window. Attachments are not
+/// included; POP3 already keeps whole messages.
 /// </summary>
 public partial class SyncService
 {
@@ -24,7 +25,19 @@ public partial class SyncService
 
     private const int ProgressEvery = 10;
 
+    /// <summary>
+    /// A short gap between fetches: this is background caching, and a burst of hundreds of
+    /// back-to-back fetches is what pushes Graph into 503 and an IMAP server into throttling.
+    /// Settable so tests do not pay it.
+    /// </summary>
+    internal TimeSpan FetchPacing { get; set; } = TimeSpan.FromMilliseconds(100);
+
+    // One pass at a time: the startup pass, a sweep, and a Settings-widen backfill would otherwise
+    // plan overlapping id lists and fetch the same bodies twice.
+    private readonly SemaphoreSlim _bodiesPassGate = new(1, 1);
+
     public event Action<int, int>? OfflineBodyProgressChanged;
+    public event Action<int, int>? OfflineBodyPassCompleted;
 
     public Task BackfillOfflineBodiesAsync(
         IEnumerable<AccountModel> accounts,
@@ -45,8 +58,28 @@ public partial class SyncService
         if (_probeMode) return;
         var days = _config.Load().EffectiveOfflineBodyDays;
         if (days <= 0) return;
-        var since = DateTimeOffset.UtcNow.AddDays(-days);
 
+        if (!await _bodiesPassGate.WaitAsync(0, ct))
+        {
+            LogService.Debug("Offline bodies: a pass is already running; skipping this one.");
+            return;
+        }
+        try
+        {
+            await RunPassAsync(accounts, cachedFolders, DateTimeOffset.UtcNow.AddDays(-days), ct);
+        }
+        finally
+        {
+            _bodiesPassGate.Release();
+        }
+    }
+
+    private async Task RunPassAsync(
+        List<AccountModel> accounts,
+        IReadOnlyDictionary<Guid, List<MailFolderModel>> cachedFolders,
+        DateTimeOffset since,
+        CancellationToken ct)
+    {
         // Plan first so the progress total is the whole pass, not one account at a time.
         var work = new List<(AccountModel Account, MailFolderModel Folder, List<string> Ids)>();
         foreach (var account in accounts.Where(EligibleForBodies))
@@ -63,24 +96,29 @@ public partial class SyncService
 
         var total = work.Sum(w => w.Ids.Count);
         if (total == 0) return;
-        _ui.Post(() => OfflineBodyProgressChanged?.Invoke(0, total));
+        ReportProgress(0, total);
 
         var done = 0;
         foreach (var (account, folder, ids) in work)
         {
             var timer = Stopwatch.StartNew();
-            var fetched = await DownloadBodiesForIdsAsync(account, folder, ids, ct, n => ReportProgress(done + n, total));
+            var before = done;
+            // Intermediate progress never reaches the total: the pass reports its own end, once,
+            // with the count it actually cached.
+            var fetched = await DownloadBodiesForIdsAsync(account, folder, ids, ct,
+                n => { if (before + n < total) ReportProgress(before + n, total); });
             done += fetched;
             LogService.Log($"Offline bodies {account.AccountLabel}/{folder.DisplayName}: {fetched} of {ids.Count} downloaded in {timer.ElapsedMilliseconds} ms");
         }
-        ReportProgress(total, total);
+        _ui.Post(() => OfflineBodyPassCompleted?.Invoke(done, total));
     }
 
     private void ReportProgress(int done, int total)
         => _ui.Post(() => OfflineBodyProgressChanged?.Invoke(done, total));
 
     /// <summary>
-    /// Fetches and caches each body in turn. A connection failure stops this account's batch — there
+    /// Fetches and caches each body in turn, skipping any that arrived in the cache meanwhile (an
+    /// open, a prefetch, the arrival hook). A connection failure stops this account's batch — there
     /// is no point hammering a server that just went away — and tells the connectivity service;
     /// any other failure is logged and the next id is tried. Returns how many were cached.
     /// </summary>
@@ -94,11 +132,16 @@ public partial class SyncService
             ct.ThrowIfCancellationRequested();
             try
             {
+                if (await _store.LoadDetailAsync(account.Id, folder.FullName, id) != null)
+                    continue;
+
                 // Background lease, and no \Seen: this is caching, not reading.
                 var detail = await _imap.PrefetchMessageDetailAsync(account.Id, folder.FullName, id, ct);
                 await _store.UpsertDetailAsync(detail);
                 fetched++;
                 if (fetched % ProgressEvery == 0) progress?.Invoke(fetched);
+                if (FetchPacing > TimeSpan.Zero)
+                    await Task.Delay(FetchPacing, ct);
             }
             catch (OperationCanceledException) { throw; }
             catch (Exception ex) when (ConnectionFailure.IsConnectionFailure(ex, ct))
@@ -116,9 +159,11 @@ public partial class SyncService
     }
 
     /// <summary>
-    /// The arrival hook: new Inbox mail inside the window gets its body cached right away, so the
-    /// setting stays true between sweeps (IDLE, the fallback poll and the periodic sweep all pass
-    /// through here). Fire-and-forget, a handful of ids at a time, no progress events.
+    /// The arrival hook, on the IDLE path only: new Inbox mail inside the window gets its body
+    /// cached right away, so the setting stays true between sweeps. The startup sync and the
+    /// periodic sweep run the full pass themselves, so they do not hook — hooking there would queue
+    /// the whole first window while the sync is still using the same background leases, and then
+    /// fetch it all again in the pass. Fire-and-forget, a handful of ids, no progress events.
     /// </summary>
     private void QueueArrivalBodies(AccountModel account, MailFolderModel folder, IReadOnlyList<MailMessageSummary> arrivals, CancellationToken ct)
     {
@@ -131,13 +176,7 @@ public partial class SyncService
         var ids = arrivals.Where(m => m.Date >= since).Select(m => m.MessageId).ToList();
         if (ids.Count == 0) return;
 
-        Task.Run(async () =>
-        {
-            // Skip anything the open-time cache or the prefetch already stored.
-            var missing = new HashSet<string>(await _store.GetMessageIdsMissingDetailAsync(account.Id, folder.FullName, since, MaxBodiesPerPass), StringComparer.Ordinal);
-            var wanted = ids.Where(missing.Contains).ToList();
-            if (wanted.Count > 0)
-                await DownloadBodiesForIdsAsync(account, folder, wanted, ct);
-        }, ct).LogFaults("offline bodies for arrivals");
+        Task.Run(() => DownloadBodiesForIdsAsync(account, folder, ids, ct), ct)
+            .LogFaults("offline bodies for arrivals");
     }
 }

--- a/QuickMail/Services/SyncService.OfflineBodies.cs
+++ b/QuickMail/Services/SyncService.OfflineBodies.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using QuickMail.Helpers;
+using QuickMail.Models;
+
+namespace QuickMail.Services;
+
+/// <summary>
+/// The offline-bodies pass (#637): when <see cref="ConfigModel.OfflineBodyDays"/> is set, sync
+/// downloads the full bodies of recent Inbox messages that have no cached body yet, so they read
+/// offline. Runs after every full sweep (behind the previews), on each Inbox arrival, and on demand
+/// when Settings widens the window. Attachments are not included; POP3 already keeps whole messages.
+/// </summary>
+public partial class SyncService
+{
+    private readonly IConnectivityService? _connectivity;
+
+    /// <summary>Upper bound per pass; the next sweep picks up where this one stopped (newest first).</summary>
+    internal const int MaxBodiesPerPass = 500;
+
+    private const int ProgressEvery = 10;
+
+    public event Action<int, int>? OfflineBodyProgressChanged;
+
+    public Task BackfillOfflineBodiesAsync(
+        IEnumerable<AccountModel> accounts,
+        IReadOnlyDictionary<Guid, List<MailFolderModel>> cachedFolders,
+        CancellationToken ct)
+        => DownloadOfflineBodiesAsync(accounts.ToList(), cachedFolders, ct);
+
+    private static bool EligibleForBodies(AccountModel account)
+        // POP3 downloads whole messages already; a shared mailbox reads through its parent and gets
+        // no background work of its own (#31).
+        => account.BackendKind != BackendKind.Pop3Smtp && !account.IsShared;
+
+    private async Task DownloadOfflineBodiesAsync(
+        List<AccountModel> accounts,
+        IReadOnlyDictionary<Guid, List<MailFolderModel>> cachedFolders,
+        CancellationToken ct)
+    {
+        if (_probeMode) return;
+        var days = _config.Load().EffectiveOfflineBodyDays;
+        if (days <= 0) return;
+        var since = DateTimeOffset.UtcNow.AddDays(-days);
+
+        // Plan first so the progress total is the whole pass, not one account at a time.
+        var work = new List<(AccountModel Account, MailFolderModel Folder, List<string> Ids)>();
+        foreach (var account in accounts.Where(EligibleForBodies))
+        {
+            if (_connectivity != null && !_connectivity.IsAccountOnline(account.Id)) continue;
+            if (!cachedFolders.TryGetValue(account.Id, out var folders)) continue;
+            foreach (var folder in folders.Where(f => f.Kind == SpecialFolderKind.Inbox))
+            {
+                ct.ThrowIfCancellationRequested();
+                var ids = await _store.GetMessageIdsMissingDetailAsync(account.Id, folder.FullName, since, MaxBodiesPerPass);
+                if (ids.Count > 0) work.Add((account, folder, ids));
+            }
+        }
+
+        var total = work.Sum(w => w.Ids.Count);
+        if (total == 0) return;
+        _ui.Post(() => OfflineBodyProgressChanged?.Invoke(0, total));
+
+        var done = 0;
+        foreach (var (account, folder, ids) in work)
+        {
+            var timer = Stopwatch.StartNew();
+            var fetched = await DownloadBodiesForIdsAsync(account, folder, ids, ct, n => ReportProgress(done + n, total));
+            done += fetched;
+            LogService.Log($"Offline bodies {account.AccountLabel}/{folder.DisplayName}: {fetched} of {ids.Count} downloaded in {timer.ElapsedMilliseconds} ms");
+        }
+        ReportProgress(total, total);
+    }
+
+    private void ReportProgress(int done, int total)
+        => _ui.Post(() => OfflineBodyProgressChanged?.Invoke(done, total));
+
+    /// <summary>
+    /// Fetches and caches each body in turn. A connection failure stops this account's batch — there
+    /// is no point hammering a server that just went away — and tells the connectivity service;
+    /// any other failure is logged and the next id is tried. Returns how many were cached.
+    /// </summary>
+    private async Task<int> DownloadBodiesForIdsAsync(
+        AccountModel account, MailFolderModel folder, IReadOnlyList<string> ids,
+        CancellationToken ct, Action<int>? progress = null)
+    {
+        var fetched = 0;
+        foreach (var id in ids)
+        {
+            ct.ThrowIfCancellationRequested();
+            try
+            {
+                // Background lease, and no \Seen: this is caching, not reading.
+                var detail = await _imap.PrefetchMessageDetailAsync(account.Id, folder.FullName, id, ct);
+                await _store.UpsertDetailAsync(detail);
+                fetched++;
+                if (fetched % ProgressEvery == 0) progress?.Invoke(fetched);
+            }
+            catch (OperationCanceledException) { throw; }
+            catch (Exception ex) when (ConnectionFailure.IsConnectionFailure(ex, ct))
+            {
+                _connectivity?.NoteAccountUnreachable(account.Id, "offline-bodies");
+                LogService.Log($"Offline bodies {account.AccountLabel}: server unreachable, stopping this pass", ex);
+                break;
+            }
+            catch (Exception ex)
+            {
+                LogService.Log($"Offline bodies {account.AccountLabel}/{folder.DisplayName} msgId={id}", ex);
+            }
+        }
+        return fetched;
+    }
+
+    /// <summary>
+    /// The arrival hook: new Inbox mail inside the window gets its body cached right away, so the
+    /// setting stays true between sweeps (IDLE, the fallback poll and the periodic sweep all pass
+    /// through here). Fire-and-forget, a handful of ids at a time, no progress events.
+    /// </summary>
+    private void QueueArrivalBodies(AccountModel account, MailFolderModel folder, IReadOnlyList<MailMessageSummary> arrivals, CancellationToken ct)
+    {
+        if (_probeMode || arrivals.Count == 0) return;
+        if (folder.Kind != SpecialFolderKind.Inbox || !EligibleForBodies(account)) return;
+        var days = _config.Load().EffectiveOfflineBodyDays;
+        if (days <= 0) return;
+
+        var since = DateTimeOffset.UtcNow.AddDays(-days);
+        var ids = arrivals.Where(m => m.Date >= since).Select(m => m.MessageId).ToList();
+        if (ids.Count == 0) return;
+
+        Task.Run(async () =>
+        {
+            // Skip anything the open-time cache or the prefetch already stored.
+            var missing = new HashSet<string>(await _store.GetMessageIdsMissingDetailAsync(account.Id, folder.FullName, since, MaxBodiesPerPass), StringComparer.Ordinal);
+            var wanted = ids.Where(missing.Contains).ToList();
+            if (wanted.Count > 0)
+                await DownloadBodiesForIdsAsync(account, folder, wanted, ct);
+        }, ct).LogFaults("offline bodies for arrivals");
+    }
+}

--- a/QuickMail/Services/SyncService.cs
+++ b/QuickMail/Services/SyncService.cs
@@ -9,7 +9,7 @@ using QuickMail.Models;
 
 namespace QuickMail.Services;
 
-public class SyncService : ISyncService
+public partial class SyncService : ISyncService
 {
     private readonly IMailService _imap;
     private readonly ILocalStoreService _store;
@@ -24,13 +24,14 @@ public class SyncService : ISyncService
     private readonly bool _probeMode;
 
     public SyncService(IMailService imap, ILocalStoreService store, IConfigService config, IRuleService rules,
-        IUiDispatcher? ui = null, bool probeMode = false)
+        IUiDispatcher? ui = null, bool probeMode = false, IConnectivityService? connectivity = null)
     {
         _imap   = imap;
         _store  = store;
         _config = config;
         _rules  = rules;
         _probeMode = probeMode;
+        _connectivity = connectivity;
         // WpfUiDispatcher marshals only when the real QuickMail App is present, and runs inline
         // otherwise — a plain Application.Current null-check is NOT enough (tests create a pumpless
         // Application, so InvokeAsync would park forever).
@@ -222,9 +223,21 @@ public class SyncService : ISyncService
         // don't race with the sync IMAP calls on the same shared client.
         // They run sequentially — fire-and-forget the whole batch so SyncAllAccounts
         // returns promptly and the status bar updates, while previews trickle in.
-        if (!previewJobs.IsEmpty)
-            FetchAllPreviewsAsync(previewJobs.ToList(), ct)
-                .LogFaults("sync: preview fetch batch");
+        // The offline-bodies pass (#637) follows the previews on the same trickle, so it never
+        // competes with them or with the sync for background leases.
+        RunPostSyncTrickleAsync(previewJobs.ToList(), accountList, cachedFolders, ct)
+            .LogFaults("sync: post-sync trickle");
+    }
+
+    private async Task RunPostSyncTrickleAsync(
+        List<(AccountModel Account, MailFolderModel Folder, List<MailMessageSummary> Incoming)> previewJobs,
+        List<AccountModel> accounts,
+        IReadOnlyDictionary<Guid, List<MailFolderModel>> cachedFolders,
+        CancellationToken ct)
+    {
+        if (previewJobs.Count > 0)
+            await FetchAllPreviewsAsync(previewJobs, ct);
+        await DownloadOfflineBodiesAsync(accounts, cachedFolders, ct);
     }
 
     private async Task FetchAllPreviewsAsync(
@@ -450,6 +463,7 @@ public class SyncService : ISyncService
             IReadOnlyCollection<string>? preFetch = account.BackendKind == BackendKind.Pop3Smtp
                 ? Array.Empty<string>() : null;
             incoming = await ApplyRulesToArrivalsAsync(account, folder, incoming, persisted: true, consumeRebuildBaseline: false, ct, preFetch);
+            QueueArrivalBodies(account, folder, incoming, ct);
             _ui.Post(() => FolderSynced?.Invoke(incoming));
         }
         return incoming;
@@ -508,6 +522,7 @@ public class SyncService : ISyncService
             // RulesApplied / MessagesRemoved; here we just surface the survivors to the UI —
             // immediately, without waiting for body preview fetches.
             incoming = await ApplyRulesToArrivalsAsync(account, folder, incoming, persisted: true, consumeRebuildBaseline: true, ct);
+            QueueArrivalBodies(account, folder, incoming, ct);
             _ui.Post(() => FolderSynced?.Invoke(incoming));
         }
 
@@ -657,6 +672,7 @@ public class SyncService : ISyncService
         IReadOnlyCollection<string>? preFetchKnownIds = null)
     {
         var incoming = await ApplyRulesToArrivalsAsync(account, folder, fetched, persisted: true, consumeRebuildBaseline: true, ct, preFetchKnownIds);
+        QueueArrivalBodies(account, folder, incoming, ct);
         if (incoming.Count > 0)
             _ui.Post(() => FolderSynced?.Invoke(incoming));
         return incoming;

--- a/QuickMail/Services/SyncService.cs
+++ b/QuickMail/Services/SyncService.cs
@@ -522,7 +522,6 @@ public partial class SyncService : ISyncService
             // RulesApplied / MessagesRemoved; here we just surface the survivors to the UI —
             // immediately, without waiting for body preview fetches.
             incoming = await ApplyRulesToArrivalsAsync(account, folder, incoming, persisted: true, consumeRebuildBaseline: true, ct);
-            QueueArrivalBodies(account, folder, incoming, ct);
             _ui.Post(() => FolderSynced?.Invoke(incoming));
         }
 
@@ -672,7 +671,6 @@ public partial class SyncService : ISyncService
         IReadOnlyCollection<string>? preFetchKnownIds = null)
     {
         var incoming = await ApplyRulesToArrivalsAsync(account, folder, fetched, persisted: true, consumeRebuildBaseline: true, ct, preFetchKnownIds);
-        QueueArrivalBodies(account, folder, incoming, ct);
         if (incoming.Count > 0)
             _ui.Post(() => FolderSynced?.Invoke(incoming));
         return incoming;

--- a/QuickMail/ViewModels/MainViewModel.Connectivity.cs
+++ b/QuickMail/ViewModels/MainViewModel.Connectivity.cs
@@ -140,6 +140,32 @@ public partial class MainViewModel
         Announce(OnlineMode ? "Offline." : "Offline. Showing cached messages.", AnnouncementCategory.Status);
     }
 
+    // ── Offline bodies (#637) ───────────────────────────────────────────────────
+
+    private int _offlineBodyDays;
+
+    /// <summary>
+    /// One announcement when a pass finishes, never one per batch — the pass runs behind the
+    /// previews after every sweep and would otherwise chatter every ten messages.
+    /// </summary>
+    private void OnOfflineBodyProgress(int done, int total)
+    {
+        if (total > 0 && done >= total)
+            Announce($"Downloaded {total} {(total == 1 ? "message" : "messages")} for offline reading.", AnnouncementCategory.Status);
+    }
+
+    /// <summary>A widened window is backfilled now rather than at the next sweep; a narrowed one just stops fetching.</summary>
+    private void ApplyOfflineBodySetting(ConfigModel cfg)
+    {
+        var was = _offlineBodyDays;
+        _offlineBodyDays = cfg.OfflineBodyDays;
+        if (OnlineMode || cfg.OfflineBodyDays <= was) return;
+        var connected = Accounts.Where(a => _connectedAccountIds.Contains(a.Id)).ToList();
+        if (connected.Count == 0) return;
+        _syncService.BackfillOfflineBodiesAsync(connected, _cachedFolders, _bgSyncCts?.Token ?? CancellationToken.None)
+            .LogFaults("offline bodies backfill");
+    }
+
     /// <summary>Chooses the status-bar wording for a failed server call: offline wording for a transport failure, the raw error otherwise.</summary>
     private static string OfflineOrErrorStatus(Exception ex, CancellationToken ct, Func<string> offline, Func<string> error)
         => ConnectionFailure.IsConnectionFailure(ex, ct) ? offline() : error();

--- a/QuickMail/ViewModels/MainViewModel.Connectivity.cs
+++ b/QuickMail/ViewModels/MainViewModel.Connectivity.cs
@@ -146,24 +146,52 @@ public partial class MainViewModel
 
     /// <summary>
     /// One announcement when a pass finishes, never one per batch — the pass runs behind the
-    /// previews after every sweep and would otherwise chatter every ten messages.
+    /// previews and after every sweep and would otherwise chatter every ten messages. Says what
+    /// was actually cached; a pass that cached nothing (the server went away) says nothing, the
+    /// offline announcement covers that.
     /// </summary>
-    private void OnOfflineBodyProgress(int done, int total)
+    private void OnOfflineBodyPassCompleted(int downloaded, int planned)
     {
-        if (total > 0 && done >= total)
-            Announce($"Downloaded {total} {(total == 1 ? "message" : "messages")} for offline reading.", AnnouncementCategory.Status);
+        if (downloaded <= 0) return;
+        var noun = downloaded == 1 ? "message" : "messages";
+        Announce(downloaded >= planned
+            ? $"Downloaded {downloaded} {noun} for offline reading."
+            : $"Downloaded {downloaded} of {planned} messages for offline reading.",
+            AnnouncementCategory.Status);
     }
 
-    /// <summary>A widened window is backfilled now rather than at the next sweep; a narrowed one just stops fetching.</summary>
+    /// <summary>
+    /// A widened window is backfilled now rather than at the next sweep; a narrowed one just stops
+    /// fetching. Compares the effective window, so widening SyncDays under a capped setting counts.
+    /// </summary>
     private void ApplyOfflineBodySetting(ConfigModel cfg)
     {
         var was = _offlineBodyDays;
-        _offlineBodyDays = cfg.OfflineBodyDays;
-        if (OnlineMode || cfg.OfflineBodyDays <= was) return;
+        _offlineBodyDays = cfg.EffectiveOfflineBodyDays;
+        if (OnlineMode || _offlineBodyDays <= was) return;
         var connected = Accounts.Where(a => _connectedAccountIds.Contains(a.Id)).ToList();
         if (connected.Count == 0) return;
-        _syncService.BackfillOfflineBodiesAsync(connected, _cachedFolders, _bgSyncCts?.Token ?? CancellationToken.None)
+        BackfillOfflineBodiesQuietlyAsync(connected, _bgSyncCts?.Token ?? CancellationToken.None)
             .LogFaults("offline bodies backfill");
+    }
+
+    /// <summary>
+    /// Runs the offline-bodies pass for the given accounts with a UI-thread snapshot of their
+    /// folder lists, and never lets a failure escape — the periodic sweep and a Settings save both
+    /// call this and neither should die for it.
+    /// </summary>
+    private async Task BackfillOfflineBodiesQuietlyAsync(List<AccountModel> accounts, CancellationToken ct)
+    {
+        if (OnlineMode || accounts.Count == 0) return;
+        var folders = new Dictionary<Guid, List<MailFolderModel>>();
+        _ui.Invoke(() =>
+        {
+            foreach (var a in accounts)
+                if (_cachedFolders.TryGetValue(a.Id, out var f)) folders[a.Id] = f;
+        });
+        try { await _syncService.BackfillOfflineBodiesAsync(accounts, folders, ct).ConfigureAwait(false); }
+        catch (OperationCanceledException) { }
+        catch (Exception ex) { LogService.Log("Offline bodies pass", ex); }
     }
 
     /// <summary>Chooses the status-bar wording for a failed server call: offline wording for a transport failure, the raw error otherwise.</summary>

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -163,6 +163,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
         }
         UnsubscribeConnectivity();
         DrainCts(ref _offlineRetryCts);
+        _syncService.OfflineBodyProgressChanged -= OnOfflineBodyProgress;
         if (_rowLayoutService != null && _onRowLayoutsChanged != null)
         {
             _rowLayoutService.LayoutsChanged -= _onRowLayoutsChanged;
@@ -1751,6 +1752,8 @@ public partial class MainViewModel : ObservableObject, IDisposable
         _previewLines = cfg.PreviewLines;
         _showPreview = _previewLines > 0;
         _syncDays = cfg.SyncDays;
+        _offlineBodyDays = cfg.OfflineBodyDays;
+        _syncService.OfflineBodyProgressChanged += OnOfflineBodyProgress;
         _viewMode = ConfigModel.ParseViewMode(cfg.ViewMode);
         _listDensity = cfg.AppearanceListDensity == "compact" ? "compact" : "comfortable";
         MessageOpenMode = cfg.Windowing.MessageOpenMode;
@@ -2482,6 +2485,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
         _themeService?.ApplyAppearance(cfg);
 
         ApplyConnectionDiagnosticsSetting(cfg.ConnectionDiagnostics);
+        ApplyOfflineBodySetting(cfg);
 
         // Keep the View menu's density check marks in sync with a Settings save.
         ListDensity = cfg.AppearanceListDensity == "compact" ? "compact" : "comfortable";

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -163,7 +163,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
         }
         UnsubscribeConnectivity();
         DrainCts(ref _offlineRetryCts);
-        _syncService.OfflineBodyProgressChanged -= OnOfflineBodyProgress;
+        _syncService.OfflineBodyPassCompleted -= OnOfflineBodyPassCompleted;
         if (_rowLayoutService != null && _onRowLayoutsChanged != null)
         {
             _rowLayoutService.LayoutsChanged -= _onRowLayoutsChanged;
@@ -1752,8 +1752,8 @@ public partial class MainViewModel : ObservableObject, IDisposable
         _previewLines = cfg.PreviewLines;
         _showPreview = _previewLines > 0;
         _syncDays = cfg.SyncDays;
-        _offlineBodyDays = cfg.OfflineBodyDays;
-        _syncService.OfflineBodyProgressChanged += OnOfflineBodyProgress;
+        _offlineBodyDays = cfg.EffectiveOfflineBodyDays;
+        _syncService.OfflineBodyPassCompleted += OnOfflineBodyPassCompleted;
         _viewMode = ConfigModel.ParseViewMode(cfg.ViewMode);
         _listDensity = cfg.AppearanceListDensity == "compact" ? "compact" : "comfortable";
         MessageOpenMode = cfg.Windowing.MessageOpenMode;
@@ -3605,6 +3605,13 @@ public partial class MainViewModel : ObservableObject, IDisposable
                     try { await Task.Delay(TimeSpan.FromMilliseconds(250), ct).ConfigureAwait(false); pacedDelays++; }
                     catch (OperationCanceledException) { break; }
                 }
+
+                // The offline-bodies pass (#637) rides the same timer, after the folders: it picks up
+                // where the startup pass stopped (the per-pass cap), and covers an account that was
+                // unreachable at launch. Quiet: never lets the sweep die for it.
+                if (!ct.IsCancellationRequested)
+                    await BackfillOfflineBodiesQuietlyAsync(
+                        jobs.Select(j => j.Account).Distinct().ToList(), ct).ConfigureAwait(false);
 
                 // Per-cycle summary at Debug (a measurement aid, not always-on telemetry; #462). The paced
                 // figure is the count of delays actually executed × 250 ms — measured, not derived from the

--- a/QuickMail/ViewModels/SettingsViewModel.cs
+++ b/QuickMail/ViewModels/SettingsViewModel.cs
@@ -36,6 +36,10 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty]
     private int _mailSyncPollMinutes;
 
+    /// <summary>Days of Inbox mail whose bodies sync downloads for offline reading; 0 = off (#637).</summary>
+    [ObservableProperty]
+    private int _offlineBodyDays;
+
     [ObservableProperty]
     private bool _customAnnouncements;
 
@@ -449,6 +453,7 @@ public partial class SettingsViewModel : ObservableObject
         SyncDays = cfg.SyncDays;
         InitialSyncCount = cfg.InitialSyncCount;
         MailSyncPollMinutes = cfg.MailSyncPollMinutes;
+        OfflineBodyDays = cfg.OfflineBodyDays;
         CustomAnnouncements = cfg.CustomAnnouncements;
         AnnounceHints       = cfg.AnnounceHints;
         AnnounceStatus      = cfg.AnnounceStatus;
@@ -532,6 +537,7 @@ public partial class SettingsViewModel : ObservableObject
         cfg.SyncDays = SyncDays;
         cfg.InitialSyncCount = InitialSyncCount;
         cfg.MailSyncPollMinutes = MailSyncPollMinutes;
+        cfg.OfflineBodyDays = OfflineBodyDays;
         cfg.CustomAnnouncements = CustomAnnouncements;
         cfg.AnnounceHints       = AnnounceHints;
         cfg.AnnounceStatus      = AnnounceStatus;

--- a/QuickMail/Views/SettingsDialog.xaml
+++ b/QuickMail/Views/SettingsDialog.xaml
@@ -163,7 +163,7 @@
                                      so the ToString() rule for Selector items does not apply. -->
                                 <StackPanel Margin="0,8,0,0">
                                     <Label x:Name="OfflineBodyLabel"
-                                           Content="Download messages for offline _reading:"
+                                           Content="Download _messages for offline reading:"
                                            Target="{Binding ElementName=OfflineBodyCombo}"
                                            FontWeight="SemiBold"/>
                                     <ComboBox x:Name="OfflineBodyCombo"

--- a/QuickMail/Views/SettingsDialog.xaml
+++ b/QuickMail/Views/SettingsDialog.xaml
@@ -158,6 +158,27 @@
                                                Foreground="{DynamicResource Theme.TextSecondary}" FontSize="{DynamicResource Theme.FontSizeSmall}"
                                                TextWrapping="Wrap" Margin="0,3,0,0"/>
                                 </StackPanel>
+
+                                <!-- Offline bodies (#637). Static items, like SyncDaysCombo: no bound item type,
+                                     so the ToString() rule for Selector items does not apply. -->
+                                <StackPanel Margin="0,8,0,0">
+                                    <Label x:Name="OfflineBodyLabel"
+                                           Content="Download messages for offline _reading:"
+                                           Target="{Binding ElementName=OfflineBodyCombo}"
+                                           FontWeight="SemiBold"/>
+                                    <ComboBox x:Name="OfflineBodyCombo"
+                                              SelectedValue="{Binding OfflineBodyDays, Mode=TwoWay}"
+                                              SelectedValuePath="Tag"
+                                              AutomationProperties.LabeledBy="{Binding ElementName=OfflineBodyLabel}">
+                                        <ComboBoxItem Tag="0" Content="Off"/>
+                                        <ComboBoxItem Tag="7" Content="Last 7 days"/>
+                                        <ComboBoxItem Tag="30" Content="Last 30 days"/>
+                                        <ComboBoxItem Tag="90" Content="Last 90 days"/>
+                                    </ComboBox>
+                                    <TextBlock Text="Keeps the full text of recent Inbox messages on this computer so you can read them without a connection. Never wider than the sync range above. Attachments are fetched when you open them and need a connection."
+                                               Foreground="{DynamicResource Theme.TextSecondary}" FontSize="{DynamicResource Theme.FontSizeSmall}"
+                                               TextWrapping="Wrap" Margin="0,3,0,0"/>
+                                </StackPanel>
                             </StackPanel>
                         </GroupBox>
 

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -1536,10 +1536,10 @@ When you open a folder offline the status bar reads "Offline — showing 12 cach
 
 By default QuickMail keeps the full text of a message only once you have opened it, or when it fetched a few ahead of time. To have more ready before the connection drops, choose a window under **Settings → General → Sync → Download messages for offline reading**: **Off** (the default), or the last **7**, **30** or **90** days.
 
-With a window set, every background sync finishes by downloading the text of each Inbox message in that window that QuickMail does not have yet, newest first, and new mail gets its text as it arrives. When a pass completes you hear "Downloaded 120 messages for offline reading." once. A few things to know:
+With a window set, the sync at launch and each background check (**Check for new mail every**) finish by downloading the text of each Inbox message in that window that QuickMail does not have yet, newest first, a few hundred at a time; new mail arriving in the Inbox gets its text straight away. When a pass completes you hear "Downloaded 120 messages for offline reading." once. A few things to know:
 
 - Inbox only. Other folders keep working the way they always have: a message is kept once you open it.
-- Never wider than the **Sync the last** range above it, since QuickMail cannot keep what it has not synced.
+- Never wider than the **Sync range** above it, since QuickMail cannot keep what it has not synced.
 - Attachments are not included. Opening one still needs a connection.
 - POP3 accounts already keep every message whole, so the setting does not apply to them.
 - The text lives in `mail.db` in QuickMail's data folder, which grows accordingly — roughly tens of megabytes for a month of a busy Inbox.

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -1519,7 +1519,7 @@ QuickMail keeps a copy of your recent mail on this computer, and when the connec
 
 ### What works offline
 
-- Reading any message you have opened before, or that QuickMail fetched ahead of time (it keeps the newest messages of each folder you open, and the ones around any message you read).
+- Reading any message you have opened before, or that QuickMail fetched ahead of time (it keeps the newest messages of each folder you open, and the ones around any message you read). To keep more, see [Reading recent messages without a connection](#reading-recent-messages-without-a-connection).
 - The message list of every folder you have opened, with its unread state and flags.
 - Searching and filtering what is on this computer, the calendar, and the address book.
 - Composing. Saving a draft keeps it on this computer, and Send queues the message; both go to your account the moment the connection returns. See [Working Offline: Drafts and the Outbox](#working-offline-drafts-and-the-outbox).
@@ -1531,6 +1531,18 @@ When you open a folder offline the status bar reads "Offline — showing 12 cach
 - A message that was never downloaded: "This message is not available offline." Reply and Forward on it say the same and open nothing.
 - Attachments: "Attachments are not available offline."
 - New mail, folder changes, and everything else a server has to do. Marking read, flagging, moving and deleting are not queued: offline they fail with a message, and the next sync after the connection returns puts the message back the way the server has it. Only composing waits for you.
+
+### Reading recent messages without a connection
+
+By default QuickMail keeps the full text of a message only once you have opened it, or when it fetched a few ahead of time. To have more ready before the connection drops, choose a window under **Settings → General → Sync → Download messages for offline reading**: **Off** (the default), or the last **7**, **30** or **90** days.
+
+With a window set, every background sync finishes by downloading the text of each Inbox message in that window that QuickMail does not have yet, newest first, and new mail gets its text as it arrives. When a pass completes you hear "Downloaded 120 messages for offline reading." once. A few things to know:
+
+- Inbox only. Other folders keep working the way they always have: a message is kept once you open it.
+- Never wider than the **Sync the last** range above it, since QuickMail cannot keep what it has not synced.
+- Attachments are not included. Opening one still needs a connection.
+- POP3 accounts already keep every message whole, so the setting does not apply to them.
+- The text lives in `mail.db` in QuickMail's data folder, which grows accordingly — roughly tens of megabytes for a month of a busy Inbox.
 
 ### Getting back online
 


### PR DESCRIPTION
Part 3 of 3 for #637. Stacked on #657 (part 2), which is stacked on #656 (part 1); the base is #657's branch, so this diff shows only the offline-bodies work. Retarget as the ones below merge.

## What changes for the user

A new setting, **Settings → General → Sync → Download messages for offline reading**: Off (the default), or the last 7, 30 or 90 days. With a window set, every background sync finishes by downloading the full text of each Inbox message in that window that QuickMail does not have yet, newest first, and new Inbox mail gets its text as it arrives. Widening the window in Settings backfills right away. One announcement when a pass completes: "Downloaded 120 messages for offline reading." (Status).

Deliberate limits, all documented: Inbox only; never wider than the sync range; attachments are not included (they still need a connection); POP3 accounts are skipped because they already keep whole messages; an account the app knows is unreachable is skipped, and a transport failure stops that account's batch and reports it to the connectivity service.

## How

- `ConfigModel.OfflineBodyDays` (+ `EffectiveOfflineBodyDays`, capped by `SyncDays`), parsed and written by `ConfigService`, bound by `SettingsViewModel`.
- `ILocalStoreService.GetMessageIdsMissingDetailAsync`: summaries in the window with no `MessageDetail` row, newest first, limited (LEFT JOIN on the shared composite key).
- `SyncService` Pass 3 (`SyncService.OfflineBodies.cs`): runs behind the preview trickle after every full sweep so it never competes with the sync for background leases; up to 500 ids per pass; `PrefetchMessageDetailAsync` (no `\Seen`) then `UpsertDetailAsync`; progress every ten and at the end via `OfflineBodyProgressChanged`. The arrival hook sits after each persisted `ApplyRulesToArrivalsAsync` call, so IDLE, the fallback poll and the periodic sweep all feed it. `--online` is a no-op (the startup sync never runs there).
- The Settings combo uses static `ComboBoxItem`s exactly like `SyncDaysCombo`, so there is no bound item type and nothing to add to `SelectorItemAccessibilityTests`; the label reaches the combo through `Target` and `LabeledBy`.

## Tests

- New: `SyncServiceOfflineBodiesTests` (off → nothing; in-window Inbox mail without a body only, newest first; second pass idle; the cap theory; POP3/shared skipped; offline account skipped; connection failure stops the account and reports; cancellation; the arrival hook; the store query's order and limit), plus round-trips in `SettingsViewModelTests` and `ConfigServiceSaveTests`.
- Full suite: 3492 passed, 3 skipped.

## Not verified here, please check before merge

- **The Settings tab's visual.** `Views/SettingsDialog.xaml` changed, but the General/Sync tab is not a surface in `scripts/ui-probe-plan.json` (only appearance and startup are) and my desktop session was disconnected, so `scripts\ui-probe.ps1` could not run. Please run it, or open Settings in parchment and dark and check the new combo sits like the one above it.
- Set 7 days, restart, watch the log for `Offline bodies {account}/Inbox: n of m downloaded`, then read last week's unopened mail with wifi off.

## Docs

User guide: "Reading recent messages without a connection" under Working Offline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
