### PR TITLE
Fix #679 and #687: the rules status line and Test report only what is true

### DIFF
--- a/QuickMail.Tests/StubServices.cs
+++ b/QuickMail.Tests/StubServices.cs
@@ -571,7 +571,10 @@ sealed class StubRuleService : IRuleService
     public int ApplyRulesReturnValue { get; set; } = 0;
     public List<MailMessageSummary> ApplyRulesRemovedMessages { get; set; } = [];
 
-    public List<MailRule> LoadRules() => LoadedRules;
+    /// <summary>Set to make <see cref="LoadRules"/> throw, so a failed client-rule load can be exercised.</summary>
+    public Exception? ThrowOnLoad { get; set; }
+
+    public List<MailRule> LoadRules() => ThrowOnLoad is { } ex ? throw ex : LoadedRules;
     public void SaveRules(List<MailRule> rules) => LoadedRules = rules;
 
     public Task<(int MatchedCount, List<MailMessageSummary> RemovedMessages)> ApplyRulesAsync(

--- a/QuickMail.Tests/UnifiedRulesViewModelTests.cs
+++ b/QuickMail.Tests/UnifiedRulesViewModelTests.cs
@@ -532,6 +532,32 @@ public class UnifiedRulesViewModelTests
     }
 
     [Fact]
+    public async Task AFailedServerLoad_CountsOnlyTheClientRulesThatLoaded() // #679
+    {
+        // "0 on server" straight after "Couldn't load server rules" reads as "this account has none" — the
+        // misreading the failure text is there to prevent.
+        var a = Guid.NewGuid();
+        var server = new FakeServerRules { ThrowOnList = new Exception("Graph unreachable") };
+        var client = new StubRuleService { LoadedRules = [Client("C1", a), Client("C2", a)] };
+        var vm = new UnifiedRulesViewModel(client, server, [Graph(a)], preferredAccountId: a);
+
+        await vm.RefreshCommand.ExecuteAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal("Couldn't load server rules: Graph unreachable. 2 client-side rules. " + UnifiedRulesViewModel.ModeClause(true),
+                     vm.StatusText);
+    }
+
+    [Fact]
+    public void AFailedClientLoad_CountsOnlyTheServerRulesThatLoaded() // #679
+    {
+        var rows = new List<UnifiedRuleRow> { UnifiedRuleRow.ForServer(Server("S1"), false) };
+
+        Assert.Equal("Couldn't load client-side rules: disk full. 1 server-side rule. " + UnifiedRulesViewModel.ModeClause(true),
+                     UnifiedRulesViewModel.BuildStatus(rows, ["Couldn't load client-side rules: disk full"],
+                         supportsServerRules: true, clientLoadFailed: true));
+    }
+
+    [Fact]
     public async Task EveryStatusLine_SaysWhatKindsTheAccountCanHold()
     {
         // The guide promises this unconditionally, and the mode used to be spoken on every load. All four
@@ -683,7 +709,11 @@ public class UnifiedRulesViewModelTests
             var rules = new RuleService(new StubImapMailService(), new StubLocalStoreService(), dir);
             rules.SaveRules([new MailRule { Name = "From Alice", AccountId = a, FromContains = "alice", Action = RuleAction.MarkAsRead }]);
 
-            var messages = new[] { Msg("1", "alice@example.com"), Msg("2", "bob@example.com") };
+            // A third message, from another account, matches the rule's condition but is not counted (#687).
+            var messages = new[] { Msg("1", "alice@example.com"), Msg("2", "bob@example.com"), Msg("3", "alice@example.com") };
+            messages[0].AccountId = a;
+            messages[1].AccountId = a;
+            messages[2].AccountId = Guid.NewGuid();
             var vm = new UnifiedRulesViewModel(rules, new FakeServerRules(), [Graph(a)],
                 preferredAccountId: a, selectedMessagesForTest: messages);
             await vm.RefreshCommand.ExecuteAsync(TestContext.Current.CancellationToken);
@@ -694,7 +724,7 @@ public class UnifiedRulesViewModelTests
 
             vm.TestRuleCommand.Execute(null);
 
-            Assert.Equal("Rule would match 1 of 2 messages in the list.", vm.StatusText);
+            Assert.Equal("Rule would match 1 of the 2 messages from Work in the list.", vm.StatusText);
             Assert.NotNull(announced);
             Assert.Equal(AnnouncementCategory.Result, announced!.Value.Cat);
         }
@@ -731,6 +761,25 @@ public class UnifiedRulesViewModelTests
         vm.TestRuleCommand.Execute(null);
 
         Assert.Equal("The message list is empty, so there is nothing to test the rule against.", vm.StatusText);
+    }
+
+    [Fact]
+    public async Task TestRule_ListHoldsNoneOfTheRulesAccount_SaysSo() // #687
+    {
+        // Opened from a shared mailbox (#678) or from another account's folder, the list can hold only other
+        // accounts' mail. "0 of 3" would count messages the rule can never act on.
+        var a = Guid.NewGuid();
+        var client = new StubRuleService { LoadedRules = [Client("C1", a)] };
+        var others = new[] { Msg("1"), Msg("2"), Msg("3") };
+        foreach (var m in others) m.AccountId = Guid.NewGuid();
+        var vm = new UnifiedRulesViewModel(client, new FakeServerRules(), [Graph(a)],
+            preferredAccountId: a, selectedMessagesForTest: others);
+        await vm.RefreshCommand.ExecuteAsync(TestContext.Current.CancellationToken);
+        vm.SelectedRule = vm.Rules.First(r => r.RunsWhere == RuleRunsWhere.Client);
+
+        vm.TestRuleCommand.Execute(null);
+
+        Assert.Equal("The message list has no messages from Work, so there is nothing to test the rule against.", vm.StatusText);
     }
 
     // ── Field labels (#493 Gap 1: honor RuleListShowFieldLabels in the unified list) ──────────

--- a/QuickMail.Tests/UnifiedRulesViewModelTests.cs
+++ b/QuickMail.Tests/UnifiedRulesViewModelTests.cs
@@ -512,7 +512,9 @@ public class UnifiedRulesViewModelTests
 
         // The WHOLE line, not two Contains: the defect this replaced was a missing full stop between
         // the failure and the clause, which every substring assertion passed straight over.
-        Assert.Equal("Couldn't load server rules: Graph unreachable. " + UnifiedRulesViewModel.ModeClause(true),
+        // The client half loaded and is empty, and says so (#679): otherwise nothing tells that apart from
+        // a client half that was never read.
+        Assert.Equal("Couldn't load server rules: Graph unreachable. No client-side rules. " + UnifiedRulesViewModel.ModeClause(true),
                      vm.StatusText);
     }
 
@@ -555,6 +557,21 @@ public class UnifiedRulesViewModelTests
         Assert.Equal("Couldn't load client-side rules: disk full. 1 server-side rule. " + UnifiedRulesViewModel.ModeClause(true),
                      UnifiedRulesViewModel.BuildStatus(rows, ["Couldn't load client-side rules: disk full"],
                          supportsServerRules: true, clientLoadFailed: true));
+    }
+
+    [Fact]
+    public async Task AFailedClientLoad_IsFlaggedByTheRefresh() // #679
+    {
+        // Through a real load, so dropping the flag in RefreshCoreAsync is caught, not only BuildStatus.
+        var a = Guid.NewGuid();
+        var server = new FakeServerRules { Stored = [Server("S1")] };
+        var client = new StubRuleService { ThrowOnLoad = new Exception("disk full") };
+        var vm = new UnifiedRulesViewModel(client, server, [Graph(a)], preferredAccountId: a);
+
+        await vm.RefreshCommand.ExecuteAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal("Couldn't load client-side rules: disk full. 1 server-side rule. " + UnifiedRulesViewModel.ModeClause(true),
+                     vm.StatusText);
     }
 
     [Fact]
@@ -724,7 +741,7 @@ public class UnifiedRulesViewModelTests
 
             vm.TestRuleCommand.Execute(null);
 
-            Assert.Equal("Rule would match 1 of the 2 messages from Work in the list.", vm.StatusText);
+            Assert.Equal("Rule would match 1 of the 2 messages in the list for the Work account.", vm.StatusText);
             Assert.NotNull(announced);
             Assert.Equal(AnnouncementCategory.Result, announced!.Value.Cat);
         }
@@ -779,7 +796,25 @@ public class UnifiedRulesViewModelTests
 
         vm.TestRuleCommand.Execute(null);
 
-        Assert.Equal("The message list has no messages from Work, so there is nothing to test the rule against.", vm.StatusText);
+        Assert.Equal("The message list has no messages for the Work account, so there is nothing to test the rule against.", vm.StatusText);
+    }
+
+    [Fact]
+    public async Task TestRule_OneMessageFromTheRulesAccount_SaysTheOnlyMessage() // #687
+    {
+        // "1 of the 1 messages" reads badly.
+        var a = Guid.NewGuid();
+        var client = new StubRuleService { LoadedRules = [Client("C1", a)] };   // the stub matches everything
+        var one = Msg("1");
+        one.AccountId = a;
+        var vm = new UnifiedRulesViewModel(client, new FakeServerRules(), [Graph(a)],
+            preferredAccountId: a, selectedMessagesForTest: [one]);
+        await vm.RefreshCommand.ExecuteAsync(TestContext.Current.CancellationToken);
+        vm.SelectedRule = vm.Rules.First(r => r.RunsWhere == RuleRunsWhere.Client);
+
+        vm.TestRuleCommand.Execute(null);
+
+        Assert.Equal("Rule would match the only message in the list for the Work account.", vm.StatusText);
     }
 
     // ── Field labels (#493 Gap 1: honor RuleListShowFieldLabels in the unified list) ──────────

--- a/QuickMail.Tests/UnifiedRulesViewModelTests.cs
+++ b/QuickMail.Tests/UnifiedRulesViewModelTests.cs
@@ -560,6 +560,21 @@ public class UnifiedRulesViewModelTests
     }
 
     [Fact]
+    public void FailedLoads_CountAHalfOnlyWhenItAloneFailed_OnAnAccountWithBoth() // #679
+    {
+        // Both halves failed: nothing loaded, so nothing is counted. Counting a "loaded" half here would put
+        // "No client-side rules." straight after "Couldn't load client-side rules".
+        Assert.Equal("Couldn't load server rules: E1. Couldn't load client-side rules: E2. " + UnifiedRulesViewModel.ModeClause(true),
+                     UnifiedRulesViewModel.BuildStatus([], ["Couldn't load server rules: E1", "Couldn't load client-side rules: E2"],
+                         supportsServerRules: true, serverLoadFailed: true, clientLoadFailed: true));
+        // A client-only account has no server half, so a failed client load has no other half to count, and
+        // must not report "No server-side rules." for rules it never tried to load.
+        Assert.Equal("Couldn't load client-side rules: E. " + UnifiedRulesViewModel.ModeClause(false),
+                     UnifiedRulesViewModel.BuildStatus([], ["Couldn't load client-side rules: E"],
+                         supportsServerRules: false, clientLoadFailed: true));
+    }
+
+    [Fact]
     public async Task AFailedClientLoad_IsFlaggedByTheRefresh() // #679
     {
         // Through a real load, so dropping the flag in RefreshCoreAsync is caught, not only BuildStatus.
@@ -816,6 +831,39 @@ public class UnifiedRulesViewModelTests
 
         Assert.Equal("Rule would match the only message in the list for the Work account.", vm.StatusText);
     }
+
+    [Fact]
+    public async Task TestRule_OneMessageThatDoesNotMatch_SaysSo() // #687
+    {
+        // Real RuleService: the stub matches everything, so it could never reach the "not" branch.
+        var a = Guid.NewGuid();
+        var dir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), Guid.NewGuid().ToString());
+        try
+        {
+            var rules = new RuleService(new StubImapMailService(), new StubLocalStoreService(), dir);
+            rules.SaveRules([new MailRule { Name = "From Alice", AccountId = a, FromContains = "alice", Action = RuleAction.MarkAsRead }]);
+            var bob = Msg("1", "bob@example.com");
+            bob.AccountId = a;
+            var vm = new UnifiedRulesViewModel(rules, new FakeServerRules(), [Graph(a)],
+                preferredAccountId: a, selectedMessagesForTest: [bob]);
+            await vm.RefreshCommand.ExecuteAsync(TestContext.Current.CancellationToken);
+            vm.SelectedRule = vm.Rules.First(r => r.RunsWhere == RuleRunsWhere.Client);
+
+            vm.TestRuleCommand.Execute(null);
+
+            Assert.Equal("Rule would not match the only message in the list for the Work account.", vm.StatusText);
+        }
+        finally { try { System.IO.Directory.Delete(dir, true); } catch { } }
+    }
+
+    [Theory]
+    [InlineData("Work", "the Work account")]
+    [InlineData("Work Account", "the Work Account")]   // not "the Work Account account"
+    [InlineData("me@example.com", "the me@example.com account")]
+    [InlineData("  ", "this account")]
+    [InlineData(null, "this account")]
+    public void TestRule_NamesTheAccountOnce(string? label, string expected) // #687
+        => Assert.Equal(expected, UnifiedRulesViewModel.AccountPhrase(label));
 
     // ── Field labels (#493 Gap 1: honor RuleListShowFieldLabels in the unified list) ──────────
 

--- a/QuickMail.Tests/UnifiedRulesViewModelTests.cs
+++ b/QuickMail.Tests/UnifiedRulesViewModelTests.cs
@@ -406,7 +406,7 @@ public class UnifiedRulesViewModelTests
 
         await vm.RefreshCommand.ExecuteAsync(null);
 
-        Assert.Contains("Couldn't load server rules", vm.StatusText);   // the evidence survives …
+        Assert.Contains("Couldn't load server-side rules", vm.StatusText);   // the evidence survives …
         Assert.Contains("Graph unreachable", vm.StatusText);
         Assert.DoesNotContain("No rules yet", vm.StatusText);              // … not overwritten by BuildStatus
     }
@@ -514,7 +514,7 @@ public class UnifiedRulesViewModelTests
         // the failure and the clause, which every substring assertion passed straight over.
         // The client half loaded and is empty, and says so (#679): otherwise nothing tells that apart from
         // a client half that was never read.
-        Assert.Equal("Couldn't load server rules: Graph unreachable. No client-side rules. " + UnifiedRulesViewModel.ModeClause(true),
+        Assert.Equal("Couldn't load server-side rules: Graph unreachable. No client-side rules. " + UnifiedRulesViewModel.ModeClause(true),
                      vm.StatusText);
     }
 
@@ -536,7 +536,7 @@ public class UnifiedRulesViewModelTests
     [Fact]
     public async Task AFailedServerLoad_CountsOnlyTheClientRulesThatLoaded() // #679
     {
-        // "0 on server" straight after "Couldn't load server rules" reads as "this account has none" — the
+        // "0 on server" straight after "Couldn't load server-side rules" reads as "this account has none" — the
         // misreading the failure text is there to prevent.
         var a = Guid.NewGuid();
         var server = new FakeServerRules { ThrowOnList = new Exception("Graph unreachable") };
@@ -545,7 +545,7 @@ public class UnifiedRulesViewModelTests
 
         await vm.RefreshCommand.ExecuteAsync(TestContext.Current.CancellationToken);
 
-        Assert.Equal("Couldn't load server rules: Graph unreachable. 2 client-side rules. " + UnifiedRulesViewModel.ModeClause(true),
+        Assert.Equal("Couldn't load server-side rules: Graph unreachable. 2 client-side rules. " + UnifiedRulesViewModel.ModeClause(true),
                      vm.StatusText);
     }
 
@@ -564,8 +564,8 @@ public class UnifiedRulesViewModelTests
     {
         // Both halves failed: nothing loaded, so nothing is counted. Counting a "loaded" half here would put
         // "No client-side rules." straight after "Couldn't load client-side rules".
-        Assert.Equal("Couldn't load server rules: E1. Couldn't load client-side rules: E2. " + UnifiedRulesViewModel.ModeClause(true),
-                     UnifiedRulesViewModel.BuildStatus([], ["Couldn't load server rules: E1", "Couldn't load client-side rules: E2"],
+        Assert.Equal("Couldn't load server-side rules: E1. Couldn't load client-side rules: E2. " + UnifiedRulesViewModel.ModeClause(true),
+                     UnifiedRulesViewModel.BuildStatus([], ["Couldn't load server-side rules: E1", "Couldn't load client-side rules: E2"],
                          supportsServerRules: true, serverLoadFailed: true, clientLoadFailed: true));
         // A client-only account has no server half, so a failed client load has no other half to count, and
         // must not report "No server-side rules." for rules it never tried to load.

--- a/QuickMail/ViewModels/UnifiedRulesViewModel.cs
+++ b/QuickMail/ViewModels/UnifiedRulesViewModel.cs
@@ -635,7 +635,7 @@ public partial class UnifiedRulesViewModel : ObservableObject
                 catch (Exception ex)
                 {
                     serverFailed = true;
-                    failures.Add($"Couldn't load server rules: {ex.Message}");
+                    failures.Add($"Couldn't load server-side rules: {ex.Message}");
                     LogService.Log("UnifiedRules: server load failed", ex);
                 }
             }
@@ -721,7 +721,7 @@ public partial class UnifiedRulesViewModel : ObservableObject
     /// </para>
     /// </summary>
     /// <remarks>Names its subject rather than opening with "It": the clause is appended to a count and
-    /// to a load failure, and after "Couldn't load server rules: …" the nearest noun an "It" could attach
+    /// to a load failure, and after "Couldn't load server-side rules: …" the nearest noun an "It" could attach
     /// to is <em>server rules</em>.</remarks>
     internal static string ModeClause(bool supportsServerRules)
         => supportsServerRules
@@ -786,7 +786,7 @@ public partial class UnifiedRulesViewModel : ObservableObject
         return rows.Count == 0 ? NoRulesStatus(supportsServerRules) : Counts(rows, supportsServerRules);
 
         // After one half failed to load, count only the half that did (#679). "0 on server" straight after
-        // "Couldn't load server rules" reads as "this account has none" — the very misreading the failure
+        // "Couldn't load server-side rules" reads as "this account has none" — the very misreading the failure
         // text is there to prevent.
         static string LoadedCount(List<UnifiedRuleRow> r, bool supportsServer, bool serverFailed)
         {

--- a/QuickMail/ViewModels/UnifiedRulesViewModel.cs
+++ b/QuickMail/ViewModels/UnifiedRulesViewModel.cs
@@ -322,16 +322,29 @@ public partial class UnifiedRulesViewModel : ObservableObject
     {
         if (SelectedRule is not { RunsWhere: RuleRunsWhere.Client } row) return;   // defensive; CanExecute gates it
 
-        var messages = _selectedMessagesForTest?.ToList() ?? [];
-        if (messages.Count == 0)
+        var list = _selectedMessagesForTest?.ToList() ?? [];
+        if (list.Count == 0)
         {
             StatusText = "The message list is empty, so there is nothing to test the rule against.";
             Announce(StatusText, AnnouncementCategory.Result);
             return;
         }
 
+        // A client rule acts only on its own account's mail, so it is tested only against that (#687). The
+        // list can hold several accounts' messages: All Inboxes, or a shared mailbox's folder, which opens
+        // this window on another account (#678).
+        var accountId = row.Client!.AccountId ?? SelectedAccount?.Id;
+        var accountName = SelectedAccount?.DisplayName ?? "this account";
+        var messages = list.Where(m => m.AccountId == accountId).ToList();
+        if (messages.Count == 0)
+        {
+            StatusText = $"The message list has no messages from {accountName}, so there is nothing to test the rule against.";
+            Announce(StatusText, AnnouncementCategory.Result);
+            return;
+        }
+
         var matched = _clientRules.TestRule(row.Client!, messages);
-        StatusText = $"Rule would match {matched.Count} of {messages.Count} messages in the list.";
+        StatusText = $"Rule would match {matched.Count} of the {messages.Count} messages from {accountName} in the list.";
         Announce(StatusText, AnnouncementCategory.Result);
     }
 
@@ -581,6 +594,9 @@ public partial class UnifiedRulesViewModel : ObservableObject
         {
             var rows = new List<UnifiedRuleRow>();
             var failures = new List<string>();
+            // Which half failed, so the status line counts only what actually loaded (#679).
+            var serverFailed = false;
+            var clientFailed = false;
 
             // Server rules — Graph accounts only. Isolated so a Graph/network failure still lets the
             // client rules below load.
@@ -604,6 +620,7 @@ public partial class UnifiedRulesViewModel : ObservableObject
                 catch (OperationCanceledException) { return; }   // superseded — leave state untouched
                 catch (Exception ex)
                 {
+                    serverFailed = true;
                     failures.Add($"Couldn't load server rules: {ex.Message}");
                     LogService.Log("UnifiedRules: server load failed", ex);
                 }
@@ -626,6 +643,7 @@ public partial class UnifiedRulesViewModel : ObservableObject
             }
             catch (Exception ex)
             {
+                clientFailed = true;
                 failures.Add($"Couldn't load client-side rules: {ex.Message}");
                 LogService.Log("UnifiedRules: client load failed", ex);
             }
@@ -647,7 +665,8 @@ public partial class UnifiedRulesViewModel : ObservableObject
 
             // A load failure must survive to the status line — otherwise "couldn't reach Graph" reads
             // as "this account has no server rules", which invites the wrong next action.
-            StatusText = SharedMailboxPreamble() + BuildStatus(rows, failures, AccountSupportsServerRules);
+            StatusText = SharedMailboxPreamble()
+                + BuildStatus(rows, failures, AccountSupportsServerRules, serverFailed, clientFailed);
         }
         finally
         {
@@ -727,7 +746,8 @@ public partial class UnifiedRulesViewModel : ObservableObject
         return t.Length == 0 || t[^1] is '.' or '!' or '?' ? t : t + ".";
     }
 
-    internal static string BuildStatus(List<UnifiedRuleRow> rows, List<string> failures, bool supportsServerRules)
+    internal static string BuildStatus(List<UnifiedRuleRow> rows, List<string> failures, bool supportsServerRules,
+        bool serverLoadFailed = false, bool clientLoadFailed = false)
     {
         if (failures.Count > 0)
         {
@@ -739,10 +759,23 @@ public partial class UnifiedRulesViewModel : ObservableObject
             // one run-on with no break to read.
             var loaded = rows.Count == 0
                 ? " " + ModeClause(supportsServerRules)
-                : " " + Counts(rows, supportsServerRules);
+                : " " + (serverLoadFailed || clientLoadFailed
+                    ? LoadedCount(rows, supportsServerRules, serverLoadFailed)
+                    : Counts(rows, supportsServerRules));
             return string.Join(" ", failures.Select(Terminated)) + loaded;
         }
         return rows.Count == 0 ? NoRulesStatus(supportsServerRules) : Counts(rows, supportsServerRules);
+
+        // After one half failed to load, count only the half that did (#679). "0 on server" straight after
+        // "Couldn't load server rules" reads as "this account has none" — the very misreading the failure
+        // text is there to prevent.
+        static string LoadedCount(List<UnifiedRuleRow> r, bool supportsServer, bool serverFailed)
+        {
+            var kind = serverFailed ? RuleRunsWhere.Client : RuleRunsWhere.Server;
+            var n = r.Count(x => x.RunsWhere == kind);
+            var noun = kind == RuleRunsWhere.Client ? "client-side" : "server-side";
+            return $"{n} {noun} rule{(n == 1 ? "" : "s")}. " + ModeClause(supportsServer);
+        }
 
         static string Counts(List<UnifiedRuleRow> r, bool supportsServer)
         {

--- a/QuickMail/ViewModels/UnifiedRulesViewModel.cs
+++ b/QuickMail/ViewModels/UnifiedRulesViewModel.cs
@@ -334,17 +334,22 @@ public partial class UnifiedRulesViewModel : ObservableObject
         // list can hold several accounts' messages: All Inboxes, or a shared mailbox's folder, which opens
         // this window on another account (#678).
         var accountId = row.Client!.AccountId ?? SelectedAccount?.Id;
-        var accountName = SelectedAccount?.DisplayName ?? "this account";
+        // Named from the account being tested, not the list's selection, which can already be moving to
+        // another account. "for the … account" rather than "from …": an account with no name of its own is
+        // labelled by its address, and "messages from me@example.com" would read as a sender.
+        var account = $"the {AccountOptions.FirstOrDefault(o => o.Id == accountId)?.DisplayName ?? SelectedAccount?.DisplayName} account";
         var messages = list.Where(m => m.AccountId == accountId).ToList();
         if (messages.Count == 0)
         {
-            StatusText = $"The message list has no messages from {accountName}, so there is nothing to test the rule against.";
+            StatusText = $"The message list has no messages for {account}, so there is nothing to test the rule against.";
             Announce(StatusText, AnnouncementCategory.Result);
             return;
         }
 
-        var matched = _clientRules.TestRule(row.Client!, messages);
-        StatusText = $"Rule would match {matched.Count} of the {messages.Count} messages from {accountName} in the list.";
+        var matched = _clientRules.TestRule(row.Client!, messages).Count;
+        StatusText = messages.Count == 1
+            ? $"Rule would {(matched == 1 ? "" : "not ")}match the only message in the list for {account}."
+            : $"Rule would match {matched} of the {messages.Count} messages in the list for {account}.";
         Announce(StatusText, AnnouncementCategory.Result);
     }
 
@@ -757,11 +762,14 @@ public partial class UnifiedRulesViewModel : ObservableObject
             // window has no other surface that tells them apart. Each failure is terminated first: an
             // exception message rarely ends in a full stop, and gluing the next sentence onto it gives
             // one run-on with no break to read.
-            var loaded = rows.Count == 0
-                ? " " + ModeClause(supportsServerRules)
-                : " " + (serverLoadFailed || clientLoadFailed
-                    ? LoadedCount(rows, supportsServerRules, serverLoadFailed)
-                    : Counts(rows, supportsServerRules));
+            // One half failed on an account that has both: count the half that loaded, even when it holds
+            // none, so "No client-side rules." says it was read rather than leaving it unknown.
+            var oneHalfFailed = supportsServerRules && serverLoadFailed != clientLoadFailed;
+            var loaded = oneHalfFailed
+                ? " " + LoadedCount(rows, supportsServerRules, serverLoadFailed)
+                : rows.Count == 0
+                    ? " " + ModeClause(supportsServerRules)
+                    : " " + Counts(rows, supportsServerRules);
             return string.Join(" ", failures.Select(Terminated)) + loaded;
         }
         return rows.Count == 0 ? NoRulesStatus(supportsServerRules) : Counts(rows, supportsServerRules);
@@ -774,7 +782,8 @@ public partial class UnifiedRulesViewModel : ObservableObject
             var kind = serverFailed ? RuleRunsWhere.Client : RuleRunsWhere.Server;
             var n = r.Count(x => x.RunsWhere == kind);
             var noun = kind == RuleRunsWhere.Client ? "client-side" : "server-side";
-            return $"{n} {noun} rule{(n == 1 ? "" : "s")}. " + ModeClause(supportsServer);
+            var count = n == 0 ? $"No {noun} rules." : $"{n} {noun} rule{(n == 1 ? "" : "s")}.";
+            return count + " " + ModeClause(supportsServer);
         }
 
         static string Counts(List<UnifiedRuleRow> r, bool supportsServer)

--- a/QuickMail/ViewModels/UnifiedRulesViewModel.cs
+++ b/QuickMail/ViewModels/UnifiedRulesViewModel.cs
@@ -337,7 +337,7 @@ public partial class UnifiedRulesViewModel : ObservableObject
         // Named from the account being tested, not the list's selection, which can already be moving to
         // another account. "for the … account" rather than "from …": an account with no name of its own is
         // labelled by its address, and "messages from me@example.com" would read as a sender.
-        var account = $"the {AccountOptions.FirstOrDefault(o => o.Id == accountId)?.DisplayName ?? SelectedAccount?.DisplayName} account";
+        var account = AccountPhrase(AccountOptions.FirstOrDefault(o => o.Id == accountId)?.DisplayName ?? SelectedAccount?.DisplayName);
         var messages = list.Where(m => m.AccountId == accountId).ToList();
         if (messages.Count == 0)
         {
@@ -351,6 +351,15 @@ public partial class UnifiedRulesViewModel : ObservableObject
             ? $"Rule would {(matched == 1 ? "" : "not ")}match the only message in the list for {account}."
             : $"Rule would match {matched} of the {messages.Count} messages in the list for {account}.";
         Announce(StatusText, AnnouncementCategory.Result);
+    }
+
+    /// <summary>"the Work account", for Test's result. A label that already ends in "account" does not get a
+    /// second one: "the Work Account", not "the Work Account account".</summary>
+    internal static string AccountPhrase(string? label)
+    {
+        var name = label?.Trim();
+        if (string.IsNullOrEmpty(name)) return "this account";
+        return name.EndsWith("account", StringComparison.OrdinalIgnoreCase) ? $"the {name}" : $"the {name} account";
     }
 
     // ── Save routing ────────────────────────────────────────────────────────
@@ -763,7 +772,9 @@ public partial class UnifiedRulesViewModel : ObservableObject
             // exception message rarely ends in a full stop, and gluing the next sentence onto it gives
             // one run-on with no break to read.
             // One half failed on an account that has both: count the half that loaded, even when it holds
-            // none, so "No client-side rules." says it was read rather than leaving it unknown.
+            // none, so its count is stated rather than left to be inferred. "No client-side rules." is only as
+            // sure as the load behind it: RuleService.LoadRules returns an empty list for a rules file it
+            // cannot read, so that case arrives here as loaded and empty.
             var oneHalfFailed = supportsServerRules && serverLoadFailed != clientLoadFailed;
             var loaded = oneHalfFailed
                 ? " " + LoadedCount(rows, supportsServerRules, serverLoadFailed)

--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -594,7 +594,7 @@ A **client-side** rule is run by QuickMail on this computer, on Inbox mail as it
 - Press **Ctrl+Shift+L**, or
 - Open the command palette (`Ctrl+Shift+P`) and type "Manage Rules".
 
-The Rules Manager lists one account's rules at a time; choose the account in the **Account** list at the top. It opens on the account you were in, and from a view that spans accounts, such as All Inboxes, on your default account. Beside the list, the **Rule detail** pane reads out the selected rule, and the status line below the account list says how many rules the account has, where they run, and which kinds the account can have. **F6** cycles through the account list, the rules, the details, and the status line.
+The Rules Manager lists one account's rules at a time; choose the account in the **Account** list at the top. It opens on the account you were in, and from a view that spans accounts, such as All Inboxes, on your default account. Beside the list, the **Rule detail** pane reads out the selected rule, and the status line below the account list says how many rules the account has, where they run, and which kinds the account can have. If one kind can't be loaded, the status line says so and counts only the kind that did. **F6** cycles through the account list, the rules, the details, and the status line.
 
 ### Creating a rule
 
@@ -616,7 +616,7 @@ Create Rule from Message is not in the context menu for a message in a shared ma
 
 ### Testing a rule
 
-Select a client-side rule and activate **Test**. QuickMail runs it against the messages from that rule's account that were in the message list when you opened the Rules Manager, and the status line says how many of them would match, for example "Rule would match 3 of the 50 messages in the list for the Work account." Messages from other accounts aren't counted, because the rule never acts on them. **Test** is turned off for server-side rules, which run on the server.
+Select a client-side rule and activate **Test**. QuickMail runs it against the messages that were in the message list when you opened the Rules Manager, counting only those in the rule's own account, and the status line says how many would match, for example "Rule would match 3 of the 50 messages in the list for the Work account." Messages in other accounts aren't counted, because the rule never acts on them. **Test** is turned off for server-side rules, which run on the server.
 
 ### Enabling and disabling rules
 

--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -616,7 +616,7 @@ Create Rule from Message is not in the context menu for a message in a shared ma
 
 ### Testing a rule
 
-Select a client-side rule and activate **Test**. QuickMail runs it against the messages that were in the message list when you opened the Rules Manager, and the status line says how many of them would match, for example "Rule would match 3 of 50 messages in the list." **Test** is turned off for server-side rules, which run on the server.
+Select a client-side rule and activate **Test**. QuickMail runs it against the messages from that rule's account that were in the message list when you opened the Rules Manager, and the status line says how many of them would match, for example "Rule would match 3 of the 50 messages from Work in the list." Messages from other accounts aren't counted, because the rule never acts on them. **Test** is turned off for server-side rules, which run on the server.
 
 ### Enabling and disabling rules
 

--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -616,7 +616,7 @@ Create Rule from Message is not in the context menu for a message in a shared ma
 
 ### Testing a rule
 
-Select a client-side rule and activate **Test**. QuickMail runs it against the messages from that rule's account that were in the message list when you opened the Rules Manager, and the status line says how many of them would match, for example "Rule would match 3 of the 50 messages from Work in the list." Messages from other accounts aren't counted, because the rule never acts on them. **Test** is turned off for server-side rules, which run on the server.
+Select a client-side rule and activate **Test**. QuickMail runs it against the messages from that rule's account that were in the message list when you opened the Rules Manager, and the status line says how many of them would match, for example "Rule would match 3 of the 50 messages in the list for the Work account." Messages from other accounts aren't counted, because the rule never acts on them. **Test** is turned off for server-side rules, which run on the server.
 
 ### Enabling and disabling rules
 

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -1149,7 +1149,7 @@ The list shows one account at a time, so a row does not repeat the account: it s
 
 In the list, **Enter** edits the selected rule, **Space** turns it on or off, and **Delete** deletes it after asking. The buttons below the list are **New**, **Edit**, **Delete**, **Enable** or **Disable**, **Move Up**, **Move Down**, **Test**, **Run on Existing Mail**, and **Close**; most are on the list's context menu as well, and every one is in the command palette (`Ctrl+Shift+P`). **Escape** closes the window.
 
-**Test** runs the selected client-side rule against the messages from its account that were in the message list when you opened the Rules Manager, and says how many of them it would match — messages from other accounts aren't counted, because the rule never acts on them — so you can check a rule before letting it loose.
+**Test** runs the selected client-side rule against the messages that were in the message list when you opened the Rules Manager, and says how many of them it would match, so you can check a rule before letting it loose. Only messages in the rule's own account are counted, because the rule never acts on any others.
 
 ### Creating a Rule from a Message
 

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -1149,7 +1149,7 @@ The list shows one account at a time, so a row does not repeat the account: it s
 
 In the list, **Enter** edits the selected rule, **Space** turns it on or off, and **Delete** deletes it after asking. The buttons below the list are **New**, **Edit**, **Delete**, **Enable** or **Disable**, **Move Up**, **Move Down**, **Test**, **Run on Existing Mail**, and **Close**; most are on the list's context menu as well, and every one is in the command palette (`Ctrl+Shift+P`). **Escape** closes the window.
 
-**Test** runs the selected client-side rule against the messages that were in the message list when you opened the Rules Manager, and says how many of them it would match, so you can check a rule before letting it loose.
+**Test** runs the selected client-side rule against the messages from its account that were in the message list when you opened the Rules Manager, and says how many of them it would match — messages from other accounts aren't counted, because the rule never acts on them — so you can check a rule before letting it loose.
 
 ### Creating a Rule from a Message
 
@@ -1161,7 +1161,7 @@ If you have a **work or school** Microsoft 365 (Exchange) account, the Rules Man
 
 Server-side rules are an organization feature, so **personal Outlook.com, Hotmail, and Live.com accounts do not have them** — even when connected through Microsoft 365 directly. For a personal account the Rules Manager shows only client-side rules, the same as any other non-Exchange account.
 
-**One list, marked where each rule runs.** For a work or school account, server-side and client-side rules appear together in a single list. Each row says where the rule runs — **on server** or **on client** — along with its name and whether it is enabled. Creating, editing, enabling or disabling, and deleting all work the same way whichever kind a rule is; only server-side rules can be reordered. The status line counts them the same way — "4 rules: 3 on server, 1 on client" — so which kinds an account is holding is on screen, and **F6** cycles round to read it back.
+**One list, marked where each rule runs.** For a work or school account, server-side and client-side rules appear together in a single list. Each row says where the rule runs — **on server** or **on client** — along with its name and whether it is enabled. Creating, editing, enabling or disabling, and deleting all work the same way whichever kind a rule is; only server-side rules can be reordered. The status line counts them the same way — "4 rules: 3 on server, 1 on client" — so which kinds an account is holding is on screen, and **F6** cycles round to read it back. If one kind can't be loaded, the status line says so and counts only the kind that did.
 
 **QuickMail chooses where a new rule lives.** When you create a rule, QuickMail saves it as a server rule whenever it can, so it keeps working while QuickMail is closed. A rule that needs something only QuickMail can do — today that is **Mark as unread** — is saved as a client-side rule instead. On a work or school account, which *does* also do server rules, QuickMail announces that when it happens; the saved rule's own row says **on client** either way, so where it went is there to read whether or not you have announcements turned on.
 


### PR DESCRIPTION
Fixes #679. Fixes #687.

The Rules Manager's status line and Test reported numbers that weren't true.

## What changes

- **After a failed load, the status line counts only what loaded (#679).**
  - When the server-rule load failed but client rules loaded, the line read "Couldn't load server rules: Graph unreachable. 2 rules: 0 on server, 2 on client." The "0 on server" was never counted.
  - `RefreshCoreAsync` now records which half failed. `BuildStatus` counts only the half that loaded: "Couldn't load server rules: Graph unreachable. 2 client-side rules. This account supports server-side and client-side rules."
  - When the half that loaded is empty, it says so ("No client-side rules."). Otherwise nothing tells that apart from a half that was never read.
  - The mirror case (client load failed, server loaded) works the same way. Both failing, or a client-only account whose load fails, keep the previous line.
- **Test counts only the rule's own account (#687).**
  - `TestRule` matched a client rule against every message in the main window's list, whatever account each belonged to. A client rule only ever acts on its own account's Inbox.
  - It now filters to the rule's account, and the result names it: "Rule would match 1 of the 2 messages in the list for the Work account."
  - It says "for the Work account" rather than "from Work" because an account with no name of its own is labelled by its address. "Messages from me@example.com" would read as a sender.
  - An account whose name already ends in "account" is named once: "for the Work Account", not "the Work Account account".
  - One message reads "Rule would match the only message in the list for the Work account." When the list holds none of that account's mail, it says so. That case is likelier since #678, which opens the window on another account from a shared mailbox.
  - The account named is the one tested, not the Account list's selection, which can already be moving to another account.
- **Both user guides** describe Test's account scope and the partial count.

Release notes for this and the other 0.8.45 fixes come in a separate small PR, so they don't conflict.

## Tests

- **Failed loads:**
  - A failed server load counts only the two client rules that loaded, checked against the whole status line.
  - A failed client load is driven through a real refresh, so dropping its flag is caught.
  - A failed server load with no client rules says "No client-side rules."
  - Nothing is counted when both halves fail, or when a client-only account's load fails.
- **Test:**
  - It ignores a matching message from another account.
  - It says so when the list holds no message from the rule's account.
  - It words a single message as "the only message", and a single non-matching one as "would not match the only message".
  - An account's name is not followed by a second "account".

Every test fails when its fix is removed: fourteen mutation checks across the three commits, all caught. Release build: 0 warnings, 0 errors.

"No client-side rules." is only as reliable as `RuleService.LoadRules`, which returns an empty list for a rules file it cannot read. That predates this PR and is left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
