### PR TITLE
Add the 0.8.45 release notes for #694, #696, #697 and #698

### DIFF
--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -461,7 +461,7 @@ The **View → Filter** submenu (and the command palette) let you narrow the mes
 
 **Applying a filter:**
 - Open **View → Filter** and choose an option, or
-- Open the command palette (`Ctrl+Shift+P`) and type the filter name (e.g. "unread").
+- Open the command palette (`Ctrl+Shift+P`) and choose the filter, for example **Show Unread Only**.
 
 **Clearing a filter:**
 - Open **View → Filter → Show All**, or run **Show All Messages** from the command palette.
@@ -691,7 +691,7 @@ Once you have saved views, you can reach them in four ways:
 
 - **View menu** — Open **View → Views** and press the view name. The active view has a checkmark next to it. The current keyboard shortcut (if any) is shown next to each item.
 - **Folder tree** — A **Views** group appears at the top of the folder tree. Expand it and choose a view name to apply it.
-- **Command palette** — Press **Ctrl+Shift+P** and type part of the view's name. Views appear in the **Views** category.
+- **Command palette** — Press **Ctrl+Shift+P** and type the first letters of the view's name to jump to it. Views appear in the **Views** category.
 - **View Manager** — Select a view in the list and press **Apply View** to activate it and close the dialog.
 
 While a view is active:
@@ -882,10 +882,12 @@ Select a group and press **Delete** (or activate the **Delete** button). A confi
 
 ## Command palette
 
-Press **Ctrl+Shift+P** to open the command palette. Type any part of a command name and press **Enter** (or click) to run it — no need to remember every shortcut.
+Press **Ctrl+Shift+P** to open the command palette: one list of every command, sorted by category and then by name, with each command's shortcut key where it has one. No need to remember every shortcut.
 
-- All actions are searchable, including folder navigation, compose, delete, view switching, and account management.
+- Arrow to a command, or type the first letters of its name to jump to it, and press **Enter** to run it.
+- Every action is in it, including folder navigation, compose, delete, view switching, and account management, and the many actions that have no shortcut key.
 - Press **Escape** to close without running a command. Focus returns to where it was before.
+- It opens while you are reading a message in the reading pane too. Closing it puts you back where you were reading, and a command you choose runs before focus returns to the message.
 
 ---
 

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -667,7 +667,9 @@ Press **F5** to manually refresh the current folder.
 
 ### Command Palette
 
-Press **Ctrl+Shift+P** to open the command palette. Type any part of a command name to find it. Press Enter to run it. This is the fastest way to discover and run any action in the app.
+Press **Ctrl+Shift+P** to open the command palette: one list of every command, sorted by category and then by name, with each command's shortcut key where it has one. Arrow to a command, or type the first letters of its name to jump to it, and press Enter to run it; Escape closes the palette. This is the fastest way to discover and run any action in the app, including the many that have no shortcut key.
+
+The palette opens from anywhere in the main window, including while you are reading a message in the reading pane. Closing it puts you back where you were reading, and a command you choose runs before focus returns to the message.
 
 ### Keyboard Customization
 

--- a/docs/release-notes-v0.8.45.md
+++ b/docs/release-notes-v0.8.45.md
@@ -17,9 +17,6 @@ it previously did not.
 It affects QuickMail 0.7.0 and later. It was found by review rather than by anything going wrong,
 and was reported privately rather than published.
 
-Found and reported privately by Timothy Spaulding, with a working proof of concept and a diagnosis
-that named both flaws exactly.
-
 ---
 
 ## Fixed: every rule condition now has a checkbox

--- a/docs/release-notes-v0.8.45.md
+++ b/docs/release-notes-v0.8.45.md
@@ -110,7 +110,8 @@ no Microsoft 365 account got a window that gave every new rule your default acco
 one got a window that opened on whichever account you had last visited or read a message from.
 
 In the rules list, **Space** on a rule reliably turns it on or off. And **Test**, which checks a rule
-against the messages in the message list, now says so instead of calling them your selected messages.
+against its own account's messages in the message list, now says so instead of calling them your
+selected messages.
 ([#550](https://github.com/kellylford/QuickMail/issues/550))
 
 ---
@@ -155,8 +156,8 @@ What still speaks is anything you could not otherwise know: a count when you act
 once ("3 messages deleted"), "Folder is now empty" when the last one goes, and every failure. All
 of it still appears in the status bar, and `Ctrl+9` reads the status bar on demand.
 
-This is not the announcement setting doing its job — **Settings → Accessibility → Announce delete
-and archive actions** is still on by default and still controls the announcements that remain.
+This is not the announcement setting doing its job — **Settings → Accessibility → Announce delete,
+archive and move actions** is still on by default and still controls the announcements that remain.
 Nothing to turn off, and nothing to turn back on.
 ([#667](https://github.com/kellylford/QuickMail/issues/667))
 
@@ -253,6 +254,71 @@ Both now use the same test, and it is one that works while you are reading.
   message was counted twice. A moved or deleted message is now out of the running for the rules after
   it, as it already was for mail as it arrives.
   ([#685](https://github.com/kellylford/QuickMail/issues/685))
+
+---
+
+## Fixed: the Rules Manager's status line and Test count what they say
+
+- **After a failed load, the status line counts only what loaded.** When the server-side rules
+  couldn't be loaded but the client-side ones could, the status line said the account had "0 on
+  server", straight after saying the server rules couldn't be loaded. It now counts only the kind it
+  loaded, for example "2 client-side rules."
+  ([#679](https://github.com/kellylford/QuickMail/issues/679))
+- **Test counts only the rule's own account.** **Test** counted a client-side rule's matches across
+  every message in the list, whatever account each came from, though the rule only ever acts on its
+  own account's mail. It now counts only that account's messages, names the account, and says so when
+  the list holds none of them.
+  ([#687](https://github.com/kellylford/QuickMail/issues/687))
+
+---
+
+## Fixed: two dark-theme readability problems
+
+- **The status bar's Rules and update buttons** drew their text in black in every theme, which was
+  nearly invisible on the dark theme's status bar. They now use the theme's text colour.
+  ([#689](https://github.com/kellylford/QuickMail/issues/689))
+- **The selected rule in the Rules Manager** was near-white text on a near-white highlight in the dark
+  theme. It now uses the theme's selection colours.
+  ([#690](https://github.com/kellylford/QuickMail/issues/690))
+
+---
+
+## Fixed: keyboard access in the message menus and the reading pane
+
+- **Ctrl+Shift+P opens the command palette while you read a message** in the reading pane, as it
+  already did in a message window. Before, you had to leave the message first. Closing the palette
+  puts you back where you were reading, and a command you choose from it runs before focus goes back
+  to the message.
+  ([#676](https://github.com/kellylford/QuickMail/issues/676))
+- **Each item in the message menus has its own access key.** In the message context menu and the
+  Message menu, **Reply All** and **Move to Archive** both used A, so pressing A only moved between
+  them. **Move to Archive** now uses H, and **Grab Addresses from Message** uses G. In the From, To and
+  Conversations menus, **Reply** and the archive item both used R; the archive items now use H too. In
+  the context menu, **Create Rule from Message** uses T, because R is **Reply**'s.
+  ([#692](https://github.com/kellylford/QuickMail/issues/692))
+- **Caps Lock no longer mixes up Ctrl+W and Ctrl+Shift+W in a message.** With Caps Lock on,
+  Ctrl+Shift+W in the reading pane closed the message instead of watching its conversation, and Ctrl+W
+  in a message window did nothing. Both now work whether Caps Lock is on or off.
+  ([#697](https://github.com/kellylford/QuickMail/pull/697))
+
+---
+
+## Fixed: no "unavailable" after moving or unwatching
+
+Moving messages to another folder, or unwatching a conversation while the **Watched Conversations**
+folder is open, could make a screen reader say "unavailable" before the next message, as deleting did
+before 0.8.45. Focus now lands on the next message before the moved or unwatched ones leave the list.
+When the last message goes, focus goes to the empty list, instead of staying in a message that is no
+longer there. Unwatching a conversation from a message window, or from the Watched Conversations
+manager, no longer pulls focus into the main window.
+
+Moving now speaks as deleting does. A single move says nothing, since the next message is being read,
+while moving several says the count, and emptying the folder says so. The setting that controls
+these is renamed **Settings → Accessibility → Announce delete, archive and move actions**. A move
+that fails is announced as a result, so you hear it even with that setting off. If you had turned that
+setting off but left **Announce action results** on, you will no longer hear how many messages a move
+moved: those counts used to be results.
+([#670](https://github.com/kellylford/QuickMail/issues/670))
 
 ---
 


### PR DESCRIPTION
Release notes for the 0.8.45 fixes that shipped without their own: #694, #696, #697 and #698. #699 already carries its section. Docs only.

## What changes in `docs/release-notes-v0.8.45.md`

- **Four new sections**, after the #699 section and before Reporting Issues:
  - The Rules Manager's status line and Test count what they say (#679, #687, from #696).
  - Two dark-theme readability problems (#689, #690, from #694). #690 stays open for the other lists it names; the note describes only the Rules Manager's selected rule, which #694 fixed.
  - Keyboard access in the message menus and the reading pane (#676, #692, and the Caps Lock fix, from #697).
  - No "unavailable" after moving or unwatching (#670, from #698). This includes the focus fix for the last message found by ear, and the renamed announcement setting.
- **The #667 section** quotes the setting by its new name: **Announce delete, archive and move actions**.
- **The #550 section** now says Test checks the rule's own account's messages, to match #687.

## The user guides' command palette text

Both guides described the palette as searchable ("type any part of a command name"). It has no search box: it's one list, sorted by category and then name, which you arrow through or jump into by typing a command's first letters. Before the release:

- **`docs/USER-GUIDE.md`, Command Palette:** describes the list as it is. It now says the palette opens while reading a message in the reading pane, and that closing it returns you to where you were (#676).
- **`USERGUIDE.md`, Command palette:** the same corrections. It also drops "(or click)" and "searchable".
- **`USERGUIDE.md`, filters:** you "choose the filter, for example Show Unread Only", instead of typing "unread", which wouldn't match.
- **`USERGUIDE.md`, saved views:** you type the first letters of the view's name, rather than any part of it.

Nothing names a screen reader product, and nothing says "click". The order is still: what's new, then Reporting Issues, then Download.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
