### PR TITLE
Fix #670: no "unavailable" after moving or unwatching

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,7 +161,7 @@ All custom screen reader announcements are user-configurable and governed by `Co
 - `CustomAnnouncements` — Master on/off switch for all programmatic announcements
 - `AnnounceHints` — Instructional tips (e.g. "Press Escape to return")
 - `AnnounceStatus` — Background progress (e.g. "Syncing…", "N messages loaded", connection state)
-- `AnnounceResults` — Action outcomes (e.g. "3 messages moved", "Delete may not have completed")
+- `AnnounceResults` — Action outcomes (e.g. "3 messages copied", "Delete may not have completed")
 - `AnnounceSpellingWhileTyping` — Misspellings during typing (off by default, adds overhead)
 - `AnnounceSpellingWhileNavigating` — Misspellings on navigation
 

--- a/QuickMail.Tests/FocusLandingGuardTests.cs
+++ b/QuickMail.Tests/FocusLandingGuardTests.cs
@@ -27,6 +27,23 @@ public class FocusLandingGuardTests
         Assert.True(focus < 0 || guard < focus, "The active-window check must come before a row is focused.");
     }
 
+    [Fact]
+    public void WithEveryRowLeaving_FocusGoesToTheListItself() // #670
+    {
+        // Moving or unwatching the last row leaves nothing selected. Focus goes to the list, which is about to be
+        // empty, instead of staying on a row that has gone or in a message the reading pane has just cleared. The
+        // active-window check still comes first, so this never pulls focus out of another window either.
+        var code = File.ReadAllText(Path.Combine(RepoRoot(), "QuickMail", "Views", "MainWindow.xaml.cs"));
+        var start = code.IndexOf("private bool FocusSelectedMessageRowNow()", StringComparison.Ordinal);
+        Assert.True(start >= 0, "FocusSelectedMessageRowNow is gone.");
+        var body = code[start..code.IndexOf("\n    }", start, StringComparison.Ordinal)];
+
+        var guard = body.IndexOf("if (!IsActive) return true;", StringComparison.Ordinal);
+        var park = body.IndexOf("return MessageList.Focus();", StringComparison.Ordinal);
+        Assert.True(park >= 0, "With nothing selected, FocusSelectedMessageRowNow no longer puts focus on the list.");
+        Assert.True(guard >= 0 && guard < park, "The active-window check must still come first.");
+    }
+
     private static string RepoRoot()
     {
         for (var dir = new DirectoryInfo(AppContext.BaseDirectory); dir != null; dir = dir.Parent)

--- a/QuickMail.Tests/FocusLandingGuardTests.cs
+++ b/QuickMail.Tests/FocusLandingGuardTests.cs
@@ -1,0 +1,39 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// The View half of landing focus before rows leave (#667, #670). The ViewModel half is covered in
+/// <see cref="MessageRemovalFocusTests"/>; this is read from source because it needs a real, active window.
+/// </summary>
+public class FocusLandingGuardTests
+{
+    [Fact]
+    public void LandingFocus_NeverPullsItIntoAnInactiveMainWindow() // #670
+    {
+        // Unwatching from a message window or the Watched Conversations manager, or a slow move the user has
+        // left, lands focus in the main window while another window is active. Focusing a row then would take
+        // the user out of the window they are in, so the check has to come before any row is focused.
+        var code = File.ReadAllText(Path.Combine(RepoRoot(), "QuickMail", "Views", "MainWindow.xaml.cs"));
+        var start = code.IndexOf("private bool FocusSelectedMessageRowNow()", StringComparison.Ordinal);
+        Assert.True(start >= 0, "FocusSelectedMessageRowNow is gone.");
+        var body = code[start..code.IndexOf("\n    }", start, StringComparison.Ordinal)];
+
+        var guard = body.IndexOf("if (!IsActive) return true;", StringComparison.Ordinal);
+        var focus = body.IndexOf(".Focus()", StringComparison.Ordinal);
+        Assert.True(guard >= 0, "FocusSelectedMessageRowNow no longer checks that the main window is active.");
+        Assert.True(focus < 0 || guard < focus, "The active-window check must come before a row is focused.");
+    }
+
+    private static string RepoRoot()
+    {
+        for (var dir = new DirectoryInfo(AppContext.BaseDirectory); dir != null; dir = dir.Parent)
+        {
+            if (Directory.Exists(Path.Combine(dir.FullName, "QuickMail", "Views")))
+                return dir.FullName;
+        }
+        throw new InvalidOperationException($"Repo source tree not found from {AppContext.BaseDirectory}.");
+    }
+}

--- a/QuickMail.Tests/MessageRemovalFocusTests.cs
+++ b/QuickMail.Tests/MessageRemovalFocusTests.cs
@@ -162,6 +162,7 @@ public class MessageRemovalFocusTests
     {
         var f = await Fixture.CreateAsync();
         var moving = f.Row("b");
+        f.Vm.SelectedMessage = moving;
 
         await f.Vm.MoveSelectedMessagesToFolderAsync([moving], Folder("Archive", SpecialFolderKind.Archive));
 
@@ -170,6 +171,69 @@ public class MessageRemovalFocusTests
         Assert.Equal("c", call.Selected?.MessageId);         // … with the selection already on the survivor
         Assert.Equal(0, f.QueuedFocusCalls);                 // landed, so no second focus move afterwards
         Assert.DoesNotContain(moving, f.Vm.Messages);
+    }
+
+    [Fact]
+    public async Task MoveFallsBackToTheQueuedFocusWhenLandingFails() // #670
+    {
+        var f = await Fixture.CreateAsync();
+        f.FocusNowSucceeds = false;
+        f.Vm.SelectedMessage = f.Row("b");
+
+        await f.Vm.MoveSelectedMessagesToFolderAsync([f.Row("b")], Folder("Archive", SpecialFolderKind.Archive));
+
+        Assert.Equal(1, f.QueuedFocusCalls);
+        Assert.Equal("c", f.Vm.SelectedMessage?.MessageId);
+    }
+
+    [Fact]
+    public async Task MoveLeavesTheSelectionAlone_WhenItIsNotAmongTheMoved() // #670
+    {
+        // The landing runs after the server move, and by then the user may be somewhere else in the list.
+        var f = await Fixture.CreateAsync();
+        f.Vm.SelectedMessage = f.Row("e");
+
+        await f.Vm.MoveSelectedMessagesToFolderAsync([f.Row("b")], Folder("Archive", SpecialFolderKind.Archive));
+
+        Assert.Empty(f.FocusNowCalls);
+        Assert.Equal("e", f.Vm.SelectedMessage?.MessageId);
+    }
+
+    [Fact]
+    public async Task MovingTheOpenMessage_ClosesTheReadingPane() // #670
+    {
+        // As delete, archive and unwatch do: otherwise the pane keeps showing a message no longer in the list.
+        var f = await Fixture.CreateAsync();
+        f.Vm.SelectedMessage = f.Row("b");
+        f.Vm.IsMessageOpen = true;
+
+        await f.Vm.MoveSelectedMessagesToFolderAsync([f.Row("b")], Folder("Archive", SpecialFolderKind.Archive));
+
+        Assert.False(f.Vm.IsMessageOpen);
+    }
+
+    [Fact]
+    public async Task MovingOneMessageIsNeverSpoken() // #670, as #667 for delete
+    {
+        // The next message has just been read out; "1 message moved" would interrupt it.
+        var f = await Fixture.CreateAsync();
+        f.Vm.SelectedMessage = f.Row("b");
+
+        await f.Vm.MoveSelectedMessagesToFolderAsync([f.Row("b")], Folder("Archive", SpecialFolderKind.Archive));
+
+        Assert.DoesNotContain(f.Announced.Announced, a => a.Category != AnnouncementCategory.Silent);
+        Assert.Equal(("1 message moved to Archive.", AnnouncementCategory.Silent), f.Announced.Last);
+    }
+
+    [Fact]
+    public async Task MovingSeveralMessagesSaysTheCount() // #670
+    {
+        var f = await Fixture.CreateAsync();
+        f.Vm.SelectedMessage = f.Row("b");
+
+        await f.Vm.MoveSelectedMessagesToFolderAsync([f.Row("b"), f.Row("c")], Folder("Archive", SpecialFolderKind.Archive));
+
+        Assert.Equal(("2 messages moved to Archive.", AnnouncementCategory.MessageAction), f.Announced.Last);
     }
 
     [Fact]

--- a/QuickMail.Tests/MessageRemovalFocusTests.cs
+++ b/QuickMail.Tests/MessageRemovalFocusTests.cs
@@ -184,19 +184,52 @@ public class MessageRemovalFocusTests
 
         Assert.Equal(1, f.QueuedFocusCalls);
         Assert.Equal("c", f.Vm.SelectedMessage?.MessageId);
+        // Still a single move: not spoken, as a single delete is not, whether or not landing worked.
+        Assert.DoesNotContain(f.Announced.Announced, a => a.Category != AnnouncementCategory.Silent);
     }
 
     [Fact]
     public async Task MoveLeavesTheSelectionAlone_WhenItIsNotAmongTheMoved() // #670
     {
-        // The landing runs after the server move, and by then the user may be somewhere else in the list.
+        // The landing runs after the server move, and by then the user may be somewhere else: on another row,
+        // reading it. Neither focus nor the reading pane is taken from them.
         var f = await Fixture.CreateAsync();
         f.Vm.SelectedMessage = f.Row("e");
+        f.Vm.IsMessageOpen = true;
 
         await f.Vm.MoveSelectedMessagesToFolderAsync([f.Row("b")], Folder("Archive", SpecialFolderKind.Archive));
 
         Assert.Empty(f.FocusNowCalls);
+        Assert.Equal(0, f.QueuedFocusCalls);
         Assert.Equal("e", f.Vm.SelectedMessage?.MessageId);
+        Assert.True(f.Vm.IsMessageOpen);
+    }
+
+    [Fact]
+    public async Task MovingInAGroupView_ClearsTheMovedSelection() // #670, as delete does
+    {
+        // In the trees, focus is the view's business after the rebuild. A selection left on a moved message
+        // keeps the per-message hotkeys live against a message that has gone.
+        var f = await Fixture.CreateAsync();
+        f.Vm.ViewMode = ViewMode.Conversations;
+        f.Vm.SelectedMessage = f.Row("b");
+
+        await f.Vm.MoveSelectedMessagesToFolderAsync([f.Row("b")], Folder("Archive", SpecialFolderKind.Archive));
+
+        Assert.Null(f.Vm.SelectedMessage);
+        Assert.Equal(0, f.QueuedFocusCalls);
+    }
+
+    [Fact]
+    public async Task MovingTheLastMessageSaysTheFolderIsNowEmpty() // #670, as delete says it
+    {
+        var f = await Fixture.CreateAsync(messageCount: 1);
+        f.Vm.SelectedMessage = f.Row("a");
+
+        await f.Vm.MoveSelectedMessagesToFolderAsync([f.Row("a")], Folder("Archive", SpecialFolderKind.Archive));
+
+        Assert.Equal(("1 message moved to Archive. Folder is now empty.", AnnouncementCategory.MessageAction),
+            f.Announced.Last);
     }
 
     [Fact]

--- a/QuickMail.Tests/MessageRemovalFocusTests.cs
+++ b/QuickMail.Tests/MessageRemovalFocusTests.cs
@@ -221,6 +221,26 @@ public class MessageRemovalFocusTests
     }
 
     [Fact]
+    public async Task MovingEveryMessage_PutsFocusOnTheListBeforeTheRowsLeave() // #670
+    {
+        // With no survivor to land on, focus would stay on a row that has gone, or in a message the reading pane has
+        // just cleared: a blank page a screen reader user could leave only with Alt+Tab. The list itself takes it,
+        // asked for while the row is still there.
+        var f = await Fixture.CreateAsync(messageCount: 1);
+        var only = f.Row("a");
+        f.Vm.SelectedMessage = only;
+        f.Vm.IsMessageOpen = true;
+
+        await f.Vm.MoveSelectedMessagesToFolderAsync([only], Folder("Archive", SpecialFolderKind.Archive));
+
+        var call = Assert.Single(f.FocusNowCalls);
+        Assert.Null(call.Selected);            // nothing left to select: the list itself takes focus
+        Assert.Contains(only, call.Rows);      // asked for while the row was still listed
+        Assert.Equal(0, f.QueuedFocusCalls);
+        Assert.Empty(f.Vm.Messages);
+    }
+
+    [Fact]
     public async Task MovingTheLastMessageSaysTheFolderIsNowEmpty() // #670, as delete says it
     {
         var f = await Fixture.CreateAsync(messageCount: 1);

--- a/QuickMail.Tests/MessageRemovalFocusTests.cs
+++ b/QuickMail.Tests/MessageRemovalFocusTests.cs
@@ -158,6 +158,21 @@ public class MessageRemovalFocusTests
     }
 
     [Fact]
+    public async Task MoveAsksForFocusWhileTheMovedRowIsStillInTheList() // #670
+    {
+        var f = await Fixture.CreateAsync();
+        var moving = f.Row("b");
+
+        await f.Vm.MoveSelectedMessagesToFolderAsync([moving], Folder("Archive", SpecialFolderKind.Archive));
+
+        var call = Assert.Single(f.FocusNowCalls);
+        Assert.Contains(moving, call.Rows);                  // asked for while the row was still there …
+        Assert.Equal("c", call.Selected?.MessageId);         // … with the selection already on the survivor
+        Assert.Equal(0, f.QueuedFocusCalls);                 // landed, so no second focus move afterwards
+        Assert.DoesNotContain(moving, f.Vm.Messages);
+    }
+
+    [Fact]
     public async Task DeleteLandsOnTheRowAfterTheDeletedBlock()
     {
         var f = await Fixture.CreateAsync();

--- a/QuickMail.Tests/WatchedConversationsPhase2Tests.cs
+++ b/QuickMail.Tests/WatchedConversationsPhase2Tests.cs
@@ -444,6 +444,40 @@ public class WatchedConversationsPhase2Tests
         Assert.Equal(["2"], vm.Messages.Select(m => m.MessageId).ToArray());
     }
 
+    [Fact]
+    public async Task UnwatchingInTheWatchedFolder_LandsFocusBeforeTheRowsLeave() // #670
+    {
+        // Removing the row that holds keyboard focus is what a screen reader describes as "unavailable", so
+        // focus has to land on the survivor while the conversation's rows are still in the list.
+        var (vm, watch) = MakeVm(
+        [
+            Msg("1", "Budget Review",  daysAgo: 1),
+            Msg("2", "Trip to Dublin", daysAgo: 0),
+        ]);
+        watch.Watch("Budget Review");
+        watch.Watch("Trip to Dublin");
+        await vm.SelectFolderCommand.ExecuteAsync(MainViewModel.AllWatchedFolder);
+        var leaving = vm.Messages.Single(m => m.MessageId == "1");
+        vm.SelectedMessage = leaving;
+
+        var calls = new System.Collections.Generic.List<(string? Selected, bool LeavingStillListed)>();
+        vm.MessageListFocusNowRequested += () =>
+        {
+            calls.Add((vm.SelectedMessage?.MessageId, vm.Messages.Contains(leaving)));
+            return true;
+        };
+        var queued = 0;
+        vm.MessageListFocusRequested += () => queued++;
+
+        vm.ToggleWatchConversationFor("Budget Review");   // unwatch
+
+        var call = Assert.Single(calls);
+        Assert.True(call.LeavingStillListed);   // asked for while the row was still there …
+        Assert.Equal("2", call.Selected);       // … with the selection already on the survivor
+        Assert.Equal(0, queued);                // landed, so no second focus move afterwards
+        Assert.Equal(["2"], vm.Messages.Select(m => m.MessageId).ToArray());
+    }
+
     // ── Notifications: the ordering contract ─────────────────────────────────
     //
     // MaybeNotifyWatchedMail and MaybeNotifyNewMail share _notifiedMessageKeys, and

--- a/QuickMail.Tests/WatchedConversationsPhase2Tests.cs
+++ b/QuickMail.Tests/WatchedConversationsPhase2Tests.cs
@@ -509,6 +509,30 @@ public class WatchedConversationsPhase2Tests
         Assert.DoesNotContain(vm.Messages, m => m.MessageId == "1");
     }
 
+    [Fact]
+    public async Task UnwatchingAConversationTheUserIsNotOn_InAGroupView_KeepsTheirSelection() // #670
+    {
+        // In the trees too: clearing a selection that isn't leaving turns off the per-message shortcuts on a
+        // message that is still there, and still open in the reading pane.
+        var (vm, watch) = MakeVm(
+        [
+            Msg("1", "Budget Review",  daysAgo: 2),
+            Msg("2", "Trip to Dublin", daysAgo: 1),
+            Msg("3", "Offsite Plans",  daysAgo: 0),
+        ]);
+        watch.Watch("Budget Review");
+        watch.Watch("Trip to Dublin");
+        watch.Watch("Offsite Plans");
+        await vm.SelectFolderCommand.ExecuteAsync(MainViewModel.AllWatchedFolder);
+        vm.ViewMode = ViewMode.Conversations;
+        vm.SelectedMessage = vm.Messages.Single(m => m.MessageId == "3");
+
+        vm.ToggleWatchConversationFor("Budget Review");   // unwatch
+
+        Assert.Equal("3", vm.SelectedMessage?.MessageId);
+        Assert.DoesNotContain(vm.Messages, m => m.MessageId == "1");
+    }
+
     [Theory]
     [InlineData(true,  AnnouncementCategory.Silent)]   // landed: the row is being read, so don't talk over it
     [InlineData(false, AnnouncementCategory.Status)]   // didn't land: nothing is being read, so the count is said

--- a/QuickMail.Tests/WatchedConversationsPhase2Tests.cs
+++ b/QuickMail.Tests/WatchedConversationsPhase2Tests.cs
@@ -510,6 +510,37 @@ public class WatchedConversationsPhase2Tests
     }
 
     [Fact]
+    public async Task UnwatchingTheLastConversation_PutsFocusOnTheList() // #670
+    {
+        // Found by ear: unwatching the only watched conversation from inside it emptied the folder and left focus in
+        // the cleared reading pane, a blank page. Focus goes to the list itself while the rows are still there.
+        var (vm, watch) = MakeVm(
+        [
+            Msg("1", "Budget Review", daysAgo: 0),
+        ]);
+        watch.Watch("Budget Review");
+        await vm.SelectFolderCommand.ExecuteAsync(MainViewModel.AllWatchedFolder);
+        var only = vm.Messages.Single();
+        vm.SelectedMessage = only;
+        vm.IsMessageOpen = true;
+
+        var calls = new System.Collections.Generic.List<(string? Selected, bool StillListed)>();
+        vm.MessageListFocusNowRequested += () =>
+        {
+            calls.Add((vm.SelectedMessage?.MessageId, vm.Messages.Contains(only)));
+            return true;
+        };
+
+        vm.ToggleWatchConversationFor("Budget Review");   // unwatch
+
+        var call = Assert.Single(calls);
+        Assert.Null(call.Selected);      // nothing left to select: the list itself takes focus
+        Assert.True(call.StillListed);   // asked for while the row was still there
+        Assert.Empty(vm.Messages);
+        Assert.False(vm.IsMessageOpen);
+    }
+
+    [Fact]
     public async Task UnwatchingAConversationTheUserIsNotOn_InAGroupView_KeepsTheirSelection() // #670
     {
         // In the trees too: clearing a selection that isn't leaving turns off the per-message shortcuts on a

--- a/QuickMail.Tests/WatchedConversationsPhase2Tests.cs
+++ b/QuickMail.Tests/WatchedConversationsPhase2Tests.cs
@@ -478,6 +478,59 @@ public class WatchedConversationsPhase2Tests
         Assert.Equal(["2"], vm.Messages.Select(m => m.MessageId).ToArray());
     }
 
+    [Fact]
+    public async Task UnwatchingAConversationTheUserIsNotOn_LeavesTheirPlaceAlone() // #670
+    {
+        // From the manager, the conversation unwatched need not be the one selected in the list.
+        var (vm, watch) = MakeVm(
+        [
+            Msg("1", "Budget Review",  daysAgo: 2),
+            Msg("2", "Trip to Dublin", daysAgo: 1),
+            Msg("3", "Offsite Plans",  daysAgo: 0),
+        ]);
+        watch.Watch("Budget Review");
+        watch.Watch("Trip to Dublin");
+        watch.Watch("Offsite Plans");
+        await vm.SelectFolderCommand.ExecuteAsync(MainViewModel.AllWatchedFolder);
+        vm.SelectedMessage = vm.Messages.Single(m => m.MessageId == "3");
+        vm.IsMessageOpen = true;
+
+        var focusNow = 0;
+        vm.MessageListFocusNowRequested += () => { focusNow++; return true; };
+        var queued = 0;
+        vm.MessageListFocusRequested += () => queued++;
+
+        vm.ToggleWatchConversationFor("Budget Review");   // unwatch
+
+        Assert.Equal(0, focusNow);
+        Assert.Equal(0, queued);
+        Assert.Equal("3", vm.SelectedMessage?.MessageId);
+        Assert.True(vm.IsMessageOpen);
+        Assert.DoesNotContain(vm.Messages, m => m.MessageId == "1");
+    }
+
+    [Theory]
+    [InlineData(true,  AnnouncementCategory.Silent)]   // landed: the row is being read, so don't talk over it
+    [InlineData(false, AnnouncementCategory.Status)]   // didn't land: nothing is being read, so the count is said
+    public async Task TheWatchedCountAfterUnwatching_IsSilentOnlyWhenFocusLanded(bool lands, AnnouncementCategory expected) // #670
+    {
+        var (vm, watch) = MakeVm(
+        [
+            Msg("1", "Budget Review",  daysAgo: 1),
+            Msg("2", "Trip to Dublin", daysAgo: 0),
+        ]);
+        watch.Watch("Budget Review");
+        watch.Watch("Trip to Dublin");
+        await vm.SelectFolderCommand.ExecuteAsync(MainViewModel.AllWatchedFolder);
+        vm.SelectedMessage = vm.Messages.Single(m => m.MessageId == "1");
+        vm.MessageListFocusNowRequested += () => lands;
+        var status = StatusAnnouncementRecorder.Watch(vm);
+
+        vm.ToggleWatchConversationFor("Budget Review");   // unwatch
+
+        Assert.Contains(("1 watched message.", expected), status.Announced);
+    }
+
     // ── Notifications: the ordering contract ─────────────────────────────────
     //
     // MaybeNotifyWatchedMail and MaybeNotifyNewMail share _notifiedMessageKeys, and

--- a/QuickMail/Models/AnnouncementCategory.cs
+++ b/QuickMail/Models/AnnouncementCategory.cs
@@ -5,7 +5,7 @@ public enum AnnouncementCategory
     Hint,          // instructional tips the user can silence once familiar
     Status,        // background loading and sync progress
     Result,        // direct outcome of a user action
-    MessageAction, // outcome of a common message command (delete, archive) — its own toggle (issue #317)
+    MessageAction, // outcome of a common message command (delete, archive, move) — its own toggle (issues #317, #670)
 
     /// <summary>
     /// Status-bar text that is never spoken, whatever the user's announcement settings.

--- a/QuickMail/Models/ConfigModel.cs
+++ b/QuickMail/Models/ConfigModel.cs
@@ -187,7 +187,8 @@ public class ConfigModel
     /// <summary>Announce background loading and sync progress.</summary>
     public bool AnnounceStatus { get; set; } = true;
 
-    /// <summary>Announce action results (search counts, move/delete confirmations).</summary>
+    /// <summary>Announce action results (search counts, copy confirmations). Delete, archive and move have their own
+    /// setting, <see cref="AnnounceMessageActions"/>.</summary>
     public bool AnnounceResults { get; set; } = true;
 
     /// <summary>

--- a/QuickMail/Models/ConfigModel.cs
+++ b/QuickMail/Models/ConfigModel.cs
@@ -191,7 +191,7 @@ public class ConfigModel
     public bool AnnounceResults { get; set; } = true;
 
     /// <summary>
-    /// Announce the outcome of common message commands — delete and archive (issue #317). Split out
+    /// Announce the outcome of common message commands — delete, archive (issue #317) and move (#670). Split out
     /// from <see cref="AnnounceStatus"/> so users can silence this frequent chatter (it can interrupt
     /// the screen reader reading the next message) without muting sync/loading progress. On by default.
     /// </summary>

--- a/QuickMail/Services/ConfigService.cs
+++ b/QuickMail/Services/ConfigService.cs
@@ -550,7 +550,7 @@ public class ConfigService : IConfigService
         sb.AppendLine();
 
         sb.AppendLine($"AnnounceResults = {(config.AnnounceResults ? "on" : "off")}");
-        sb.AppendLine("# Announce action outcomes such as search result counts and move confirmations.");
+        sb.AppendLine("# Announce action outcomes such as search result counts and copy confirmations.");
         sb.AppendLine("# Values: on, off.");
         sb.AppendLine();
 

--- a/QuickMail/Services/ConfigService.cs
+++ b/QuickMail/Services/ConfigService.cs
@@ -555,7 +555,7 @@ public class ConfigService : IConfigService
         sb.AppendLine();
 
         sb.AppendLine($"AnnounceMessageActions = {(config.AnnounceMessageActions ? "on" : "off")}");
-        sb.AppendLine("# Announce delete and archive outcomes (e.g. \"1 message archived\"). Split from");
+        sb.AppendLine("# Announce delete, archive and move outcomes (e.g. \"3 messages archived\"). Split from");
         sb.AppendLine("# AnnounceStatus so this frequent chatter can be silenced on its own. Values: on, off.");
         sb.AppendLine();
 

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -6824,7 +6824,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
         // user is not on, and their place in the list should stay where it is. Unwatching from a message window
         // usually does count as leaving, since the list's selection stays on the message the window came from.
         var selectionLeaving = SelectedMessage == null || leaving.Contains(SelectedMessage);
-        var landed = selectionLeaving ? LandFocusBeforeRemoval(leaving) : null;
+        var landed = selectionLeaving ? LandFocusBeforeRemoval(leaving, parkOnEmptyList: true) : null;
 
         _rawMessages.RemoveAll(SameConversation);
         foreach (var m in leaving)
@@ -7365,7 +7365,9 @@ public partial class MainViewModel : ObservableObject, IDisposable
     /// the last survivor before it — the same row the caller's post-removal index arithmetic picks,
     /// so what the user lands on does not change.</para>
     /// </summary>
-    private MailMessageSummary? LandFocusBeforeRemoval(IReadOnlyList<MailMessageSummary> leaving)
+    /// <param name="parkOnEmptyList">When every row is leaving, clear the selection and ask for focus on the list
+    /// itself, before the rows go (#670, move and unwatch). Delete leaves it false.</param>
+    private MailMessageSummary? LandFocusBeforeRemoval(IReadOnlyList<MailMessageSummary> leaving, bool parkOnEmptyList = false)
     {
         // The group trees own their own focus after RebuildActiveGroupView replaces their items;
         // this is the flat list's business only.
@@ -7387,7 +7389,19 @@ public partial class MainViewModel : ObservableObject, IDisposable
         for (var i = first - 1; i >= 0 && landing == null; i--)
             if (!doomed.Contains(Messages[i])) landing = Messages[i];
 
-        if (landing == null) return null;         // the whole list is leaving
+        if (landing == null)
+        {
+            // The whole list is leaving, so there is no survivor to land on. Move and unwatch put focus on the list
+            // itself (#670): otherwise it stays on a row that is about to go, or inside a message the reading pane
+            // has just cleared, which left a screen reader user in a blank page with no way back but Alt+Tab.
+            // Delete does not ask, by the choice DeletingEveryRowAsksForNoFocusMoveAtAll pins.
+            if (parkOnEmptyList)
+            {
+                SelectedMessage = null;
+                MessageListFocusNowRequested?.Invoke();
+            }
+            return null;
+        }
 
         SelectedMessage = landing;
 
@@ -9177,7 +9191,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
             // Land focus on the surviving row before the moved rows leave, as delete does (#670): removing the
             // row that holds keyboard focus is what a screen reader describes as "unavailable". Only when the
             // selection is among them: this runs after the server move, and the user may have moved on.
-            var landed = selectionLeaving ? LandFocusBeforeRemoval(messages) : null;
+            var landed = selectionLeaving ? LandFocusBeforeRemoval(messages, parkOnEmptyList: true) : null;
             foreach (var msg in messages)
                 Messages.Remove(msg);
 

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -6819,8 +6819,11 @@ public partial class MainViewModel : ObservableObject, IDisposable
         }
 
         // Land focus on the surviving row before the conversation's rows leave, as delete does, so the row
-        // holding keyboard focus is never the one removed (#670; see LandFocusBeforeRemoval).
-        var landed = LandFocusBeforeRemoval(leaving);
+        // holding keyboard focus is never the one removed (#670; see LandFocusBeforeRemoval). Only when the
+        // selection is among them: unwatching from the manager or a message window can remove a conversation
+        // the user is not on, and their place in the list should stay where it is.
+        var selectionLeaving = SelectedMessage == null || leaving.Contains(SelectedMessage);
+        var landed = selectionLeaving ? LandFocusBeforeRemoval(leaving) : null;
 
         _rawMessages.RemoveAll(SameConversation);
         foreach (var m in leaving)
@@ -6839,13 +6842,17 @@ public partial class MainViewModel : ObservableObject, IDisposable
         }
 
         var n = Messages.Count;
-        StatusText = $"{n} watched {(n == 1 ? "message" : "messages")}.";
+        var watchedCount = $"{n} watched {(n == 1 ? "message" : "messages")}.";
+        if (landed != null)
+            SetStatusSilently(watchedCount);   // the row just landed on is being read; don't talk over it (#667)
+        else
+            StatusText = watchedCount;
 
         if (ViewMode == ViewMode.Messages)
         {
             // Only when LandFocusBeforeRemoval could not land. When it did, focus is on that row already,
             // and asking again would queue a second focus move that reads the row out twice (see there).
-            if (landed == null || !Messages.Contains(landed))
+            if (selectionLeaving && (landed == null || !Messages.Contains(landed)))
             {
                 SelectedMessage = Messages[Math.Min(firstIndex, Messages.Count - 1)];
                 MessageListFocusRequested?.Invoke();
@@ -9128,7 +9135,9 @@ public partial class MainViewModel : ObservableObject, IDisposable
         }
 
         var label  = messages.Count == 1 ? "message" : $"{messages.Count} messages";
-        StatusText = $"Moving {label}…";
+        // A single move is silent, as a single delete is (#667): it would talk over the message being read.
+        SetStatus($"Moving {label}…",
+            messages.Count == 1 ? AnnouncementCategory.Silent : AnnouncementCategory.MessageAction);
         IsBusy     = true;
         try
         {
@@ -9154,9 +9163,19 @@ public partial class MainViewModel : ObservableObject, IDisposable
                 foreach (var acctId in messages.Select(m => m.AccountId).Distinct())
                     ScheduleFolderCountRefresh(acctId);
 
+            // The open message may be one of those leaving: clear the reading pane first, as delete, archive
+            // and unwatch do, or it keeps showing a message that is no longer in the list.
+            var selectionLeaving = SelectedMessage != null && messages.Contains(SelectedMessage);
+            if (selectionLeaving)
+            {
+                MessageDetail = null;
+                IsMessageOpen = false;
+            }
+
             // Land focus on the surviving row before the moved rows leave, as delete does (#670): removing the
-            // row that holds keyboard focus is what a screen reader describes as "unavailable".
-            var landed = LandFocusBeforeRemoval(messages);
+            // row that holds keyboard focus is what a screen reader describes as "unavailable". Only when the
+            // selection is among them: this runs after the server move, and the user may have moved on.
+            var landed = selectionLeaving ? LandFocusBeforeRemoval(messages) : null;
             foreach (var msg in messages)
                 Messages.Remove(msg);
 
@@ -9165,8 +9184,13 @@ public partial class MainViewModel : ObservableObject, IDisposable
 
             RememberMessageDestination(destination, copy: false);
 
-            StatusText = $"{messages.Count} {(messages.Count == 1 ? "message" : "messages")} moved to {destination.DisplayName}.";
-            Announce(StatusText);
+            var moved = $"{messages.Count} {(messages.Count == 1 ? "message" : "messages")} moved to {destination.DisplayName}.";
+            if (messages.Count == 1 && landed != null)
+                // Self-evident, as a single delete is (#667): the row has gone and the next one has just
+                // been read, and the destination was the user's own choice a moment ago. Status bar only.
+                SetStatusSilently(moved);
+            else
+                SetStatus(moved, AnnouncementCategory.MessageAction);
             // Conversations/From: LandOnX in the view handles focus after rebuild. In the flat list, only
             // when LandFocusBeforeRemoval could not land (a second focus move reads the row out twice).
             if (ViewMode == ViewMode.Messages && Messages.Count > 0 && (landed == null || !Messages.Contains(landed)))

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -6818,6 +6818,10 @@ public partial class MainViewModel : ObservableObject, IDisposable
             IsMessageOpen = false;
         }
 
+        // Land focus on the surviving row before the conversation's rows leave, as delete does, so the row
+        // holding keyboard focus is never the one removed (#670; see LandFocusBeforeRemoval).
+        var landed = LandFocusBeforeRemoval(leaving);
+
         _rawMessages.RemoveAll(SameConversation);
         foreach (var m in leaving)
             Messages.Remove(m);
@@ -6839,10 +6843,13 @@ public partial class MainViewModel : ObservableObject, IDisposable
 
         if (ViewMode == ViewMode.Messages)
         {
-            // The row that had keyboard focus was just removed from the ListView, so focus has to be
-            // asked back explicitly — same as archive.
-            SelectedMessage = Messages[Math.Min(firstIndex, Messages.Count - 1)];
-            MessageListFocusRequested?.Invoke();
+            // Only when LandFocusBeforeRemoval could not land. When it did, focus is on that row already,
+            // and asking again would queue a second focus move that reads the row out twice (see there).
+            if (landed == null || !Messages.Contains(landed))
+            {
+                SelectedMessage = Messages[Math.Min(firstIndex, Messages.Count - 1)];
+                MessageListFocusRequested?.Invoke();
+            }
         }
         else
         {
@@ -9147,6 +9154,9 @@ public partial class MainViewModel : ObservableObject, IDisposable
                 foreach (var acctId in messages.Select(m => m.AccountId).Distinct())
                     ScheduleFolderCountRefresh(acctId);
 
+            // Land focus on the surviving row before the moved rows leave, as delete does (#670): removing the
+            // row that holds keyboard focus is what a screen reader describes as "unavailable".
+            var landed = LandFocusBeforeRemoval(messages);
             foreach (var msg in messages)
                 Messages.Remove(msg);
 
@@ -9157,8 +9167,9 @@ public partial class MainViewModel : ObservableObject, IDisposable
 
             StatusText = $"{messages.Count} {(messages.Count == 1 ? "message" : "messages")} moved to {destination.DisplayName}.";
             Announce(StatusText);
-            // Conversations/From: LandOnX in the view handles focus after rebuild.
-            if (ViewMode == ViewMode.Messages && Messages.Count > 0)
+            // Conversations/From: LandOnX in the view handles focus after rebuild. In the flat list, only
+            // when LandFocusBeforeRemoval could not land (a second focus move reads the row out twice).
+            if (ViewMode == ViewMode.Messages && Messages.Count > 0 && (landed == null || !Messages.Contains(landed)))
                 MessageListFocusRequested?.Invoke();
         }
         catch (OperationCanceledException) { StatusText = "Move cancelled."; }

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -6859,12 +6859,13 @@ public partial class MainViewModel : ObservableObject, IDisposable
                 MessageListFocusRequested?.Invoke();
             }
         }
-        else
+        else if (selectionLeaving)
         {
             // In the group trees, focus is the tree's business after RebuildActiveGroupView replaces
             // its items. Clearing SelectedMessage keeps HasSelectedMessage false so the global
             // per-message hotkeys don't act on a row the user never selected. (Same rationale as
-            // archive and delete.)
+            // archive and delete.) Only when it is among the rows leaving: unwatching another
+            // conversation from the manager leaves the user's selection, and their shortcuts, alone.
             SelectedMessage = null;
         }
     }

--- a/QuickMail/ViewModels/MainViewModel.cs
+++ b/QuickMail/ViewModels/MainViewModel.cs
@@ -6820,8 +6820,9 @@ public partial class MainViewModel : ObservableObject, IDisposable
 
         // Land focus on the surviving row before the conversation's rows leave, as delete does, so the row
         // holding keyboard focus is never the one removed (#670; see LandFocusBeforeRemoval). Only when the
-        // selection is among them: unwatching from the manager or a message window can remove a conversation
-        // the user is not on, and their place in the list should stay where it is.
+        // selection is among them, or there is none: unwatching from the manager can remove a conversation the
+        // user is not on, and their place in the list should stay where it is. Unwatching from a message window
+        // usually does count as leaving, since the list's selection stays on the message the window came from.
         var selectionLeaving = SelectedMessage == null || leaving.Contains(SelectedMessage);
         var landed = selectionLeaving ? LandFocusBeforeRemoval(leaving) : null;
 
@@ -9185,21 +9186,39 @@ public partial class MainViewModel : ObservableObject, IDisposable
             RememberMessageDestination(destination, copy: false);
 
             var moved = $"{messages.Count} {(messages.Count == 1 ? "message" : "messages")} moved to {destination.DisplayName}.";
-            if (messages.Count == 1 && landed != null)
+            if (Messages.Count == 0)
+                // As delete says it: no next row is being read, so there is nothing to interrupt, and "empty"
+                // is a state the user cannot otherwise get from a list that shows nothing.
+                SetStatus($"{moved} Folder is now empty.", AnnouncementCategory.MessageAction);
+            else if (messages.Count == 1)
                 // Self-evident, as a single delete is (#667): the row has gone and the next one has just
                 // been read, and the destination was the user's own choice a moment ago. Status bar only.
                 SetStatusSilently(moved);
             else
                 SetStatus(moved, AnnouncementCategory.MessageAction);
-            // Conversations/From: LandOnX in the view handles focus after rebuild. In the flat list, only
-            // when LandFocusBeforeRemoval could not land (a second focus move reads the row out twice).
-            if (ViewMode == ViewMode.Messages && Messages.Count > 0 && (landed == null || !Messages.Contains(landed)))
-                MessageListFocusRequested?.Invoke();
+
+            if (ViewMode == ViewMode.Messages)
+            {
+                // Only when the selection was among the moved rows and LandFocusBeforeRemoval could not land
+                // (a second focus move reads the row out twice). With the selection elsewhere the user has
+                // moved on while the server move ran, and focus stays where they put it.
+                if (selectionLeaving && Messages.Count > 0 && (landed == null || !Messages.Contains(landed)))
+                    MessageListFocusRequested?.Invoke();
+            }
+            else if (selectionLeaving)
+            {
+                // Conversations/From/To: LandOnX in the view handles focus after the rebuild. Clear the moved
+                // selection, as delete, archive and unwatch do, so the per-message hotkeys don't act on a
+                // message that has gone.
+                SelectedMessage = null;
+            }
         }
-        catch (OperationCanceledException) { StatusText = "Move cancelled."; }
+        catch (OperationCanceledException) { SetStatus("Move cancelled.", AnnouncementCategory.MessageAction); }
         catch (Exception ex)
         {
-            StatusText = $"Failed to move: {ex.Message}";
+            // A Result, not MessageAction, as a failed delete is, so the failure is heard even with message-
+            // action announcements turned off.
+            SetStatus($"Failed to move: {ex.Message}", AnnouncementCategory.Result);
             LogService.Log("MoveMessages", ex);
         }
         finally { IsBusy = false; }

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -6663,7 +6663,8 @@ public partial class MainWindow : Window
         await _vm.MoveSelectedMessagesToFolderAsync(messages, picker.SelectedFolder);
 
         // Conversations/From: LandOnX waits for the async rebuild before focusing.
-        // Messages view: MessageListFocusRequested in MoveSelectedMessagesToFolderAsync handles it.
+        // Messages view: MoveSelectedMessagesToFolderAsync lands focus before the rows leave (#670), with
+        // MessageListFocusRequested only as its fallback.
         // Filing a whole group empties its row, so land where it was — the row that takes its place,
         // as the group context menus do — rather than jumping the user back to the top of the list.
         if (_vm.IsConversationsView)

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -3919,6 +3919,12 @@ public partial class MainWindow : Window
         // does not mean MessageList is visible; ReturnFocusToMessageList tests the same pair.
         if (_vm.IsCalendarView || _vm.ViewMode != ViewMode.Messages) return false;
 
+        // Not while another window is active: a message window or the Watched Conversations manager that
+        // unwatched a conversation, or wherever the user went during a slow move (#670). Focusing a row here
+        // would pull them back. Reported as landed, so no queued focus move follows either; OnActivated puts
+        // focus on the list's selection, the survivor, when they come back.
+        if (!IsActive) return true;
+
         // From the ViewModel's own selection, not MessageList.SelectedIndex: the caller set
         // SelectedMessage a statement ago and the two-way binding is what would have to have
         // propagated for SelectedIndex to be right. Reading the source removes the assumption —

--- a/QuickMail/Views/MainWindow.xaml.cs
+++ b/QuickMail/Views/MainWindow.xaml.cs
@@ -3930,7 +3930,12 @@ public partial class MainWindow : Window
         // propagated for SelectedIndex to be right. Reading the source removes the assumption —
         // and a stale index here would focus the row that is about to be removed, which is the
         // whole bug.
-        if (_vm.SelectedMessage is not { } target) return false;
+        //
+        // Nothing selected means every row is leaving (move or unwatch, #670): there is no survivor, so focus goes
+        // to the list itself, about to be empty, rather than staying on a row that has gone or in a message the
+        // reading pane has just cleared.
+        if (_vm.SelectedMessage is not { } target)
+            return MessageList.Focus();
 
         var idx = MessageList.Items.IndexOf(target);
         if (idx < 0) return false;

--- a/QuickMail/Views/SettingsDialog.xaml
+++ b/QuickMail/Views/SettingsDialog.xaml
@@ -306,7 +306,7 @@
                                 <CheckBox Content="Announce _delete, archive and move actions"
                                           IsChecked="{Binding AnnounceMessageActions, Mode=TwoWay}"
                                           Margin="16,4,0,0"
-                                          AutomationProperties.Name="Announce delete, archive and move outcomes"/>
+                                          AutomationProperties.Name="Announce delete, archive and move actions"/>
                                 <TextBlock Text="Turn off to stop delete, archive and move announcements from interrupting the next message."
                                            Foreground="{DynamicResource Theme.TextSecondary}" FontSize="{DynamicResource Theme.FontSizeSmall}" Margin="16,0,0,8"/>
 

--- a/QuickMail/Views/SettingsDialog.xaml
+++ b/QuickMail/Views/SettingsDialog.xaml
@@ -301,13 +301,13 @@
                                 <CheckBox Content="Announce action _results"
                                           IsChecked="{Binding AnnounceResults, Mode=TwoWay}"
                                           Margin="16,4,0,0"
-                                          AutomationProperties.Name="Announce outcomes such as search result counts and move confirmations"/>
+                                          AutomationProperties.Name="Announce outcomes such as search result counts and copy confirmations"/>
 
-                                <CheckBox Content="Announce _delete and archive actions"
+                                <CheckBox Content="Announce _delete, archive and move actions"
                                           IsChecked="{Binding AnnounceMessageActions, Mode=TwoWay}"
                                           Margin="16,4,0,0"
-                                          AutomationProperties.Name="Announce delete and archive outcomes"/>
-                                <TextBlock Text="Turn off to stop delete and archive announcements from interrupting the next message."
+                                          AutomationProperties.Name="Announce delete, archive and move outcomes"/>
+                                <TextBlock Text="Turn off to stop delete, archive and move announcements from interrupting the next message."
                                            Foreground="{DynamicResource Theme.TextSecondary}" FontSize="{DynamicResource Theme.FontSizeSmall}" Margin="16,0,0,8"/>
 
                                 <CheckBox Content="Announce spelling errors _when typing"

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -1803,8 +1803,8 @@ Control which categories of announcements QuickMail makes:
 | Custom Announcements | Master on/off for all programmatic announcements |
 | Announce hints | Instructional tips ("Press Escape to return") |
 | Announce status | Background progress (sync, loading, connection state) |
-| Announce results | Action outcomes (messages moved, addresses saved, flag changes) |
-| Announce delete, archive and move actions | Delete, archive and move outcomes that are worth saying: a count when you acted on several at once ("3 messages deleted"), and "Folder is now empty". Deleting, archiving or moving a single message says nothing either way — the row is gone and the next one is read, so there is nothing left to tell you. Failures are announced as results, so they are heard even with this turned off |
+| Announce results | Action outcomes (messages copied, addresses saved, flag changes) |
+| Announce delete, archive and move actions | Delete, archive and move outcomes that are worth saying: a count when you acted on several at once ("3 messages deleted"), and "Folder is now empty". Deleting, archiving or moving a single message says nothing either way — the row is gone and the next one is read, so there is nothing left to tell you. Failures are announced as results, so they are heard even with this turned off, as long as **Announce action results** is on |
 | Announce formatting while navigating | Block type announced when caret enters a new paragraph type in HTML compose |
 | Announce spelling errors when typing | Misspellings called out as you type them |
 | Announce spelling errors while navigating | Misspellings called out as you move the cursor through the message |

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -1804,7 +1804,7 @@ Control which categories of announcements QuickMail makes:
 | Announce hints | Instructional tips ("Press Escape to return") |
 | Announce status | Background progress (sync, loading, connection state) |
 | Announce results | Action outcomes (messages moved, addresses saved, flag changes) |
-| Announce delete and archive actions | Delete and archive outcomes that are worth saying: a count when you acted on several at once ("3 messages deleted"), and "Folder is now empty". Deleting or archiving a single message says nothing either way — the row is gone and the next one is read, so there is nothing left to tell you. Failures are always announced |
+| Announce delete, archive and move actions | Delete, archive and move outcomes that are worth saying: a count when you acted on several at once ("3 messages deleted"), and "Folder is now empty". Deleting, archiving or moving a single message says nothing either way — the row is gone and the next one is read, so there is nothing left to tell you. Failures are announced as results, so they are heard even with this turned off |
 | Announce formatting while navigating | Block type announced when caret enters a new paragraph type in HTML compose |
 | Announce spelling errors when typing | Misspellings called out as you type them |
 | Announce spelling errors while navigating | Misspellings called out as you move the cursor through the message |


### PR DESCRIPTION
Fixes #670.

## What changes

- **Why it spoke "unavailable":**
  - Removing the row that holds keyboard focus leaves focus on a container whose item is gone. WPF's automation peer for it then reports `IsEnabled = false`, and a screen reader describes the row as unavailable.
  - #669 fixed this for delete and archive by landing focus on the surviving row before the rows leave (`LandFocusBeforeRemoval`, #667).
- **Move to folder** (`MoveSelectedMessagesToFolderAsync`):
  - **Focus:** it now lands focus on the next message before the moved rows leave, and skips the queued focus request when that worked, as delete does.
    - It lands only when the selection is among the moved messages. The landing runs after the server move returns, and by then you may have moved on in the list. In that case neither focus nor the reading pane is touched.
    - In a group view it clears the moved selection, as delete, archive and unwatch do, so the per-message hotkeys don't act on a message that has gone.
  - **Reading pane:** moving the open message clears the reading pane first, as delete, archive and unwatch do. It used to keep showing a message no longer in the list.
  - **Announcements:** move now speaks as delete does.
    - A single move's "Moving…" and "1 message moved to X." are shown on the status bar but not spoken. That now holds in group views, and when landing failed, as well.
    - Several messages say their count, and a move that empties the folder adds "Folder is now empty."
    - All of this is in the MessageAction category. Before, the outcome was announced as a Result on top of a Status announcement.
    - A failed move is a Result, as a failed delete is, so it is heard with message-action announcements off.
  - **The setting that governs it is renamed** to **Announce delete, archive and move actions**: the label, automation name, help text, user guide and config comments. Anyone who had turned it off would otherwise have lost move's announcements without the setting saying so. The results checkbox's automation name now gives copy, not move, as its example.
- **Unwatching a conversation while the Watched folder is open** (`RefreshWatchState`):
  - It uses the same landing, again only when the selection is leaving, so unwatching a conversation you're not on, from the Watched Conversations manager, doesn't move your place.
  - In a group view it clears the selection only when the selection is leaving, as move does.
  - The watched-folder count after it is shown but not spoken when focus landed.
- **When a move or unwatch empties the list, focus goes to the list itself** (`LandFocusBeforeRemoval(…, parkOnEmptyList: true)`). Found by ear: unwatching the only watched conversation from inside it emptied the folder, cleared the reading pane, and left focus in the empty message body. The screen reader reported "about:blank", and the only way out was Alt+Tab. Now the selection is cleared and focus goes to the list while the rows are still there. Tim chose the empty list over the folder list, and asked for move to be covered too. Delete is unchanged: not moving focus when every row leaves is the choice `DeletingEveryRowAsksForNoFocusMoveAtAll` pins.
- **Landing never pulls focus into an inactive main window** (`FocusSelectedMessageRowNow`). That covers a message window or the manager unwatching a conversation, and wherever you went during a slow move. It reports the row as landed, so no queued focus move follows either, and `OnActivated` puts focus on the surviving row when you come back.
- **Docs and labels:** the renamed checkbox's automation name matches its label. Five places that still filed move under "action results" now don't: the user guide's settings table, the config.ini comment, `ConfigModel`, `AnnouncementCategory` and CLAUDE.md.

## Tests

- **Move:**
  - It asks for focus while the moved row is still listed, with the selection already on the survivor, and asks no second time.
  - When landing fails, the queued focus request still runs, on the survivor, and a single move still isn't spoken.
  - A move with the selection elsewhere leaves the selection, focus and reading pane alone.
  - Moving the open message closes the reading pane.
  - Moving in a group view clears the moved selection.
  - A single move is never spoken; several say their count, and emptying the folder says so.
- **Unwatch:**
  - Unwatching in the Watched folder lands focus the same way.
  - Unwatching a conversation you're not on leaves the selection, focus and reading pane alone.
  - The count is silent only when focus landed.
  - In a group view, unwatching a conversation you're not on keeps your selection.
- **The main window** refuses to land focus while it isn't active (read from source, since that needs a real window).

- **Emptying the list:** moving every message, and unwatching the last conversation, each ask for focus on the list while the rows are still there. The main window then focuses the list itself, after its active-window check.

Every test fails when its fix is removed: nineteen mutation checks across the five commits, all caught.

**Tested by ear (Tim, 2026-09-11, reading pane):** no "unavailable" after a move, and focus lands on the message below. The same holds after unwatching in the Watched folder, with the right count on the status bar. Unwatching the last conversation lands on the empty list. The one change not pinned is the failed move's category: the test mail service can't be made to fail a move. Release build: 0 warnings, 0 errors.

## For hands-on testing

Kelly's note on #670 suggested confirming by ear which path actually speaks. Tim, worth a listen on the next test build:

1. Move a message, then unwatch a conversation from the Watched folder. Do you still hear "unavailable"?
2. Unwatch a message from its own message window. The main list's selection is on that message, so it counts as leaving and focus lands in the main window. Does that pull you out of the message window?
3. Move every message out of a folder, or unwatch the last watched conversation. Is anything like "unavailable" heard before "Folder is now empty."? When every row leaves there is no survivor to land on, and delete deliberately moves no focus in that case (a test pins it), so this PR leaves it alone.
4. During a slow multi-message move, press F6 to the folder tree. Is focus pulled back to the list when the move finishes? The window is still active then, so the new check doesn't apply.

("Stopped watching: …" after unwatching stays spoken, as Tim chose.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
