### PR TITLE
Harden the message-body sanitizer and CSP placement

### DIFF
--- a/QuickMail.Tests/MessageBodyHtmlBuilderTests.cs
+++ b/QuickMail.Tests/MessageBodyHtmlBuilderTests.cs
@@ -317,4 +317,109 @@ public class MessageBodyHtmlBuilderTests
         Assert.DoesNotContain("_blank", html);
         Assert.Contains("https://example.com/reset", html);
     }
+
+    // ---------------------------------------------------------------------------------------
+    // Script execution from a crafted message (reported privately 2026-09-09).
+    //
+    // Two independent gaps combined into arbitrary script in the reading pane from a message the
+    // user only had to open: the CSP was spliced in at the first literal "<head>" ANYWHERE in the
+    // sender's markup, so a sender who wrote that string mid-paragraph got the policy emitted into
+    // body content where a browser ignores it; and the sanitizer's end-tag patterns required a
+    // literal "</script>", while the tokenizer also closes the element at "</script >".
+    //
+    // These assert the invariants, not the two shapes of the original proof of concept: the CSP is
+    // a child of the real head no matter what the sender writes, and an end tag is recognised in
+    // every form the tokenizer recognises it.
+    // ---------------------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("</script>")]
+    [InlineData("</script >")]
+    [InlineData("</script\t>")]
+    [InlineData("</script/>")]
+    [InlineData("</script foo=\"bar\">")]
+    [InlineData("</SCRIPT >")]
+    public void BuildSanitizedDocument_ScriptClosedAnyTokenizerWay_IsStripped(string endTag)
+    {
+        var body = "<p>Hello.</p><script>window.__pwned=1;" + endTag;
+
+        Assert.True(MessageBodyHtmlBuilder.TryBuildSanitizedHtmlDocument("Subj", body, out var doc));
+
+        Assert.DoesNotContain("__pwned", doc, System.StringComparison.Ordinal);
+        Assert.Contains("Hello.", doc, System.StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("</style>")]
+    [InlineData("</style >")]
+    [InlineData("</style/>")]
+    public void BuildSanitizedDocument_StyleClosedAnyTokenizerWay_IsStripped(string endTag)
+    {
+        // A surviving sender stylesheet is not merely a rendering problem: [aria-live]{display:none}
+        // or content-visibility:hidden takes the in-document status regions (#329, #671) out of the
+        // accessibility tree, and a status region that announces nothing reads as success.
+        var body = "<p>Hello.</p><style>[aria-live]{content-visibility:hidden !important}" + endTag;
+
+        Assert.True(MessageBodyHtmlBuilder.TryBuildSanitizedHtmlDocument("Subj", body, out var doc));
+
+        Assert.DoesNotContain("aria-live]", doc, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BuildSanitizedDocument_EndTagOfLongerName_IsNotTreatedAsMatch()
+    {
+        // "</scriptable>" closes a different element; accepting it would silently eat real content.
+        const string body = "<p>Hi.</p><scriptable>keep me</scriptable>";
+
+        Assert.True(MessageBodyHtmlBuilder.TryBuildSanitizedHtmlDocument("Subj", body, out var doc));
+
+        Assert.Contains("keep me", doc, System.StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("<p>Hello.</p><head><script>window.__pwned=1;</script >")]
+    [InlineData("<p>Hello.</p><HEAD>")]
+    [InlineData("<html><head><title>Sender title</title></head><body><p>Hello.</p></body></html>")]
+    public void BuildSanitizedDocument_WhateverTheSenderWrites_CspIsInsideTheRealHead(string body)
+    {
+        Assert.True(MessageBodyHtmlBuilder.TryBuildSanitizedHtmlDocument("Subj", body, out var doc));
+
+        // A meta CSP is a policy only as a child of the document's own head. Asserting the document
+        // merely CONTAINS the meta is what let the original bug through: it was present every time,
+        // and inert whenever a sender supplied the string "<head>".
+        var headStart = doc.IndexOf("<head>", System.StringComparison.Ordinal);
+        var headEnd   = doc.IndexOf("</head>", System.StringComparison.Ordinal);
+        var cspIdx    = doc.IndexOf("Content-Security-Policy", System.StringComparison.Ordinal);
+
+        Assert.StartsWith("<!DOCTYPE html><html lang=\"en\"><head>", doc, System.StringComparison.Ordinal);
+        Assert.InRange(cspIdx, headStart, headEnd);
+        Assert.Contains("Hello.", doc, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BuildSanitizedDocument_SenderStructuralTags_DoNotReachTheDocumentsOwnElements()
+    {
+        // A stray <body> start tag in body content is ignored by the parser, but its ATTRIBUTES are
+        // merged onto the real body element.
+        const string body = "<p>Hi.</p><body class=\"sender\" data-evil=\"1\">more";
+
+        Assert.True(MessageBodyHtmlBuilder.TryBuildSanitizedHtmlDocument("Subj", body, out var doc));
+
+        Assert.DoesNotContain("data-evil", doc, System.StringComparison.Ordinal);
+        Assert.Contains("<body tabindex=\"0\">", doc, System.StringComparison.Ordinal);
+        Assert.Contains("more", doc, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BuildSanitizedDocument_SenderTitle_DoesNotBecomeTheDocumentTitle()
+    {
+        // <title> in body content is handled by the parser's in-head rules, so a sender one would
+        // set document.title over the message's own subject.
+        const string body = "<p>Hi.</p><title>Sender title</title>";
+
+        Assert.True(MessageBodyHtmlBuilder.TryBuildSanitizedHtmlDocument("Subj", body, out var doc));
+
+        Assert.DoesNotContain("Sender title", doc, System.StringComparison.Ordinal);
+        Assert.Contains("<title>Subj</title>", doc, System.StringComparison.Ordinal);
+    }
 }

--- a/QuickMail/Helpers/EventCardHtmlBuilder.cs
+++ b/QuickMail/Helpers/EventCardHtmlBuilder.cs
@@ -115,8 +115,16 @@ public static class EventCardHtmlBuilder
             // Live status region for RSVP feedback (issue #329), updated in place via
             // ExecuteScriptAsync so the result is announced from inside the document — a host-window
             // notification is dropped while focus is in the WebView2. Empty until the user responds.
+            // The visibility declarations are !important for the same reason the link menu's status
+            // region pins its own: this card is injected after sanitization, so the sender cannot
+            // remove it — but a sender stylesheet reaching [aria-live] could hide it, and a hidden
+            // live region announces nothing. Losing the RSVP result silently is worse than any
+            // rendering the sender could otherwise ruin, because it is indistinguishable from the
+            // response having been sent.
             sb.Append("<div id=\"qm-invite-status\" aria-live=\"assertive\" aria-atomic=\"true\" " +
-                      "style=\"margin-top:8px;font-weight:600;\"></div>");
+                      "style=\"margin-top:8px;font-weight:600;" +
+                      "display:block !important;visibility:visible !important;" +
+                      "content-visibility:visible !important;\"></div>");
         }
 
         sb.Append("</div>");

--- a/QuickMail/Helpers/MessageBodyHtmlBuilder.cs
+++ b/QuickMail/Helpers/MessageBodyHtmlBuilder.cs
@@ -162,13 +162,21 @@ public static class MessageBodyHtmlBuilder
             "a{color:var(--qm-link, #0645ad);}</style>";
         var styleBlock = ThemeStyleTag(themeCss) + css;
 
-        var headIdx = body.IndexOf("<head>", StringComparison.OrdinalIgnoreCase);
-        if (headIdx >= 0)
-        {
-            body = RemoveTitle(body);
-            body = body.Insert(headIdx + 6, "<meta charset=\"utf-8\">" + titleTag + cspTag + styleBlock);
-            return EnsureBodyFocusable(body);
-        }
+        // The document is ALWAYS one this method builds, and the sender's markup is always content
+        // inside its body. An earlier version spliced the head block in at the first literal
+        // "<head>" found anywhere in the message, which a sender could simply write in the middle
+        // of a paragraph: the CSP meta then landed in body content, where a browser ignores it, and
+        // the document rendered with no policy at all. A meta CSP is only a policy when it is a
+        // child of the real head, so the real head is the only place this may put it.
+        //
+        // The sender's own structural tags are removed rather than left to the parser. A stray
+        // <html>/<head>/<body> start tag in body content is ignored, but its ATTRIBUTES are merged
+        // onto the existing element — so "<body onload=…>" buried in a message would be writing
+        // attributes onto the document's real body. The on* handler is stripped above; nothing
+        // should depend on that being the only such attribute anyone ever finds.
+        body = RemoveTitle(body);
+        body = SafeRegexReplace(body, "</?(html|head|body)\\b[^>]*>", string.Empty,
+                                RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
         return "<!DOCTYPE html><html lang=\"en\"><head><meta charset=\"utf-8\">" +
                titleTag + cspTag + styleBlock +
@@ -239,10 +247,36 @@ public static class MessageBodyHtmlBuilder
     /// attributes, malformed nesting); the strict CSP injected by
     /// ComposeSanitizedDocument — script-src 'none', default-src 'none' — is what actually
     /// prevents execution and remote loads. Never weaken that CSP on the assumption that
-    /// this stripping protects the document. Returns false when any pass timed out, in
+    /// this stripping protects the document.
+    ///
+    /// <para>
+    /// The obvious extra layer, <c>CoreWebView2Settings.IsScriptEnabled = false</c> on the two
+    /// message-body surfaces, was measured against WebView2 1.0.4022.49 and MUST NOT be adopted.
+    /// It does block page script, and <c>ExecuteScriptAsync</c> and the top level of an
+    /// <c>AddScriptToExecuteOnDocumentCreatedAsync</c> script still run — but any CALLBACK those
+    /// register never fires. That silently removes the reading pane's keydown relay (Escape, F6,
+    /// Ctrl+W, Alt+A all become unreachable from inside the document, where focus lands when a
+    /// message opens) and the link menu's status region, which is appended on DOMContentLoaded.
+    /// Trading a keyboard trap and a dead live region for defence in depth behind a CSP that
+    /// already denies script is not a trade worth making. If a second layer is wanted, the one to
+    /// build is a CSP HEADER — serve the message body through <c>WebResourceRequested</c> rather
+    /// than <c>NavigateToString</c> — since a header cannot be displaced by document structure the
+    /// way a meta element can.
+    /// </para>
+    ///
+    /// Returns false when any pass timed out, in
     /// which case <paramref name="stripped"/> holds a PARTIALLY stripped document that
     /// must not be rendered.
     /// </summary>
+    /// <summary>
+    /// An end tag for <paramref name="name"/> as the HTML tokenizer accepts one: the name must be
+    /// followed by whitespace, a solidus, or the closing bracket — so <c>&lt;/script&gt;</c>,
+    /// <c>&lt;/script &gt;</c>, <c>&lt;/script/&gt;</c> and <c>&lt;/script foo="bar"&gt;</c> all
+    /// match, while <c>&lt;/scriptable&gt;</c> (a different element) does not.
+    /// <paramref name="name"/> may be a backreference such as <c>\1</c>.
+    /// </summary>
+    private static string EndTag(string name) => "</" + name + "(?=[\\s/>])[^>]*>";
+
     internal static bool TryStripHeavyHtml(string html, TimeSpan timeout, out string stripped)
     {
         var complete = true;
@@ -264,13 +298,18 @@ public static class MessageBodyHtmlBuilder
         // Remove elements hidden via inline display:none (e.g. newsletter preheader padding divs).
         // Must run before style-attribute stripping, which would make these visible.
         body = Step(body,
-            @"<(div|span|p)\b[^>]*\bstyle\s*=\s*(?:""[^""]*display\s*:\s*none[^""]*""|'[^']*display\s*:\s*none[^']*')[^>]*>.*?</\1>",
+            @"<(div|span|p)\b[^>]*\bstyle\s*=\s*(?:""[^""]*display\s*:\s*none[^""]*""|'[^']*display\s*:\s*none[^']*')[^>]*>.*?" + EndTag("\\1"),
             RegexOptions.IgnoreCase | RegexOptions.Singleline);
         body = Step(body, "<!--.*?-->", RegexOptions.Singleline);
-        body = Step(body, "<script\\b.*?</script>", RegexOptions.IgnoreCase | RegexOptions.Singleline);
-        body = Step(body, "<style\\b.*?</style>", RegexOptions.IgnoreCase | RegexOptions.Singleline);
-        body = Step(body, "<svg\\b.*?</svg>", RegexOptions.IgnoreCase | RegexOptions.Singleline);
-        body = Step(body, "<(iframe|object|embed|video|audio|canvas|form)\\b.*?</\\1>", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+        // End tags use EndTag() rather than a literal "</script>": the HTML tokenizer closes an
+        // element at "</script >", "</script/>" and "</script foo>" as readily as at "</script>",
+        // and a pattern that accepts only the last of those leaves the other three to be stripped
+        // by nobody and executed by the parser. Reported privately 2026-09-09 with a working
+        // proof of concept; the same asymmetry applied to every rule below.
+        body = Step(body, "<script\\b.*?" + EndTag("script"), RegexOptions.IgnoreCase | RegexOptions.Singleline);
+        body = Step(body, "<style\\b.*?" + EndTag("style"), RegexOptions.IgnoreCase | RegexOptions.Singleline);
+        body = Step(body, "<svg\\b.*?" + EndTag("svg"), RegexOptions.IgnoreCase | RegexOptions.Singleline);
+        body = Step(body, "<(iframe|object|embed|video|audio|canvas|form)\\b.*?" + EndTag("\\1"), RegexOptions.IgnoreCase | RegexOptions.Singleline);
         // Substitute each image's alt text before images are removed (issue #163). Removing the
         // element outright discards the only name the image has: the CSP blocks the pixels either
         // way, so what is lost is not the picture but the words describing it. Worst where the
@@ -305,21 +344,14 @@ public static class MessageBodyHtmlBuilder
         return alt.Length == 0 ? string.Empty : WebUtility.HtmlEncode(WebUtility.HtmlDecode(alt));
     }
 
+    /// <summary>
+    /// Removes any &lt;title&gt; the sender wrote. It must go even though the sender's markup ends
+    /// up in the document's BODY: a title start tag in body content is handled by the parser's
+    /// in-head rules, so a sender one would otherwise set document.title — which the reading pane
+    /// uses for the message's own subject.
+    /// </summary>
     public static string RemoveTitle(string html) =>
-        SafeRegexReplace(html, "<title[^>]*>.*?</title>", string.Empty, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-
-    public static string EnsureBodyFocusable(string html)
-    {
-        var bodyIdx = html.IndexOf("<body", StringComparison.OrdinalIgnoreCase);
-        if (bodyIdx < 0) return html;
-        // Scope the check to the opening tag only — attribute values elsewhere in the
-        // document can contain the substring "tabindex=" and must not trigger a false positive.
-        var tagEnd  = html.IndexOf('>', bodyIdx);
-        var openTag = tagEnd >= 0 ? html[bodyIdx..tagEnd] : html[bodyIdx..];
-        if (openTag.Contains("tabindex=", StringComparison.OrdinalIgnoreCase))
-            return html;
-        return SafeRegexReplace(html, "<body\\b", "<body tabindex=\"0\"", RegexOptions.IgnoreCase);
-    }
+        SafeRegexReplace(html, "<title[^>]*>.*?" + EndTag("title"), string.Empty, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
     public static string HtmlToText(string html)
     {

--- a/QuickMail/Views/LinkContextMenuSupport.cs
+++ b/QuickMail/Views/LinkContextMenuSupport.cs
@@ -264,10 +264,13 @@ public static class LinkContextMenuSupport
         // prevent. Capturing createElement but then reading getElementsByTagName off the live
         // document only moved the hole, which is how the second version of this shipped.
         //
-        // The inline display/visibility are !important because the sanitizer's <style> rule needs
-        // a literal </style>, and the tokenizer also accepts "</style >" — so a sender stylesheet
-        // survives and [aria-live]{display:none} would take the region out of the accessibility
-        // tree. An inline !important beats an author !important.
+        // The inline display/visibility/content-visibility are !important against a sender
+        // stylesheet: [aria-live]{display:none} would take this region out of the accessibility
+        // tree, and content-visibility:hidden does the same thing by a different name. An inline
+        // !important beats an author !important. (The tokenizer/regex asymmetry that let such a
+        // stylesheet through at all — "</style >" closing an element the sanitizer's literal
+        // "</style>" rule did not match — is fixed in MessageBodyHtmlBuilder.EndTag; this stays
+        // because the region must survive whatever else gets past that pass.)
         "(function(){" +
         "var C=document.createElement.bind(document);" +
         "var G=document.getElementsByTagName.bind(document);" +
@@ -277,7 +280,8 @@ public static class LinkContextMenuSupport
         "var d=C('div');" +
         "d.setAttribute('aria-live','assertive');d.setAttribute('aria-atomic','true');" +
         "d.style.cssText='margin-top:12px;font-weight:600;'+" +
-        "'display:block !important;visibility:visible !important';" +
+        "'display:block !important;visibility:visible !important;'+" +
+        "'content-visibility:visible !important';" +
         "d.__qmOwned=1;A.call(b,d);window.__qmLinkStatus=d;" +
         "}catch(e){window.__qmLinkStatusError=String(e);}});})();";
 

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -3365,6 +3365,12 @@ public partial class MainWindow : Window
             MessageBody.CoreWebView2.Settings.AreDefaultContextMenusEnabled = true;
             MessageBody.CoreWebView2.Settings.AreDevToolsEnabled = false;
             MessageBody.CoreWebView2.Settings.IsStatusBarEnabled = false;
+            // IsScriptEnabled is deliberately left at its default of true. Turning it off looks
+            // like free hardening on untrusted message content, and it does block page script —
+            // but it also stops any callback a host-injected script registers from ever firing,
+            // which takes the keydown relay below (Escape, F6, Ctrl+W, Alt+A) and the link menu's
+            // status region with it. Measured against 1.0.4022.49, not assumed; the full result is
+            // in the security note on MessageBodyHtmlBuilder.TryStripHeavyHtml.
 
             ApplyWebViewColorScheme();
 

--- a/QuickMail/Views/MessageWindow.xaml.cs
+++ b/QuickMail/Views/MessageWindow.xaml.cs
@@ -219,6 +219,10 @@ public partial class MessageWindow : Window
             MessageBody.CoreWebView2.Settings.AreDefaultContextMenusEnabled = true;
             MessageBody.CoreWebView2.Settings.AreDevToolsEnabled             = false;
             MessageBody.CoreWebView2.Settings.IsStatusBarEnabled             = false;
+            // IsScriptEnabled is deliberately left at its default of true — see the note at the
+            // matching block in MainWindow. Turning it off blocks page script but also stops every
+            // callback a host-injected script registers, which would strand focus inside this
+            // document by killing the keydown relay below.
 
             ApplyWebViewColorScheme();
 

--- a/docs/release-notes-v0.8.45.md
+++ b/docs/release-notes-v0.8.45.md
@@ -1,5 +1,27 @@
 # QuickMail v0.8.45 Release Notes
 
+## Security: a crafted message could run script in the reading pane
+
+**Please update.** A specially written HTML email could run its own JavaScript inside the component
+that displays message bodies, on nothing more than opening the message. Script that ran this way
+could read the message you were reading and send it elsewhere, and it could suppress the spoken
+confirmations QuickMail delivers from inside a message — the invitation RSVP result, and the link
+menu's report when a copy fails — so that an action appeared to have succeeded when it had not.
+
+Message bodies are displayed under a Content Security Policy that forbids script, and a stripping
+pass removes script blocks before they ever reach the display. Two flaws had to line up for either
+to be got past, and both are fixed: the policy is now always written into the part of the document
+where a browser reads it, and the stripping pass now recognises the ways of closing an element that
+it previously did not.
+
+It affects QuickMail 0.7.0 and later. It was found by review rather than by anything going wrong,
+and was reported privately rather than published.
+
+Found and reported privately by Timothy Spaulding, with a working proof of concept and a diagnosis
+that named both flaws exactly.
+
+---
+
 ## Fixed: every rule condition now has a checkbox
 
 **Create Rule from Message** (`Ctrl+Shift+T`) filled in the sender *and* the subject of the message


### PR DESCRIPTION
Fixes two flaws in how message bodies are prepared for display, reported privately by Timothy
Spaulding on 2026-09-09 with a working proof of concept.

- The Content Security Policy meta element is now always emitted into the document head this code
  builds, rather than spliced in at a `<head>` string found in sender markup. A meta CSP is a
  policy only as a child of the real head.
- The sanitizer's end-tag patterns now match every form the HTML tokenizer accepts, via a single
  `EndTag()` helper, and only those.
- `content-visibility` is pinned alongside `display` and `visibility` on both in-document status
  regions (#329, #671), so a sender stylesheet cannot take a live region out of the accessibility
  tree.

`IsScriptEnabled = false` was measured as a third layer and rejected — it stops any callback a
host-injected script registers, which would kill the reading pane's keydown relay and the link
menu's status region. The measurement is recorded in comments so it is not retried.

Seven regression tests cover the invariants rather than the two shapes of the proof of concept.
Full suite green: 3660 passed, 3 skipped.

Ships in 0.8.45; release notes updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)