### PR TITLE
Fix #673: recognise the reading pane as the pane that has focus

### DIFF
--- a/QuickMail.Tests/ContextMenuFocusPolicyTests.cs
+++ b/QuickMail.Tests/ContextMenuFocusPolicyTests.cs
@@ -209,6 +209,37 @@ public class ContextMenuFocusPolicyTests
         Assert.Contains("return IntPtr.Zero;",  swallow, System.StringComparison.Ordinal);
     }
 
+    /// <summary>
+    /// Issue #673: F6 out of the message body cycled from the wrong pane, and focus was not
+    /// restored to the reading pane after a view-mode change, because both sites asked
+    /// <c>MessageBody.IsKeyboardFocusWithin</c> — false in exactly the state they were asking
+    /// about, since Win32 focus is inside the WebView2's child HWND and WPF has no focused element.
+    ///
+    /// Both now go through one predicate. They asked the same wrong question in two places and were
+    /// fixed in neither for months; a shared predicate is what stops them drifting apart again.
+    /// </summary>
+    [Fact]
+    public void TheReadingPaneIsRecognisedAsFocused_AtEverySiteThatAsks()
+    {
+        var source = MainWindowSource();
+
+        Assert.Contains("private bool IsMessageBodyFocused =>", source, System.StringComparison.Ordinal);
+        Assert.Contains("_messageBodyHasFocus && _vm.IsMessageOpen", source,
+                        System.StringComparison.Ordinal);
+
+        // Neither site may go back to asking the property on its own.
+        var pane = source[source.IndexOf("private int GetFocusedPaneIndex", System.StringComparison.Ordinal)..];
+        pane = pane[..pane.IndexOf("\n    }", System.StringComparison.Ordinal)];
+        Assert.Contains("IsMessageBodyFocused", pane, System.StringComparison.Ordinal);
+        Assert.DoesNotContain("MessageBody.IsKeyboardFocusWithin", pane, System.StringComparison.Ordinal);
+
+        var restore = source[source.IndexOf("ShouldRestoreMessagePanelFocusAfterViewModeChange() =>",
+                                            System.StringComparison.Ordinal)..];
+        restore = restore[..restore.IndexOf(");", System.StringComparison.Ordinal)];
+        Assert.Contains("IsMessageBodyFocused", restore, System.StringComparison.Ordinal);
+        Assert.DoesNotContain("MessageBody.IsKeyboardFocusWithin", restore, System.StringComparison.Ordinal);
+    }
+
     private static string MainWindowSource() =>
         File.ReadAllText(Path.Combine(RepoRoot(), "QuickMail", "Views", "MainWindow.xaml.cs"));
 

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -4015,7 +4015,7 @@ public partial class MainWindow : Window
         ConversationTree.IsKeyboardFocusWithin ||
         SenderGroupTree.IsKeyboardFocusWithin ||
         ToGroupTree.IsKeyboardFocusWithin ||
-        MessageBody.IsKeyboardFocusWithin ||
+        IsMessageBodyFocused ||
         ViewModeButton.IsKeyboardFocusWithin);
 
     // Focuses the first status bar region and announces it to screen readers.
@@ -4279,6 +4279,27 @@ public partial class MainWindow : Window
     //   3 = Message list / Conversation tree, 4 = Reading pane (WebView2),
     //   5 = Status bar.
     // Falls back to 0 if no match.
+    /// <summary>
+    /// Whether the reading pane's message body holds focus.
+    ///
+    /// <para>
+    /// <c>MessageBody.IsKeyboardFocusWithin</c> alone is not enough, and is false in exactly the
+    /// state it is being asked about: it is derived from the focused element's ancestor chain, and
+    /// while the document holds focus there is no WPF focused element at all — Win32 focus has
+    /// moved into the WebView2's child HWND. So the tracked flag answers the common case and the
+    /// property covers the moment focus is on the host element itself, before it reaches the
+    /// document (issue #673, the same root confusion as #672).
+    /// </para>
+    ///
+    /// <para>
+    /// Paired with <c>IsMessageOpen</c> for the reason the context-menu guards are: the flag is
+    /// cleared only by focus landing on another element, so a path that closes the pane without
+    /// moving focus would leave it standing. A stale flag cannot outlive the open message.
+    /// </para>
+    /// </summary>
+    private bool IsMessageBodyFocused =>
+        MessageBody.IsKeyboardFocusWithin || (_messageBodyHasFocus && _vm.IsMessageOpen);
+
     private int GetFocusedPaneIndex()
     {
         if (MainToolbar.IsKeyboardFocusWithin)  return 0;
@@ -4287,7 +4308,7 @@ public partial class MainWindow : Window
         if (SearchBox.IsKeyboardFocusWithin)    return 6;
         if (MessageList.IsKeyboardFocusWithin || ConversationTree.IsKeyboardFocusWithin || SenderGroupTree.IsKeyboardFocusWithin || ToGroupTree.IsKeyboardFocusWithin || CalendarList.IsKeyboardFocusWithin || MonthGrid.IsKeyboardFocusWithin || CalendarDetails.IsKeyboardFocusWithin || CalendarSearchBox.IsKeyboardFocusWithin) return 3;
         if (TabStrip.IsKeyboardFocusWithin)     return 7; // between message list and reading pane
-        if (MessageBody.IsKeyboardFocusWithin)  return 4;
+        if (IsMessageBodyFocused)               return 4;
         if (MainStatusBar.IsKeyboardFocusWithin) return 5;
         return 0;
     }

--- a/docs/release-notes-v0.8.45.md
+++ b/docs/release-notes-v0.8.45.md
@@ -129,6 +129,22 @@ internal to QuickMail; on ordinary body text the key does nothing, as before.
 
 ---
 
+## Fixed: F6 out of an open message goes to the next pane
+
+Pressing **F6** while reading a message skipped ahead: instead of moving to the pane after the
+reading pane, it carried on from the toolbar and landed on the account list. Coming back the other
+way, focus was not returned to the message after changing the view mode.
+
+Windows reports no focused element while the message body has focus — the message is drawn by a
+separate component with its own window, so the focus QuickMail can see has moved outside its own
+controls. Two pieces of code asked the question in a way that could not be true at the time they
+asked it, so the reading pane was never recognised as the pane you were in.
+
+Both now use the same test, and it is one that works while you are reading.
+([#673](https://github.com/kellylford/QuickMail/issues/673))
+
+---
+
 ## Reporting Issues
 
 Found a problem or have a suggestion? There are three ways to reach us — pick the one that fits:


### PR DESCRIPTION
**F6** out of an open message skipped ahead: instead of the pane after the reading pane it carried on
from the toolbar and landed on the account list. Coming back the other way, focus was not returned to
the message panel after a view-mode change.

## Cause

Both sites asked `MessageBody.IsKeyboardFocusWithin` — which is false in exactly the state they were
asking about. That property is derived from the focused element's ancestor chain, and while the
document holds focus there is no WPF focused element at all: Win32 focus has moved into the WebView2's
child HWND. `GetFocusedPaneIndex()` therefore fell through to `0`, and F6 cycled onward from the
toolbar.

Same root confusion as #672, in two more places.

## Fix

One predicate, used by both:

```csharp
private bool IsMessageBodyFocused =>
    MessageBody.IsKeyboardFocusWithin || (_messageBodyHasFocus && _vm.IsMessageOpen);
```

`_messageBodyHasFocus` is the flag #672 already tracks from the window-level `GotKeyboardFocus` event,
which is correct in the state the property cannot see. The property is kept for the moment focus is on
the host element itself, before it reaches the document. `IsMessageOpen` is paired with the flag for
the reason the context-menu guards do it: the flag is cleared only by focus landing on another
element, so a path that closes the pane without moving focus would leave it standing — and a stale
flag cannot outlive the open message.

A shared predicate rather than the same one-line change written out twice. The two sites asked the
same wrong question independently and stayed wrong in both; the test asserts neither can go back to
asking the property on its own, and it was mutation-checked — reverting either site fails it.

## Verification

**F6 is verified by hand.** From an open message it now moves to the status bar, which is what the
ring puts after the reading pane (`CycleFocusAsync` appends `5` last and always includes it).

**The view-mode half is not verified by hand, and I would rather say so than imply otherwise.** It is
the same predicate applied consistently, but exercising it needs the view mode to change while focus
is inside the body, and that turns out not to be reachable by keyboard: the reading pane does not
relay `Ctrl+Shift+P` out of the document, so the command palette cannot be opened from there. Found
while testing this, filed as #676.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
