### PR TITLE
Fix #663: View Mode announces four choices, not eight

### DIFF
--- a/QuickMail.Tests/ViewModeMenuTests.cs
+++ b/QuickMail.Tests/ViewModeMenuTests.cs
@@ -1,0 +1,243 @@
+using System.Linq;
+using System.Windows;
+using System.Windows.Automation;
+using System.Windows.Automation.Peers;
+using System.Windows.Controls;
+using QuickMail.Models;
+using QuickMail.ViewModels;
+using QuickMail.Views;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// View → View Mode, and the toolbar's View mode button (issue #663).
+///
+/// The menu carries two mutually exclusive sets: the mail groupings (Messages, Conversations,
+/// From, To) and the calendar slices (Agenda, Day, Week, Month). It used to
+/// declare all eight items and collapse the inapplicable four. A collapsed MenuItem is still a
+/// child of its parent in the automation tree, so a screen reader counted eight items in a menu
+/// that showed four and announced "1 of 8" while arrowing through it.
+///
+/// The fix binds both menus to <see cref="MainViewModel.ViewModeOptions"/>, which holds only the
+/// applicable four. These tests guard the two halves of that: the collection never carries the
+/// other set, and both menus really are bound to it (a menu that quietly went back to declaring
+/// its items in XAML is the regression).
+/// </summary>
+[Collection("WpfTests")]
+public class ViewModeMenuTests
+{
+    private static void EnsureThemedApplication() =>
+        WpfTestHost.EnsureStyles("AccessibleStyles", "ThemedControls");
+
+    private static MainViewModel MakeVm()
+    {
+        var imap     = new StubImapMailService();
+        var accounts = new StubAccountService();
+        var creds    = new StubCredentialService();
+        var store    = new StubLocalStoreService();
+        var config   = new StubConfigService();
+        var registry = new StubCommandRegistry();
+
+        return new MainViewModel(imap, accounts, creds, store, new StubOAuthService(),
+            new StubSyncService(), config, registry, new StubViewService(), new StubRuleService(),
+            new StubSmtpService());
+    }
+
+    private static MainWindow MakeWindow(out MainViewModel vm)
+    {
+        var imap     = new StubImapMailService();
+        var accounts = new StubAccountService();
+        var creds    = new StubCredentialService();
+        var store    = new StubLocalStoreService();
+        var config   = new StubConfigService();
+        var registry = new StubCommandRegistry();
+
+        vm = new MainViewModel(imap, accounts, creds, store, new StubOAuthService(),
+            new StubSyncService(), config, registry, new StubViewService(), new StubRuleService(),
+            new StubSmtpService());
+
+        return new MainWindow(vm, new StubSmtpService(), accounts, creds, imap,
+            new StubOAuthService(), registry, new StubContactService(), config, store,
+            new StubViewService(), new StubRuleService(), new StubTemplateService(),
+            new StubFeatureGate());
+    }
+
+    private static MailFolderModel CalendarFolder() => new()
+    {
+        FullName    = MainViewModel.CalendarSourcePrefix + "local",
+        DisplayName = "Local Calendar",
+    };
+
+    // ── The collection ────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The count is the bug. Four mail modes must mean four entries — not four plus four
+    /// hidden calendar slices.
+    /// </summary>
+    [Fact]
+    public void MailModes_AreTheOnlyEntries_WhenTheCalendarIsNotOpen()
+    {
+        var vm = MakeVm();
+
+        Assert.False(vm.IsCalendarView);
+        Assert.Equal(new[] { "Messages", "Conversations", "From", "To" },
+                     vm.ViewModeOptions.Select(o => o.Id).ToArray());
+        Assert.Equal(new[] { "Messages", "Conversations", "From", "To" },
+                     vm.ViewModeOptions.Select(o => o.Name).ToArray());
+        Assert.All(vm.ViewModeOptions, o => Assert.False(o.IsCalendarMode));
+    }
+
+    /// <summary>Selecting the calendar swaps the set rather than adding to it.</summary>
+    [Fact]
+    public void CalendarSlices_ReplaceTheMailModes_WhenTheCalendarOpens()
+    {
+        var vm = MakeVm();
+        vm.SelectedFolder = CalendarFolder();
+
+        Assert.True(vm.IsCalendarView);
+        Assert.Equal(new[] { "Agenda", "Day", "Week", "Month" },
+                     vm.ViewModeOptions.Select(o => o.Id).ToArray());
+        Assert.All(vm.ViewModeOptions, o => Assert.True(o.IsCalendarMode));
+
+        // …and back, so leaving the calendar does not strand the calendar slices in the menu.
+        vm.SelectedFolder = new MailFolderModel { FullName = "INBOX", DisplayName = "Inbox" };
+        Assert.Equal(new[] { "Messages", "Conversations", "From", "To" },
+                     vm.ViewModeOptions.Select(o => o.Id).ToArray());
+    }
+
+    /// <summary>
+    /// Exactly one entry is checked, and it follows the mode in effect. This is what a screen
+    /// reader announces as the checked item while arrowing through the menu.
+    /// </summary>
+    [Fact]
+    public void ExactlyOneEntryIsChecked_AndItTracksTheActiveMode()
+    {
+        var vm = MakeVm();
+
+        Assert.Equal("Messages", Assert.Single(vm.ViewModeOptions.Where(o => o.IsSelected)).Id);
+
+        vm.ViewMode = ViewMode.From;
+        Assert.Equal("From", Assert.Single(vm.ViewModeOptions.Where(o => o.IsSelected)).Id);
+    }
+
+    /// <summary>Activating an entry is what actually changes the mode.</summary>
+    [Fact]
+    public void ActivatingAnEntry_SwitchesTheViewMode()
+    {
+        var vm = MakeVm();
+        var conversations = vm.ViewModeOptions.Single(o => o.Id == "Conversations");
+
+        vm.SelectViewModeCommand.Execute(conversations);
+
+        Assert.Equal(ViewMode.Conversations, vm.ViewMode);
+        Assert.Equal("Conversations", Assert.Single(vm.ViewModeOptions.Where(o => o.IsSelected)).Id);
+    }
+
+    /// <summary>
+    /// Re-choosing the mode already in effect must leave it checked. Activating a checkable
+    /// MenuItem clears its own IsChecked locally; the option re-raises PropertyChanged so the
+    /// authoritative value is pushed back.
+    /// </summary>
+    [Fact]
+    public void ReChoosingTheActiveMode_LeavesItChecked()
+    {
+        var vm = MakeVm();
+        var messages = vm.ViewModeOptions.Single(o => o.Id == "Messages");
+        var raised = 0;
+        messages.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(ViewModeOption.IsSelected)) raised++;
+        };
+
+        vm.SelectViewModeCommand.Execute(messages);
+
+        Assert.True(messages.IsSelected);
+        Assert.True(raised > 0);
+    }
+
+    // ── The menus ─────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Both View Mode surfaces are bound to the one collection. Asserting the resolved
+    /// ItemsSource — not just that a binding exists — is what catches a menu that went back to
+    /// declaring eight items in XAML, and a DataContext that silently fails to resolve.
+    /// </summary>
+    [StaFact]
+    public void BothViewModeMenus_AreBoundToTheOptionsCollection()
+    {
+        EnsureThemedApplication();
+        var window = MakeWindow(out var vm);
+        try
+        {
+            var menuItem = window.FindName("ViewModeMenuItem") as MenuItem;
+            Assert.NotNull(menuItem);
+            DoEvents();   // bindings on the unrealized submenu resolve at Dispatcher priority
+            Assert.Same(vm.ViewModeOptions, menuItem!.ItemsSource);
+            Assert.Equal(4, vm.ViewModeOptions.Count);
+
+            var button = window.FindName("ViewModeButton") as Button;
+            Assert.NotNull(button);
+            var menu = button!.ContextMenu;
+            Assert.NotNull(menu);
+
+            // The toolbar menu takes its DataContext from the button it drops from, which the
+            // window sets just before opening it.
+            menu!.PlacementTarget = button;
+            DoEvents();
+            Assert.Same(vm.ViewModeOptions, menu.ItemsSource);
+        }
+        finally { window.Close(); }
+    }
+
+    /// <summary>
+    /// The generated menu item announces the mode without the mnemonic underscore, exposes the
+    /// Toggle pattern (so the active mode reads as checked), and is wired to the command through
+    /// its MenuBase ancestor. That last binding fails silently in XAML — nothing happens on
+    /// Enter — so it is asserted from the live style.
+    /// </summary>
+    [StaFact]
+    public void GeneratedMenuItem_AnnouncesTheMode_AndIsWiredToTheCommand()
+    {
+        EnsureThemedApplication();
+        var window = MakeWindow(out var vm);
+        try
+        {
+            var style = window.FindResource("ViewModeMenuItemStyle") as Style;
+            Assert.NotNull(style);
+
+            var option = vm.ViewModeOptions.Single(o => o.Id == "From");
+
+            // Stand the container up the way the generator does: logical parent is a MenuBase
+            // carrying the ViewModel, DataContext is the option.
+            var host = new ContextMenu { DataContext = vm };
+            var item = new MenuItem();
+            host.Items.Add(item);
+            item.DataContext = option;
+            item.BeginInit();
+            item.Style = style;
+            item.EndInit();
+            DoEvents();
+
+            Assert.Equal("_From", item.Header);
+            Assert.Equal("From", AutomationProperties.GetName(item));
+            Assert.True(item.IsCheckable);
+            Assert.NotNull(item.Command);
+            Assert.Same(option, item.CommandParameter);
+
+            var peer = UIElementAutomationPeer.CreatePeerForElement(item);
+            Assert.NotNull(peer);
+            Assert.Equal("From", peer!.GetName());
+
+            // The command reached through the ancestor is the ViewModel's, and it works.
+            Assert.True(item.Command!.CanExecute(option));
+            item.Command.Execute(option);
+            Assert.Equal(ViewMode.From, vm.ViewMode);
+        }
+        finally { window.Close(); }
+    }
+
+    private static void DoEvents() =>
+        System.Windows.Threading.Dispatcher.CurrentDispatcher.Invoke(
+            System.Windows.Threading.DispatcherPriority.Background, new System.Action(() => { }));
+}

--- a/QuickMail.Tests/ViewModeMenuTests.cs
+++ b/QuickMail.Tests/ViewModeMenuTests.cs
@@ -1,8 +1,10 @@
+using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
 using System.Windows.Automation;
 using System.Windows.Automation.Peers;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using QuickMail.Models;
 using QuickMail.ViewModels;
 using QuickMail.Views;
@@ -235,6 +237,65 @@ public class ViewModeMenuTests
             Assert.Equal(ViewMode.From, vm.ViewMode);
         }
         finally { window.Close(); }
+    }
+
+    /// <summary>
+    /// The count is the whole of issue #663, so it is asserted on the containers the View menu
+    /// really generates, in their real ancestry — two levels inside the menu bar, which is what
+    /// the command's MenuBase ancestor binding has to resolve through. Containers are generated
+    /// here the way an open submenu's items host generates them, so the test needs no shown
+    /// window and no synthesized input.
+    /// </summary>
+    [StaFact]
+    public void TheViewModeSubmenu_GeneratesFourItems_EachWiredToTheCommand()
+    {
+        EnsureThemedApplication();
+        var window = MakeWindow(out var vm);
+        try
+        {
+            var submenu = window.FindName("ViewModeMenuItem") as MenuItem;
+            Assert.NotNull(submenu);
+            DoEvents();
+
+            var items = Generate(submenu!);
+
+            // Four on screen, four generated. Before the fix the menu declared eight.
+            Assert.Equal(4, items.Count);
+            Assert.Equal(new[] { "Messages", "Conversations", "From", "To" },
+                         items.Select(AutomationProperties.GetName).ToArray());
+            Assert.Equal(new[] { "_Messages", "_Conversations", "_From", "_To" },
+                         items.Select(i => i.Header as string).ToArray());
+            Assert.All(items, i => Assert.True(i.IsCheckable));
+            Assert.Equal("Messages", AutomationProperties.GetName(Assert.Single(items.Where(i => i.IsChecked))));
+
+            vm.SelectedFolder = CalendarFolder();
+            DoEvents();
+            Assert.Equal(new[] { "Agenda", "Day", "Week", "Month" },
+                         Generate(submenu).Select(AutomationProperties.GetName).ToArray());
+        }
+        finally { window.Close(); }
+    }
+
+    /// <summary>
+    /// Realizes an ItemsControl's containers without opening its popup — the same calls an items
+    /// host makes, so the containers get the ItemContainerStyle and their item as DataContext.
+    /// It does not attach them to a parent, so the Command setter's ancestor binding stays
+    /// unresolved here; GeneratedMenuItem_AnnouncesTheMode_AndIsWiredToTheCommand covers that.
+    /// </summary>
+    private static List<MenuItem> Generate(ItemsControl owner)
+    {
+        var generator = (IItemContainerGenerator)owner.ItemContainerGenerator;
+        var containers = new List<MenuItem>();
+        using (generator.StartAt(new GeneratorPosition(-1, 0), GeneratorDirection.Forward))
+        {
+            while (generator.GenerateNext() is MenuItem container)
+            {
+                generator.PrepareItemContainer(container);
+                containers.Add(container);
+            }
+        }
+        DoEvents();
+        return containers;
     }
 
     private static void DoEvents() =>

--- a/QuickMail/Models/ViewModeOption.cs
+++ b/QuickMail/Models/ViewModeOption.cs
@@ -1,0 +1,64 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace QuickMail.Models;
+
+/// <summary>
+/// One entry in the "View Mode" menu — a mail grouping (Messages / Conversations /
+/// By Sender / By Recipient) or a calendar slice (Agenda / Day / Week / Month).
+///
+/// The two sets are mutually exclusive, and the menu used to hold all eight items at once
+/// with <c>Visibility</c> hiding the inapplicable set. A collapsed <c>MenuItem</c> is still a
+/// child of its parent's automation peer, so screen readers counted all eight and announced
+/// "1 of 8" over a four-item menu (issue #663). Binding the menu to a collection that holds
+/// only the applicable options removes the hidden items from the tree entirely, so the
+/// position and count a screen reader reports match what is on screen.
+/// </summary>
+public sealed class ViewModeOption : ObservableObject
+{
+    public ViewModeOption(string id, string name, string header, bool isCalendarMode)
+    {
+        Id             = id;
+        Name           = name;
+        Header         = header;
+        IsCalendarMode = isCalendarMode;
+    }
+
+    /// <summary>
+    /// Matches the enum member this option selects — a <c>ViewMode</c> name for mail
+    /// ("Messages", "Conversations", "From", "To") or a <c>CalendarViewMode</c> name for the
+    /// calendar ("Agenda", "Day", "Week", "Month").
+    /// </summary>
+    public string Id { get; }
+
+    /// <summary>The accessible name of the menu item — no mnemonic underscore.</summary>
+    public string Name { get; }
+
+    /// <summary>Menu text, including the mnemonic underscore.</summary>
+    public string Header { get; }
+
+    /// <summary>True for the calendar slices, false for the mail groupings.</summary>
+    public bool IsCalendarMode { get; }
+
+    private bool _isSelected;
+
+    /// <summary>
+    /// True for the mode currently in effect. Bound to the menu item's IsChecked so a screen
+    /// reader announces which mode is active as the user arrows through the menu.
+    /// </summary>
+    public bool IsSelected
+    {
+        get => _isSelected;
+        set => SetProperty(ref _isSelected, value);
+    }
+
+    /// <summary>
+    /// Re-raises PropertyChanged for <see cref="IsSelected"/> even when the value did not
+    /// change. Activating a checkable menu item toggles its IsChecked locally (via
+    /// SetCurrentValue, which leaves the binding intact); re-raising pushes the authoritative
+    /// value back so re-choosing the already-active mode does not leave the check mark cleared.
+    /// </summary>
+    public void RefreshIsSelected() => OnPropertyChanged(nameof(IsSelected));
+
+    /// <summary>Display text for any Selector or menu this is bound into (see CLAUDE.md).</summary>
+    public override string ToString() => Name;
+}

--- a/QuickMail/QuickMail.csproj
+++ b/QuickMail/QuickMail.csproj
@@ -15,9 +15,9 @@
          System.Windows(.Media) types this codebase uses unqualified (Point, Size, Color, Brush,
          Application, MessageBox, ...). -->
     <UseWindowsForms>true</UseWindowsForms>
-    <Version>0.8.44</Version>
-    <AssemblyVersion>0.8.44</AssemblyVersion>
-    <FileVersion>0.8.44</FileVersion>
+    <Version>0.8.45</Version>
+    <AssemblyVersion>0.8.45</AssemblyVersion>
+    <FileVersion>0.8.45</FileVersion>
     <!-- Velopack needs a hand-written Main that runs VelopackApp.Build().Run() before WPF
          initializes (install/update/uninstall hooks run and may exit the process). App.xaml
          therefore compiles as Page (no generated Main) and the entry point is declared here. -->

--- a/QuickMail/ViewModels/CalendarViewModel.cs
+++ b/QuickMail/ViewModels/CalendarViewModel.cs
@@ -96,7 +96,8 @@ public partial class CalendarViewModel : ObservableObject
     [NotifyPropertyChangedFor(nameof(IsListView))]
     private CalendarViewMode _viewMode = CalendarViewMode.Agenda;
 
-    /// <summary>Which slice is in effect, for check states and view-specific behaviour.</summary>
+    /// <summary>Which slice is in effect. IsMonthView drives the Month grid's visibility and
+    /// the focus routing that goes with it; the other three are read by the calendar's tests.</summary>
     public bool IsAgendaView => ViewMode == CalendarViewMode.Agenda;
     public bool IsDayView => ViewMode == CalendarViewMode.Day;
     public bool IsWeekView => ViewMode == CalendarViewMode.Week;

--- a/QuickMail/ViewModels/CalendarViewModel.cs
+++ b/QuickMail/ViewModels/CalendarViewModel.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -96,7 +96,7 @@ public partial class CalendarViewModel : ObservableObject
     [NotifyPropertyChangedFor(nameof(IsListView))]
     private CalendarViewMode _viewMode = CalendarViewMode.Agenda;
 
-    /// <summary>Check-state helpers for the View Mode menu.</summary>
+    /// <summary>Which slice is in effect, for check states and view-specific behaviour.</summary>
     public bool IsAgendaView => ViewMode == CalendarViewMode.Agenda;
     public bool IsDayView => ViewMode == CalendarViewMode.Day;
     public bool IsWeekView => ViewMode == CalendarViewMode.Week;

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -9180,14 +9180,15 @@ public partial class MainViewModel : ObservableObject, IDisposable
     /// refreshes which entry is checked. The collection is replaced in place only when the set
     /// actually changes, so arrowing through an open menu does not regenerate its containers.
     /// </summary>
-    public void RebuildViewModeOptions()
+    private void RebuildViewModeOptions()
     {
-        var wanted = BuildViewModeOptions(IsCalendarView);
-        if (ViewModeOptions.Count != wanted.Length
-            || !ViewModeOptions.Select(o => o.Id).SequenceEqual(wanted.Select(o => o.Id), StringComparer.Ordinal))
+        // Folder selection is a hot path, so the common case — the set is already right —
+        // costs one comparison and builds nothing.
+        var calendar = IsCalendarView;
+        if (ViewModeOptions.Count == 0 || ViewModeOptions[0].IsCalendarMode != calendar)
         {
             ViewModeOptions.Clear();
-            foreach (var option in wanted) ViewModeOptions.Add(option);
+            foreach (var option in BuildViewModeOptions(calendar)) ViewModeOptions.Add(option);
         }
         RefreshViewModeOptionChecks();
     }

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -156,6 +156,8 @@ public partial class MainViewModel : ObservableObject, IDisposable
     {
         if (_screenshotCapture != null)
             _screenshotCapture.EnabledChanged -= OnScreenshotCaptureEnabledChanged;
+        if (CalendarVm != null)
+            CalendarVm.PropertyChanged -= OnCalendarVmPropertyChanged;
         if (_outbox != null)
         {
             _outbox.Changed        -= OnOutboxChanged;
@@ -1079,6 +1081,10 @@ public partial class MainViewModel : ObservableObject, IDisposable
     [NotifyPropertyChangedFor(nameof(IsContactMailView))]
     private MailFolderModel? _selectedFolder;
 
+    // Selecting the calendar folder (or leaving it) swaps the View Mode menu between the mail
+    // groupings and the calendar slices — see RebuildViewModeOptions and issue #663.
+    partial void OnSelectedFolderChanged(MailFolderModel? value) => RebuildViewModeOptions();
+
     [ObservableProperty]
     private BatchObservableCollection<MailMessageSummary> _messages = [];
 
@@ -1785,7 +1791,12 @@ public partial class MainViewModel : ObservableObject, IDisposable
             RemindersEnabled = cfg.CalendarReminders;
             ReminderLeadMinutes = cfg.CalendarReminderMinutes;
             StartReminderTimer();
+            // Keeps the View Mode menu's check mark on the calendar slice actually in effect,
+            // whichever way the user switched (menu, hotkey, or drilling into a month cell).
+            CalendarVm.PropertyChanged += OnCalendarVmPropertyChanged;
         }
+
+        RebuildViewModeOptions();
 
         _syncService.FolderSynced    += OnFolderSynced;
         _syncService.MessagesRemoved += OnMessagesRemoved;
@@ -5067,6 +5078,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
         OnPropertyChanged(nameof(IsToView));
         OnPropertyChanged(nameof(ViewModeLabel));
         OnPropertyChanged(nameof(IsCountSortAvailable));
+        RefreshViewModeOptionChecks();
 
         // The stale collections are always cleared; only the rebuilds are suppressed. Leaving
         // the previous folder's groups in place while navigating is what would be read out.
@@ -9134,12 +9146,99 @@ public partial class MainViewModel : ObservableObject, IDisposable
         await ArchiveMessagesAsync(group.Messages);
     }
 
-    // ── View mode command ─────────────────────────────────────────────────────
+    // ── View mode menu ────────────────────────────────────────────────────────
 
-    [RelayCommand]
-    private void SetViewMode(string? mode)
+    /// <summary>
+    /// The entries the "View Mode" menu shows right now — the four mail groupings, or the four
+    /// calendar slices while the calendar is open. Never both: the menu used to declare all
+    /// eight and collapse the inapplicable four, and a collapsed MenuItem still counts in its
+    /// parent's automation peer, so a screen reader announced "1 of 8" over a four-item menu
+    /// (issue #663). Rebuilding the collection is what keeps the announced count honest.
+    /// </summary>
+    public ObservableCollection<ViewModeOption> ViewModeOptions { get; } = [];
+
+    private static ViewModeOption[] BuildViewModeOptions(bool calendar) => calendar
+        ? [
+            new ViewModeOption("Agenda", "Agenda", "_Agenda", isCalendarMode: true),
+            new ViewModeOption("Day",    "Day",    "_Day",    isCalendarMode: true),
+            new ViewModeOption("Week",   "Week",   "_Week",   isCalendarMode: true),
+            new ViewModeOption("Month",  "Month",  "M_onth",  isCalendarMode: true),
+          ]
+        : [
+            new ViewModeOption("Messages",      "Messages",     "_Messages",      isCalendarMode: false),
+            new ViewModeOption("Conversations", "Conversations", "_Conversations", isCalendarMode: false),
+            // "From"/"To" everywhere: it is what the toolbar button label, the folder-tree
+            // headings and the user guide already call these two. The View menu used to say
+            // "By Sender"/"By Recipient" — the odd one out, and now that both menus draw from
+            // this one list it could no longer differ from the button it drops from.
+            new ViewModeOption("From",          "From",         "_From",          isCalendarMode: false),
+            new ViewModeOption("To",            "To",           "_To",            isCalendarMode: false),
+          ];
+
+    /// <summary>
+    /// Swaps the menu between the mail and calendar sets when the active folder changes, and
+    /// refreshes which entry is checked. The collection is replaced in place only when the set
+    /// actually changes, so arrowing through an open menu does not regenerate its containers.
+    /// </summary>
+    public void RebuildViewModeOptions()
     {
-        ViewMode = ConfigModel.ParseViewMode(mode);
+        var wanted = BuildViewModeOptions(IsCalendarView);
+        if (ViewModeOptions.Count != wanted.Length
+            || !ViewModeOptions.Select(o => o.Id).SequenceEqual(wanted.Select(o => o.Id), StringComparer.Ordinal))
+        {
+            ViewModeOptions.Clear();
+            foreach (var option in wanted) ViewModeOptions.Add(option);
+        }
+        RefreshViewModeOptionChecks();
+    }
+
+    private void OnCalendarVmPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(CalendarViewModel.ViewMode)) RefreshViewModeOptionChecks();
+    }
+
+    /// <summary>Pushes the current mode onto the menu's check marks.</summary>
+    private void RefreshViewModeOptionChecks()
+    {
+        var current = IsCalendarView
+            ? (CalendarVm?.ViewMode.ToString() ?? nameof(CalendarViewMode.Agenda))
+            : ViewMode.ToString();
+
+        foreach (var option in ViewModeOptions)
+        {
+            var selected = string.Equals(option.Id, current, StringComparison.Ordinal);
+            if (option.IsSelected != selected) option.IsSelected = selected;
+            else option.RefreshIsSelected();
+        }
+    }
+
+    /// <summary>
+    /// Activation of a View Mode menu entry. Calendar entries go through the calendar's own
+    /// commands, which also re-filter, re-announce the period, and move focus to the control
+    /// the new slice shows — setting <c>CalendarVm.ViewMode</c> directly would skip all three.
+    /// </summary>
+    [RelayCommand]
+    private void SelectViewMode(ViewModeOption? option)
+    {
+        if (option == null) return;
+
+        if (option.IsCalendarMode)
+        {
+            if (CalendarVm == null) return;
+            switch (option.Id)
+            {
+                case nameof(CalendarViewMode.Agenda): CalendarVm.ShowAgendaCommand.Execute(null); break;
+                case nameof(CalendarViewMode.Day):    CalendarVm.ShowDayCommand.Execute(null);    break;
+                case nameof(CalendarViewMode.Week):   CalendarVm.ShowWeekCommand.Execute(null);   break;
+                case nameof(CalendarViewMode.Month):  CalendarVm.ShowMonthCommand.Execute(null);  break;
+            }
+        }
+        else
+        {
+            ViewMode = ConfigModel.ParseViewMode(option.Id);
+        }
+
+        RefreshViewModeOptionChecks();
     }
 
     // ── List density command (#421, View menu) ────────────────────────────────

--- a/QuickMail/Views/MainWindow.xaml
+++ b/QuickMail/Views/MainWindow.xaml
@@ -6,6 +6,7 @@
         xmlns:local="clr-namespace:QuickMail.Views"
         xmlns:models="clr-namespace:QuickMail.Models"
         xmlns:wv2="clr-namespace:Microsoft.Web.WebView2.Wpf;assembly=Microsoft.Web.WebView2.Wpf"
+        xmlns:prim="clr-namespace:System.Windows.Controls.Primitives;assembly=PresentationFramework"
         mc:Ignorable="d"
         Title="{Binding WindowTitle}"
         Height="650" Width="1000"
@@ -22,6 +23,30 @@
         <local:BoolToGridLengthConverter        x:Key="BoolToGridLengthConverter"/>
         <local:StringToVisibilityConverter      x:Key="StringToVisibilityConverter"/>
         <local:StringToBrushConverter           x:Key="StringToBrushConverter"/>
+
+        <!-- View Mode menu entries (#663).
+             The menu is bound to MainViewModel.ViewModeOptions, which holds only the four
+             modes that apply right now — the mail groupings, or the calendar slices. It used
+             to declare all eight and collapse the inapplicable four, but a collapsed MenuItem
+             is still a child of its parent's automation peer, so a screen reader counted eight
+             items in a menu showing four.
+
+             The ancestor for the command is MenuBase, which covers both hosts: the View menu
+             (inside a Menu) and the toolbar button's ContextMenu. Both carry the MainViewModel
+             as their DataContext — the ContextMenu by way of its PlacementTarget binding. -->
+        <Style x:Key="ViewModeMenuItemStyle" TargetType="MenuItem" BasedOn="{StaticResource {x:Type MenuItem}}">
+            <Setter Property="Header" Value="{Binding Header}"/>
+            <!-- The header carries a mnemonic underscore; the accessible name must not. -->
+            <Setter Property="AutomationProperties.Name" Value="{Binding Name}"/>
+            <!-- IsCheckable="True" is what makes the automation peer expose the Toggle
+                 pattern, so the active mode is announced as checked. -->
+            <Setter Property="IsCheckable" Value="True"/>
+            <Setter Property="IsChecked" Value="{Binding IsSelected, Mode=OneWay}"/>
+            <Setter Property="Command"
+                    Value="{Binding DataContext.SelectViewModeCommand,
+                                    RelativeSource={RelativeSource AncestorType={x:Type prim:MenuBase}}}"/>
+            <Setter Property="CommandParameter" Value="{Binding}"/>
+        </Style>
 
         <!-- ── Shared context menus ── -->
 
@@ -472,54 +497,12 @@
                           Click="MenuPlainText_Click"
                           InputGestureText="Ctrl+Shift+H"/>
                 <Separator/>
-                <MenuItem Header="View _Mode">
-                    <!-- Mail view modes — hidden while the calendar is open. -->
-                    <MenuItem Header="_Messages"
-                              Visibility="{Binding IsCalendarView, Converter={StaticResource InverseBoolToVisibilityConverter}}"
-                              IsCheckable="True"
-                              IsChecked="{Binding IsMessagesView, Mode=OneWay}"
-                              Command="{Binding SetViewModeCommand}"
-                              CommandParameter="Messages"/>
-                    <MenuItem Header="_Conversations"
-                              Visibility="{Binding IsCalendarView, Converter={StaticResource InverseBoolToVisibilityConverter}}"
-                              IsCheckable="True"
-                              IsChecked="{Binding IsConversationsView, Mode=OneWay}"
-                              Command="{Binding SetViewModeCommand}"
-                              CommandParameter="Conversations"/>
-                    <MenuItem Header="By _Sender"
-                              Visibility="{Binding IsCalendarView, Converter={StaticResource InverseBoolToVisibilityConverter}}"
-                              IsCheckable="True"
-                              IsChecked="{Binding IsFromView, Mode=OneWay}"
-                              Command="{Binding SetViewModeCommand}"
-                              CommandParameter="From"/>
-                    <MenuItem Header="By _Recipient"
-                              Visibility="{Binding IsCalendarView, Converter={StaticResource InverseBoolToVisibilityConverter}}"
-                              IsCheckable="True"
-                              IsChecked="{Binding IsToView, Mode=OneWay}"
-                              Command="{Binding SetViewModeCommand}"
-                              CommandParameter="To"/>
-                    <!-- Calendar view modes — shown only while the calendar is open. -->
-                    <MenuItem Header="_Agenda"
-                              Visibility="{Binding IsCalendarView, Converter={StaticResource BoolToVisibilityConverter}}"
-                              IsCheckable="True"
-                              IsChecked="{Binding CalendarVm.IsAgendaView, Mode=OneWay}"
-                              Command="{Binding CalendarVm.ShowAgendaCommand}"/>
-                    <MenuItem Header="_Day"
-                              Visibility="{Binding IsCalendarView, Converter={StaticResource BoolToVisibilityConverter}}"
-                              IsCheckable="True"
-                              IsChecked="{Binding CalendarVm.IsDayView, Mode=OneWay}"
-                              Command="{Binding CalendarVm.ShowDayCommand}"/>
-                    <MenuItem Header="_Week"
-                              Visibility="{Binding IsCalendarView, Converter={StaticResource BoolToVisibilityConverter}}"
-                              IsCheckable="True"
-                              IsChecked="{Binding CalendarVm.IsWeekView, Mode=OneWay}"
-                              Command="{Binding CalendarVm.ShowWeekCommand}"/>
-                    <MenuItem Header="M_onth"
-                              Visibility="{Binding IsCalendarView, Converter={StaticResource BoolToVisibilityConverter}}"
-                              IsCheckable="True"
-                              IsChecked="{Binding CalendarVm.IsMonthView, Mode=OneWay}"
-                              Command="{Binding CalendarVm.ShowMonthCommand}"/>
-                </MenuItem>
+                <!-- Only the four modes that apply are in the tree at all (#663) — see
+                     ViewModeMenuItemStyle. -->
+                <MenuItem Header="View _Mode"
+                          x:Name="ViewModeMenuItem"
+                          ItemsSource="{Binding ViewModeOptions}"
+                          ItemContainerStyle="{StaticResource ViewModeMenuItemStyle}"/>
                 <!-- Density (#421): the same setting as Settings → Appearance,
                      adjustable in place. Padding only — never the accessibility
                      surface. Registered as view.density.* for palette/hotkeys. -->
@@ -853,48 +836,13 @@
                     ToolTip="Select message view mode (Ctrl+Shift+V)"
                     Click="ViewModeButton_Click">
                 <Button.ContextMenu>
-                    <ContextMenu AutomationProperties.Name="View mode"
-                                 DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
-                        <MenuItem Header="_Messages"
-                                  Visibility="{Binding IsCalendarView, Converter={StaticResource InverseBoolToVisibilityConverter}}"
-                                  IsCheckable="True"
-                                  IsChecked="{Binding IsMessagesView, Mode=OneWay}"
-                                  Command="{Binding SetViewModeCommand}"
-                                  CommandParameter="Messages"/>
-                        <MenuItem Header="_Conversations"
-                                  Visibility="{Binding IsCalendarView, Converter={StaticResource InverseBoolToVisibilityConverter}}"
-                                  IsCheckable="True"
-                                  IsChecked="{Binding IsConversationsView, Mode=OneWay}"
-                                  Command="{Binding SetViewModeCommand}"
-                                  CommandParameter="Conversations"/>
-                        <MenuItem Header="_From"
-                                  Visibility="{Binding IsCalendarView, Converter={StaticResource InverseBoolToVisibilityConverter}}"
-                                  IsCheckable="True"
-                                  IsChecked="{Binding IsFromView, Mode=OneWay}"
-                                  Command="{Binding SetViewModeCommand}"
-                                  CommandParameter="From"/>
-                        <MenuItem Header="_To"
-                                  Visibility="{Binding IsCalendarView, Converter={StaticResource InverseBoolToVisibilityConverter}}"
-                                  IsCheckable="True"
-                                  IsChecked="{Binding IsToView, Mode=OneWay}"
-                                  Command="{Binding SetViewModeCommand}"
-                                  CommandParameter="To"/>
-                        <MenuItem Header="_Agenda"
-                                  Visibility="{Binding IsCalendarView, Converter={StaticResource BoolToVisibilityConverter}}"
-                                  IsCheckable="True"
-                                  IsChecked="{Binding CalendarVm.IsAgendaView, Mode=OneWay}"
-                                  Command="{Binding CalendarVm.ShowAgendaCommand}"/>
-                        <MenuItem Header="_Day"
-                                  Visibility="{Binding IsCalendarView, Converter={StaticResource BoolToVisibilityConverter}}"
-                                  IsCheckable="True"
-                                  IsChecked="{Binding CalendarVm.IsDayView, Mode=OneWay}"
-                                  Command="{Binding CalendarVm.ShowDayCommand}"/>
-                        <MenuItem Header="_Week"
-                                  Visibility="{Binding IsCalendarView, Converter={StaticResource BoolToVisibilityConverter}}"
-                                  IsCheckable="True"
-                                  IsChecked="{Binding CalendarVm.IsWeekView, Mode=OneWay}"
-                                  Command="{Binding CalendarVm.ShowWeekCommand}"/>
-                    </ContextMenu>
+                    <!-- Same collection the View menu binds, so the toolbar offers exactly the
+                         modes that apply and announces the right count (#663). -->
+                    <ContextMenu x:Name="ViewModeMenu"
+                                 AutomationProperties.Name="View mode"
+                                 DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}"
+                                 ItemsSource="{Binding ViewModeOptions}"
+                                 ItemContainerStyle="{StaticResource ViewModeMenuItemStyle}"/>
                 </Button.ContextMenu>
             </Button>
             <Separator/>

--- a/QuickMail/Views/MainWindow.xaml
+++ b/QuickMail/Views/MainWindow.xaml
@@ -19,7 +19,6 @@
     <Window.Resources>
         <local:BoolToFontWeightConverter x:Key="BoolToWeightConverter"/>
         <BooleanToVisibilityConverter    x:Key="BoolToVisibilityConverter"/>
-        <local:InverseBoolToVisibilityConverter x:Key="InverseBoolToVisibilityConverter"/>
         <local:BoolToGridLengthConverter        x:Key="BoolToGridLengthConverter"/>
         <local:StringToVisibilityConverter      x:Key="StringToVisibilityConverter"/>
         <local:StringToBrushConverter           x:Key="StringToBrushConverter"/>

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -37,19 +37,6 @@ public class BoolToFontWeightConverter : IValueConverter
 }
 
 /// <summary>
-/// Converts bool to Visibility: true → Collapsed, false → Visible.
-/// Used to hide the standard message ListView when conversation view is on.
-/// </summary>
-public class InverseBoolToVisibilityConverter : IValueConverter
-{
-    public object Convert(object value, Type targetType, object parameter, CultureInfo culture) =>
-        value is true ? Visibility.Collapsed : Visibility.Visible;
-
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) =>
-        throw new NotSupportedException();
-}
-
-/// <summary>
 /// Converts a bool to a GridLength using a "trueValue|falseValue" parameter, e.g. "*|0" or
 /// "Auto|*". Each token is parsed as a GridLength ("*", "Auto", "0", "2*", "200"). Used to swap
 /// the message-list and reading-pane row sizes so a message opened in a tab fills the content

--- a/QuickMail/Views/SettingsDialog.xaml
+++ b/QuickMail/Views/SettingsDialog.xaml
@@ -80,8 +80,8 @@
                                               AutomationProperties.LabeledBy="{Binding ElementName=ViewModeLabel}">
                                         <ComboBoxItem Tag="messages" Content="Messages (flat list)"/>
                                         <ComboBoxItem Tag="conversations" Content="Conversations (grouped by subject)"/>
-                                        <ComboBoxItem Tag="from" Content="By Sender"/>
-                                        <ComboBoxItem Tag="to" Content="By Recipient"/>
+                                        <ComboBoxItem Tag="from" Content="From (grouped by sender)"/>
+                                        <ComboBoxItem Tag="to" Content="To (grouped by recipient)"/>
                                     </ComboBox>
                                 </StackPanel>
 

--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -86,7 +86,7 @@ The menu bar at the top of the window provides access to all major features, org
 |------|----------|
 | **File** | New Message, Manage Accounts, Address Book, Settings (`Ctrl+,`), Exit |
 | **Message** | Reply, Reply All, Forward, Delete, Empty Trash, Move/Copy to Folder, Grab Addresses |
-| **View** | Refresh, View Mode (Messages / Conversations / By Sender / By Recipient), Filter (All / Unread / Read / With Attachments / Replied / Forwarded / To Me), Sort (Newest First / Oldest First / A → Z / Z → A / Most Messages / Fewest Messages), Views (saved views list, Save View, Manage Views, Clear View), Sync Range (7 Days / 30 Days / 6 Months / 1 Year / All Mail), Go to Folder, Search Folders, Command Palette |
+| **View** | Refresh, View Mode (Messages / Conversations / From / To), Filter (All / Unread / Read / With Attachments / Replied / Forwarded / To Me), Sort (Newest First / Oldest First / A → Z / Z → A / Most Messages / Fewest Messages), Views (saved views list, Save View, Manage Views, Clear View), Sync Range (7 Days / 30 Days / 6 Months / 1 Year / All Mail), Go to Folder, Search Folders, Command Palette |
 | **Help** | User Guide |
 
 All menu items show their keyboard shortcuts for quick reference. You can also press **Alt** or **F10** to activate the menu bar if you prefer keyboard-only navigation.
@@ -167,7 +167,7 @@ Open **File → Settings** (or press `Ctrl+,`) to change application-wide prefer
 
 | Setting | What it controls |
 |---------|------------------|
-| **View Mode** | Default message grouping when the app starts (Messages, Conversations, By Sender, By Recipient) |
+| **View Mode** | Default message grouping when the app starts (Messages, Conversations, From, To) |
 | **Sync Days** | How many days back to fetch messages on sync. `0` means all mail. |
 | **Preview Lines** | Number of body-preview lines shown under each subject in the message list (0–5). |
 | **Initial Sync Count** | Maximum messages fetched per folder on the first sync of a newly connected account. |
@@ -572,7 +572,7 @@ The **View → Sort** submenu controls the order in which messages or groups are
 | **Most Messages** | Groups with the most messages first — grouped views only |
 | **Fewest Messages** | Groups with the fewest messages first — grouped views only |
 
-**Most Messages** and **Fewest Messages** only apply when a grouped view is active (Conversations, By Sender, or By Recipient) and are greyed out in the flat Messages view. They let you instantly see, for example, who you have the most correspondence with.
+**Most Messages** and **Fewest Messages** only apply when a grouped view is active (Conversations, From, or To) and are greyed out in the flat Messages view. They let you instantly see, for example, who you have the most correspondence with.
 
 **Applying a sort:**
 - Open **View → Sort** and choose an option.

--- a/docs/release-notes-v0.8.45.md
+++ b/docs/release-notes-v0.8.45.md
@@ -16,7 +16,8 @@ The **View mode** button on the toolbar (`Ctrl+Shift+V`) drops the same list, so
 same way — it was counting seven — and it gains **Month**, which it had been missing while the
 calendar is open. Two View menu entries are renamed to match what the toolbar button, the folder
 tree and the user guide have always called them: **By Sender** and **By Recipient** are now **From**
-and **To**.
+and **To**. **Settings → General → View → Display mode**, which sets the same four modes, follows
+suit and reads **From (grouped by sender)** and **To (grouped by recipient)**.
 ([#663](https://github.com/kellylford/QuickMail/issues/663))
 
 ---

--- a/docs/release-notes-v0.8.45.md
+++ b/docs/release-notes-v0.8.45.md
@@ -1,0 +1,49 @@
+# QuickMail v0.8.45 Release Notes
+
+## Fixed: View Mode counts its choices correctly
+
+**View → View Mode** offers four choices — Messages, Conversations, From, To — but arrowing
+through them announced *"1 of 8"*, *"2 of 8"*, and so on. The menu actually held eight items: the
+four above plus the four calendar views (Agenda, Day, Week, Month), which were hidden rather than
+removed while you were reading mail. Hiding a menu item takes it off the screen but leaves it in
+the menu, so it still counted.
+
+The menu now holds only the choices that apply: the four mail views while you are in a mail
+folder, and the four calendar views while the calendar is open. The count you hear matches what
+is there.
+
+The **View mode** button on the toolbar (`Ctrl+Shift+V`) drops the same list, so it is fixed the
+same way — it was counting seven — and it gains **Month**, which it had been missing while the
+calendar is open. Two View menu entries are renamed to match what the toolbar button, the folder
+tree and the user guide have always called them: **By Sender** and **By Recipient** are now **From**
+and **To**.
+([#663](https://github.com/kellylford/QuickMail/issues/663))
+
+---
+
+## Reporting Issues
+
+Found a problem or have a suggestion? There are three ways to reach us — pick the one that fits:
+
+1. **Report a Bug → Send** (Help menu, inside QuickMail). Files the report for you anonymously — it includes no email address or other identifying information, so there is no way to follow up with you. **Best when you don't want any follow-up.**
+2. **Report a Bug → Copy report and open GitHub** (Help menu). Opens a pre-filled issue that you submit under your own GitHub account, so your GitHub contact information is attached. **Best when you have a GitHub account and want automatic filing plus direct contact.**
+3. **Email** [support@theideaplace.net](mailto:support@theideaplace.net). **Best when you don't mind sending email and want a personal follow-up.**
+
+Full details, including exactly what a report contains (and what it never contains), are in the [Reporting Issues section of the User Guide](https://kellylford.github.io/QuickMail/reporting-issues.html).
+
+---
+
+## Download
+
+There are four downloads. Take a regular one unless you know your PC has an ARM processor — to check, open **Settings → System → About** and read **System type**.
+
+| Download | When to use |
+|----------|-------------|
+| [**QuickMail-0.8.45-win.msi**](https://github.com/kellylford/QuickMail/releases/download/v0.8.45/QuickMail-0.8.45-win.msi) — Windows installer | Recommended for most users. A standard setup wizard with license agreement; installs per-user with no elevation required, adds the WebView2 Runtime if missing, and enables automatic updates. |
+| [**QuickMail-0.8.45-win-arm64.msi**](https://github.com/kellylford/QuickMail/releases/download/v0.8.45/QuickMail-0.8.45-win-arm64.msi) — Windows installer, ARM | The same installer for PCs with an ARM processor, such as the Snapdragon X models of Surface Laptop and Surface Pro. |
+| [**QuickMail.exe**](https://github.com/kellylford/QuickMail/releases/download/v0.8.45/QuickMail.exe) — standalone portable executable | No installation required. Copy it anywhere and run. |
+| [**QuickMail-arm64.exe**](https://github.com/kellylford/QuickMail/releases/download/v0.8.45/QuickMail-arm64.exe) — standalone portable executable, ARM | The portable version for PCs with an ARM processor. |
+
+The regular downloads run on every supported PC, ARM ones included — just not as quickly there. The ARM downloads will not start at all on a non-ARM PC, so if you are unsure, the regular one is the safe guess.
+
+All downloads include the .NET 8 runtime — you do not need to install .NET separately.


### PR DESCRIPTION
Closes #663.

## The bug

Arrowing **View → View Mode** announced *"1 of 8"*, *"2 of 8"* over a menu showing four
items. The menu declared all eight modes — the four mail groupings and the four calendar
slices — and collapsed the inapplicable set with `Visibility`. A collapsed `MenuItem` is
still a child of its parent in the automation tree, so the count a screen reader reports
counted the hidden four. The toolbar's **View mode** button (`Ctrl+Shift+V`) had the same
fault, counting seven.

## The fix

Both surfaces now bind to `MainViewModel.ViewModeOptions`, a collection holding only the
four options that apply right now, so the inapplicable ones are not in the tree at all.

- The collection swaps sets when the calendar folder is selected or left, and tracks the
  check mark through both `MainViewModel.ViewMode` and `CalendarVm.ViewMode`.
- Calendar entries dispatch to the calendar's own commands, which also re-filter,
  re-announce the period and move focus — setting `CalendarVm.ViewMode` directly would
  skip all three.
- One shared `ItemContainerStyle` puts the mnemonic in `Header` and the clean label in
  `AutomationProperties.Name`, and keeps `IsCheckable="True"` so the active mode is
  announced as checked.

Two side effects of sharing one collection, both intended:

- The toolbar menu gains **Month**, which it had been missing while the calendar is open.
- The View menu's **By Sender** / **By Recipient** become **From** / **To** — what the
  toolbar button label, the folder-tree headings and the user guide already call them, and
  what the button the menu drops from says. The two surfaces can no longer disagree.

`SetViewModeCommand` is removed; nothing referenced it once both menus moved to
`SelectViewModeCommand`.

## Tests

`QuickMail.Tests/ViewModeMenuTests.cs` (7 tests): the collection never carries the other
set in either direction, exactly one entry is checked and it tracks the active mode,
re-choosing the active mode leaves it checked, activating an entry switches the mode, both
menus really resolve to the one collection, and a generated container announces the mode
without its mnemonic and is wired to the command through its `MenuBase` ancestor.

Full suite: 3531 passed, 3 skipped (the opt-in input tests), 0 failed.

## Release

Starts 0.8.45 — version bumped and `docs/release-notes-v0.8.45.md` added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
