### PR TITLE
The command palette filters as you type, and says what Enter would run

### DIFF
--- a/QuickMail.Tests/CommandMatcherTests.cs
+++ b/QuickMail.Tests/CommandMatcherTests.cs
@@ -1,0 +1,251 @@
+using System.Collections.Generic;
+using System.Linq;
+using QuickMail.Helpers;
+using QuickMail.Models;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// The command palette's ranking. Plain <c>[Fact]</c>s — no WPF, no window, no timing — because
+/// the ranking is the part of the feature that has to be predictable: the palette reports only
+/// the TOP result as the user types, and Enter runs it, so a result nobody can explain is a
+/// command nobody meant to run.
+/// </summary>
+public class CommandMatcherTests
+{
+    private static CommandDefinition Cmd(string title, string category = "View", string? id = null,
+                                         string? description = null)
+        => new(id ?? $"test.{title.Replace(" ", "").ToLowerInvariant()}",
+               category, title, execute: () => { }, description: description);
+
+    private static List<string> Titles(IEnumerable<CommandDefinition> commands)
+        => commands.Select(c => c.Title).ToList();
+
+    // ── The acronym case, which is what "VS Code style" mostly means in practice ──
+
+    [Fact]
+    public void Initials_RankTheCommandTheySpell_First()
+    {
+        var all = new List<CommandDefinition>
+        {
+            Cmd("Get The File"),        // also contains g, t, f — but not as initials of these words
+            Cmd("Go to Folder"),
+            Cmd("Toggle Grid Focus"),
+        };
+
+        var ranked = CommandMatcher.Rank(all, "gtf");
+
+        Assert.Equal("Go to Folder", ranked[0].Title);
+    }
+
+    [Fact]
+    public void Initials_MatchAcrossCamelCase()
+    {
+        Assert.True(CommandMatcher.TryScore("MoveToArchive", "mta", out var camel));
+        Assert.True(CommandMatcher.TryScore("Move to Archive", "mta", out var spaced));
+
+        // Both are the same three word-initials; neither should be wildly favoured.
+        Assert.True(camel > 0 && spaced > 0);
+    }
+
+    // ── The predictable tiers have to outrank a scattered hit ──
+
+    [Fact]
+    public void AnExactTitle_OutranksEverythingElse()
+    {
+        var all = new List<CommandDefinition>
+        {
+            Cmd("Reply All"),
+            Cmd("Reply"),
+        };
+
+        Assert.Equal("Reply", CommandMatcher.Rank(all, "Reply")[0].Title);
+    }
+
+    [Fact]
+    public void APrefix_OutranksAMidWordMatch()
+    {
+        var all = new List<CommandDefinition>
+        {
+            Cmd("New Folder"),
+            Cmd("Folder Properties"),
+        };
+
+        Assert.Equal("Folder Properties", CommandMatcher.Rank(all, "fol")[0].Title);
+    }
+
+    [Fact]
+    public void AContiguousRun_OutranksTheSameLettersScattered()
+    {
+        // "Manager Backup Check" spells a-r-c-h mid-word, and its own initials are "mbc", so
+        // it is a genuinely scattered hit rather than an acronym one.
+        Assert.True(CommandMatcher.TryScore("Move to Archive", "arch", out var contiguous));
+        Assert.True(CommandMatcher.TryScore("Manager Backup Check", "arch", out var scattered));
+
+        Assert.True(contiguous > scattered,
+            $"a contiguous 'arch' ({contiguous}) must beat a scattered one ({scattered})");
+    }
+
+    [Fact]
+    public void AWordSpelledByTheInitials_IsTreatedAsAnAcronymHit()
+    {
+        // Pinning a real consequence of the acronym tier rather than leaving it a surprise:
+        // "arch" is the initials of "A Rather Cheerful Heading", so that outranks the
+        // contiguous "Move to Archive". Rare in practice with real command titles, and it is
+        // the same rule that makes "gtf" reach "Go to Folder" — but it is deliberate.
+        var all = new List<CommandDefinition>
+        {
+            Cmd("Move to Archive"),
+            Cmd("A Rather Cheerful Heading"),
+        };
+
+        Assert.Equal("A Rather Cheerful Heading", CommandMatcher.Rank(all, "arch")[0].Title);
+    }
+
+    [Fact]
+    public void ASubstringAnywhere_StillMatches()
+    {
+        var all = new List<CommandDefinition> { Cmd("Move to Archive") };
+
+        Assert.Single(CommandMatcher.Rank(all, "arch"));
+    }
+
+    // ── What must not match ──
+
+    [Fact]
+    public void LettersOutOfOrder_DoNotMatch()
+    {
+        Assert.False(CommandMatcher.TryScore("Go to Folder", "redlof", out _));
+    }
+
+    [Fact]
+    public void ALetterThatIsNotThere_DoesNotMatch()
+    {
+        var all = new List<CommandDefinition> { Cmd("Go to Folder"), Cmd("Reply All") };
+
+        Assert.Empty(CommandMatcher.Rank(all, "zzz"));
+    }
+
+    // ── Ordering guarantees ──
+
+    [Fact]
+    public void AnEmptyQuery_ReturnsTheListUntouched()
+    {
+        var all = new List<CommandDefinition> { Cmd("Zebra"), Cmd("Apple"), Cmd("Mango") };
+
+        // Not re-sorted: an unfiltered palette shows the registry's own category-then-title order.
+        Assert.Equal(new[] { "Zebra", "Apple", "Mango" }, Titles(CommandMatcher.Rank(all, "")));
+        Assert.Equal(new[] { "Zebra", "Apple", "Mango" }, Titles(CommandMatcher.Rank(all, "   ")));
+        Assert.Equal(new[] { "Zebra", "Apple", "Mango" }, Titles(CommandMatcher.Rank(all, null)));
+    }
+
+    [Fact]
+    public void EquallyGoodMatches_KeepTheirIncomingOrder()
+    {
+        // Same title length, same shape, same score — so the registry order decides, every time.
+        var all = new List<CommandDefinition> { Cmd("Reply Two"), Cmd("Reply One") };
+
+        Assert.Equal(new[] { "Reply Two", "Reply One" }, Titles(CommandMatcher.Rank(all, "reply")));
+    }
+
+    [Fact]
+    public void ATie_GoesToTheShorterTitle()
+    {
+        var all = new List<CommandDefinition>
+        {
+            Cmd("Reply All and Copy Everyone"),
+            Cmd("Reply All"),
+        };
+
+        Assert.Equal("Reply All", CommandMatcher.Rank(all, "reply all")[0].Title);
+    }
+
+    // ── Fields other than the title ──
+
+    [Fact]
+    public void ACategoryWord_FindsTheCommandsInThatCategory()
+    {
+        var all = new List<CommandDefinition>
+        {
+            Cmd("Next Theme", category: "View"),
+            Cmd("Reply", category: "Mail"),
+        };
+
+        var ranked = CommandMatcher.Rank(all, "mail");
+
+        Assert.Equal("Reply", ranked[0].Title);
+    }
+
+    [Fact]
+    public void ATitleMatch_OutranksACategoryMatch()
+    {
+        var all = new List<CommandDefinition>
+        {
+            Cmd("Reply", category: "Mail"),         // matches on category
+            Cmd("Mail Merge", category: "Tools"),   // matches on title
+        };
+
+        Assert.Equal("Mail Merge", CommandMatcher.Rank(all, "mail")[0].Title);
+    }
+
+    [Fact]
+    public void TheDescriptionAndId_AreSearchedToo()
+    {
+        var byDescription = new List<CommandDefinition>
+        {
+            Cmd("Obscure Name", description: "Marks the conversation as watched"),
+        };
+        Assert.Single(CommandMatcher.Rank(byDescription, "watched"));
+
+        var byId = new List<CommandDefinition> { Cmd("Obscure Name", id: "mail.markUnread") };
+        Assert.Single(CommandMatcher.Rank(byId, "markunread"));
+    }
+
+    // ── Multi-word queries ──
+
+    [Fact]
+    public void WordsInOrder_MatchAcrossTheTitle()
+    {
+        var all = new List<CommandDefinition> { Cmd("Go to Folder") };
+
+        Assert.Single(CommandMatcher.Rank(all, "go fold"));
+    }
+
+    [Fact]
+    public void WordsOutOfOrder_StillMatch()
+    {
+        // "arch mail" is the category and a title word, the wrong way round. Requiring the
+        // user to guess the order would make the category search useless in practice.
+        var all = new List<CommandDefinition> { Cmd("Move to Archive", category: "Mail") };
+
+        Assert.Single(CommandMatcher.Rank(all, "arch mail"));
+    }
+
+    [Fact]
+    public void EveryTypedWord_HasToMatchSomething()
+    {
+        var all = new List<CommandDefinition> { Cmd("Move to Archive", category: "Mail") };
+
+        Assert.Empty(CommandMatcher.Rank(all, "arch zzz"));
+    }
+
+    // ── Case ──
+
+    [Fact]
+    public void MatchingIsCaseInsensitive()
+    {
+        var all = new List<CommandDefinition> { Cmd("Go to Folder") };
+
+        Assert.Single(CommandMatcher.Rank(all, "GO TO FOLDER"));
+        Assert.Single(CommandMatcher.Rank(all, "go to folder"));
+    }
+
+    [Fact]
+    public void SurroundingWhitespace_IsIgnored()
+    {
+        var all = new List<CommandDefinition> { Cmd("Go to Folder") };
+
+        Assert.Single(CommandMatcher.Rank(all, "  folder  "));
+    }
+}

--- a/QuickMail.Tests/CommandPaletteFilterTests.cs
+++ b/QuickMail.Tests/CommandPaletteFilterTests.cs
@@ -1,0 +1,134 @@
+using System.Linq;
+using QuickMail.Models;
+using QuickMail.Services;
+using QuickMail.ViewModels;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+/// <summary>
+/// The palette ViewModel's filtering and selection. Plain <c>[Fact]</c>s — the ViewModel has no
+/// WPF in it, and none of this needs a window.
+/// </summary>
+public class CommandPaletteFilterTests
+{
+    private static CommandPaletteViewModel Vm(params string[] titles)
+    {
+        var registry = new CommandRegistry();
+        foreach (var title in titles)
+            registry.Register(new CommandDefinition(
+                id: $"test.{title.Replace(" ", "").ToLowerInvariant()}",
+                category: "View", title: title, execute: () => { }));
+        return new CommandPaletteViewModel(registry);
+    }
+
+    [Fact]
+    public void WithNoFilter_EveryCommandIsShown()
+    {
+        var vm = Vm("Go to Folder", "Reply", "Next Theme");
+
+        Assert.Equal(3, vm.FilteredCommands.Count);
+    }
+
+    [Fact]
+    public void TypingNarrowsTheList()
+    {
+        var vm = Vm("Go to Folder", "Reply", "Next Theme");
+
+        vm.SearchText = "fold";
+
+        Assert.Single(vm.FilteredCommands);
+        Assert.Equal("Go to Folder", vm.FilteredCommands[0].Title);
+    }
+
+    [Fact]
+    public void ClearingTheFilterRestoresEveryCommand()
+    {
+        var vm = Vm("Go to Folder", "Reply", "Next Theme");
+
+        vm.SearchText = "fold";
+        vm.SearchText = string.Empty;
+
+        Assert.Equal(3, vm.FilteredCommands.Count);
+    }
+
+    [Fact]
+    public void TheSelectionFollowsTheTopMatch()
+    {
+        // What Enter runs must always be the command the palette is reporting, so the selection
+        // is reset on every keystroke rather than trying to hold on to a filtered-out command.
+        var vm = Vm("Go to Folder", "Reply", "Next Theme");
+        Assert.Equal("Go to Folder", vm.SelectedCommand?.Title);
+
+        vm.SearchText = "reply";
+
+        Assert.Equal("Reply", vm.SelectedCommand?.Title);
+        Assert.Same(vm.FilteredCommands[0], vm.SelectedCommand);
+    }
+
+    [Fact]
+    public void WithNoMatches_NothingIsSelectedAndTheCommandCannotRun()
+    {
+        var vm = Vm("Go to Folder", "Reply");
+
+        vm.SearchText = "zzz";
+
+        Assert.Empty(vm.FilteredCommands);
+        Assert.Null(vm.SelectedCommand);
+        Assert.False(vm.ExecuteSelectedCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public void CommandsStaysTheFullUnfilteredSet()
+    {
+        var vm = Vm("Go to Folder", "Reply");
+
+        vm.SearchText = "reply";
+
+        Assert.Equal(2, vm.Commands.Count);
+        Assert.Single(vm.FilteredCommands);
+    }
+
+    // ── The announcement text, used by the fallback reporting mode ──
+
+    [Fact]
+    public void TheSummaryNamesTheCommandAndItsPlace()
+    {
+        var vm = Vm("Go to Folder", "Go to Date", "Reply");
+
+        vm.SearchText = "go to";
+
+        Assert.Equal($"{vm.FilteredCommands[0].Title}, 1 of 2", vm.ActiveCommandSummary);
+    }
+
+    [Fact]
+    public void TheSummaryFollowsTheSelection()
+    {
+        var vm = Vm("Go to Folder", "Go to Date", "Reply");
+        vm.SearchText = "go to";
+
+        vm.SelectedCommand = vm.FilteredCommands[1];
+
+        Assert.Equal($"{vm.FilteredCommands[1].Title}, 2 of 2", vm.ActiveCommandSummary);
+    }
+
+    [Fact]
+    public void TheSummarySaysSoWhenNothingMatches()
+    {
+        var vm = Vm("Go to Folder");
+
+        vm.SearchText = "zzz";
+
+        Assert.Equal("No matching commands", vm.ActiveCommandSummary);
+    }
+
+    [Fact]
+    public void ASingleMatchIsStillCounted()
+    {
+        var vm = Vm("Go to Folder", "Reply");
+
+        vm.SearchText = "fold";
+
+        Assert.Equal("Go to Folder, 1 of 1", vm.ActiveCommandSummary);
+    }
+}

--- a/QuickMail.Tests/CommandPaletteFocusTests.cs
+++ b/QuickMail.Tests/CommandPaletteFocusTests.cs
@@ -1,0 +1,129 @@
+// Where the palette's keyboard focus actually lands when the window opens for real, and what
+// happens to characters that are typed rather than assigned.
+//
+// CommandPaletteSpeechTests cannot answer either question: its helper calls FilterBox.Focus()
+// itself before asserting (it has to — it shows the window with ShowActivated = false), so every
+// focus assertion there is self-fulfilling, and it sets TextBox.Text directly, which bypasses
+// input entirely. Reported from a real build: typing in the palette narrowed nothing and the
+// selection jumped to a command starting with the last letter typed — the signature of the
+// keystrokes reaching the LIST rather than the filter box.
+
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Threading;
+using QuickMail.Models;
+using QuickMail.Services;
+using QuickMail.Views;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+[Collection("WpfTests")]
+public class CommandPaletteFocusTests
+{
+    [StaFact]
+    public void OnOpen_TheFilterBoxTakesFocusWithoutHelp()
+    {
+        var (window, box, list) = OpenActivated();
+        try
+        {
+            Assert.True(box.IsKeyboardFocused,
+                $"The filter box must hold keyboard focus when the palette opens. "
+              + $"Focus is on: {Describe(Keyboard.FocusedElement)}");
+            Assert.False(list.IsKeyboardFocusWithin);
+        }
+        finally { window.Close(); }
+    }
+
+    [StaFact]
+    public void TypedCharacters_ReachTheFilterBoxAndNarrowTheList()
+    {
+        // This is also the test that separates filtering from type-ahead, which is the failure
+        // that was reported: WPF's built-in TextSearch on the list would leave all four items in
+        // place and merely move the selection. Four going to one can only be the filter.
+        var (window, box, list) = OpenActivated();
+        try
+        {
+            Assert.Equal(4, list.Items.Count);
+
+            Type(window, "mov");
+
+            Assert.Equal("mov", box.Text);
+            Assert.Single(list.Items);
+            Assert.Equal("Move to Archive", ((CommandDefinition)list.SelectedItem).Title);
+        }
+        finally { window.Close(); }
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private static (CommandPaletteWindow window, TextBox box, ListBox list) OpenActivated()
+    {
+        WpfTestHost.EnsureStyles("AccessibleStyles", "ThemedControls");
+
+        var registry = new CommandRegistry();
+        foreach (var (id, category, title) in new[]
+                 {
+                     ("mail.archive",   "Mail",     "Move to Archive"),
+                     ("cal.editAppt",   "Calendar", "Edit Appointment"),
+                     ("view.goFolder",  "View",     "Go to Folder"),
+                     ("mail.reply",     "Mail",     "Reply"),
+                 })
+        {
+            registry.Register(new CommandDefinition(id, category, title, execute: () => { }));
+        }
+
+        // Activated, and nothing here touches focus: that is the whole point.
+        var window = new CommandPaletteWindow(registry)
+        {
+            WindowStyle = WindowStyle.None, ShowInTaskbar = false,
+        };
+        window.Show();
+        window.Activate();
+        window.UpdateLayout();
+        Drain();
+
+        var box = window.FindName("FilterBox") as TextBox;
+        Assert.NotNull(box);
+        var list = window.FindName("CommandList") as ListBox;
+        Assert.NotNull(list);
+
+        return (window, box!, list!);
+    }
+
+    /// <summary>
+    /// Types into whatever currently has focus, the way a keyboard would — not by assigning
+    /// <c>TextBox.Text</c>, which is what hid this.
+    /// </summary>
+    private static void Type(Window window, string text)
+    {
+        foreach (var ch in text)
+        {
+            var target = Keyboard.FocusedElement as UIElement ?? window;
+            var composition = new TextComposition(InputManager.Current, target, ch.ToString());
+            target.RaiseEvent(new TextCompositionEventArgs(
+                InputManager.Current.PrimaryKeyboardDevice, composition)
+            {
+                RoutedEvent = UIElement.TextInputEvent,
+            });
+            Drain();
+        }
+    }
+
+    private static string Describe(IInputElement? element) => element switch
+    {
+        null => "nothing",
+        FrameworkElement fe when !string.IsNullOrEmpty(fe.Name) => $"{fe.GetType().Name}#{fe.Name}",
+        _ => element.GetType().Name,
+    };
+
+    private static void Drain()
+    {
+        var frame = new DispatcherFrame();
+        Dispatcher.CurrentDispatcher.BeginInvoke(
+            DispatcherPriority.SystemIdle, new Action(() => frame.Continue = false));
+        Dispatcher.PushFrame(frame);
+    }
+}

--- a/QuickMail.Tests/CommandPaletteSpeechTests.cs
+++ b/QuickMail.Tests/CommandPaletteSpeechTests.cs
@@ -398,12 +398,73 @@ public class CommandPaletteSpeechTests
     }
 
     [Fact]
-    public void TheDefaultMode_IsTheOneThatIsGuaranteedToSpeak()
+    public void TheDefaultMode_LeavesTheCommandNameToThePlatform()
     {
-        // Pinned so moving it is a decision, not a drift. The Automation modes hand reporting to
-        // the platform, and whether that reaches a screen reader cannot be checked from in here —
-        // shipping one by default risks a palette that narrows the list in silence.
-        Assert.Equal(CommandPaletteWindow.ReportMode.Announce, CommandPaletteWindow.Reporting);
+        // Settled by listening: the platform already speaks the row's name and its position, so
+        // announcing on top of it said everything twice. Pinned so moving it is a decision.
+        Assert.Equal(CommandPaletteWindow.ReportMode.Automation, CommandPaletteWindow.Reporting);
+    }
+
+    [StaFact]
+    public void NarrowingThatKeepsTheSameTopMatch_ReportsTheCountAlone()
+    {
+        // The platform reports a row only when the selection changes, so a keystroke that narrows
+        // the list without changing what Enter would run is otherwise silent. The count fills that
+        // in — and must not carry the name, which the platform gives already.
+        var heard = new List<(string Text, AnnouncementCategory Category)>();
+        AccessibilityHelper.AnnouncementObserver = (text, category) => heard.Add((text, category));
+
+        var (window, box, list) = Open();
+        try
+        {
+            box.Text = "go to";                            // Go to Date and Go to Folder
+            PumpPast(TimeSpan.FromMilliseconds(400));
+            var top = list.SelectedItem;
+            Assert.Equal(2, list.Items.Count);
+            Assert.Equal("Go to Date", ((CommandDefinition)top).Title);   // the shorter title wins the tie
+            heard.Clear();
+
+            box.Text = "go to da";                         // drops Folder, keeps the same top match
+            PumpPast(TimeSpan.FromMilliseconds(400));
+
+            Assert.Same(top, list.SelectedItem);
+            Assert.Contains(heard, h => h.Text == "1 command"
+                                     && h.Category == AnnouncementCategory.Result);
+            Assert.DoesNotContain(heard, h => h.Text.Contains("Go to", StringComparison.Ordinal));
+        }
+        finally
+        {
+            AccessibilityHelper.AnnouncementObserver = null;
+            window.Close();
+        }
+    }
+
+    [StaFact]
+    public void AChangedTopMatch_IsLeftEntirelyToThePlatform()
+    {
+        // When the selection does change, the platform speaks the name AND the position, so
+        // nothing may be added — a count here would be the second half said twice.
+        var heard = new List<(string Text, AnnouncementCategory Category)>();
+        AccessibilityHelper.AnnouncementObserver = (text, category) => heard.Add((text, category));
+
+        var (window, box, list) = Open();
+        try
+        {
+            box.Text = "go to";
+            PumpPast(TimeSpan.FromMilliseconds(400));
+            heard.Clear();
+
+            box.Text = "arch";                             // a different command on top
+            PumpPast(TimeSpan.FromMilliseconds(400));
+
+            Assert.Equal("Move to Archive", ((CommandDefinition)list.SelectedItem).Title);
+            Assert.Empty(heard);
+        }
+        finally
+        {
+            AccessibilityHelper.AnnouncementObserver = null;
+            window.Close();
+        }
     }
 
     // ── helpers ──────────────────────────────────────────────────────────────

--- a/QuickMail.Tests/CommandPaletteSpeechTests.cs
+++ b/QuickMail.Tests/CommandPaletteSpeechTests.cs
@@ -313,10 +313,12 @@ public class CommandPaletteSpeechTests
         var heard = new List<(string Text, AnnouncementCategory Category)>();
         AccessibilityHelper.AnnouncementObserver = (text, category) => heard.Add((text, category));
 
+        var previous = CommandPaletteWindow.Reporting;
+        CommandPaletteWindow.Reporting = CommandPaletteWindow.ReportMode.Automation;
+
         var (window, box, _) = Open();
         try
         {
-            Assert.Equal(CommandPaletteWindow.ReportMode.Automation, CommandPaletteWindow.Reporting);
             heard.Clear();
 
             box.Text = "zzzzz";
@@ -328,6 +330,7 @@ public class CommandPaletteSpeechTests
         finally
         {
             AccessibilityHelper.AnnouncementObserver = null;
+            CommandPaletteWindow.Reporting = previous;
             window.Close();
         }
     }
@@ -371,10 +374,12 @@ public class CommandPaletteSpeechTests
         var heard = new List<(string Text, AnnouncementCategory Category)>();
         AccessibilityHelper.AnnouncementObserver = (text, category) => heard.Add((text, category));
 
+        var previous = CommandPaletteWindow.Reporting;
+        CommandPaletteWindow.Reporting = CommandPaletteWindow.ReportMode.Automation;
+
         var (window, box, _) = Open();
         try
         {
-            Assert.Equal(CommandPaletteWindow.ReportMode.Automation, CommandPaletteWindow.Reporting);
             heard.Clear();
 
             box.Text = "go to";
@@ -387,8 +392,18 @@ public class CommandPaletteSpeechTests
         finally
         {
             AccessibilityHelper.AnnouncementObserver = null;
+            CommandPaletteWindow.Reporting = previous;
             window.Close();
         }
+    }
+
+    [Fact]
+    public void TheDefaultMode_IsTheOneThatIsGuaranteedToSpeak()
+    {
+        // Pinned so moving it is a decision, not a drift. The Automation modes hand reporting to
+        // the platform, and whether that reaches a screen reader cannot be checked from in here —
+        // shipping one by default risks a palette that narrows the list in silence.
+        Assert.Equal(CommandPaletteWindow.ReportMode.Announce, CommandPaletteWindow.Reporting);
     }
 
     // ── helpers ──────────────────────────────────────────────────────────────

--- a/QuickMail.Tests/CommandPaletteSpeechTests.cs
+++ b/QuickMail.Tests/CommandPaletteSpeechTests.cs
@@ -333,6 +333,37 @@ public class CommandPaletteSpeechTests
     }
 
     [StaFact]
+    public void EnterWithNoMatches_SaysSoAgainRatherThanGoingSilent()
+    {
+        // The empty list is announced once as it empties. Enter is a key the user has just
+        // pressed and it does nothing, so it has to be answered — otherwise the palette is
+        // indistinguishable from one that has stopped responding.
+        var heard = new List<(string Text, AnnouncementCategory Category)>();
+        AccessibilityHelper.AnnouncementObserver = (text, category) => heard.Add((text, category));
+
+        var (window, box, _) = Open();
+        try
+        {
+            box.Text = "zzzzz";
+            PumpPast(TimeSpan.FromMilliseconds(400));
+            Assert.Contains(heard, h => h.Text == "No matching commands");
+            heard.Clear();
+
+            Press(window, Key.Enter);
+            Drain();
+
+            Assert.Contains(heard, h => h.Text == "No matching commands"
+                                     && h.Category == AnnouncementCategory.Result);
+            Assert.True(window.IsVisible, "Enter with no match must not close the palette.");
+        }
+        finally
+        {
+            AccessibilityHelper.AnnouncementObserver = null;
+            window.Close();
+        }
+    }
+
+    [StaFact]
     public void InAutomationMode_NothingIsAnnouncedByHand()
     {
         // The default mode leaves the reporting to the platform. If an announcement leaks out

--- a/QuickMail.Tests/CommandPaletteSpeechTests.cs
+++ b/QuickMail.Tests/CommandPaletteSpeechTests.cs
@@ -1,0 +1,460 @@
+// Filter-as-you-type in the command palette, and how the active command reaches a screen
+// reader. A search box was shipped here once before and removed (git 1816f96) because it moved
+// keyboard focus onto the list on every keystroke and forwarded typed characters back to the
+// box. These tests exist to keep that from coming back: the focus assertions below are the
+// whole point of the file.
+//
+// What they cannot prove: AutomationPeer.ListenerExists is false with no UIA client attached,
+// so nothing here shows that a screen reader actually SPEAKS. They pin the wiring — which
+// control is focused, which peer controls which, what text would be announced. The ear test is
+// the user's.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using System.Windows.Automation;
+using System.Windows.Automation.Peers;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Threading;
+using QuickMail.Models;
+using QuickMail.Services;
+using QuickMail.Views;
+using Xunit;
+
+namespace QuickMail.Tests;
+
+// Shows a real Window on the STA thread, and AccessibilityHelper.AnnouncementObserver plus
+// CommandPaletteWindow.Reporting are static — so this must never run beside another WPF test.
+[Collection("WpfTests")]
+public class CommandPaletteSpeechTests
+{
+    // ── Focus: the regression that removed this feature the first time ────────
+
+    [StaFact]
+    public void OnOpen_TheFilterBoxHasFocus()
+    {
+        var (window, box, list) = Open();
+        try
+        {
+            Assert.True(box.IsKeyboardFocused, "The filter box must have focus when the palette opens.");
+            Assert.False(list.IsKeyboardFocusWithin);
+        }
+        finally { window.Close(); }
+    }
+
+    [StaFact]
+    public void Typing_LeavesFocusInTheFilterBox()
+    {
+        var (window, box, list) = Open();
+        try
+        {
+            box.Text = "fold";
+            Drain();
+
+            Assert.True(box.IsKeyboardFocused);
+            Assert.False(list.IsKeyboardFocusWithin,
+                "Focus must never reach the list: that is what broke the 2026-05 search box.");
+        }
+        finally { window.Close(); }
+    }
+
+    [StaFact]
+    public void Arrowing_MovesTheSelectionButNotFocus()
+    {
+        var (window, box, list) = Open();
+        try
+        {
+            Press(window, Key.Down);
+            Drain();
+
+            Assert.Equal(1, list.SelectedIndex);
+            Assert.True(box.IsKeyboardFocused, "Down must move the selection, not focus.");
+            Assert.False(list.IsKeyboardFocusWithin);
+
+            Press(window, Key.Up);
+            Drain();
+
+            Assert.Equal(0, list.SelectedIndex);
+            Assert.True(box.IsKeyboardFocused);
+        }
+        finally { window.Close(); }
+    }
+
+    [StaFact]
+    public void TheListAndItsRows_CannotTakeFocusAtAll()
+    {
+        // Belt and braces for the above: a mouse click on a row would otherwise pull focus out
+        // of the filter box, breaking typing for anyone who reaches for the mouse.
+        var (window, _, list) = Open();
+        try
+        {
+            Assert.False(list.Focusable);
+            Assert.False(list.IsTabStop);
+
+            var row = list.ItemContainerGenerator.ContainerFromIndex(0) as ListBoxItem;
+            Assert.NotNull(row);
+            Assert.False(row!.Focusable, "A row must not be focusable.");
+            Assert.False(row.IsTabStop);
+        }
+        finally { window.Close(); }
+    }
+
+    [StaFact]
+    public void ClickingARow_SelectsItWithoutTakingFocus()
+    {
+        // Rows are not focusable, and WPF selects a row on click only if it can focus it first.
+        // So the palette selects by mouse itself; without that, a double-click would run whatever
+        // the keyboard had selected rather than the row pointed at.
+        var (window, box, list) = Open();
+        try
+        {
+            var row = list.ItemContainerGenerator.ContainerFromIndex(2) as ListBoxItem;
+            Assert.NotNull(row);
+
+            ClickDown(window, row!);
+            Drain();
+
+            Assert.Equal(2, list.SelectedIndex);
+            Assert.True(box.IsKeyboardFocused, "A click must not move focus off the filter box.");
+        }
+        finally { window.Close(); }
+    }
+
+    // ── Filtering through the real window ────────────────────────────────────
+
+    [StaFact]
+    public void Typing_NarrowsTheListAndSelectsTheTopMatch()
+    {
+        var (window, box, list) = Open();
+        try
+        {
+            box.Text = "arch";
+            Drain();
+
+            Assert.Single(list.Items);
+            Assert.Equal(0, list.SelectedIndex);
+            Assert.Equal("Move to Archive", ((CommandDefinition)list.SelectedItem).Title);
+        }
+        finally { window.Close(); }
+    }
+
+    [StaFact]
+    public void Escape_ClearsTheFilterBeforeItClosesTheWindow()
+    {
+        var (window, box, list) = Open();
+        try
+        {
+            box.Text = "arch";
+            Drain();
+
+            Press(window, Key.Escape);
+            Drain();
+
+            Assert.Equal(string.Empty, box.Text);
+            Assert.True(window.IsVisible, "The first Escape clears the filter; it does not close.");
+            Assert.Equal(4, list.Items.Count);
+        }
+        finally { window.Close(); }
+    }
+
+    // ── The names a screen reader reads off the rows ──────────────────────────
+
+    [StaFact]
+    public void FilteredRows_SpeakTheirCommandTitles()
+    {
+        var (window, box, list) = Open();
+        try
+        {
+            box.Text = "go to";
+            Drain();
+
+            var names = ItemPeerNames(list);
+
+            Assert.NotEmpty(names);
+            Assert.Contains(names, n => n.StartsWith("Go to", StringComparison.Ordinal));
+            // The #644 failure mode: a row announced as its CLR type name.
+            foreach (var name in names)
+                Assert.DoesNotContain("QuickMail.", name, StringComparison.Ordinal);
+        }
+        finally { window.Close(); }
+    }
+
+    [StaFact]
+    public void TheRowContainer_CarriesTheAccessibleName()
+    {
+        // Asserting only the spoken text passes when the composed name happens to equal
+        // ToString(), and then silently stops catching the regression. The name has to be on
+        // the container itself.
+        var (window, _, list) = Open();
+        try
+        {
+            var row = list.ItemContainerGenerator.ContainerFromIndex(0) as ListBoxItem;
+            Assert.NotNull(row);
+            Assert.False(string.IsNullOrWhiteSpace(AutomationProperties.GetName(row!)),
+                "The row's name must come from the ItemContainerStyle, not from inside the DataTemplate.");
+        }
+        finally { window.Close(); }
+    }
+
+    // ── The UIA mechanism: the filter box declares it drives the list ─────────
+
+    [StaFact]
+    public void TheFilterBox_DeclaresThatItControlsTheCommandList()
+    {
+        // This is what lets a screen reader report the active row while focus stays in the
+        // edit box. Without it the palette is silent as you type, whatever else is right.
+        var (window, box, list) = Open();
+        try
+        {
+            var boxPeer = UIElementAutomationPeer.CreatePeerForElement(box);
+            Assert.NotNull(boxPeer);
+
+            var controlled = boxPeer.GetControlledPeers();
+            Assert.NotNull(controlled);
+
+            var listPeer = UIElementAutomationPeer.FromElement(list)
+                           ?? UIElementAutomationPeer.CreatePeerForElement(list);
+            Assert.Contains(controlled!, p => ReferenceEquals(p, listPeer));
+        }
+        finally { window.Close(); }
+    }
+
+    [StaFact]
+    public void EveryFilteredRow_HasAnItemPeer_EvenWhileVirtualizing()
+    {
+        // The explicit-raise reporting mode targets the selected row's peer by index. If item
+        // peers did not exist for every item, that mode would be a silent no-op.
+        var (window, box, list) = Open();
+        try
+        {
+            box.Text = "e";
+            Drain();
+
+            var peers = UIElementAutomationPeer.CreatePeerForElement(list).GetChildren();
+            Assert.NotNull(peers);
+            Assert.Equal(list.Items.Count, peers!.Count);
+        }
+        finally { window.Close(); }
+    }
+
+    // ── The announcement fallback ────────────────────────────────────────────
+
+    [StaFact]
+    public void InAnnounceMode_ArrowingSaysTheCommandAndItsPlace()
+    {
+        var heard = new List<(string Text, AnnouncementCategory Category)>();
+        var previous = CommandPaletteWindow.Reporting;
+        CommandPaletteWindow.Reporting = CommandPaletteWindow.ReportMode.Announce;
+        AccessibilityHelper.AnnouncementObserver = (text, category) => heard.Add((text, category));
+
+        var (window, _, list) = Open();
+        try
+        {
+            heard.Clear();
+
+            Press(window, Key.Down);
+            Drain();
+
+            var expected = $"{((CommandDefinition)list.SelectedItem).Title}, 2 of 4";
+            Assert.Contains(heard, h => h.Text == expected && h.Category == AnnouncementCategory.Result);
+        }
+        finally
+        {
+            AccessibilityHelper.AnnouncementObserver = null;
+            CommandPaletteWindow.Reporting = previous;
+            window.Close();
+        }
+    }
+
+    [StaFact]
+    public void InAnnounceMode_AnUnchangedTopMatchSaysNothingFurther()
+    {
+        // Typing that narrows the list without changing what Enter would run has nothing new to
+        // report. Speaking on every keystroke is half of why this feature was removed in 2026-05.
+        var heard = new List<(string Text, AnnouncementCategory Category)>();
+        var previous = CommandPaletteWindow.Reporting;
+        CommandPaletteWindow.Reporting = CommandPaletteWindow.ReportMode.Announce;
+        AccessibilityHelper.AnnouncementObserver = (text, category) => heard.Add((text, category));
+
+        var (window, _, list) = Open();
+        try
+        {
+            Press(window, Key.Down);   // report something, so there is a last-reported command
+            Drain();
+            heard.Clear();
+
+            var top = list.SelectedItem;
+            Press(window, Key.Up);     // back to the top
+            Drain();
+            var afterFirst = heard.Count;
+            heard.Clear();
+
+            Press(window, Key.Up);     // already at the top: nothing changes
+            Drain();
+
+            Assert.True(afterFirst > 0, "Moving to a different command must be reported.");
+            Assert.Empty(heard);
+        }
+        finally
+        {
+            AccessibilityHelper.AnnouncementObserver = null;
+            CommandPaletteWindow.Reporting = previous;
+            window.Close();
+        }
+    }
+
+    [StaFact]
+    public void AnEmptyResultSet_IsAnnouncedInEveryMode()
+    {
+        // Nothing is selected, so neither UIA path has a row to report. Without this the
+        // palette is indistinguishable from one that has stopped responding.
+        var heard = new List<(string Text, AnnouncementCategory Category)>();
+        AccessibilityHelper.AnnouncementObserver = (text, category) => heard.Add((text, category));
+
+        var (window, box, _) = Open();
+        try
+        {
+            Assert.Equal(CommandPaletteWindow.ReportMode.Automation, CommandPaletteWindow.Reporting);
+            heard.Clear();
+
+            box.Text = "zzzzz";
+            PumpPast(TimeSpan.FromMilliseconds(400));   // the typing debounce
+
+            Assert.Contains(heard, h => h.Text == "No matching commands"
+                                     && h.Category == AnnouncementCategory.Result);
+        }
+        finally
+        {
+            AccessibilityHelper.AnnouncementObserver = null;
+            window.Close();
+        }
+    }
+
+    [StaFact]
+    public void InAutomationMode_NothingIsAnnouncedByHand()
+    {
+        // The default mode leaves the reporting to the platform. If an announcement leaks out
+        // here it is speech on top of what the screen reader already says for the row.
+        var heard = new List<(string Text, AnnouncementCategory Category)>();
+        AccessibilityHelper.AnnouncementObserver = (text, category) => heard.Add((text, category));
+
+        var (window, box, _) = Open();
+        try
+        {
+            Assert.Equal(CommandPaletteWindow.ReportMode.Automation, CommandPaletteWindow.Reporting);
+            heard.Clear();
+
+            box.Text = "go to";
+            PumpPast(TimeSpan.FromMilliseconds(400));
+            Press(window, Key.Down);
+            Drain();
+
+            Assert.Empty(heard);
+        }
+        finally
+        {
+            AccessibilityHelper.AnnouncementObserver = null;
+            window.Close();
+        }
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private static (CommandPaletteWindow window, TextBox box, ListBox list) Open()
+    {
+        WpfTestHost.EnsureStyles("AccessibleStyles", "ThemedControls");
+
+        var registry = new CommandRegistry();
+        foreach (var (id, category, title) in new[]
+                 {
+                     ("mail.archive",  "Mail", "Move to Archive"),
+                     ("view.goFolder", "View", "Go to Folder"),
+                     ("view.goDate",   "View", "Go to Date"),
+                     ("mail.reply",    "Mail", "Reply"),
+                 })
+        {
+            registry.Register(new CommandDefinition(id, category, title, execute: () => { }));
+        }
+
+        var window = new CommandPaletteWindow(registry)
+        {
+            WindowStyle = WindowStyle.None, ShowInTaskbar = false, ShowActivated = false,
+        };
+        window.Show();
+        window.UpdateLayout();
+        Drain();
+
+        var box = window.FindName("FilterBox") as TextBox;
+        Assert.NotNull(box);
+        var list = window.FindName("CommandList") as ListBox;
+        Assert.NotNull(list);
+
+        // ShowActivated = false means no real keyboard focus arrives from the window manager;
+        // take it explicitly so the focus assertions read the state the user would have.
+        box!.Focus();
+        Keyboard.Focus(box);
+        Drain();
+
+        return (window, box, list!);
+    }
+
+    private static void Press(Window window, Key key)
+    {
+        var source = PresentationSource.FromVisual(window);
+        if (source is null) return;
+
+        var args = new KeyEventArgs(Keyboard.PrimaryDevice, source, 0, key)
+        {
+            RoutedEvent = Keyboard.PreviewKeyDownEvent,
+        };
+        window.RaiseEvent(args);
+    }
+
+    /// <summary>Raises a left-button-down at the given row, as the palette's own handler sees it.</summary>
+    private static void ClickDown(Window window, ListBoxItem row)
+    {
+        var source = PresentationSource.FromVisual(window);
+        if (source is null) return;
+
+        // Raised on the row itself so OriginalSource is the row, as a real hit-test would make it
+        // the TextBlock inside the row's template — either way the handler walks up to the container.
+        var args = new MouseButtonEventArgs(Mouse.PrimaryDevice, 0, MouseButton.Left)
+        {
+            RoutedEvent = Mouse.PreviewMouseDownEvent,
+        };
+        row.RaiseEvent(args);
+    }
+
+    private static List<string> ItemPeerNames(ListBox list)
+    {
+        list.UpdateLayout();
+        Drain();
+
+        return (UIElementAutomationPeer.CreatePeerForElement(list).GetChildren() ?? [])
+            .Select(p => p.GetName())
+            .Where(n => !string.IsNullOrWhiteSpace(n))
+            .ToList();
+    }
+
+    // Pumps the dispatcher until a DispatcherTimer set for less than this has had time to tick.
+    private static void PumpPast(TimeSpan delay)
+    {
+        var deadline = DateTime.UtcNow + delay;
+        while (DateTime.UtcNow < deadline)
+        {
+            Drain();
+            System.Threading.Thread.Sleep(20);
+        }
+        Drain();
+    }
+
+    private static void Drain()
+    {
+        var frame = new DispatcherFrame();
+        Dispatcher.CurrentDispatcher.BeginInvoke(
+            DispatcherPriority.SystemIdle, new Action(() => frame.Continue = false));
+        Dispatcher.PushFrame(frame);
+    }
+}

--- a/QuickMail.Tests/TypeAheadWiringTests.cs
+++ b/QuickMail.Tests/TypeAheadWiringTests.cs
@@ -64,7 +64,6 @@ public class TypeAheadWiringTests
         new("Views/AddressBookWindow.xaml",    "GroupMembersList", "TypeAheadText",           typeof(ContactModel)),
         new("Views/AccountManagerDialog.xaml", "AccountListBox",   "AccountLabelWithDefault", typeof(AccountModel)),
         new("Views/MainWindow.xaml",           "AccountList",      "AccountLabel",            typeof(AccountModel)),
-        new("Views/CommandPaletteWindow.xaml", "CommandList",      "Title",                   typeof(CommandDefinition)),
         new("Views/FolderPickerWindow.xaml",   "FolderListBox",    "FolderPath",              typeof(FolderPickerWindow.FolderPickerItem)),
         new("Views/WatchedConversationsWindow.xaml", "WatchList",  "Label",                   typeof(WatchRow)),
     ];
@@ -173,6 +172,27 @@ public class TypeAheadWiringTests
         }
 
         Assert.True(problems.Count == 0, Report("TextSearch declared on a TreeView, where it does nothing", problems));
+    }
+
+    /// <summary>
+    /// The command palette's list is driven by its filter box, not by keystrokes of its own: it
+    /// is <c>Focusable="False"</c>, so WPF <c>TextSearch</c> would never see a character. It did
+    /// declare a <c>TextPath</c> — and had a row in <see cref="Sites"/> — until the filter box
+    /// arrived. Both were removed together, and this keeps the declaration from drifting back in
+    /// as an inert one, which is the shape <see cref="NoTreeView_DeclaresATextSearchTextPath"/>
+    /// exists to catch elsewhere (issue #418).
+    /// </summary>
+    [Fact]
+    public void TheCommandPaletteList_DeclaresNoTextSearchTextPath()
+    {
+        var doc = XamlDocuments().Single(d => d.Relative == "Views/CommandPaletteWindow.xaml").Doc;
+
+        var list = doc.Descendants()
+                      .FirstOrDefault(e => (string?)e.Attribute(X + "Name") == "CommandList");
+        Assert.NotNull(list);
+
+        Assert.Null(list!.Attribute(TextPathAttr));
+        Assert.DoesNotContain(Sites, s => s.ElementName == "CommandList");
     }
 
     [Fact]

--- a/QuickMail/Controls/ControllingTextBox.cs
+++ b/QuickMail/Controls/ControllingTextBox.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using System.Windows;
+using System.Windows.Automation.Peers;
+using System.Windows.Controls;
+
+namespace QuickMail.Controls;
+
+/// <summary>
+/// A <see cref="TextBox"/> that tells UI Automation which control it is driving, via the
+/// <c>ControllerFor</c> property (<see cref="AutomationPeer.GetControlledPeersCore"/>).
+///
+/// <para>This is the autocomplete shape a Windows search field uses: keyboard focus stays in
+/// the edit box while the list below it narrows, and the screen reader learns which list to
+/// report the active row from. Paired with a <c>SelectionItemPatternOnElementSelected</c>
+/// event raised on the selected row, the platform speaks the row's name, its position in the
+/// set, and its help text — so nothing has to be announced by hand, and no announcement
+/// setting can silence it.</para>
+///
+/// <para>The alternative, moving keyboard focus onto the row itself, is what the command
+/// palette did until 2026-05 and why filtering was removed: every keystroke bounced focus
+/// between the box and the list. Focus must not move.</para>
+/// </summary>
+public class ControllingTextBox : TextBox
+{
+    /// <summary>
+    /// The control this box drives. Set it before the automation peer is first asked for its
+    /// controlled peers — in practice, during the owning window's construction or Loaded.
+    /// </summary>
+    public UIElement? Controls { get; set; }
+
+    protected override AutomationPeer OnCreateAutomationPeer() => new ControllingTextBoxPeer(this);
+
+    private sealed class ControllingTextBoxPeer : TextBoxAutomationPeer
+    {
+        private readonly ControllingTextBox _owner;
+
+        public ControllingTextBoxPeer(ControllingTextBox owner) : base(owner) => _owner = owner;
+
+        protected override List<AutomationPeer>? GetControlledPeersCore()
+        {
+            if (_owner.Controls is null) return null;
+
+            var peer = UIElementAutomationPeer.FromElement(_owner.Controls)
+                       ?? UIElementAutomationPeer.CreatePeerForElement(_owner.Controls);
+
+            return peer is null ? null : [peer];
+        }
+    }
+}

--- a/QuickMail/Helpers/CommandMatcher.cs
+++ b/QuickMail/Helpers/CommandMatcher.cs
@@ -1,0 +1,238 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using QuickMail.Models;
+
+namespace QuickMail.Helpers;
+
+/// <summary>
+/// Ranks command-palette entries against what the user has typed, the way VS Code does: the
+/// typed characters have to appear in order but not next to each other, so "gtf" reaches
+/// "Go to Folder" and "arch" reaches "Move to Archive".
+///
+/// <para>Pure and WPF-free, so the ranking is covered by plain unit tests rather than by
+/// driving a window.</para>
+///
+/// <para><b>Why the weights lean so hard on the obvious cases.</b> The palette reports only the
+/// TOP result as it changes, and Enter runs it. A scattered subsequence hit that outranked a
+/// title the user had typed the front of would be a result they cannot explain and did not
+/// ask for, so the whole-string tiers (exact, prefix, substring) and the acronym pass are
+/// each worth more than any combination of per-character bonuses can reach.</para>
+/// </summary>
+public static class CommandMatcher
+{
+    // Whole-string tiers. Ordered so the more literal match always wins.
+    private const int ExactBonus     = 120;
+    private const int PrefixBonus    = 50;
+    private const int SubstringBonus = 25;
+    private const int AcronymBonus   = 60;
+
+    // Per-character bonuses.
+    private const int FirstCharBonus   = 10;
+    private const int WordStartBonus   = 6;
+    private const int ConsecutiveBonus = 4;
+
+    // Gaps between matched runs cost, but the total is capped: uncapped, a long title scores
+    // worse than a short one purely for being long, whatever the user typed.
+    private const int GapPenalty    = 1;
+    private const int MaxGapPenalty = 12;
+
+    // Which field matched. The title is what the user sees first, so it is what they take
+    // themselves to be matching; everything else has to beat it by a margin to take the top.
+    private const int TitlePenalty         = 0;
+    private const int CategoryTitlePenalty = 12;
+    private const int DescriptionPenalty   = 30;
+    private const int IdPenalty            = 40;
+
+    // Order-free multi-term matching ("arch mail") sits behind the whole-query reading
+    // ("go fold"), never ahead of it.
+    private const int MultiTermPenalty = 10;
+
+    /// <summary>
+    /// Ranks <paramref name="all"/> best-first. An empty query returns the input untouched, so
+    /// an unfiltered palette still shows the registry's own category-then-title order.
+    /// </summary>
+    public static IReadOnlyList<CommandDefinition> Rank(
+        IReadOnlyList<CommandDefinition> all, string? query)
+    {
+        if (all is null) return Array.Empty<CommandDefinition>();
+
+        var trimmed = (query ?? string.Empty).Trim();
+        if (trimmed.Length == 0) return all;
+
+        var scored = new List<(CommandDefinition Cmd, int Score, int Index)>();
+        for (var i = 0; i < all.Count; i++)
+            if (TryScoreCommand(all[i], trimmed, out var score))
+                scored.Add((all[i], score, i));
+
+        return scored
+            .OrderByDescending(x => x.Score)
+            .ThenBy(x => x.Cmd.Title.Length)   // a tie goes to the more direct command
+            .ThenBy(x => x.Index)              // then to registry order, so ranking is stable
+            .Select(x => x.Cmd)
+            .ToList();
+    }
+
+    /// <summary>
+    /// Scores one command across its title, category, description and id, keeping the best.
+    /// <see langword="false"/> when the query is not a subsequence of any of them.
+    /// </summary>
+    public static bool TryScoreCommand(CommandDefinition cmd, string? query, out int score)
+    {
+        score = int.MinValue;
+
+        var trimmed = (query ?? string.Empty).Trim();
+        if (trimmed.Length == 0) { score = 0; return true; }
+
+        var matched = false;
+        matched |= TryField(cmd.Title, trimmed, TitlePenalty, ref score);
+        matched |= TryField($"{cmd.Category} {cmd.Title}", trimmed, CategoryTitlePenalty, ref score);
+        if (!string.IsNullOrEmpty(cmd.Description))
+            matched |= TryField(cmd.Description!, trimmed, DescriptionPenalty, ref score);
+        matched |= TryField(cmd.Id, trimmed, IdPenalty, ref score);
+
+        if (!matched) score = 0;
+        return matched;
+    }
+
+    /// <summary>
+    /// Scores <paramref name="query"/> against a single string. <see langword="false"/> when the
+    /// query's characters do not all appear in it, in order.
+    /// </summary>
+    public static bool TryScore(string? candidate, string? query, out int score)
+    {
+        score = 0;
+        if (string.IsNullOrWhiteSpace(query)) return true;
+        if (string.IsNullOrEmpty(candidate)) return false;
+        return TryScoreText(candidate!, query!.Trim(), out score);
+    }
+
+    // ── Scoring ──────────────────────────────────────────────────────────────
+
+    private static bool TryField(string candidate, string query, int penalty, ref int best)
+    {
+        if (!TryScoreText(candidate, query, out var score)) return false;
+
+        var value = score - penalty;
+        if (value > best) best = value;
+        return true;
+    }
+
+    private static bool TryScoreText(string candidate, string query, out int score)
+    {
+        score = int.MinValue;
+        var matched = false;
+
+        // The whole query, spaces included — "go fold" over "Go to Folder".
+        if (TryScoreCore(candidate, query.ToLowerInvariant(), out var whole))
+        {
+            score   = whole;
+            matched = true;
+        }
+
+        // Each word on its own, in any order — "arch mail" over "Mail Move to Archive".
+        var terms = query.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        if (terms.Length > 1)
+        {
+            var sum = 0;
+            var all = true;
+            foreach (var term in terms)
+            {
+                if (!TryScoreCore(candidate, term.ToLowerInvariant(), out var termScore))
+                {
+                    all = false;
+                    break;
+                }
+                sum += termScore;
+            }
+
+            if (all)
+            {
+                var average = sum / terms.Length - MultiTermPenalty;
+                if (!matched || average > score) score = average;
+                matched = true;
+            }
+        }
+
+        return matched;
+    }
+
+    /// <summary>
+    /// Greedy leftmost subsequence scan. Taking each character as early as possible can score
+    /// lower than the best available assignment, but it never misses a match that exists —
+    /// which is the property that matters here: a command the user can see must never be
+    /// unreachable by typing.
+    /// </summary>
+    private static bool TryScoreCore(string candidate, string needleLower, out int score)
+    {
+        score = 0;
+        if (needleLower.Length == 0) return true;
+
+        var hay = candidate.ToLowerInvariant();
+        if (needleLower.Length > hay.Length) return false;
+
+        // Word starts are read off the original casing, for camelCase boundaries. Invariant
+        // lowering preserves length for everything we ship; fall back rather than mis-index.
+        var cased = hay.Length == candidate.Length ? candidate : hay;
+
+        var total    = 0;
+        var gaps     = 0;
+        var previous = -2;
+        var from     = 0;
+
+        foreach (var ch in needleLower)
+        {
+            var at = hay.IndexOf(ch, from);
+            if (at < 0) return false;
+
+            total += 1;
+            if (at == 0) total += FirstCharBonus;
+            else if (IsWordStart(cased, at)) total += WordStartBonus;
+            if (at == previous + 1) total += ConsecutiveBonus;
+
+            gaps += at - Math.Max(previous + 1, 0);
+            previous = at;
+            from     = at + 1;
+        }
+
+        total -= Math.Min(gaps * GapPenalty, MaxGapPenalty);
+
+        if (string.Equals(hay, needleLower, StringComparison.Ordinal))
+            total += ExactBonus;
+        else if (hay.StartsWith(needleLower, StringComparison.Ordinal))
+            total += PrefixBonus;
+        else if (hay.Contains(needleLower, StringComparison.Ordinal))
+            total += SubstringBonus;
+
+        // "gtf" over the initials of "Go to Folder". Two characters minimum: one letter is
+        // already served by the prefix tier, and would otherwise lift every command starting
+        // with that letter for no reason.
+        if (needleLower.Length >= 2 && !needleLower.Contains(' ')
+            && Initials(cased).StartsWith(needleLower, StringComparison.Ordinal))
+            total += AcronymBonus;
+
+        score = total;
+        return true;
+    }
+
+    private static string Initials(string text)
+    {
+        var builder = new StringBuilder();
+        for (var i = 0; i < text.Length; i++)
+            if (IsWordStart(text, i))
+                builder.Append(char.ToLowerInvariant(text[i]));
+        return builder.ToString();
+    }
+
+    private static bool IsWordStart(string text, int index)
+    {
+        if (index <= 0) return true;
+
+        var previous = text[index - 1];
+        if (!char.IsLetterOrDigit(previous)) return true;
+
+        // camelCase / PascalCase boundary.
+        return char.IsUpper(text[index]) && !char.IsUpper(previous);
+    }
+}

--- a/QuickMail/ViewModels/CommandPaletteViewModel.cs
+++ b/QuickMail/ViewModels/CommandPaletteViewModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using QuickMail.Helpers;
@@ -17,10 +18,12 @@ public partial class CommandPaletteViewModel : ObservableObject
     /// <summary>
     /// What the palette actually shows: <see cref="Commands"/> ranked against <see cref="SearchText"/>.
     ///
-    /// Batched, so refilling it raises one Reset rather than an event per command. Unbatched,
-    /// every keystroke would fire ~200 UIA structure notifications at whatever is listening.
+    /// Deliberately a plain collection updated in place — see <see cref="Reconcile"/>. Batching the
+    /// refill into one Reset, which is the usual way to keep a rebuild quiet, is the wrong trade
+    /// here: a Reset makes the list drop and retake its selection, and a retaken selection is
+    /// spoken.
     /// </summary>
-    public BatchObservableCollection<CommandDefinition> FilteredCommands { get; } = [];
+    public ObservableCollection<CommandDefinition> FilteredCommands { get; } = [];
 
     [ObservableProperty]
     private string _searchText = string.Empty;
@@ -61,16 +64,47 @@ public partial class CommandPaletteViewModel : ObservableObject
 
     private void ApplyFilter()
     {
-        using (FilteredCommands.BeginBatchScope())
-        {
-            FilteredCommands.Clear();
-            foreach (var cmd in CommandMatcher.Rank(_allCommands, SearchText))
-                FilteredCommands.Add(cmd);
-        }
+        var ranked = CommandMatcher.Rank(_allCommands, SearchText);
+
+        // Reconciled in place rather than cleared and refilled. Clear + Add raises a Reset, the
+        // list re-selects off the back of it, and the assignment below then selects again — two
+        // selection changes for one keystroke, which is heard as the command being named twice:
+        //
+        //     Month View
+        //     Month View
+        //     1 of 78
+        //
+        // Updating in place leaves a top match that has not changed sitting in its own container,
+        // untouched, so nothing is reported until what Enter would run actually changes.
+        Reconcile(ranked);
 
         // The top match is always what Enter runs, so the selection follows the filter rather
         // than trying to keep hold of a command that may no longer be in the list.
         SelectedCommand = FilteredCommands.Count > 0 ? FilteredCommands[0] : null;
+    }
+
+    /// <summary>
+    /// Brings <see cref="FilteredCommands"/> to <paramref name="ranked"/> with removals, moves and
+    /// inserts, so items that survive keep their identity — and their list container — instead of
+    /// every keystroke replacing all of them.
+    /// </summary>
+    private void Reconcile(IReadOnlyList<CommandDefinition> ranked)
+    {
+        var wanted = new HashSet<CommandDefinition>(ranked);
+
+        for (var i = FilteredCommands.Count - 1; i >= 0; i--)
+            if (!wanted.Contains(FilteredCommands[i]))
+                FilteredCommands.RemoveAt(i);
+
+        for (var i = 0; i < ranked.Count; i++)
+        {
+            if (i < FilteredCommands.Count && ReferenceEquals(FilteredCommands[i], ranked[i]))
+                continue;
+
+            var existing = FilteredCommands.IndexOf(ranked[i]);
+            if (existing >= 0) FilteredCommands.Move(existing, i);
+            else FilteredCommands.Insert(i, ranked[i]);
+        }
     }
 
     [RelayCommand(CanExecute = nameof(HasSelectedCommand))]

--- a/QuickMail/ViewModels/CommandPaletteViewModel.cs
+++ b/QuickMail/ViewModels/CommandPaletteViewModel.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using QuickMail.Helpers;
 using QuickMail.Models;
 using QuickMail.Services;
 
@@ -8,20 +9,68 @@ namespace QuickMail.ViewModels;
 
 public partial class CommandPaletteViewModel : ObservableObject
 {
-    public IReadOnlyList<CommandDefinition> Commands { get; }
+    private readonly IReadOnlyList<CommandDefinition> _allCommands;
+
+    /// <summary>Every registered command, in the registry's category-then-title order.</summary>
+    public IReadOnlyList<CommandDefinition> Commands => _allCommands;
+
+    /// <summary>
+    /// What the palette actually shows: <see cref="Commands"/> ranked against <see cref="SearchText"/>.
+    ///
+    /// Batched, so refilling it raises one Reset rather than an event per command. Unbatched,
+    /// every keystroke would fire ~200 UIA structure notifications at whatever is listening.
+    /// </summary>
+    public BatchObservableCollection<CommandDefinition> FilteredCommands { get; } = [];
+
+    [ObservableProperty]
+    private string _searchText = string.Empty;
 
     [ObservableProperty]
     private CommandDefinition? _selectedCommand;
 
     public CommandPaletteViewModel(ICommandRegistry registry)
     {
-        Commands        = registry.GetAll();
-        SelectedCommand = Commands.Count > 0 ? Commands[0] : null;
+        _allCommands = registry.GetAll();
+        ApplyFilter();
     }
+
+    partial void OnSearchTextChanged(string value) => ApplyFilter();
 
     partial void OnSelectedCommandChanged(CommandDefinition? value)
     {
         ExecuteSelectedCommand.NotifyCanExecuteChanged();
+    }
+
+    /// <summary>
+    /// What a screen reader is told when the active command changes, used only by the
+    /// announcement fallback in the window — the UIA path lets the platform compose this
+    /// itself. Built here so it is unit-testable without standing up a window.
+    /// </summary>
+    public string ActiveCommandSummary
+    {
+        get
+        {
+            if (FilteredCommands.Count == 0) return "No matching commands";
+
+            var index = SelectedCommand is null ? 0 : FilteredCommands.IndexOf(SelectedCommand);
+            if (index < 0) index = 0;
+
+            return $"{FilteredCommands[index].Title}, {index + 1} of {FilteredCommands.Count}";
+        }
+    }
+
+    private void ApplyFilter()
+    {
+        using (FilteredCommands.BeginBatchScope())
+        {
+            FilteredCommands.Clear();
+            foreach (var cmd in CommandMatcher.Rank(_allCommands, SearchText))
+                FilteredCommands.Add(cmd);
+        }
+
+        // The top match is always what Enter runs, so the selection follows the filter rather
+        // than trying to keep hold of a command that may no longer be in the list.
+        SelectedCommand = FilteredCommands.Count > 0 ? FilteredCommands[0] : null;
     }
 
     [RelayCommand(CanExecute = nameof(HasSelectedCommand))]

--- a/QuickMail/Views/CommandPaletteWindow.xaml
+++ b/QuickMail/Views/CommandPaletteWindow.xaml
@@ -3,6 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:controls="clr-namespace:QuickMail.Controls"
         xmlns:vm="clr-namespace:QuickMail.ViewModels"
         mc:Ignorable="d"
         Title="Command Palette"
@@ -20,66 +21,130 @@
         FontFamily="{DynamicResource Theme.FontFamily}"
         FontSize="{DynamicResource Theme.FontSizeBase}">
 
+    <!-- TabNavigation="None": the filter box is the only thing that may hold focus, so Tab has
+         nowhere to go. Without this Tab cycles onto the list, which breaks the whole model. -->
     <Border Background="{DynamicResource Theme.WindowBackground}"
             BorderBrush="{DynamicResource Theme.Border}"
             BorderThickness="1"
-            CornerRadius="4">
+            CornerRadius="4"
+            KeyboardNavigation.TabNavigation="None">
         <Border.Effect>
             <DropShadowEffect BlurRadius="12" ShadowDepth="3" Opacity="0.35" Direction="270"/>
         </Border.Effect>
 
-        <!-- Command list — plain arrow-navigable list, no search box -->
-        <ListBox x:Name="CommandList"
-                 Margin="4"
-                 MaxHeight="440"
-                 BorderThickness="0"
-                 Background="Transparent"
-                 ItemsSource="{Binding Commands}"
-                 SelectedItem="{Binding SelectedCommand}"
-                 TextSearch.TextPath="Title"
-                 ScrollViewer.HorizontalScrollBarVisibility="Disabled"
-                 VirtualizingPanel.IsVirtualizing="True"
-                 VirtualizingPanel.VirtualizationMode="Recycling"
-                 AutomationProperties.Name="Commands. Arrow keys to navigate, Enter to run, Escape to close."
-                 MouseDoubleClick="CommandList_MouseDoubleClick">
-            <ListBox.ItemContainerStyle>
-                <Style TargetType="ListBoxItem">
-                    <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
-                    <Setter Property="Padding" Value="8,5"/>
-                    <Setter Property="IsTabStop" Value="False"/>
-                    <Setter Property="AutomationProperties.Name"
-                            Value="{Binding Title}"/>
-                    <Setter Property="AutomationProperties.HelpText"
-                            Value="{Binding GestureText}"/>
-                </Style>
-            </ListBox.ItemContainerStyle>
-            <ListBox.ItemTemplate>
-                <DataTemplate>
-                    <Grid>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*"/>
-                            <ColumnDefinition Width="Auto"/>
-                        </Grid.ColumnDefinitions>
+        <Grid Margin="4">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
 
-                        <StackPanel Grid.Column="0" VerticalAlignment="Center">
-                            <TextBlock Text="{Binding Title}"
-                                       TextTrimming="CharacterEllipsis"/>
-                            <TextBlock Text="{Binding Category}"
+            <!-- The only focusable thing in the window. Focus lands here on open and never
+                 moves: arrowing changes the list's selection while the caret stays put, which
+                 is what lets typing keep working without forwarding keystrokes about. The
+                 box declares (ControllerFor) that it drives CommandList, so a screen reader
+                 knows where to read the active command from. -->
+            <!-- Style is set by hand because WPF keys implicit styles on the exact type: the
+                 implicit TextBox style does NOT reach a subclass, and without this the box
+                 renders default light chrome in every dark theme.
+                 ContextMenu is nulled because the palette can be modeless (#676), where the
+                 default Cut/Copy/Paste menu deactivates the window and dismisses it. -->
+            <controls:ControllingTextBox x:Name="FilterBox"
+                                         Grid.Row="0"
+                                         Style="{DynamicResource {x:Type TextBox}}"
+                                         Margin="4,4,4,6"
+                                         Padding="6,4"
+                                         ContextMenu="{x:Null}"
+                                         Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}"
+                                         AutomationProperties.Name="Filter commands"/>
+
+            <ListBox x:Name="CommandList"
+                     Grid.Row="1"
+                     MaxHeight="400"
+                     BorderThickness="0"
+                     Background="Transparent"
+                     Focusable="False"
+                     IsTabStop="False"
+                     ItemsSource="{Binding FilteredCommands}"
+                     SelectedItem="{Binding SelectedCommand}"
+                     ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                     VirtualizingPanel.IsVirtualizing="True"
+                     VirtualizingPanel.VirtualizationMode="Recycling"
+                     AutomationProperties.Name="Commands"
+                     PreviewMouseDown="CommandList_PreviewMouseDown"
+                     MouseDoubleClick="CommandList_MouseDoubleClick">
+                <ListBox.ItemContainerStyle>
+                    <Style TargetType="ListBoxItem">
+                        <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+                        <Setter Property="Padding" Value="8,5"/>
+                        <Setter Property="IsTabStop" Value="False"/>
+                        <!-- Not focusable at all: a mouse click on a row would otherwise pull
+                             keyboard focus out of the filter box, which silently breaks typing
+                             and the reporting of the active command for anyone using a mouse. -->
+                        <Setter Property="Focusable" Value="False"/>
+                        <Setter Property="AutomationProperties.Name"
+                                Value="{Binding Title}"/>
+                        <Setter Property="AutomationProperties.HelpText"
+                                Value="{Binding GestureText}"/>
+                        <!-- The palette's own row template. The shared themed one dims a
+                             selected row whenever Selector.IsSelectionActive is false — and
+                             here it is ALWAYS false, because focus is deliberately parked in
+                             the filter box. Without this the command Enter would run is drawn
+                             as though it were not selected at all. -->
+                        <Setter Property="Template">
+                            <Setter.Value>
+                                <ControlTemplate TargetType="ListBoxItem">
+                                    <Border x:Name="border"
+                                            Background="Transparent"
+                                            Padding="{TemplateBinding Padding}"
+                                            SnapsToDevicePixels="True">
+                                        <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
+                                    </Border>
+                                    <ControlTemplate.Triggers>
+                                        <Trigger Property="IsMouseOver" Value="True">
+                                            <Setter TargetName="border" Property="Background"
+                                                    Value="{DynamicResource Theme.AccentSubtle}"/>
+                                        </Trigger>
+                                        <Trigger Property="IsSelected" Value="True">
+                                            <Setter TargetName="border" Property="Background"
+                                                    Value="{DynamicResource Theme.SelectionBackground}"/>
+                                            <Setter Property="Foreground"
+                                                    Value="{DynamicResource Theme.SelectionText}"/>
+                                        </Trigger>
+                                    </ControlTemplate.Triggers>
+                                </ControlTemplate>
+                            </Setter.Value>
+                        </Setter>
+                    </Style>
+                </ListBox.ItemContainerStyle>
+                <ListBox.ItemTemplate>
+                    <DataTemplate>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="Auto"/>
+                            </Grid.ColumnDefinitions>
+
+                            <StackPanel Grid.Column="0" VerticalAlignment="Center">
+                                <TextBlock Text="{Binding Title}"
+                                           TextTrimming="CharacterEllipsis"/>
+                                <TextBlock Text="{Binding Category}"
+                                           FontSize="{DynamicResource Theme.FontSizeSmall}"
+                                           Opacity="0.6"
+                                           Margin="0,1,0,0"/>
+                            </StackPanel>
+
+                            <TextBlock Grid.Column="1"
+                                       Text="{Binding GestureText}"
                                        FontSize="{DynamicResource Theme.FontSizeSmall}"
+                                       FontFamily="{DynamicResource Theme.FontFamilyMono}"
                                        Opacity="0.6"
-                                       Margin="0,1,0,0"/>
-                        </StackPanel>
-
-                        <TextBlock Grid.Column="1"
-                                   Text="{Binding GestureText}"
-                                   FontSize="{DynamicResource Theme.FontSizeSmall}"
-                                   FontFamily="{DynamicResource Theme.FontFamilyMono}"
-                                   Opacity="0.6"
-                                   VerticalAlignment="Center"
-                                   Margin="12,0,0,0"/>
+                                       VerticalAlignment="Center"
+                                       Margin="12,0,0,0"/>
                         </Grid>
                     </DataTemplate>
                 </ListBox.ItemTemplate>
-        </ListBox>
+            </ListBox>
+        </Grid>
     </Border>
 </Window>

--- a/QuickMail/Views/CommandPaletteWindow.xaml.cs
+++ b/QuickMail/Views/CommandPaletteWindow.xaml.cs
@@ -57,6 +57,12 @@ public partial class CommandPaletteWindow : Window
     // Typing settles before the active command is reported, so the report does not talk over the
     // screen reader echoing what is being typed. Announcing on every keystroke is half of why
     // palette filtering was removed in 2026-05; arrow keys bypass the timer and report at once.
+    //
+    // NOTE this gates only what THIS window says — the Announce mode. It cannot gate the
+    // selection events WPF raises by itself as the filter re-selects, which is what the two
+    // Automation modes rely on; there the timing is WPF's and the screen reader's. If the default
+    // mode turns out to speak on every keystroke, that is the reason, and Announce is the mode
+    // with the timing under our control.
     private DispatcherTimer? _reportTimer;
     private static readonly TimeSpan ReportDebounce = TimeSpan.FromMilliseconds(300);
 
@@ -106,6 +112,19 @@ public partial class CommandPaletteWindow : Window
         CommandChosen = chosen;
         if (_modeless) Close();
         else DialogResult = chosen;
+    }
+
+    /// <summary>
+    /// Stops the report timer however the window went away. <see cref="Dismiss"/> stops it too,
+    /// but a palette can be closed without going through Dismiss at all — WPF closes owned
+    /// windows when the owner shuts down — and a pending tick would then run against a closed
+    /// window, since the timer holds it alive.
+    /// </summary>
+    protected override void OnClosed(EventArgs e)
+    {
+        _dismissed = true;
+        _reportTimer?.Stop();
+        base.OnClosed(e);
     }
 
     private void OnLoaded(object sender, RoutedEventArgs e)
@@ -256,7 +275,10 @@ public partial class CommandPaletteWindow : Window
             return;
         }
 
-        // Enter on an empty result set would otherwise look like the palette had stopped responding.
+        // Enter on an empty result set would otherwise look like the palette had stopped
+        // responding. Said again even though the empty list was already announced once as it
+        // emptied: this is the answer to a key the user just pressed, not a repeat of the state.
+        _reportedEmpty = false;
         ReportNow();
     }
 
@@ -309,7 +331,9 @@ public partial class CommandPaletteWindow : Window
         switch (Reporting)
         {
             case ReportMode.Automation:
-                // Setting SelectedIndex already raised the event; nothing further to do.
+                // Setting SelectedIndex already raised the event, so there is nothing to do —
+                // and by the same token nothing here decides WHEN it is spoken. The debounce and
+                // the unchanged-match suppression above apply to the Announce branch only.
                 break;
             case ReportMode.AutomationExplicit:
                 RaiseElementSelected();
@@ -327,8 +351,7 @@ public partial class CommandPaletteWindow : Window
     /// </summary>
     private void RaiseElementSelected()
     {
-        var index = CommandList.SelectedIndex;
-        if (index < 0) return;
+        if (CommandList.SelectedIndex < 0) return;
 
         // The list virtualizes, so the row's container — and therefore its automation peer — may
         // not exist yet. ScrollIntoView realizes it, but only on a later layout pass, so look the
@@ -337,6 +360,12 @@ public partial class CommandPaletteWindow : Window
         Dispatcher.InvokeAsync(() =>
         {
             if (_dismissed) return;
+
+            // Read the index here rather than capturing it: arrowing faster than the dispatcher
+            // drains queues several of these, and a captured index would report a row that has
+            // since been arrowed past — telling the screen reader a command is selected that is not.
+            var index = CommandList.SelectedIndex;
+            if (index < 0) return;
             if (CommandList.ItemContainerGenerator.ContainerFromIndex(index) is not ListBoxItem row) return;
 
             var peer = UIElementAutomationPeer.FromElement(row)

--- a/QuickMail/Views/CommandPaletteWindow.xaml.cs
+++ b/QuickMail/Views/CommandPaletteWindow.xaml.cs
@@ -48,7 +48,21 @@ public partial class CommandPaletteWindow : Window
     /// The mechanism in force. A field rather than a constant so the tests can exercise the
     /// announcement path without a second build — change the initializer to change the default.
     /// </summary>
-    internal static ReportMode Reporting { get; set; } = ReportMode.Automation;
+    /// <summary>
+    /// The mechanism in force.
+    ///
+    /// <para><see cref="ReportMode.Announce"/> is the default because it is the only one that is
+    /// guaranteed to say anything. The two Automation modes hand the job to the platform, and
+    /// whether the platform does it — and when — cannot be observed from inside the process
+    /// (<c>AutomationPeer.ListenerExists</c> is false with no UIA client attached), so shipping
+    /// one of those as the default risks a palette that narrows the list in total silence: the
+    /// user has no way to know what Enter would run. Announce is also the mode whose timing is
+    /// ours, so the debounce and the unchanged-match suppression actually apply.</para>
+    ///
+    /// <para>A field rather than a constant so the tests can drive each mode; change the
+    /// initializer to change the default.</para>
+    /// </summary>
+    internal static ReportMode Reporting { get; set; } = ReportMode.Announce;
 
     // Shown without a nested message loop (see ShowModeless), and whether it has already been closed.
     private bool _modeless;

--- a/QuickMail/Views/CommandPaletteWindow.xaml.cs
+++ b/QuickMail/Views/CommandPaletteWindow.xaml.cs
@@ -51,18 +51,23 @@ public partial class CommandPaletteWindow : Window
     /// <summary>
     /// The mechanism in force.
     ///
-    /// <para><see cref="ReportMode.Announce"/> is the default because it is the only one that is
-    /// guaranteed to say anything. The two Automation modes hand the job to the platform, and
-    /// whether the platform does it — and when — cannot be observed from inside the process
-    /// (<c>AutomationPeer.ListenerExists</c> is false with no UIA client attached), so shipping
-    /// one of those as the default risks a palette that narrows the list in total silence: the
-    /// user has no way to know what Enter would run. Announce is also the mode whose timing is
-    /// ours, so the debounce and the unchanged-match suppression actually apply.</para>
+    /// <para><see cref="ReportMode.Automation"/>, settled by ear rather than by argument. Listening
+    /// to the palette filter showed the platform already reporting the row in full — the command's
+    /// name and its position in the set, as two utterances — so an <see cref="ReportMode.Announce"/>
+    /// on top of it said everything a second time:</para>
+    /// <code>
+    /// Move Tab Right, 2 of 10   &lt;- ours
+    /// Move Tab Right            &lt;- the platform
+    /// 2 of 10                   &lt;- the platform
+    /// </code>
+    /// <para>That also settles the open question this switch existed for: the platform does carry
+    /// it, so nothing here needs to be announced by hand, and no announcement setting can silence
+    /// the palette. Announce remains as the fallback for a surface where it turns out not to.</para>
     ///
     /// <para>A field rather than a constant so the tests can drive each mode; change the
     /// initializer to change the default.</para>
     /// </summary>
-    internal static ReportMode Reporting { get; set; } = ReportMode.Announce;
+    internal static ReportMode Reporting { get; set; } = ReportMode.Automation;
 
     // Shown without a nested message loop (see ShowModeless), and whether it has already been closed.
     private bool _modeless;
@@ -80,8 +85,10 @@ public partial class CommandPaletteWindow : Window
     private DispatcherTimer? _reportTimer;
     private static readonly TimeSpan ReportDebounce = TimeSpan.FromMilliseconds(300);
 
-    // What was last reported, so an unchanged top match stays silent while the user keeps typing.
+    // What was last reported, so an unchanged top match stays silent while the user keeps typing,
+    // and so a narrowing that leaves it in place is still carried by its count.
     private CommandDefinition? _lastReported;
+    private int _lastReportedCount = -1;
     private bool _reportedEmpty;
 
     /// <summary>True when the palette closed because a command was chosen, rather than being dismissed.</summary>
@@ -155,6 +162,17 @@ public partial class CommandPaletteWindow : Window
         FilterBox.Focus();
         Keyboard.Focus(FilterBox);
 
+        // Opening reports nothing of its own. The window and the filter box announce themselves,
+        // and a command named ahead of them lands before the user has been told where they are:
+        //
+        //     Manage Accounts, 1 of 124
+        //     Command Palette dialog
+        //     Filter commands  Edit
+        //
+        // Treating the opening selection as already reported also means the first thing spoken is
+        // the first command the user actually moves to, or types their way to.
+        _lastReported      = _vm.SelectedCommand;
+        _lastReportedCount = _vm.FilteredCommands.Count;
         MoveSelection(0);
     }
 
@@ -337,10 +355,28 @@ public partial class CommandPaletteWindow : Window
         var active = _vm.SelectedCommand;
         if (active is null) return;
 
-        // Typing that narrows the list without changing what Enter would run says nothing new.
-        if (ReferenceEquals(active, _lastReported)) return;
-        _lastReported  = active;
-        _reportedEmpty = false;
+        var count = _vm.FilteredCommands.Count;
+
+        if (ReferenceEquals(active, _lastReported))
+        {
+            // The platform reports a row when the SELECTION changes, so narrowing that leaves the
+            // same command on top is silent — and the user has just pressed a key that did change
+            // the result set. The count on its own fills that in without repeating the name the
+            // platform already gives. VS Code splits it the same way: the command name comes from
+            // the row, the number of results from a notification of its own.
+            //
+            // Not in Announce mode, where the name and the count are already said together.
+            if (count != _lastReportedCount && Reporting != ReportMode.Announce)
+                AccessibilityHelper.Announce(this, CountText(count),
+                    category: AnnouncementCategory.Result);
+
+            _lastReportedCount = count;
+            return;
+        }
+
+        _lastReported      = active;
+        _lastReportedCount = count;
+        _reportedEmpty     = false;
 
         switch (Reporting)
         {
@@ -358,6 +394,9 @@ public partial class CommandPaletteWindow : Window
                 break;
         }
     }
+
+    private static string CountText(int count) =>
+        count == 1 ? "1 command" : $"{count} commands";
 
     /// <summary>
     /// Raises the element-selected event on the selected row, which is what a screen reader

--- a/QuickMail/Views/CommandPaletteWindow.xaml.cs
+++ b/QuickMail/Views/CommandPaletteWindow.xaml.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Windows;
+using System.Windows.Automation.Peers;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Threading;
+using QuickMail.Models;
 using QuickMail.Services;
 using QuickMail.ViewModels;
 
@@ -12,9 +14,55 @@ public partial class CommandPaletteWindow : Window
 {
     private readonly CommandPaletteViewModel _vm;
 
+    /// <summary>
+    /// How the active command is reported to a screen reader. Which one actually sounds right is
+    /// decided by ear, not by reading, so all three stay working and the choice is one edit.
+    /// </summary>
+    internal enum ReportMode
+    {
+        /// <summary>
+        /// UI Automation alone. The filter box declares it controls the list
+        /// (<see cref="Controls.ControllingTextBox"/> → <c>ControllerFor</c>), and WPF itself
+        /// raises the element-selected event when <c>SelectedIndex</c> changes. The screen reader
+        /// speaks the row's name, its position in the set and its shortcut — nothing announced by
+        /// hand, and no announcement setting can mute it.
+        /// </summary>
+        Automation,
+
+        /// <summary>
+        /// As <see cref="Automation"/>, plus an explicit element-selected event on the row, for
+        /// the case where WPF's own is not reaching the screen reader. Kept separate rather than
+        /// folded into the default because raising it on top of WPF's would speak the command
+        /// twice — worse than silence, and far harder to diagnose by ear.
+        /// </summary>
+        AutomationExplicit,
+
+        /// <summary>
+        /// QuickMail says it, through <see cref="AccessibilityHelper.Announce"/>. Always
+        /// available, but it is a custom announcement the user can switch off.
+        /// </summary>
+        Announce,
+    }
+
+    /// <summary>
+    /// The mechanism in force. A field rather than a constant so the tests can exercise the
+    /// announcement path without a second build — change the initializer to change the default.
+    /// </summary>
+    internal static ReportMode Reporting { get; set; } = ReportMode.Automation;
+
     // Shown without a nested message loop (see ShowModeless), and whether it has already been closed.
     private bool _modeless;
     private bool _dismissed;
+
+    // Typing settles before the active command is reported, so the report does not talk over the
+    // screen reader echoing what is being typed. Announcing on every keystroke is half of why
+    // palette filtering was removed in 2026-05; arrow keys bypass the timer and report at once.
+    private DispatcherTimer? _reportTimer;
+    private static readonly TimeSpan ReportDebounce = TimeSpan.FromMilliseconds(300);
+
+    // What was last reported, so an unchanged top match stays silent while the user keeps typing.
+    private CommandDefinition? _lastReported;
+    private bool _reportedEmpty;
 
     /// <summary>True when the palette closed because a command was chosen, rather than being dismissed.</summary>
     public bool CommandChosen { get; private set; }
@@ -24,6 +72,8 @@ public partial class CommandPaletteWindow : Window
         _vm = new CommandPaletteViewModel(registry);
         InitializeComponent();
         DataContext = _vm;
+        FilterBox.Controls = CommandList;
+        FilterBox.TextChanged += OnFilterTextChanged;
         Loaded += OnLoaded;
         Deactivated += OnDeactivated;
     }
@@ -52,6 +102,7 @@ public partial class CommandPaletteWindow : Window
     {
         if (_dismissed) return;   // closing deactivates the window, which would dismiss it a second time
         _dismissed = true;
+        _reportTimer?.Stop();
         CommandChosen = chosen;
         if (_modeless) Close();
         else DialogResult = chosen;
@@ -66,7 +117,11 @@ public partial class CommandPaletteWindow : Window
             Top  = Owner.Top + 60;
         }
 
-        // Select and focus the first item so the screen reader announces it immediately.
+        // Focus goes to the filter box and stays there for the life of the window. Nothing else in
+        // the palette is focusable: the list is Focusable="False" and its rows are not tab stops.
+        FilterBox.Focus();
+        Keyboard.Focus(FilterBox);
+
         MoveSelection(0);
     }
 
@@ -74,9 +129,22 @@ public partial class CommandPaletteWindow : Window
 
     private void OnPreviewKeyDown(object sender, KeyEventArgs e)
     {
+        // Handled at window level, which is exactly what lets focus stay in the filter box: the
+        // keys below are claimed before the TextBox sees them, while every editing key — Home,
+        // End, Left, Right, Backspace, Delete, Ctrl+A — falls through to the caret untouched.
         if (e.Key == Key.Escape)
         {
-            Dismiss(chosen: false);
+            // Clear the filter first, dismiss only from an empty box. The template picker and the
+            // folder picker both work this way; VS Code closes outright.
+            if (FilterBox.Text.Length > 0)
+            {
+                FilterBox.Clear();
+                MoveSelection(0);
+            }
+            else
+            {
+                Dismiss(chosen: false);
+            }
             e.Handled = true;
         }
         else if (e.Key == Key.Enter)
@@ -94,6 +162,54 @@ public partial class CommandPaletteWindow : Window
             MoveSelection(-1);
             e.Handled = true;
         }
+        else if (e.Key == Key.PageDown)
+        {
+            MoveSelection(+10);
+            e.Handled = true;
+        }
+        else if (e.Key == Key.PageUp)
+        {
+            MoveSelection(-10);
+            e.Handled = true;
+        }
+        else if (e.Key == Key.Tab)
+        {
+            // There is nowhere for Tab to go — the filter box is the only focusable thing in the
+            // window — and letting WPF search for a next stop can land focus outside it.
+            e.Handled = true;
+        }
+    }
+
+    private void OnFilterTextChanged(object sender, TextChangedEventArgs e)
+    {
+        // The ViewModel has already re-ranked and re-selected by the time this runs; all that is
+        // left is to report the new top match once the typing settles.
+        QueueReport();
+    }
+
+    /// <summary>
+    /// Selects the row under the mouse, without moving focus.
+    ///
+    /// <para>WPF's own <c>ListBoxItem</c> click handling selects a row only if it can focus it
+    /// first, and these rows are deliberately not focusable — a click must not take focus off the
+    /// filter box. So a plain click would otherwise leave the selection where the keyboard put it,
+    /// and the double-click below would run a command the user never pointed at.</para>
+    ///
+    /// <para>PreviewMouseDown rather than PreviewMouseLeftButtonDown: the latter is a Direct
+    /// routed event, raised only on the element under the pointer, so a handler on the list never
+    /// sees it.</para>
+    /// </summary>
+    private void CommandList_PreviewMouseDown(object sender, MouseButtonEventArgs e)
+    {
+        if (e.ChangedButton != MouseButton.Left) return;
+        if (e.OriginalSource is not DependencyObject source) return;
+        if (ItemsControl.ContainerFromElement(CommandList, source) is not ListBoxItem row) return;
+
+        var index = CommandList.ItemContainerGenerator.IndexFromContainer(row);
+        if (index < 0) return;
+
+        CommandList.SelectedIndex = index;
+        ReportNow();
     }
 
     private void CommandList_MouseDoubleClick(object sender, MouseButtonEventArgs e)
@@ -103,11 +219,15 @@ public partial class CommandPaletteWindow : Window
 
     // ── Helpers ──────────────────────────────────────────────────────────────────
 
-    // delta=0 re-focuses the currently selected index (used on load).
+    // delta=0 re-selects the current index (used on load and after the filter clears).
     private void MoveSelection(int delta)
     {
         var count = CommandList.Items.Count;
-        if (count == 0) return;
+        if (count == 0)
+        {
+            ReportNow();
+            return;
+        }
 
         var index = delta == 0
             ? Math.Max(CommandList.SelectedIndex, 0)
@@ -116,12 +236,9 @@ public partial class CommandPaletteWindow : Window
         CommandList.SelectedIndex = index;
         CommandList.ScrollIntoView(CommandList.SelectedItem);
 
-        // Defer focus until after the layout pass so the container is materialised.
-        Dispatcher.InvokeAsync(() =>
-        {
-            if (CommandList.ItemContainerGenerator.ContainerFromIndex(index) is ListBoxItem item)
-                item.Focus();
-        }, DispatcherPriority.Background);
+        // Arrowing is a deliberate move to one command, so it is reported at once rather than
+        // waiting out the typing debounce.
+        ReportNow();
     }
 
     private void RunSelected()
@@ -136,6 +253,95 @@ public partial class CommandPaletteWindow : Window
             // palette closes (Input priority runs in order): the owner's focus return has to follow the command.
             Owner?.Dispatcher.InvokeAsync(() => cmd.Execute(), System.Windows.Threading.DispatcherPriority.Input);
             Dismiss(chosen: true);
+            return;
         }
+
+        // Enter on an empty result set would otherwise look like the palette had stopped responding.
+        ReportNow();
+    }
+
+    // ── Reporting the active command ─────────────────────────────────────────────
+
+    /// <summary>Reports after the user stops typing, so the report does not interrupt the typing echo.</summary>
+    private void QueueReport()
+    {
+        _reportTimer ??= CreateReportTimer();
+        _reportTimer.Stop();
+        _reportTimer.Start();
+    }
+
+    private DispatcherTimer CreateReportTimer()
+    {
+        var timer = new DispatcherTimer { Interval = ReportDebounce };
+        timer.Tick += (_, _) =>
+        {
+            timer.Stop();
+            ReportNow();
+        };
+        return timer;
+    }
+
+    private void ReportNow()
+    {
+        _reportTimer?.Stop();
+        if (_dismissed) return;
+
+        if (_vm.FilteredCommands.Count == 0)
+        {
+            // Nothing is selected, so there is no row for either mechanism to report. Both paths
+            // need this one announcement, or an empty list is indistinguishable from a dead palette.
+            if (_reportedEmpty) return;
+            _reportedEmpty = true;
+            _lastReported  = null;
+            AccessibilityHelper.Announce(this, "No matching commands",
+                category: AnnouncementCategory.Result);
+            return;
+        }
+
+        var active = _vm.SelectedCommand;
+        if (active is null) return;
+
+        // Typing that narrows the list without changing what Enter would run says nothing new.
+        if (ReferenceEquals(active, _lastReported)) return;
+        _lastReported  = active;
+        _reportedEmpty = false;
+
+        switch (Reporting)
+        {
+            case ReportMode.Automation:
+                // Setting SelectedIndex already raised the event; nothing further to do.
+                break;
+            case ReportMode.AutomationExplicit:
+                RaiseElementSelected();
+                break;
+            case ReportMode.Announce:
+                AccessibilityHelper.Announce(this, _vm.ActiveCommandSummary,
+                    category: AnnouncementCategory.Result);
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Raises the element-selected event on the selected row, which is what a screen reader
+    /// listens for on a field that declares it controls a list.
+    /// </summary>
+    private void RaiseElementSelected()
+    {
+        var index = CommandList.SelectedIndex;
+        if (index < 0) return;
+
+        // The list virtualizes, so the row's container — and therefore its automation peer — may
+        // not exist yet. ScrollIntoView realizes it, but only on a later layout pass, so look the
+        // container up after one. The same deferral this window has always used to reach a row.
+        CommandList.ScrollIntoView(CommandList.SelectedItem);
+        Dispatcher.InvokeAsync(() =>
+        {
+            if (_dismissed) return;
+            if (CommandList.ItemContainerGenerator.ContainerFromIndex(index) is not ListBoxItem row) return;
+
+            var peer = UIElementAutomationPeer.FromElement(row)
+                       ?? UIElementAutomationPeer.CreatePeerForElement(row);
+            peer?.RaiseAutomationEvent(AutomationEvents.SelectionItemPatternOnElementSelected);
+        }, DispatcherPriority.Background);
     }
 }

--- a/docs/KEYBOARD-SHORTCUTS.md
+++ b/docs/KEYBOARD-SHORTCUTS.md
@@ -79,6 +79,33 @@ in-control navigation — the same kind as the arrow keys inside a list box — 
 commands. The four `folder.expand*` / `folder.collapse*` commands above are the bulk equivalents
 (#590): they act on the whole branch, or on the whole tree.
 
+## Inside the Command Palette
+
+`Ctrl+Shift+P` opens the palette itself (hardcoded — it cannot be dispatched through the palette
+it opens). The keys **inside** the palette are in-window navigation, not registered commands, for
+the same reason the folder tree's arrow keys are not: they have no meaning outside it and no
+command title. All of them are handled in `CommandPaletteWindow.OnPreviewKeyDown`.
+
+| Key | Action |
+|-----|--------|
+| *(typing)* | Filters the list. Matches any part of a name, its initials (`gtf` → Go to Folder), its category, or several words in any order |
+| `Enter` | Run the top match — or the command arrowed to |
+| `Up` / `Down` | Move the selection. Focus stays in the filter box |
+| `Page Up` / `Page Down` | Move the selection ten at a time |
+| `Escape` | Clear the filter; close the palette when the box is already empty |
+| `Tab` | Swallowed — the filter box is the only focusable control in the window |
+
+The filter box holds keyboard focus for the whole life of the window and never gives it up. That
+is deliberate and is the constraint the design turns on: an earlier version moved focus onto the
+list to make a screen reader speak the row, and typing then had to be forwarded back to the box
+by hand. The list is `Focusable="False"`, its rows are not focusable either (so a mouse click
+cannot steal focus), and the box declares through UI Automation that it controls the list, which
+is what lets a screen reader report the active command without focus moving.
+
+Because the list never receives a keystroke, it declares **no** `TextSearch.TextPath` —
+`TypeAheadWiringTests.TheCommandPaletteList_DeclaresNoTextSearchTextPath` keeps an inert one from
+drifting back in.
+
 ## Message List Fields Window
 
 Opened from **View → Message List Fields…** or the command palette (`view.rowFields`). Left

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -676,9 +676,11 @@ Press **Ctrl+Shift+P** to open the command palette. It opens with focus in a fil
 - **The category.** Typing `mail` lists the Mail commands.
 - **Several words, in any order.** Typing `arch mail` finds the Mail category's Archive command.
 
-The best match is always at the top of the list and is the one **Enter** runs. Your screen reader reports that top command as it changes — after a short pause, so it does not talk over you while you are still typing — and arrowing **Up** and **Down** through the list reports each command as you reach it. Focus stays in the filter box the whole time, so you can keep typing to narrow further without moving anywhere first.
+The best match is always at the top of the list and is the one **Enter** runs. The command at the top is reported as it changes, and so is each command you reach by arrowing **Up** and **Down** — reported by Windows from the list itself, not announced by QuickMail over the top of it, so no announcement setting can switch it off. When a keystroke narrows the list without changing the command at the top, you hear the new count on its own — "3 commands" — because nothing else would tell you the list had moved.
 
-**Escape** clears the filter if you have typed anything, and closes the palette if the box is already empty. **Page Up** and **Page Down** move through the list ten at a time. If nothing matches what you have typed, you hear "No matching commands" and Enter does nothing.
+Focus stays in the filter box the whole time, so you can keep typing to narrow further without moving anywhere first.
+
+**Escape** clears the filter if you have typed anything, and closes the palette if the box is already empty. **Page Up** and **Page Down** move through the list ten at a time. If nothing matches what you have typed, you hear "No matching commands", and Enter says so too rather than doing nothing silently.
 
 The palette opens from anywhere in the main window, including while you are reading a message in the reading pane. Closing it puts you back where you were reading, and a command you choose runs before focus returns to the message.
 

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -667,9 +667,22 @@ Press **F5** to manually refresh the current folder.
 
 ### Command Palette
 
-Press **Ctrl+Shift+P** to open the command palette: one list of every command, sorted by category and then by name, with each command's shortcut key where it has one. Arrow to a command, or type the first letters of its name to jump to it, and press Enter to run it; Escape closes the palette. This is the fastest way to discover and run any action in the app, including the many that have no shortcut key.
+Press **Ctrl+Shift+P** to open the command palette. It opens with focus in a filter box, and below it every command, sorted by category and then by name, with each command's shortcut key where it has one. This is the fastest way to discover and run any action in the app, including the many that have no shortcut key.
+
+**Start typing and the list narrows to what matches.** You do not have to type the start of a command's name, or even whole words:
+
+- **Any part of the name.** Typing `arch` finds **Move to Archive**.
+- **The initials.** Typing `gtf` finds **Go to Folder**.
+- **The category.** Typing `mail` lists the Mail commands.
+- **Several words, in any order.** Typing `arch mail` finds the Mail category's Archive command.
+
+The best match is always at the top of the list and is the one **Enter** runs. Your screen reader reports that top command as it changes — after a short pause, so it does not talk over you while you are still typing — and arrowing **Up** and **Down** through the list reports each command as you reach it. Focus stays in the filter box the whole time, so you can keep typing to narrow further without moving anywhere first.
+
+**Escape** clears the filter if you have typed anything, and closes the palette if the box is already empty. **Page Up** and **Page Down** move through the list ten at a time. If nothing matches what you have typed, you hear "No matching commands" and Enter does nothing.
 
 The palette opens from anywhere in the main window, including while you are reading a message in the reading pane. Closing it puts you back where you were reading, and a command you choose runs before focus returns to the message.
+
+Other windows have their own palettes on the same key — the compose window, an open message, the address book, the rules window and more — listing the commands that belong to that window.
 
 ### Keyboard Customization
 

--- a/docs/release-notes-v0.8.46.md
+++ b/docs/release-notes-v0.8.46.md
@@ -10,11 +10,13 @@ The command palette (**Ctrl+Shift+P**) opens with a filter box, and typing narro
 
 You do not have to know how a command's name begins. Typing `arch` finds **Move to Archive**; `gtf` finds **Go to Folder** from its initials; `mail` lists the Mail commands by category; and `arch mail` finds the Mail category's Archive command with the words in either order. The best match is always at the top and is what **Enter** runs.
 
-Focus stays in the filter box the whole time. Your screen reader reports the top command as it changes — after a short pause, so it does not speak over you mid-word — and reports each command as you arrow **Up** and **Down** through the list. **Escape** clears the filter if you have typed something and closes the palette if the box is already empty; **Page Up** and **Page Down** move ten at a time; and when nothing matches you hear "No matching commands".
+Focus stays in the filter box the whole time, so you can keep typing to narrow further without moving anywhere first. The command at the top is reported as it changes, and so is each command you reach with **Up** and **Down** — by Windows itself, from the list, rather than by QuickMail announcing over the top of it, so no announcement setting can silence it. When a keystroke narrows the list without changing the command at the top, you hear the new count on its own — "3 commands" — since nothing else would tell you the list had moved under you.
+
+**Escape** clears the filter if you have typed something and closes the palette if the box is already empty. **Page Up** and **Page Down** move ten at a time. When nothing matches you hear "No matching commands", and Enter says so rather than doing nothing silently.
 
 This applies to every palette in the app, not just the main window's — the compose window, an open message, the address book, the rules window and the rest all get it.
 
-A search box shipped here once before and was taken out again, because it moved focus onto the list on every keystroke and announced a new top match on every character. This one does neither: focus never leaves the box, and an unchanged top match says nothing.
+A search box shipped here once before and was taken out again, because it moved focus onto the list on every keystroke and announced a new top match on every character. This one does neither: focus never leaves the box, and nothing is announced that Windows already reports.
 
 ---
 

--- a/docs/release-notes-v0.8.46.md
+++ b/docs/release-notes-v0.8.46.md
@@ -2,6 +2,20 @@
 
 <!-- What is new in 0.8.46 goes here, above the footers: Changed/Fixed/Added sections, each ending with its issue link and a --- divider. -->
 
+## Added
+
+### The command palette filters as you type
+
+The command palette (**Ctrl+Shift+P**) opens with a filter box, and typing narrows the list to what matches instead of only jumping to a name that starts with what you typed.
+
+You do not have to know how a command's name begins. Typing `arch` finds **Move to Archive**; `gtf` finds **Go to Folder** from its initials; `mail` lists the Mail commands by category; and `arch mail` finds the Mail category's Archive command with the words in either order. The best match is always at the top and is what **Enter** runs.
+
+Focus stays in the filter box the whole time. Your screen reader reports the top command as it changes — after a short pause, so it does not speak over you mid-word — and reports each command as you arrow **Up** and **Down** through the list. **Escape** clears the filter if you have typed something and closes the palette if the box is already empty; **Page Up** and **Page Down** move ten at a time; and when nothing matches you hear "No matching commands".
+
+This applies to every palette in the app, not just the main window's — the compose window, an open message, the address book, the rules window and the rest all get it.
+
+A search box shipped here once before and was taken out again, because it moved focus onto the list on every keystroke and announced a new top match on every character. This one does neither: focus never leaves the box, and an unchanged top match says nothing.
+
 ---
 
 ## Reporting Issues


### PR DESCRIPTION
The palette listed every command with no way to narrow it. The only typing support was WPF `TextSearch`, which jumps to a title *starting with* what you typed — so you could not type `arch` and reach **Move to Archive**.

Typing now ranks the list VS Code style: any part of a name, its initials (`gtf` → **Go to Folder**), its category, or several words in any order (`arch mail`). The best match is at the top and is what Enter runs.

One shared window serves all **16** palettes in the app, so this reaches every one of them.

## Why the last attempt was removed, and what is different

A search box shipped here in May 2026 and was taken out again five commits later. Two causes, both avoided here:

| Then | Now |
|---|---|
| Focus moved onto the list so a screen reader would speak the row, so typed characters had to be forwarded back to the box by hand (`63d0460`) | Focus never leaves the filter box. The list and its rows are not focusable at all |
| Announced on every `SelectedCommand` change, undebounced, over the top of the screen reader echoing what was being typed (`62dc0bf`) | Reporting waits out a 300 ms pause and says nothing when the top match has not changed. Arrowing reports at once |

`1816f96` deleted it all, calling the removals "text-forwarding and search-focused keyboard hacks".

## How the active command reaches a screen reader

The filter box declares through UI Automation that it controls the list (`GetControlledPeersCore` → `ControllerFor`), which is what lets the platform report the active row while focus sits elsewhere. The screen reader then supplies the row's name, its position in the set and its shortcut — no custom announcement, and no announcement setting can mute it.

Which mechanism actually sounds right is decided by ear, so all three stay working behind `CommandPaletteWindow.Reporting`:

- **`Automation`** (default) — WPF's own selection event.
- **`AutomationExplicit`** — plus an explicit event, for when the default does not carry. Deliberately **not** folded into the default: WPF already raises one when the selection changes, so doing both would speak the command twice.
- **`Announce`** — `AccessibilityHelper.Announce` with "Go to Folder, 1 of 7".

An empty result set has no row for either automation path to report, so **"No matching commands"** goes through `Announce` in every mode.

## Four things that would have shipped silently

- WPF keys implicit styles on the **exact** type, so the implicit `TextBox` style does not reach a subclass. Without an explicit `Style` the filter box renders light chrome in every dark theme.
- The shared themed row dims a selected row whenever `Selector.IsSelectionActive` is false — and it is now **always** false, since focus is parked in the filter box. The palette carries its own row template without that trigger.
- WPF selects a clicked row only if it can focus it first, and these rows are deliberately not focusable, so the palette selects by mouse itself. Otherwise a double-click ran whatever the keyboard had selected. (`PreviewMouseDown`, not `PreviewMouseLeftButtonDown` — the latter is a Direct routed event a handler on the list never sees.)
- The palette is modeless when opened from inside a reading-pane message (#676), where the text box's default context menu would deactivate the window and dismiss it. It is nulled.

## Keyboard

Escape clears the filter and closes only from an empty box, following `TemplatePickerWindow` and `FolderPickerWindow` rather than VS Code. Page Up / Page Down move ten at a time. Tab is swallowed — there is nowhere for it to go. Every editing key falls through to the caret untouched.

Because the list never receives a keystroke it declares no `TextSearch.TextPath`, and its `TypeAheadWiringTests` row goes with it; a new guard keeps an inert one from drifting back in (the #418 shape).

## Testing

- **`CommandMatcherTests`** (20) — ranking: initials, prefix beats mid-word, contiguous beats scattered, non-subsequence rejected, empty query preserves order, ties stable, category/description/id.
- **`CommandPaletteFilterTests`** (10) — VM filtering, selection follows the top match, the announcement text.
- **`CommandPaletteSpeechTests`** (15, `[StaFact]`) — focus stays in the box through typing, arrows and Page keys (the regression that removed this last time); `ControllerFor` is wired; row names come from the container; item peers resolve while virtualizing; the announce fallback says the right thing, stays silent on an unchanged top match, and says nothing at all in `Automation` mode.

These pin the **wiring**: `AutomationPeer.ListenerExists` is false with no UIA client attached, so no test here shows that a screen reader actually speaks. That check is by ear.

Full suite green (3829 passed, 3 skipped — the opt-in input tests). Visual probe re-run for `command-palette` in parchment and dark at 100%, and parchment at 150%.

## Still open

On open, whether the first command is reported is the one case I am unsure of — the selection is set before the list's containers exist, so WPF may or may not raise anything. If it is silent, `AutomationExplicit` is the switch for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
