### PR TITLE
Publish the user guide from the release run, not a remembered manual click

### DIFF
--- a/.github/workflows/publish-user-guide.yml
+++ b/.github/workflows/publish-user-guide.yml
@@ -2,12 +2,25 @@ name: Publish User Guide
 
 on:
   workflow_dispatch:
+  # Called by the release job in quickmail.yml once a v* tag's release is out. This,
+  # not the `release` trigger below, is what publishes the guide for a release: our
+  # releases are created by softprops/action-gh-release using GITHUB_TOKEN, and GitHub
+  # does not start workflow runs from events raised by a GITHUB_TOKEN, so the
+  # `release: published` event never arrives. It stayed unnoticed because every publish
+  # had been run by hand right after a release -- until 0.8.44 shipped and the site sat
+  # at 0.8.43.
+  workflow_call:
+  # Kept for a release created by hand in the GitHub UI, which does raise the event.
+  # A hand-made release from an existing tag does not re-run quickmail.yml, so this is
+  # that path's only trigger and cannot double up with the workflow_call above.
   release:
     types: [published]
 
 jobs:
   publish-guide:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write   # peaceiris/actions-gh-pages pushes the gh-pages branch
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/quickmail.yml
+++ b/.github/workflows/quickmail.yml
@@ -607,3 +607,22 @@ jobs:
           # the release page. If a future release needs the same treatment, add the input
           # for that release and REMOVE IT IN THE SAME PR THAT TAGS THE NEXT ONE — or
           # simply tag it, then untick "Set as the latest release" once by hand.
+
+  # Publish the user guide for the release the build job just created.
+  #
+  # This exists because publish-user-guide.yml's `release: published` trigger never
+  # fires here: the Release step above creates the release with GITHUB_TOKEN, and
+  # GitHub does not start workflow runs from events a GITHUB_TOKEN raised. So the
+  # guide has only ever gone out when somebody remembered to run it by hand -- and
+  # when nobody did, 0.8.44 shipped while the site kept saying 0.8.43. Calling the
+  # workflow directly needs no PAT and cannot be forgotten.
+  #
+  # The version on the published page is read from QuickMail.csproj, not from the tag,
+  # so this must run off the same tagged commit the release was built from -- which a
+  # `needs: build` job in this run does by construction.
+  publish-guide:
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
+    uses: ./.github/workflows/publish-user-guide.yml
+    permissions:
+      contents: write   # the called workflow pushes the gh-pages branch

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,10 +82,27 @@ The user guide (`docs/USER-GUIDE.md`) is automatically converted to HTML and pub
 2. Workflow generates single-page (`full.html`) and sectioned HTML with navigation (`index.html`)
 3. Deployed to `https://kellylford.github.io/QuickMail/`
 
-**Automatic publish** — triggered by GitHub release creation:
-- When you create a release, the workflow runs and publishes the current user guide automatically.
+**Automatic publish** — the `publish-guide` job at the end of `quickmail.yml` calls this
+workflow after the release job, on every `v*` tag.
 
-**Before you ship a release**: Update `docs/USER-GUIDE.md` with any changes, then publish (manual or automatic).
+Do **not** rely on the `release: published` trigger in `publish-user-guide.yml` for that.
+It is real but never fires for our releases: `softprops/action-gh-release` creates them
+with `GITHUB_TOKEN`, and GitHub does not start workflow runs from events a `GITHUB_TOKEN`
+raised. It has never worked (the trigger dates from the workflow's first commit,
+53ae694), and went unnoticed because somebody always ran the workflow by hand a minute
+after tagging — until 0.8.44 shipped and nobody did, leaving the site saying 0.8.43 with
+none of the offline documentation on it. The trigger is kept only for a release made
+by hand in the GitHub UI, which does raise the event; that path does not re-run
+`quickmail.yml`, so the two cannot double up.
+
+The version shown on the page comes from `<Version>` in `QuickMail.csproj`, **not** from
+the tag and not from anything in `USER-GUIDE.md` — the guide contains no version string.
+So a site showing a stale version means the workflow has not run since the version bump,
+never that a document needs editing. It also means the publish must run from the tagged
+commit; `needs: build` in the same run guarantees that.
+
+**Before you ship a release**: Update `docs/USER-GUIDE.md` with any changes. The tag
+publishes it; a manual run is only for guide edits between releases.
 
 **The Pages site is more than the user guide.** `peaceiris/actions-gh-pages` replaces the whole `gh-pages` branch on every run, so anything that is not written into `build/docs/` during the workflow is deleted on deploy — a file added to the branch by hand does not survive. That is why `docs/privacy.html` 404'd for months while sitting in the repository (issue #556). Every standalone page is therefore either generated (the articles step) or copied (`docs/privacy.html`) inside the workflow. The privacy URL, `https://kellylford.github.io/QuickMail/privacy.html`, is cited by Google OAuth verification and by the winget manifest's `PrivacyUrl`; the copy step fails the run rather than deploying without it.
 


### PR DESCRIPTION
The published user guide said **Version 0.8.43** the day after 0.8.44 shipped, with none of the offline documentation on it.

## The document was fine

`docs/USER-GUIDE.md` carries no version string at all, and its Working Offline / Outbox sections had already landed. The version on the page is injected at publish time from `<Version>` in `QuickMail.csproj`, so a stale version there only ever means the workflow has not run since the bump — never that a document needs editing.

## Why it had not run

`publish-user-guide.yml` listens for `release: published`, and that trigger does not fire for our releases and never has. `softprops/action-gh-release` creates them with `GITHUB_TOKEN`, and GitHub does not start workflow runs from events a `GITHUB_TOKEN` raised.

Every run in the workflow's history is a `workflow_dispatch`, several of them a minute after a release. That habit is what kept this hidden since the workflow's first commit (53ae694, 2026-06-25) — until 0.8.44 shipped and nobody clicked.

## The fix

- `publish-user-guide.yml` gains a `workflow_call` trigger and an explicit `contents: write` on its job.
- `quickmail.yml` gains a `publish-guide` job that calls it, gated on the same `startsWith(github.ref, 'refs/tags/v')` condition as the Release step and hung off `needs: build`.

No PAT required, and running inside the tag's own build guarantees the csproj it reads is the one the release was built from.

The `release: published` trigger stays, for a release created by hand in the GitHub UI — that path does raise the event and does not re-run `quickmail.yml`, so the two cannot double up.

`CLAUDE.md` is corrected: it had documented the automatic publish as working.

## Verification

- Both workflows parse; the new job resolves to `needs: build`, the tag `if`, the local `uses:`, and `contents: write`.
- The 0.8.44 guide was published by hand in the meantime (run 33748910551). The live site now reads **Version 0.8.44** on both `index.html` and `full.html`, the Working Offline section is present, and `privacy.html` still returns 200.

The end-to-end path only exercises itself at the next `v*` tag — worth a glance at the Actions run then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
