### PR TITLE
Fix #672: reading a message is not the same as having nothing focused

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -343,12 +343,20 @@ Every user-facing keyboard shortcut **must** be registered in `CommandRegistry` 
 ### Rules
 
 - **Register first, hardcode never.** Do not add a raw `if (modifiers == ... && key == ...)` block in `PreviewKeyDown` for a new action. Register the command with `defaultKey` / `defaultModifiers` and let the registry dispatch it.
-- **Five exceptions** are allowed to remain hardcoded (they are framework-level or in-control, not user actions):
+- **Six exceptions** are allowed to remain hardcoded (they are framework-level or in-control, not user actions):
   - `Ctrl+Shift+P` — opens the Command Palette itself (cannot dispatch through the palette)
   - Navigation shortcuts `Ctrl+0–3`, `Ctrl+9`, `Ctrl+Y`, `F6` — focus-only pane jumps with no associated command title
   - The stepping gestures inside `Controls/DateTimeField` (arrows, Shift+arrows, Page keys) — in-field editing keys like the arrow keys inside any `TextBox`, meaningless outside the field. See `docs/KEYBOARD-SHORTCUTS.md`.
   - Left/Right/Home/End on a tab header (`Helpers/TabStripNavigation.cs`, issue #528) — in-control navigation, the same kind as the arrow keys inside a list box, and meaningless outside a tab strip. See `docs/KEYBOARD-SHORTCUTS.md`.
   - Tab/Shift+Tab across the folder picker's tree/buttons boundary (`FolderPickerWindow.HandleTreeTab`) — framework focus navigation with no command title, wired by hand only because WPF's reverse traversal cannot enter a `TreeView` at all (`TreeViewItem` leaves `IsTabStop` false). See `docs/KEYBOARD-SHORTCUTS.md`.
+  - `Shift+F10` and the Applications key at the window level (`MainWindow.OnWindowKeyDown`, the
+    `WM_CONTEXTMENU` hook `OnWmContextMenu`, and the attachment lists in `MainWindow` and
+    `MessageWindow`, which open their own menu via `Helpers/ContextMenuKeys.cs`) —
+    Windows' own context-menu gestures, with no command title. The focus decision behind them is
+    `Helpers/ContextMenuFocusPolicy.cs`, kept a pure function so it can be unit-tested; route any
+    new site through it rather than testing `Keyboard.FocusedElement` directly, which is null both
+    at startup and while the reading pane holds focus (issues #148, #672). See
+    `docs/KEYBOARD-SHORTCUTS.md`.
 - **`InputGestureText` in menus** must match the registered default key, e.g. `InputGestureText="Ctrl+Shift+F"`.
 - **Category** must be one of: `View`, `Mail`, `Account`, `Contacts`, `Calendar`, `Settings`, `Help`. (`Calendar` added 2026-07-17 per the full-calendar spec, resolved question Q4.)
 

--- a/QuickMail.Tests/ContextMenuFocusPolicyTests.cs
+++ b/QuickMail.Tests/ContextMenuFocusPolicyTests.cs
@@ -1,0 +1,225 @@
+using System.IO;
+using System.Text.RegularExpressions;
+using QuickMail.Helpers;
+using Xunit;
+
+using Decision = QuickMail.Helpers.ContextMenuFocusPolicy.Decision;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// Issue #672: Shift+F10 (and the Applications key) while reading a message moved focus out of the
+/// reading pane and back to the message list, with no menu — which reads, to someone using a screen
+/// reader, as the message having closed itself.
+///
+/// <para>
+/// The cause is that <c>Keyboard.FocusedElement</c> is null in two unrelated situations: at startup
+/// before any pane has been focused, and whenever Win32 focus is inside the WebView2's child HWND.
+/// The window-level handlers treated the second as the first and ran a startup focus repair on
+/// someone who was simply reading.
+/// </para>
+///
+/// <para>
+/// The decision is a pure function so it can be tested for real, the same carve-out
+/// <see cref="ContextMenuKeys"/> got for issue #631. These are behavioural tests over every input
+/// combination; the source-text guards below cover only the part that genuinely cannot be reached
+/// without a live window — that the handlers still consult the policy at all.
+/// </para>
+/// </summary>
+public class ContextMenuFocusPolicyTests
+{
+    // attachmentFocus, bodyFocus, messageOpen, hasWpfFocus
+
+    /// <summary>The bug: reading the body must never be mistaken for "nothing is focused".</summary>
+    [Theory]
+    [InlineData(false, true, true, false)]
+    // The same answer with a focused element present: whatever WPF thinks it has, the reader is in
+    // the body and their position is not ours to move.
+    [InlineData(false, true, true, true)]
+    public void ReadingTheBody_LeavesFocusAlone(bool att, bool body, bool open, bool wpf)
+        => Assert.Equal(Decision.LeaveFocusInMessageBody,
+                        ContextMenuFocusPolicy.Decide(att, body, open, wpf));
+
+    /// <summary>
+    /// The startup case the repair exists for (issue #148): nothing focused, nothing open.
+    /// Deleting the repair to fix #672 would trade one bug for another.
+    /// </summary>
+    [Fact]
+    public void NothingFocusedAndNothingOpen_RepairsFocus()
+        => Assert.Equal(Decision.RepairFocus,
+                        ContextMenuFocusPolicy.Decide(false, false, false, false));
+
+    /// <summary>
+    /// The staleness class, and the reason <c>isMessageOpen</c> is a parameter rather than a
+    /// nicety. The flag is only ever cleared by focus landing somewhere else, so a path that closes
+    /// the reading pane without moving focus leaves it set. Acting on it then would suppress the
+    /// repair and strand the user with no focus, no menu and no keyboard way out — worse than the
+    /// bug being fixed. With no message open the flag must not be believed.
+    /// </summary>
+    [Fact]
+    public void StaleBodyFocus_WithNoMessageOpen_StillRepairsFocus()
+        => Assert.Equal(Decision.RepairFocus,
+                        ContextMenuFocusPolicy.Decide(false, true, false, false));
+
+    /// <summary>
+    /// Issue #255: with the folder tree (or any real panel) focused, that panel's own menu must
+    /// open. Redirecting here once replaced the folder menu with the message menu.
+    /// </summary>
+    [Theory]
+    [InlineData(false, false, false, true)]   // a panel focused, no message open
+    [InlineData(false, false, true, true)]    // a panel focused while a message is open in the pane
+    [InlineData(false, true, false, true)]    // stale flag, but a real element holds focus
+    public void APanelHoldingFocus_IsLeftAlone(bool att, bool body, bool open, bool wpf)
+        => Assert.Equal(Decision.LeaveAlone, ContextMenuFocusPolicy.Decide(att, body, open, wpf));
+
+    /// <summary>
+    /// Issue #631/#148: the attachment list is answered first and opens its own menu. It wins over
+    /// every other input — the combinations cannot co-occur in practice, but the ordering must not
+    /// depend on that.
+    /// </summary>
+    [Theory]
+    [InlineData(true, false, false, false)]
+    [InlineData(true, true, true, false)]
+    [InlineData(true, true, true, true)]
+    public void TheAttachmentList_WinsOverEverything(bool att, bool body, bool open, bool wpf)
+        => Assert.Equal(Decision.LeaveAlone, ContextMenuFocusPolicy.Decide(att, body, open, wpf));
+
+    /// <summary>
+    /// A message open in the reading pane but nothing focused — reachable at launch when the last
+    /// session left a message open. Still the startup case, so the repair must run. Without this,
+    /// widening the LeaveAlone condition to include an open message passes every other test here
+    /// while re-breaking issue #148.
+    /// </summary>
+    [Fact]
+    public void AMessageOpenButNothingFocused_StillRepairsFocus()
+        => Assert.Equal(Decision.RepairFocus,
+                        ContextMenuFocusPolicy.Decide(false, false, true, false));
+
+    /// <summary>
+    /// Exhaustive: all 16 inputs are decided, and only the intended two produce
+    /// <see cref="Decision.LeaveFocusInMessageBody"/>. Guards against a future condition that
+    /// widens the suppression — the failure mode here is silence, which nobody reports.
+    /// </summary>
+    [Fact]
+    public void OnlyReadingWithAMessageOpen_EverSuppresses()
+    {
+        for (var i = 0; i < 16; i++)
+        {
+            bool att = (i & 1) != 0, body = (i & 2) != 0, open = (i & 4) != 0, wpf = (i & 8) != 0;
+            var expected = !att && body && open;
+            Assert.Equal(expected,
+                ContextMenuFocusPolicy.Decide(att, body, open, wpf)
+                    == Decision.LeaveFocusInMessageBody);
+        }
+    }
+
+    // ── The window wiring, which no unit test can reach ──────────────────────────────────────────
+
+    /// <summary>
+    /// Both gesture paths must consult the policy. Shift+F10 arrives twice over — once as a key in
+    /// <c>PreviewKeyDown</c>, and again as WM_CONTEXTMENU in the window hook — and the Applications
+    /// key arrives ONLY as WM_CONTEXTMENU, on key up (see <see cref="ContextMenuKeys"/>). Wiring
+    /// one and not the other leaves the unwired path free to move focus, which is how the second
+    /// site was missed the first time.
+    /// </summary>
+    [Theory]
+    [InlineData("if (key == Key.F10 && modifiers == ModifierKeys.Shift)")]
+    [InlineData("if (msg == WM_CONTEXTMENU)")]
+    public void BothGesturePaths_ConsultThePolicy(string blockStart)
+    {
+        var source = MainWindowSource();
+        var start  = source.IndexOf(blockStart, System.StringComparison.Ordinal);
+        Assert.True(start >= 0, $"the block starting \"{blockStart}\" is gone");
+
+        // Bounded to this block: unbounded, the search finds the OTHER site and passes on its
+        // wiring instead of this one's.
+        var end = source.IndexOf("\n        }", start, System.StringComparison.Ordinal);
+        Assert.True(end > start, $"could not find the end of \"{blockStart}\"");
+
+        var block = source[start..end];
+
+        // The argument LIST, in order, with whitespace collapsed so the assertion survives
+        // reformatting but not reordering. Asserting the identifiers separately does not pin
+        // position: swapping the first two arguments leaves every one of them present, and makes
+        // reading the body decide LeaveAlone — issues #148 and #672 restored together. Inverting
+        // the focus test hands a focused folder tree in as "nothing focused", so the repair yanks
+        // focus to the message list: issue #255, also with every identifier still present.
+        var normalised = Regex.Replace(block, @"\s+", " ");
+        Assert.Contains(
+            "ContextMenuFocusPolicy.Decide( ReadingPaneAttachmentList.IsKeyboardFocusWithin, "
+            + "_messageBodyHasFocus, _vm.IsMessageOpen, focused != null)",
+            normalised, System.StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The flag is tracked, not derived — deriving it from <c>Keyboard.FocusedElement</c> at call
+    /// time is the bug itself. <c>handledEventsToo</c> carries the clearing half: focus landing on a
+    /// control that marks the event handled must still reset the flag, and it is exactly the edit
+    /// that leaves every other assertion here green while restoring #672 in full.
+    /// </summary>
+    [Fact]
+    public void MessageBodyFocus_IsTrackedWithHandledEventsToo()
+    {
+        var source = MainWindowSource();
+
+        Assert.Contains("private bool _messageBodyHasFocus;", source, System.StringComparison.Ordinal);
+        Assert.Contains("UIElement.GotKeyboardFocusEvent", source, System.StringComparison.Ordinal);
+        Assert.Contains("_messageBodyHasFocus = ReferenceEquals(e.NewFocus, MessageBody)",
+                        source, System.StringComparison.Ordinal);
+        // Scoped to this AddHandler: searching the whole file passes the moment any other
+        // handler registers with handledEventsToo, which is the failure mode two assertions in
+        // this file already had to be tightened out of.
+        var reg = source[source.IndexOf("AddHandler(UIElement.GotKeyboardFocusEvent",
+                                        System.StringComparison.Ordinal)..];
+        reg = reg[..reg.IndexOf(";", System.StringComparison.Ordinal)];
+        Assert.Contains("handledEventsToo: true", reg, System.StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The hook swallows only the keyboard-raised message. It sits on the top-level HWND, so a
+    /// right-click anywhere in the window arrives there too, and <c>lParam</c> is what tells them
+    /// apart (-1 for the keyboard, screen coordinates for the mouse).
+    /// </summary>
+    [Fact]
+    public void TheHook_SwallowsOnlyTheKeyboardGesture()
+    {
+        var source = MainWindowSource();
+        var start  = source.IndexOf("if (msg == WM_CONTEXTMENU)", System.StringComparison.Ordinal);
+        Assert.True(start >= 0);
+
+        var block = source[start..source.IndexOf("\n        }", start, System.StringComparison.Ordinal)];
+        Assert.Contains("(long)lParam == -1", block, System.StringComparison.Ordinal);
+
+        // The suppression itself must be gated on it. Asserting only that the expression exists
+        // somewhere in the block passes while the swallow ignores it — which is exactly what a
+        // mutation run caught this assertion doing.
+        Assert.Contains("keyboardRaised && decision == ContextMenuFocusPolicy.Decision.LeaveFocusInMessageBody",
+                        block, System.StringComparison.Ordinal);
+
+        // Scoped to the suppression branch itself. The #148 recovery below also sets handled,
+        // so an unscoped assertion matches that one instead and passes while this branch hands
+        // the gesture straight back to DefWindowProc — the Win32 system menu, issue #148 again.
+        // A mutation run caught the unscoped version doing exactly that.
+        var swallow = block[block.IndexOf(
+            "if (keyboardRaised && decision == ContextMenuFocusPolicy.Decision.LeaveFocusInMessageBody)",
+            System.StringComparison.Ordinal)..];
+        swallow = swallow[..swallow.IndexOf("\n            }", System.StringComparison.Ordinal)];
+
+        Assert.Contains("handled = true;",      swallow, System.StringComparison.Ordinal);
+        Assert.Contains("return IntPtr.Zero;",  swallow, System.StringComparison.Ordinal);
+    }
+
+    private static string MainWindowSource() =>
+        File.ReadAllText(Path.Combine(RepoRoot(), "QuickMail", "Views", "MainWindow.xaml.cs"));
+
+    private static string RepoRoot()
+    {
+        // AppContext.BaseDirectory rather than the current directory: runner-independent.
+        var dir = new DirectoryInfo(System.AppContext.BaseDirectory);
+        while (dir is not null && !Directory.Exists(Path.Combine(dir.FullName, "QuickMail", "Views")))
+            dir = dir.Parent;
+
+        Assert.NotNull(dir);
+        return dir!.FullName;
+    }
+}

--- a/QuickMail/Helpers/ContextMenuFocusPolicy.cs
+++ b/QuickMail/Helpers/ContextMenuFocusPolicy.cs
@@ -1,0 +1,80 @@
+namespace QuickMail.Helpers;
+
+/// <summary>
+/// Decides what the window-level context-menu gesture handlers should do about focus (issue #672).
+///
+/// <para>
+/// <c>Keyboard.FocusedElement</c> being null means two unrelated things, and telling them apart is
+/// the whole problem. It is null at startup, before any pane has been focused — the case
+/// <see cref="Decision.RepairFocus"/> exists for (issue #148). It is <em>also</em> null whenever
+/// Win32 focus sits inside the reading pane's WebView2, because focus has left the WPF tree
+/// entirely for a child HWND. Treating the second as the first ran the startup repair on someone
+/// who was simply reading, moving focus to the message list — the reported symptom, which reads as
+/// the message having closed itself.
+/// </para>
+///
+/// <para>
+/// Carved out as a pure function for the same reason <see cref="ContextMenuKeys"/> was (issue
+/// #631): the real path needs a WebView2 holding Win32 focus and a live window message, which no
+/// unit test can stand up, while the decision itself is three booleans and is worth pinning
+/// exactly. The handlers keep the parts that genuinely need a window — reading the focus state,
+/// and acting on the answer.
+/// </para>
+/// </summary>
+public static class ContextMenuFocusPolicy
+{
+    /// <summary>What a window-level context-menu gesture handler should do.</summary>
+    public enum Decision
+    {
+        /// <summary>
+        /// Do nothing and let the gesture take its ordinary course. The attachment list's own
+        /// <c>ContextMenu</c> opens this way, and so does every pane that already holds real WPF
+        /// focus — routing <c>ContextMenuOpening</c> from the focused element (issue #255: the
+        /// folder tree must keep its own menu rather than be handed the message menu).
+        /// </summary>
+        LeaveAlone,
+
+        /// <summary>
+        /// The user is reading the message body. Do not move focus. For the WM_CONTEXTMENU hook
+        /// this also means swallowing the message: with no WPF focus, <c>DefWindowProc</c> would
+        /// answer with the Win32 system menu (issue #148's symptom).
+        /// </summary>
+        LeaveFocusInMessageBody,
+
+        /// <summary>
+        /// Nothing holds focus and no message is open — genuinely the startup case. Park focus on
+        /// the active panel so <c>ContextMenuOpening</c> has an element to route from.
+        /// </summary>
+        RepairFocus,
+    }
+
+    /// <param name="attachmentListHasFocus">
+    /// The reading pane's attachment list holds focus. It opens its own menu and needs no help,
+    /// so it is answered first — before the message-body test, which cannot be true at the same
+    /// time but must not be relied on for that.
+    /// </param>
+    /// <param name="messageBodyHasFocus">
+    /// The reading pane's WebView2 last received keyboard focus. Tracked by the window rather than
+    /// derived at call time, because the focus state this describes is exactly the one WPF reports
+    /// as "nothing is focused".
+    /// </param>
+    /// <param name="isMessageOpen">
+    /// A message is open in the reading pane. Required alongside
+    /// <paramref name="messageBodyHasFocus"/>: the flag is only ever cleared by focus landing
+    /// somewhere else, so a path that closes the reading pane without moving focus leaves it
+    /// stale-true. Acting on a stale flag would suppress <see cref="Decision.RepairFocus"/> and
+    /// strand the user with no focus, no menu and no keyboard way out — worse than the bug this
+    /// policy exists to fix. A stale flag cannot outlive the open message, so the pairing removes
+    /// the whole class.
+    /// </param>
+    /// <param name="hasWpfFocus">
+    /// WPF reports a focused element (<c>Keyboard.FocusedElement != null</c>).
+    /// </param>
+    public static Decision Decide(bool attachmentListHasFocus, bool messageBodyHasFocus,
+                                  bool isMessageOpen, bool hasWpfFocus)
+    {
+        if (attachmentListHasFocus)               return Decision.LeaveAlone;
+        if (messageBodyHasFocus && isMessageOpen) return Decision.LeaveFocusInMessageBody;
+        return hasWpfFocus ? Decision.LeaveAlone : Decision.RepairFocus;
+    }
+}

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -117,6 +117,12 @@ public partial class MainWindow : Window
     // duration of a synchronous call made on another window's behalf. See AnnouncementRequested.
     private UIElement? _announceTarget;
     private bool _webViewReady;
+
+    // True while the reading pane's message body owns keyboard focus. Tracked rather than derived
+    // from Keyboard.FocusedElement, which is null BOTH at startup before any pane has been focused
+    // AND whenever Win32 focus sits inside the WebView2's child HWND — the two states this has to
+    // tell apart (issue #672).
+    private bool _messageBodyHasFocus;
     private CoreWebView2Environment? _webViewEnvironment;
     private readonly TypeAheadPrefixTracker _typeAhead = new();
     private int _messageBodyRenderVersion;
@@ -259,6 +265,14 @@ public partial class MainWindow : Window
         _connectivity     = connectivity;
         InitializeComponent();
         DataContext = vm;
+
+        // Focus moving to the message body, or away from it, is recorded in one place, so no pane
+        // handler has to remember to clear it. handledEventsToo is needed for the CLEARING half:
+        // focus landing on a control that marks the event handled must still reset the flag, and a
+        // flag left set while another pane holds focus is the staleness the guards below reject.
+        AddHandler(UIElement.GotKeyboardFocusEvent, new KeyboardFocusChangedEventHandler(
+            (_, e) => _messageBodyHasFocus = ReferenceEquals(e.NewFocus, MessageBody)),
+            handledEventsToo: true);
 
         if (_themeService != null)
         {
@@ -1544,7 +1558,33 @@ public partial class MainWindow : Window
             LogService.Debug($"[ATTLOG] WM_CONTEXTMENU: FocusedElement={focused?.GetType().Name ?? "null"}, " +
                            $"AttachListFocusWithin={ReadingPaneAttachmentList.IsKeyboardFocusWithin}, " +
                            $"AttachListFocused={ReferenceEquals(focused, ReadingPaneAttachmentList)}");
-            if (focused == null)
+
+            // lParam is -1 for a keyboard-raised menu, screen coordinates for a mouse one. This
+            // hook is on the top-level HWND, so a right-click anywhere in the window arrives here
+            // too, and only the keyboard gesture is ours to answer.
+            var keyboardRaised = (long)lParam == -1;
+
+            var decision = ContextMenuFocusPolicy.Decide(
+                ReadingPaneAttachmentList.IsKeyboardFocusWithin,
+                _messageBodyHasFocus, _vm.IsMessageOpen, focused != null);
+
+            // Belt and braces, not the operative fix for #672. In practice this hook does not see
+            // the gesture while the body has focus at all: WM_CONTEXTMENU goes to the WebView2's
+            // own child HWND and stops there — /debug logs across several sessions show no firing
+            // here for a Shift+F10 pressed while reading. The guard covers the case where it does
+            // arrive, since with no WPF focus DefWindowProc answers with the Win32 system menu
+            // (issue #148). Only the keyboard gesture is suppressed, and the repair below still
+            // answers everything else that reaches it. One behaviour does change: a right-click
+            // inside the body while reading used to run the repair and pull keyboard focus out of
+            // the message. It no longer does, which is the better answer — WPF routes a mouse
+            // context menu from the hit-test target, not from Keyboard.FocusedElement.
+            if (keyboardRaised && decision == ContextMenuFocusPolicy.Decision.LeaveFocusInMessageBody)
+            {
+                handled = true;
+                return IntPtr.Zero;
+            }
+
+            if (decision == ContextMenuFocusPolicy.Decision.RepairFocus)
             {
                 FocusPanelSynchronously();
 
@@ -1694,23 +1734,46 @@ public partial class MainWindow : Window
             var focused = Keyboard.FocusedElement;
             LogService.Debug($"[ATTLOG] OnWindowKeyDown Shift+F10: FocusedElement={focused?.GetType().Name ?? "null"}, " +
                            $"AttachListFocusWithin={ReadingPaneAttachmentList.IsKeyboardFocusWithin}");
-            // If focus is in the attachment list, leave it — its ContextMenu opens
-            // correctly via WM_CONTEXTMENU without needing a focus redirect.
+            // Unchanged: the attachment list opens its ContextMenu correctly via WM_CONTEXTMENU
+            // and needs no focus redirect.
             if (ReadingPaneAttachmentList.IsKeyboardFocusWithin)
                 return;
 
-            // Only supply a focus target when WPF has NONE (e.g. WebView2 stole Win32 focus at
-            // startup, leaving FocusedElement null). If focus is already in a real panel — the
-            // folder tree, the account list, a message panel — leave it so that panel's own
-            // context menu opens. Redirecting on any non-message focus wrongly replaced the folder
-            // tree's FolderContextMenu with the message menu (#255 follow-up: Shift+F10 on the
-            // folder list showed Reply/Reply All instead of New/Move/Delete Folder).
-            if (focused == null)
+            switch (ContextMenuFocusPolicy.Decide(
+                        ReadingPaneAttachmentList.IsKeyboardFocusWithin,
+                        _messageBodyHasFocus, _vm.IsMessageOpen, focused != null))
             {
-                if (_vm.IsConversationsView)      ConversationTree.Focus();
-                else if (_vm.IsFromView)           SenderGroupTree.Focus();
-                else if (_vm.IsToView)             ToGroupTree.Focus();
-                else if (_vm.IsMessagesView)       MessageList.Focus();
+                // Reading the message body is NOT "no focus" (issue #672). This repair fired while
+                // the user was simply reading and moved focus to the message list — the whole bug.
+                // It never marks the event handled (see the note below), so nothing here consumed
+                // the gesture: with focus inside the WebView2's child HWND the WM_CONTEXTMENU goes
+                // to Chromium, which drops it because its own menus are off. Net effect while
+                // reading is that the gesture does nothing, which is the intended outcome until the
+                // body has a menu of its own (#671).
+                // break, not return: skipping the repair is the whole point, but the rest of this
+                // handler must still run. Nothing binds Shift+F10 by default, so returning here
+                // looked equivalent — except to someone who has remapped it in keyboard
+                // customizations, whose command would then silently do nothing while reading.
+                case ContextMenuFocusPolicy.Decision.LeaveFocusInMessageBody:
+                    break;
+
+                // Nothing holds focus and no message is open: the startup case this repair exists
+                // for. Give ContextMenuOpening a real element to route from.
+                case ContextMenuFocusPolicy.Decision.RepairFocus:
+                    if (_vm.IsConversationsView)      ConversationTree.Focus();
+                    else if (_vm.IsFromView)           SenderGroupTree.Focus();
+                    else if (_vm.IsToView)             ToGroupTree.Focus();
+                    else if (_vm.IsMessagesView)       MessageList.Focus();
+                    break;
+
+                // Focus is already in a real panel — the folder tree, the account list, a message
+                // panel — so that panel's own menu opens. Redirecting on any non-message focus
+                // wrongly replaced the folder tree's FolderContextMenu with the message menu
+                // (#255 follow-up: Shift+F10 on the folder list showed Reply/Reply All instead of
+                // New/Move/Delete Folder). Falls through to the rest of the handler exactly as
+                // before, so a user-remapped binding on this gesture still dispatches.
+                case ContextMenuFocusPolicy.Decision.LeaveAlone:
+                    break;
             }
             // Do not mark e.Handled — WM_CONTEXTMENU must still fire so ContextMenuOpening
             // reaches the tree/list handler and opens the QuickMail context menu.

--- a/docs/KEYBOARD-SHORTCUTS.md
+++ b/docs/KEYBOARD-SHORTCUTS.md
@@ -236,3 +236,37 @@ commands, and they carry no command title to show in the palette. Any other modi
 — `Ctrl+Tab` and friends fall straight through. The flat list presentation ("Go to Folder") is not
 touched by any of this: `ListBoxItem` is a tab stop, so it traverses correctly both ways on its
 own. Covered by `FolderPickerTabOrderTests`.
+
+## Context-menu gestures: Shift+F10 and the Applications key
+
+Neither is registered in `CommandRegistry`. They are Windows' own context-menu gestures, carry no
+command title, and mean nothing outside the control they are pressed on — the same category as the
+in-control keys above. What follows is where they are handled and why, because three separate
+pieces of code answer them and the reasons are not guessable from any one of them.
+
+They do not reach an application the same way. `DefWindowProc` turns Shift+F10 into
+`WM_CONTEXTMENU` while processing the key **down**; the Applications key becomes `WM_CONTEXTMENU`
+only on the key **up**. `Helpers/ContextMenuKeys.cs` carries the full account (issue #631) — it is
+why the attachment lists open their own menu for Shift+F10 and deliberately leave the Applications
+key to Windows.
+
+`MainWindow` answers both at the window level, in `OnWindowKeyDown` (Shift+F10 only) and in the
+`WM_CONTEXTMENU` hook `OnWmContextMenu` (both keys). Each consults
+`Helpers/ContextMenuFocusPolicy.cs`, which exists because `Keyboard.FocusedElement` being null
+means two unrelated things:
+
+- **Nothing has been focused yet**, at startup. The panel is focused synchronously so
+  `ContextMenuOpening` has an element to route from; without it the Win32 system menu
+  (Move/Size/Close) appears instead of QuickMail's (issue #148).
+- **Focus is inside the reading pane's WebView2**, a child HWND outside the WPF tree. Treating this
+  as the first ran the startup repair on someone who was simply reading and moved focus to the
+  message list (issue #672).
+
+So while a message is being read, both gestures are left alone and the `WM_CONTEXTMENU` is
+swallowed — the message body has no context menu of its own yet, and falling through would answer
+with the Win32 system menu. The swallow is scoped to the keyboard gesture (`lParam == -1`); the
+hook is on the top-level window, so a right-click anywhere in it arrives there too.
+
+The policy is a pure function so the decision can be unit-tested, the same carve-out
+`ContextMenuKeys` got: `ContextMenuFocusPolicyTests` covers all sixteen input combinations, since
+the failure mode at stake is silence and nobody reports silence.

--- a/docs/release-notes-v0.8.45.md
+++ b/docs/release-notes-v0.8.45.md
@@ -72,6 +72,29 @@ Nothing to turn off, and nothing to turn back on.
 
 ---
 
+## Fixed: Shift+F10 while reading no longer throws you back to the message list
+
+Pressing **Shift+F10** with focus in the message body moved focus out of the message and back to
+the message list. Nothing had closed, but there was no way to tell that from the outside: you were
+reading, and then you were on the list.
+
+Windows reports "no element has focus" in two unrelated situations — at startup, before any pane
+has been focused, and whenever focus is inside the message body, which sits in a separate window of
+its own underneath. QuickMail had a piece of startup repair that read the second as the first, and
+moved focus to the message list to correct a problem that was not happening.
+
+Reading a message is now told apart from having nothing focused, so focus stays where you are
+reading. To be plain about what this does and does not do: **the message body still has no context
+menu of its own, so the key now does nothing there** rather than doing the wrong thing. A menu for
+links inside a message is a separate piece of work, tracked as
+[#671](https://github.com/kellylford/QuickMail/issues/671).
+
+Shift+F10 and the Applications key on the message list, the folder tree, and the attachment list
+are unaffected and open the same menus as before, including on the first press after launch.
+([#672](https://github.com/kellylford/QuickMail/issues/672))
+
+---
+
 ## Reporting Issues
 
 Found a problem or have a suggestion? There are three ways to reach us — pick the one that fits:


### PR DESCRIPTION
Pressing **Shift+F10** with focus in the reading pane's message body moved focus out of the message
and back to the message list. Nothing had closed, but there was no way to tell that from the
outside — you were reading, and then you were on the list.

## Cause

`Keyboard.FocusedElement` is null in two unrelated situations:

- at startup, before any pane has been focused — the case the focus repair exists for (#148);
- whenever Win32 focus is inside the WebView2's child HWND, because focus has left the WPF tree.

Both `OnWindowKeyDown` and the `WM_CONTEXTMENU` hook `OnWmContextMenu` tested only for null, so the
startup repair ran on someone who was simply reading.

## Fix

The decision moves into `Helpers/ContextMenuFocusPolicy.cs` as a pure function, carved out for the
same reason `ContextMenuKeys` was in #631 — the real path needs a WebView2 holding Win32 focus and a
live window message, which no unit test can stand up, while the decision itself is three booleans
worth pinning exactly:

```csharp
if (attachmentListHasFocus)               return Decision.LeaveAlone;
if (messageBodyHasFocus && isMessageOpen) return Decision.LeaveFocusInMessageBody;
return hasWpfFocus ? Decision.LeaveAlone : Decision.RepairFocus;
```

`_messageBodyHasFocus` is tracked from a single window-level `GotKeyboardFocus` handler, so focus
landing anywhere else clears it. It is paired with `IsMessageOpen` everywhere it is read: the flag is
only cleared by a focus move, so a path that closes the reading pane without moving focus leaves it
stale-true, and acting on that would suppress the #148 recovery and strand the user with no focus, no
menu and no keyboard way out — worse than the bug being fixed.

The `WM_CONTEXTMENU` suppression is scoped to the keyboard gesture (`lParam == -1`); that hook is on
the top-level HWND, so a right-click anywhere in the window arrives there too.

## Behaviour elsewhere is unchanged

The message list, folder tree and attachment list open the same menus, including on the first press
after launch. A focused panel still falls through to the rest of the handler, so a user-remapped
binding on this gesture still dispatches.

## Verification

Hand-tested in the reading pane, in a message window, and on the message list and folder tree, on
Windows 11 ARM64.

`ContextMenuFocusPolicyTests` covers all sixteen policy inputs. The remaining source-text assertions
were mutation-tested rather than trusted — five deliberate breakages, each caught, including an
argument swap that would restore #148 and #672 together while leaving every other assertion green.
Two assertions had to be tightened after surviving their mutation.

## Three things worth knowing, rather than buried

- **The Applications key is not claimed as fixed.** An earlier draft said it was. `/debug` logs show
  `OnWmContextMenu` never fires during a reading-pane Shift+F10 — `WM_CONTEXTMENU` goes to the
  WebView2's own child HWND and stops there — so the Apps key most likely never had this symptom in
  the reading pane. The hook guard is deliberately kept as defence-in-depth for the case where the
  message does arrive, and is commented as such.
- **Entering the body with a *mouse* is unverified.** If clicking into the WebView2 does not raise
  WPF `GotKeyboardFocus`, the flag stays false and #672 still reproduces on that path. That is an
  incompletely-fixed case rather than a regression — the path was broken before this change too —
  but it needs a live check with a mouse.
- **`MessageWindow` is deliberately untouched.** It has no `WM_CONTEXTMENU` hook and no window-level
  focus repair, so the symptom cannot occur there. Confirmed by hand in Window mode: nothing happens,
  and no Win32 system menu appears.

## Follow-up filed, not fixed here

#673 — `GetFocusedPaneIndex()` cannot see the message body for the same underlying reason, so F6 out
of the reading pane cycles from the wrong pane. Left out to keep this to one logical change; the new
flag makes it a one-line fix.

The message body still has no context menu of its own, so the gesture now does nothing there rather
than doing the wrong thing. A menu for links is #671, which is blocked on this and comes next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
