### PR TITLE
Update the NuGet packages Dependabot has not been proposing (#382)

### DIFF
--- a/.github/workflows/winget-install-matrix.yml
+++ b/.github/workflows/winget-install-matrix.yml
@@ -50,7 +50,7 @@ jobs:
             rid: win-arm64
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       # Before the six-minute publish, not after it. The probe script is the last step in
       # this job, so a syntax error in it costs a full build to discover otherwise — which

--- a/QuickMail.IntegrationTests/QuickMail.IntegrationTests.csproj
+++ b/QuickMail.IntegrationTests/QuickMail.IntegrationTests.csproj
@@ -20,8 +20,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
-    <PackageReference Include="WireMock.Net" Version="2.13.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.10.0" />
+    <PackageReference Include="WireMock.Net" Version="2.15.0" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>

--- a/QuickMail.Tests/QuickMail.Tests.csproj
+++ b/QuickMail.Tests/QuickMail.Tests.csproj
@@ -26,7 +26,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="10.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.10.0" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
     <!-- STA-thread fact attribute for WPF tests -->

--- a/QuickMail/QuickMail.csproj
+++ b/QuickMail/QuickMail.csproj
@@ -84,25 +84,33 @@
 
   <ItemGroup>
     <PackageReference Include="AdysTech.CredentialManager" Version="3.1.0" />
-    <PackageReference Include="Google.Apis.Auth" Version="1.75.0" />
+    <PackageReference Include="Google.Apis.Auth" Version="1.76.0" />
     <PackageReference Include="Markdig" Version="1.3.2" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.10" />
-    <!-- Transitive-vulnerability overrides. SQLitePCLRaw.bundle_e_sqlite3: Microsoft.Data.Sqlite
-         still pins 2.1.11, whose bundled SQLite is vulnerable (GHSA-2m69-gcr7-jv3q); 2.1.12 ships
-         the fixed SQLite. System.Drawing.Common: Microsoft.Toolkit.Uwp.Notifications 7.1.3 (its
-         final release) pins 4.7.0, vulnerable to GHSA-rxg9-xrhp-64gj; 4.7.2 is the patched build. -->
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.12" />
+    <!-- Transitive-vulnerability overrides. SQLitePCLRaw.bundle_e_sqlite3: pinned to 2.1.12 for
+         the fixed bundled SQLite (GHSA-2m69-gcr7-jv3q). Microsoft.Data.Sqlite 10.0.12 now asks
+         for 2.1.12 itself, so the pin is a floor rather than a bump — keep it so a future
+         Microsoft.Data.Sqlite cannot quietly drag the bundle back down. Deliberately NOT moved to
+         3.0.5: that is a major rewrite of the provider bundle and Microsoft.Data.Sqlite still
+         resolves SQLitePCLRaw.core 2.1.12 alongside it, which would mix 2.x and 3.x assemblies.
+         System.Drawing.Common: Microsoft.Toolkit.Uwp.Notifications 7.1.3 (its final release) pins
+         4.7.0, vulnerable to GHSA-rxg9-xrhp-64gj. Held at the 8.0.x band to match the net8.0
+         runtime this app targets and ships self-contained; 9.x/10.x are the out-of-band packages
+         for later runtimes. At run time the WindowsDesktop shared framework supplies these types
+         anyway (UseWindowsForms) — the reference exists so NuGetAuditMode=all sees a patched
+         version rather than the vulnerable transitive one. -->
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.12" />
-    <PackageReference Include="System.Drawing.Common" Version="4.7.2" />
+    <PackageReference Include="System.Drawing.Common" Version="8.0.31" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
     <PackageReference Include="MailKit" Version="4.17.0" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.85.2" />
-    <PackageReference Include="Microsoft.Identity.Client.Desktop" Version="4.85.2" />
-    <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.85.2" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.89.0" />
+    <PackageReference Include="Microsoft.Identity.Client.Desktop" Version="4.89.0" />
+    <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.89.0" />
     <!-- Windows toast (app) notifications for unpackaged Win32 apps: ToastNotificationManagerCompat
          auto-registers the AppUserModelID + COM activator, no MSIX manifest required. -->
     <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
-    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.4022.49" />
-    <PackageReference Include="Roslynator.Analyzers" Version="4.15.0">
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.4191.47" />
+    <PackageReference Include="Roslynator.Analyzers" Version="5.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Dependabot's NuGet updater has proposed nothing since 2026-07-13. It runs weekly, reports **succeeded**, and says "No PRs affected" — because its design-time build of the WPF project fails and it determines zero dependencies. #382 has the full diagnosis and is still open.

This bumps by hand what it would have offered, so the drift stops growing while that stays unresolved. No source changes — project files and one workflow line only.

## Bumped

| Package | From | To |
|---|---|---|
| Google.Apis.Auth | 1.75.0 | 1.76.0 |
| Microsoft.Data.Sqlite | 10.0.10 | 10.0.12 |
| Microsoft.Identity.Client (+ `.Desktop`, `.Extensions.Msal`) | 4.85.2 | 4.89.0 |
| Microsoft.Web.WebView2 | 1.0.4022.49 | 1.0.4191.47 |
| Roslynator.Analyzers | 4.15.0 | 5.0.0 |
| System.Drawing.Common | 4.7.2 | 8.0.31 |
| Microsoft.NET.Test.Sdk (both test projects) | 18.8.1 | 18.10.0 |
| WireMock.Net | 2.13.0 | 2.15.0 |
| `actions/checkout` in `winget-install-matrix.yml` | v6 | v7 |

MSAL 4.86–4.89 touch managed identity, Azure Arc and diagnostics; nothing in the release notes affects `AcquireTokenInteractive`, `AcquireTokenSilent`, `WithUseEmbeddedWebView` or `WithWindowsEmbeddedBrowserSupport`, which is the whole of this app's MSAL surface. Roslynator 5.0.0 raises no new diagnostics here — a full `--no-incremental` rebuild produces the same warning set as 4.15.0.

## Deliberately not bumped

Each reason is also recorded in `QuickMail.csproj` next to the reference it applies to.

- **xunit.v3 3.2.2 → 4.0.1** (with `Xunit.StaFact` 4.0.23 and `xunit.runner.visualstudio` 4.0.0). v4 discontinues Microsoft Testing Platform v1 and makes MTP v2 the default, which changes what `dotnet test` does under the .NET 10 SDK this repo builds with. That is a migration with its own CI and CLAUDE.md consequences, not a version bump.
- **SQLitePCLRaw.bundle_e_sqlite3 2.1.12 → 3.0.5.** Microsoft.Data.Sqlite 10.0.12 still resolves `SQLitePCLRaw.core` 2.1.12, so taking the bundle to 3.x would mix 2.x and 3.x provider assemblies. The 2.1.12 pin stays as a floor — Microsoft.Data.Sqlite now asks for it itself, so it is no longer a bump, but it keeps a future version from quietly dragging the bundle back down.
- **System.Drawing.Common held in the 8.0.x band** rather than 10.0.12. The out-of-band package should match the runtime the app targets and ships self-contained (net8.0); 9.x and 10.x are for later runtimes. At run time the WindowsDesktop shared framework supplies these types anyway — the reference exists so `NuGetAuditMode=all` sees a patched version instead of the vulnerable 4.7.0 that Microsoft.Toolkit.Uwp.Notifications pins.

## The `checkout@v6` line is its own signal

`winget-install-matrix.yml` was added on 2026-08-16 using `actions/checkout@v6`, while every other workflow was already on v7. Four weeks later no Dependabot PR had come for it. #382 recorded the GitHub Actions updater as working normally (#292, #376); on this evidence it may not be. Worth checking both ecosystems' last-run rows in **Insights → Dependency graph → Dependabot**, which needs UI access.

## Verification

- `dotnet build QuickMail.sln -c Release --no-incremental` — 0 errors, 3078 warnings, the same count and the same warning-code profile as before the change. No `NU19xx` audit warnings, so the transitive-vulnerability overrides still hold.
- `dotnet test QuickMail.Tests -c Release --blame-hang` — **3835 passed, 0 failed, 3 skipped**. Byte-identical to a baseline run of the full suite on `main` before any of these edits.
- `dotnet test QuickMail.IntegrationTests -c Release` — 9 passed, 0 failed, 40 skipped (the skips are the live-credential tests).
- `build.bat publish` — produces the single-file self-contained `publish\QuickMail.exe`. This is the check that matters for the WebView2 bump, since the native loader is extracted from the single file at run time.

Not verified here: a live sign-in against the MSAL bump, and the reading pane against the WebView2 bump. Both want a real run of the published exe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
