### PR TITLE
Fix #667: land focus before removing a row, and stop announcing a single delete

### DIFF
--- a/QuickMail.Tests/MessageRemovalFocusTests.cs
+++ b/QuickMail.Tests/MessageRemovalFocusTests.cs
@@ -90,12 +90,22 @@ public class MessageRemovalFocusTests
         /// <summary>What Messages held each time the ViewModel asked for a synchronous focus move.</summary>
         public List<(MailMessageSummary? Selected, List<MailMessageSummary> Rows)> FocusNowCalls { get; } = new();
 
+        /// <summary>How many times the ViewModel asked for the queued (post-removal) focus move.</summary>
+        public int QueuedFocusCalls { get; private set; }
+
+        /// <summary>What the stand-in View reports back: did focus reach the row?</summary>
+        public bool FocusNowSucceeds { get; set; } = true;
+
         private Fixture(MainViewModel vm)
         {
             Vm        = vm;
             Announced = StatusAnnouncementRecorder.Watch(vm);
             vm.MessageListFocusNowRequested += () =>
+            {
                 FocusNowCalls.Add((vm.SelectedMessage, vm.Messages.ToList()));
+                return FocusNowSucceeds;
+            };
+            vm.MessageListFocusRequested += () => QueuedFocusCalls++;
         }
 
         public static async Task<Fixture> CreateAsync(int messageCount = 5)
@@ -179,6 +189,35 @@ public class MessageRemovalFocusTests
         // Nowhere to land, so nothing is asked for — rather than focusing a row about to vanish.
         Assert.Empty(f.FocusNowCalls);
         Assert.Empty(f.Vm.Messages);
+    }
+
+    [Fact]
+    public async Task FocusIsNotAskedForTwiceWhenItAlreadyLanded()
+    {
+        var f = await Fixture.CreateAsync();
+
+        await f.Vm.DeleteMessagesAsync([f.Row("b")]);
+
+        // The queued request lands on a later dispatcher pass, by which time the removal may have
+        // regenerated the container — focusing a fresh one reads the row out a second time. Once
+        // focus has landed there is nothing left to ask for.
+        Assert.Single(f.FocusNowCalls);
+        Assert.Equal(0, f.QueuedFocusCalls);
+    }
+
+    [Fact]
+    public async Task TheQueuedRequestStillRunsWhenFocusCouldNotLand()
+    {
+        var f = await Fixture.CreateAsync();
+        f.FocusNowSucceeds = false;   // e.g. the container was never realized
+
+        await f.Vm.DeleteMessagesAsync([f.Row("b")]);
+
+        // Skipping the fallback is only safe when focus actually arrived. It did not, so the user
+        // must not be left with focus nowhere.
+        Assert.Single(f.FocusNowCalls);
+        Assert.Equal(1, f.QueuedFocusCalls);
+        Assert.Equal("c", f.Vm.SelectedMessage?.MessageId);
     }
 
     [Fact]

--- a/QuickMail.Tests/MessageRemovalFocusTests.cs
+++ b/QuickMail.Tests/MessageRemovalFocusTests.cs
@@ -1,0 +1,269 @@
+// Deleting and archiving from the flat message list — issue #667.
+//
+// Two things are pinned here, and both are inaudible to a test that only checks the end state.
+//
+// 1. ORDER. Focus has to land on the surviving row BEFORE the doomed rows leave the collection.
+//    Remove the row that owns keyboard focus and WPF is left with focus on a container whose item
+//    is gone; its ItemAutomationPeer then reports IsEnabled = false, and a screen reader says
+//    "unavailable" before it reads the next message. Every end-state assertion passes either way —
+//    the selection and the list are identical once the dust settles — so these tests capture the
+//    state at the moment MessageListFocusNowRequested fires and assert on that.
+//
+// 2. WHAT IS SPOKEN. Deleting one message says nothing: the row has gone and the next one has just
+//    been read, so a spoken "1 message deleted" repeats what the user was told a moment ago and
+//    interrupts the reading to do it. A count of several, an emptied folder and every failure stay
+//    audible. The category is one-shot, so it is captured through StatusAnnouncementRecorder, which
+//    listens the way MainWindow does.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using QuickMail.Models;
+using QuickMail.Services;
+using QuickMail.ViewModels;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+public class MessageRemovalFocusTests
+{
+    private static readonly Guid Work = Guid.Parse("11111111-1111-1111-1111-111111111111");
+
+    private static AccountModel Account() => new()
+    {
+        Id = Work, AccountName = "Work", Username = "work@example.com", AuthType = AuthType.OAuth2Microsoft,
+    };
+
+    private static MailFolderModel Folder(string fullName, SpecialFolderKind kind) => new()
+    {
+        AccountId = Work, FullName = fullName, DisplayName = fullName, Kind = kind,
+    };
+
+    private static MailMessageSummary Msg(string id, int daysAgo) => new()
+    {
+        MessageId  = id,
+        AccountId  = Work,
+        FolderName = "INBOX",
+        From       = "someone@example.com",
+        Subject    = $"Subject {id}",
+        Date       = DateTimeOffset.Now.AddDays(-daysAgo),
+    };
+
+    private sealed class SilentSyncService : ISyncService
+    {
+#pragma warning disable CS0067 // nothing in these tests raises them
+        public event Action<IReadOnlyList<MailMessageSummary>>? MessagesRemoved;
+        public event Action<IReadOnlyList<MailMessageSummary>>? FolderReadStatesReconciled;
+        public event Action<IReadOnlyList<MailMessageSummary>>? FolderSynced;
+        public event Action<int>? RulesApplied;
+        public event Action<int, int>? SyncProgressChanged;
+        public event Action<int, int>? OfflineBodyProgressChanged;
+        public event Action<int, int>? OfflineBodyPassCompleted;
+#pragma warning restore CS0067
+
+        public Task SyncAllAccountsAsync(IEnumerable<AccountModel> accounts,
+            IReadOnlyDictionary<Guid, List<MailFolderModel>> cachedFolders, CancellationToken ct) => Task.CompletedTask;
+        public Task<IReadOnlyList<MailMessageSummary>> SyncOneFolderAsync(AccountModel account, MailFolderModel folder, CancellationToken ct)
+            => Task.FromResult<IReadOnlyList<MailMessageSummary>>(Array.Empty<MailMessageSummary>());
+        public Task<IReadOnlyList<MailMessageSummary>> SyncOneFolderOnlineAsync(AccountModel account, MailFolderModel folder, CancellationToken ct)
+            => Task.FromResult<IReadOnlyList<MailMessageSummary>>(Array.Empty<MailMessageSummary>());
+        public Task<IReadOnlyList<MailMessageSummary>> SyncFolderFullAsync(AccountModel account, MailFolderModel folder, CancellationToken ct)
+            => Task.FromResult<IReadOnlyList<MailMessageSummary>>(Array.Empty<MailMessageSummary>());
+        public Task<int> ReconcileFolderAsync(AccountModel account, MailFolderModel folder, CancellationToken ct) => Task.FromResult(0);
+        public DateTimeOffset? LastSyncedUtc(Guid accountId) => null;
+        public void SeedRebuildBaseline(IEnumerable<Guid> accountIds) { }
+        public Task BackfillOfflineBodiesAsync(IEnumerable<AccountModel> accounts,
+            IReadOnlyDictionary<Guid, List<MailFolderModel>> cachedFolders, CancellationToken ct) => Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// A view model on a five-message inbox (newest first, so "a" is row 0 and "e" is row 4), with
+    /// an Archive folder available, plus the recording hooks the assertions need.
+    /// </summary>
+    private sealed class Fixture
+    {
+        public MainViewModel Vm { get; }
+        public StatusAnnouncementRecorder Announced { get; }
+
+        /// <summary>What Messages held each time the ViewModel asked for a synchronous focus move.</summary>
+        public List<(MailMessageSummary? Selected, List<MailMessageSummary> Rows)> FocusNowCalls { get; } = new();
+
+        private Fixture(MainViewModel vm)
+        {
+            Vm        = vm;
+            Announced = StatusAnnouncementRecorder.Watch(vm);
+            vm.MessageListFocusNowRequested += () =>
+                FocusNowCalls.Add((vm.SelectedMessage, vm.Messages.ToList()));
+        }
+
+        public static async Task<Fixture> CreateAsync(int messageCount = 5)
+        {
+            var inbox   = Folder("INBOX", SpecialFolderKind.Inbox);
+            var archive = Folder("Archive", SpecialFolderKind.Archive);
+            var ids     = "abcdefgh".Substring(0, messageCount);
+
+            var vm = new MainViewModel(
+                new FolderedMailService(
+                    new Dictionary<Guid, List<MailFolderModel>> { [Work] = [inbox, archive] },
+                    new Dictionary<(Guid, string), List<MailMessageSummary>>
+                    {
+                        // daysAgo ascending with the letter, so newest-first order is a, b, c, …
+                        [(Work, "INBOX")] = [.. ids.Select((c, i) => Msg(c.ToString(), i))],
+                    }),
+                new StubAccountService(), new StubCredentialService(), new StubLocalStoreService(),
+                new StubOAuthService(), new SilentSyncService(), new StubConfigService(),
+                new StubCommandRegistry(), new StubViewService(), new StubRuleService(),
+                new StubSmtpService());
+
+            vm.Accounts.Add(Account());
+            await vm.ConnectAllAccountsAsync();
+            await vm.SelectFolderCommand.ExecuteAsync(inbox);
+
+            var f = new Fixture(vm);
+            Assert.Equal(ViewMode.Messages, vm.ViewMode);
+            Assert.Equal(messageCount, vm.Messages.Count);
+            return f;
+        }
+
+        public MailMessageSummary Row(string id) => Vm.Messages.First(m => m.MessageId == id);
+    }
+
+    // ── Order: focus lands before the row leaves ─────────────────────────────────
+
+    [Fact]
+    public async Task DeleteAsksForFocusWhileTheDoomedRowIsStillInTheList()
+    {
+        var f = await Fixture.CreateAsync();
+        var doomed = f.Row("b");
+
+        await f.Vm.DeleteMessagesAsync([doomed]);
+
+        var call = Assert.Single(f.FocusNowCalls);
+        // The whole point: at the moment focus was asked for, the row being deleted had not left.
+        Assert.Contains(doomed, call.Rows);
+        // …and the selection had already moved off it, onto the row that survives.
+        Assert.Equal("c", call.Selected?.MessageId);
+    }
+
+    [Fact]
+    public async Task DeleteLandsOnTheRowAfterTheDeletedBlock()
+    {
+        var f = await Fixture.CreateAsync();
+
+        await f.Vm.DeleteMessagesAsync([f.Row("b"), f.Row("c")]);
+
+        Assert.Equal("d", Assert.Single(f.FocusNowCalls).Selected?.MessageId);
+        Assert.Equal("d", f.Vm.SelectedMessage?.MessageId);
+    }
+
+    [Fact]
+    public async Task DeletingTheLastRowLandsOnTheOneBeforeIt()
+    {
+        var f = await Fixture.CreateAsync();
+
+        await f.Vm.DeleteMessagesAsync([f.Row("e")]);
+
+        Assert.Equal("d", Assert.Single(f.FocusNowCalls).Selected?.MessageId);
+        Assert.Equal("d", f.Vm.SelectedMessage?.MessageId);
+    }
+
+    [Fact]
+    public async Task DeletingEveryRowAsksForNoFocusMoveAtAll()
+    {
+        var f = await Fixture.CreateAsync();
+
+        await f.Vm.DeleteMessagesAsync([.. f.Vm.Messages]);
+
+        // Nowhere to land, so nothing is asked for — rather than focusing a row about to vanish.
+        Assert.Empty(f.FocusNowCalls);
+        Assert.Empty(f.Vm.Messages);
+    }
+
+    [Fact]
+    public async Task ArchiveAsksForFocusWhileTheDoomedRowIsStillInTheList()
+    {
+        var f = await Fixture.CreateAsync();
+        var doomed = f.Row("b");
+
+        await f.Vm.ArchiveMessagesAsync([doomed]);
+
+        var call = Assert.Single(f.FocusNowCalls);
+        Assert.Contains(doomed, call.Rows);
+        Assert.Equal("c", call.Selected?.MessageId);
+    }
+
+    // ── What is spoken ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task DeletingOneMessageIsNeverSpoken()
+    {
+        var f = await Fixture.CreateAsync();
+
+        await f.Vm.DeleteMessagesAsync([f.Row("b")]);
+
+        Assert.DoesNotContain(f.Announced.Announced, a => a.Category != AnnouncementCategory.Silent);
+        // The status bar still says it — this is about speech, not about hiding the outcome.
+        Assert.Equal("1 message deleted.", f.Vm.StatusText);
+    }
+
+    [Fact]
+    public async Task DeletingSeveralMessagesSpeaksTheCount()
+    {
+        var f = await Fixture.CreateAsync();
+
+        await f.Vm.DeleteMessagesAsync([f.Row("b"), f.Row("c"), f.Row("d")]);
+
+        Assert.Equal(("3 messages deleted.", AnnouncementCategory.MessageAction), f.Announced.Last);
+    }
+
+    [Fact]
+    public async Task EmptyingTheFolderBySayingSoIsSpoken()
+    {
+        var f = await Fixture.CreateAsync(messageCount: 1);
+
+        await f.Vm.DeleteMessagesAsync([f.Row("a")]);
+
+        // No next row is being read, so there is nothing to interrupt, and "empty" is a state the
+        // user cannot otherwise get from a list that shows nothing.
+        Assert.Equal(("1 message deleted. Folder is now empty.", AnnouncementCategory.MessageAction),
+            f.Announced.Last);
+    }
+
+    [Fact]
+    public async Task ArchivingOneMessageIsNeverSpoken()
+    {
+        var f = await Fixture.CreateAsync();
+
+        await f.Vm.ArchiveMessagesAsync([f.Row("b")]);
+
+        Assert.DoesNotContain(f.Announced.Announced, a => a.Category != AnnouncementCategory.Silent);
+        Assert.Equal("1 message archived.", f.Vm.StatusText);
+    }
+
+    [Fact]
+    public async Task ArchivingSeveralMessagesSpeaksTheCount()
+    {
+        var f = await Fixture.CreateAsync();
+
+        await f.Vm.ArchiveMessagesAsync([f.Row("b"), f.Row("c")]);
+
+        Assert.Equal(("2 messages archived.", AnnouncementCategory.MessageAction), f.Announced.Last);
+    }
+
+    [Fact]
+    public void SilentIsNotSomethingTheUserCanTurnBackOn()
+    {
+        // Every other category answers to a setting. Silent does not: it is the statement that a
+        // status carries nothing new, which no preference makes untrue. If this starts failing
+        // because Silent became configurable, the announcement it was meant to remove is back.
+        var configurable = new[]
+        {
+            AnnouncementCategory.Hint, AnnouncementCategory.Status,
+            AnnouncementCategory.Result, AnnouncementCategory.MessageAction,
+        };
+        Assert.DoesNotContain(AnnouncementCategory.Silent, configurable);
+        Assert.Equal(configurable.Length + 1, Enum.GetValues<AnnouncementCategory>().Length);
+    }
+}

--- a/QuickMail/Models/AnnouncementCategory.cs
+++ b/QuickMail/Models/AnnouncementCategory.cs
@@ -5,5 +5,21 @@ public enum AnnouncementCategory
     Hint,          // instructional tips the user can silence once familiar
     Status,        // background loading and sync progress
     Result,        // direct outcome of a user action
-    MessageAction  // outcome of a common message command (delete, archive) — its own toggle (issue #317)
+    MessageAction, // outcome of a common message command (delete, archive) — its own toggle (issue #317)
+
+    /// <summary>
+    /// Status-bar text that is never spoken, whatever the user's announcement settings.
+    ///
+    /// <para>Not a per-case mute of an announcement that otherwise exists — it is how a status
+    /// string says it carries nothing the user does not already have. Deleting one message is the
+    /// case it was added for (issue #667): the row is gone from the list and the next row has just
+    /// been read, so "1 message deleted" tells the user only what they were told a moment ago, and
+    /// costs an interruption to hear. The text still appears in the status bar, which is where a
+    /// sighted user reads it and where <c>Ctrl+9</c> reads it back on demand.</para>
+    ///
+    /// <para>Use it only where the outcome is genuinely self-evident from the UI. A count the user
+    /// cannot otherwise get ("3 messages deleted"), a state change they cannot see ("Folder is now
+    /// empty") and every failure stay audible.</para>
+    /// </summary>
+    Silent
 }

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -1355,6 +1355,12 @@ public partial class MainViewModel : ObservableObject, IDisposable
         StatusAnnouncementCategory = AnnouncementCategory.Status;
     }
 
+    /// <summary>
+    /// Puts <paramref name="text"/> in the status bar without speaking it. For an outcome the user
+    /// already has from the UI itself — see <see cref="AnnouncementCategory.Silent"/>.
+    /// </summary>
+    private void SetStatusSilently(string text) => SetStatus(text, AnnouncementCategory.Silent);
+
     [ObservableProperty]
     private string _rulesStatusText = string.Empty;
 
@@ -7181,6 +7187,58 @@ public partial class MainViewModel : ObservableObject, IDisposable
         return Task.CompletedTask;
     }
 
+    /// <summary>
+    /// Moves selection and keyboard focus onto the row that will survive <paramref name="leaving"/>,
+    /// <em>before</em> those rows are taken out of <see cref="Messages"/>. Returns the row it landed
+    /// on, or null when there was nowhere to land (a group view, or every row is leaving).
+    ///
+    /// <para>Removing the row that owns keyboard focus leaves focus sitting on a container whose
+    /// item is gone. WPF exposes a row through an <c>ItemAutomationPeer</c> that throws
+    /// <c>ElementNotAvailableException</c> from <c>IsEnabledCore()</c> once its container has gone,
+    /// and UI Automation turns a throwing provider into the property's default — <c>false</c> for
+    /// <c>IsEnabled</c>. A screen reader reading that peer therefore finds a disabled element and
+    /// says so, and the user hears "unavailable" before the next message (issue #667). Nothing in
+    /// QuickMail was ever disabled.</para>
+    ///
+    /// <para>Landing first is what fixes it, and only landing first: deferring the focus move,
+    /// making it synchronous, or turning virtualization off were each measured against a screen
+    /// reader and each still spoke. The focus move must therefore be synchronous, which is why
+    /// this raises <see cref="MessageListFocusNowRequested"/> rather than
+    /// <see cref="MessageListFocusRequested"/>.</para>
+    ///
+    /// <para>The landing row is the first survivor after the block being removed, falling back to
+    /// the last survivor before it — the same row the caller's post-removal index arithmetic picks,
+    /// so what the user lands on does not change.</para>
+    /// </summary>
+    private MailMessageSummary? LandFocusBeforeRemoval(IReadOnlyList<MailMessageSummary> leaving)
+    {
+        // The group trees own their own focus after RebuildActiveGroupView replaces their items;
+        // this is the flat list's business only.
+        if (ViewMode != ViewMode.Messages) return null;
+
+        var doomed = new HashSet<MailMessageSummary>(leaving);
+
+        var first = int.MaxValue;
+        foreach (var m in leaving)
+        {
+            var i = Messages.IndexOf(m);
+            if (i >= 0 && i < first) first = i;
+        }
+        if (first == int.MaxValue) return null;   // none of them are in the flat list
+
+        MailMessageSummary? landing = null;
+        for (var i = first + 1; i < Messages.Count && landing == null; i++)
+            if (!doomed.Contains(Messages[i])) landing = Messages[i];
+        for (var i = first - 1; i >= 0 && landing == null; i--)
+            if (!doomed.Contains(Messages[i])) landing = Messages[i];
+
+        if (landing == null) return null;         // the whole list is leaving
+
+        SelectedMessage = landing;
+        MessageListFocusNowRequested?.Invoke();
+        return landing;
+    }
+
     [RelayCommand]
     private async Task DeleteMessageAsync()
     {
@@ -7208,7 +7266,9 @@ public partial class MainViewModel : ObservableObject, IDisposable
         var label  = toDelete.Count == 1 ? "message" : $"{toDelete.Count} messages";
         // Delete/archive progress + outcome go through the MessageAction category (issue #317) so users
         // can silence this frequent chatter — it can interrupt the screen reader reading the next message.
-        SetStatus($"Deleting {label}…", AnnouncementCategory.MessageAction);
+        // Deleting a single message is silent: see the outcome status at the end of the try block.
+        SetStatus($"Deleting {label}…",
+            toDelete.Count == 1 ? AnnouncementCategory.Silent : AnnouncementCategory.MessageAction);
         IsBusy        = true;
         MessageDetail = null;
         IsMessageOpen = false;
@@ -7218,6 +7278,11 @@ public partial class MainViewModel : ObservableObject, IDisposable
         // messages vanish instantly, focus lands correctly, and the IMAP
         // move-to-trash runs afterwards. If it fails the messages will reappear
         // on the next background sync.
+        //
+        // Focus lands on the surviving row FIRST, so that none of the rows about to be removed is
+        // the one holding keyboard focus — see LandFocusBeforeRemoval (issue #667).
+        var landed = LandFocusBeforeRemoval(toDelete);
+
         int removed = 0;
         foreach (var msg in toDelete)
         {
@@ -7239,8 +7304,14 @@ public partial class MainViewModel : ObservableObject, IDisposable
         {
             // In flat Messages view: advance selection to the next item so the
             // global Delete hotkey (HasSelectedMessage guard) stays coherent.
-            var landIdx = Math.Max(0, Math.Min(minIdx, Messages.Count - 1));
-            SelectedMessage = Messages[landIdx];
+            // Normally LandFocusBeforeRemoval has already done this and its row is still here, so
+            // this is the fallback for when it could not land — and the re-focus below is a no-op
+            // when focus is already on the row, but recovers it if the container was regenerated.
+            if (landed == null || !Messages.Contains(landed))
+            {
+                var landIdx = Math.Max(0, Math.Min(minIdx, Messages.Count - 1));
+                SelectedMessage = Messages[landIdx];
+            }
             MessageListFocusRequested?.Invoke();
         }
         else
@@ -7301,10 +7372,18 @@ public partial class MainViewModel : ObservableObject, IDisposable
                     ScheduleFolderCountRefresh(acctId);
 
             var count = toDelete.Count;
-            SetStatus(Messages.Count > 0
-                ? $"{count} {(count == 1 ? "message" : "messages")} deleted."
-                : $"{count} {(count == 1 ? "message" : "messages")} deleted. Folder is now empty.",
-                AnnouncementCategory.MessageAction);
+            if (Messages.Count == 0)
+                // The list is empty, so there is no next row being read and nothing to interrupt —
+                // and "the folder is empty now" is a state the user cannot see any other way.
+                SetStatus($"{count} {(count == 1 ? "message" : "messages")} deleted. Folder is now empty.",
+                    AnnouncementCategory.MessageAction);
+            else if (count == 1)
+                // Self-evident: the row is gone and the next one has just been read. Saying so as
+                // well only interrupts that reading. Status bar only (issue #667).
+                SetStatusSilently("1 message deleted.");
+            else
+                // The count is information the user cannot get by looking at what is left.
+                SetStatus($"{count} messages deleted.", AnnouncementCategory.MessageAction);
         }
         catch (OperationCanceledException)
         {
@@ -7449,12 +7528,17 @@ public partial class MainViewModel : ObservableObject, IDisposable
         var actionable = plan.SelectMany(p => p.Group).ToList();
         var minIdx = actionable.Min(m => Messages.IndexOf(m));
         var label  = actionable.Count == 1 ? "message" : $"{actionable.Count} messages";
-        SetStatus($"Archiving {label}…", AnnouncementCategory.MessageAction);
+        SetStatus($"Archiving {label}…",
+            actionable.Count == 1 ? AnnouncementCategory.Silent : AnnouncementCategory.MessageAction);
         IsBusy        = true;
         MessageDetail = null;
         IsMessageOpen = false;
 
         // ── Step 1: Remove from UI immediately (same optimistic pattern as delete) ──
+        // Focus lands on the surviving row before anything leaves the list, for the reason set out
+        // in LandFocusBeforeRemoval (issue #667).
+        var landed = LandFocusBeforeRemoval(actionable);
+
         foreach (var msg in actionable)
             Messages.Remove(msg);
 
@@ -7468,8 +7552,12 @@ public partial class MainViewModel : ObservableObject, IDisposable
 
         if (ViewMode == ViewMode.Messages && Messages.Count > 0)
         {
-            var landIdx = Math.Max(0, Math.Min(minIdx, Messages.Count - 1));
-            SelectedMessage = Messages[landIdx];
+            // Fallback for when LandFocusBeforeRemoval could not land, exactly as in delete.
+            if (landed == null || !Messages.Contains(landed))
+            {
+                var landIdx = Math.Max(0, Math.Min(minIdx, Messages.Count - 1));
+                SelectedMessage = Messages[landIdx];
+            }
             MessageListFocusRequested?.Invoke();
         }
         else
@@ -7516,8 +7604,13 @@ public partial class MainViewModel : ObservableObject, IDisposable
                     ScheduleFolderCountRefresh(acctId);
 
             var count = actionable.Count;
-            SetStatus($"{count} {(count == 1 ? "message" : "messages")} archived.",
-                AnnouncementCategory.MessageAction);
+            if (count == 1 && Messages.Count > 0)
+                // Self-evident, same as a single delete (issue #667): the row has gone and the next
+                // one has just been read. Status bar only.
+                SetStatusSilently("1 message archived.");
+            else
+                SetStatus($"{count} {(count == 1 ? "message" : "messages")} archived.",
+                    AnnouncementCategory.MessageAction);
         }
         catch (OperationCanceledException)
         {
@@ -7569,6 +7662,17 @@ public partial class MainViewModel : ObservableObject, IDisposable
     public event Func<IReadOnlyList<AttachmentModel>, Task<IReadOnlyList<AttachmentModel>?>>? SelectAttachmentsForForwardRequested;
     public event Action? ManageAccountsRequested;
     public event Action? MessageListFocusRequested;
+
+    /// <summary>
+    /// Asks the View to put keyboard focus on the selected message row <em>synchronously</em>,
+    /// before this method returns — unlike <see cref="MessageListFocusRequested"/>, which queues
+    /// the focus move and lands it on a later dispatcher pass.
+    ///
+    /// <para>Raised only by <see cref="LandFocusBeforeRemoval"/>, and only for that purpose: the
+    /// focused row must stop being a row that is about to be removed, and "later" is too late for
+    /// that. See <see cref="LandFocusBeforeRemoval"/> for why (issue #667).</para>
+    /// </summary>
+    public event Action? MessageListFocusNowRequested;
     public event EventHandler<(string Text, AnnouncementCategory Category)>? AnnouncementRequested;
     public event EventHandler? RulesManagerRequested;
     public event EventHandler<MailRule>? CreateRuleFromMessageRequested;

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -7235,8 +7235,13 @@ public partial class MainViewModel : ObservableObject, IDisposable
         if (landing == null) return null;         // the whole list is leaving
 
         SelectedMessage = landing;
-        MessageListFocusNowRequested?.Invoke();
-        return landing;
+
+        // Null unless focus genuinely reached the row. A non-null return is the caller's licence to
+        // skip the queued MessageListFocusRequested afterwards, and skipping it is the point: that
+        // request lands on a later dispatcher pass, by which time the removal may have regenerated
+        // the container, and focusing a fresh container raises a second focus event that reads the
+        // row out again. The sequence measured as silent does not re-focus after the removal.
+        return MessageListFocusNowRequested?.Invoke() == true ? landing : null;
     }
 
     [RelayCommand]
@@ -7304,15 +7309,15 @@ public partial class MainViewModel : ObservableObject, IDisposable
         {
             // In flat Messages view: advance selection to the next item so the
             // global Delete hotkey (HasSelectedMessage guard) stays coherent.
-            // Normally LandFocusBeforeRemoval has already done this and its row is still here, so
-            // this is the fallback for when it could not land — and the re-focus below is a no-op
-            // when focus is already on the row, but recovers it if the container was regenerated.
+            //
+            // Only when LandFocusBeforeRemoval did not already do it. When it did, focus is on that
+            // row now and asking again would queue a second focus move — see the comment there.
             if (landed == null || !Messages.Contains(landed))
             {
                 var landIdx = Math.Max(0, Math.Min(minIdx, Messages.Count - 1));
                 SelectedMessage = Messages[landIdx];
+                MessageListFocusRequested?.Invoke();
             }
-            MessageListFocusRequested?.Invoke();
         }
         else
         {
@@ -7552,13 +7557,14 @@ public partial class MainViewModel : ObservableObject, IDisposable
 
         if (ViewMode == ViewMode.Messages && Messages.Count > 0)
         {
-            // Fallback for when LandFocusBeforeRemoval could not land, exactly as in delete.
+            // Fallback for when LandFocusBeforeRemoval could not land, exactly as in delete —
+            // including not re-asking for focus when it did land.
             if (landed == null || !Messages.Contains(landed))
             {
                 var landIdx = Math.Max(0, Math.Min(minIdx, Messages.Count - 1));
                 SelectedMessage = Messages[landIdx];
+                MessageListFocusRequested?.Invoke();
             }
-            MessageListFocusRequested?.Invoke();
         }
         else
         {
@@ -7671,8 +7677,12 @@ public partial class MainViewModel : ObservableObject, IDisposable
     /// <para>Raised only by <see cref="LandFocusBeforeRemoval"/>, and only for that purpose: the
     /// focused row must stop being a row that is about to be removed, and "later" is too late for
     /// that. See <see cref="LandFocusBeforeRemoval"/> for why (issue #667).</para>
+    ///
+    /// <para>Returns whether focus actually reached the row, so the caller knows whether it still
+    /// needs the queued request as a fallback — and, just as importantly, knows when it must not
+    /// ask again. (One subscriber, so the multicast return value is that subscriber's.)</para>
     /// </summary>
-    public event Action? MessageListFocusNowRequested;
+    public event Func<bool>? MessageListFocusNowRequested;
     public event EventHandler<(string Text, AnnouncementCategory Category)>? AnnouncementRequested;
     public event EventHandler? RulesManagerRequested;
     public event EventHandler<MailRule>? CreateRuleFromMessageRequested;

--- a/QuickMail/Views/AccessibilityHelper.cs
+++ b/QuickMail/Views/AccessibilityHelper.cs
@@ -104,6 +104,9 @@ internal static class AccessibilityHelper
         AnnouncementCategory.Status        => _statusEnabled,
         AnnouncementCategory.Result        => _resultsEnabled,
         AnnouncementCategory.MessageAction => _messageActionsEnabled,
+        // Never spoken, and deliberately not user-configurable: a Silent status carries nothing
+        // the user does not already have from the UI itself. See the enum for the reasoning.
+        AnnouncementCategory.Silent        => false,
         _                                  => true
     };
 

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -3719,24 +3719,32 @@ public partial class MainWindow : Window
     // the reasoning is in MainViewModel.LandFocusBeforeRemoval). A queued focus move lands after
     // the removal has already happened, which is exactly the case being avoided, so this one
     // realizes the container synchronously and focuses it.
-    private void FocusSelectedMessageRowNow()
+    // Returns whether keyboard focus actually reached the row; false leaves the ViewModel to fall
+    // back to its queued MessageListFocusRequested.
+    private bool FocusSelectedMessageRowNow()
     {
-        // The flat list only. The group trees keep their own selection, and the ViewModel does not
-        // ask for this in those views.
-        if (_vm.ViewMode != ViewMode.Messages) return;
+        // The flat list only, and only when it is the list on screen. ViewMode is orthogonal to
+        // IsCalendarView — that one comes from the selected folder — so ViewMode == Messages alone
+        // does not mean MessageList is visible; ReturnFocusToMessageList tests the same pair.
+        if (_vm.IsCalendarView || _vm.ViewMode != ViewMode.Messages) return false;
 
-        var idx = MessageList.SelectedIndex;
-        if (idx < 0 || idx >= MessageList.Items.Count) return;
+        // From the ViewModel's own selection, not MessageList.SelectedIndex: the caller set
+        // SelectedMessage a statement ago and the two-way binding is what would have to have
+        // propagated for SelectedIndex to be right. Reading the source removes the assumption —
+        // and a stale index here would focus the row that is about to be removed, which is the
+        // whole bug.
+        if (_vm.SelectedMessage is not { } target) return false;
 
-        MessageList.ScrollIntoView(MessageList.Items[idx]);
+        var idx = MessageList.Items.IndexOf(target);
+        if (idx < 0) return false;
+
+        MessageList.ScrollIntoView(target);
         // ScrollIntoView only schedules the panel's measure pass; without this the container for a
         // row that was off screen does not exist yet and there is nothing to focus.
         MessageList.UpdateLayout();
 
-        if (MessageList.ItemContainerGenerator.ContainerFromIndex(idx) is ListViewItem row)
-            row.Focus();
-        // No fallback here on purpose: the caller follows up with MessageListFocusRequested after
-        // the removal, which recovers focus if the container could not be realized.
+        return MessageList.ItemContainerGenerator.ContainerFromIndex(idx) is ListViewItem row
+               && row.Focus();
     }
 
     // Return keyboard focus to the active message panel after reading a message.

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -288,6 +288,7 @@ public partial class MainWindow : Window
         vm.ManageAccountsRequested += OpenAccountManager;
         vm.OpenAccountSettingsRequested += OpenAccountManagerForAccount;
         vm.MessageListFocusRequested += ReturnFocusToMessageList;
+        vm.MessageListFocusNowRequested += FocusSelectedMessageRowNow;
         // Normally the main window is where a VM announcement belongs. _announceTarget redirects it
         // for the duration of a call made on behalf of another window — a UIA notification raised on
         // a background window's peer is not what the user is looking at.
@@ -3708,6 +3709,34 @@ public partial class MainWindow : Window
         _vm.IsMessageOpen = false;
         _vm.MessageDetail = null;
         ReturnFocusToMessageList();
+    }
+
+    // Puts keyboard focus on the selected message row before this method returns, rather than
+    // queueing the move the way ReturnFocusToMessageList does.
+    //
+    // This exists for one caller: the ViewModel is about to remove rows from the list, and focus
+    // has to be off the doomed rows BEFORE they go, or the user hears "unavailable" (issue #667 —
+    // the reasoning is in MainViewModel.LandFocusBeforeRemoval). A queued focus move lands after
+    // the removal has already happened, which is exactly the case being avoided, so this one
+    // realizes the container synchronously and focuses it.
+    private void FocusSelectedMessageRowNow()
+    {
+        // The flat list only. The group trees keep their own selection, and the ViewModel does not
+        // ask for this in those views.
+        if (_vm.ViewMode != ViewMode.Messages) return;
+
+        var idx = MessageList.SelectedIndex;
+        if (idx < 0 || idx >= MessageList.Items.Count) return;
+
+        MessageList.ScrollIntoView(MessageList.Items[idx]);
+        // ScrollIntoView only schedules the panel's measure pass; without this the container for a
+        // row that was off screen does not exist yet and there is nothing to focus.
+        MessageList.UpdateLayout();
+
+        if (MessageList.ItemContainerGenerator.ContainerFromIndex(idx) is ListViewItem row)
+            row.Focus();
+        // No fallback here on purpose: the caller follows up with MessageListFocusRequested after
+        // the removal, which recovers focus if the container could not be realized.
     }
 
     // Return keyboard focus to the active message panel after reading a message.

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -1789,7 +1789,7 @@ Control which categories of announcements QuickMail makes:
 | Announce hints | Instructional tips ("Press Escape to return") |
 | Announce status | Background progress (sync, loading, connection state) |
 | Announce results | Action outcomes (messages moved, addresses saved, flag changes) |
-| Announce delete and archive actions | Delete and archive outcomes ("1 message archived"). Turn off to stop these from interrupting the screen reader as it reads the next message; failures are still announced |
+| Announce delete and archive actions | Delete and archive outcomes that are worth saying: a count when you acted on several at once ("3 messages deleted"), and "Folder is now empty". Deleting or archiving a single message says nothing either way — the row is gone and the next one is read, so there is nothing left to tell you. Failures are always announced |
 | Announce formatting while navigating | Block type announced when caret enters a new paragraph type in HTML compose |
 | Announce spelling errors when typing | Misspellings called out as you type them |
 | Announce spelling errors while navigating | Misspellings called out as you move the cursor through the message |

--- a/docs/release-notes-v0.8.45.md
+++ b/docs/release-notes-v0.8.45.md
@@ -44,6 +44,34 @@ suit and reads **From (grouped by sender)** and **To (grouped by recipient)**.
 
 ---
 
+## Fixed: deleting a message no longer talks over the next one
+
+Pressing Delete on a message could produce a spoken **"unavailable"** before the next message was
+read, and the confirmation that followed could cut that reading off. Two separate faults, both now
+fixed.
+
+The **"unavailable"** came from the order things happened in. The deleted row was taken out of the
+list while it still held keyboard focus, which leaves focus on a row that no longer exists —
+Windows then describes that row as a disabled control, and a screen reader says so. Focus now moves
+to the message you are about to land on *before* the deleted one leaves the list, so there is never
+a moment where the focused row is a row that has gone. Delete and Archive both do this.
+
+The confirmation was the second half. Deleting one message announced **"1 message deleted"** a
+moment after the next message started being read — telling you something you had just been told,
+by interrupting the sentence that told you. **A single delete or archive now says nothing.** The
+row is gone and the next one is read: that is the confirmation.
+
+What still speaks is anything you could not otherwise know: a count when you acted on several at
+once ("3 messages deleted"), "Folder is now empty" when the last one goes, and every failure. All
+of it still appears in the status bar, and `Ctrl+9` reads the status bar on demand.
+
+This is not the announcement setting doing its job — **Settings → Accessibility → Announce delete
+and archive actions** is still on by default and still controls the announcements that remain.
+Nothing to turn off, and nothing to turn back on.
+([#667](https://github.com/kellylford/QuickMail/issues/667))
+
+---
+
 ## Reporting Issues
 
 Found a problem or have a suggestion? There are three ways to reach us — pick the one that fits:


### PR DESCRIPTION
Fixes #667.

Deleting a message spoke **"unavailable"** before the next message was read, and the
"1 message deleted" that followed cut that reading off. Two separate faults; both fixed here.

Diagnosed with a standalone WPF repro (source is in
[the issue](https://github.com/kellylford/QuickMail/issues/667#issuecomment-5574477034)) so the
behaviour could be heard outside QuickMail and compared across screen readers.

## 1. "unavailable" — an ordering bug

The focused row was taken out of `Messages` while it still held keyboard focus, which leaves focus
on a container whose item is gone. WPF exposes a row through an `ItemAutomationPeer` that throws
`ElementNotAvailableException` from `IsEnabledCore()` once its container has gone, and UI
Automation turns a throwing provider into the property's default — `false` for `IsEnabled`. The row
is then described as a disabled control. Nothing in QuickMail was ever disabled; there is no
`IsEnabled = false` anywhere on this path.

`LandFocusBeforeRemoval` moves selection and keyboard focus onto the surviving row **first**, so no
row being removed is ever the focused one. It picks the first survivor after the removed block,
falling back to the last survivor before it — the same row the existing post-removal index
arithmetic picked, so what the user lands on does not change.

The move has to be synchronous, which is why this adds `MessageListFocusNowRequested` alongside the
existing queued `MessageListFocusRequested`. Four sequences were measured against a screen reader
in the repro:

| Strategy | Result |
|----------|--------|
| Remove, then focus from a queued callback (what shipped) | says "unavailable" |
| Remove, then focus immediately | says "unavailable" |
| **Focus the landing row first, then remove** | **silent** |
| Remove-then-queued with virtualization off | says "unavailable" |

The existing queued `MessageListFocusRequested` call is kept after the removal as the recovery path
for when the pre-removal landing could not happen — it is a no-op when focus is already on the row.

## 2. The announcement — saying what the user already has

A single delete or archive now says nothing. The row is gone and the next one has been read, so
speaking "1 message deleted" repeats what the user was told a moment ago, and interrupts the
sentence that told them to do it. `AnnouncementCategory.Silent` puts the text in the status bar
without speech.

Still spoken, because none of it is otherwise available:

- a count when several were acted on — "3 messages deleted"
- "Folder is now empty" (nothing is being read at that point, so nothing is interrupted)
- every failure, which was already `Result` rather than `MessageAction`

`Settings → Accessibility → Announce delete and archive actions` is unchanged and still governs
what remains. `Silent` is deliberately not configurable — it is the statement that a status carries
nothing new, which no preference makes untrue.

## Scope

Delete and archive. Move-to-folder and unwatch-conversation share the removal shape and can produce
the same "unavailable"; they are **not** touched here. Move never lands a selection at all — it
relies on the ListView's own behaviour — so it needs its own design rather than a call to this
helper. Follow-up issue to come.

## Tests

`MessageRemovalFocusTests` — 11 tests. The ordering ones capture the state at the moment
`MessageListFocusNowRequested` fires, because every end-state assertion passes either way: the
selection and the list are identical once the dust settles. Verified they fail against the old
sequence (3 failures) and pass with it.

Full suite: 3559 passed, 0 failed, 3 skipped (the opt-in synthesized-input tests).

## Docs

Release notes for 0.8.45, and the User Guide row for the announcement setting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
