### PR TITLE
Fix #689: readable status-bar buttons and selected rule in the dark theme

### DIFF
--- a/QuickMail.Tests/DarkThemeReadabilityTests.cs
+++ b/QuickMail.Tests/DarkThemeReadabilityTests.cs
@@ -1,0 +1,48 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// Two dark-theme contrast failures measured by the UI probe (#689, #690). Both came from a style that took
+/// its colour from WPF's defaults instead of the theme, which looks right in the light themes and so
+/// passes every sighted spot-check there.
+/// </summary>
+public class DarkThemeReadabilityTests
+{
+    [Fact]
+    public void StatusBarButtons_TakeTheThemesTextColour() // #689
+    {
+        // A Button's default style sets the system control-text colour, which beats the colour the themed
+        // StatusBar passes down, so the rule summary and update notice were black on the dark status bar.
+        var xaml = File.ReadAllText(Path.Combine(RepoRoot(), "QuickMail", "Styles", "AccessibleStyles.xaml"));
+        var start = xaml.IndexOf("x:Key=\"StatusBarButtonStyle\"", StringComparison.Ordinal);
+        Assert.True(start >= 0, "StatusBarButtonStyle is gone.");
+        var style = xaml[start..xaml.IndexOf("</Style>", start, StringComparison.Ordinal)];
+
+        Assert.Contains("<Setter Property=\"Foreground\" Value=\"{DynamicResource Theme.TextPrimary}\"/>",
+                        style, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TheRulesList_BuildsOnTheThemedRowStyle() // #690
+    {
+        // Without BasedOn, the item-container style replaces the themed ListBoxItem style, and a selected
+        // row gets WPF's own highlight under the theme's light text: about 1.1:1 in the dark theme.
+        var xaml = File.ReadAllText(Path.Combine(RepoRoot(), "QuickMail", "Views", "UnifiedRulesWindow.xaml"));
+
+        Assert.Contains("<Style TargetType=\"ListBoxItem\" BasedOn=\"{StaticResource {x:Type ListBoxItem}}\">",
+                        xaml, StringComparison.Ordinal);
+    }
+
+    private static string RepoRoot()
+    {
+        for (var dir = new DirectoryInfo(AppContext.BaseDirectory); dir != null; dir = dir.Parent)
+        {
+            if (Directory.Exists(Path.Combine(dir.FullName, "QuickMail", "Views")))
+                return dir.FullName;
+        }
+        throw new InvalidOperationException($"Repo source tree not found from {AppContext.BaseDirectory}.");
+    }
+}

--- a/QuickMail.Tests/DarkThemeReadabilityTests.cs
+++ b/QuickMail.Tests/DarkThemeReadabilityTests.cs
@@ -21,8 +21,10 @@ public class DarkThemeReadabilityTests
         Assert.True(start >= 0, "StatusBarButtonStyle is gone.");
         var style = xaml[start..xaml.IndexOf("</Style>", start, StringComparison.Ordinal)];
 
-        Assert.Contains("<Setter Property=\"Foreground\" Value=\"{DynamicResource Theme.TextPrimary}\"/>",
-                        style, StringComparison.Ordinal);
+        // Spacing-tolerant: the neighbouring setters pad Value into a column.
+        Assert.Matches(@"<Setter\s+Property=""Foreground""\s+Value=""\{DynamicResource Theme\.TextPrimary\}""\s*/>", style);
+        // And held down, the selection pair rather than that text colour on Theme.Border (3.5-4.0:1).
+        Assert.Matches(@"Property=""IsPressed""[\s\S]*?Theme\.SelectionBackground[\s\S]*?Theme\.SelectionText", style);
     }
 
     [Fact]

--- a/QuickMail/Styles/AccessibleStyles.xaml
+++ b/QuickMail/Styles/AccessibleStyles.xaml
@@ -142,6 +142,10 @@
         <Setter Property="FocusVisualStyle" Value="{StaticResource FocusVisual}"/>
         <Setter Property="BorderThickness"  Value="0"/>
         <Setter Property="Background"       Value="Transparent"/>
+        <!-- The status bar's own themed text colour, stated here because a Button's default style sets the
+             system control-text colour, which beats the colour the StatusBar passes down: the text was
+             black in every theme, 1.56:1 on the dark status bar (#689). -->
+        <Setter Property="Foreground" Value="{DynamicResource Theme.TextPrimary}"/>
         <Setter Property="Padding"          Value="0"/>
         <Setter Property="Cursor"           Value="Hand"/>
         <Setter Property="VerticalAlignment" Value="Center"/>

--- a/QuickMail/Styles/AccessibleStyles.xaml
+++ b/QuickMail/Styles/AccessibleStyles.xaml
@@ -171,9 +171,12 @@
                             <Setter TargetName="border" Property="Background"
                                     Value="{DynamicResource Theme.AccentSubtle}"/>
                         </Trigger>
+                        <!-- The selection pair, as the themed Button uses when pressed: the theme's text colour
+                             on Theme.Border measured 3.5-4.0:1, below AA while the button was held. -->
                         <Trigger Property="IsPressed" Value="True">
                             <Setter TargetName="border" Property="Background"
-                                    Value="{DynamicResource Theme.Border}"/>
+                                    Value="{DynamicResource Theme.SelectionBackground}"/>
+                            <Setter Property="Foreground" Value="{DynamicResource Theme.SelectionText}"/>
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>

--- a/QuickMail/Views/UnifiedRulesWindow.xaml
+++ b/QuickMail/Views/UnifiedRulesWindow.xaml
@@ -58,7 +58,9 @@
                      KeyDown="RulesListBox_KeyDown"
                      VirtualizingPanel.IsVirtualizing="False">
                 <ListBox.ItemContainerStyle>
-                    <Style TargetType="ListBoxItem">
+                    <!-- Built on the themed row style, or the selected row falls back to WPF's own highlight
+                         under the theme's text colour: near-white on near-white in the dark theme (#690). -->
+                    <Style TargetType="ListBoxItem" BasedOn="{StaticResource {x:Type ListBoxItem}}">
                         <Setter Property="Padding" Value="6,4"/>
                         <Setter Property="AutomationProperties.Name" Value="{Binding RowText}"/>
                     </Style>


### PR DESCRIPTION
Fixes #689. Refs #690.

Two dark-theme contrast failures, measured by the UI probe while testing #688.

## What changes

- **The status-bar buttons use the theme's text colour (#689).**
  - The rule summary and the update notice use `StatusBarButtonStyle`, which set no `Foreground`. A Button's default style then applies the system control-text colour, which beats the colour the themed `StatusBar` passes down.
  - The text was black in every theme: 1.56:1 on the dark status bar.
  - The style now sets `Theme.TextPrimary`.
- **The Rules Manager's rows build on the themed row style (#690).**
  - The rules list's `ItemContainerStyle` replaced the themed `ListBoxItem` style instead of building on it. A selected rule got WPF's own highlight under the theme's light text: about 1.1:1 in the dark theme.
  - It now uses `BasedOn`.
  - The other ten lists #690 names share the pattern. They each need checking and stay open there.

## Verification

- `DarkThemeReadabilityTests` pins both changes.
- Release build: 0 warnings, 0 errors.
- The UI probe measured the status-bar rule text at 10.81:1 in the dark theme (it was 1.56:1) and 13.50:1 in parchment, and the selected rule reads correctly in both themes.
- The accessibility review computed, across the built-in themes: 4.6-7.1:1 for the selected rule with focus and 8.0-11.8:1 without, and 4.6-7.1:1 for a status-bar button while pressed. The pressed state was 3.5-4.0:1 in this branch's first commit and is fixed in the second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
