### PR TITLE
Fix #676 and #692: the palette from the reading pane, and one access key per menu item

### DIFF
--- a/QuickMail.Tests/MessageBodyKeyRelayTests.cs
+++ b/QuickMail.Tests/MessageBodyKeyRelayTests.cs
@@ -80,7 +80,33 @@ public class MessageBodyKeyRelayTests
         var queued = body[chosen..];
         Assert.Contains("Dispatcher.InvokeAsync(", queued, StringComparison.Ordinal);
         Assert.Contains("DispatcherPriority.Input", queued, StringComparison.Ordinal);
-        Assert.Contains("IsActive && _vm.IsMessageOpen", queued, StringComparison.Ordinal);
+        Assert.Contains("if (!IsActive || !untouched) return;", queued, StringComparison.Ordinal);
+        // A command that closed the message without placing focus still ends on the list, as it did when
+        // OnActivated sent it there.
+        Assert.Contains("else ReturnFocusToMessageList();", queued, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ReactivatingAfterThePalette_LeavesTheReturnToTheMessageAlone()
+    {
+        // Closing the palette reactivates the main window, and OnActivated sends focus that was in the message
+        // body to the list. Unless it stands aside while the palette puts focus back, the list wins every time.
+        var code = Source("MainWindow.xaml.cs");
+        var start = code.IndexOf("private void OpenCommandPalette()", StringComparison.Ordinal);
+        Assert.True(start >= 0, "OpenCommandPalette is gone.");
+        var palette = code[start..code.IndexOf("\n    }", start, StringComparison.Ordinal)];
+        var set = palette.IndexOf("_paletteRestoresFocus = fromMessageBody && _vm.IsMessageOpen;", StringComparison.Ordinal);
+        var shown = palette.IndexOf("palette.ShowDialog()", StringComparison.Ordinal);
+        Assert.True(set >= 0 && shown > set, "The flag must be set before the palette opens: the activation comes while it closes.");
+        Assert.Contains("Dispatcher.InvokeAsync(() => _paletteRestoresFocus = false, DispatcherPriority.Input);",
+                        palette[shown..], StringComparison.Ordinal);
+
+        var activated = code.IndexOf("private void OnActivated(", StringComparison.Ordinal);
+        Assert.True(activated >= 0, "OnActivated is gone.");
+        var body = code[activated..code.IndexOf("\n    }", activated, StringComparison.Ordinal)];
+        var skip = body.IndexOf("if (_paletteRestoresFocus) return;", StringComparison.Ordinal);
+        var restore = body.IndexOf("ReturnFocusToMessageList()", StringComparison.Ordinal);
+        Assert.True(skip >= 0 && restore > skip, "OnActivated must check the flag before sending focus to the list.");
     }
 
     [Theory]

--- a/QuickMail.Tests/MessageBodyKeyRelayTests.cs
+++ b/QuickMail.Tests/MessageBodyKeyRelayTests.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// A key pressed inside a message body goes to the WebView2, never to the window's own key handling, so
+/// the reading pane and the message window each inject a script that relays a set of gestures back to
+/// WPF. The two sets have drifted apart twice: #483, and #676, where the reading pane had no Ctrl+Shift+P
+/// and the command palette could not be opened while reading.
+/// </summary>
+public class MessageBodyKeyRelayTests
+{
+    // Gestures both message bodies must relay. Each surface may relay more of its own (the reading pane
+    // also jumps to the folder tree).
+    private static readonly string[] Shared =
+        ["escape", "f6", "shift-f6", "shift-tab", "focus-attachments", "ctrl-w", "ctrl-shift-w", "ctrl-shift-p"];
+
+    [Theory]
+    [InlineData("MainWindow.xaml.cs")]
+    [InlineData("MessageWindow.xaml.cs")]
+    public void EveryMessageBody_RelaysTheSharedGestures(string file)
+    {
+        var posted = Posted(Source(file));
+
+        foreach (var gesture in Shared)
+            Assert.True(posted.Contains(gesture), $"{file} does not relay '{gesture}' out of the message body.");
+    }
+
+    [Theory]
+    [InlineData("MainWindow.xaml.cs")]
+    [InlineData("MessageWindow.xaml.cs")]
+    public void EveryRelayedGesture_IsHandled(string file)
+    {
+        // A relay with no handler is a key that is swallowed: the script prevents the default and nothing acts.
+        var code = Source(file);
+
+        foreach (var gesture in Posted(code))
+            Assert.True(code.Contains($"msg == \"{gesture}\"", StringComparison.Ordinal)
+                        || code.Contains($"case \"{gesture}\":", StringComparison.Ordinal),
+                        $"{file} relays '{gesture}' but nothing handles it.");
+    }
+
+    /// <summary>Every name the file's injected scripts pass to <c>postMessage</c>.</summary>
+    private static HashSet<string> Posted(string code)
+        => Regex.Matches(code, @"postMessage\(([^)]*)\)")
+                .SelectMany(call => Regex.Matches(call.Groups[1].Value, @"'([a-z0-9-]+)'").Select(m => m.Groups[1].Value))
+                .ToHashSet(StringComparer.Ordinal);
+
+    private static string Source(string file)
+        => File.ReadAllText(Path.Combine(RepoRoot(), "QuickMail", "Views", file));
+
+    private static string RepoRoot()
+    {
+        for (var dir = new DirectoryInfo(AppContext.BaseDirectory); dir != null; dir = dir.Parent)
+        {
+            if (Directory.Exists(Path.Combine(dir.FullName, "QuickMail", "Views")))
+                return dir.FullName;
+        }
+        throw new InvalidOperationException($"Repo source tree not found from {AppContext.BaseDirectory}.");
+    }
+}

--- a/QuickMail.Tests/MessageBodyKeyRelayTests.cs
+++ b/QuickMail.Tests/MessageBodyKeyRelayTests.cs
@@ -57,10 +57,37 @@ public class MessageBodyKeyRelayTests
 
         // Where focus was is read before the palette opens, since afterwards it is on the palette's owner.
         var captured = body.IndexOf("var fromMessageBody = IsMessageBodyFocused;", StringComparison.Ordinal);
-        var shown = body.IndexOf("palette.ShowDialog()", StringComparison.Ordinal);
+        var shown = body.IndexOf("palette.ShowModeless();", StringComparison.Ordinal);
         Assert.True(captured >= 0 && shown > captured, "fromMessageBody must be read before the palette is shown.");
         Assert.Contains("if (!(fromMessageBody && _vm.IsMessageOpen))", body, StringComparison.Ordinal);
-        Assert.Contains("FocusMessageBodyHost();", body[shown..], StringComparison.Ordinal);
+        var closed = body.IndexOf("palette.Closed +=", StringComparison.Ordinal);
+        Assert.True(closed >= 0 && closed < shown, "The return must be wired to the palette closing, before it is shown.");
+        Assert.Contains("if (_vm.IsMessageOpen) FocusMessageBodyHost();", body[closed..shown], StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FromInsideAMessage_ThePaletteIsModeless()
+    {
+        // Opened modally from inside a reading-pane message, the palette crashed a screen reader, where opened from
+        // the message list it did not (#676, found by ear). That is the modal loop + WebView2 combination CLAUDE.md
+        // describes for GrabAddresses, and the fix is the same: no ShowDialog on the path from the message body.
+        var code = Source("MainWindow.xaml.cs");
+        var start = code.IndexOf("private void OpenCommandPalette()", StringComparison.Ordinal);
+        Assert.True(start >= 0, "OpenCommandPalette is gone.");
+        var body = code[start..code.IndexOf("\n    }", start, StringComparison.Ordinal)];
+        var branch = body.IndexOf("if (!(fromMessageBody && _vm.IsMessageOpen))", StringComparison.Ordinal);
+        Assert.True(branch >= 0, "The branch for a palette opened outside the message body is gone.");
+        var ret = body.IndexOf("return;", branch, StringComparison.Ordinal);
+        Assert.True(ret > branch, "The branch for a palette opened outside the message body must return.");
+        var fromBody = body[ret..];
+        Assert.Contains("palette.ShowModeless();", fromBody, StringComparison.Ordinal);
+        Assert.DoesNotContain("ShowDialog", fromBody, StringComparison.Ordinal);
+
+        // A modeless palette closes itself rather than setting DialogResult, which throws outside ShowDialog, and
+        // closes when the user moves to another window, since nothing else would.
+        var palette = Source("CommandPaletteWindow.xaml.cs");
+        Assert.Contains("if (_modeless) Close();", palette, StringComparison.Ordinal);
+        Assert.Contains("if (_modeless) Dismiss(chosen: false);", palette, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -74,16 +101,25 @@ public class MessageBodyKeyRelayTests
         Assert.True(start >= 0, "OpenCommandPalette is gone.");
         var body = code[start..code.IndexOf("\n    }", start, StringComparison.Ordinal)];
 
-        Assert.Contains("var commandChosen = palette.ShowDialog() == true;", body, StringComparison.Ordinal);
-        var chosen = body.IndexOf("else if (!commandChosen)", StringComparison.Ordinal);
-        Assert.True(chosen >= 0, "Returning straight into the message must be only for a dismissed palette.");
-        var queued = body[chosen..];
-        Assert.Contains("Dispatcher.InvokeAsync(", queued, StringComparison.Ordinal);
-        Assert.Contains("DispatcherPriority.Input", queued, StringComparison.Ordinal);
-        Assert.Contains("if (!IsActive || !untouched) return;", queued, StringComparison.Ordinal);
+        var closed = body.IndexOf("palette.Closed +=", StringComparison.Ordinal);
+        Assert.True(closed >= 0, "The return to the message must be wired to the palette closing.");
+        var handler = body[closed..];
+        Assert.Contains("Dispatcher.InvokeAsync(", handler, StringComparison.Ordinal);
+        Assert.Contains("DispatcherPriority.Input", handler, StringComparison.Ordinal);
+        Assert.Contains("if (!IsActive) return;", handler, StringComparison.Ordinal);
+        Assert.Contains("if (!untouched) return;", handler, StringComparison.Ordinal);
         // A command that closed the message without placing focus still ends on the list, as it did when
         // OnActivated sent it there.
-        Assert.Contains("else ReturnFocusToMessageList();", queued, StringComparison.Ordinal);
+        Assert.Contains("else ReturnFocusToMessageList();", handler, StringComparison.Ordinal);
+
+        // The palette queues the command before it closes, so the return queued on close runs after it.
+        var palette = Source("CommandPaletteWindow.xaml.cs");
+        var run = palette.IndexOf("private void RunSelected()", StringComparison.Ordinal);
+        Assert.True(run >= 0, "RunSelected is gone.");
+        var runBody = palette[run..palette.IndexOf("\n    }", run, StringComparison.Ordinal)];
+        var queue = runBody.IndexOf("InvokeAsync(() => cmd.Execute()", StringComparison.Ordinal);
+        var dismiss = runBody.IndexOf("Dismiss(chosen: true);", StringComparison.Ordinal);
+        Assert.True(queue >= 0 && dismiss > queue, "The command must be queued before the palette closes.");
     }
 
     [Fact]
@@ -95,11 +131,11 @@ public class MessageBodyKeyRelayTests
         var start = code.IndexOf("private void OpenCommandPalette()", StringComparison.Ordinal);
         Assert.True(start >= 0, "OpenCommandPalette is gone.");
         var palette = code[start..code.IndexOf("\n    }", start, StringComparison.Ordinal)];
-        var set = palette.IndexOf("_paletteRestoresFocus = fromMessageBody && _vm.IsMessageOpen;", StringComparison.Ordinal);
-        var shown = palette.IndexOf("palette.ShowDialog()", StringComparison.Ordinal);
+        var set = palette.IndexOf("_paletteRestoresFocus = true;", StringComparison.Ordinal);
+        var shown = palette.IndexOf("palette.ShowModeless();", StringComparison.Ordinal);
         Assert.True(set >= 0 && shown > set, "The flag must be set before the palette opens: the activation comes while it closes.");
         Assert.Contains("Dispatcher.InvokeAsync(() => _paletteRestoresFocus = false, DispatcherPriority.Input);",
-                        palette[shown..], StringComparison.Ordinal);
+                        palette, StringComparison.Ordinal);
 
         var activated = code.IndexOf("private void OnActivated(", StringComparison.Ordinal);
         Assert.True(activated >= 0, "OnActivated is gone.");

--- a/QuickMail.Tests/MessageBodyKeyRelayTests.cs
+++ b/QuickMail.Tests/MessageBodyKeyRelayTests.cs
@@ -55,9 +55,44 @@ public class MessageBodyKeyRelayTests
         Assert.True(start >= 0, "OpenCommandPalette is gone.");
         var body = code[start..code.IndexOf("\n    }", start, StringComparison.Ordinal)];
 
-        Assert.Contains("var fromMessageBody = IsMessageBodyFocused;", body, StringComparison.Ordinal);
-        Assert.Contains("if (fromMessageBody && _vm.IsMessageOpen)", body, StringComparison.Ordinal);
-        Assert.Contains("FocusMessageBodyHost();", body, StringComparison.Ordinal);
+        // Where focus was is read before the palette opens, since afterwards it is on the palette's owner.
+        var captured = body.IndexOf("var fromMessageBody = IsMessageBodyFocused;", StringComparison.Ordinal);
+        var shown = body.IndexOf("palette.ShowDialog()", StringComparison.Ordinal);
+        Assert.True(captured >= 0 && shown > captured, "fromMessageBody must be read before the palette is shown.");
+        Assert.Contains("if (!(fromMessageBody && _vm.IsMessageOpen))", body, StringComparison.Ordinal);
+        Assert.Contains("FocusMessageBodyHost();", body[shown..], StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AfterAPaletteCommand_FocusReturnsToTheMessageOnlyOnceItHasRun()
+    {
+        // The palette queues the chosen command at Input priority. Putting focus into the WebView2 before it
+        // runs would open a dialog with a text box over a focused message body. So with a command chosen, the
+        // return is queued behind it, and only taken while this window is active with the message still open.
+        var code = Source("MainWindow.xaml.cs");
+        var start = code.IndexOf("private void OpenCommandPalette()", StringComparison.Ordinal);
+        Assert.True(start >= 0, "OpenCommandPalette is gone.");
+        var body = code[start..code.IndexOf("\n    }", start, StringComparison.Ordinal)];
+
+        Assert.Contains("var commandChosen = palette.ShowDialog() == true;", body, StringComparison.Ordinal);
+        var chosen = body.IndexOf("else if (!commandChosen)", StringComparison.Ordinal);
+        Assert.True(chosen >= 0, "Returning straight into the message must be only for a dismissed palette.");
+        var queued = body[chosen..];
+        Assert.Contains("Dispatcher.InvokeAsync(", queued, StringComparison.Ordinal);
+        Assert.Contains("DispatcherPriority.Input", queued, StringComparison.Ordinal);
+        Assert.Contains("IsActive && _vm.IsMessageOpen", queued, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("MainWindow.xaml.cs")]
+    [InlineData("MessageWindow.xaml.cs")]
+    public void CtrlW_IsRelayedOnlyWithShiftUp_InEitherCase(string file)
+    {
+        // With Caps Lock on, Ctrl+W arrives as 'W' and Ctrl+Shift+W as 'w', so the case says nothing about
+        // Shift. Ctrl+W's branch has to check Shift itself and accept both cases, or one gesture is lost or
+        // taken by the other.
+        Assert.Contains("e.ctrlKey&&!e.shiftKey&&(e.key==='w'||e.key==='W')){window.chrome.webview.postMessage('ctrl-w')",
+                        Source(file), StringComparison.Ordinal);
     }
 
     /// <summary>Every name the file's injected scripts pass to <c>postMessage</c>.</summary>

--- a/QuickMail.Tests/MessageBodyKeyRelayTests.cs
+++ b/QuickMail.Tests/MessageBodyKeyRelayTests.cs
@@ -45,6 +45,21 @@ public class MessageBodyKeyRelayTests
                         $"{file} relays '{gesture}' but nothing handles it.");
     }
 
+    [Fact]
+    public void ClosingThePaletteFromTheReadingPane_ReturnsToTheMessage()
+    {
+        // WPF reports nothing focused inside the message body (#672), so the palette's own "restore what had
+        // focus" fell back to the message list, and closing it read as the message having closed itself.
+        var code = Source("MainWindow.xaml.cs");
+        var start = code.IndexOf("private void OpenCommandPalette()", StringComparison.Ordinal);
+        Assert.True(start >= 0, "OpenCommandPalette is gone.");
+        var body = code[start..code.IndexOf("\n    }", start, StringComparison.Ordinal)];
+
+        Assert.Contains("var fromMessageBody = IsMessageBodyFocused;", body, StringComparison.Ordinal);
+        Assert.Contains("if (fromMessageBody && _vm.IsMessageOpen)", body, StringComparison.Ordinal);
+        Assert.Contains("FocusMessageBodyHost();", body, StringComparison.Ordinal);
+    }
+
     /// <summary>Every name the file's injected scripts pass to <c>postMessage</c>.</summary>
     private static HashSet<string> Posted(string code)
         => Regex.Matches(code, @"postMessage\(([^)]*)\)")

--- a/QuickMail.Tests/MessageMenuAccessKeyTests.cs
+++ b/QuickMail.Tests/MessageMenuAccessKeyTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Xml;
 using System.Xml.Linq;
 using Xunit;
 
@@ -18,20 +19,21 @@ public class MessageMenuAccessKeyTests
     private static readonly XNamespace Wpf = "http://schemas.microsoft.com/winfx/2006/xaml/presentation";
     private static readonly XNamespace Xaml = "http://schemas.microsoft.com/winfx/2006/xaml";
 
-    public static TheoryData<string> ContextMenuKeys()
+    /// <summary>Every context menu in the main window, keyed or not: the sync range, account actions and
+    /// attachment menus have no <c>x:Key</c>, and were once left out.</summary>
+    public static TheoryData<string> ContextMenus()
     {
         var data = new TheoryData<string>();
-        foreach (var key in MainWindow().Descendants(Wpf + "ContextMenu")
-                     .Select(m => (string?)m.Attribute(Xaml + "Key")).OfType<string>())
-            data.Add(key);
+        foreach (var menu in MainWindow().Descendants(Wpf + "ContextMenu"))
+            data.Add(MenuId(menu));
         return data;
     }
 
     [Theory]
-    [MemberData(nameof(ContextMenuKeys))]
-    public void NoTwoItemsInAContextMenuShareAnAccessKey(string key)
+    [MemberData(nameof(ContextMenus))]
+    public void NoTwoItemsInAContextMenuShareAnAccessKey(string menuId)
     {
-        var menu = MainWindow().Descendants(Wpf + "ContextMenu").Single(m => (string?)m.Attribute(Xaml + "Key") == key);
+        var menu = MainWindow().Descendants(Wpf + "ContextMenu").Single(m => MenuId(m) == menuId);
 
         Assert.Empty(Clashes(menu));
     }
@@ -54,6 +56,39 @@ public class MessageMenuAccessKeyTests
         Assert.All(DirectHeaders(menu), h => Assert.True(h.Contains('_'), $"'{h}' has no access key."));
     }
 
+    [Fact]
+    public void NoMenuItemShowsItsNameWithASpaceMissing()
+    {
+        // Moving Archive's access key once took the space after it along with the old underscore, so the
+        // menus showed "ArchiveConversation". Each of those items has its own AutomationProperties.Name, so
+        // it was still spoken correctly and could not be caught by ear.
+        var pairs = MainWindow().Descendants(Wpf + "MenuItem")
+            .Select(m => (Header: (string?)m.Attribute("Header"), Name: (string?)m.Attribute("AutomationProperties.Name")))
+            .Where(p => p.Header is { } h && p.Name is { } n && !h.StartsWith('{') && !n.StartsWith('{'))
+            .Select(p => (p.Header, Shown: Plain(p.Header!.Replace("_", "", StringComparison.Ordinal)), Spoken: Plain(p.Name!)))
+            .ToList();
+        Assert.NotEmpty(pairs);   // the parse found items that carry both
+
+        var squashed = pairs
+            .Where(p => Squash(p.Shown) == Squash(p.Spoken)
+                        && !string.Equals(p.Shown, p.Spoken, StringComparison.OrdinalIgnoreCase))
+            .Select(p => $"'{p.Header}' shows as '{p.Shown}' but is spoken as '{p.Spoken}'");
+        Assert.Empty(squashed);
+    }
+
+    /// <summary>A menu's name for test output: its key, else its name, else its line in the file.</summary>
+    private static string MenuId(XElement menu)
+        => (string?)menu.Attribute(Xaml + "Key")
+           ?? (string?)menu.Attribute(Xaml + "Name")
+           ?? (string?)menu.Attribute("Name")
+           ?? $"line {((IXmlLineInfo)menu).LineNumber}";
+
+    private static string Plain(string text)
+        => text.Replace("…", "", StringComparison.Ordinal).Replace("...", "", StringComparison.Ordinal).Trim();
+
+    private static string Squash(string text)
+        => new string(text.Where(c => !char.IsWhiteSpace(c)).ToArray()).ToLowerInvariant();
+
     /// <summary>The literal headers of a menu's own items: not nested submenus, and not bound headers.</summary>
     private static List<string> DirectHeaders(XElement menu)
         => menu.Elements(Wpf + "MenuItem")
@@ -72,7 +107,7 @@ public class MessageMenuAccessKeyTests
             .ToList();
 
     private static XDocument MainWindow()
-        => XDocument.Load(Path.Combine(RepoRoot(), "QuickMail", "Views", "MainWindow.xaml"));
+        => XDocument.Load(Path.Combine(RepoRoot(), "QuickMail", "Views", "MainWindow.xaml"), LoadOptions.SetLineInfo);
 
     private static string RepoRoot()
     {

--- a/QuickMail.Tests/MessageMenuAccessKeyTests.cs
+++ b/QuickMail.Tests/MessageMenuAccessKeyTests.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// With two menu items on one access key, pressing it moves between them instead of choosing either. The
+/// message menus have had two such clashes: Reply and Create Rule from Message on R (fixed in #688), and
+/// Reply All and Move to Archive on A (#692), in both the message context menu and the menu bar's
+/// Message menu.
+/// </summary>
+public class MessageMenuAccessKeyTests
+{
+    [Fact]
+    public void NoTwoItemsInTheMessageContextMenuShareAnAccessKey()
+    {
+        var xaml = MainWindowXaml();
+        var start = xaml.IndexOf("x:Key=\"MessageContextMenu\"", StringComparison.Ordinal);
+        Assert.True(start >= 0, "MessageContextMenu is gone.");
+        var menu = xaml[start..xaml.IndexOf("</ContextMenu>", start, StringComparison.Ordinal)];
+
+        var headers = Regex.Matches(menu, "Header=\"([^\"]*)\"").Select(m => m.Groups[1].Value).ToList();
+        Assert.All(headers, h => Assert.True(h.Contains('_'), $"'{h}' has no access key."));
+        Assert.Empty(Clashes(headers));
+    }
+
+    [Fact]
+    public void NoTwoItemsInTheMenuBarsMessageMenuShareAnAccessKey()
+    {
+        // The menu bar's Message menu and its siblings are indented 12 spaces and their direct items 16, so
+        // the items of the Message menu are the 16-space headers before the next 12-space one.
+        var xaml = MainWindowXaml();
+        var start = xaml.IndexOf("<MenuItem Header=\"_Message\"", StringComparison.Ordinal);
+        Assert.True(start >= 0, "The Message menu is gone.");
+        var next = Regex.Match(xaml[(start + 1)..], @"\n {12}<MenuItem Header=");
+        var menu = next.Success ? xaml.Substring(start, next.Index + 1) : xaml[start..];
+
+        var headers = Regex.Matches(menu, "\n {16}<MenuItem Header=\"([^\"]*)\"").Select(m => m.Groups[1].Value).ToList();
+        Assert.Contains("Reply _All", headers);   // the parse found the real items
+        Assert.Empty(Clashes(headers));
+    }
+
+    /// <summary>Each access key used by more than one of <paramref name="headers"/>, with the items that share it.</summary>
+    private static List<string> Clashes(IEnumerable<string> headers)
+        => headers
+            .Where(h => h.Contains('_'))
+            .GroupBy(h => char.ToLowerInvariant(h[h.IndexOf('_') + 1]))
+            .Where(g => g.Count() > 1)
+            .Select(g => $"{g.Key}: {string.Join(", ", g)}")
+            .ToList();
+
+    private static string MainWindowXaml()
+        => File.ReadAllText(Path.Combine(RepoRoot(), "QuickMail", "Views", "MainWindow.xaml"));
+
+    private static string RepoRoot()
+    {
+        for (var dir = new DirectoryInfo(AppContext.BaseDirectory); dir != null; dir = dir.Parent)
+        {
+            if (Directory.Exists(Path.Combine(dir.FullName, "QuickMail", "Views")))
+                return dir.FullName;
+        }
+        throw new InvalidOperationException($"Repo source tree not found from {AppContext.BaseDirectory}.");
+    }
+}

--- a/QuickMail.Tests/MessageMenuAccessKeyTests.cs
+++ b/QuickMail.Tests/MessageMenuAccessKeyTests.cs
@@ -2,59 +2,77 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text.RegularExpressions;
+using System.Xml.Linq;
 using Xunit;
 
 namespace QuickMail.Tests;
 
 /// <summary>
-/// With two menu items on one access key, pressing it moves between them instead of choosing either. The
-/// message menus have had two such clashes: Reply and Create Rule from Message on R (fixed in #688), and
-/// Reply All and Move to Archive on A (#692), in both the message context menu and the menu bar's
-/// Message menu.
+/// With two items in one menu on the same access key, pressing it moves between them instead of choosing
+/// either. The message menus have had several: Reply and Create Rule from Message on R (fixed in #688);
+/// Reply All with Move to Archive and with Grab Addresses on A, and Reply with the group menus' Archive
+/// items on R (#692). The main window's XAML is read as XML, so only a menu's direct items are compared.
 /// </summary>
 public class MessageMenuAccessKeyTests
 {
-    [Fact]
-    public void NoTwoItemsInTheMessageContextMenuShareAnAccessKey()
-    {
-        var xaml = MainWindowXaml();
-        var start = xaml.IndexOf("x:Key=\"MessageContextMenu\"", StringComparison.Ordinal);
-        Assert.True(start >= 0, "MessageContextMenu is gone.");
-        var menu = xaml[start..xaml.IndexOf("</ContextMenu>", start, StringComparison.Ordinal)];
+    private static readonly XNamespace Wpf = "http://schemas.microsoft.com/winfx/2006/xaml/presentation";
+    private static readonly XNamespace Xaml = "http://schemas.microsoft.com/winfx/2006/xaml";
 
-        var headers = Regex.Matches(menu, "Header=\"([^\"]*)\"").Select(m => m.Groups[1].Value).ToList();
-        Assert.All(headers, h => Assert.True(h.Contains('_'), $"'{h}' has no access key."));
-        Assert.Empty(Clashes(headers));
+    public static TheoryData<string> ContextMenuKeys()
+    {
+        var data = new TheoryData<string>();
+        foreach (var key in MainWindow().Descendants(Wpf + "ContextMenu")
+                     .Select(m => (string?)m.Attribute(Xaml + "Key")).OfType<string>())
+            data.Add(key);
+        return data;
+    }
+
+    [Theory]
+    [MemberData(nameof(ContextMenuKeys))]
+    public void NoTwoItemsInAContextMenuShareAnAccessKey(string key)
+    {
+        var menu = MainWindow().Descendants(Wpf + "ContextMenu").Single(m => (string?)m.Attribute(Xaml + "Key") == key);
+
+        Assert.Empty(Clashes(menu));
     }
 
     [Fact]
     public void NoTwoItemsInTheMenuBarsMessageMenuShareAnAccessKey()
     {
-        // The menu bar's Message menu and its siblings are indented 12 spaces and their direct items 16, so
-        // the items of the Message menu are the 16-space headers before the next 12-space one.
-        var xaml = MainWindowXaml();
-        var start = xaml.IndexOf("<MenuItem Header=\"_Message\"", StringComparison.Ordinal);
-        Assert.True(start >= 0, "The Message menu is gone.");
-        var next = Regex.Match(xaml[(start + 1)..], @"\n {12}<MenuItem Header=");
-        var menu = next.Success ? xaml.Substring(start, next.Index + 1) : xaml[start..];
+        var menu = MainWindow().Descendants(Wpf + "MenuItem").Single(m => (string?)m.Attribute("Header") == "_Message");
 
-        var headers = Regex.Matches(menu, "\n {16}<MenuItem Header=\"([^\"]*)\"").Select(m => m.Groups[1].Value).ToList();
-        Assert.Contains("Reply _All", headers);   // the parse found the real items
-        Assert.Empty(Clashes(headers));
+        Assert.Contains("Reply _All", DirectHeaders(menu));   // the parse found the real items
+        Assert.Empty(Clashes(menu));
     }
 
-    /// <summary>Each access key used by more than one of <paramref name="headers"/>, with the items that share it.</summary>
-    private static List<string> Clashes(IEnumerable<string> headers)
-        => headers
+    [Fact]
+    public void EveryItemInTheMessageContextMenuHasAnAccessKey()
+    {
+        var menu = MainWindow().Descendants(Wpf + "ContextMenu")
+            .Single(m => (string?)m.Attribute(Xaml + "Key") == "MessageContextMenu");
+
+        Assert.All(DirectHeaders(menu), h => Assert.True(h.Contains('_'), $"'{h}' has no access key."));
+    }
+
+    /// <summary>The literal headers of a menu's own items: not nested submenus, and not bound headers.</summary>
+    private static List<string> DirectHeaders(XElement menu)
+        => menu.Elements(Wpf + "MenuItem")
+            .Select(m => (string?)m.Attribute("Header"))
+            .OfType<string>()
+            .Where(h => !h.StartsWith('{'))
+            .ToList();
+
+    /// <summary>Each access key used by more than one of the menu's items, with the items that share it.</summary>
+    private static List<string> Clashes(XElement menu)
+        => DirectHeaders(menu)
             .Where(h => h.Contains('_'))
             .GroupBy(h => char.ToLowerInvariant(h[h.IndexOf('_') + 1]))
             .Where(g => g.Count() > 1)
             .Select(g => $"{g.Key}: {string.Join(", ", g)}")
             .ToList();
 
-    private static string MainWindowXaml()
-        => File.ReadAllText(Path.Combine(RepoRoot(), "QuickMail", "Views", "MainWindow.xaml"));
+    private static XDocument MainWindow()
+        => XDocument.Load(Path.Combine(RepoRoot(), "QuickMail", "Views", "MainWindow.xaml"));
 
     private static string RepoRoot()
     {

--- a/QuickMail/Views/CommandPaletteWindow.xaml.cs
+++ b/QuickMail/Views/CommandPaletteWindow.xaml.cs
@@ -12,12 +12,49 @@ public partial class CommandPaletteWindow : Window
 {
     private readonly CommandPaletteViewModel _vm;
 
+    // Shown without a nested message loop (see ShowModeless), and whether it has already been closed.
+    private bool _modeless;
+    private bool _dismissed;
+
+    /// <summary>True when the palette closed because a command was chosen, rather than being dismissed.</summary>
+    public bool CommandChosen { get; private set; }
+
     public CommandPaletteWindow(ICommandRegistry registry)
     {
         _vm = new CommandPaletteViewModel(registry);
         InitializeComponent();
         DataContext = _vm;
         Loaded += OnLoaded;
+        Deactivated += OnDeactivated;
+    }
+
+    /// <summary>
+    /// Shows the palette without a nested message loop, for a caller whose focus is inside a WebView2 (a message
+    /// body). Opened modally from there, the palette crashed a screen reader, where opened from the message list it
+    /// did not (#676, found by ear): the modal loop + WebView2 + assistive technology combination CLAUDE.md
+    /// describes for GrabAddresses, with the same fix. The caller handles <see cref="Window.Closed"/> and reads
+    /// <see cref="CommandChosen"/>.
+    /// </summary>
+    public void ShowModeless()
+    {
+        _modeless = true;
+        Show();
+    }
+
+    // A modeless palette closes when the user moves to another window, as a modal one could not have been left
+    // open behind them.
+    private void OnDeactivated(object? sender, EventArgs e)
+    {
+        if (_modeless) Dismiss(chosen: false);
+    }
+
+    private void Dismiss(bool chosen)
+    {
+        if (_dismissed) return;   // closing deactivates the window, which would dismiss it a second time
+        _dismissed = true;
+        CommandChosen = chosen;
+        if (_modeless) Close();
+        else DialogResult = chosen;
     }
 
     private void OnLoaded(object sender, RoutedEventArgs e)
@@ -39,7 +76,7 @@ public partial class CommandPaletteWindow : Window
     {
         if (e.Key == Key.Escape)
         {
-            DialogResult = false;
+            Dismiss(chosen: false);
             e.Handled = true;
         }
         else if (e.Key == Key.Enter)
@@ -92,12 +129,13 @@ public partial class CommandPaletteWindow : Window
         if (_vm.SelectedCommand != null)
         {
             var cmd = _vm.SelectedCommand;
-            // Close the palette first so focus returns to the main window before the
-            // command runs. Commands like view.showProperties call GetFocusedPaneIndex()
-            // to determine context; if the palette window still has focus when Execute()
-            // runs, the pane index is wrong and the command silently does nothing.
-            DialogResult = true;
+            // The command runs after the palette has closed, so focus is back in the main window when it does.
+            // Commands like view.showProperties call GetFocusedPaneIndex() to determine context; if the palette
+            // window still has focus when Execute() runs, the pane index is wrong and the command silently does
+            // nothing. It is queued BEFORE closing, so that it runs ahead of anything the owner queues when the
+            // palette closes (Input priority runs in order): the owner's focus return has to follow the command.
             Owner?.Dispatcher.InvokeAsync(() => cmd.Execute(), System.Windows.Threading.DispatcherPriority.Input);
+            Dismiss(chosen: true);
         }
     }
 }

--- a/QuickMail/Views/MainWindow.xaml
+++ b/QuickMail/Views/MainWindow.xaml
@@ -77,7 +77,7 @@
                       AutomationProperties.Name="Delete All from Sender"
                       Command="{Binding DeleteSenderGroupCommand}"
                       CommandParameter="{Binding PlacementTarget.SelectedItem, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
-            <MenuItem Header="Arc_hiveAll from Sender"
+            <MenuItem Header="Arc_hive All from Sender"
                       AutomationProperties.Name="Archive All from Sender"
                       Command="{Binding ArchiveSenderGroupCommand}"
                       CommandParameter="{Binding PlacementTarget.SelectedItem, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
@@ -130,7 +130,7 @@
                       AutomationProperties.Name="Delete All to Recipient"
                       Command="{Binding DeleteToGroupCommand}"
                       CommandParameter="{Binding PlacementTarget.SelectedItem, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
-            <MenuItem Header="Arc_hiveAll to Recipient"
+            <MenuItem Header="Arc_hive All to Recipient"
                       AutomationProperties.Name="Archive All to Recipient"
                       Command="{Binding ArchiveToGroupCommand}"
                       CommandParameter="{Binding PlacementTarget.SelectedItem, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
@@ -184,7 +184,7 @@
                       AutomationProperties.Name="Delete Conversation"
                       Command="{Binding DeleteConversationCommand}"
                       CommandParameter="{Binding PlacementTarget.SelectedItem, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
-            <MenuItem Header="Arc_hiveConversation"
+            <MenuItem Header="Arc_hive Conversation"
                       AutomationProperties.Name="Archive Conversation"
                       Command="{Binding ArchiveConversationCommand}"
                       CommandParameter="{Binding PlacementTarget.SelectedItem, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>

--- a/QuickMail/Views/MainWindow.xaml
+++ b/QuickMail/Views/MainWindow.xaml
@@ -234,7 +234,7 @@
             <MenuItem Header="_Delete"
                       AutomationProperties.Name="Delete"
                       Click="MessageContextMenu_Delete_Click"/>
-            <MenuItem Header="Move to _Archive"
+            <MenuItem Header="Move to Arc_hive"
                       InputGestureText="Ctrl+Shift+M"
                       AutomationProperties.Name="Move to Archive"
                       Click="MessageContextMenu_Archive_Click"/>
@@ -389,7 +389,7 @@
                 <MenuItem Header="_Delete"
                           Command="{Binding DeleteMessageCommand}"
                           InputGestureText="Del"/>
-                <MenuItem Header="Move to _Archive"
+                <MenuItem Header="Move to Arc_hive"
                           Command="{Binding ArchiveMessageCommand}"
                           InputGestureText="Ctrl+Shift+M"/>
                 <MenuItem Header="Empty _Trash"
@@ -449,7 +449,7 @@
                     </MenuItem.Style>
                 </MenuItem>
                 <Separator/>
-                <MenuItem Header="Grab _Addresses from Message"
+                <MenuItem Header="_Grab Addresses from Message"
                           Click="MenuGrabAddresses_Click"
                           InputGestureText="Ctrl+Shift+G">
                     <MenuItem.Style>

--- a/QuickMail/Views/MainWindow.xaml
+++ b/QuickMail/Views/MainWindow.xaml
@@ -77,7 +77,7 @@
                       AutomationProperties.Name="Delete All from Sender"
                       Command="{Binding DeleteSenderGroupCommand}"
                       CommandParameter="{Binding PlacementTarget.SelectedItem, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
-            <MenuItem Header="A_rchive All from Sender"
+            <MenuItem Header="Arc_hiveAll from Sender"
                       AutomationProperties.Name="Archive All from Sender"
                       Command="{Binding ArchiveSenderGroupCommand}"
                       CommandParameter="{Binding PlacementTarget.SelectedItem, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
@@ -130,7 +130,7 @@
                       AutomationProperties.Name="Delete All to Recipient"
                       Command="{Binding DeleteToGroupCommand}"
                       CommandParameter="{Binding PlacementTarget.SelectedItem, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
-            <MenuItem Header="A_rchive All to Recipient"
+            <MenuItem Header="Arc_hiveAll to Recipient"
                       AutomationProperties.Name="Archive All to Recipient"
                       Command="{Binding ArchiveToGroupCommand}"
                       CommandParameter="{Binding PlacementTarget.SelectedItem, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
@@ -184,7 +184,7 @@
                       AutomationProperties.Name="Delete Conversation"
                       Command="{Binding DeleteConversationCommand}"
                       CommandParameter="{Binding PlacementTarget.SelectedItem, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
-            <MenuItem Header="A_rchive Conversation"
+            <MenuItem Header="Arc_hiveConversation"
                       AutomationProperties.Name="Archive Conversation"
                       Command="{Binding ArchiveConversationCommand}"
                       CommandParameter="{Binding PlacementTarget.SelectedItem, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -1927,21 +1927,41 @@ public partial class MainWindow : Window
 
     private void OpenCommandPalette()
     {
-        // Remember what had focus so we can restore it if the user dismisses without running a command.
-        // Inside the message body WPF reports nothing focused (#672), so note that separately: otherwise
-        // closing a palette opened while reading (#676) dropped the user on the message list.
+        // Remember what had focus so it can be restored. Inside the message body WPF reports nothing focused
+        // (#672), so note that separately: otherwise closing a palette opened while reading (#676) dropped
+        // the user on the message list.
         var previousFocus = Keyboard.FocusedElement as IInputElement;
         var fromMessageBody = IsMessageBodyFocused;
 
         var palette = new CommandPaletteWindow(_registry) { Owner = this };
-        palette.ShowDialog();
+        var commandChosen = palette.ShowDialog() == true;
 
-        // Restore focus: back into the message if that is where it was and it is still open; otherwise to
-        // what had focus, falling back to the message list.
-        if (fromMessageBody && _vm.IsMessageOpen)
-            FocusMessageBodyHost();
-        else
+        if (!(fromMessageBody && _vm.IsMessageOpen))
+        {
+            // Restore what had focus, falling back to the message list. A chosen command runs after this, so
+            // one that moves focus still ends where it put it.
             (previousFocus ?? MessageList).Focus();
+        }
+        else if (!commandChosen)
+        {
+            FocusMessageBodyHost();
+        }
+        else
+        {
+            // The palette queued the chosen command at Input priority. Go back into the message only after it
+            // has run, never before: focusing the WebView2 first would open a dialog with a text box (Go to
+            // Folder, New Folder, Save View) straight over a focused message body, close to the nested-modal
+            // freeze in CLAUDE.md. Queued at the same priority, this runs after the command. While a dialog the
+            // command opened is up this window is not active, so it does nothing; and it leaves focus alone if
+            // the command closed the message or put focus somewhere of its own.
+            Dispatcher.InvokeAsync(() =>
+            {
+                var focused = Keyboard.FocusedElement;
+                if (IsActive && _vm.IsMessageOpen
+                    && (focused is null || ReferenceEquals(focused, this) || ReferenceEquals(focused, previousFocus) || IsMessageBodyFocused))
+                    FocusMessageBodyHost();
+            }, DispatcherPriority.Input);
+        }
     }
 
     private void ViewModeButton_Click(object sender, RoutedEventArgs e) => OpenViewMenu();
@@ -3404,7 +3424,7 @@ public partial class MainWindow : Window
                 // arrives as a lowercase w, so it closed the message instead of watching the conversation.
                 +"else if(e.ctrlKey&&!e.shiftKey&&(e.key==='w'||e.key==='W')){window.chrome.webview.postMessage('ctrl-w');e.preventDefault();}"
                 // Watching a thread while reading it is the most natural moment to do so, and focus
-                // is inside this WebView2 then. Note the key is 'W' (upper case) with Shift held.
+                // is inside this WebView2 then. Either case is accepted: Caps Lock makes it lowercase with Shift held.
                 +"else if(e.ctrlKey&&e.shiftKey&&(e.key==='w'||e.key==='W')){window.chrome.webview.postMessage('ctrl-shift-w');e.preventDefault();}"
                 // The command palette, as the message window already relays it (#676): focus is inside this
                 // document for as long as the user is reading, so the window's own key handling never sees it.

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -3397,6 +3397,9 @@ public partial class MainWindow : Window
                 // Watching a thread while reading it is the most natural moment to do so, and focus
                 // is inside this WebView2 then. Note the key is 'W' (upper case) with Shift held.
                 +"else if(e.ctrlKey&&e.shiftKey&&(e.key==='w'||e.key==='W')){window.chrome.webview.postMessage('ctrl-shift-w');e.preventDefault();}"
+                // The command palette, as the message window already relays it (#676): focus is inside this
+                // document for as long as the user is reading, so the window's own key handling never sees it.
+                +"else if(e.ctrlKey&&e.shiftKey&&(e.key==='p'||e.key==='P')){window.chrome.webview.postMessage('ctrl-shift-p');e.preventDefault();}"
                 +"});"
                 // The live region the link menu writes outcomes into (issues #671, #329).
                 + LinkContextMenuSupport.StatusRegionScript);
@@ -3429,6 +3432,8 @@ public partial class MainWindow : Window
                         () => _registry.FindByGesture(Key.W, ModifierKeys.Control | ModifierKeys.Shift)
                                        ?.Execute(),
                         DispatcherPriority.Input);
+                else if (msg == "ctrl-shift-p")
+                    Dispatcher.InvokeAsync(OpenCommandPalette, DispatcherPriority.Input);
             };
 
             MessageBody.CoreWebView2.NavigationStarting += (_, args) =>

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -1938,44 +1938,49 @@ public partial class MainWindow : Window
         var fromMessageBody = IsMessageBodyFocused;
 
         var palette = new CommandPaletteWindow(_registry) { Owner = this };
-        // Closing the palette reactivates this window, and OnActivated would then queue focus that was in the
-        // message body over to the list, undoing the return below. Set before the palette opens, since the
-        // activation comes while it closes.
-        _paletteRestoresFocus = fromMessageBody && _vm.IsMessageOpen;
-        var commandChosen = palette.ShowDialog() == true;
 
         if (!(fromMessageBody && _vm.IsMessageOpen))
         {
             // Restore what had focus, falling back to the message list. A chosen command runs after this, so
             // one that moves focus still ends where it put it.
+            palette.ShowDialog();
             (previousFocus ?? MessageList).Focus();
+            return;
         }
-        else if (!commandChosen)
+
+        // From inside the message body the palette is modeless. Opened modally from there it crashed a screen
+        // reader, where opened from the message list it did not (#676, found by ear): the modal loop + WebView2 +
+        // assistive technology combination CLAUDE.md describes for GrabAddresses, with the same fix.
+        //
+        // Closing it reactivates this window, and OnActivated would then queue focus that was in the message body
+        // over to the list, undoing the return below. The flag makes it stand aside until that return has run.
+        _paletteRestoresFocus = true;
+        palette.Closed += (_, _) =>
         {
-            FocusMessageBodyHost();
-        }
-        else
-        {
-            // The palette queued the chosen command at Input priority. Go back into the message only after it
-            // has run, never before: focusing the WebView2 first would open a dialog with a text box (Go to
-            // Folder, New Folder, Save View) straight over a focused message body, close to the nested-modal
-            // freeze in CLAUDE.md. Queued at the same priority, this runs after the command. While a dialog the
-            // command opened is up this window is not active, so it does nothing; and it leaves focus alone if
-            // the command put focus somewhere of its own. A command that closed the message without placing
-            // focus gets the message list, as OnActivated would have given it.
+            // Queued at Input priority, behind a chosen command, which the palette queues before it closes. Going
+            // back into the WebView2 first would open a dialog with a text box (Go to Folder, New Folder, Save
+            // View) straight over a focused message body. While a dialog the command opened is up this window is
+            // not active, so this does nothing; and after a command it leaves focus alone if the command put focus
+            // somewhere of its own. A message the command closed without placing focus gets the message list, as
+            // OnActivated would have given it.
             Dispatcher.InvokeAsync(() =>
             {
-                var focused = Keyboard.FocusedElement;
-                var untouched = focused is null || ReferenceEquals(focused, this)
-                                || ReferenceEquals(focused, previousFocus) || IsMessageBodyFocused;
-                if (!IsActive || !untouched) return;
+                if (!IsActive) return;
+                if (palette.CommandChosen)
+                {
+                    var focused = Keyboard.FocusedElement;
+                    var untouched = focused is null || ReferenceEquals(focused, this)
+                                    || ReferenceEquals(focused, previousFocus) || IsMessageBodyFocused;
+                    if (!untouched) return;
+                }
                 if (_vm.IsMessageOpen) FocusMessageBodyHost();
                 else ReturnFocusToMessageList();
             }, DispatcherPriority.Input);
-        }
 
-        // Cleared behind the returns queued above, so an activation that arrives late is covered too.
-        Dispatcher.InvokeAsync(() => _paletteRestoresFocus = false, DispatcherPriority.Input);
+            // Cleared behind that return, so an activation that arrives late is covered too.
+            Dispatcher.InvokeAsync(() => _paletteRestoresFocus = false, DispatcherPriority.Input);
+        };
+        palette.ShowModeless();
     }
 
     private void ViewModeButton_Click(object sender, RoutedEventArgs e) => OpenViewMenu();

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -139,6 +139,10 @@ public partial class MainWindow : Window
     // so we can restore focus on re-activation.  -1 = not yet deactivated / unknown.
     private int _paneIndexBeforeDeactivation = -1;
 
+    // Set while OpenCommandPalette puts focus back into the message body itself, so that OnActivated, which
+    // otherwise sends focus that was in the message body to the list, stands aside (#676).
+    private bool _paletteRestoresFocus;
+
     // Debounces StatusText announcements so rapid per-folder sync updates ("5 messages",
     // "12 messages", …) coalesce into a single final reading by the screen reader.
     private DispatcherTimer? _statusAnnounceTimer;
@@ -1934,6 +1938,10 @@ public partial class MainWindow : Window
         var fromMessageBody = IsMessageBodyFocused;
 
         var palette = new CommandPaletteWindow(_registry) { Owner = this };
+        // Closing the palette reactivates this window, and OnActivated would then queue focus that was in the
+        // message body over to the list, undoing the return below. Set before the palette opens, since the
+        // activation comes while it closes.
+        _paletteRestoresFocus = fromMessageBody && _vm.IsMessageOpen;
         var commandChosen = palette.ShowDialog() == true;
 
         if (!(fromMessageBody && _vm.IsMessageOpen))
@@ -1953,15 +1961,21 @@ public partial class MainWindow : Window
             // Folder, New Folder, Save View) straight over a focused message body, close to the nested-modal
             // freeze in CLAUDE.md. Queued at the same priority, this runs after the command. While a dialog the
             // command opened is up this window is not active, so it does nothing; and it leaves focus alone if
-            // the command closed the message or put focus somewhere of its own.
+            // the command put focus somewhere of its own. A command that closed the message without placing
+            // focus gets the message list, as OnActivated would have given it.
             Dispatcher.InvokeAsync(() =>
             {
                 var focused = Keyboard.FocusedElement;
-                if (IsActive && _vm.IsMessageOpen
-                    && (focused is null || ReferenceEquals(focused, this) || ReferenceEquals(focused, previousFocus) || IsMessageBodyFocused))
-                    FocusMessageBodyHost();
+                var untouched = focused is null || ReferenceEquals(focused, this)
+                                || ReferenceEquals(focused, previousFocus) || IsMessageBodyFocused;
+                if (!IsActive || !untouched) return;
+                if (_vm.IsMessageOpen) FocusMessageBodyHost();
+                else ReturnFocusToMessageList();
             }, DispatcherPriority.Input);
         }
+
+        // Cleared behind the returns queued above, so an activation that arrives late is covered too.
+        Dispatcher.InvokeAsync(() => _paletteRestoresFocus = false, DispatcherPriority.Input);
     }
 
     private void ViewModeButton_Click(object sender, RoutedEventArgs e) => OpenViewMenu();
@@ -4035,6 +4049,7 @@ public partial class MainWindow : Window
     private void OnActivated(object? sender, EventArgs e)
     {
         LogService.Debug($"[FOCUS] Activated lastPane={_paneIndexBeforeDeactivation} {FocusInfo()}");
+        if (_paletteRestoresFocus) return;   // OpenCommandPalette is putting focus back into the message (#676)
         if (_paneIndexBeforeDeactivation == 3 || _paneIndexBeforeDeactivation == 4)
             // Re-check IsActive at callback time: a transient activation (e.g. a modeless child of the
             // Rules Manager closing and briefly bouncing foreground through here) must NOT pull focus

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -1928,13 +1928,20 @@ public partial class MainWindow : Window
     private void OpenCommandPalette()
     {
         // Remember what had focus so we can restore it if the user dismisses without running a command.
+        // Inside the message body WPF reports nothing focused (#672), so note that separately: otherwise
+        // closing a palette opened while reading (#676) dropped the user on the message list.
         var previousFocus = Keyboard.FocusedElement as IInputElement;
+        var fromMessageBody = IsMessageBodyFocused;
 
         var palette = new CommandPaletteWindow(_registry) { Owner = this };
         palette.ShowDialog();
 
-        // Restore focus. Fall back to the message list if nothing was previously focused.
-        (previousFocus ?? MessageList).Focus();
+        // Restore focus: back into the message if that is where it was and it is still open; otherwise to
+        // what had focus, falling back to the message list.
+        if (fromMessageBody && _vm.IsMessageOpen)
+            FocusMessageBodyHost();
+        else
+            (previousFocus ?? MessageList).Focus();
     }
 
     private void ViewModeButton_Click(object sender, RoutedEventArgs e) => OpenViewMenu();
@@ -3393,7 +3400,9 @@ public partial class MainWindow : Window
                 +"else if(e.ctrlKey&&(e.key==='2'||e.key==='y'||e.key==='Y')){window.chrome.webview.postMessage('focus-folders');e.preventDefault();}"
                 +"else if(e.key==='Tab'&&e.shiftKey){window.chrome.webview.postMessage('shift-tab');e.preventDefault();}"
                 +"else if(e.altKey&&(e.key==='a'||e.key==='A')){window.chrome.webview.postMessage('focus-attachments');e.preventDefault();}"
-                +"else if(e.ctrlKey&&e.key==='w'){window.chrome.webview.postMessage('ctrl-w');e.preventDefault();}"
+                // Not with Shift held: this branch runs before Ctrl+Shift+W's, and with Caps Lock on that key
+                // arrives as a lowercase w, so it closed the message instead of watching the conversation.
+                +"else if(e.ctrlKey&&!e.shiftKey&&(e.key==='w'||e.key==='W')){window.chrome.webview.postMessage('ctrl-w');e.preventDefault();}"
                 // Watching a thread while reading it is the most natural moment to do so, and focus
                 // is inside this WebView2 then. Note the key is 'W' (upper case) with Shift held.
                 +"else if(e.ctrlKey&&e.shiftKey&&(e.key==='w'||e.key==='W')){window.chrome.webview.postMessage('ctrl-shift-w');e.preventDefault();}"

--- a/QuickMail/Views/MessageWindow.xaml.cs
+++ b/QuickMail/Views/MessageWindow.xaml.cs
@@ -230,9 +230,9 @@ public partial class MessageWindow : Window
             //
             // Focus lands INSIDE this document as soon as the window opens, so a gesture that is
             // only handled by the WPF key ladder is unreachable in practice — which is why watching
-            // a thread had to be relayed here as well as registered there. Note the Ctrl+Shift+W
-            // test must accept 'W': the browser reports the upper-case key when Shift is held, so
-            // the lower-case-only Ctrl+W branch below cannot match it (and must not).
+            // a thread had to be relayed here as well as registered there. Both Ctrl+W tests accept
+            // either case, since Caps Lock flips it, so Ctrl+W's checks that Shift is up: the case of
+            // the key says nothing about Shift.
             await MessageBody.CoreWebView2.AddScriptToExecuteOnDocumentCreatedAsync(
                 "window.addEventListener('keydown',function(e){" +
                 "if(e.key==='Escape'){window.chrome.webview.postMessage('escape');e.preventDefault();}" +
@@ -241,7 +241,7 @@ public partial class MessageWindow : Window
                 "else if(e.key==='F6'&&e.shiftKey){window.chrome.webview.postMessage('shift-f6');e.preventDefault();}" +
                 "else if(e.altKey&&(e.key==='a'||e.key==='A')){window.chrome.webview.postMessage('focus-attachments');e.preventDefault();}" +
                 "else if(e.ctrlKey&&e.shiftKey&&(e.key==='w'||e.key==='W')){window.chrome.webview.postMessage('ctrl-shift-w');e.preventDefault();}" +
-                "else if(e.ctrlKey&&e.key==='w'){window.chrome.webview.postMessage('ctrl-w');e.preventDefault();}" +
+                "else if(e.ctrlKey&&!e.shiftKey&&(e.key==='w'||e.key==='W')){window.chrome.webview.postMessage('ctrl-w');e.preventDefault();}" +
                 "else if(e.ctrlKey&&e.shiftKey&&(e.key==='p'||e.key==='P')){window.chrome.webview.postMessage('ctrl-shift-p');e.preventDefault();}" +
                 "});");
 


### PR DESCRIPTION
Fixes #676. Fixes #692.

## What changes

- **Ctrl+Shift+P opens the command palette from the reading pane (#676).**
  - While you read a message, focus is inside the WebView2, and a key pressed there never reaches the window.
  - Each message body therefore injects a script that relays certain gestures back to WPF. The message window's script relays Ctrl+Shift+P; the reading pane's didn't. So the palette, and every command with no default key, was out of reach while reading.
  - The reading pane now relays `ctrl-shift-p`, and `MainWindow` opens its palette.
  - Closing the palette returns focus to the message. WPF reports nothing focused inside the message body (#672), so the palette's "restore what had focus" used to fall back to the message list.
  - When a command is chosen, focus goes back into the message only after the command has run. It goes back only if the window is still active, the message is still open, and the command hasn't put focus somewhere else. Returning first would open a dialog with a text box, such as Go to Folder, over a focused message body. That is close to the nested-modal freeze described in CLAUDE.md. A command that closed the message without placing focus ends on the message list.
  - **From inside a message the palette is modeless.** Opened modally from inside a reading-pane message, it crashed a screen reader, several times; opened from the message list it did not. That is the modal loop + WebView2 + assistive technology combination CLAUDE.md describes for the GrabAddresses lockup, and the fix is the same. `CommandPaletteWindow.ShowModeless()` closes itself, since a modeless window has no `DialogResult`, and it closes when you move to another window. From anywhere else the palette is modal, as before. Tim verified by ear: no crash, and focus returns to where he was reading.
  - The message window still opens its palette modally from its message body, the same shape. It hasn't been reported crashing there, so it's left as a follow-up.
  - `OnActivated` stands aside while this happens. Closing the palette reactivates the main window, and `OnActivated` sends focus that was in the message body to the list, which runs after the return above and undid it. A flag set before the palette opens, and cleared behind the queued returns, tells it the palette is handling focus.
- **Caps Lock no longer mixes up Ctrl+W and Ctrl+Shift+W in a message.**
  - In the reading pane, Ctrl+W's branch ran first and didn't require Shift to be up. So with Caps Lock on, Ctrl+Shift+W closed the message instead of watching the conversation.
  - In the message window, Ctrl+W with Caps Lock on arrived as `W` and wasn't relayed.
  - Both now check Shift and accept either case.
- **No two items in a message menu share an access key (#692).**
  - In the message context menu and the menu bar's Message menu, Reply All and Move to Archive both used A. The Message menu's Grab Addresses from Message used A too.
  - The group context menus (From, To, Conversations) had Reply and their Archive item both on R.
  - Archive is now H everywhere ("Move to Arc_hive", "Arc_hive Conversation", …), and Grab Addresses is G, matching the message window.
  - Clashes in other menu-bar menus (View, Sort, Help) are filed as #695.

## Tests

- `MessageBodyKeyRelayTests`:
  - Both message bodies relay the shared gestures.
  - Every gesture either one relays has a handler (the two surfaces have drifted apart before).
  - A palette opened from the reading pane reads where focus was before it opens, and returns to the message.
  - After a command, the return to the message is queued behind it and gated on the window being active, and a closed message ends on the list.
  - `OnActivated` checks the palette's flag before sending focus to the list, and the flag is set before the palette opens.
  - Both bodies relay Ctrl+W only with Shift up, in either case.
  - These focus checks are read from source. Where focus really ends needs a real window, so it's among the hands-on checks below.
- `MessageMenuAccessKeyTests` reads `MainWindow.xaml` as XML. It checks the menu bar's Message menu and every context menu for clashes, including the three context menus with no `x:Key`.
  - It also checks that each menu item's on-screen text matches its automation name, so a lost space ("ArchiveConversation") is caught even though it is spoken correctly.

Every review fix fails its test when removed: eleven mutation checks across three rounds, all caught. The tests also pin that the palette opens modelessly from inside a message, and that it queues a chosen command before it closes. Release build: 0 warnings, 0 errors.

## For hands-on testing

These need a screen reader and a real message:

1. After Escape from the palette, do you land where you were in the message, or at its top? Returning uses the same entry point as opening a message (the first focus stop).
2. Choose Go to Folder, New Folder, Address Book or Save View from the palette while in a message. Each should open without freezing and without extra speech.
3. After running a command that doesn't move focus, such as Mark as Read, are you back in the message?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
